### PR TITLE
RUE-844: enforce typed payload ownership guardrails

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -315,6 +315,31 @@ sh_test(
 )
 
 sh_test(
+    name = "payload-ownership-inventory-validation",
+    test = "scripts/validate-payload-ownership.py",
+    args = [
+        "--source", "rue-rir=$(location //crates/rue-rir:payload-ownership-inventory-sources)",
+        "--source", "rue-air=$(location //crates/rue-air:payload-ownership-inventory-sources)",
+        "--source", "rue-cfg=$(location //crates/rue-cfg:payload-ownership-inventory-sources)",
+        "--source", "rue-codegen=$(location //crates/rue-codegen:payload-ownership-inventory-sources)",
+    ],
+)
+
+sh_test(
+    name = "payload-ownership-inventory-tool-tests",
+    test = "scripts/test-payload-ownership.py",
+    resources = ["scripts/validate-payload-ownership.py"],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+    },
+)
+
+test_suite(
+    name = "payload-ownership-compile-fail-tests",
+    tests = ["//crates/rue-rir:rue-rir[doc]"],
+)
+
+sh_test(
     name = "benchmark-tool-tests",
     test = "scripts/test-benchmark-tools.py",
     env = {

--- a/crates/rue-air/BUCK
+++ b/crates/rue-air/BUCK
@@ -12,6 +12,12 @@ filegroup(
     visibility = ["PUBLIC"],
 )
 
+filegroup(
+    name = "payload-ownership-inventory-sources",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+)
+
 rue_crate(
     name = "rue-air",
     deps = [

--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -179,4 +179,43 @@ fn air_payload_ownership_and_validation_boundary_cannot_regress() {
     assert!(exports.contains("ValidatedAir"));
     assert!(semantic_output.contains("pub air: crate::ValidatedAir"));
     assert!(imported_body.contains("pub air: crate::ValidatedAir"));
+
+    let air = inst
+        .split("pub struct Air {")
+        .nth(1)
+        .and_then(|rest| rest.split("\n}").next())
+        .expect("AIR owner declaration");
+    for store in ["instructions", "extra", "projections", "places"] {
+        assert!(
+            !air.contains(&format!("pub {store}:")),
+            "AIR exposed {store} store"
+        );
+    }
+    let place = inst
+        .split("pub struct AirPlace {")
+        .nth(1)
+        .and_then(|rest| rest.split("\n}").next())
+        .expect("AIR place declaration");
+    assert!(!place.contains("pub projections:"));
+    for raw_api in [
+        "pub fn add_extra(",
+        "pub fn get_extra(",
+        "pub fn extra_mut(",
+        "pub fn projection_store_mut(",
+        "pub fn from_parts(",
+    ] {
+        assert!(
+            !inst.contains(raw_api),
+            "AIR exposed raw payload API: {raw_api}"
+        );
+    }
+    assert_eq!(inst.matches("word_range!(Air").count(), 10);
+    assert_eq!(crate::AIR_PAYLOAD_FAMILY_NAMES.len(), 10);
+
+    // Semantic consumers receive an immutable RIR. Its payload fields and
+    // stores remain inaccessible, so this lower-level entry point is not a
+    // payload escape hatch.
+    let sema = include_str!("sema/mod.rs");
+    assert!(sema.contains("pub fn new(\n        rir: &'a Rir,"));
+    assert!(!sema.contains("&'a mut Rir"));
 }

--- a/crates/rue-cfg/BUCK
+++ b/crates/rue-cfg/BUCK
@@ -12,6 +12,12 @@ filegroup(
     visibility = ["PUBLIC"],
 )
 
+filegroup(
+    name = "payload-ownership-inventory-sources",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+)
+
 rue_crate(
     name = "rue-cfg",
     deps = [

--- a/crates/rue-cfg/src/api_inventory.rs
+++ b/crates/rue-cfg/src/api_inventory.rs
@@ -1,0 +1,50 @@
+//! Structural guardrails for the CFG payload ownership boundary.
+
+#[test]
+fn cfg_payload_stores_and_codegen_boundary_stay_typed() {
+    let owner = include_str!("inst.rs");
+    let schemas = include_str!("payload.rs");
+    let facade = include_str!("lib.rs");
+
+    let cfg = owner
+        .split("pub struct Cfg {")
+        .nth(1)
+        .and_then(|rest| rest.split("\n}").next())
+        .expect("CFG owner declaration");
+    for store in [
+        "values",
+        "extra",
+        "call_args",
+        "switch_cases",
+        "projections",
+    ] {
+        assert!(
+            !cfg.contains(&format!("pub {store}:")),
+            "CFG exposed {store} store"
+        );
+    }
+
+    let family = schemas
+        .split("macro_rules! family")
+        .nth(1)
+        .and_then(|rest| rest.split("family!(\n    CfgIntrinsicArgs").next())
+        .expect("CFG payload-family declaration");
+    assert!(family.contains("pub(crate) struct $name"));
+    assert!(!family.contains("pub struct $name"));
+    assert!(!facade.contains("CfgIntrinsicArgs"));
+    assert_eq!(schemas.matches("family!(").count(), 10);
+    assert_eq!(crate::CFG_PAYLOAD_FAMILY_NAMES.len(), 10);
+
+    for raw_api in [
+        "pub fn payload_store_mut(",
+        "pub fn values_mut(",
+        "pub fn call_args_mut(",
+        "pub fn switch_cases_mut(",
+        "pub fn projections_mut(",
+    ] {
+        assert!(
+            !owner.contains(raw_api),
+            "CFG exposed raw payload API: {raw_api}"
+        );
+    }
+}

--- a/crates/rue-cfg/src/lib.rs
+++ b/crates/rue-cfg/src/lib.rs
@@ -16,6 +16,8 @@
 //! AIR (structured) → CFG (explicit control flow) → X86Mir (machine code)
 //! ```
 
+#[cfg(test)]
+mod api_inventory;
 mod build;
 mod dominators;
 mod inst;

--- a/crates/rue-codegen/BUCK
+++ b/crates/rue-codegen/BUCK
@@ -12,6 +12,12 @@ filegroup(
     visibility = ["PUBLIC"],
 )
 
+filegroup(
+    name = "payload-ownership-inventory-sources",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+)
+
 rue_crate(
     name = "rue-codegen",
     deps = [

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use lasso::ThreadedRodeo;
 use rue_air::FrozenTypeInternPool;
-use rue_cfg::{BlockId, Cfg, CfgValue, Type};
+use rue_cfg::{BlockId, Cfg, CfgValue, Type, ValidatedCfg};
 use rue_error::CompileResult;
 use rue_target::Target;
 
@@ -101,6 +101,25 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
 impl<'a> CfgLower<'a> {
     /// Create a new CFG lowering pass.
     pub fn new(
+        cfg: &'a ValidatedCfg,
+        type_pool: &'a FrozenTypeInternPool,
+        interner: &'a ThreadedRodeo,
+        target: Target,
+    ) -> Self {
+        Self::new_inner(cfg, type_pool, interner, target)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_unchecked(
+        cfg: &'a Cfg,
+        type_pool: &'a FrozenTypeInternPool,
+        interner: &'a ThreadedRodeo,
+        target: Target,
+    ) -> Self {
+        Self::new_inner(cfg, type_pool, interner, target)
+    }
+
+    fn new_inner(
         cfg: &'a Cfg,
         type_pool: &'a FrozenTypeInternPool,
         interner: &'a ThreadedRodeo,
@@ -2564,7 +2583,11 @@ impl crate::terminator_plan::CfgLowerAdapter for CfgLower<'_> {
 
     fn value_description(&self, value: CfgValue) -> String {
         let inst = self.ctx.cfg.get_inst(value);
-        crate::format_cfg_inst_data_with_interner(self.ctx.cfg, &inst.data, self.interner)
+        crate::cfg_lower::format_cfg_inst_data_with_interner(
+            self.ctx.cfg,
+            &inst.data,
+            self.interner,
+        )
     }
 
     fn instruction_count(&self) -> usize {

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -28,7 +28,7 @@ pub use regalloc::RegAlloc;
 
 use lasso::ThreadedRodeo;
 use rue_air::FrozenTypeInternPool;
-use rue_cfg::Cfg;
+use rue_cfg::ValidatedCfg;
 use rue_error::CompileResult;
 use rue_target::Target;
 
@@ -39,7 +39,7 @@ use crate::regalloc::RegAllocDebugInfo;
 pub use super::{EmittedCode, EmittedRelocation};
 
 fn prepare_backend(
-    cfg: &Cfg,
+    cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
     target: Target,
@@ -59,7 +59,7 @@ fn prepare_backend(
 }
 
 fn generate_inner<T, Emit>(
-    cfg: &Cfg,
+    cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
@@ -107,7 +107,7 @@ where
 ///
 /// This is the main entry point for AArch64 code generation.
 pub fn generate(
-    cfg: &Cfg,
+    cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
@@ -130,7 +130,7 @@ pub fn generate(
 /// This returns both machine code bytes and human-readable assembly text
 /// showing the actual emitted instructions (including prologue/epilogue).
 pub fn generate_with_asm(
-    cfg: &Cfg,
+    cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
@@ -154,7 +154,7 @@ pub fn generate_with_asm(
 /// This returns information about the register allocation process,
 /// including live ranges, interference, and allocation decisions.
 pub fn generate_regalloc_info(
-    cfg: &Cfg,
+    cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
     target: Target,

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -33,7 +33,7 @@ use crate::vreg::VReg;
 /// Implementations are thin: `emit_load_slot` is a single frame-relative load
 /// instruction (`mov dst, [rbp+offset]` / `ldr dst, [fp, #offset]`); the rest
 /// expose existing lowerer state.
-pub trait SlotBackend: BoundsCheckBackend {
+pub(crate) trait SlotBackend: BoundsCheckBackend {
     /// The shared lowering context (CFG, type pool, slot counts).
     fn ctx(&self) -> &CfgLowerContext<'_>;
 
@@ -72,7 +72,10 @@ pub trait SlotBackend: BoundsCheckBackend {
 /// Returns `None` for non-aggregate types. Valid multi-slot aggregate values
 /// are either materialized directly here or are lowered on demand and read
 /// from the cache populated by their lowering rule.
-pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) -> Option<Vec<VReg>> {
+pub(crate) fn get_or_compute_field_vregs<B: SlotBackend>(
+    b: &mut B,
+    value: CfgValue,
+) -> Option<Vec<VReg>> {
     if let Some(vregs) = b.slot_cache().get(&value).cloned() {
         return Some(vregs);
     }
@@ -93,7 +96,7 @@ pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) ->
 /// a primary vreg alone would emit a partial value. Missing or incorrectly
 /// sized representations therefore indicate malformed internal IR and fail an
 /// invariant in release builds.
-pub fn require_aggregate_slots<B: SlotBackend>(b: &mut B, value: CfgValue) -> Vec<VReg> {
+pub(crate) fn require_aggregate_slots<B: SlotBackend>(b: &mut B, value: CfgValue) -> Vec<VReg> {
     let ty = b.ctx().cfg.get_inst(value).ty;
     let plan = crate::value_plan::ValuePlan::for_value(b.ctx(), value);
     assert!(
@@ -133,7 +136,7 @@ fn assert_complete_slot_count(value: CfgValue, actual: usize, expected: usize) {
 /// 0 and freshly-allocated vregs for the remaining slots. Zero-slot aggregates
 /// intentionally cache an empty list, matching their source values and keeping
 /// join-edge slot-count checks honest (RUE-167, RUE-194, RUE-248).
-pub fn preallocate_block_param_slots<B: SlotBackend>(
+pub(crate) fn preallocate_block_param_slots<B: SlotBackend>(
     b: &mut B,
     param_value: CfgValue,
     ty: Type,
@@ -161,7 +164,7 @@ pub fn preallocate_block_param_slots<B: SlotBackend>(
 /// (a higher slot number is a lower address), so logical slot `k` is stored at
 /// frame slot `base_slot + (len-1) - k` — the region's low end is its
 /// highest-numbered slot.
-pub fn store_slots<B: SlotBackend>(b: &mut B, vals: &[VReg], base_slot: u32) {
+pub(crate) fn store_slots<B: SlotBackend>(b: &mut B, vals: &[VReg], base_slot: u32) {
     let low_slot = base_slot + (vals.len() as u32).saturating_sub(1);
     store_slots_at_low(b, vals, low_slot);
 }
@@ -170,7 +173,7 @@ pub fn store_slots<B: SlotBackend>(b: &mut B, vals: &[VReg], base_slot: u32) {
 /// low-end (slot-0) at frame slot `low_slot`; logical slot `k` lands at frame
 /// slot `low_slot - k` (each higher slot at a higher address — ascending,
 /// ADR-0040).
-pub fn store_slots_at_low<B: SlotBackend>(b: &mut B, vals: &[VReg], low_slot: u32) {
+pub(crate) fn store_slots_at_low<B: SlotBackend>(b: &mut B, vals: &[VReg], low_slot: u32) {
     for (k, val) in vals.iter().enumerate() {
         b.emit_store_slot(*val, low_slot - k as u32);
     }
@@ -181,7 +184,7 @@ pub fn store_slots_at_low<B: SlotBackend>(b: &mut B, vals: &[VReg], low_slot: u3
 /// pointee's low-end address (what `@raw` and `@ptr_offset` yield, and where
 /// `@alloc` blocks begin), so aggregate slots ascend uniformly for pointers of
 /// every origin — stack, heap, or `@int_to_ptr` (ADR-0040 / RUE-311).
-pub fn store_slots_through_ptr<B: SlotBackend>(
+pub(crate) fn store_slots_through_ptr<B: SlotBackend>(
     b: &mut B,
     vals: &[VReg],
     ptr: VReg,
@@ -199,7 +202,7 @@ pub fn store_slots_through_ptr<B: SlotBackend>(
 /// aggregate memory access now uses (ADR-0040 / RUE-311).
 ///
 /// See `crate::cfg_lower::type_uses_sret_return` for when returns use sret.
-pub fn store_slots_to_sret<B: SlotBackend>(b: &mut B, vals: &[VReg]) {
+pub(crate) fn store_slots_to_sret<B: SlotBackend>(b: &mut B, vals: &[VReg]) {
     let ptr = b.alloc_vreg();
     let sret_slot = b.ctx().sret_ptr_slot();
     b.emit_load_slot(ptr, sret_slot);
@@ -215,7 +218,11 @@ pub fn store_slots_to_sret<B: SlotBackend>(b: &mut B, vals: &[VReg]) {
 /// field (RUE-242). `ptr` is the pointee's low-end address; every value of an
 /// aggregate type occupies `type_slot_count` consecutive ascending slots
 /// (ADR-0040 / RUE-311).
-pub fn load_slots_through_ptr<B: SlotBackend>(b: &mut B, ptr: VReg, count: u32) -> Vec<VReg> {
+pub(crate) fn load_slots_through_ptr<B: SlotBackend>(
+    b: &mut B,
+    ptr: VReg,
+    count: u32,
+) -> Vec<VReg> {
     load_through_ptr(b, ptr, count)
 }
 
@@ -226,7 +233,7 @@ pub fn load_slots_through_ptr<B: SlotBackend>(b: &mut B, ptr: VReg, count: u32) 
 /// Load `count` logical slots (slot 0 first) from the frame with the value's
 /// low-end (slot 0) at frame slot `low_slot`; logical slot `k` is read from
 /// frame slot `low_slot - k` (ascending, ADR-0040).
-pub fn load_slots_at_low<B: SlotBackend>(b: &mut B, low_slot: u32, count: u32) -> Vec<VReg> {
+pub(crate) fn load_slots_at_low<B: SlotBackend>(b: &mut B, low_slot: u32, count: u32) -> Vec<VReg> {
     let mut vregs = Vec::with_capacity(count as usize);
     for k in 0..count {
         let vreg = b.alloc_vreg();

--- a/crates/rue-codegen/src/api_inventory.rs
+++ b/crates/rue-codegen/src/api_inventory.rs
@@ -1,0 +1,57 @@
+//! Guard the validated CFG boundary at public backend entry points.
+
+#[test]
+fn production_generate_entry_points_require_validated_cfg() {
+    for backend in [
+        include_str!("x86_64/mod.rs"),
+        include_str!("aarch64/mod.rs"),
+    ] {
+        for entry_point in ["generate", "generate_with_asm", "generate_regalloc_info"] {
+            let signature = backend
+                .split(&format!("pub fn {entry_point}("))
+                .nth(1)
+                .and_then(|rest| rest.split(')').next())
+                .unwrap_or_else(|| panic!("backend {entry_point} signature"));
+            assert!(
+                signature.contains("cfg: &ValidatedCfg"),
+                "{entry_point} accepts an unvalidated CFG"
+            );
+            assert!(!signature.contains("cfg: &Cfg,"));
+        }
+    }
+
+    for lowering in [
+        include_str!("x86_64/cfg_lower.rs"),
+        include_str!("aarch64/cfg_lower.rs"),
+    ] {
+        let constructor = lowering
+            .split("pub fn new(")
+            .nth(1)
+            .and_then(|rest| rest.split(") -> Self").next())
+            .expect("public CFG lowering constructor");
+        assert!(constructor.contains("cfg: &'a ValidatedCfg"));
+        assert!(!constructor.contains("cfg: &'a Cfg"));
+    }
+
+    let shared = include_str!("cfg_lower.rs");
+    assert!(shared.contains("pub(crate) struct CfgLowerContext<'a>"));
+    assert!(!shared.contains("pub struct CfgLowerContext<'a>"));
+    assert!(!shared.contains("pub cfg: &'a Cfg"));
+    for planning in [
+        include_str!("value_plan.rs"),
+        include_str!("terminator_plan.rs"),
+    ] {
+        for raw_entry in [
+            "pub fn for_value(",
+            "pub fn lower_value",
+            "pub fn by_ref_param_slots(",
+            "pub fn plan_terminator",
+            "pub fn lower_cfg",
+        ] {
+            assert!(
+                !planning.contains(raw_entry),
+                "public raw planning entry: {raw_entry}"
+            );
+        }
+    }
+}

--- a/crates/rue-codegen/src/byref_args.rs
+++ b/crates/rue-codegen/src/byref_args.rs
@@ -24,7 +24,7 @@ use crate::vreg::VReg;
 /// Sema accepts as a by-ref argument a place: a variable (`Load`/`Param`) or a
 /// field/index projection chain rooted at one (`PlaceRead`). A non-place value
 /// with no storage to address is a violated sema/CFG invariant (RUE-760).
-pub fn lower_byref_arg_addr<B: PlaceLowerBackend + ?Sized>(
+pub(crate) fn lower_byref_arg_addr<B: PlaceLowerBackend + ?Sized>(
     b: &mut B,
     plan: &ByRefAddressPlan,
 ) -> VReg {

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -208,7 +208,7 @@ pub struct CallInputs {
 }
 
 impl CallInputs {
-    pub fn from_cfg(
+    pub(crate) fn from_cfg(
         cfg: &Cfg,
         type_pool: &FrozenTypeInternPool,
         return_ty: Type,

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -124,15 +124,8 @@ impl fmt::Display for LoweringDebugInfo {
     }
 }
 
-/// Format a CFG instruction data as a human-readable string. Takes the `Cfg`
-/// so places render with their projections resolved (`$0.#StructId(2).1`), not as raw
-/// projection-arena index ranges (`$0[3..5]`).
-pub fn format_cfg_inst_data(cfg: &rue_cfg::Cfg, data: &rue_cfg::CfgInstData) -> String {
-    format_cfg_inst_data_impl(cfg, data, None)
-}
-
 /// Format CFG instruction data with interned symbols resolved to stable names.
-pub fn format_cfg_inst_data_with_interner(
+pub(crate) fn format_cfg_inst_data_with_interner(
     cfg: &rue_cfg::Cfg,
     data: &rue_cfg::CfgInstData,
     interner: &ThreadedRodeo,
@@ -298,7 +291,7 @@ pub fn type_uses_sret_return(
 
 /// Does this function return its value via the sret convention?
 /// See [`type_uses_sret_return`] for the convention.
-pub fn fn_uses_sret_return(
+pub(crate) fn fn_uses_sret_return(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,
     ret_reg_budget: u32,
@@ -321,20 +314,20 @@ pub fn fn_uses_sret_return(
 ///
 /// Each backend's `CfgLower` embeds this context and delegates to its methods.
 #[derive(Clone, Copy)]
-pub struct CfgLowerContext<'a> {
+pub(crate) struct CfgLowerContext<'a> {
     /// The CFG being lowered.
-    pub cfg: &'a Cfg,
+    pub(crate) cfg: &'a Cfg,
     /// Type intern pool for struct/enum/array lookups.
-    pub type_pool: &'a FrozenTypeInternPool,
+    pub(crate) type_pool: &'a FrozenTypeInternPool,
     /// Number of local variable slots.
-    pub num_locals: u32,
+    pub(crate) num_locals: u32,
     /// Number of parameter slots.
-    pub num_params: u32,
+    pub(crate) num_params: u32,
 }
 
 impl<'a> CfgLowerContext<'a> {
     /// Create a new CFG lowering context.
-    pub fn new(cfg: &'a Cfg, type_pool: &'a FrozenTypeInternPool) -> Self {
+    pub(crate) fn new(cfg: &'a Cfg, type_pool: &'a FrozenTypeInternPool) -> Self {
         Self {
             cfg,
             type_pool,
@@ -350,13 +343,6 @@ impl<'a> CfgLowerContext<'a> {
     /// Get the length of an array type.
     pub fn array_length(&self, array_type: Type) -> u64 {
         types::array_length_from_type(self.type_pool, array_type)
-    }
-
-    /// Get the array type definition.
-    ///
-    /// Returns `Some((element_type, length))` for array types, `None` otherwise.
-    pub fn array_type_def(&self, array_type: Type) -> Option<(Type, u64)> {
-        types::array_type_def_from_type(self.type_pool, array_type)
     }
 
     /// Calculate the total number of slots needed to store a type.
@@ -381,13 +367,6 @@ impl<'a> CfgLowerContext<'a> {
     /// Calculate the slot offset for a field within a struct.
     pub fn struct_field_slot_offset(&self, struct_id: StructId, field_index: u32) -> u32 {
         types::struct_field_slot_offset(self.type_pool, struct_id, field_index)
-    }
-
-    /// Total slot count of a struct (sum of its fields' slot counts). Used as
-    /// the root-object origin shift for ascending place addressing
-    /// (ADR-0040 / RUE-311).
-    pub fn struct_total_slot_count(&self, struct_id: StructId) -> u32 {
-        types::struct_slot_count(self.type_pool, struct_id)
     }
 
     // ========================================================================
@@ -418,19 +397,8 @@ impl<'a> CfgLowerContext<'a> {
         }
     }
 
-    /// Does a by-value return of `ty` use the sret convention for the
-    /// backend's return-register budget? See [`type_uses_sret_return`].
-    pub fn type_uses_sret(&self, ty: Type, ret_reg_budget: u32) -> bool {
-        type_uses_sret_return(self.type_pool, ty, ret_reg_budget)
-    }
-
-    /// Does the function being lowered return via the sret convention?
-    pub fn uses_sret_return(&self, ret_reg_budget: u32) -> bool {
-        self.type_uses_sret(self.cfg.return_type(), ret_reg_budget)
-    }
-
     /// The frame slot holding the incoming sret pointer, one past the param
-    /// area (only meaningful when [`Self::uses_sret_return`] is true). The
+    /// area (only meaningful for an sret-returning function). The
     /// prologue stores the hidden first argument here; the return path loads
     /// it back to write the result through. Register-allocator spill slots
     /// start after this slot.

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -52,8 +52,10 @@ pub mod terminator_plan;
 pub mod value_plan;
 
 pub mod aarch64;
-pub mod agg_slots;
+mod agg_slots;
 pub mod aggregate_eq;
+#[cfg(test)]
+mod api_inventory;
 pub mod byref_args;
 pub mod cfg_lower;
 pub mod index_map;
@@ -384,7 +386,6 @@ pub use x86_64::generate;
 // Re-export shared types
 pub use cfg_lower::{
     BlockLoweringInfo, LoweringDebugInfo, LoweringDecision, TerminatorLoweringDecision,
-    format_cfg_inst_data, format_cfg_inst_data_with_interner,
 };
 pub use index_map::{Handle, IndexMap};
 pub use regalloc::{

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -22,7 +22,7 @@ use rue_air::Type;
 pub type ResolvedPlace = crate::value_plan::PlacePlan;
 
 /// Per-target instruction leaves used by shared place lowering.
-pub trait PlaceLowerBackend: SlotBackend {
+pub(crate) trait PlaceLowerBackend: SlotBackend {
     /// Get or lazily materialize a received by-reference parameter pointer.
     fn ensure_by_ref_param_ptr(&mut self, param_slot: u32) -> VReg;
 
@@ -165,7 +165,7 @@ fn frame_access<B: PlaceLowerBackend + ?Sized>(
     }
 }
 
-pub fn lower_place_read_plan<B: PlaceLowerBackend>(
+pub(crate) fn lower_place_read_plan<B: PlaceLowerBackend>(
     b: &mut B,
     dst: VReg,
     place: &ResolvedPlace,
@@ -200,7 +200,7 @@ pub fn lower_place_read_plan<B: PlaceLowerBackend>(
     }
 }
 
-pub fn lower_place_write_plan<B: PlaceLowerBackend>(
+pub(crate) fn lower_place_write_plan<B: PlaceLowerBackend>(
     b: &mut B,
     place: &ResolvedPlace,
     vals: &[VReg],
@@ -282,7 +282,7 @@ fn lower_place_addr_plan_with_bounds<B: PlaceLowerBackend + ?Sized>(
 /// Form a place address after applying the shared bounds policy. Aggregate
 /// reads use this entry point so their multi-slot load path cannot bypass an
 /// indexed-place trap.
-pub fn lower_checked_place_addr_plan<B: PlaceLowerBackend + ?Sized>(
+pub(crate) fn lower_checked_place_addr_plan<B: PlaceLowerBackend + ?Sized>(
     b: &mut B,
     dst: VReg,
     place: &ResolvedPlace,
@@ -292,7 +292,7 @@ pub fn lower_checked_place_addr_plan<B: PlaceLowerBackend + ?Sized>(
 
 /// Form an unchecked place address for target leaves whose caller has already
 /// established the policy (for example raw ABI pointer materialization).
-pub fn lower_place_addr_plan<B: PlaceLowerBackend + ?Sized>(
+pub(crate) fn lower_place_addr_plan<B: PlaceLowerBackend + ?Sized>(
     b: &mut B,
     dst: VReg,
     place: &ResolvedPlace,
@@ -396,12 +396,17 @@ mod tests {
         };
         let cfg = build_cfg("main");
 
-        let x86 = X86CfgLower::new(&cfg, &output.type_pool, &interner)
+        let x86 = X86CfgLower::new_unchecked(&cfg, &output.type_pool, &interner)
             .lower()
             .expect("x86 fixture should lower");
-        let arm = Aarch64CfgLower::new(&cfg, &output.type_pool, &interner, Target::Aarch64Linux)
-            .lower()
-            .expect("AArch64 fixture should lower");
+        let arm = Aarch64CfgLower::new_unchecked(
+            &cfg,
+            &output.type_pool,
+            &interner,
+            Target::Aarch64Linux,
+        )
+        .lower()
+        .expect("AArch64 fixture should lower");
 
         // RHS read, write destination, @raw's argument read/address pair, and
         // final read each walk both indices. Only the write emits an indexed
@@ -523,10 +528,10 @@ mod tests {
             )
             .unwrap();
         indexed_cfg.set_return(indexed_entry, Some(read));
-        let pair_x86 = X86CfgLower::new(&indexed_cfg, &synthetic_types, &interner)
+        let pair_x86 = X86CfgLower::new_unchecked(&indexed_cfg, &synthetic_types, &interner)
             .lower()
             .expect("x86 indexed aggregate read should lower");
-        let pair_arm = Aarch64CfgLower::new(
+        let pair_arm = Aarch64CfgLower::new_unchecked(
             &indexed_cfg,
             &synthetic_types,
             &interner,
@@ -599,10 +604,10 @@ mod tests {
         // root-origin address arithmetic (and x86 keeps its 64-bit immediate).
         for by_ref_fn in ["read_borrow", "read_inout"] {
             let by_ref_cfg = build_cfg(by_ref_fn);
-            let by_ref_x86 = X86CfgLower::new(&by_ref_cfg, &output.type_pool, &interner)
+            let by_ref_x86 = X86CfgLower::new_unchecked(&by_ref_cfg, &output.type_pool, &interner)
                 .lower()
                 .expect("x86 by-ref fixture should lower");
-            let by_ref_arm = Aarch64CfgLower::new(
+            let by_ref_arm = Aarch64CfgLower::new_unchecked(
                 &by_ref_cfg,
                 &output.type_pool,
                 &interner,
@@ -631,10 +636,10 @@ mod tests {
         }
 
         let unit_cfg = build_cfg("read_unit");
-        let unit_x86 = X86CfgLower::new(&unit_cfg, &output.type_pool, &interner)
+        let unit_x86 = X86CfgLower::new_unchecked(&unit_cfg, &output.type_pool, &interner)
             .lower()
             .expect("x86 ZST fixture should lower");
-        let unit_arm = Aarch64CfgLower::new(
+        let unit_arm = Aarch64CfgLower::new_unchecked(
             &unit_cfg,
             &output.type_pool,
             &interner,
@@ -655,10 +660,11 @@ mod tests {
         // language-level bounds check. Both the value and address paths must
         // retain the shared trap edge even though they materialize no bytes.
         let unit_index_cfg = build_cfg("read_unit_index");
-        let unit_index_x86 = X86CfgLower::new(&unit_index_cfg, &output.type_pool, &interner)
-            .lower()
-            .expect("x86 indexed ZST fixture should lower");
-        let unit_index_arm = Aarch64CfgLower::new(
+        let unit_index_x86 =
+            X86CfgLower::new_unchecked(&unit_index_cfg, &output.type_pool, &interner)
+                .lower()
+                .expect("x86 indexed ZST fixture should lower");
+        let unit_index_arm = Aarch64CfgLower::new_unchecked(
             &unit_index_cfg,
             &output.type_pool,
             &interner,
@@ -674,10 +680,11 @@ mod tests {
         }));
 
         let unit_write_cfg = build_cfg("write_unit_index");
-        let unit_write_x86 = X86CfgLower::new(&unit_write_cfg, &output.type_pool, &interner)
-            .lower()
-            .expect("x86 indexed ZST write fixture should lower");
-        let unit_write_arm = Aarch64CfgLower::new(
+        let unit_write_x86 =
+            X86CfgLower::new_unchecked(&unit_write_cfg, &output.type_pool, &interner)
+                .lower()
+                .expect("x86 indexed ZST write fixture should lower");
+        let unit_write_arm = Aarch64CfgLower::new_unchecked(
             &unit_write_cfg,
             &output.type_pool,
             &interner,

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -6,7 +6,7 @@
 
 use lasso::ThreadedRodeo;
 use rue_air::FrozenTypeInternPool;
-use rue_cfg::Cfg;
+use rue_cfg::ValidatedCfg;
 use rue_error::CompileResult;
 use rue_target::{Arch, Target};
 
@@ -252,7 +252,7 @@ impl std::fmt::Display for StackFrameInfo {
 /// This function runs the codegen pipeline up to register allocation to determine
 /// the actual stack layout, including spill slots and callee-saved registers.
 pub fn generate_stack_frame_info(
-    cfg: &Cfg,
+    cfg: &ValidatedCfg,
     function_name: &str,
     type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
@@ -270,7 +270,7 @@ pub fn generate_stack_frame_info(
 
 /// Generate stack frame info for x86-64.
 fn generate_x86_64_stack_frame(
-    cfg: &Cfg,
+    cfg: &ValidatedCfg,
     function_name: &str,
     type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
@@ -418,7 +418,7 @@ fn generate_x86_64_stack_frame(
 
 /// Generate stack frame info for AArch64.
 fn generate_aarch64_stack_frame(
-    cfg: &Cfg,
+    cfg: &ValidatedCfg,
     function_name: &str,
     type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,

--- a/crates/rue-codegen/src/terminator_plan.rs
+++ b/crates/rue-codegen/src/terminator_plan.rs
@@ -354,7 +354,7 @@ fn return_value<A: TerminatorAdapter>(
 }
 
 /// Build the one canonical plan for a CFG terminator.
-pub fn plan_terminator<A: TerminatorAdapter>(
+pub(crate) fn plan_terminator<A: TerminatorAdapter>(
     ctx: &CfgLowerContext<'_>,
     adapter: &mut A,
     block: &BasicBlock,
@@ -469,7 +469,7 @@ pub fn plan_terminator<A: TerminatorAdapter>(
 /// Lower every CFG block through the same block order, label policy, and
 /// terminator planner.  The optional debug sink observes these exact plans;
 /// it does not invoke a presentation-specific lowerer.
-pub fn lower_cfg<A: CfgLowerAdapter>(
+pub(crate) fn lower_cfg<A: CfgLowerAdapter>(
     ctx: &CfgLowerContext<'_>,
     adapter: &mut A,
     mut debug_info: Option<&mut crate::LoweringDebugInfo>,
@@ -599,12 +599,13 @@ mod tests {
         crate::aarch64::Aarch64Mir,
         crate::LoweringDebugInfo,
     ) {
-        let (x86, x86_debug) = X86CfgLower::new(cfg, pool, interner)
+        let (x86, x86_debug) = X86CfgLower::new_unchecked(cfg, pool, interner)
             .lower_with_debug()
             .expect("x86 fixture should lower");
-        let (arm, arm_debug) = Aarch64CfgLower::new(cfg, pool, interner, Target::Aarch64Linux)
-            .lower_with_debug()
-            .expect("AArch64 fixture should lower");
+        let (arm, arm_debug) =
+            Aarch64CfgLower::new_unchecked(cfg, pool, interner, Target::Aarch64Linux)
+                .lower_with_debug()
+                .expect("AArch64 fixture should lower");
         (x86, x86_debug, arm, arm_debug)
     }
 

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -7,7 +7,7 @@
 //! canonical `FrozenTypeInternPool` (ADR-0024).
 
 use rue_air::{ArrayTypeId, EnumId, FrozenTypeInternPool, StructId, TypeKind};
-use rue_cfg::{Cfg, CfgInstData, CfgValue, Type};
+use rue_cfg::{CfgInstData, CfgValue, Type, ValidatedCfg};
 use std::collections::HashMap;
 
 use crate::vreg::VReg;
@@ -265,7 +265,7 @@ pub fn struct_field_slot_offset(
 /// * `value` - The CFG value to collect vregs from
 /// * `get_vreg` - Closure to get/allocate a vreg for a given CFG value
 pub fn collect_array_scalar_vregs(
-    cfg: &Cfg,
+    cfg: &ValidatedCfg,
     struct_slot_vregs: &HashMap<CfgValue, Vec<VReg>>,
     value: CfgValue,
     get_vreg: &mut impl FnMut(CfgValue) -> VReg,
@@ -378,7 +378,7 @@ fn type_name(ty: Type, type_pool: &FrozenTypeInternPool) -> String {
 /// * `value` - The CFG value to collect vregs from
 /// * `get_vreg` - Closure to get/allocate a vreg for a given CFG value
 pub fn collect_struct_scalar_vregs(
-    cfg: &Cfg,
+    cfg: &ValidatedCfg,
     struct_slot_vregs: &HashMap<CfgValue, Vec<VReg>>,
     value: CfgValue,
     get_vreg: &mut impl FnMut(CfgValue) -> VReg,

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -528,7 +528,7 @@ pub struct ValuePlan {
 impl ValuePlan {
     /// Decide the policy for one CFG instruction.  `value` is only used to
     /// inspect operand types; it is not retained in the returned plan.
-    pub fn for_value(ctx: &CfgLowerContext<'_>, value: CfgValue) -> Self {
+    pub(crate) fn for_value(ctx: &CfgLowerContext<'_>, value: CfgValue) -> Self {
         let inst = ctx.cfg.get_inst(value);
         let ty = inst.ty;
         let shape = shape(ctx, ty);
@@ -1144,7 +1144,7 @@ fn residual_kind(plan: &ResidualValuePlan) -> ValueKind {
 }
 
 /// The sole raw CFG semantic dispatcher and cache association owner.
-pub fn lower_value<A: ValueLowerAdapter>(
+pub(crate) fn lower_value<A: ValueLowerAdapter>(
     ctx: &CfgLowerContext<'_>,
     adapter: &mut A,
     value: CfgValue,
@@ -2024,7 +2024,7 @@ pub fn integer_range(width: IntegerWidth) -> (i64, i64) {
 
 /// Return the by-reference parameter slots that must be preloaded before the
 /// block walk.  Both backends use this exact policy and cache rule.
-pub fn by_ref_param_slots(ctx: &CfgLowerContext<'_>) -> Vec<u32> {
+pub(crate) fn by_ref_param_slots(ctx: &CfgLowerContext<'_>) -> Vec<u32> {
     (0..ctx.num_params)
         .filter(|&slot| ctx.cfg.is_param_by_ref(slot))
         .collect()
@@ -2406,7 +2406,7 @@ mod tests {
             })
         );
 
-        let x86 = X86CfgLower::new(&cfg, &pool, &interner)
+        let x86 = X86CfgLower::new_unchecked(&cfg, &pool, &interner)
             .lower()
             .expect("x86 enum comparison should lower");
         assert!(
@@ -2420,7 +2420,7 @@ mod tests {
                 .any(|instruction| matches!(instruction, X86Inst::Cmp64RR { .. }))
         );
 
-        let arm = Aarch64CfgLower::new(&cfg, &pool, &interner, Target::Aarch64Linux)
+        let arm = Aarch64CfgLower::new_unchecked(&cfg, &pool, &interner, Target::Aarch64Linux)
             .lower()
             .expect("AArch64 enum comparison should lower");
         assert!(
@@ -2681,12 +2681,13 @@ mod tests {
         let cfg = synthetic_cfg(values, 0, 0, vec![], CfgValue::from_raw(4));
         let pool = rue_air::FrozenTypeInternPool::new();
         let interner = ThreadedRodeo::new();
-        let (x86, x86_debug) = X86CfgLower::new(&cfg, &pool, &interner)
+        let (x86, x86_debug) = X86CfgLower::new_unchecked(&cfg, &pool, &interner)
             .lower_with_debug()
             .expect("x86 fixture should lower");
-        let (arm, arm_debug) = Aarch64CfgLower::new(&cfg, &pool, &interner, Target::Aarch64Linux)
-            .lower_with_debug()
-            .expect("AArch64 fixture should lower");
+        let (arm, arm_debug) =
+            Aarch64CfgLower::new_unchecked(&cfg, &pool, &interner, Target::Aarch64Linux)
+                .lower_with_debug()
+                .expect("AArch64 fixture should lower");
 
         let x86_debug_cases = x86_debug
             .blocks
@@ -2724,12 +2725,13 @@ mod tests {
             vec![true],
             dummy_value(),
         );
-        let x86_byref = X86CfgLower::new(&byref_cfg, &pool, &interner)
+        let x86_byref = X86CfgLower::new_unchecked(&byref_cfg, &pool, &interner)
             .lower()
             .expect("x86 by-ref fixture should lower");
-        let arm_byref = Aarch64CfgLower::new(&byref_cfg, &pool, &interner, Target::Aarch64Linux)
-            .lower()
-            .expect("AArch64 by-ref fixture should lower");
+        let arm_byref =
+            Aarch64CfgLower::new_unchecked(&byref_cfg, &pool, &interner, Target::Aarch64Linux)
+                .lower()
+                .expect("AArch64 by-ref fixture should lower");
         assert!(
             x86_byref
                 .instructions()
@@ -2747,12 +2749,13 @@ mod tests {
     #[test]
     fn both_target_debug_traces_cover_every_cfg_value_variant() {
         let (cfg, pool, interner, values) = every_cfg_value_fixture();
-        let (x86, x86_debug) = X86CfgLower::new(&cfg, &pool, &interner)
+        let (x86, x86_debug) = X86CfgLower::new_unchecked(&cfg, &pool, &interner)
             .lower_with_debug()
             .expect("x86 coverage fixture should lower");
-        let (arm, arm_debug) = Aarch64CfgLower::new(&cfg, &pool, &interner, Target::Aarch64Linux)
-            .lower_with_debug()
-            .expect("AArch64 coverage fixture should lower");
+        let (arm, arm_debug) =
+            Aarch64CfgLower::new_unchecked(&cfg, &pool, &interner, Target::Aarch64Linux)
+                .lower_with_debug()
+                .expect("AArch64 coverage fixture should lower");
 
         let signature = |debug: &crate::LoweringDebugInfo| {
             let mut entries = debug
@@ -2836,10 +2839,10 @@ mod tests {
         cfg.set_return(entry, Some(param));
         let interner = ThreadedRodeo::new();
 
-        let x86 = X86CfgLower::new(&cfg, &pool, &interner)
+        let x86 = X86CfgLower::new_unchecked(&cfg, &pool, &interner)
             .lower()
             .expect("x86 zero-slot parameter should lower");
-        let arm = Aarch64CfgLower::new(&cfg, &pool, &interner, Target::Aarch64Linux)
+        let arm = Aarch64CfgLower::new_unchecked(&cfg, &pool, &interner, Target::Aarch64Linux)
             .lower()
             .expect("AArch64 zero-slot parameter should lower");
         assert!(
@@ -2911,7 +2914,7 @@ mod tests {
         let pool = pool.freeze();
 
         let x86_ctx = crate::cfg_lower::CfgLowerContext::new(&cfg, &pool);
-        let mut x86 = X86CfgLower::new(&cfg, &pool, &interner);
+        let mut x86 = X86CfgLower::new_unchecked(&cfg, &pool, &interner);
         let x86_value = super::operand(&x86_ctx, &mut x86, value);
         let x86_actions = super::drop_plan(&x86_ctx, &mut x86, value);
         assert_eq!(x86_value.slots.len(), 3);
@@ -2920,7 +2923,7 @@ mod tests {
         assert_eq!(x86_actions[0].slots, x86_value.slots);
 
         let arm_ctx = crate::cfg_lower::CfgLowerContext::new(&cfg, &pool);
-        let mut arm = Aarch64CfgLower::new(&cfg, &pool, &interner, Target::Aarch64Linux);
+        let mut arm = Aarch64CfgLower::new_unchecked(&cfg, &pool, &interner, Target::Aarch64Linux);
         let arm_value = super::operand(&arm_ctx, &mut arm, value);
         let arm_actions = super::drop_plan(&arm_ctx, &mut arm, value);
         assert_eq!(arm_value.slots.len(), 3);
@@ -3163,12 +3166,13 @@ mod tests {
         );
 
         let interner = ThreadedRodeo::new();
-        let (_, x86_debug) = X86CfgLower::new(&cfg, &pool, &interner)
+        let (_, x86_debug) = X86CfgLower::new_unchecked(&cfg, &pool, &interner)
             .lower_with_debug()
             .expect("x86 zero-slot storage fixture should lower");
-        let (_, arm_debug) = Aarch64CfgLower::new(&cfg, &pool, &interner, Target::Aarch64Linux)
-            .lower_with_debug()
-            .expect("AArch64 zero-slot storage fixture should lower");
+        let (_, arm_debug) =
+            Aarch64CfgLower::new_unchecked(&cfg, &pool, &interner, Target::Aarch64Linux)
+                .lower_with_debug()
+                .expect("AArch64 zero-slot storage fixture should lower");
 
         for value in [alloc, load, store, param_store] {
             let x86 = x86_debug

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -29,7 +29,7 @@ use std::collections::HashMap;
 
 use lasso::ThreadedRodeo;
 use rue_air::{FrozenTypeInternPool, TypeKind};
-use rue_cfg::{BlockId, Cfg, CfgValue, Type};
+use rue_cfg::{BlockId, Cfg, CfgValue, Type, ValidatedCfg};
 use rue_error::CompileResult;
 
 use super::mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
@@ -107,6 +107,23 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
 impl<'a> CfgLower<'a> {
     /// Create a new CFG lowering pass.
     pub fn new(
+        cfg: &'a ValidatedCfg,
+        type_pool: &'a FrozenTypeInternPool,
+        interner: &'a ThreadedRodeo,
+    ) -> Self {
+        Self::new_inner(cfg, type_pool, interner)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_unchecked(
+        cfg: &'a Cfg,
+        type_pool: &'a FrozenTypeInternPool,
+        interner: &'a ThreadedRodeo,
+    ) -> Self {
+        Self::new_inner(cfg, type_pool, interner)
+    }
+
+    fn new_inner(
         cfg: &'a Cfg,
         type_pool: &'a FrozenTypeInternPool,
         interner: &'a ThreadedRodeo,
@@ -2399,7 +2416,11 @@ impl crate::terminator_plan::CfgLowerAdapter for CfgLower<'_> {
 
     fn value_description(&self, value: CfgValue) -> String {
         let inst = self.ctx.cfg.get_inst(value);
-        crate::format_cfg_inst_data_with_interner(self.ctx.cfg, &inst.data, self.interner)
+        crate::cfg_lower::format_cfg_inst_data_with_interner(
+            self.ctx.cfg,
+            &inst.data,
+            self.interner,
+        )
     }
 
     fn instruction_count(&self) -> usize {

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -30,14 +30,14 @@ use crate::regalloc::RegAllocDebugInfo;
 
 use lasso::ThreadedRodeo;
 use rue_air::FrozenTypeInternPool;
-use rue_cfg::Cfg;
+use rue_cfg::ValidatedCfg;
 use rue_error::CompileResult;
 
 // Re-export from parent
 pub use super::{EmittedCode, EmittedRelocation, MachineCode};
 
 fn prepare_backend(
-    cfg: &Cfg,
+    cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
 ) -> CompileResult<crate::codegen_pipeline::PreparedMir<X86Mir, Reg>> {
@@ -56,7 +56,7 @@ fn prepare_backend(
 }
 
 fn generate_inner<T, Emit>(
-    cfg: &Cfg,
+    cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
@@ -104,7 +104,7 @@ where
 /// This is the main entry point for x86-64 code generation.
 /// The pipeline is: CFG → X86Mir → Machine Code
 pub fn generate(
-    cfg: &Cfg,
+    cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
@@ -126,7 +126,7 @@ pub fn generate(
 /// This returns both machine code bytes and human-readable assembly text
 /// showing the actual emitted instructions (including prologue/epilogue).
 pub fn generate_with_asm(
-    cfg: &Cfg,
+    cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
@@ -148,7 +148,7 @@ pub fn generate_with_asm(
 /// This returns information about the register allocation process,
 /// including live ranges, interference, and allocation decisions.
 pub fn generate_regalloc_info(
-    cfg: &Cfg,
+    cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
 ) -> CompileResult<RegAllocDebugInfo<Reg>> {

--- a/crates/rue-rir/BUCK
+++ b/crates/rue-rir/BUCK
@@ -1,5 +1,11 @@
 load("//crates:defs.bzl", "rue_crate")
 
+filegroup(
+    name = "payload-ownership-inventory-sources",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+)
+
 rue_crate(
     name = "rue-rir",
     deps = [

--- a/crates/rue-rir/src/api_inventory.rs
+++ b/crates/rue-rir/src/api_inventory.rs
@@ -1,0 +1,53 @@
+//! Structural guardrails for the RIR payload ownership boundary.
+
+#[test]
+fn rir_payload_storage_and_raw_ranges_stay_owner_private() {
+    let owner = include_str!("inst.rs");
+    let producer = include_str!("astgen.rs");
+    let facade = include_str!("lib.rs");
+
+    let rir = owner
+        .split("pub struct Rir {")
+        .nth(1)
+        .and_then(|rest| rest.split("\n}").next())
+        .expect("RIR owner declaration");
+    assert!(rir.contains("instructions: Vec<Inst>"));
+    assert!(rir.contains("extra: Vec<u32>"));
+    assert!(!rir.contains("pub instructions"));
+    assert!(!rir.contains("pub extra"));
+
+    let range = owner
+        .split("macro_rules! payload_family")
+        .nth(1)
+        .and_then(|rest| rest.split("pub(crate) trait PayloadFallback").next())
+        .expect("RIR payload-family declaration");
+    assert!(range.contains("const fn from_parts("));
+    assert!(!range.contains("pub fn from_parts("));
+    assert!(!range.contains("pub const fn from_parts("));
+    assert!(!range.contains("pub start"));
+    assert!(!range.contains("pub extent"));
+    assert!(range.contains("#[derive(PartialEq, Eq)]\n        pub struct $name"));
+    assert!(!range.contains("#[derive(Clone, Copy, PartialEq, Eq)]\n        pub struct $name"));
+
+    for raw_api in [
+        "pub fn append_payload(",
+        "pub fn payload_words(",
+        "pub fn get_extra(",
+        "pub fn extra_mut(",
+    ] {
+        assert!(
+            !owner.contains(raw_api),
+            "RIR exposed raw payload API: {raw_api}"
+        );
+        assert!(
+            !facade.contains(raw_api),
+            "RIR facade exposed raw payload API: {raw_api}"
+        );
+    }
+
+    assert_eq!(owner.matches("payload_family!(").count(), 17);
+    assert_eq!(crate::RIR_PAYLOAD_FAMILY_NAMES.len(), 17);
+    assert!(!producer.contains(".extra["));
+    assert!(!producer.contains(".extra."));
+    assert!(!producer.contains("from_parts("));
+}

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -945,6 +945,46 @@ pub struct Rir {
 
 /// Mutable construction-phase owner. Payload descriptors never leave this
 /// owner through the public API; callers add or replace complete nodes.
+///
+/// Family identities cannot be interchanged:
+///
+/// ```compile_fail
+/// use rue_rir::{Rir, RirParamsRange};
+/// fn wrong_family(rir: &Rir, params: &RirParamsRange) {
+///     let _ = rir.call_args(params);
+/// }
+/// ```
+///
+/// Raw positions cannot be reconstructed:
+///
+/// ```compile_fail
+/// use rue_rir::RirCallArgsRange;
+/// let _ = RirCallArgsRange::from_parts(0, 0);
+/// ```
+///
+/// A descriptor cannot be extracted from a published owner for movement to a
+/// different editor:
+///
+/// ```compile_fail
+/// use rue_rir::{InstData, InstRef, Rir, RirCallArgsRange};
+/// fn extract(rir: &Rir, inst: InstRef) -> RirCallArgsRange {
+///     match &rir.get_inst(inst).data {
+///         InstData::Call { args, .. } => *args,
+///         _ => panic!("not a call"),
+///     }
+/// }
+/// ```
+///
+/// Consequently a payload-bearing node cannot be detached from one owner and
+/// inserted into another:
+///
+/// ```compile_fail
+/// use rue_rir::{Inst, InstData, InstRef, Rir, RirEditor};
+/// fn detach(source: &Rir, destination: &mut RirEditor, inst: InstRef) {
+///     let borrowed = source.get_inst(inst);
+///     destination.add_inst(Inst { data: borrowed.data, span: borrowed.span });
+/// }
+/// ```
 #[derive(Debug, Default)]
 pub struct RirEditor {
     rir: Rir,

--- a/crates/rue-rir/src/lib.rs
+++ b/crates/rue-rir/src/lib.rs
@@ -20,6 +20,8 @@
 //!
 //! Inspired by Zig's ZIR (Zig Intermediate Representation).
 
+#[cfg(test)]
+mod api_inventory;
 mod astgen;
 mod inst;
 

--- a/docs/designs/0056-typed-ir-payload-schemas.md
+++ b/docs/designs/0056-typed-ir-payload-schemas.md
@@ -1,12 +1,12 @@
 ---
 id: 0056
 title: Typed IR payload schemas
-status: accepted
+status: implemented
 tags: [architecture, compiler, ir, performance, validation]
 feature-flag: null
 created: 2026-07-16
 accepted: 2026-07-16
-implemented:
+implemented: 2026-07-17
 spec-sections: []
 superseded-by:
 relates: ["RUE-790", "RUE-839", "RUE-840", "RUE-841", "RUE-842", "RUE-843", "RUE-844"]
@@ -21,8 +21,11 @@ review required enforceable artifact-instance provenance, separate logical
 family and physical-store markers, owning validation typestate with canonical
 external contexts, and explicit M5/performance/guardrail gates. This is an
 internal compiler architecture decision. It does not change Rue language
-semantics, the specification, or a preview feature. Production M6 migrations
-remain gated on RUE-838.
+semantics, the specification, or a preview feature. The production M6
+migrations were gated on RUE-838 and are complete as of 2026-07-17 under
+RUE-844. RIR, AIR, and CFG now own typed payload schemas, validated
+owner/editor boundaries, malformed-data and fuzz coverage, and source/API
+inventories that prevent raw storage paths from returning.
 
 The maintainer approved one measured performance-gate amendment on 2026-07-17
 under RUE-843. An AIR owner-local incremental rebuild may regress by at most 4%
@@ -49,11 +52,12 @@ support malformed-data tests without `unsafe` or a second decoder.
 
 ## Context
 
-Rue's compact side tables are valuable, but their type and layout contracts are
-currently spread between instruction fields, producers, and consumers.
+Rue's compact side tables are valuable. Before this decision was implemented,
+their type and layout contracts were spread between instruction fields,
+producers, and consumers.
 
-In `crates/rue-rir/src/inst.rs`, `Rir` owns `extra: Vec<u32>`. `InstData`
-variants store raw `(start, len)` fields, and the module manually keeps layout
+In the pre-migration RIR, `Rir` owned `extra: Vec<u32>`. `InstData` variants
+stored raw `(start, len)` fields, and the module manually kept layout
 constants such as `CALL_ARG_SIZE`, `PARAM_SIZE`, and the pattern sizes in sync
 with `add_*` and `get_*` methods. `get_inst_refs`, `get_symbols`,
 `get_call_args`, `get_params`, `get_match_arms`, `get_field_inits`,
@@ -62,7 +66,7 @@ specifically requires those reads to become zero-allocation. Variable-width
 path patterns and directives also perform positional arithmetic directly, so a
 producer and a consumer can disagree about an offset or encoded count.
 
-In `crates/rue-air/src/inst.rs`, `Air` owns `extra: Vec<u32>` and a separate
+In the pre-migration AIR, `Air` owned `extra: Vec<u32>` and a separate
 `Vec<AirProjection>`. Some reads, including `get_air_refs`, `get_call_args`,
 and `get_match_arms`, already return iterators, and projection reads already
 borrow a slice. Nevertheless, instruction data and `AirPlace` still expose raw
@@ -70,20 +74,19 @@ start/length pairs. Encoding, tag decoding, direct extra slicing, and range
 arithmetic remain distributed between `AirPattern`, `Air`, semantic producers,
 and downstream consumers.
 
-In `crates/rue-cfg/src/inst.rs`, `Cfg` deliberately uses several element
-stores: `Vec<CfgValue>`, `Vec<CfgCallArg>`, `Vec<(i64, BlockId)>`, and
+In the pre-migration CFG, `Cfg` deliberately used several element stores:
+`Vec<CfgValue>`, `Vec<CfgCallArg>`, `Vec<(i64, BlockId)>`, and
 `Vec<Projection>`. Instructions, places, and terminators refer to them with raw
 `u32` start/length pairs. The similar arithmetic hides the fact that the
 element types and invariants are different. A common design must preserve this
 phase-specific representation rather than forcing all CFG payloads through a
 `u32` serialization layer.
 
-These raw APIs escape their owning modules. Semantic analysis constructs and
-reads RIR and AIR payloads; CFG construction, optimizers, and verification
-read and rewrite CFG payloads; codegen consumes CFG ranges; compiler-owned drop
-glue and artifact projection cross the same boundaries. A localized helper
-that leaves public raw constructors and fields in place would only create a
-second, optional path.
+Those raw APIs escaped their owning modules. The implemented architecture now
+keeps construction and mutation in the owner, while semantic analysis,
+optimizers, codegen, display, and artifact projection consume typed borrowing
+views. Public machine-code generation requires a validated CFG; the read-only
+`Sema::new(&Rir)` boundary cannot access payload positions or storage.
 
 The failure modes are architectural, not merely ergonomic:
 
@@ -765,50 +768,50 @@ This decision does not:
 
 ADR-0056 becomes implemented only when:
 
-- [ ] RUE-790 and RUE-839 through RUE-844 are merged in their dependency order.
-- [ ] RUE-838 is merged before the production M6 migrations begin, and Linear
+- [x] RUE-790 and RUE-839 through RUE-844 are merged in their dependency order.
+- [x] RUE-838 is merged before the production M6 migrations begin, and Linear
       records the external M5 gate on the first runnable M6 issues.
-- [ ] RIR, AIR, and CFG each own handwritten phase-local schema modules under
+- [x] RIR, AIR, and CFG each own handwritten phase-local schema modules under
       the common contract, with no shared erased store or schema generator.
-- [ ] All production instruction, place, and terminator payload fields use
+- [x] All production instruction, place, and terminator payload fields use
       family-specific typed ranges or indices.
-- [ ] Compile-time assertions prove stored ranges remain two `u32`s with the
+- [x] Compile-time assertions prove stored ranges remain two `u32`s with the
       expected alignment.
-- [ ] Raw range construction, physical store mutation, and range fields are
+- [x] Raw range construction, physical store mutation, and range fields are
       private to owning schema/artifact modules.
-- [ ] Payload-bearing nodes cannot be cloned or inserted detached from their
+- [x] Payload-bearing nodes cannot be cloned or inserted detached from their
       owner; whole-owner clone is coherent and selective transfer rebuilds.
-- [ ] Each family has one authoritative width/tag/count/offset implementation
+- [x] Each family has one authoritative width/tag/count/offset implementation
       used by its builder, checked decoder, and artifact validator.
-- [ ] Builders check every conversion and arithmetic operation, append
+- [x] Builders check every conversion and arithmetic operation, append
       atomically, and cover empty and maximum-size behavior.
-- [ ] Checked malformed fixtures cover truncation, overflow metadata, unknown
+- [x] Checked malformed fixtures cover truncation, overflow metadata, unknown
       tags, noncanonical booleans, bad IDs/references, trailing words, and
       bad same-family ranges without `unsafe` or undefined behavior;
       compile-fail tests cover family/store mismatch, raw construction, range
       extraction or cross-editor movement, and detached node insertion.
-- [ ] RIR getters named in the context traverse without allocating, and all
+- [x] RIR getters named in the context traverse without allocating, and all
       migrated family iterators implement `ExactSizeIterator`.
-- [ ] AIR and CFG borrowing consumers retain their phase-specific typed element
+- [x] AIR and CFG borrowing consumers retain their phase-specific typed element
       stores rather than being flattened into words.
-- [ ] Editors are the only mutable form; consuming validation with canonical
+- [x] Editors are the only mutable form; consuming validation with canonical
       interner/source/type contexts produces immutable validated owners, and
       `CompilerSession` publishes only those owners.
-- [ ] Import, whole-owner clone, selective remap, transform, rewrite, fuzz, and
+- [x] Import, whole-owner clone, selective remap, transform, rewrite, fuzz, and
       canonical publication paths use the production schema validators and
       preserve or rebuild owner provenance.
-- [ ] Infallible validated-artifact access delegates to the checked decoder;
+- [x] Infallible validated-artifact access delegates to the checked decoder;
       no unsafe or duplicate trusted decoder exists.
-- [ ] The benchmark matrix records paired before/after wall time, RSS,
+- [x] The benchmark matrix records paired before/after wall time, RSS,
       allocations, phase timing, compiler clean build, and incremental rebuild
       evidence, including logical/capacity/staging bytes, and all structural
       and non-regression gates pass.
-- [ ] RUE-844's inventory proves public raw constructors, direct side-table
+- [x] RUE-844's inventory proves public raw constructors, direct side-table
       indexing, raw enum casts, allocating default getters, mutable raw side
       tables, and compatibility payload paths are absent from production code.
-- [ ] Focused tests, `scripts/rue quick`, relevant compiler/CFG/codegen suites,
+- [x] Focused tests, `scripts/rue quick`, relevant compiler/CFG/codegen suites,
       and CI pass.
-- [ ] RUE-844 updates this ADR's context, checklist, status, and generated index
+- [x] RUE-844 updates this ADR's context, checklist, status, and generated index
       to describe the verified final architecture.
 
 ## Open questions

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -218,6 +218,6 @@ The table is generated from ADR frontmatter. Run
 | [0053](0053-typed-compiler-query-state.md) | Typed CompilerSession query state | Accepted | architecture, compiler, incremental, tooling |
 | [0054](0054-loop-optimizations.md) | Loop Optimizations — LICM and Unrolling | Accepted | compiler, codegen, optimization |
 | [0055](0055-typed-runtime-abi-manifest.md) | Typed compiler-runtime ABI manifest | Implemented | architecture, compiler, runtime, abi, codegen |
-| [0056](0056-typed-ir-payload-schemas.md) | Typed IR payload schemas | Accepted | architecture, compiler, ir, performance, validation |
+| [0056](0056-typed-ir-payload-schemas.md) | Typed IR payload schemas | Implemented | architecture, compiler, ir, performance, validation |
 | [0057](0057-file-io-v0.md) | File IO v0: pure-Rue fs over @syscall with normalized FileError | Accepted | stdlib, io, syscalls, runtime, error-handling, ownership |
 <!-- ADR-INDEX:END -->

--- a/docs/process/typed-payload-verification.md
+++ b/docs/process/typed-payload-verification.md
@@ -79,6 +79,36 @@ production compiler-session path. Those hooks are compiled through dedicated
 fuzz-support Buck targets and are absent from the production RIR, AIR, and CFG
 crate surfaces.
 
+## Evolving a payload schema
+
+A payload family is owned by exactly one of `rue-rir`, `rue-air`, or
+`rue-cfg`. Add or change it in that owner's schema/artifact module; consumers
+must receive only its opaque family range and traverse it through the owner's
+typed borrowing view. Do not expose a raw start, extent, physical store, or
+detached payload-bearing node, and do not duplicate width, tag, count, or
+offset arithmetic in a producer or consumer.
+
+Every schema change must update the owner family-name inventory and the
+compiler's deliberately repeated cross-phase inventory. Add owner tests for
+round trips, empty and boundary sizes, malformed metadata and records,
+atomic-failure rollback, range layout, and zero-allocation traversal. Exercise
+owner cloning or selective remapping when the family participates in either,
+and extend the safe fuzz corruption hook. The API/source inventory tests must
+continue to prove that stores, constructors, range fields, and raw mutation
+remain private. Finally run the focused owner, compiler payload-schema, and
+fuzz tests plus `scripts/rue quick`; use the full suite for a cross-phase or
+representation change.
+
+`Sema::new(&Rir)` is a read-only semantic-consumption boundary: `Rir` exposes
+neither its payload store nor a mutable/raw range API. Public machine-code
+generation accepts `&ValidatedCfg`, preventing an editor from bypassing CFG
+verification. The publicly re-exported backend lowering constructors likewise
+require `&ValidatedCfg`; only crate-private helpers borrow the underlying
+`&Cfg` after that checked boundary, and they use typed getters. The shared
+lowering context and value/terminator planning entry points are crate-private,
+so a public consumer cannot assemble an unchecked lowering path from those
+pieces.
+
 ## Whole-compiler result
 
 One warmup preceded seven fresh-process pairs with alternating pair order. The

--- a/scripts/test-payload-ownership.py
+++ b/scripts/test-payload-ownership.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Self-tests for validate-payload-ownership.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("validate-payload-ownership.py")
+SPEC = importlib.util.spec_from_file_location("payload_inventory", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def roots(base: Path) -> list[tuple[str, Path]]:
+    result = []
+    for crate in MODULE.OWNER_PATHS:
+        root = base / crate
+        root.mkdir()
+        result.append((crate, root))
+    return result
+
+
+def errors_for(source: str, crate: str = "rue-codegen", relative: str = "consumer.rs") -> list[str]:
+    with tempfile.TemporaryDirectory() as temporary:
+        base = Path(temporary)
+        sources = roots(base)
+        path = base / crate / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(source)
+        return MODULE.validate(sources)
+
+
+def main() -> None:
+    assert not errors_for("pub fn typed() -> usize { 0 }\n")
+    cases = {
+        "direct side-table access": "fn bad(cfg: &Cfg) { cfg.values.push(x); }\n",
+        "raw range construction": "fn bad() { OtherRange::from_parts(0, 1); }\n",
+        "raw enum cast": "fn bad() { let _ = PatternKind::Path as u32; }\n",
+        "raw public accessor": "pub fn words() -> &[u32] { todo!() }\n",
+        "allocating getter": "pub fn get_payload() -> Vec<u32> { vec![] }\n",
+        "lifetime raw CFG": "pub fn lower(cfg: &'a Cfg) {}\n",
+        "qualified raw CFG": "pub fn lower(cfg: &rue_cfg::Cfg) {}\n",
+        "mutable non-u32 store": "pub fn values_mut() -> &mut Vec<CfgValue> { todo!() }\n",
+    }
+    for label, source in cases.items():
+        assert errors_for(source), f"validator missed {label}"
+    assert errors_for(
+        "pub struct Air {\n    pub places: Vec<AirPlace>,\n}\n",
+        "rue-air",
+        "inst.rs",
+    ), "validator missed AIR place store field"
+    print("payload ownership inventory tool tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate-payload-ownership.py
+++ b/scripts/validate-payload-ownership.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Fail closed when typed IR payload storage escapes its owning module."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+OWNER_PATHS = {
+    "rue-rir": {Path("inst.rs"), Path("inst/payload_support.rs")},
+    "rue-air": {Path("inst.rs"), Path("inst/payload_support.rs")},
+    "rue-cfg": {Path("inst.rs"), Path("inst/payload_metrics.rs"), Path("payload.rs")},
+    "rue-codegen": set(),
+}
+
+DIRECT_STORE_ACCESS = re.compile(
+    r"\b(?:rir|air|cfg)\.(?:instructions|extra|values|call_args|switch_cases|projections|places)\s*"
+    r"(?:\[|\.(?:push|extend|extend_from_slice|truncate|get_mut|as_mut|clear|reserve)\b)"
+)
+PUBLIC_PHYSICAL_STORE = re.compile(
+    r"^\s*pub\s+(?:\([^)]*\)\s+)?(?P<field>[A-Za-z0-9_]+)\s*:\s*"
+    r"Vec\s*<\s*(?:u32|CfgValue|CfgInst|CfgCallArg|AirPlace|AirProjection|Projection|\(\s*i64\s*,\s*BlockId\s*\))\s*>",
+    re.MULTILINE,
+)
+PUBLIC_STORE_ALLOWLIST = {
+    ("rue-cfg", Path("inst.rs"), "insts"),  # typed block membership, not a side table
+}
+RAW_CFG_ARGUMENT = re.compile(
+    r"\bcfg\s*:\s*&\s*(?:'[A-Za-z_][A-Za-z0-9_]*\s+)?(?:rue_cfg::)?Cfg\b"
+)
+MUTABLE_PHYSICAL_STORE_RETURN = re.compile(
+    r"->\s*&\s*mut\s*(?:Vec\s*<\s*)?(?:\[\s*)?"
+    r"(?:u32|CfgValue|CfgInst|CfgCallArg|AirPlace|AirProjection|Projection|\(\s*i64\s*,\s*BlockId\s*\))"
+)
+RAW_RANGE_CONSTRUCTION = re.compile(r"\b[A-Za-z0-9_]*Range::from_parts\s*\(")
+PAYLOAD_ENUM_CAST = re.compile(
+    r"\b(?:PatternKind|AirPattern|AirProjection|CfgInstData|Terminator)::[A-Za-z0-9_]+\s+as\s+(?:u32|usize)\b"
+)
+
+
+def public_function_headers(source: str) -> list[tuple[int, str]]:
+    headers: list[tuple[int, str]] = []
+    offset = 0
+    while True:
+        match = re.search(r"^\s*pub\s+(?:const\s+)?fn\s+", source[offset:], re.MULTILINE)
+        if match is None:
+            return headers
+        start = offset + match.start()
+        end = start
+        depth = 0
+        while end < len(source):
+            char = source[end]
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth = max(depth - 1, 0)
+            elif char in "{;" and depth == 0:
+                end += 1
+                break
+            end += 1
+        headers.append((source.count("\n", 0, start) + 1, source[start:end]))
+        offset = end
+
+
+def source_files(sources: list[tuple[str, Path]]) -> list[tuple[str, Path, Path]]:
+    files: list[tuple[str, Path, Path]] = []
+    for crate, root in sources:
+        for path in sorted(root.rglob("*.rs")):
+            files.append((crate, root, path))
+    return files
+
+
+def validate(sources: list[tuple[str, Path]]) -> list[str]:
+    errors: list[str] = []
+    for crate, root in sources:
+        if not root.exists():
+            errors.append(f"missing payload inventory source directory: {root}")
+
+    for crate, root, path in source_files(sources):
+        source = path.read_text()
+        relative = path.relative_to(root)
+        if relative.parts and relative.parts[0] == "src":
+            relative = Path(*relative.parts[1:])
+        display = Path("crates") / crate / "src" / relative
+        owner = relative in OWNER_PATHS[crate]
+
+        if owner:
+            for match in PUBLIC_PHYSICAL_STORE.finditer(source):
+                key = (crate, relative, match.group("field"))
+                if key not in PUBLIC_STORE_ALLOWLIST:
+                    line = source.count("\n", 0, match.start()) + 1
+                    errors.append(
+                        f"{display}:{line}: public mutable physical store field: {match.group(0).strip()}"
+                    )
+
+        for pattern, reason in [
+            (RAW_RANGE_CONSTRUCTION, "raw range construction outside its declaration"),
+            (PAYLOAD_ENUM_CAST, "raw payload enum cast"),
+        ]:
+            for match in pattern.finditer(source):
+                # Range construction and payload-tag encoding are implementation
+                # details permitted only in the reviewed owner allowlist.
+                if owner and pattern in {RAW_RANGE_CONSTRUCTION, PAYLOAD_ENUM_CAST}:
+                    continue
+                line = source.count("\n", 0, match.start()) + 1
+                errors.append(f"{display}:{line}: {reason}: {match.group(0)!r}")
+
+        if not owner and relative.name not in {"tests.rs", "api_inventory.rs"}:
+            for match in DIRECT_STORE_ACCESS.finditer(source):
+                line = source.count("\n", 0, match.start()) + 1
+                errors.append(
+                    f"{display}:{line}: direct side-table access outside owner: {match.group(0)!r}"
+                )
+
+        for line, header in public_function_headers(source):
+            compact = " ".join(header.split())
+            raw_shape = any(
+                token in compact
+                for token in (
+                    "-> &[u32]",
+                    "-> &mut [u32]",
+                    "-> &Vec<u32>",
+                    "-> &mut Vec<u32>",
+                    "-> (u32, u32)",
+                    "start: u32, extent: u32",
+                )
+            ) or RAW_CFG_ARGUMENT.search(compact) or MUTABLE_PHYSICAL_STORE_RETURN.search(compact)
+            allocating_getter = re.search(r"\bfn\s+(?:get|read|decode)_[A-Za-z0-9_]+", compact) and re.search(
+                r"->\s+(?:Result<)?Vec<", compact
+            )
+            if raw_shape or allocating_getter:
+                errors.append(f"{display}:{line}: unreviewed public payload API: {compact}")
+
+    return errors
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", action="append", default=[], metavar="CRATE=DIR")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    sources: list[tuple[str, Path]] = []
+    for item in args.source:
+        crate, separator, directory = item.partition("=")
+        if not separator or crate not in OWNER_PATHS:
+            print(f"invalid --source {item!r}", file=sys.stderr)
+            return 2
+        sources.append((crate, Path(directory)))
+    errors = validate(sources)
+    if errors:
+        print("typed payload ownership inventory failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print("typed payload ownership inventory passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- require validated CFGs at all public codegen and lowering boundaries on both backends
- add whole-source ownership inventories for RIR, AIR, CFG, and codegen with detector mutation tests
- wire compile-fail coverage for family mismatch, raw construction, cross-owner movement, and detached insertion
- document the schema-evolution process and mark ADR-0056 implemented

## Validation

- scripts/rue fmt
- payload ownership inventory validation and detector self-tests
- payload ownership compile-fail tests (4/4)
- scripts/rue quick
- scripts/rue test

Fixes RUE-844