### PR TITLE
RUE-948: evaluate member-access type paths as comptime arguments

### DIFF
--- a/crates/rue-air-profile/src/main.rs
+++ b/crates/rue-air-profile/src/main.rs
@@ -68,9 +68,7 @@ fn air_payload_storage_stats(air: &Air) -> AirPayloadStorageStats {
     stats.peak_staging_bytes = stats.peak_staging_bytes.max(
         air.places()
             .iter()
-            .map(|place| {
-                std::mem::size_of_val(air.get_place_projections(place))
-            })
+            .map(|place| std::mem::size_of_val(air.get_place_projections(place)))
             .max()
             .unwrap_or(0),
     );

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -6104,16 +6104,26 @@ impl<'a> BodySema<'a> {
                         || self.is_comptime_param_forward(arg.value, ctx);
                     if !is_comptime_known {
                         let param_name = self.interner.resolve(&param_names[i]).to_string();
+                        // A module-qualified member-access value path is
+                        // compile-time known but not yet folded in argument
+                        // position (RUE-948): name that limitation and the
+                        // file-level `const` workaround instead of the generic
+                        // "requires a compile-time known value" wording.
+                        let help = self
+                            .comptime_arg_member_access_help(arg.value, ctx)
+                            .unwrap_or_else(|| {
+                                format!(
+                                    "parameter '{}' is declared as 'comptime' and requires a compile-time known value",
+                                    param_name
+                                )
+                            });
                         return Err(CompileError::new(
                             ErrorKind::ComptimeArgNotConst {
                                 param_name: param_name.clone(),
                             },
                             self.rir.get(arg.value).span,
                         )
-                        .with_help(format!(
-                            "parameter '{}' is declared as 'comptime' and requires a compile-time known value",
-                            param_name
-                        )));
+                        .with_help(help));
                     }
                 }
             }
@@ -6183,17 +6193,26 @@ impl<'a> BodySema<'a> {
                             }
                             None => {
                                 let param_name = self.interner.resolve(&param_names[i]).to_string();
+                                let arg_value = args.get(i).unwrap().value;
+                                // RUE-948: a module-member value path is
+                                // compile-time known but unfolded here; point
+                                // at the file-level `const` workaround.
+                                let help = self
+                                    .comptime_arg_member_access_help(arg_value, ctx)
+                                    .unwrap_or_else(|| {
+                                        format!(
+                                            "parameter '{}' is declared as 'comptime' and requires \
+                                             a compile-time known value",
+                                            param_name
+                                        )
+                                    });
                                 return Err(CompileError::new(
                                     ErrorKind::ComptimeArgNotConst {
                                         param_name: param_name.clone(),
                                     },
-                                    self.rir.get(args.get(i).unwrap().value).span,
+                                    self.rir.get(arg_value).span,
                                 )
-                                .with_help(format!(
-                                    "parameter '{}' is declared as 'comptime' and requires \
-                                     a compile-time known value",
-                                    param_name
-                                )));
+                                .with_help(help));
                             }
                         }
                         runtime_args.push(air_arg.clone());

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1202,9 +1202,20 @@ impl<D: DeclarationPhase> Sema<'_, D> {
             // (with privacy checks) before evaluation — see the
             // `const_module_members` field — since the engine has no file or
             // constant-collector context to resolve it here. A member absent
-            // from the map (a non-module base, or a re-export used as a value)
-            // is not evaluable, so the caller reports it (RUE-267).
-            InstData::FieldGet { .. } => Ok(env.const_module_members.get(&inst_ref).copied()),
+            // from the map may still be a member-access *type* path used as a
+            // comptime type-constructor argument (`std.strbuf.StrBuf` in
+            // `Result(std.strbuf.StrBuf, i32)`, RUE-948): resolve that chain to
+            // its nominal type through the same walker the qualified
+            // type-annotation position uses. A base that is neither a
+            // pre-resolved member value nor a module type path (a runtime
+            // value's field) stays non-evaluable, so the caller reports it
+            // (RUE-267).
+            InstData::FieldGet { .. } => {
+                if let Some(&value) = env.const_module_members.get(&inst_ref) {
+                    return Ok(Some(value));
+                }
+                self.eval_field_get_type_path(inst_ref, span, env)
+            }
 
             // Type intrinsic in comptime position. `@require_droppable(T)` is the
             // owning-container well-formedness gate (RUE-388/RUE-646): std's
@@ -1384,6 +1395,154 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         // environment so `T` (an enclosing comptime parameter) still resolves.
         self.eval_comptime_type_call(function_key, args, env, true)
             .map_err(|e| Self::label_ctor_instantiation_site(e, span))
+    }
+
+    /// Reduce a member-access chain (`std.strbuf.StrBuf`) that appears in
+    /// *value position* — a comptime type-constructor argument — to its nominal
+    /// type value (RUE-948). The `FieldGet` arm of [`eval_const_expr`] reaches
+    /// here only after the chain was not found among the pre-resolved
+    /// `const_module_members`, so this is the type-path case: `spec 4.14:26`
+    /// treats a chain of const/import member accesses as comptime-evaluable, and
+    /// the qualified type-annotation position already resolves the identical
+    /// spelling. Route the value-position case through the same walker so
+    /// `Result(std.strbuf.StrBuf, i32)` behaves like the accepted return-type
+    /// form `-> Result(std.strbuf.StrBuf, i32)` and the alias workaround
+    /// (`let S = std.strbuf.StrBuf; Result(S, i32)`).
+    ///
+    /// Returns `Ok(None)` (non-evaluable) when the chain is not a module type
+    /// path — a shadowed root, no file context, a runtime value's field, or a
+    /// member that is not a type — leaving the caller to report it. A privacy
+    /// violation on an otherwise-valid path surfaces as its real diagnostic.
+    fn eval_field_get_type_path(
+        &mut self,
+        inst_ref: InstRef,
+        span: Span,
+        env: &ComptimeEnv,
+    ) -> CompileResult<Option<ConstValue>> {
+        // Collect the dotted spine down to its root name, exactly as the
+        // module-qualified call walk does. Any non-`FieldGet`/`VarRef` link
+        // (a runtime value's field) is not a type path.
+        let mut chain_rev: Vec<Spur> = Vec::new();
+        let mut cursor = inst_ref;
+        let root_name = loop {
+            match self.rir.get(cursor).data {
+                InstData::VarRef { name } => break name,
+                InstData::FieldGet { base, field } => {
+                    chain_rev.push(field);
+                    cursor = base;
+                }
+                _ => return Ok(None),
+            }
+        };
+        // A `let`-binding, runtime local, runtime parameter, or comptime
+        // parameter of the same name shadows the module import (spec 4.14:6);
+        // the chain is then a field access on that binding, not a type path.
+        if env.locals.contains_key(&root_name) {
+            return Ok(None);
+        }
+        if let Some(locals) = env.runtime_locals
+            && locals.contains_key(&root_name)
+        {
+            return Ok(None);
+        }
+        if let Some(names) = env.runtime_binding_names
+            && names.contains(&root_name)
+        {
+            return Ok(None);
+        }
+        if let Some(params) = env.runtime_params
+            && params.iter().any(|param| param.name == root_name)
+        {
+            return Ok(None);
+        }
+        if env.type_subst.contains_key(&root_name) || env.value_subst.contains_key(&root_name) {
+            return Ok(None);
+        }
+        // The root names an import of the file whose body is being reduced; the
+        // remaining segments walk re-export bindings and the final member the
+        // same way qualified type annotations do.
+        let Some(root_file) = env.defining_file else {
+            return Ok(None);
+        };
+        let mut segments: Vec<&str> = vec![self.interner.resolve(&root_name)];
+        segments.extend(chain_rev.iter().rev().map(|s| self.interner.resolve(s)));
+        match self.resolve_qualified_type_name_in_file(root_file, &segments, span) {
+            Ok(ty) => Ok(Some(ConstValue::Type(ty))),
+            // An unknown member / non-module base is simply not a type path
+            // here; defer to the caller (a genuine runtime field access, or the
+            // comptime-arg check's E1201). Other errors — a privacy violation
+            // on a real member — are hard diagnostics that must surface.
+            Err(error)
+                if matches!(
+                    error.kind,
+                    ErrorKind::UnknownType(_) | ErrorKind::UnknownModuleMember { .. }
+                ) =>
+            {
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Tailored E1201 help for the member-access paths that remain
+    /// non-evaluable in comptime-argument position after RUE-948's type-path
+    /// fix: a module-qualified path (`lib.nums.K`) that names a compile-time
+    /// *value* — a re-exported `const` — rather than a type. Such a value is
+    /// genuinely compile-time known, so the generic "requires a compile-time
+    /// known value" wording is wrong-headed; the real limitation is that this
+    /// version does not yet fold a module-member value directly in argument
+    /// position (a `let`-local of it is a runtime binding and does not help,
+    /// but a file-level `const` alias does).
+    ///
+    /// Returns `None` for any other argument shape — a runtime `let`/parameter
+    /// reference, an overflowed literal, an aggregate value — so those keep the
+    /// generic help. Only a `FieldGet` chain rooted at an *unshadowed* module
+    /// import of the current file qualifies.
+    pub(crate) fn comptime_arg_member_access_help(
+        &self,
+        arg: InstRef,
+        ctx: &AnalysisContext,
+    ) -> Option<String> {
+        // Walk the FieldGet chain to its root, collecting the dotted spine.
+        let mut fields_rev: Vec<Spur> = Vec::new();
+        let mut cursor = arg;
+        let root_name = loop {
+            match self.rir.get(cursor).data {
+                InstData::VarRef { name } => break name,
+                InstData::FieldGet { base, field } => {
+                    fields_rev.push(field);
+                    cursor = base;
+                }
+                _ => return None,
+            }
+        };
+        // A bare `VarRef` (no field) is a plain runtime binding, not a path.
+        if fields_rev.is_empty() {
+            return None;
+        }
+        // A runtime local or parameter of the same name shadows the import, so
+        // this is an ordinary field access on a value — the generic help is
+        // correct there.
+        if ctx.locals.contains_key(&root_name)
+            || ctx.params.iter().any(|param| param.name == root_name)
+        {
+            return None;
+        }
+        // The root must name a module import of the current file for this to be
+        // a module-qualified member-access path at all.
+        let binding = self
+            .module_bindings
+            .get(&(ctx.current_file_id, root_name))?;
+        binding.ty.as_module()?;
+        let mut segments: Vec<&str> = vec![self.interner.resolve(&root_name)];
+        segments.extend(fields_rev.iter().rev().map(|s| self.interner.resolve(s)));
+        let path = segments.join(".");
+        Some(format!(
+            "the module-qualified path `{path}` names a compile-time value that \
+             this version does not yet evaluate directly in a comptime-argument \
+             position; bind it to a file-level `const` and pass that \
+             (`const X = {path};` then use `X`)"
+        ))
     }
 
     /// The `@require_droppable(T)` well-formedness gate for owning growable

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -888,14 +888,29 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
 
     fn resolve_qualified_type_name(&mut self, path: &str, span: Span) -> CompileResult<Type> {
         let segments: Vec<&str> = path.split('.').collect();
+        self.resolve_qualified_type_name_in_file(span.file_id, &segments, span)
+    }
+
+    /// Like [`Self::resolve_qualified_type_name`], but with the file whose
+    /// imports anchor the path's first segment made explicit. The comptime
+    /// engine resolves a member-access type path (`std.strbuf.StrBuf` as a
+    /// value-position type-constructor argument) against its environment's
+    /// `defining_file`, the same file the qualified type-annotation path walks
+    /// (RUE-948, mirroring the RUE-511/RUE-609 receiver walk).
+    pub(crate) fn resolve_qualified_type_name_in_file(
+        &mut self,
+        root_file: FileId,
+        segments: &[&str],
+        span: Span,
+    ) -> CompileResult<Type> {
         if segments.len() < 2 || segments.iter().any(|s| s.is_empty()) {
             return Err(CompileError::new(
-                ErrorKind::UnknownType(path.to_string()),
+                ErrorKind::UnknownType(segments.join(".")),
                 span,
             ));
         }
-        let (module_id, module_file_id, _module_file_path) =
-            self.resolve_type_module_prefix(&segments[..segments.len() - 1], span)?;
+        let (module_id, module_file_id, _module_file_path) = self
+            .resolve_type_module_prefix_in_file(root_file, &segments[..segments.len() - 1], span)?;
         let member = segments[segments.len() - 1];
         let member_sym = self.interner.get_or_intern(member);
 

--- a/crates/rue-cli-tests/cases/const_alias_inference.toml
+++ b/crates/rue-cli-tests/cases/const_alias_inference.toml
@@ -295,3 +295,69 @@ pub enum Pick {
 """ },
 ]
 exit_code = 42
+
+[[case]]
+name = "member_access_path_ctor_args_value_and_pattern_position"
+description = "A member-access type path (`std.fs.FileError`) as a comptime type-constructor argument now works in value/construction AND pattern position, not only return-type position — the last alias tax removed (RUE-948). Runs end-to-end: Ok(42) selects the first arm."
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const std = @import("std");
+
+fn classify(n: i32) -> std.result.Result(i32, std.fs.FileError) {
+    std.result.Result(i32, std.fs.FileError).Ok(n)
+}
+
+fn main() -> i32 {
+    let r = classify(42);
+    match r {
+        std.result.Result(i32, std.fs.FileError).Ok(v) => v,
+        std.result.Result(i32, std.fs.FileError).Err(e) => { let _ = e; 1 },
+    }
+}
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "member_access_value_path_comptime_arg_names_limitation"
+description = "RUE-948 fix 2: a module-qualified member-access path naming a compile-time VALUE const (not a type) is still not folded in comptime-argument position, but E1201 now names the real limitation and the file-level `const` workaround instead of claiming the value is not compile-time known."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib.rue");
+fn dbl(comptime n: i32) -> i32 { n * 2 }
+fn main() -> i32 {
+    dbl(lib.nums.K)
+}
+""" },
+    { path = "lib.rue", source = """
+pub const nums = @import("kmod.rue");
+""" },
+    { path = "kmod.rue", source = """
+pub const K: i32 = 5;
+""" },
+]
+compile_fail = true
+error_contains = ["E1201", "module-qualified path `lib.nums.K`", "file-level `const`"]
+
+[[case]]
+name = "member_access_value_path_file_const_workaround_runs"
+description = "RUE-948 fix 2: the suggested file-level `const` alias makes the member-access value usable in comptime-argument position (5 * 2 = 10)."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib.rue");
+const K: i32 = lib.nums.K;
+fn dbl(comptime n: i32) -> i32 { n * 2 }
+fn main() -> i32 {
+    dbl(K)
+}
+""" },
+    { path = "lib.rue", source = """
+pub const nums = @import("kmod.rue");
+""" },
+    { path = "kmod.rue", source = """
+pub const K: i32 = 5;
+""" },
+]
+exit_code = 10

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -2751,3 +2751,88 @@ fn main() -> i32 { 0 }
 aux_files = { "mode_type_helper.rue" = "pub fn Box(comptime T: type) -> type { struct { value: T } }" }
 compile_fail = true
 error_contains = "[E0209]"
+
+# RUE-948: a member-access type path (`std.strbuf.StrBuf`) used as a
+# value-position comptime type-constructor argument is comptime-evaluable — it
+# names a re-exported named type, a `const`-item reference under rule 4.14:26 —
+# and must resolve to the same type the accepted return-type position
+# (`-> Result(std.strbuf.StrBuf, i32)`) and the local-alias workaround
+# (`let S = std.strbuf.StrBuf; Result(S, i32)`) already produce. It was wrongly
+# rejected with E1201 in value position only.
+[[case]]
+name = "type_ctor_member_access_path_arg"
+spec = ["4.14:26", "4.14:22"]
+description = "A module-qualified member-access type path as a comptime type-constructor argument resolves like a const reference (RUE-948, the filed repro)."
+source = """
+const std = @import("std");
+fn main() -> i32 {
+    let R1 = std.result.Result(std.strbuf.StrBuf, i32);
+    let _ = R1;
+    0
+}
+"""
+real_std = true
+exit_code = 0
+
+# RUE-948: member-access paths compose to any nesting depth, since each argument
+# is recursively comptime-evaluated — a path appearing as the argument of a
+# nested type-constructor call resolves the same way it does at the outer level.
+[[case]]
+name = "type_ctor_member_access_path_arg_deep_nested"
+spec = ["4.14:26", "4.14:22", "4.14:28"]
+description = "Member-access type paths nested inside nested type-constructor calls all resolve (RUE-948 deep nesting)."
+source = """
+const std = @import("std");
+fn main() -> i32 {
+    let R = std.result.Result(std.arraybuf.ArrayBuf(std.strbuf.StrBuf), std.fs.FileError);
+    let _ = R;
+    0
+}
+"""
+real_std = true
+exit_code = 0
+
+# RUE-948: the same path spelling works std-independently through a plain
+# import facade, in value position as a type-constructor argument.
+[[case]]
+name = "type_ctor_member_access_path_arg_local_modules"
+spec = ["4.14:26", "4.14:22"]
+description = "A member-access type path through a plain import facade resolves as a comptime type-constructor argument (RUE-948, no std)."
+source = """
+const lib = @import("lib.rue");
+fn main() -> i32 {
+    let R = lib.res.Res(lib.strs.Str, i32);
+    let _ = R;
+    0
+}
+"""
+aux_files = { "lib.rue" = """
+pub const strs = @import("strs.rue");
+pub const res = @import("res.rue");
+""", "strs.rue" = "pub struct Str { n: i32 }", "res.rue" = "pub fn Res(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }" }
+exit_code = 0
+
+# RUE-948: with the value-position path now accepted, a qualified pattern head
+# whose ARGS are member-access paths works in BOTH construction and match
+# position (previously the last alias-tax case, failing E0421). The instantiated
+# type is identical across the construction and the two arms, so the payload
+# binds and the arm value is returned.
+[[case]]
+name = "type_ctor_member_access_path_head_construct_and_match"
+spec = ["4.14:26", "4.14:22", "4.14:24"]
+description = "A qualified type-constructor path head whose arguments are member-access paths works in construction and pattern position (RUE-948)."
+source = """
+const lib = @import("lib.rue");
+fn main() -> i32 {
+    let r = lib.res.Res(lib.strs.Str, i32).Ok(lib.strs.Str { n: 42 });
+    match r {
+        lib.res.Res(lib.strs.Str, i32).Ok(v) => v.n,
+        lib.res.Res(lib.strs.Str, i32).Err(e) => e,
+    }
+}
+"""
+aux_files = { "lib.rue" = """
+pub const strs = @import("strs.rue");
+pub const res = @import("res.rue");
+""", "strs.rue" = "pub struct Str { n: i32 }", "res.rue" = "pub fn Res(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }" }
+exit_code = 42

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -571,7 +571,10 @@ following base cases:
   (`()`);
 - a reference to a `const` item (Chapter 6), whose initializer is itself
   comptime-evaluable — every `const` initializer is required to be
-  comptime-evaluable, so every `const` reference qualifies;
+  comptime-evaluable, so every `const` reference qualifies. This includes a
+  module-qualified member-access path that names a named type re-exported
+  through an import chain (`std.strbuf.StrBuf`), which denotes the same
+  comptime-evaluable type a qualified type annotation of that spelling resolves;
 - a reference to a `comptime` parameter in scope (4.14:5), including a
   `comptime T: type` parameter, whose bound value is fixed at each
   specialization.


### PR DESCRIPTION
Kills the empirically-worst papercut (6 recorded hits across every dogfood program): member-access type paths were rejected as value-position comptime arguments (E1201) while the identical shape worked in return-type position, forcing a 3–5 line alias preamble in every function touching generic std types.

**Root cause** — the comptime evaluators `FieldGet` arm only consulted `const_module_members`, which is populated during const-initializer collection and empty for function-body evaluation. The `MethodCall` arm already walked module-qualified call chains (why nested ctor-call args worked); the bare path arm just gave up. **Fix** — on a map miss, the arm falls back to the type-annotation resolver (`resolve_qualified_type_name`, refactored to take an explicit root file per the RUE-511 precedent) with the same shadowing guards the call arm applies. Deep nesting works via existing per-argument recursion; spec 4.14:26s existing const-reference claim now holds in value position.

**The remaining genuine gap** — a path naming a compile-time *value* const as a comptime value argument — now gets a diagnostic naming the real limitation and the file-level-`const` workaround instead of the misleading "requires a compile-time known value".

**Effect**: `std.result.Result(std.strbuf.StrBuf, std.fs.FileError)` now writes inline in construction, pattern-head, and deep-nested positions with zero alias lines — an independent verification program doing exactly that (plus a match over it) exits 42.

Tests: filed repro, deep nesting, std-free module fixture, ruewc2-shaped construct-and-match spec cases; CLI end-to-end + diagnostic + workaround cases. spec comptime 194/0, types 538/0, inference 11/0; CLI const_alias 19/0, comptime 126/0; quick 30/0; full `./test.sh` green post-rebase over #1739.

Fixes RUE-948