### PR TITLE
RUE-938, RUE-939: StrMap(V) and a word-frequency exercise program

### DIFF
--- a/crates/rue-cli-tests/cases/examples_wordfreq.toml
+++ b/crates/rue-cli-tests/cases/examples_wordfreq.toml
@@ -1,0 +1,31 @@
+# The word-frequency counter written in Rue (RUE-939): examples/wordfreq/. This
+# case compiles the checked-in example directly via `source_path` (so the suite
+# stays pinned to the program users actually see), then runs it on a small
+# fixture text file passed as an argument and asserts its exact stdout.
+#
+# The fixture exercises the behaviors that matter: repeated words, ASCII case
+# folding ("The"/"the"/"QUICK" all fold together), punctuation and whitespace as
+# separators, and a single clear most-frequent word ("the", 6 occurrences). The
+# pinned output is exactly what the program prints, verified at authoring time.
+
+[section]
+id = "cli.examples_wordfreq"
+name = "Word-frequency counter written in Rue (wordfreq)"
+description = "compile examples/wordfreq and run it on a fixture, asserting the exact words/distinct/top summary"
+
+[[case]]
+name = "wordfreq_counts_fixture"
+description = "wordfreq folds case, splits on punctuation, and reports the unique top word with its count."
+source_path = "examples/wordfreq/main.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "input.txt", source = """
+The quick brown fox. The lazy dog; the QUICK fox!
+The fox, the fox, the fox.
+""" }]
+program_args = ["input.txt"]
+exit_code = 0
+stdout = """
+words=16
+distinct=6
+top=the count=6
+"""

--- a/crates/rue-cli-tests/cases/std_strmap.toml
+++ b/crates/rue-cli-tests/cases/std_strmap.toml
@@ -1,0 +1,95 @@
+# Standard library v1 — StrMap(V), the StrBuf-keyed open-addressing hash map
+# (RUE-938), through the real std bundle. Mirrors the score-accumulation smoke
+# pattern of std_collections.toml: one program runs every StrMap operation and
+# exits 42 only when all checks pass.
+#
+# Coverage: insert/get roundtrip, overwrite (does not grow len), missing key ->
+# None, contains true/false, remove then contains=false, a second remove
+# returning false, re-insert after remove, growth past several rehashes (60
+# generated keys, all retrievable, len correct), original keys surviving the
+# rehashes, and two distinct keys mapping to distinct values.
+
+[section]
+id = "cli.std_strmap"
+name = "Standard library v1 — StrMap"
+description = "StrMap(V): StrBuf-keyed open-addressing hash map with FNV-1a hashing, through @import(\"std\")."
+
+[[case]]
+name = "std_strmap_smoke"
+description = "All StrMap operations produce correct results (17 checks -> exit 42)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 42
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let M = std.strmap.StrMap(u64);
+    let OU = std.option.Option(u64);
+    let mut m = M.new(0);
+    let mut score: i64 = 0;
+
+    let apple: StrBuf = "apple";
+    let banana: StrBuf = "banana";
+    let cherry: StrBuf = "cherry";
+
+    // insert / get roundtrip, two distinct keys -> distinct values
+    m.insert(borrow apple, 1);
+    m.insert(borrow banana, 2);
+    match m.get(borrow apple) { OU.Some(v) => { if v == 1 { score = score + 1; } }, OU.None => {} }
+    match m.get(borrow banana) { OU.Some(v) => { if v == 2 { score = score + 1; } }, OU.None => {} }
+    if !StrBuf.equals_borrowed(borrow apple, borrow banana) { score = score + 1; }
+
+    // overwrite an existing key; len is unchanged
+    m.insert(borrow apple, 99);
+    match m.get(borrow apple) { OU.Some(v) => { if v == 99 { score = score + 1; } }, OU.None => {} }
+    if m.len() == 2 { score = score + 1; }
+
+    // missing key -> None
+    match m.get(borrow cherry) { OU.Some(v) => {}, OU.None => { score = score + 1; } }
+
+    // contains true / false
+    if m.contains(borrow banana) { score = score + 1; }
+    if !m.contains(borrow cherry) { score = score + 1; }
+
+    // remove, then contains is false; a second remove reports absence
+    if m.remove(borrow banana) { score = score + 1; }
+    if !m.contains(borrow banana) { score = score + 1; }
+    if m.len() == 1 { score = score + 1; }
+    if !m.remove(borrow banana) { score = score + 1; }
+
+    // re-insert after remove
+    m.insert(borrow banana, 7);
+    match m.get(borrow banana) { OU.Some(v) => { if v == 7 { score = score + 1; } }, OU.None => {} }
+    if m.len() == 2 { score = score + 1; }
+
+    // growth past several rehashes: 60 generated keys
+    let mut i: u64 = 0;
+    while i < 60 {
+        let mut key: StrBuf = "gen";
+        key.push_str(@to_string(i));
+        m.insert(borrow key, i + 1000);
+        i = i + 1;
+    }
+    if m.len() == 62 { score = score + 1; }
+
+    let mut all_ok = true;
+    i = 0;
+    while i < 60 {
+        let mut key: StrBuf = "gen";
+        key.push_str(@to_string(i));
+        match m.get(borrow key) {
+            OU.Some(v) => { if v != i + 1000 { all_ok = false; } },
+            OU.None => { all_ok = false; },
+        }
+        i = i + 1;
+    }
+    if all_ok { score = score + 1; }
+
+    // original keys survive the rehashes
+    match m.get(borrow apple) { OU.Some(v) => { if v == 99 { score = score + 1; } }, OU.None => {} }
+
+    if score == 17 { 42 } else { @intCast(score) }
+}
+""" }]

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -992,6 +992,12 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
+        "cli.std_strmap",
+        "std_strmap_smoke",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
+    Entry::new(
         "cli.str_fixed_type",
         "str_fixed_exact_borrow_is_by_reference",
         semantic(SemanticGapKind::TextProjectionRead),

--- a/examples/wordfreq/firstseen.rue
+++ b/examples/wordfreq/firstseen.rue
@@ -1,0 +1,67 @@
+// firstseen — records distinct words in first-seen (insertion) order.
+//
+// The frequency count itself lives in a `std.strmap.StrMap(u64)`, whose probe
+// order must never leak into program output. To break count ties by "which word
+// appeared first in the input", wordfreq keeps this parallel append-only list of
+// the distinct words in the order they were first seen.
+//
+// Like the map's key store (and examples/ruelex/interner.rue), words cannot live
+// in an `ArrayBuf(StrBuf)` (by-copy reads are gated for drop-glue element types,
+// RUE-651), so the bytes are concatenated into one `pool: StrBuf` with parallel
+// `offs`/`lens` arrays describing each word's slice.
+
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const U64s = std.arraybuf.ArrayBuf(u64);
+const OptU8 = std.option.Option(u8);
+
+fn _byte_of(borrow value: StrBuf, index: u64) -> u8 {
+    match value.byte_at(index) {
+        OptU8.Some(x) => x,
+        OptU8.None => 0,
+    }
+}
+
+pub struct FirstSeen {
+    pool: StrBuf,
+    offs: U64s,
+    lens: U64s,
+
+    fn new() -> Self {
+        Self {
+            pool: StrBuf.new(),
+            offs: U64s.new(),
+            lens: U64s.new(),
+        }
+    }
+
+    // Number of distinct words recorded.
+    fn len(borrow self) -> u64 {
+        self.offs.len()
+    }
+
+    // Append `w` as the next first-seen word. Callers add a word exactly once,
+    // when it is first inserted into the frequency map.
+    fn add(inout self, borrow w: StrBuf) {
+        let off = self.pool.len();
+        let len = w.len();
+        let mut j: u64 = 0;
+        while j < len {
+            self.pool.push(_byte_of(borrow w, j));
+            j = j + 1;
+        }
+        self.offs.push(off);
+        self.lens.push(len);
+    }
+
+    // Append the bytes of recorded word `i` to `out`.
+    fn append_word(borrow self, i: u64, inout out: StrBuf) {
+        let off = self.offs.get_or(i, 0);
+        let len = self.lens.get_or(i, 0);
+        let mut j: u64 = 0;
+        while j < len {
+            out.push(_byte_of(borrow self.pool, off + j));
+            j = j + 1;
+        }
+    }
+}

--- a/examples/wordfreq/main.rue
+++ b/examples/wordfreq/main.rue
@@ -1,0 +1,170 @@
+// wordfreq — a word-frequency counter, exercising std.strmap (RUE-939).
+//
+// Reads a text file named on the command line, tokenizes it into words (a word
+// is a maximal run of ASCII letters, folded to lowercase), counts occurrences in
+// a `std.strmap.StrMap(u64)`, and prints a deterministic summary:
+//
+//     words=<total number of word occurrences>
+//     distinct=<number of distinct words>
+//     top=<most frequent word> count=<its count>
+//
+// The `top` line names the single most frequent word. Ties are broken by first
+// appearance in the input — the earliest-seen word wins — so map probe order
+// never leaks into the output. First-seen order is tracked separately in a
+// `FirstSeen` list (firstseen.rue). An empty input prints the two count lines
+// (both zero) and no `top` line.
+//
+// Usage:  wordfreq <file>
+//
+// Reading uses std.fs (open + chunked read loop); the path comes from std.env;
+// numbers are formatted with `@to_string` and output goes to stdout via the
+// `print`/`println` builtins (word bytes are emitted verbatim). On a missing
+// argument or a failed open the program prints a short message and exits 1.
+
+const std = @import("std");
+const firstseen = @import("firstseen.rue");
+const StrBuf = std.strbuf.StrBuf;
+const Bytes = std.arraybuf.ArrayBuf(u8);
+const OptStr = std.option.Option(StrBuf);
+const OptU64 = std.option.Option(u64);
+const OptBytes = std.option.Option(Bytes);
+const FileRes = std.result.Result(std.fs.File, std.fs.FileError);
+const ReadRes = std.result.Result(u64, std.fs.FileError);
+
+// Whether `b` is an ASCII letter (A-Z or a-z).
+fn is_letter(b: u8) -> bool {
+    (b >= 65 && b <= 90) || (b >= 97 && b <= 122)
+}
+
+// Lowercase an ASCII letter byte; other bytes pass through unchanged.
+fn to_lower(b: u8) -> u8 {
+    if b >= 65 && b <= 90 {
+        b + 32
+    } else {
+        b
+    }
+}
+
+// Read the whole file at `path` into a byte buffer. Returns `None` when the file
+// cannot be opened, so the caller can report the error and exit nonzero.
+fn read_file(borrow path: StrBuf) -> OptBytes {
+    let O = OptBytes;
+    let mut data = Bytes.new();
+    let mut f = match std.fs.File.open(borrow path) {
+        FileRes.Ok(file) => file,
+        FileRes.Err(e) => {
+            return O.None;
+        },
+    };
+    let chunk: u64 = 65536;
+    loop {
+        data.reserve(chunk);
+        let n = match f.read(inout data) {
+            ReadRes.Ok(k) => k,
+            ReadRes.Err(e) => 0,
+        };
+        if n == 0 {
+            break;
+        }
+    }
+    let _ = f.close();
+    O.Some(data)
+}
+
+// Count one completed word: bump its tally, recording it in `order` the first
+// time it is seen.
+fn count_word(
+    borrow word: StrBuf,
+    inout counts: std.strmap.StrMap(u64),
+    inout order: firstseen.FirstSeen,
+) {
+    match counts.get(borrow word) {
+        OptU64.Some(c) => {
+            counts.insert(borrow word, c + 1);
+        },
+        OptU64.None => {
+            counts.insert(borrow word, 1);
+            order.add(borrow word);
+        },
+    }
+}
+
+fn main() -> i32 {
+    let path = match std.env.arg(1) {
+        OptStr.Some(p) => p,
+        OptStr.None => {
+            println("usage: wordfreq <file>");
+            return 1;
+        },
+    };
+
+    let data = match read_file(borrow path) {
+        OptBytes.Some(d) => d,
+        OptBytes.None => {
+            println("error: cannot open input file");
+            return 1;
+        },
+    };
+
+    let M = std.strmap.StrMap(u64);
+    let mut counts = M.new(0);
+    let mut order = firstseen.FirstSeen.new();
+    let mut words_total: u64 = 0;
+
+    // Tokenize: accumulate letters (lowercased) into `word`; a non-letter byte
+    // ends the current word.
+    let mut word = StrBuf.new();
+    let n = data.len();
+    let mut i: u64 = 0;
+    while i < n {
+        let b = data.get_or(i, 0);
+        if is_letter(b) {
+            word.push(to_lower(b));
+        } else if word.len() > 0 {
+            count_word(borrow word, inout counts, inout order);
+            words_total = words_total + 1;
+            word.clear();
+        }
+        i = i + 1;
+    }
+    // Flush a trailing word not terminated by a separator.
+    if word.len() > 0 {
+        count_word(borrow word, inout counts, inout order);
+        words_total = words_total + 1;
+    }
+
+    let distinct = order.len();
+
+    println("words=" + @to_string(words_total));
+    println("distinct=" + @to_string(distinct));
+
+    // Most frequent word, breaking ties toward the earliest first appearance.
+    // Scanning `order` in first-seen sequence and updating only on a strictly
+    // greater count means the earliest word at the winning count is kept.
+    if distinct > 0 {
+        let mut best_idx: u64 = 0;
+        let mut best_count: u64 = 0;
+        let mut k: u64 = 0;
+        while k < distinct {
+            let mut w = StrBuf.new();
+            order.append_word(k, inout w);
+            let c = match counts.get(borrow w) {
+                OptU64.Some(v) => v,
+                OptU64.None => 0,
+            };
+            if c > best_count {
+                best_count = c;
+                best_idx = k;
+            }
+            k = k + 1;
+        }
+        let mut line = StrBuf.new();
+        line.push_str("top=");
+        order.append_word(best_idx, inout line);
+        line.push_str(" count=");
+        line.push_str(@to_string(best_count));
+        println(line);
+    }
+
+    0
+}

--- a/examples/wordfreq/main.rue
+++ b/examples/wordfreq/main.rue
@@ -45,8 +45,9 @@ fn to_lower(b: u8) -> u8 {
     }
 }
 
-// Read the whole file at `path` into a byte buffer. Returns `None` when the file
-// cannot be opened, so the caller can report the error and exit nonzero.
+// Read the whole file at `path` into a byte buffer. Returns `None` when the
+// file cannot be opened or a read fails, so the caller can report the error and
+// exit nonzero; a partial read is never returned as if it were the whole file.
 fn read_file(borrow path: StrBuf) -> OptBytes {
     let O = OptBytes;
     let mut data = Bytes.new();
@@ -61,7 +62,9 @@ fn read_file(borrow path: StrBuf) -> OptBytes {
         data.reserve(chunk);
         let n = match f.read(inout data) {
             ReadRes.Ok(k) => k,
-            ReadRes.Err(e) => 0,
+            ReadRes.Err(e) => {
+                return O.None;
+            },
         };
         if n == 0 {
             break;
@@ -101,7 +104,7 @@ fn main() -> i32 {
     let data = match read_file(borrow path) {
         OptBytes.Some(d) => d,
         OptBytes.None => {
-            println("error: cannot open input file");
+            println("error: cannot read input file");
             return 1;
         },
     };

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -11,6 +11,7 @@
 // - std.fmt: scalar-to-string formatting (int/bool, hex/binary)
 // - std.option.Option: Optional values
 // - std.result.Result: Fallible values (Ok/Err), propagated with `?`
+// - std.intmap.IntMap / std.strmap.StrMap: open-addressing hash maps
 // - std.strbuf.StrBuf: Source-defined growable string buffer header
 // - std.arraybuf.ArrayBuf: Growable heap-backed collections
 // - std.fs.File: File IO v0 (open/create/append/read/write/close over @syscall)
@@ -36,6 +37,7 @@ pub const deque = @import("deque.rue");
 pub const grid = @import("grid.rue");
 pub const binary_heap = @import("binary_heap.rue");
 pub const intmap = @import("intmap.rue");
+pub const strmap = @import("strmap.rue");
 pub const bitset = @import("bitset.rue");
 
 // Algorithms & text (Standard library v1, M3).

--- a/std/strmap.rue
+++ b/std/strmap.rue
@@ -1,0 +1,316 @@
+// std.collections — StrMap(V): an interim open-addressing hash map with
+// `StrBuf` keys and `Copy` value type `V` (RUE-938). The generic `HashMap(K,V)`
+// (M4) needs function values / traits (RUE-643/RUE-246); this covers the common
+// string-keyed case now, alongside the integer-keyed `IntMap(V)`.
+//
+// `new(filler)` takes a throwaway `V` used to initialise empty value slots (Rue
+// has no generic zero-init); it is never read as a real value — the per-slot
+// state guards that.
+//
+//     const std = @import("std");
+//     let M = std.strmap.StrMap(u64);
+//     let mut m = M.new(0);
+//     let k: StrBuf = "hello";
+//     m.insert(borrow k, 100);
+//     m.get(borrow k);        // Some(100)
+//
+// STORAGE — keys cannot live in `ArrayBuf(StrBuf)`, whose by-copy reads are
+// gated for drop-glue element types (RUE-651). Instead every key's bytes are
+// concatenated into one `pool: StrBuf`, and each slot records where its key
+// lives with parallel `ArrayBuf(u64)` arrays: `offs` (start byte in the pool),
+// `lens` (byte length), and `hashes` (the cached 64-bit key hash). Caching the
+// hash lets a rehash skip re-reading key bytes and lets a probe reject a slot on
+// the hash before comparing bytes. This mirrors the pooled-bytes interner in
+// examples/ruelex/interner.rue.
+//
+// POOL COMPACTION — inserting over a tombstone (or growing) appends the new
+// key's bytes to `pool` and leaves the old key's bytes stranded in it. Those
+// dead bytes would accumulate forever, so `_grow_to` rebuilds `pool` from
+// scratch, copying only the bytes of OCCUPIED slots. A rehash therefore also
+// compacts the key pool, and the old pool (with its dead bytes) is freed when
+// it is overwritten.
+
+const arraybuf = @import("arraybuf.rue");
+const option = @import("option.rue");
+const strbuf = @import("strbuf.rue");
+const StrBuf = strbuf.StrBuf;
+
+// Slot states.
+fn _EMPTY() -> u8 {
+    0
+}
+fn _OCCUPIED() -> u8 {
+    1
+}
+fn _TOMBSTONE() -> u8 {
+    2
+}
+
+// One byte of `value` at `index`, or 0 past the end. Reads through the
+// borrow-safe `byte_at` accessor so it never moves out of a borrowed `StrBuf`.
+fn _byte_of(borrow value: StrBuf, index: u64) -> u8 {
+    let O = option.Option(u8);
+    match value.byte_at(index) {
+        O.Some(x) => x,
+        O.None => 0,
+    }
+}
+
+// FNV-1a 64-bit hash of `key`'s bytes. `@wrapping_mul` (RUE-647) never traps, so
+// the real prime multiply is used directly rather than a mod-by-prime stand-in.
+fn _fnv1a(borrow key: StrBuf) -> u64 {
+    let mut h: u64 = 14695981039346656037;
+    let n = key.len();
+    let mut i: u64 = 0;
+    while i < n {
+        let b: u64 = @intCast(_byte_of(borrow key, i));
+        h = h ^ b;
+        h = @wrapping_mul(h, 1099511628211);
+        i = i + 1;
+    }
+    h
+}
+
+pub fn StrMap(comptime V: type) -> type {
+    let U64s = arraybuf.ArrayBuf(u64);
+    let Vals = arraybuf.ArrayBuf(V);
+    let States = arraybuf.ArrayBuf(u8);
+    struct {
+        pool: StrBuf,
+        offs: U64s,
+        lens: U64s,
+        hashes: U64s,
+        vals: Vals,
+        states: States,
+        count: u64,
+        cap: u64,
+        filler: V,
+
+        fn new(filler: V) -> Self {
+            let ub = arraybuf.ArrayBuf(u64);
+            let vb = arraybuf.ArrayBuf(V);
+            let sb = arraybuf.ArrayBuf(u8);
+            let mut m = Self {
+                pool: StrBuf.new(),
+                offs: ub.new(),
+                lens: ub.new(),
+                hashes: ub.new(),
+                vals: vb.new(),
+                states: sb.new(),
+                count: 0,
+                cap: 0,
+                filler: filler,
+            };
+            m._grow_to(8);
+            m
+        }
+
+        fn len(borrow self) -> u64 {
+            self.count
+        }
+        fn is_empty(borrow self) -> bool {
+            self.count == 0
+        }
+
+        // Whether the OCCUPIED slot `slot` holds exactly the bytes of `k`. The
+        // cached hash is compared first, then the length, then the pooled key
+        // bytes against the borrowed key — cheapest rejections first.
+        fn _key_eq(borrow self, slot: u64, borrow k: StrBuf, khash: u64, klen: u64) -> bool {
+            if self.hashes.get_or(slot, 0) != khash {
+                return false;
+            }
+            let len = self.lens.get_or(slot, 0);
+            if len != klen {
+                return false;
+            }
+            let off = self.offs.get_or(slot, 0);
+            let mut j: u64 = 0;
+            while j < len {
+                let a = _byte_of(borrow self.pool, off + j);
+                let b = _byte_of(borrow k, j);
+                if a != b {
+                    return false;
+                }
+                j = j + 1;
+            }
+            true
+        }
+
+        // Re-hash into a table of `new_cap` slots, rebuilding (compacting) the
+        // key pool so only live keys' bytes survive.
+        fn _grow_to(inout self, new_cap: u64) {
+            let ub = arraybuf.ArrayBuf(u64);
+            let vb = arraybuf.ArrayBuf(V);
+            let sb = arraybuf.ArrayBuf(u8);
+            let mut no = ub.new();
+            let mut nl = ub.new();
+            let mut nh = ub.new();
+            let mut nv = vb.new();
+            let mut ns = sb.new();
+            let mut np = StrBuf.new();
+            let mut i: u64 = 0;
+            while i < new_cap {
+                no.push(0);
+                nl.push(0);
+                nh.push(0);
+                nv.push(self.filler);
+                ns.push(_EMPTY());
+                i = i + 1;
+            }
+            // Move existing entries over, copying only live key bytes into the
+            // fresh pool (this is the compaction step).
+            let old_cap = self.cap;
+            let mut j: u64 = 0;
+            while j < old_cap {
+                if self.states.get_or(j, _EMPTY()) == _OCCUPIED() {
+                    let h = self.hashes.get_or(j, 0);
+                    let v = self.vals.get_or(j, self.filler);
+                    let old_off = self.offs.get_or(j, 0);
+                    let len = self.lens.get_or(j, 0);
+                    // Append this key's bytes to the compacted pool.
+                    let new_off = np.len();
+                    let mut b: u64 = 0;
+                    while b < len {
+                        np.push(_byte_of(borrow self.pool, old_off + b));
+                        b = b + 1;
+                    }
+                    // Insert into the new table by linear probing.
+                    let mut idx = h % new_cap;
+                    while ns.get_or(idx, _EMPTY()) == _OCCUPIED() {
+                        idx = (idx + 1) % new_cap;
+                    }
+                    no.set(idx, new_off);
+                    nl.set(idx, len);
+                    nh.set(idx, h);
+                    nv.set(idx, v);
+                    ns.set(idx, _OCCUPIED());
+                }
+                j = j + 1;
+            }
+            self.pool = np;
+            self.offs = no;
+            self.lens = nl;
+            self.hashes = nh;
+            self.vals = nv;
+            self.states = ns;
+            self.cap = new_cap;
+        }
+
+        // Write `k -> v` into `target`, appending the key bytes to the pool.
+        fn _place(inout self, target: u64, borrow k: StrBuf, khash: u64, klen: u64, v: V) {
+            let off = self.pool.len();
+            let mut j: u64 = 0;
+            while j < klen {
+                self.pool.push(_byte_of(borrow k, j));
+                j = j + 1;
+            }
+            self.offs.set(target, off);
+            self.lens.set(target, klen);
+            self.hashes.set(target, khash);
+            self.vals.set(target, v);
+            self.states.set(target, _OCCUPIED());
+            self.count = self.count + 1;
+        }
+
+        // Insert or overwrite `k -> v`.
+        fn insert(inout self, borrow k: StrBuf, v: V) {
+            // Grow above 70% load without overflowing intermediate products.
+            if self.count == 18446744073709551615 {
+                @panic("out of memory");
+            }
+            let next_count = self.count + 1;
+            let threshold = (self.cap / 10) * 7 + ((self.cap % 10) * 7) / 10;
+            if next_count > threshold {
+                if self.cap > 9223372036854775807 {
+                    @panic("out of memory");
+                }
+                self._grow_to(self.cap * 2);
+            }
+            let khash = _fnv1a(borrow k);
+            let klen = k.len();
+            let mut idx = khash % self.cap;
+            let mut first_tomb: u64 = self.cap;
+            // Probe at most `cap` slots: a table can run out of EMPTY slots
+            // entirely (every non-live slot a tombstone) while `count` stays
+            // under the growth threshold, so an unbounded probe would spin.
+            let mut probes: u64 = 0;
+            while probes < self.cap {
+                let st = self.states.get_or(idx, _EMPTY());
+                if st == _EMPTY() {
+                    let target = if first_tomb < self.cap { first_tomb } else { idx };
+                    self._place(target, borrow k, khash, klen, v);
+                    return;
+                } else if st == _OCCUPIED() {
+                    if self._key_eq(idx, borrow k, khash, klen) {
+                        self.vals.set(idx, v);
+                        return;
+                    }
+                } else {
+                    if first_tomb >= self.cap {
+                        first_tomb = idx;
+                    }
+                }
+                idx = (idx + 1) % self.cap;
+                probes = probes + 1;
+            }
+            // Every slot probed, none EMPTY and no key match. Growth keeps
+            // `count` below `cap`, so some slot is a tombstone; reuse the first.
+            self._place(first_tomb, borrow k, khash, klen, v);
+        }
+
+        // The value for `k`, or `None`.
+        fn get(borrow self, borrow k: StrBuf) -> option.Option(V) {
+            let O = option.Option(V);
+            let khash = _fnv1a(borrow k);
+            let klen = k.len();
+            let mut idx = khash % self.cap;
+            let mut probes: u64 = 0;
+            while probes < self.cap {
+                let st = self.states.get_or(idx, _EMPTY());
+                if st == _EMPTY() {
+                    return O.None;
+                } else if st == _OCCUPIED() {
+                    if self._key_eq(idx, borrow k, khash, klen) {
+                        return O.Some(self.vals.get_or(idx, self.filler));
+                    }
+                }
+                idx = (idx + 1) % self.cap;
+                probes = probes + 1;
+            }
+            O.None
+        }
+
+        fn contains(borrow self, borrow k: StrBuf) -> bool {
+            let O = option.Option(V);
+            match self.get(borrow k) {
+                O.Some(v) => true,
+                O.None => false,
+            }
+        }
+
+        // Remove `k`; returns whether it was present. The slot becomes a
+        // tombstone; its key bytes stay in the pool until the next `_grow_to`
+        // compacts them away.
+        fn remove(inout self, borrow k: StrBuf) -> bool {
+            let khash = _fnv1a(borrow k);
+            let klen = k.len();
+            let mut idx = khash % self.cap;
+            let mut probes: u64 = 0;
+            while probes < self.cap {
+                let st = self.states.get_or(idx, _EMPTY());
+                if st == _EMPTY() {
+                    return false;
+                } else if st == _OCCUPIED() {
+                    if self._key_eq(idx, borrow k, khash, klen) {
+                        self.states.set(idx, _TOMBSTONE());
+                        self.count = self.count - 1;
+                        return true;
+                    }
+                }
+                idx = (idx + 1) % self.cap;
+                probes = probes + 1;
+            }
+            false
+        }
+    }
+}


### PR DESCRIPTION
Maturity rung 1: a Rue program can now implement a string-keyed hash table with a real byte hash, written the ordinary way.

## `std.strmap.StrMap(comptime V)` (RUE-938)

An interim StrBuf-keyed open-addressing hash map mirroring `IntMap` (linear probing, tombstones, growth above 70% load, `new(filler)` slot initialisation), with the API from the issue: `new` / `insert(borrow k, v)` / `get(borrow k) -> Option(V)` / `contains` / `remove` / `len` / `is_empty`.

- **Real hash, no contortions**: FNV-1a 64-bit over the key bytes using `@wrapping_mul` (RUE-647) and `byte_at` (RUE-602) — no mod-by-prime stand-in.
- **Key storage**: `ArrayBuf(StrBuf)` by-copy reads are gated for drop-glue element types (RUE-651), so key bytes live concatenated in one `pool: StrBuf` with parallel `offs`/`lens`/`hashes` arrays per slot (the pattern proven by `examples/ruelex/interner.rue`). Cached hashes let probes reject slots before byte comparison and let rehashes skip re-reading keys.
- **Pool compaction**: `_grow_to` rebuilds the pool from live slots only, so tombstoned keys' bytes don't accumulate forever.
- **Bounded insert probing**: tombstone churn can exhaust a table's EMPTY slots while `count` stays under the growth threshold; insert probes at most `cap` slots and then reuses the first tombstone instead of spinning. (`IntMap` has the analogous unbounded loop; tracked separately.)
- `insert` takes `borrow` keys (bytes are copied into the pool), so inserting does not consume the caller's key.

## `examples/wordfreq` (RUE-939)

The rung's benchmark-style exercise program: reads a file named on the command line (`std.env` + `std.fs`), tokenizes it into maximal runs of ASCII letters folded to lowercase, counts occurrences in a `StrMap(u64)`, and prints `words=` / `distinct=` / `top=<word> count=<n>`. Ties break toward the earliest first-seen word, tracked in a parallel append-only list, so map probe order never leaks into output.

## Tests

- `cli.std_strmap` — smoke case (17 checks → exit 42): insert/get roundtrip, overwrite, missing keys, contains, remove and re-insert over tombstones, and growth through several rehashes with ~60 generated keys all retrievable.
- `cli.examples_wordfreq` — compiles the checked-in example via `source_path` and pins exact stdout for a fixture exercising case folding, punctuation separators, and a unique top word.
- The strmap smoke is registered as an oracle model gap (`IntToPointer`) like the other heap-allocating std cases.

Verified: `scripts/rue cli` full suite 1514 passed; `scripts/rue quick` green except the two pre-existing `unreadable_*` permission tests that cannot fail as root in this sandbox; a tombstone-churn stress program (200 insert/remove rounds at fixed capacity plus full refill) runs clean.

Fixes RUE-938
Fixes RUE-939

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYzTk9wF3BaxizpCeTgnqL)_