### PR TITLE
RUE-849: share canonical semantic body algebra

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -186,6 +186,29 @@ fn query_attempts_have_one_family_owned_representation() {
 }
 
 #[test]
+fn canonical_semantic_body_has_no_compiler_owned_peer_algebra() {
+    let durable_body = include_str!("durable_body.rs");
+    for removed in [
+        "pub enum DurableAirInstData",
+        "pub struct DurableAirInst",
+        "pub struct DurablePlace",
+        "pub enum DurableProjection",
+        "pub enum DurablePattern",
+        "pub struct DurableBodyAnchor",
+    ] {
+        assert!(
+            !durable_body.contains(removed),
+            "compiler-owned canonical body mirror returned: {removed}"
+        );
+    }
+    assert!(
+        durable_body
+            .contains("pub body: rue_air::SemanticBody<StableDefinitionKey, crate::ModuleId>"),
+        "durable envelope must retain rue-air's canonical body algebra directly"
+    );
+}
+
+#[test]
 fn import_resolution_remains_discovery_owned() {
     let production = PRODUCTION_MODULES
         .iter()

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -195,6 +195,7 @@ fn canonical_semantic_body_has_no_compiler_owned_peer_algebra() {
         "pub enum DurableProjection",
         "pub enum DurablePattern",
         "pub struct DurableBodyAnchor",
+        "pub struct DurableSpecializationIdentity",
     ] {
         assert!(
             !durable_body.contains(removed),
@@ -205,6 +206,12 @@ fn canonical_semantic_body_has_no_compiler_owned_peer_algebra() {
         durable_body
             .contains("pub body: rue_air::SemanticBody<StableDefinitionKey, crate::ModuleId>"),
         "durable envelope must retain rue-air's canonical body algebra directly"
+    );
+    assert!(
+        durable_body.contains(
+            "rue_air::SemanticSpecializationIdentity<StableDefinitionKey, crate::ModuleId>"
+        ),
+        "specialized envelopes must retain rue-air's canonical identity directly"
     );
 }
 

--- a/crates/rue-compiler/src/durable_body.rs
+++ b/crates/rue-compiler/src/durable_body.rs
@@ -15,12 +15,12 @@ use rue_air::{
 };
 
 use crate::{
-    BoundDefinitionSet, CanonicalMergedProgram, DurableType, StableBodyDependencyInputRecord,
+    BoundDefinitionSet, CanonicalMergedProgram, StableBodyDependencyInputRecord,
     StableDefinitionKey, StableDefinitionKind,
 };
 
 pub const DURABLE_ORDINARY_BODY_SCHEMA_VERSION: u32 = 6;
-pub const DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION: u32 = 4;
+pub const DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION: u32 = 5;
 
 /// Durable specialization of AIR's canonical body algebra. These aliases keep
 /// compiler consumers explicit about the stable identity domain.
@@ -70,38 +70,10 @@ pub struct DurableOrdinaryBody {
     pub inputs: StableBodyDependencyInputRecord,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DurableSpecializationIdentity {
-    pub base: StableDefinitionKey,
-    pub type_arguments: Arc<[DurableType]>,
-    pub value_arguments: Arc<[crate::DurableConstValue]>,
-}
-
-#[cfg(test)]
-impl DurableSpecializationIdentity {
-    fn import_dto(&self) -> rue_air::SemanticSpecializationIdentity<StableDefinitionKey, Arc<str>> {
-        rue_air::SemanticSpecializationIdentity {
-            base: self.base.clone(),
-            type_arguments: self
-                .type_arguments
-                .iter()
-                .map(DurableType::import_dto)
-                .collect::<Vec<_>>()
-                .into(),
-            value_arguments: self
-                .value_arguments
-                .iter()
-                .map(crate::DurableConstValue::import_dto)
-                .collect::<Vec<_>>()
-                .into(),
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DurableSpecializedBodyPayload {
     pub schema_version: u32,
-    pub identity: DurableSpecializationIdentity,
+    pub identity: rue_air::SemanticSpecializationIdentity<StableDefinitionKey, crate::ModuleId>,
     /// The completed body uses the same durable AIR algebra as ordinary bodies.
     pub body: DurableOrdinaryBodyPayload,
     pub dependencies: Arc<[StableDefinitionKey]>,
@@ -117,7 +89,9 @@ pub struct DurableSpecializedBody {
 }
 
 impl DurableSpecializedBody {
-    pub fn identity(&self) -> &DurableSpecializationIdentity {
+    pub fn identity(
+        &self,
+    ) -> &rue_air::SemanticSpecializationIdentity<StableDefinitionKey, crate::ModuleId> {
         &self.payload.identity
     }
 
@@ -160,35 +134,15 @@ impl DurableSpecializedBodyPayload {
             work.projection_failures += 1;
             return Err(DurableBodyProjectionFailure::SchemaVersionMismatch);
         }
-        let value = |value: &crate::DurableConstValue| match value {
-            crate::DurableConstValue::Integer(value) => SemanticImportConstValue::Integer(*value),
-            crate::DurableConstValue::Bool(value) => SemanticImportConstValue::Bool(*value),
-            crate::DurableConstValue::Type(value) => {
-                SemanticImportConstValue::Type(value.import_dto())
-            }
-            crate::DurableConstValue::Function(value) => {
-                SemanticImportConstValue::Function(value.clone())
-            }
-            crate::DurableConstValue::Unit => SemanticImportConstValue::Unit,
-        };
+        let identity = self
+            .identity
+            .try_map_keys(
+                &|key| Ok::<_, std::convert::Infallible>(key.clone()),
+                &|module| Ok::<_, std::convert::Infallible>(Arc::from(module.as_str())),
+            )
+            .expect("canonical specialization identity projection is infallible");
         Ok(rue_air::SemanticSpecializedBodyCandidate {
-            identity: rue_air::SemanticSpecializationIdentity {
-                base: self.identity.base.clone(),
-                type_arguments: self
-                    .identity
-                    .type_arguments
-                    .iter()
-                    .map(DurableType::import_dto)
-                    .collect::<Vec<_>>()
-                    .into(),
-                value_arguments: self
-                    .identity
-                    .value_arguments
-                    .iter()
-                    .map(value)
-                    .collect::<Vec<_>>()
-                    .into(),
-            },
+            identity,
             body_span,
             body: self.body.project_semantic_body(work)?,
             dependencies: self.dependencies.clone(),
@@ -249,6 +203,7 @@ pub enum DurableBodyProjectionFailure {
     InvalidParameterModes,
     InvalidParameterDrop,
     InvalidBorrowSlot,
+    WarningProducingBody,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -391,26 +346,29 @@ fn join_definition<'a>(
     index.join(identity, work)
 }
 
-fn durable_type(
+fn canonical_type(
     ty: &SemanticImportType<SemanticBodyDefinitionIdentity, Arc<str>>,
     merged: &CanonicalMergedProgram,
     index: &DefinitionJoinIndex<'_>,
     work: &mut DurableBodyWork,
-) -> Result<DurableType, DurableBodyConversionFailure> {
+) -> Result<SemanticImportType<StableDefinitionKey, crate::ModuleId>, DurableBodyConversionFailure>
+{
     Ok(match ty {
-        SemanticImportType::I8 => DurableType::I8,
-        SemanticImportType::I16 => DurableType::I16,
-        SemanticImportType::I32 => DurableType::I32,
-        SemanticImportType::I64 => DurableType::I64,
-        SemanticImportType::U8 => DurableType::U8,
-        SemanticImportType::U16 => DurableType::U16,
-        SemanticImportType::U32 => DurableType::U32,
-        SemanticImportType::U64 => DurableType::U64,
-        SemanticImportType::Bool => DurableType::Bool,
-        SemanticImportType::Unit => DurableType::Unit,
-        SemanticImportType::Never => DurableType::Never,
-        SemanticImportType::ComptimeType => DurableType::ComptimeType,
-        SemanticImportType::BuiltinNominal { name, kind } => durable_builtin_nominal(name, *kind)?,
+        SemanticImportType::I8 => SemanticImportType::I8,
+        SemanticImportType::I16 => SemanticImportType::I16,
+        SemanticImportType::I32 => SemanticImportType::I32,
+        SemanticImportType::I64 => SemanticImportType::I64,
+        SemanticImportType::U8 => SemanticImportType::U8,
+        SemanticImportType::U16 => SemanticImportType::U16,
+        SemanticImportType::U32 => SemanticImportType::U32,
+        SemanticImportType::U64 => SemanticImportType::U64,
+        SemanticImportType::Bool => SemanticImportType::Bool,
+        SemanticImportType::Unit => SemanticImportType::Unit,
+        SemanticImportType::Never => SemanticImportType::Never,
+        SemanticImportType::ComptimeType => SemanticImportType::ComptimeType,
+        SemanticImportType::BuiltinNominal { name, kind } => {
+            canonical_builtin_nominal(name, *kind)?
+        }
         SemanticImportType::Nominal(identity) => {
             let key = join_definition(identity, index, work)?;
             if !matches!(
@@ -419,19 +377,19 @@ fn durable_type(
             ) {
                 return Err(DurableBodyConversionFailure::WrongDefinitionKind);
             }
-            DurableType::Nominal(key.clone())
+            SemanticImportType::Nominal(key.clone())
         }
-        SemanticImportType::Array { element, len } => DurableType::Array {
-            element: Box::new(durable_type(element, merged, index, work)?),
+        SemanticImportType::Array { element, len } => SemanticImportType::Array {
+            element: Box::new(canonical_type(element, merged, index, work)?),
             len: *len,
         },
         SemanticImportType::PtrConst(value) => {
-            DurableType::PtrConst(Box::new(durable_type(value, merged, index, work)?))
+            SemanticImportType::PtrConst(Box::new(canonical_type(value, merged, index, work)?))
         }
         SemanticImportType::PtrMut(value) => {
-            DurableType::PtrMut(Box::new(durable_type(value, merged, index, work)?))
+            SemanticImportType::PtrMut(Box::new(canonical_type(value, merged, index, work)?))
         }
-        SemanticImportType::Module(path) => DurableType::Module(
+        SemanticImportType::Module(path) => SemanticImportType::Module(
             merged
                 .ast()
                 .modules()
@@ -440,34 +398,38 @@ fn durable_type(
                 .map(|module| module.module_id().clone())
                 .ok_or(DurableBodyConversionFailure::UnresolvedModule)?,
         ),
-        SemanticImportType::GenericParameter(index) => DurableType::GenericParameter(*index),
+        SemanticImportType::GenericParameter(index) => SemanticImportType::GenericParameter(*index),
     })
 }
 
-fn durable_builtin_nominal(
+fn canonical_builtin_nominal(
     name: &Arc<str>,
     kind: rue_air::SemanticImportNominalKind,
-) -> Result<DurableType, DurableBodyConversionFailure> {
+) -> Result<SemanticImportType<StableDefinitionKey, crate::ModuleId>, DurableBodyConversionFailure>
+{
     if crate::durable_semantics::builtin_nominal_kind(name) != Some(kind) {
         return Err(DurableBodyConversionFailure::WrongDefinitionKind);
     }
-    Ok(DurableType::BuiltinNominal {
+    Ok(SemanticImportType::BuiltinNominal {
         name: name.clone(),
         kind,
     })
 }
 
-fn durable_const_value(
+fn canonical_const_value(
     value: &SemanticImportConstValue<SemanticBodyDefinitionIdentity, Arc<str>>,
     merged: &CanonicalMergedProgram,
     index: &DefinitionJoinIndex<'_>,
     work: &mut DurableBodyWork,
-) -> Result<crate::DurableConstValue, DurableBodyConversionFailure> {
+) -> Result<
+    SemanticImportConstValue<StableDefinitionKey, crate::ModuleId>,
+    DurableBodyConversionFailure,
+> {
     Ok(match value {
-        SemanticImportConstValue::Integer(value) => crate::DurableConstValue::Integer(*value),
-        SemanticImportConstValue::Bool(value) => crate::DurableConstValue::Bool(*value),
+        SemanticImportConstValue::Integer(value) => SemanticImportConstValue::Integer(*value),
+        SemanticImportConstValue::Bool(value) => SemanticImportConstValue::Bool(*value),
         SemanticImportConstValue::Type(value) => {
-            crate::DurableConstValue::Type(durable_type(value, merged, index, work)?)
+            SemanticImportConstValue::Type(canonical_type(value, merged, index, work)?)
         }
         SemanticImportConstValue::Function(value) => {
             let key = join_definition(value, index, work)?;
@@ -479,9 +441,9 @@ fn durable_const_value(
             ) {
                 return Err(DurableBodyConversionFailure::WrongDefinitionKind);
             }
-            crate::DurableConstValue::Function(key.clone())
+            SemanticImportConstValue::Function(key.clone())
         }
-        SemanticImportConstValue::Unit => crate::DurableConstValue::Unit,
+        SemanticImportConstValue::Unit => SemanticImportConstValue::Unit,
     })
 }
 
@@ -490,23 +452,26 @@ fn durable_specialization_identity(
     merged: &CanonicalMergedProgram,
     index: &DefinitionJoinIndex<'_>,
     work: &mut DurableBodyWork,
-) -> Result<DurableSpecializationIdentity, DurableBodyConversionFailure> {
+) -> Result<
+    rue_air::SemanticSpecializationIdentity<StableDefinitionKey, crate::ModuleId>,
+    DurableBodyConversionFailure,
+> {
     let base = join_definition(&identity.base, index, work)?.clone();
     if base.kind() != StableDefinitionKind::Function {
         return Err(DurableBodyConversionFailure::WrongDefinitionKind);
     }
-    Ok(DurableSpecializationIdentity {
+    Ok(rue_air::SemanticSpecializationIdentity {
         base,
         type_arguments: identity
             .type_arguments
             .iter()
-            .map(|value| durable_type(value, merged, index, work))
+            .map(|value| canonical_type(value, merged, index, work))
             .collect::<Result<Vec<_>, _>>()?
             .into(),
         value_arguments: identity
             .value_arguments
             .iter()
-            .map(|value| durable_const_value(value, merged, index, work))
+            .map(|value| canonical_const_value(value, merged, index, work))
             .collect::<Result<Vec<_>, _>>()?
             .into(),
     })
@@ -517,7 +482,10 @@ pub(crate) fn convert_specialization_identity(
     merged: &CanonicalMergedProgram,
     definitions: &BoundDefinitionSet,
     work: &mut DurableBodyWork,
-) -> Result<DurableSpecializationIdentity, DurableBodyConversionFailure> {
+) -> Result<
+    rue_air::SemanticSpecializationIdentity<StableDefinitionKey, crate::ModuleId>,
+    DurableBodyConversionFailure,
+> {
     durable_specialization_identity(
         identity,
         merged,
@@ -526,17 +494,20 @@ pub(crate) fn convert_specialization_identity(
     )
 }
 
-fn durable_identity_dependency_keys(
-    identity: &DurableSpecializationIdentity,
+fn canonical_identity_dependency_keys(
+    identity: &rue_air::SemanticSpecializationIdentity<StableDefinitionKey, crate::ModuleId>,
 ) -> BTreeSet<StableDefinitionKey> {
-    fn visit_type(value: &DurableType, keys: &mut BTreeSet<StableDefinitionKey>) {
+    fn visit_type(
+        value: &SemanticImportType<StableDefinitionKey, crate::ModuleId>,
+        keys: &mut BTreeSet<StableDefinitionKey>,
+    ) {
         match value {
-            DurableType::Nominal(key) => {
+            SemanticImportType::Nominal(key) => {
                 keys.insert(key.clone());
             }
-            DurableType::Array { element, .. }
-            | DurableType::PtrConst(element)
-            | DurableType::PtrMut(element) => visit_type(element, keys),
+            SemanticImportType::Array { element, .. }
+            | SemanticImportType::PtrConst(element)
+            | SemanticImportType::PtrMut(element) => visit_type(element, keys),
             _ => {}
         }
     }
@@ -546,14 +517,24 @@ fn durable_identity_dependency_keys(
     }
     for value in identity.value_arguments.iter() {
         match value {
-            crate::DurableConstValue::Type(value) => visit_type(value, &mut keys),
-            crate::DurableConstValue::Function(key) => {
+            SemanticImportConstValue::Type(value) => visit_type(value, &mut keys),
+            SemanticImportConstValue::Function(key) => {
                 keys.insert(key.clone());
             }
             _ => {}
         }
     }
     keys
+}
+
+fn record_specialized_conversion_failure(
+    work: &mut DurableBodyWork,
+    failure: DurableBodyConversionFailure,
+) -> DurableBodyConversionFailure {
+    work.conversion_attempts += 1;
+    work.conversion_failures += 1;
+    work.atomic_discards += 1;
+    failure
 }
 
 /// Atomically joins completed specialization identities and bodies to stable
@@ -566,35 +547,45 @@ pub fn convert_semantic_specialized_body_exports(
     work: &mut DurableBodyWork,
 ) -> Result<Arc<[DurableSpecializedBodyPayload]>, DurableBodyConversionFailure> {
     if definitions.source_revision() != merged.ast().source_revision() {
+        work.conversion_attempts += exports.len();
+        work.conversion_failures += exports.len();
         work.atomic_discards += usize::from(!exports.is_empty());
         return Err(DurableBodyConversionFailure::ForeignRevision);
     }
     let index = DefinitionJoinIndex::new(merged, definitions);
     let mut converted = Vec::with_capacity(exports.len());
     for export in exports {
-        let identity = durable_specialization_identity(&export.identity, merged, &index, work)?;
-        let base = identity.base.clone();
-        let token = definitions
-            .body_owner_endpoints()
-            .into_iter()
-            .find(|endpoint| definitions.key_for_body_token(endpoint.token).ok() == Some(&base))
-            .map(|endpoint| endpoint.token)
-            .ok_or(DurableBodyConversionFailure::MissingStableDefinition)?;
+        let preflight = (|| {
+            let identity = durable_specialization_identity(&export.identity, merged, &index, work)?;
+            let base = identity.base.clone();
+            let token = definitions
+                .body_owner_endpoints()
+                .into_iter()
+                .find(|endpoint| definitions.key_for_body_token(endpoint.token).ok() == Some(&base))
+                .map(|endpoint| endpoint.token)
+                .ok_or(DurableBodyConversionFailure::MissingStableDefinition)?;
+            let mut dependencies = export
+                .dependencies
+                .iter()
+                .map(|dependency| join_definition(dependency, &index, work).cloned())
+                .collect::<Result<BTreeSet<_>, _>>()?;
+            dependencies.extend(canonical_identity_dependency_keys(&identity));
+            Ok((identity, token, dependencies))
+        })();
+        let (identity, token, dependencies) = match preflight {
+            Ok(preflight) => preflight,
+            Err(failure) => {
+                return Err(record_specialized_conversion_failure(work, failure));
+            }
+        };
         let ordinary = rue_air::SemanticBodyExport {
             owner: token,
             body: export.body.clone(),
         };
         let bodies = convert_semantic_body_exports(&[ordinary], merged, definitions, work)?;
         let [body] = bodies.as_ref() else {
-            work.atomic_discards += 1;
-            return Err(DurableBodyConversionFailure::MissingStableDefinition);
+            unreachable!("one successful body conversion returns one body")
         };
-        let mut dependencies = export
-            .dependencies
-            .iter()
-            .map(|dependency| join_definition(dependency, &index, work).cloned())
-            .collect::<Result<BTreeSet<_>, _>>()?;
-        dependencies.extend(durable_identity_dependency_keys(&identity));
         converted.push(DurableSpecializedBodyPayload {
             schema_version: DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION,
             identity,
@@ -1094,7 +1085,7 @@ impl DurableOrdinaryBodyPayload {
         }
         if !self.body.warnings.is_empty() {
             work.projection_failures += 1;
-            return Err(DurableBodyProjectionFailure::InvalidAnchor);
+            return Err(DurableBodyProjectionFailure::WarningProducingBody);
         }
         let body = self
             .body
@@ -1165,7 +1156,7 @@ mod tests {
     }
 
     #[test]
-    fn specialization_identity_preserves_all_durable_argument_kinds() {
+    fn canonical_specialization_identity_preserves_all_argument_kinds() {
         let function = StableDefinitionKey::for_test(
             ModuleId::from_logical_path("helpers.rue").unwrap(),
             StableDefinitionNamespace::Value,
@@ -1173,25 +1164,21 @@ mod tests {
             "helper",
             None,
         );
-        let identity = DurableSpecializationIdentity {
-            base: owner(),
-            type_arguments: Arc::from([DurableType::I32]),
-            value_arguments: Arc::from([
-                crate::DurableConstValue::Bool(true),
-                crate::DurableConstValue::Type(DurableType::I64),
-                crate::DurableConstValue::Function(function.clone()),
-                crate::DurableConstValue::Unit,
-            ]),
-        };
-
-        let projected = identity.import_dto();
-        assert_eq!(projected.base, owner());
+        let identity: rue_air::SemanticSpecializationIdentity<StableDefinitionKey, ModuleId> =
+            rue_air::SemanticSpecializationIdentity {
+                base: owner(),
+                type_arguments: Arc::from([SemanticImportType::I32]),
+                value_arguments: Arc::from([
+                    SemanticImportConstValue::Bool(true),
+                    SemanticImportConstValue::Type(SemanticImportType::I64),
+                    SemanticImportConstValue::Function(function.clone()),
+                    SemanticImportConstValue::Unit,
+                ]),
+            };
+        assert_eq!(identity.base, owner());
+        assert_eq!(identity.type_arguments.as_ref(), &[SemanticImportType::I32]);
         assert_eq!(
-            projected.type_arguments.as_ref(),
-            &[SemanticImportType::I32]
-        );
-        assert_eq!(
-            projected.value_arguments.as_ref(),
+            identity.value_arguments.as_ref(),
             &[
                 SemanticImportConstValue::Bool(true),
                 SemanticImportConstValue::Type(SemanticImportType::I64),
@@ -1212,6 +1199,43 @@ mod tests {
         assert_eq!(work.projection_attempts, 1);
         assert_eq!(work.projection_completions, 0);
         assert_eq!(work.projection_failures, 1);
+    }
+
+    #[test]
+    fn projection_reports_retained_warning_metadata_accurately() {
+        let mut candidate = payload(vec![]);
+        candidate.body.warnings = Arc::from([rue_air::SemanticBodyWarning {
+            code: Arc::from("W-test"),
+            message: Arc::from("retained warning"),
+            anchor: DurableBodyAnchor { start: 0, end: 0 },
+        }]);
+        let mut work = DurableBodyWork::default();
+        assert_eq!(
+            candidate.project_semantic_body(&mut work),
+            Err(DurableBodyProjectionFailure::WarningProducingBody)
+        );
+        assert_eq!(work.projection_attempts, 1);
+        assert_eq!(work.projection_completions, 0);
+        assert_eq!(work.projection_failures, 1);
+    }
+
+    #[test]
+    fn specialized_preflight_failures_are_counted_without_false_completion() {
+        for failure in [
+            DurableBodyConversionFailure::MissingStableDefinition,
+            DurableBodyConversionFailure::ForeignOwnerToken,
+            DurableBodyConversionFailure::AmbiguousStableDefinition,
+        ] {
+            let mut work = DurableBodyWork::default();
+            assert_eq!(
+                record_specialized_conversion_failure(&mut work, failure),
+                failure
+            );
+            assert_eq!(work.conversion_attempts, 1);
+            assert_eq!(work.conversion_failures, 1);
+            assert_eq!(work.atomic_discards, 1);
+            assert_eq!(work.conversion_completions, 0);
+        }
     }
 
     #[test]
@@ -1261,33 +1285,33 @@ mod tests {
     fn builtin_nominals_reject_unknown_names_and_wrong_kinds() {
         use rue_air::SemanticImportNominalKind::{Enum, Struct};
         assert_eq!(
-            durable_builtin_nominal(&Arc::from("MissingBuiltin"), Struct),
+            canonical_builtin_nominal(&Arc::from("MissingBuiltin"), Struct),
             Err(DurableBodyConversionFailure::WrongDefinitionKind)
         );
         assert_eq!(
-            durable_builtin_nominal(&Arc::from("StrBuf"), Struct),
+            canonical_builtin_nominal(&Arc::from("StrBuf"), Struct),
             Err(DurableBodyConversionFailure::WrongDefinitionKind)
         );
         assert_eq!(
-            durable_builtin_nominal(&Arc::from("str"), Struct),
-            Ok(DurableType::BuiltinNominal {
+            canonical_builtin_nominal(&Arc::from("str"), Struct),
+            Ok(SemanticImportType::BuiltinNominal {
                 name: Arc::from("str"),
                 kind: Struct,
             })
         );
         assert_eq!(
-            durable_builtin_nominal(&Arc::from("Arch"), Struct),
+            canonical_builtin_nominal(&Arc::from("Arch"), Struct),
             Err(DurableBodyConversionFailure::WrongDefinitionKind)
         );
         assert_eq!(
-            durable_builtin_nominal(&Arc::from("Arch"), Enum),
-            Ok(DurableType::BuiltinNominal {
+            canonical_builtin_nominal(&Arc::from("Arch"), Enum),
+            Ok(SemanticImportType::BuiltinNominal {
                 name: Arc::from("Arch"),
                 kind: Enum,
             })
         );
         assert_eq!(
-            durable_builtin_nominal(&Arc::from("str"), Enum),
+            canonical_builtin_nominal(&Arc::from("str"), Enum),
             Err(DurableBodyConversionFailure::WrongDefinitionKind)
         );
     }

--- a/crates/rue-compiler/src/durable_body.rs
+++ b/crates/rue-compiler/src/durable_body.rs
@@ -1,9 +1,8 @@
 //! Versioned, request-independent ordinary-body candidates.
 //!
-//! This is deliberately a compiler-owned algebra rather than an alias for
-//! `rue_air::SemanticBody`.  AIR's structured body is an exchange DTO; values
-//! in this module are the only representation eligible for retention between
-//! frontend revisions.
+//! The compiler owns the authorization envelope while `rue-air` owns the
+//! request-independent body algebra stored inside it. Compact live AIR remains
+//! separate and is relocated only at export and import boundaries.
 
 use std::{
     collections::{BTreeSet, HashMap},
@@ -11,9 +10,8 @@ use std::{
 };
 
 use rue_air::{
-    AirArgMode, AirPlaceBase, SemanticBodyDefinitionIdentity, SemanticBodyDefinitionKind,
-    SemanticBodyInstData, SemanticBodyPattern, SemanticBodyProjection, SemanticImportConstValue,
-    SemanticImportType,
+    SemanticBodyDefinitionIdentity, SemanticBodyDefinitionKind, SemanticBodyInstData,
+    SemanticBodyPattern, SemanticBodyProjection, SemanticImportConstValue, SemanticImportType,
 };
 
 use crate::{
@@ -21,202 +19,21 @@ use crate::{
     StableDefinitionKey, StableDefinitionKind,
 };
 
-pub const DURABLE_ORDINARY_BODY_SCHEMA_VERSION: u32 = 5;
-pub const DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION: u32 = 3;
+pub const DURABLE_ORDINARY_BODY_SCHEMA_VERSION: u32 = 6;
+pub const DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION: u32 = 4;
 
-pub type DurableAirRef = u32;
-pub type DurablePlaceRef = u32;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DurableBodyAnchor {
-    pub start: u32,
-    pub end: u32,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DurablePattern {
-    Wildcard,
-    Int(i64),
-    Bool(bool),
-    EnumVariant {
-        enum_key: StableDefinitionKey,
-        variant_index: u32,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DurableMatchArm {
-    pub pattern: DurablePattern,
-    pub body: DurableAirRef,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DurableCallArg {
-    pub value: DurableAirRef,
-    pub mode: AirArgMode,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DurableProjection {
-    Field {
-        struct_key: StableDefinitionKey,
-        field_index: u32,
-    },
-    Index {
-        array_type: DurableType,
-        index: DurableAirRef,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DurablePlace {
-    pub base: AirPlaceBase,
-    pub base_type: DurableType,
-    pub projections: Arc<[DurableProjection]>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DurableAirInst {
-    pub data: DurableAirInstData,
-    pub ty: DurableType,
-    pub anchor: DurableBodyAnchor,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DurableAirInstData {
-    Const(u64),
-    BoolConst(bool),
-    StringConst(u32),
-    UnitConst,
-    TypeConst(DurableType),
-    Add(DurableAirRef, DurableAirRef),
-    Sub(DurableAirRef, DurableAirRef),
-    Mul(DurableAirRef, DurableAirRef),
-    WrappingAdd(DurableAirRef, DurableAirRef),
-    WrappingSub(DurableAirRef, DurableAirRef),
-    WrappingMul(DurableAirRef, DurableAirRef),
-    Div(DurableAirRef, DurableAirRef),
-    Mod(DurableAirRef, DurableAirRef),
-    Eq(DurableAirRef, DurableAirRef),
-    Ne(DurableAirRef, DurableAirRef),
-    Lt(DurableAirRef, DurableAirRef),
-    Gt(DurableAirRef, DurableAirRef),
-    Le(DurableAirRef, DurableAirRef),
-    Ge(DurableAirRef, DurableAirRef),
-    And(DurableAirRef, DurableAirRef),
-    Or(DurableAirRef, DurableAirRef),
-    BitAnd(DurableAirRef, DurableAirRef),
-    BitOr(DurableAirRef, DurableAirRef),
-    BitXor(DurableAirRef, DurableAirRef),
-    Shl(DurableAirRef, DurableAirRef),
-    Shr(DurableAirRef, DurableAirRef),
-    Neg(DurableAirRef),
-    Not(DurableAirRef),
-    BitNot(DurableAirRef),
-    Branch {
-        cond: DurableAirRef,
-        then_value: DurableAirRef,
-        else_value: Option<DurableAirRef>,
-    },
-    Loop {
-        cond: DurableAirRef,
-        body: DurableAirRef,
-    },
-    InfiniteLoop {
-        body: DurableAirRef,
-    },
-    Match {
-        scrutinee: DurableAirRef,
-        arms: Arc<[DurableMatchArm]>,
-    },
-    Break,
-    Continue,
-    Alloc {
-        slot: u32,
-        init: DurableAirRef,
-    },
-    Load {
-        slot: u32,
-    },
-    Store {
-        slot: u32,
-        value: DurableAirRef,
-    },
-    ParamStore {
-        param_slot: u32,
-        value: DurableAirRef,
-    },
-    Ret(Option<DurableAirRef>),
-    Call {
-        function: StableDefinitionKey,
-        args: Arc<[DurableCallArg]>,
-    },
-    RuntimeCall {
-        runtime: rue_air::RuntimeCallKind,
-        args: Arc<[DurableCallArg]>,
-    },
-    CallSpecialized {
-        identity: DurableSpecializationIdentity,
-        args: Arc<[DurableCallArg]>,
-    },
-    Intrinsic {
-        runtime: Option<rue_air::RuntimeCallKind>,
-        name: Arc<str>,
-        args: Arc<[DurableCallArg]>,
-    },
-    Param {
-        index: u32,
-    },
-    Block {
-        statements: Arc<[DurableAirRef]>,
-        value: DurableAirRef,
-    },
-    StructInit {
-        struct_key: StableDefinitionKey,
-        fields: Arc<[DurableAirRef]>,
-        source_order: Arc<[u32]>,
-    },
-    ArrayInit {
-        elements: Arc<[DurableAirRef]>,
-    },
-    PlaceRead {
-        place: DurablePlaceRef,
-    },
-    PlaceWrite {
-        place: DurablePlaceRef,
-        value: DurableAirRef,
-    },
-    EnumVariant {
-        enum_key: StableDefinitionKey,
-        variant_index: u32,
-        payload: Arc<[DurableAirRef]>,
-    },
-    EnumPayloadGet {
-        base: DurableAirRef,
-        enum_key: StableDefinitionKey,
-        variant_index: u32,
-        field_index: u32,
-    },
-    IntCast {
-        value: DurableAirRef,
-        from_ty: DurableType,
-    },
-    Drop {
-        value: DurableAirRef,
-    },
-    StorageLive {
-        slot: u32,
-    },
-    StorageDead {
-        slot: u32,
-    },
-    MarkMoved {
-        value: DurableAirRef,
-        slot: u32,
-        is_param: bool,
-        place: Option<DurablePlaceRef>,
-    },
-}
+/// Durable specialization of AIR's canonical body algebra. These aliases keep
+/// compiler consumers explicit about the stable identity domain.
+pub type DurableAirRef = rue_air::SemanticBodyRef;
+pub type DurablePlaceRef = rue_air::SemanticBodyPlaceRef;
+pub type DurableBodyAnchor = rue_air::SemanticBodyAnchor;
+pub type DurablePattern = rue_air::SemanticBodyPattern<StableDefinitionKey>;
+pub type DurableMatchArm = rue_air::SemanticBodyMatchArm<StableDefinitionKey>;
+pub type DurableCallArg = rue_air::SemanticBodyCallArg;
+pub type DurableProjection = rue_air::SemanticBodyProjection<StableDefinitionKey, crate::ModuleId>;
+pub type DurablePlace = rue_air::SemanticBodyPlace<StableDefinitionKey, crate::ModuleId>;
+pub type DurableAirInst = rue_air::SemanticBodyInst<StableDefinitionKey, crate::ModuleId>;
+pub type DurableAirInstData = rue_air::SemanticBodyInstData<StableDefinitionKey, crate::ModuleId>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DurableOrdinaryBodyPayload {
@@ -225,19 +42,24 @@ pub struct DurableOrdinaryBodyPayload {
     /// Exact current-revision body/signature input captured with the live
     /// stable issuer. Finalization rejects a same-owner stale payload.
     pub expected_inputs: crate::StableDefinitionInputFingerprint,
-    pub return_type: DurableType,
-    pub instructions: Arc<[DurableAirInst]>,
-    pub places: Arc<[DurablePlace]>,
-    pub strings: Arc<[Arc<str>]>,
-    pub param_drops: Arc<[(u32, DurableType)]>,
-    pub borrow_slots: Arc<[u32]>,
-    pub num_locals: u32,
-    pub num_param_slots: u32,
-    pub param_by_ref: Arc<[bool]>,
-    pub param_writable: Arc<[bool]>,
-    // Warning-producing bodies are rejected from this schema. Global unused
-    // and CFG warnings are outside this artifact and are always recomputed.
-    pub allow_unreachable_code: bool,
+    /// The canonical request-independent semantic body algebra. Authorization
+    /// remains a property of this complete versioned envelope, never of the
+    /// bare body value.
+    pub body: rue_air::SemanticBody<StableDefinitionKey, crate::ModuleId>,
+}
+
+impl std::ops::Deref for DurableOrdinaryBodyPayload {
+    type Target = rue_air::SemanticBody<StableDefinitionKey, crate::ModuleId>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.body
+    }
+}
+
+impl std::ops::DerefMut for DurableOrdinaryBodyPayload {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.body
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -255,6 +77,7 @@ pub struct DurableSpecializationIdentity {
     pub value_arguments: Arc<[crate::DurableConstValue]>,
 }
 
+#[cfg(test)]
 impl DurableSpecializationIdentity {
     fn import_dto(&self) -> rue_air::SemanticSpecializationIdentity<StableDefinitionKey, Arc<str>> {
         rue_air::SemanticSpecializationIdentity {
@@ -531,6 +354,22 @@ impl<'a> DefinitionJoinIndex<'a> {
         work: &mut DurableBodyWork,
     ) -> Result<&'a StableDefinitionKey, DurableBodyConversionFailure> {
         work.stable_key_joins += 1;
+        match self
+            .definitions
+            .get(&DefinitionJoinIdentity::from(identity))
+        {
+            Some(IndexedDefinition::Unique(key)) => Ok(key),
+            Some(IndexedDefinition::Ambiguous) => {
+                Err(DurableBodyConversionFailure::AmbiguousStableDefinition)
+            }
+            None => Err(DurableBodyConversionFailure::MissingStableDefinition),
+        }
+    }
+
+    fn join_readonly(
+        &self,
+        identity: &SemanticBodyDefinitionIdentity,
+    ) -> Result<&'a StableDefinitionKey, DurableBodyConversionFailure> {
         match self
             .definitions
             .get(&DefinitionJoinIdentity::from(identity))
@@ -825,330 +664,71 @@ pub fn convert_semantic_body_exports(
         work.atomic_discards += usize::from(!exports.is_empty());
         return Err(DurableBodyConversionFailure::ForeignRevision);
     }
+
     let join_index = DefinitionJoinIndex::new(merged, definitions);
-    let convert = |export: &rue_air::SemanticBodyExport,
-                   work: &mut DurableBodyWork|
-     -> Result<DurableOrdinaryBodyPayload, DurableBodyConversionFailure> {
-        work.conversion_attempts += 1;
-        let owner_record = definitions
-            .definition_for_body_token(export.owner)
-            .map_err(|_| DurableBodyConversionFailure::ForeignOwnerToken)?;
-        let owner = owner_record.stable_key().clone();
-        if !matches!(
-            owner.kind(),
-            StableDefinitionKind::Function
-                | StableDefinitionKind::Method
-                | StableDefinitionKind::AssociatedFunction
-                | StableDefinitionKind::Destructor
-        ) {
-            return Err(DurableBodyConversionFailure::WrongDefinitionKind);
-        }
-        let expected_inputs = crate::session::stable_definition_input_fingerprint(
-            merged.definitions().source_snapshot(),
-            owner_record,
-        )
-        .map_err(|_| DurableBodyConversionFailure::FingerprintUnavailable)?;
-        let body = &export.body;
-        if !body.warnings.is_empty() {
-            return Err(DurableBodyConversionFailure::WarningProducingBody);
-        }
-        let key = |identity: &SemanticBodyDefinitionIdentity, work: &mut DurableBodyWork| {
-            join_definition(identity, &join_index, work).cloned()
-        };
-        let ty = |value: &SemanticImportType<SemanticBodyDefinitionIdentity, Arc<str>>,
-                  work: &mut DurableBodyWork| {
-            durable_type(value, merged, &join_index, work)
-        };
-        let arg = |arg: &rue_air::SemanticBodyCallArg| DurableCallArg {
-            value: arg.value,
-            mode: arg.mode,
-        };
-        let pattern = |value: &SemanticBodyPattern<SemanticBodyDefinitionIdentity>,
-                       work: &mut DurableBodyWork|
-         -> Result<DurablePattern, DurableBodyConversionFailure> {
-            Ok(match value {
-                SemanticBodyPattern::Wildcard => DurablePattern::Wildcard,
-                SemanticBodyPattern::Int(value) => DurablePattern::Int(*value),
-                SemanticBodyPattern::Bool(value) => DurablePattern::Bool(*value),
-                SemanticBodyPattern::EnumVariant {
-                    enum_key,
-                    variant_index,
-                } => {
-                    let enum_key = key(enum_key, work)?;
-                    if enum_key.kind() != StableDefinitionKind::Enum {
-                        return Err(DurableBodyConversionFailure::WrongDefinitionKind);
-                    }
-                    DurablePattern::EnumVariant {
-                        enum_key,
-                        variant_index: *variant_index,
-                    }
-                }
-            })
-        };
-        let data = |value: &SemanticBodyInstData<SemanticBodyDefinitionIdentity, Arc<str>>,
-                    work: &mut DurableBodyWork|
-         -> Result<DurableAirInstData, DurableBodyConversionFailure> {
-            macro_rules! bin {
-                ($variant:ident, $a:expr, $b:expr) => {
-                    DurableAirInstData::$variant(*$a, *$b)
-                };
-            }
-            Ok(match value {
-                SemanticBodyInstData::Const(v) => DurableAirInstData::Const(*v),
-                SemanticBodyInstData::BoolConst(v) => DurableAirInstData::BoolConst(*v),
-                SemanticBodyInstData::StringConst(v) => DurableAirInstData::StringConst(*v),
-                SemanticBodyInstData::UnitConst => DurableAirInstData::UnitConst,
-                SemanticBodyInstData::TypeConst(v) => DurableAirInstData::TypeConst(ty(v, work)?),
-                SemanticBodyInstData::Add(a, b) => bin!(Add, a, b),
-                SemanticBodyInstData::Sub(a, b) => bin!(Sub, a, b),
-                SemanticBodyInstData::Mul(a, b) => bin!(Mul, a, b),
-                SemanticBodyInstData::WrappingAdd(a, b) => bin!(WrappingAdd, a, b),
-                SemanticBodyInstData::WrappingSub(a, b) => bin!(WrappingSub, a, b),
-                SemanticBodyInstData::WrappingMul(a, b) => bin!(WrappingMul, a, b),
-                SemanticBodyInstData::Div(a, b) => bin!(Div, a, b),
-                SemanticBodyInstData::Mod(a, b) => bin!(Mod, a, b),
-                SemanticBodyInstData::Eq(a, b) => bin!(Eq, a, b),
-                SemanticBodyInstData::Ne(a, b) => bin!(Ne, a, b),
-                SemanticBodyInstData::Lt(a, b) => bin!(Lt, a, b),
-                SemanticBodyInstData::Gt(a, b) => bin!(Gt, a, b),
-                SemanticBodyInstData::Le(a, b) => bin!(Le, a, b),
-                SemanticBodyInstData::Ge(a, b) => bin!(Ge, a, b),
-                SemanticBodyInstData::And(a, b) => bin!(And, a, b),
-                SemanticBodyInstData::Or(a, b) => bin!(Or, a, b),
-                SemanticBodyInstData::BitAnd(a, b) => bin!(BitAnd, a, b),
-                SemanticBodyInstData::BitOr(a, b) => bin!(BitOr, a, b),
-                SemanticBodyInstData::BitXor(a, b) => bin!(BitXor, a, b),
-                SemanticBodyInstData::Shl(a, b) => bin!(Shl, a, b),
-                SemanticBodyInstData::Shr(a, b) => bin!(Shr, a, b),
-                SemanticBodyInstData::Neg(v) => DurableAirInstData::Neg(*v),
-                SemanticBodyInstData::Not(v) => DurableAirInstData::Not(*v),
-                SemanticBodyInstData::BitNot(v) => DurableAirInstData::BitNot(*v),
-                SemanticBodyInstData::Branch {
-                    cond,
-                    then_value,
-                    else_value,
-                } => DurableAirInstData::Branch {
-                    cond: *cond,
-                    then_value: *then_value,
-                    else_value: *else_value,
-                },
-                SemanticBodyInstData::Loop { cond, body } => DurableAirInstData::Loop {
-                    cond: *cond,
-                    body: *body,
-                },
-                SemanticBodyInstData::InfiniteLoop { body } => {
-                    DurableAirInstData::InfiniteLoop { body: *body }
-                }
-                SemanticBodyInstData::Match { scrutinee, arms } => DurableAirInstData::Match {
-                    scrutinee: *scrutinee,
-                    arms: arms
-                        .iter()
-                        .map(|arm| {
-                            Ok(DurableMatchArm {
-                                pattern: pattern(&arm.pattern, work)?,
-                                body: arm.body,
-                            })
-                        })
-                        .collect::<Result<Vec<_>, DurableBodyConversionFailure>>()?
-                        .into(),
-                },
-                SemanticBodyInstData::Break => DurableAirInstData::Break,
-                SemanticBodyInstData::Continue => DurableAirInstData::Continue,
-                SemanticBodyInstData::Alloc { slot, init } => DurableAirInstData::Alloc {
-                    slot: *slot,
-                    init: *init,
-                },
-                SemanticBodyInstData::Load { slot } => DurableAirInstData::Load { slot: *slot },
-                SemanticBodyInstData::Store { slot, value } => DurableAirInstData::Store {
-                    slot: *slot,
-                    value: *value,
-                },
-                SemanticBodyInstData::ParamStore { param_slot, value } => {
-                    DurableAirInstData::ParamStore {
-                        param_slot: *param_slot,
-                        value: *value,
-                    }
-                }
-                SemanticBodyInstData::Ret(value) => DurableAirInstData::Ret(*value),
-                SemanticBodyInstData::Call { function, args } => DurableAirInstData::Call {
-                    function: key(function, work)?,
-                    args: args.iter().map(arg).collect::<Vec<_>>().into(),
-                },
-                SemanticBodyInstData::RuntimeCall { runtime, args } => {
-                    DurableAirInstData::RuntimeCall {
-                        runtime: *runtime,
-                        args: args.iter().map(arg).collect::<Vec<_>>().into(),
-                    }
-                }
-                SemanticBodyInstData::CallSpecialized { identity, args } => {
-                    DurableAirInstData::CallSpecialized {
-                        identity: durable_specialization_identity(
-                            identity,
-                            merged,
-                            &join_index,
-                            work,
-                        )?,
-                        args: args.iter().map(arg).collect::<Vec<_>>().into(),
-                    }
-                }
-                SemanticBodyInstData::CallGeneric => {
-                    return Err(DurableBodyConversionFailure::UnsupportedGenericCall);
-                }
-                SemanticBodyInstData::Intrinsic {
-                    runtime,
-                    name,
-                    args,
-                } => DurableAirInstData::Intrinsic {
-                    runtime: *runtime,
-                    name: name.clone(),
-                    args: args.iter().map(arg).collect::<Vec<_>>().into(),
-                },
-                SemanticBodyInstData::Param { index } => {
-                    DurableAirInstData::Param { index: *index }
-                }
-                SemanticBodyInstData::Block { statements, value } => DurableAirInstData::Block {
-                    statements: statements.clone(),
-                    value: *value,
-                },
-                SemanticBodyInstData::StructInit {
-                    struct_key,
-                    fields,
-                    source_order,
-                } => DurableAirInstData::StructInit {
-                    struct_key: key(struct_key, work)?,
-                    fields: fields.clone(),
-                    source_order: source_order.clone(),
-                },
-                SemanticBodyInstData::ArrayInit { elements } => DurableAirInstData::ArrayInit {
-                    elements: elements.clone(),
-                },
-                SemanticBodyInstData::PlaceRead { place } => {
-                    DurableAirInstData::PlaceRead { place: *place }
-                }
-                SemanticBodyInstData::PlaceWrite { place, value } => {
-                    DurableAirInstData::PlaceWrite {
-                        place: *place,
-                        value: *value,
-                    }
-                }
-                SemanticBodyInstData::EnumVariant {
-                    enum_key,
-                    variant_index,
-                    payload,
-                } => DurableAirInstData::EnumVariant {
-                    enum_key: key(enum_key, work)?,
-                    variant_index: *variant_index,
-                    payload: payload.clone(),
-                },
-                SemanticBodyInstData::EnumPayloadGet {
-                    base,
-                    enum_key,
-                    variant_index,
-                    field_index,
-                } => DurableAirInstData::EnumPayloadGet {
-                    base: *base,
-                    enum_key: key(enum_key, work)?,
-                    variant_index: *variant_index,
-                    field_index: *field_index,
-                },
-                SemanticBodyInstData::IntCast { value, from_ty } => DurableAirInstData::IntCast {
-                    value: *value,
-                    from_ty: ty(from_ty, work)?,
-                },
-                SemanticBodyInstData::Drop { value } => DurableAirInstData::Drop { value: *value },
-                SemanticBodyInstData::StorageLive { slot } => {
-                    DurableAirInstData::StorageLive { slot: *slot }
-                }
-                SemanticBodyInstData::StorageDead { slot } => {
-                    DurableAirInstData::StorageDead { slot: *slot }
-                }
-                SemanticBodyInstData::MarkMoved {
-                    value,
-                    slot,
-                    is_param,
-                    place,
-                } => DurableAirInstData::MarkMoved {
-                    value: *value,
-                    slot: *slot,
-                    is_param: *is_param,
-                    place: *place,
-                },
-            })
-        };
-        let instructions = body
-            .instructions
-            .iter()
-            .map(|instruction| {
-                Ok(DurableAirInst {
-                    data: data(&instruction.data, work)?,
-                    ty: ty(&instruction.ty, work)?,
-                    anchor: DurableBodyAnchor {
-                        start: instruction.anchor.start,
-                        end: instruction.anchor.end,
-                    },
-                })
-            })
-            .collect::<Result<Vec<_>, DurableBodyConversionFailure>>()?;
-        let places = body
-            .places
-            .iter()
-            .map(|place| {
-                Ok(DurablePlace {
-                    base: place.base,
-                    base_type: ty(&place.base_type, work)?,
-                    projections: place
-                        .projections
-                        .iter()
-                        .map(|projection| {
-                            Ok(match projection {
-                                SemanticBodyProjection::Field {
-                                    struct_key,
-                                    field_index,
-                                } => DurableProjection::Field {
-                                    struct_key: key(struct_key, work)?,
-                                    field_index: *field_index,
-                                },
-                                SemanticBodyProjection::Index { array_type, index } => {
-                                    DurableProjection::Index {
-                                        array_type: ty(array_type, work)?,
-                                        index: *index,
-                                    }
-                                }
-                            })
-                        })
-                        .collect::<Result<Vec<_>, DurableBodyConversionFailure>>()?
-                        .into(),
-                })
-            })
-            .collect::<Result<Vec<_>, DurableBodyConversionFailure>>()?;
-        let result = DurableOrdinaryBodyPayload {
-            schema_version: DURABLE_ORDINARY_BODY_SCHEMA_VERSION,
-            owner,
-            expected_inputs,
-            return_type: ty(&body.return_type, work)?,
-            instructions: instructions.into(),
-            places: places.into(),
-            strings: body.strings.clone(),
-            param_drops: body
-                .param_drops
-                .iter()
-                .map(|(slot, value)| Ok((*slot, ty(value, work)?)))
-                .collect::<Result<Vec<_>, DurableBodyConversionFailure>>()?
-                .into(),
-            borrow_slots: body.borrow_slots.clone(),
-            num_locals: body.num_locals,
-            num_param_slots: body.num_param_slots,
-            param_by_ref: body.param_by_ref.clone(),
-            param_writable: body.param_writable.clone(),
-            allow_unreachable_code: body.allow_unreachable_code,
-        };
-        work.conversion_completions += 1;
-        Ok(result)
-    };
     let mut converted = Vec::with_capacity(exports.len());
     for export in exports {
-        match convert(export, work) {
-            Ok(body) => converted.push(body),
+        work.conversion_attempts += 1;
+        let result =
+            (|| {
+                let owner_record = definitions
+                    .definition_for_body_token(export.owner)
+                    .map_err(|_| DurableBodyConversionFailure::ForeignOwnerToken)?;
+                let owner = owner_record.stable_key().clone();
+                if !matches!(
+                    owner.kind(),
+                    StableDefinitionKind::Function
+                        | StableDefinitionKind::Method
+                        | StableDefinitionKind::AssociatedFunction
+                        | StableDefinitionKind::Destructor
+                ) {
+                    return Err(DurableBodyConversionFailure::WrongDefinitionKind);
+                }
+                if !export.body.warnings.is_empty() {
+                    return Err(DurableBodyConversionFailure::WarningProducingBody);
+                }
+                if export.body.instructions.iter().any(|instruction| {
+                    matches!(instruction.data, SemanticBodyInstData::CallGeneric)
+                }) {
+                    return Err(DurableBodyConversionFailure::UnsupportedGenericCall);
+                }
+
+                let expected_inputs = crate::session::stable_definition_input_fingerprint(
+                    merged.definitions().source_snapshot(),
+                    owner_record,
+                )
+                .map_err(|_| DurableBodyConversionFailure::FingerprintUnavailable)?;
+                let stable_key_joins = std::cell::Cell::new(0usize);
+                let body = export.body.try_map_keys(
+                    &|identity| {
+                        stable_key_joins.set(stable_key_joins.get() + 1);
+                        join_index.join_readonly(identity).cloned()
+                    },
+                    &|path| {
+                        merged
+                            .ast()
+                            .modules()
+                            .iter()
+                            .find(|module| module.module_id().as_str() == path.as_ref())
+                            .map(|module| module.module_id().clone())
+                            .ok_or(DurableBodyConversionFailure::UnresolvedModule)
+                    },
+                );
+                work.stable_key_joins += stable_key_joins.get();
+                let body = body?;
+                Ok(DurableOrdinaryBodyPayload {
+                    schema_version: DURABLE_ORDINARY_BODY_SCHEMA_VERSION,
+                    owner,
+                    expected_inputs,
+                    body,
+                })
+            })();
+
+        match result {
+            Ok(payload) => {
+                work.conversion_completions += 1;
+                converted.push(payload);
+            }
             Err(error) => {
                 work.conversion_failures += 1;
                 work.atomic_discards += 1;
@@ -1237,55 +817,68 @@ impl DurableOrdinaryBody {
 
 impl DurableOrdinaryBodyPayload {
     pub(crate) fn referenced_definition_keys(&self) -> BTreeSet<StableDefinitionKey> {
-        fn visit_type(value: &DurableType, keys: &mut BTreeSet<StableDefinitionKey>) {
+        fn visit_type(
+            value: &SemanticImportType<StableDefinitionKey, crate::ModuleId>,
+            keys: &mut BTreeSet<StableDefinitionKey>,
+        ) {
             match value {
-                DurableType::Nominal(key) => {
+                SemanticImportType::Nominal(key) => {
                     keys.insert(key.clone());
                 }
-                DurableType::Array { element, .. }
-                | DurableType::PtrConst(element)
-                | DurableType::PtrMut(element) => visit_type(element, keys),
+                SemanticImportType::Array { element, .. }
+                | SemanticImportType::PtrConst(element)
+                | SemanticImportType::PtrMut(element) => visit_type(element, keys),
                 _ => {}
             }
         }
 
+        fn visit_specialization(
+            identity: &rue_air::SemanticSpecializationIdentity<
+                StableDefinitionKey,
+                crate::ModuleId,
+            >,
+            keys: &mut BTreeSet<StableDefinitionKey>,
+        ) {
+            keys.insert(identity.base.clone());
+            for value in identity.type_arguments.iter() {
+                visit_type(value, keys);
+            }
+            for value in identity.value_arguments.iter() {
+                match value {
+                    SemanticImportConstValue::Type(value) => visit_type(value, keys),
+                    SemanticImportConstValue::Function(key) => {
+                        keys.insert(key.clone());
+                    }
+                    _ => {}
+                }
+            }
+        }
+
         let mut keys = BTreeSet::new();
-        visit_type(&self.return_type, &mut keys);
-        for instruction in self.instructions.iter() {
+        visit_type(&self.body.return_type, &mut keys);
+        for instruction in self.body.instructions.iter() {
             visit_type(&instruction.ty, &mut keys);
             match &instruction.data {
-                DurableAirInstData::TypeConst(value)
-                | DurableAirInstData::IntCast { from_ty: value, .. } => {
+                SemanticBodyInstData::TypeConst(value)
+                | SemanticBodyInstData::IntCast { from_ty: value, .. } => {
                     visit_type(value, &mut keys);
                 }
-                DurableAirInstData::Call { function, .. } => {
+                SemanticBodyInstData::Call { function, .. } => {
                     keys.insert(function.clone());
                 }
-                DurableAirInstData::CallSpecialized { identity, .. } => {
-                    keys.insert(identity.base.clone());
-                    for ty in identity.type_arguments.iter() {
-                        visit_type(ty, &mut keys);
-                    }
-                    for value in identity.value_arguments.iter() {
-                        match value {
-                            crate::DurableConstValue::Type(ty) => visit_type(ty, &mut keys),
-                            crate::DurableConstValue::Function(key) => {
-                                keys.insert(key.clone());
-                            }
-                            _ => {}
-                        }
-                    }
+                SemanticBodyInstData::CallSpecialized { identity, .. } => {
+                    visit_specialization(identity, &mut keys);
                 }
-                DurableAirInstData::StructInit { struct_key, .. } => {
+                SemanticBodyInstData::StructInit { struct_key, .. } => {
                     keys.insert(struct_key.clone());
                 }
-                DurableAirInstData::EnumVariant { enum_key, .. }
-                | DurableAirInstData::EnumPayloadGet { enum_key, .. } => {
+                SemanticBodyInstData::EnumVariant { enum_key, .. }
+                | SemanticBodyInstData::EnumPayloadGet { enum_key, .. } => {
                     keys.insert(enum_key.clone());
                 }
-                DurableAirInstData::Match { arms, .. } => {
+                SemanticBodyInstData::Match { arms, .. } => {
                     for arm in arms.iter() {
-                        if let DurablePattern::EnumVariant { enum_key, .. } = &arm.pattern {
+                        if let SemanticBodyPattern::EnumVariant { enum_key, .. } = &arm.pattern {
                             keys.insert(enum_key.clone());
                         }
                     }
@@ -1293,70 +886,70 @@ impl DurableOrdinaryBodyPayload {
                 _ => {}
             }
         }
-        for place in self.places.iter() {
+        for place in self.body.places.iter() {
             visit_type(&place.base_type, &mut keys);
             for projection in place.projections.iter() {
                 match projection {
-                    DurableProjection::Field { struct_key, .. } => {
+                    SemanticBodyProjection::Field { struct_key, .. } => {
                         keys.insert(struct_key.clone());
                     }
-                    DurableProjection::Index { array_type, .. } => {
+                    SemanticBodyProjection::Index { array_type, .. } => {
                         visit_type(array_type, &mut keys);
                     }
                 }
             }
         }
-        for (_, value) in self.param_drops.iter() {
+        for (_, value) in self.body.param_drops.iter() {
             visit_type(value, &mut keys);
         }
         keys
     }
 
-    /// Project the durable algebra into AIR's neutral import DTO. This does not
-    /// allocate any AIR instruction, type, string, nominal, or function ID.
     pub fn project_semantic_body(
         &self,
         work: &mut DurableBodyWork,
     ) -> Result<rue_air::SemanticBody<StableDefinitionKey, Arc<str>>, DurableBodyProjectionFailure>
     {
-        use rue_air::{SemanticBodyInstData as S, SemanticBodyPattern as P};
         work.projection_attempts += 1;
         if self.schema_version != DURABLE_ORDINARY_BODY_SCHEMA_VERSION {
             work.projection_failures += 1;
             return Err(DurableBodyProjectionFailure::SchemaVersionMismatch);
         }
-        if self.param_by_ref.len() != self.num_param_slots as usize
-            || self.param_writable.len() != self.num_param_slots as usize
+        if self.body.param_by_ref.len() != self.body.num_param_slots as usize
+            || self.body.param_writable.len() != self.body.num_param_slots as usize
             || self
+                .body
                 .param_writable
                 .iter()
-                .zip(self.param_by_ref.iter())
+                .zip(self.body.param_by_ref.iter())
                 .any(|(writable, by_ref)| *writable && !*by_ref)
         {
             work.projection_failures += 1;
             return Err(DurableBodyProjectionFailure::InvalidParameterModes);
         }
         if self
+            .body
             .param_drops
             .iter()
-            .any(|(slot, _)| *slot >= self.num_param_slots)
+            .any(|(slot, _)| *slot >= self.body.num_param_slots)
         {
             work.projection_failures += 1;
             return Err(DurableBodyProjectionFailure::InvalidParameterDrop);
         }
         if self
+            .body
             .borrow_slots
             .iter()
-            .any(|slot| *slot >= self.num_locals)
+            .any(|slot| *slot >= self.body.num_locals)
         {
             work.projection_failures += 1;
             return Err(DurableBodyProjectionFailure::InvalidBorrowSlot);
         }
-        let instruction_len = self.instructions.len();
-        let place_len = self.places.len();
-        for place in self.places.iter() {
+        let instruction_len = self.body.instructions.len();
+        let place_len = self.body.places.len();
+        for place in self.body.places.iter() {
             for projection in place.projections.iter() {
-                if let DurableProjection::Index { index, .. } = projection
+                if let SemanticBodyProjection::Index { index, .. } = projection
                     && *index as usize >= instruction_len
                 {
                     work.projection_failures += 1;
@@ -1364,12 +957,12 @@ impl DurableOrdinaryBodyPayload {
                 }
             }
         }
-        for (current, instruction) in self.instructions.iter().enumerate() {
+        for (current, instruction) in self.body.instructions.iter().enumerate() {
             if instruction.anchor.start > instruction.anchor.end {
                 work.projection_failures += 1;
                 return Err(DurableBodyProjectionFailure::InvalidAnchor);
             }
-            let check = |value: DurableAirRef| {
+            let check = |value: rue_air::SemanticBodyRef| {
                 let index = value as usize;
                 if index >= instruction_len {
                     Err(DurableBodyProjectionFailure::InvalidInstructionReference)
@@ -1379,10 +972,10 @@ impl DurableOrdinaryBodyPayload {
                     Ok(())
                 }
             };
-            let check_all = |values: &[DurableAirRef]| -> Result<_, _> {
+            let check_all = |values: &[rue_air::SemanticBodyRef]| -> Result<_, _> {
                 values.iter().try_for_each(|value| check(*value))
             };
-            use DurableAirInstData as D;
+            use SemanticBodyInstData as D;
             let validated = match &instruction.data {
                 D::Const(_)
                 | D::BoolConst(_)
@@ -1394,8 +987,9 @@ impl DurableOrdinaryBodyPayload {
                 | D::Param { .. }
                 | D::StorageLive { .. }
                 | D::StorageDead { .. } => Ok(()),
+                D::CallGeneric => Err(DurableBodyProjectionFailure::InvalidInstructionReference),
                 D::StringConst(index) => {
-                    if *index as usize >= self.strings.len() {
+                    if *index as usize >= self.body.strings.len() {
                         Err(DurableBodyProjectionFailure::InvalidStringReference)
                     } else {
                         Ok(())
@@ -1422,11 +1016,11 @@ impl DurableOrdinaryBodyPayload {
                 | D::BitXor(a, b)
                 | D::Shl(a, b)
                 | D::Shr(a, b) => check(*a).and_then(|()| check(*b)),
-                D::Neg(v)
-                | D::Not(v)
-                | D::BitNot(v)
-                | D::Drop { value: v }
-                | D::IntCast { value: v, .. } => check(*v),
+                D::Neg(value)
+                | D::Not(value)
+                | D::BitNot(value)
+                | D::Drop { value }
+                | D::IntCast { value, .. } => check(*value),
                 D::Branch {
                     cond,
                     then_value,
@@ -1498,241 +1092,17 @@ impl DurableOrdinaryBodyPayload {
                 return Err(error);
             }
         }
-        let arg = |a: &DurableCallArg| rue_air::SemanticBodyCallArg {
-            value: a.value,
-            mode: a.mode,
-        };
-        let pattern = |p: &DurablePattern| match p {
-            DurablePattern::Wildcard => P::Wildcard,
-            DurablePattern::Int(v) => P::Int(*v),
-            DurablePattern::Bool(v) => P::Bool(*v),
-            DurablePattern::EnumVariant {
-                enum_key,
-                variant_index,
-            } => P::EnumVariant {
-                enum_key: enum_key.clone(),
-                variant_index: *variant_index,
-            },
-        };
-        let data = |d: &DurableAirInstData| -> S<StableDefinitionKey, Arc<str>> {
-            macro_rules! bin {
-                ($v:ident, $a:expr, $b:expr) => {
-                    S::$v(*$a, *$b)
-                };
-            }
-            match d {
-                DurableAirInstData::Const(v) => S::Const(*v),
-                DurableAirInstData::BoolConst(v) => S::BoolConst(*v),
-                DurableAirInstData::StringConst(v) => S::StringConst(*v),
-                DurableAirInstData::UnitConst => S::UnitConst,
-                DurableAirInstData::TypeConst(v) => S::TypeConst(v.import_dto()),
-                DurableAirInstData::Add(a, b) => bin!(Add, a, b),
-                DurableAirInstData::Sub(a, b) => bin!(Sub, a, b),
-                DurableAirInstData::Mul(a, b) => bin!(Mul, a, b),
-                DurableAirInstData::WrappingAdd(a, b) => bin!(WrappingAdd, a, b),
-                DurableAirInstData::WrappingSub(a, b) => bin!(WrappingSub, a, b),
-                DurableAirInstData::WrappingMul(a, b) => bin!(WrappingMul, a, b),
-                DurableAirInstData::Div(a, b) => bin!(Div, a, b),
-                DurableAirInstData::Mod(a, b) => bin!(Mod, a, b),
-                DurableAirInstData::Eq(a, b) => bin!(Eq, a, b),
-                DurableAirInstData::Ne(a, b) => bin!(Ne, a, b),
-                DurableAirInstData::Lt(a, b) => bin!(Lt, a, b),
-                DurableAirInstData::Gt(a, b) => bin!(Gt, a, b),
-                DurableAirInstData::Le(a, b) => bin!(Le, a, b),
-                DurableAirInstData::Ge(a, b) => bin!(Ge, a, b),
-                DurableAirInstData::And(a, b) => bin!(And, a, b),
-                DurableAirInstData::Or(a, b) => bin!(Or, a, b),
-                DurableAirInstData::BitAnd(a, b) => bin!(BitAnd, a, b),
-                DurableAirInstData::BitOr(a, b) => bin!(BitOr, a, b),
-                DurableAirInstData::BitXor(a, b) => bin!(BitXor, a, b),
-                DurableAirInstData::Shl(a, b) => bin!(Shl, a, b),
-                DurableAirInstData::Shr(a, b) => bin!(Shr, a, b),
-                DurableAirInstData::Neg(v) => S::Neg(*v),
-                DurableAirInstData::Not(v) => S::Not(*v),
-                DurableAirInstData::BitNot(v) => S::BitNot(*v),
-                DurableAirInstData::Branch {
-                    cond,
-                    then_value,
-                    else_value,
-                } => S::Branch {
-                    cond: *cond,
-                    then_value: *then_value,
-                    else_value: *else_value,
-                },
-                DurableAirInstData::Loop { cond, body } => S::Loop {
-                    cond: *cond,
-                    body: *body,
-                },
-                DurableAirInstData::InfiniteLoop { body } => S::InfiniteLoop { body: *body },
-                DurableAirInstData::Match { scrutinee, arms } => S::Match {
-                    scrutinee: *scrutinee,
-                    arms: arms
-                        .iter()
-                        .map(|a| rue_air::SemanticBodyMatchArm {
-                            pattern: pattern(&a.pattern),
-                            body: a.body,
-                        })
-                        .collect::<Vec<_>>()
-                        .into(),
-                },
-                DurableAirInstData::Break => S::Break,
-                DurableAirInstData::Continue => S::Continue,
-                DurableAirInstData::Alloc { slot, init } => S::Alloc {
-                    slot: *slot,
-                    init: *init,
-                },
-                DurableAirInstData::Load { slot } => S::Load { slot: *slot },
-                DurableAirInstData::Store { slot, value } => S::Store {
-                    slot: *slot,
-                    value: *value,
-                },
-                DurableAirInstData::ParamStore { param_slot, value } => S::ParamStore {
-                    param_slot: *param_slot,
-                    value: *value,
-                },
-                DurableAirInstData::Ret(v) => S::Ret(*v),
-                DurableAirInstData::Call { function, args } => S::Call {
-                    function: function.clone(),
-                    args: args.iter().map(arg).collect::<Vec<_>>().into(),
-                },
-                DurableAirInstData::RuntimeCall { runtime, args } => S::RuntimeCall {
-                    runtime: *runtime,
-                    args: args.iter().map(arg).collect::<Vec<_>>().into(),
-                },
-                DurableAirInstData::CallSpecialized { identity, args } => S::CallSpecialized {
-                    identity: identity.import_dto(),
-                    args: args.iter().map(arg).collect::<Vec<_>>().into(),
-                },
-                DurableAirInstData::Intrinsic {
-                    runtime,
-                    name,
-                    args,
-                } => S::Intrinsic {
-                    runtime: *runtime,
-                    name: name.clone(),
-                    args: args.iter().map(arg).collect::<Vec<_>>().into(),
-                },
-                DurableAirInstData::Param { index } => S::Param { index: *index },
-                DurableAirInstData::Block { statements, value } => S::Block {
-                    statements: statements.clone(),
-                    value: *value,
-                },
-                DurableAirInstData::StructInit {
-                    struct_key,
-                    fields,
-                    source_order,
-                } => S::StructInit {
-                    struct_key: struct_key.clone(),
-                    fields: fields.clone(),
-                    source_order: source_order.clone(),
-                },
-                DurableAirInstData::ArrayInit { elements } => S::ArrayInit {
-                    elements: elements.clone(),
-                },
-                DurableAirInstData::PlaceRead { place } => S::PlaceRead { place: *place },
-                DurableAirInstData::PlaceWrite { place, value } => S::PlaceWrite {
-                    place: *place,
-                    value: *value,
-                },
-                DurableAirInstData::EnumVariant {
-                    enum_key,
-                    variant_index,
-                    payload,
-                } => S::EnumVariant {
-                    enum_key: enum_key.clone(),
-                    variant_index: *variant_index,
-                    payload: payload.clone(),
-                },
-                DurableAirInstData::EnumPayloadGet {
-                    base,
-                    enum_key,
-                    variant_index,
-                    field_index,
-                } => S::EnumPayloadGet {
-                    base: *base,
-                    enum_key: enum_key.clone(),
-                    variant_index: *variant_index,
-                    field_index: *field_index,
-                },
-                DurableAirInstData::IntCast { value, from_ty } => S::IntCast {
-                    value: *value,
-                    from_ty: from_ty.import_dto(),
-                },
-                DurableAirInstData::Drop { value } => S::Drop { value: *value },
-                DurableAirInstData::StorageLive { slot } => S::StorageLive { slot: *slot },
-                DurableAirInstData::StorageDead { slot } => S::StorageDead { slot: *slot },
-                DurableAirInstData::MarkMoved {
-                    value,
-                    slot,
-                    is_param,
-                    place,
-                } => S::MarkMoved {
-                    value: *value,
-                    slot: *slot,
-                    is_param: *is_param,
-                    place: *place,
-                },
-            }
-        };
-        let body = rue_air::SemanticBody {
-            return_type: self.return_type.import_dto(),
-            instructions: self
-                .instructions
-                .iter()
-                .map(|i| rue_air::SemanticBodyInst {
-                    data: data(&i.data),
-                    ty: i.ty.import_dto(),
-                    anchor: rue_air::SemanticBodyAnchor {
-                        start: i.anchor.start,
-                        end: i.anchor.end,
-                    },
-                })
-                .collect::<Vec<_>>()
-                .into(),
-            places: self
-                .places
-                .iter()
-                .map(|p| rue_air::SemanticBodyPlace {
-                    base: p.base,
-                    base_type: p.base_type.import_dto(),
-                    projections: p
-                        .projections
-                        .iter()
-                        .map(|q| match q {
-                            DurableProjection::Field {
-                                struct_key,
-                                field_index,
-                            } => rue_air::SemanticBodyProjection::Field {
-                                struct_key: struct_key.clone(),
-                                field_index: *field_index,
-                            },
-                            DurableProjection::Index { array_type, index } => {
-                                rue_air::SemanticBodyProjection::Index {
-                                    array_type: array_type.import_dto(),
-                                    index: *index,
-                                }
-                            }
-                        })
-                        .collect::<Vec<_>>()
-                        .into(),
-                })
-                .collect::<Vec<_>>()
-                .into(),
-            strings: self.strings.clone(),
-            param_drops: self
-                .param_drops
-                .iter()
-                .map(|(s, t)| (*s, t.import_dto()))
-                .collect::<Vec<_>>()
-                .into(),
-            borrow_slots: self.borrow_slots.clone(),
-            num_locals: self.num_locals,
-            num_param_slots: self.num_param_slots,
-            param_by_ref: self.param_by_ref.clone(),
-            param_writable: self.param_writable.clone(),
-            allow_unreachable_code: self.allow_unreachable_code,
-            warnings: Arc::from([]),
-        };
+        if !self.body.warnings.is_empty() {
+            work.projection_failures += 1;
+            return Err(DurableBodyProjectionFailure::InvalidAnchor);
+        }
+        let body = self
+            .body
+            .try_map_keys(
+                &|key| Ok::<_, std::convert::Infallible>(key.clone()),
+                &|module| Ok::<_, std::convert::Infallible>(Arc::from(module.as_str())),
+            )
+            .expect("canonical body key projection is infallible");
         work.projection_completions += 1;
         work.instructions_projected += body.instructions.len();
         work.places_projected += body.places.len();
@@ -1769,24 +1139,27 @@ mod tests {
                 body_or_initializer: Some(crate::StableDefinitionFingerprint::for_test(3)),
                 precision: crate::StableDefinitionFingerprintPrecision::SignatureAndBody,
             },
-            return_type: DurableType::Unit,
-            instructions: instructions.into(),
-            places: Arc::from([]),
-            strings: Arc::from([]),
-            param_drops: Arc::from([]),
-            borrow_slots: Arc::from([]),
-            num_locals: 0,
-            num_param_slots: 0,
-            param_by_ref: Arc::from([]),
-            param_writable: Arc::from([]),
-            allow_unreachable_code: false,
+            body: rue_air::SemanticBody {
+                return_type: SemanticImportType::Unit,
+                instructions: instructions.into(),
+                places: Arc::from([]),
+                strings: Arc::from([]),
+                param_drops: Arc::from([]),
+                borrow_slots: Arc::from([]),
+                num_locals: 0,
+                num_param_slots: 0,
+                param_by_ref: Arc::from([]),
+                param_writable: Arc::from([]),
+                allow_unreachable_code: false,
+                warnings: Arc::from([]),
+            },
         }
     }
 
     fn instruction(data: DurableAirInstData) -> DurableAirInst {
         DurableAirInst {
             data,
-            ty: DurableType::Unit,
+            ty: SemanticImportType::Unit,
             anchor: DurableBodyAnchor { start: 0, end: 0 },
         }
     }

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -2,16 +2,18 @@ use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 use lasso::{Key, Spur};
-use rue_air::{AirInstData, AnalyzedFunction, Type, TypeKind};
+use rue_air::{AirInstData, AnalyzedFunction, SemanticImportType, Type, TypeKind};
 use rue_span::Span;
 
-use crate::{DurableAirInstData, DurableOrdinaryBodyPayload, DurableType};
+use crate::{DurableAirInstData, DurableOrdinaryBodyPayload};
+
+type CanonicalType = SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>;
 
 fn deduplicate_type_mappings(
-    mappings: Vec<(Type, DurableType)>,
-) -> Result<Vec<(Type, DurableType)>, CfgDomainFailure> {
+    mappings: Vec<(Type, CanonicalType)>,
+) -> Result<Vec<(Type, CanonicalType)>, CfgDomainFailure> {
     let mut positions: HashMap<Type, usize> = HashMap::with_capacity(mappings.len());
-    let mut unique: Vec<(Type, DurableType)> = Vec::with_capacity(mappings.len());
+    let mut unique: Vec<(Type, CanonicalType)> = Vec::with_capacity(mappings.len());
     for (current, stable) in mappings {
         if let Some(&position) = positions.get(&current) {
             if unique[position].1 != stable {
@@ -45,12 +47,12 @@ pub(crate) enum LayoutDependencyFailure {
 pub(crate) fn body_type_dependencies(
     body: &DurableOrdinaryBodyPayload,
 ) -> BTreeSet<crate::StableDefinitionKey> {
-    fn visit(value: &DurableType, keys: &mut BTreeSet<crate::StableDefinitionKey>) {
+    fn visit(value: &CanonicalType, keys: &mut BTreeSet<crate::StableDefinitionKey>) {
         match value {
-            DurableType::Nominal(key) => {
+            SemanticImportType::Nominal(key) => {
                 keys.insert(key.clone());
             }
-            DurableType::Array { element, .. } => visit(element, keys),
+            SemanticImportType::Array { element, .. } => visit(element, keys),
             _ => {}
         }
     }
@@ -93,9 +95,8 @@ pub(crate) fn body_type_dependencies(
             for arg in args.iter() {
                 if let Some(argument) = body.instructions.get(arg.value as usize) {
                     match &argument.ty {
-                        DurableType::PtrConst(pointee) | DurableType::PtrMut(pointee) => {
-                            visit(pointee, &mut keys)
-                        }
+                        SemanticImportType::PtrConst(pointee)
+                        | SemanticImportType::PtrMut(pointee) => visit(pointee, &mut keys),
                         _ => {}
                     }
                 }
@@ -215,13 +216,15 @@ pub(crate) fn transitive_body_type_dependencies(
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum StableCfgSymbol {
     Callable(crate::StableDefinitionKey),
-    Specialization(crate::DurableSpecializationIdentity),
+    Specialization(
+        rue_air::SemanticSpecializationIdentity<crate::StableDefinitionKey, crate::ModuleId>,
+    ),
     Intrinsic(Arc<str>),
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct CfgDomainProjection {
-    types: Vec<(Type, DurableType)>,
+    types: Vec<(Type, CanonicalType)>,
     strings: Vec<(u32, Arc<str>)>,
     spans: Vec<(Span, crate::DurableBodyAnchor)>,
     symbols: Vec<(Spur, StableCfgSymbol)>,
@@ -336,24 +339,24 @@ impl CfgDomainProjection {
         })
     }
 
-    fn stable_type(&self, value: Type) -> Result<DurableType, CfgDomainFailure> {
+    fn stable_type(&self, value: Type) -> Result<CanonicalType, CfgDomainFailure> {
         self.types
             .iter()
             .find(|(current, _)| *current == value)
             .map(|(_, stable)| stable.clone())
             .ok_or(CfgDomainFailure::Missing)
     }
-    fn current_type(&self, value: &DurableType) -> Result<Type, CfgDomainFailure> {
+    fn current_type(&self, value: &CanonicalType) -> Result<Type, CfgDomainFailure> {
         self.types
             .iter()
             .find(|(_, stable)| stable == value)
             .map(|(current, _)| *current)
             .ok_or(CfgDomainFailure::Missing)
     }
-    fn stable_nominal(&self, value: Type) -> Result<DurableType, CfgDomainFailure> {
+    fn stable_nominal(&self, value: Type) -> Result<CanonicalType, CfgDomainFailure> {
         self.stable_type(value)
     }
-    fn current_nominal(&self, value: &DurableType) -> Result<Type, CfgDomainFailure> {
+    fn current_nominal(&self, value: &CanonicalType) -> Result<Type, CfgDomainFailure> {
         self.current_type(value)
     }
 
@@ -434,7 +437,7 @@ mod tests {
 
     fn projection(symbol: Spur) -> CfgDomainProjection {
         CfgDomainProjection {
-            types: vec![(Type::I32, DurableType::I32)],
+            types: vec![(Type::I32, SemanticImportType::I32)],
             strings: Vec::new(),
             spans: vec![(
                 Span::new(4, 5),
@@ -447,20 +450,23 @@ mod tests {
     #[test]
     fn type_mapping_deduplication_preserves_encounter_order_and_rejects_conflicts() {
         let mappings = deduplicate_type_mappings(vec![
-            (Type::I64, DurableType::I64),
-            (Type::I32, DurableType::I32),
-            (Type::I64, DurableType::I64),
+            (Type::I64, SemanticImportType::I64),
+            (Type::I32, SemanticImportType::I32),
+            (Type::I64, SemanticImportType::I64),
         ])
         .unwrap();
         assert_eq!(
             mappings,
-            vec![(Type::I64, DurableType::I64), (Type::I32, DurableType::I32)]
+            vec![
+                (Type::I64, SemanticImportType::I64),
+                (Type::I32, SemanticImportType::I32)
+            ]
         );
 
         assert_eq!(
             deduplicate_type_mappings(vec![
-                (Type::I32, DurableType::I32),
-                (Type::I32, DurableType::I64),
+                (Type::I32, SemanticImportType::I32),
+                (Type::I32, SemanticImportType::I64),
             ]),
             Err(CfgDomainFailure::Shape)
         );

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -32,7 +32,9 @@ pub(crate) struct StableCfgInput {
     pub identity: Arc<str>,
     pub body_span: Span,
     pub body: DurableOrdinaryBodyPayload,
-    pub specialization: Option<crate::DurableSpecializationIdentity>,
+    pub specialization: Option<
+        rue_air::SemanticSpecializationIdentity<crate::StableDefinitionKey, crate::ModuleId>,
+    >,
     pub type_inputs: Arc<[crate::StableDefinitionInputFingerprint]>,
 }
 

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -144,8 +144,8 @@ pub use durable_body::{
     DurableAirInstData, DurableAirRef, DurableBodyAnchor, DurableBodyConversionFailure,
     DurableBodyProjectionFailure, DurableBodyWork, DurableCallArg, DurableMatchArm,
     DurableOrdinaryBody, DurableOrdinaryBodyPayload, DurablePattern, DurablePlace, DurablePlaceRef,
-    DurableProjection, DurableSpecializationIdentity, DurableSpecializedBody,
-    DurableSpecializedBodyPayload, convert_semantic_specialized_body_exports,
+    DurableProjection, DurableSpecializedBody, DurableSpecializedBodyPayload,
+    convert_semantic_specialized_body_exports,
 };
 pub use durable_semantics::{
     DURABLE_SEMANTIC_SCHEMA_VERSION, DurableConstValue, DurableDeclarationPayload,

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -13575,8 +13575,12 @@ fn main() -> i32 { selected.value() }"#,
             .iter()
             .map(|payload| payload.identity.value_arguments.as_ref())
             .collect::<Vec<_>>();
-        assert!(bool_identities.contains(&[crate::DurableConstValue::Bool(true)].as_slice()));
-        assert!(bool_identities.contains(&[crate::DurableConstValue::Bool(false)].as_slice()));
+        assert!(
+            bool_identities.contains(&[rue_air::SemanticImportConstValue::Bool(true)].as_slice())
+        );
+        assert!(
+            bool_identities.contains(&[rue_air::SemanticImportConstValue::Bool(false)].as_slice())
+        );
 
         let changed_text = first_text.replace("41", "42");
         let changed_source = snapshot(

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -13501,7 +13501,7 @@ fn main() -> i32 { selected.value() }"#,
         // Projection and stable-key mapping accept this durable shape, but an
         // imported completed specialization has no declaration-scoped generic
         // context in which this type can be resolved.
-        call.type_arguments = Arc::from([crate::DurableType::GenericParameter(0)]);
+        call.type_arguments = Arc::from([rue_air::SemanticImportType::GenericParameter(0)]);
 
         let optimized = CompileOptions {
             opt_level: OptLevel::O1,
@@ -14193,8 +14193,8 @@ fn main() -> i32 { selected.value() }"#,
         let cache = session.last_successful_body_cache.as_mut().unwrap();
         let mut bodies = cache.bodies.to_vec();
         bodies[0].payload.return_type =
-            crate::DurableType::PtrConst(Box::new(crate::DurableType::Array {
-                element: Box::new(crate::DurableType::I32),
+            rue_air::SemanticImportType::PtrConst(Box::new(rue_air::SemanticImportType::Array {
+                element: Box::new(rue_air::SemanticImportType::I32),
                 len: 3,
             }));
         let mut instructions = bodies[0].payload.instructions.to_vec();


### PR DESCRIPTION
## Summary

- retain the canonical `SemanticBody<StableDefinitionKey, ModuleId>` directly in versioned durable envelopes
- replace compiler-owned mirror enums and records with aliases over the canonical `rue-air` algebra
- remove both rename-only body conversion directions while preserving fail-closed structural validation
- move CFG domain mapping onto canonical type and specialization forms
- bump ordinary and specialized body schemas and add a guard against reintroducing peer mirrors

## Validation

- `scripts/rue fmt`
- `scripts/rue unit compiler durable_` (32/32)
- `scripts/rue quick` (31 targets, zero failures)

Depends on: #1744

Linear: RUE-849
