### PR TITLE
RUE-937: ADR-0059 — unify memory intrinsics into one byte-oriented set

### DIFF
--- a/docs/designs/0059-byte-oriented-memory-intrinsics.md
+++ b/docs/designs/0059-byte-oriented-memory-intrinsics.md
@@ -1,0 +1,512 @@
+---
+id: 0059
+title: "Byte-oriented memory intrinsics: unify the two low-level families"
+status: accepted
+tags: [intrinsics, memory, pointers, allocator, bytes, semantics, stdlib, abi]
+feature-flag: raw_bytes
+created: 2026-07-17
+accepted: 2026-07-17
+implemented:
+spec-sections: []
+superseded-by:
+relates: ["RUE-937", "RUE-879", "RUE-880", "RUE-712", "ADR-0052", "ADR-0005", "ADR-0057"]
+---
+
+# ADR-0059: Byte-oriented memory intrinsics — one intentional set
+
+## Status
+
+Accepted. Ratified by Steve on 2026-07-17, resolving the RUE-937 design gate.
+The open questions below are settled by the rulings recorded in
+[Resolved at acceptance](#resolved-at-acceptance); implementation proceeds in
+the phase order given, starting with Phase 1 (bulk primitives, RUE-937) and
+Phase 2 (RUE-960). This record also serves as the first ADR of record for the
+raw-byte family
+(RUE-879), which shipped behind the `raw_bytes` preview gate without a dedicated
+design document — its semantics have lived only in ADR-0052 (as transitional
+substrate), ADR-0057 (as a consumer), the specification's §9.2, and the
+`PreviewFeature::RawBytes.adr()` string. This document becomes that record and
+proposes where the family goes next.
+
+RUE-937 was filed as "Stabilize `raw_bytes`: remove the preview gate." The
+maintainer direction on RUE-937 re-scoped it away from stabilization: rather
+than freeze the preview byte family as-is, re-orient the older typed family to
+be byte-oriented and deprecate the byte family, choosing "the right set of
+intrinsics, not just whatever we happened to build in the past." This ADR is
+that requested design.
+
+## Summary
+
+Rue has **two parallel low-level memory intrinsic families** that overlap and
+neither of which is the intended surface. This ADR proposes to collapse them
+into **one byte-oriented set**: a byte-and-alignment allocation family
+(`@alloc`/`@realloc`/`@free` carrying `(size, align)` in bytes), the existing
+pointee-typed scalar access pair (`@ptr_read`/`@ptr_write`) plus explicit
+unaligned variants, two new bulk primitives (`@byte_copy` memcpy-shaped,
+`@byte_set` memset-shaped) that replace the hand-rolled per-byte loops in std,
+the element-scaled `@ptr_offset` (kept per ADR-0040), and the segregated
+int↔pointer pair (`@ptr_to_int`/`@int_to_ptr`), all resting on the
+`@size_of`/`@align_of` reflection substrate. The five `_bytes` intrinsics are
+deprecated by folding into this set. Because both families already share the
+`__rue_alloc`/`__rue_free`/`__rue_realloc` runtime helpers, this is a **surface
+redesign, not a runtime ABI change**. The re-orientation of the typed family is
+**sequenced behind ADR-0052 / RUE-880 canonical layout**: only once
+`@size_of(u8)` reports 1 does the typed family become byte-correct, so the
+deprecation cannot precede canonical layout landing. The `raw_bytes` gate is
+**not stabilized** here; it is retargeted to govern the interim byte surface
+until RUE-880 lands.
+
+## Context
+
+### Two families, neither intentional
+
+Rue exposes two disjoint sets of memory intrinsics that do overlapping jobs:
+
+- **Typed / slot family (RUE-1 slot era).** `@alloc`, `@free`, `@realloc`,
+  `@ptr_read`, `@ptr_write`, `@ptr_offset`, `@ptr_to_int`, `@int_to_ptr`. These
+  are pointee-typed and element-count-scaled: `@alloc(count)` reserves
+  `count * @size_of(T)` bytes, `@ptr_offset(p, n)` strides `n * @size_of(T)`,
+  `@ptr_read` moves a whole `T`. Nothing in their semantic analysis hard-codes a
+  width — the analysis is written in terms of `@size_of(T)`. The "8" comes
+  entirely from Rue's current flattened eight-byte-slot layout (ADR-0052), so
+  today `@size_of(u8)` reports 8, `@alloc(n)` of `ptr mut u8` reserves `n*8`
+  bytes, and `@ptr_offset(p_u8, 1)` strides 8. That is precisely why `StrBuf`
+  could not pack bytes through this family.
+
+- **Preview byte family (RUE-879, `--preview raw_bytes`).** `@alloc_bytes`,
+  `@realloc_bytes`, `@free_bytes`, `@byte_read`, `@byte_write`. These are flat
+  `u8`, physical-byte-counted, and byte-aligned. RUE-879 added them as an
+  **expedient unblock for `StrBuf`**: the slot family could not express packed
+  single-byte storage, and the layout migration (RUE-880) was not scheduled, so
+  a byte-shaped family was bolted alongside rather than fixing layout first.
+
+### Why neither is the "right set"
+
+The maintainer direction on RUE-937 states the problem directly: the older
+intrinsics are "shaped around the 8 byte fields rather than intentionally
+designed," and the goal is "the right set of intrinsics, not just whatever we
+happened to build in the past," surveying Rust and Zig — "Rust generally has the
+right intrinsics here" and Zig "is very good at this kind of stuff." Concretely:
+
+- The typed family is slot-shaped: byte-accurate only once RUE-880 lands, and
+  even then it lacks bulk copy/set and an unaligned access mode.
+- The byte family is `u8`-only and cannot express typed multi-unit moves (which
+  `ArrayBuf` needs), has **no alignment parameter** (`@alloc_bytes` guarantees
+  only alignment 1 — flagged as an open question by ADR-0052), and has **no
+  null-pointer primitive** (its consumers reach into the *typed* family's
+  `@int_to_ptr(0)` for the null idiom).
+- Every std consumer that copies bytes hand-rolls a one-byte-at-a-time `while`
+  loop, because there is no bulk-copy primitive in either family.
+
+### The dependency and consumer landscape
+
+- **Shared runtime.** Both families lower to the same three runtime helpers;
+  `RuntimeCallKind::helper()` maps `AllocTyped | AllocBytes → __rue_alloc`,
+  `FreeTyped | FreeBytes → __rue_free`, `ReallocTyped | ReallocBytes →
+  __rue_realloc`. There are no separate `__rue_alloc_bytes` symbols. The helpers
+  already take `(size, align)`; typed calls compute `size = count * size_of(T)`
+  and `align = align_of(T)` in codegen, byte calls pass `size` through with
+  `align = 1`. Unifying the intrinsic surface therefore requires little runtime
+  change.
+- **Canonical layout (ADR-0052 / RUE-880).** ADR-0052 is a proposal; RUE-880 is
+  unscheduled. Its final migration phase is literally "reassess the RUE-879
+  raw-byte family once ordinary `u8` and typed pointer operations use physical
+  layout." The re-orientation this ADR proposes is the same endpoint ADR-0052
+  anticipates, and it presupposes canonical layout has landed or co-lands.
+- **Trusted-std carve-out.** `require_preview` authorizes `raw_bytes` for files
+  with standard-library provenance (by `file_id`, not path), and this carve-out
+  is `RawBytes`-specific. `std/strbuf.rue`, `std/fs.rue`, `std/env.rue`, and
+  `std/mem.rue` depend on it so that programs consuming std need no `--preview
+  raw_bytes`.
+- **ADR-0057 (File IO v0)** is a live consumer: `std.fs` marshals reads and
+  writes through a temporary contiguous `@alloc_bytes` buffer, copying with
+  byte-at-a-time loops, and uses `@ptr_to_int` for null checks and syscall
+  addresses. Its migration intent already points at slices; this proposal must
+  not strand it, so the interim byte surface stays available and `std.fs`
+  re-points at the unified names on the same schedule as `StrBuf`.
+- **ArrayBuf** is the typed-family consumer: it moves whole `T` values through
+  `@ptr_read`/`@ptr_write` (multi-slot aggregates) and steps elements with
+  element-scaled `@ptr_offset`. A pure `u8` byte family cannot serve it, so
+  type-width read/write and element-scaled offset must survive the unification.
+
+## Survey: Rust and Zig
+
+Rust and Zig converge strikingly on the low-level memory surface; the survey
+findings, distilled:
+
+1. **Bytes are the unit at the primitive layer.** Rust `GlobalAlloc::alloc`
+   returns `*mut u8` with size carried in `Layout`; Zig `rawAlloc(len, ...)`
+   returns `[*]u8`. Element counts are sugar computed as `n * size_of(T)` on top.
+2. **Alignment is first-class at allocation** — mandatory, and present on free.
+   Rust carries it in `Layout { size, align }` (align a power of two); Zig passes
+   an `Alignment` (log2 exponent) enum to every vtable method, `free` included.
+   Neither language lets you allocate without stating alignment. Rue's
+   `@alloc_bytes(size)` with no alignment is the one clear defect versus both.
+3. **Free and realloc are sizeless: the caller returns `(size, align)` to the
+   allocator.** Rust's layout-carrying `dealloc` and Zig's `memory: []u8` +
+   `Alignment` `free` both let the allocator avoid per-block headers.
+4. **Typed scalar read/write derive width from the pointee; aligned and
+   unaligned are distinct.** Rust makes it two intrinsics
+   (`read`/`read_unaligned`); Zig makes it one deref parameterized by
+   `*align(N) T`. The *distinction* is non-negotiable — they compile differently
+   and have different UB — but the *spelling* is a design choice.
+5. **Bulk copy and bulk set are primitives, not loops.** Rust
+   `copy_nonoverlapping` (memcpy) / `copy` (memmove) / `write_bytes` (memset);
+   Zig `@memcpy` / `@memset`. Overlap is decided up front: a non-overlapping fast
+   path plus a separate overlapping move.
+6. **Endianness is library code over byte primitives**, never in the allocator
+   or pointer surface. Rust puts it on integers (`to_le_bytes`); Zig in `std`
+   (`writeInt(..., endian)`), always with an explicit endianness argument.
+7. **Element-scaled and byte-granular pointer arithmetic are both real and
+   distinct** — "next element" versus "advance N raw bytes."
+8. **Int↔pointer conversion is a named, segregated escape hatch** kept apart
+   from arithmetic and access (Rust `addr`/`with_addr` and the provenance pair;
+   Zig `@intFromPtr`/`@ptrFromInt`), so the common path never silently launders
+   an address into a pointer.
+
+**The one divergence: alignment and access invariants in the type system vs. in
+intrinsic names.** Zig folds alignment (`*align(N)`), pointer kind (`[*]`/`[]`),
+and length into *types*, shrinking the builtin set to `@memcpy`/`@memset`/
+`@ptrCast`/`@alignCast`/`@intFromPtr`/`@ptrFromInt` plus the `@sizeOf` family.
+Rust encodes them in intrinsic *names* (`read_unaligned`) and wrapper structs
+(`Layout`, `NonNull`). Zig's approach yields fewer primitives but demands a
+richer pointer type system.
+
+**Recommendation for Rue.** Rue has comptime type parameters but does not yet
+have Zig's `*align(N)` pointer types. The pragmatic fit at Rue's stage is to
+take **Zig's byte-oriented allocator ABI** and **Rust's explicit aligned/
+unaligned intrinsic split**, deferring type-carried alignment until the pointer
+type system grows. Endianness stays out of the intrinsic surface entirely —
+binary format readers/writers are source-defined over `int ↔ [N]u8` conversion
+plus `@byte_copy`.
+
+## Decision
+
+Adopt one byte-oriented intrinsic set. Signatures below use `ptr mut u8` /
+`ptr const u8` for the byte surface and pointee-typed `ptr T` where width is
+derived from `T`. All argument sizes and offsets in the allocation and bulk
+families are **byte counts**; alignment is a byte count that must be a power of
+two. Every intrinsic remains `checked`-gated (unchecked operations) exactly as
+today.
+
+### Allocation — byte size + explicit alignment, sizeless free
+
+```text
+@alloc(size: u64, align: u64)                          -> ptr mut u8
+@realloc(p: ptr mut u8, old_size: u64, align: u64, new_size: u64) -> ptr mut u8
+@free(p: ptr mut u8, size: u64, align: u64)            -> ()
+```
+
+`size`/`old_size`/`new_size` are bytes; `align` is a power-of-two byte count.
+Null is returned on OOM; `size == 0` follows the existing zero rules. This is
+the sizeless-allocator ABI (principles 1–3): the caller returns `(size, align)`
+so the runtime stays header-free. The runtime helpers already accept
+`(size, align)`, so this is an operand-plan and signature change only — no new
+`__rue_*` symbol. Typed allocation becomes **source-defined sugar**: `ArrayBuf`
+allocates `@alloc(count * @size_of(T), @align_of(T))`, exactly as Rust
+`alloc(T, n)` and Zig `alignedAlloc` compute `n * size_of(T)` over the byte ABI.
+This absorbs `@alloc_bytes`/`@realloc_bytes`/`@free_bytes` and supplies the
+alignment parameter they lack — the defect ADR-0052 flagged.
+
+### Typed scalar access — width from the pointee, aligned + unaligned
+
+```text
+@ptr_read(p: ptr const T | ptr mut T)                  -> T
+@ptr_write(p: ptr mut T, value: T)                     -> ()
+@ptr_read_unaligned(p: ptr const T | ptr mut T)        -> T          (new)
+@ptr_write_unaligned(p: ptr mut T, value: T)           -> ()         (new)
+```
+
+**Reconciliation with the survey strawman.** The strawman spelled these
+`@ptr_read(comptime T, p)`. Rue already has the *better* shape: `@ptr_read`
+derives `T` from the pointee via HM inference (reconciled against the annotation
+to avoid silent truncation, RUE-244), so no explicit type argument is needed.
+Keep Rue's existing pointee-typed spelling. The aligned pair keeps its current
+signatures; RUE-880 makes their width physically correct (`@size_of(T)` bytes
+instead of a slot). The **new** `_unaligned` variants are the Rust-style
+explicit escape for packed/parsed data, chosen over a `*align(N)` pointer type
+because Rue lacks alignment-qualified pointers today. `@ptr_read`/`@ptr_write`
+must survive because `ArrayBuf` moves whole multi-unit `T` values a `u8`-only
+family cannot express.
+
+### Bulk memory — the missing primitives
+
+```text
+@byte_copy(dst: ptr mut u8, src: ptr const u8, size: u64) -> ()      (new; non-overlapping)
+@byte_set(dst: ptr mut u8, byte: u8, size: u64)           -> ()      (new; memset)
+```
+
+`@byte_copy` is memcpy-shaped: `dst` and `src` must not overlap. `@byte_set` is
+memset-shaped. These replace **every** hand-rolled per-byte loop in std —
+`StrBuf::copy_packed_bytes`, the `std.fs` read/write marshalling loops, and
+`std.mem.swap` — which is the single most-requested missing operation. An
+overlapping `@byte_move` (memmove) is deferred until a real overlapping use
+appears (see Open Questions); none exists in std today.
+
+### Pointer arithmetic — element-scaled, kept
+
+```text
+@ptr_offset(p: ptr T, offset: integer)                 -> ptr T
+```
+
+Kept as element-scaled (`addr + n * @size_of(T)`), unchanged in spelling.
+ADR-0040 already ratified this as standard pointer arithmetic and `ArrayBuf`
+depends on it. Post-RUE-880, at `T = u8` it strides one byte naturally, so
+byte-granular walking is `@ptr_offset` on a `ptr u8`; no separate byte-granular
+intrinsic is added at this stage (add a byte-granular variant later only on
+demonstrated need).
+
+### Int↔pointer — the segregated escape hatch, kept
+
+```text
+@ptr_to_int(p: ptr T)                                  -> u64
+@int_to_ptr(addr: u64)                                 -> ptr mut T
+```
+
+Kept unchanged. These stay distinct from arithmetic and access (principle 8).
+`@int_to_ptr(0)` remains the null-pointer idiom and `@ptr_to_int(p) == 0` the
+null check — the byte family never had these, and the unified set does not
+strand the consumers that borrow them. Names are chosen so a later strict/exposed
+provenance split does not force a rename of the common path.
+
+### Reflection substrate — kept, made byte-accurate by RUE-880
+
+`@size_of` and `@align_of` are the substrate the entire byte surface computes on
+(typed allocation, buffer sizing, field displacement). They are unchanged in
+spelling; RUE-880 makes them report physical bytes instead of slots, which is
+what makes the whole re-orientation byte-correct. `@offset_of` can join when
+aggregate layout stabilizes.
+
+### Fate of every current intrinsic
+
+All eight typed intrinsics and all five byte intrinsics — thirteen total:
+
+| Current intrinsic | Family | Fate | Detail |
+|---|---|---|---|
+| `@alloc` | typed | **Re-shape** | Becomes byte + align: `@alloc(size, align)`, size in bytes. Absorbs `@alloc_bytes`. `ArrayBuf` computes `size = count*@size_of(T)`, `align = @align_of(T)` in source. |
+| `@realloc` | typed | **Re-shape** | `@realloc(p, old_size, align, new_size)` in bytes. Absorbs `@realloc_bytes`. |
+| `@free` | typed | **Re-shape** | `@free(p, size, align)` — sizeless-allocator ABI. Absorbs `@free_bytes`. |
+| `@ptr_read` | typed | **Keep + re-semantics** | Signature kept (pointee-typed via HM). Width becomes physical `@size_of(T)` post-RUE-880, not an 8-byte slot. Gains `@ptr_read_unaligned`. |
+| `@ptr_write` | typed | **Keep + re-semantics** | Same. Gains `@ptr_write_unaligned`. |
+| `@ptr_offset` | typed | **Keep** | Element-scaled (ADR-0040). Becomes byte-exact stride post-RUE-880; strides 1 at `T = u8`. |
+| `@ptr_to_int` | typed | **Keep** | Correct escape-hatch shape; unchanged. |
+| `@int_to_ptr` | typed | **Keep** | Unchanged. Remains the null-pointer idiom for all consumers. |
+| `@alloc_bytes` | preview | **Deprecate → fold** | Into re-shaped `@alloc`; gains the missing `align` parameter. |
+| `@realloc_bytes` | preview | **Deprecate → fold** | Into re-shaped `@realloc`. |
+| `@free_bytes` | preview | **Deprecate → fold** | Into re-shaped `@free`. |
+| `@byte_read` | preview | **Deprecate → fold** | Subsumed by `@ptr_read` on a `ptr u8` (width 1 post-RUE-880); redundant once width derives from the pointee. |
+| `@byte_write` | preview | **Deprecate → fold** | Subsumed by `@ptr_write` on a `ptr u8`. |
+| — | new | **Add** | `@byte_copy`, `@byte_set`, `@ptr_read_unaligned`, `@ptr_write_unaligned`. |
+
+Net: one byte-and-alignment allocation family, the pointee-typed scalar access
+pair plus explicit unaligned variants, two bulk primitives, an element-scaled
+offset, and a segregated int↔pointer pair, all over the `@size_of`/`@align_of`
+substrate. Everything above — `StrBuf`, IO buffers, binary format readers,
+endianness — stays source-defined, matching how Rust and Zig keep policy out of
+the primitive surface.
+
+## Sequencing
+
+The re-orientation of the **typed** family is gated on ADR-0052 / RUE-880
+canonical layout. Today `@size_of` reports slot-flattened sizes, so byte-correct
+typed operations only make sense post-migration: until `@size_of(u8) == 1`, the
+typed family still strides and allocates in eight-byte slots, and `StrBuf`/
+`std.fs` cannot move onto it. "Deprecate the byte family" therefore **cannot
+precede canonical layout landing**. RUE-880's own final phase already names this
+reassessment; this ADR supplies its target shape.
+
+**Can happen now, independent of RUE-880:**
+
+- Add `@byte_copy` and `@byte_set` to the interim byte surface. They replace the
+  hand-rolled per-byte loops in `std/strbuf.rue`, `std/fs.rue`, and `std/mem.rue`
+  immediately and depend on no layout change — pure wins available today.
+- Add the alignment parameter to the byte allocator (fix the `@alloc_bytes`
+  alignment-1 defect that ADR-0052 flags), so the interim surface already carries
+  the `(size, align)` contract the final `@alloc` requires.
+
+**Must wait for RUE-880 (or co-land with its compact-representation phase):**
+
+- Re-shaping `@alloc`/`@realloc`/`@free` from element counts to byte + align and
+  folding the `_bytes` allocators into them.
+- Making `@ptr_read`/`@ptr_write`/`@ptr_offset` byte-correct and folding
+  `@byte_read`/`@byte_write` into `@ptr_read`/`@ptr_write`.
+- Adding `@ptr_read_unaligned`/`@ptr_write_unaligned` (their contract is only
+  meaningful once alignment is a real physical property).
+
+**Disposition of the moving parts:**
+
+- **The `raw_bytes` preview gate (RUE-937).** Not stabilized. RUE-937 is
+  re-scoped from "remove the gate" to "deliver the unified set." The gate is
+  retained and retargeted to govern the interim byte surface (including the new
+  bulk primitives) and the unified set until RUE-880 lands and the surface is
+  proven; it is then removed by the ADR-0005 stabilization procedure (drop
+  `preview =` from spec tests, remove `require_preview()`, remove the
+  `PreviewFeature::RawBytes` variant, set this ADR to `implemented`). Per the
+  acceptance ruling, the surface stays gated until RUE-880 lands and is
+  stabilized once, at the end — no partial early stabilization.
+- **The `trusted_std_raw_bytes` carve-out.** Retained unchanged while the gate
+  exists — `std/strbuf.rue`, `std/fs.rue`, `std/env.rue`, `std/mem.rue` keep
+  authorization by std provenance, and the two tests in
+  `std_internal_raw_bytes.toml` keep asserting it. It is removed together with
+  the gate at stabilization.
+- **Specification sweep.** The eventual sweep touches the intrinsic registry
+  table row `4.13:5a` (rename/merge of the listed names) and the normative
+  semantics in §9.2: `9.2:7` (`@ptr_offset` scaling), `9.2:10`–`9.2:13` (alloc/
+  free/realloc redefined from element counts to physical bytes), and the entire
+  gated raw-byte block `9.2:14a`–`9.2:14f` (folded in or removed) — in
+  particular the `9.2:14a` clause that explicitly *preserves* element scaling is
+  the sentence that must be rewritten. This ADR only names these paragraphs; it
+  does not edit the specification (spec edits land with the implementing phases
+  per AGENTS.md).
+
+## Implementation Phases
+
+Phases are ordered by the sequencing above. RUE-937 is the tracking issue.
+
+- [ ] **Phase 1: Bulk primitives (now, no RUE-880 dependency)** — RUE-937. Add
+  `@byte_copy` and `@byte_set` to the `raw_bytes` surface; port
+  `StrBuf::copy_packed_bytes`, the `std.fs` marshalling loops, and
+  `std.mem.swap` off their per-byte loops; add spec coverage under the existing
+  gate.
+- [ ] **Phase 2: Alignment on the byte allocator (now)** — RUE-960. Add
+  the `align` parameter to the byte allocator, giving the interim surface the
+  `(size, align)` contract; update the runtime operand plan (already
+  `(size, align)`-shaped) and `std` call sites.
+- [ ] **Phase 3: Byte-oriented allocation family (post-/co-RUE-880)** —
+  RUE-961. Re-shape `@alloc`/`@realloc`/`@free` to byte + align; fold
+  the `_bytes` allocators in; move `ArrayBuf` typed allocation to source-computed
+  `@size_of`/`@align_of` sugar.
+- [ ] **Phase 4: Byte-correct typed access (post-RUE-880)** — RUE-962.
+  Make `@ptr_read`/`@ptr_write`/`@ptr_offset` physical-layout-driven; add
+  `@ptr_read_unaligned`/`@ptr_write_unaligned`; fold `@byte_read`/`@byte_write`
+  into `@ptr_read`/`@ptr_write`. Before implementing the `_unaligned` pair,
+  re-evaluate `*align(N)` alignment-qualified pointer types (see the ruling
+  below): if RUE-880 has landed and slices have stabilized by then, type-carried
+  alignment may replace the two-intrinsic split at near-zero churn, since
+  nothing will have been built on the split yet.
+- [ ] **Phase 5: Specification sweep** — RUE-963. Rewrite `4.13:5a` and
+  `9.2:7`,`9.2:10`–`9.2:13`, and remove/fold `9.2:14a`–`9.2:14f`; update
+  traceability.
+- [ ] **Phase 6: Stabilize and de-gate** — RUE-937. Per ADR-0005: remove
+  `preview =` from spec tests, remove the five `require_preview()` sites, remove
+  the `trusted_std_raw_bytes` carve-out and `PreviewFeature::RawBytes`, set this
+  ADR `implemented`.
+
+## Consequences
+
+### Positive
+
+- **One intentional surface.** A single set matching Rust/Zig convergence
+  replaces two accidental families; the `u8`-only limitation, the missing
+  alignment parameter, and the missing null primitive all disappear.
+- **Bulk primitives available immediately.** `@byte_copy`/`@byte_set` land in
+  Phase 1 with no RUE-880 dependency and delete every hand-rolled per-byte loop
+  in std — a correctness and performance win before the layout migration.
+- **No runtime ABI churn.** The shared `__rue_alloc`/`__rue_free`/`__rue_realloc`
+  helpers already take `(size, align)`; this is a surface and operand-plan
+  redesign, not a runtime change.
+- **Alignment becomes a real contract.** The `(size, align)` allocation ABI
+  satisfies ADR-0052's requirement that raw allocation for later typed access
+  prove both size and alignment.
+- **ADR-0057 is not stranded.** `std.fs` keeps a working byte surface throughout
+  and re-points at the unified names on schedule; its slice migration is
+  orthogonal.
+
+### Negative
+
+- **Gated on an unscheduled migration.** The typed re-orientation cannot land
+  until RUE-880, which is itself a proposal; the full payoff is deferred.
+- **Std call-site churn.** `StrBuf`, `ArrayBuf`, `std.fs`, `std.env`, and
+  `std.mem` all change call sites (typed allocation becomes source-computed byte
+  sugar; per-byte loops become bulk calls).
+- **Spec rewrite of live normative text.** The §9.2 raw-byte block and the
+  element-scaling clauses must be rewritten, not merely extended.
+- **Two-step deprecation window.** While the interim and unified surfaces
+  coexist, the `raw_bytes` gate and its trusted-std carve-out persist longer
+  than a simple stabilization would.
+
+### Neutral
+
+- Endianness stays out of the intrinsic surface by design; binary formats remain
+  source-defined over `int ↔ [N]u8` plus `@byte_copy`.
+- No change to the `checked {}` requirement; every intrinsic here stays
+  unchecked-gated.
+
+## Resolved at acceptance
+
+The proposal's open questions, settled by the 2026-07-17 ratification:
+
+- **Alignment spelling: plain `align: u64`, power-of-two, validated.** Sema
+  rejects non-power-of-two constants at compile time; runtime values carry a
+  checked-gate-consistent contract. A dedicated `Align`/`Layout` type (Zig's
+  log2 `Alignment`, Rust's `Layout`) is deferred — the call-site shape does not
+  change when a typed refinement arrives.
+- **Deprecation shape: hard removal at fold-in, no alias window.** The `_bytes`
+  names have four consumers, all in `std/`, all migrated in the same PR that
+  folds them. Preview-gated user code is opted into instability by definition
+  (ADR-0005); an alias window would double the spec surface for names being
+  deleted.
+- **Gate timing: single de-gate at the end.** The unified surface stays behind
+  `raw_bytes` until RUE-880 lands and the surface is proven, then stabilizes
+  once (Phase 6). Partial early stabilization of the bulk primitives would
+  leave §9.2 describing a half-gated family, and the features users want reach
+  them ungated through std via the trusted-std carve-out regardless.
+- **Overlapping copy: deferred.** `@byte_copy` (non-overlapping) only; no std
+  consumer overlaps today, and a later `@byte_move` (memmove) is purely
+  additive.
+- **Null primitive: keep the `@int_to_ptr(0)` idiom.** A dedicated `@null_ptr`
+  acquires design questions (typed or untyped result?) better answered by the
+  future provenance work.
+- **Aligned/unaligned spelling: Rust-style `_unaligned` intrinsics, with a
+  Phase 4 checkpoint.** Type-carried `*align(N)` alignment (Zig model) changes
+  only the access split — the allocator still passes alignment explicitly even
+  in Zig, and Rue's access surface is intrinsic-shaped rather than
+  deref-shaped, so the ergonomic delta is small. Because the `_unaligned` pair
+  is Phase 4 (post-RUE-880) and nothing is built on the split before then,
+  Phase 4 explicitly re-evaluates `*align(N)` before implementing the
+  intrinsics; a byte-granular `@ptr_offset` variant is likewise deferred to
+  demonstrated need (element-scaled at `T = u8` covers byte walking
+  post-RUE-880).
+
+## Future Work
+
+Explicitly out of scope for this ADR, for later designs:
+
+- **`*align(N)` pointer types** folding the aligned/unaligned split into the
+  type system (Zig model), retiring the `_unaligned` intrinsics — when Rue's
+  pointer types grow richer (ties to ADR-0052's alignment-qualified-pointer open
+  question).
+- **Strict/exposed provenance split** on `@ptr_to_int`/`@int_to_ptr` as Rue's
+  memory model formalizes.
+- **In-place-only resize** (`@resize` returning a success bool, Zig-style) for
+  containers that manage their own copy.
+- **`@offset_of`** once aggregate layout stabilizes under RUE-880.
+- **`@alloc_zeroed`** if the allocator can zero more cheaply than `@byte_set`.
+- **Endianness** stays library-level forever (`to_le_bytes`/`from_le_bytes`-style
+  conversions over the byte primitives); no byte-order intrinsic.
+
+## References
+
+- RUE-937 — tracking issue (re-scoped from "stabilize `raw_bytes`" to this
+  unification).
+- RUE-879 — the transitional raw-byte intrinsic family (no prior ADR of record;
+  this document becomes it).
+- RUE-880 / ADR-0052 — canonical physical type layout; its final phase reassesses
+  the raw-byte family, and it flags the `@alloc_bytes` alignment defect.
+- RUE-712 / ADR-0057 — File IO v0, a live consumer of the byte family and the
+  trusted-std carve-out.
+- ADR-0005 — preview-feature gating and stabilization procedure.
+- ADR-0040 — ascending array layout and element-scaled `@ptr_offset` (preserved).
+- ADR-0028 — unchecked code and raw pointers (the `checked {}` requirement).
+- Rust `std::alloc::GlobalAlloc` and `Layout` (byte + power-of-two align,
+  layout-carrying `dealloc`): <https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html>,
+  <https://doc.rust-lang.org/std/alloc/struct.Layout.html>
+- Rust `core::ptr` (`read`/`write`/`read_unaligned`/`copy_nonoverlapping`/
+  `write_bytes`): <https://doc.rust-lang.org/std/ptr/index.html>,
+  <https://doc.rust-lang.org/std/ptr/fn.read_unaligned.html>
+- Rust pointer methods and provenance (`add`/`byte_add`, `addr`/`with_addr`):
+  <https://doc.rust-lang.org/std/primitive.pointer.html>
+- Zig `std.mem.Allocator` (byte `len`, first-class `Alignment`, sizeless
+  `free`): <https://github.com/ziglang/zig/blob/master/lib/std/mem/Allocator.zig>
+- Zig language reference (`@memcpy`/`@memset`/`@intFromPtr`/`@ptrFromInt`/
+  `*align(N)`): <https://ziglang.org/documentation/master/>

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -221,4 +221,5 @@ The table is generated from ADR frontmatter. Run
 | [0056](0056-typed-ir-payload-schemas.md) | Typed IR payload schemas | Implemented | architecture, compiler, ir, performance, validation |
 | [0057](0057-file-io-v0.md) | File IO v0: pure-Rue fs over @syscall with normalized FileError | Accepted | stdlib, io, syscalls, runtime, error-handling, ownership |
 | [0058](0058-canonical-semantic-artifact-algebra.md) | Canonical semantic artifact algebra | Accepted | architecture, compiler, incremental, semantics, validation |
+| [0059](0059-byte-oriented-memory-intrinsics.md) | Byte-oriented memory intrinsics: unify the two low-level families | Accepted | intrinsics, memory, pointers, allocator, bytes, semantics, stdlib, abi |
 <!-- ADR-INDEX:END -->


### PR DESCRIPTION
## Summary

RUE-937 was filed as "Stabilize `raw_bytes`: remove the preview gate", but the maintainer comment on the issue re-scoped it: rather than freeze the expedient RUE-879 byte family, re-orient the older slot-shaped typed family to be byte-oriented and deprecate the byte family — "the right set of intrinsics, not just whatever we happened to build in the past," informed by a Rust/Zig survey.

This PR adds **ADR-0059** (renumbered from 0058 after trunk assigned that id to the canonical semantic artifact algebra ADR), which:

- Surveys Rust (`GlobalAlloc`/`Layout`, `core::ptr`, provenance APIs) and Zig (`std.mem.Allocator`, builtins, type-carried alignment) and distills the convergent principles: bytes as the unit, mandatory `(size, align)` at allocation with sizeless free, pointee-derived access width with an explicit aligned/unaligned split, bulk copy/set as primitives, endianness kept in library code, and a segregated int↔pointer escape hatch.
- Proposes the unified set: `@alloc`/`@realloc`/`@free` re-shaped to byte size + power-of-two alignment (absorbing `@alloc_bytes`/`@realloc_bytes`/`@free_bytes`), `@ptr_read`/`@ptr_write` kept pointee-typed plus new `@ptr_read_unaligned`/`@ptr_write_unaligned`, new bulk `@byte_copy`/`@byte_set` primitives (replacing every hand-rolled per-byte loop in `std/strbuf.rue`, `std/fs.rue`, `std/mem.rue`), `@ptr_offset` kept element-scaled per ADR-0040, and `@ptr_to_int`/`@int_to_ptr` kept as the null idiom and escape hatch. Includes a fate table for all thirteen current intrinsics.
- Is recorded as **accepted**: ratified 2026-07-17, with the rulings on all six open questions captured in a "Resolved at acceptance" section (plain `u64` power-of-two alignment; hard removal of the `_bytes` names at fold-in; single de-gate at the end; `@byte_move` deferred; `@int_to_ptr(0)` null idiom kept; Rust-style `_unaligned` split with an explicit `*align(N)` re-evaluation checkpoint at Phase 4).
- Sequences the work: Phase 1 (bulk primitives) and Phase 2 (byte-allocator alignment parameter, RUE-960) can land now under the existing gate; Phases 3–4 (RUE-961/962) are gated on the ADR-0052 canonical-layout migration; Phase 5 is the spec sweep (RUE-963); Phase 6 is the single final de-gate. The `trusted_std_raw_bytes` carve-out is retained until then.
- Serves as the first ADR of record for the RUE-879 raw-byte family, and regenerates the ADR index (registry valid, 60 records).

Part of RUE-937. Deliberately no closing line: RUE-937 remains the tracking issue for the implementation phases.