### PR TITLE
RUE-937: add @byte_copy/@byte_set bulk byte intrinsics (ADR-0059 Phase 1)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1625,6 +1625,50 @@ impl<'a> ConstraintGenerator<'a> {
                         }
                     }
                     InferType::Concrete(Type::UNIT)
+                } else if intrinsic_name == "byte_copy" {
+                    // @byte_copy(dst: ptr mut u8, src: ptr const u8 | ptr mut u8,
+                    // size: u64) -> (). Constrain dst to `ptr mut u8` and size to
+                    // u64; the source pointer may be const or mut u8, so it is
+                    // left to sema's `require_u8_pointer` rather than pinned here.
+                    let ptr_ty =
+                        Type::new_ptr_mut(self.type_pool.intern_ptr_mut_from_type(Type::U8));
+                    for (i, arg_ref) in args.iter().enumerate() {
+                        let info = self.generate(*arg_ref, ctx);
+                        let expected = match i {
+                            0 => Some(ptr_ty),
+                            2 => Some(Type::U64),
+                            _ => None,
+                        };
+                        if let Some(expected) = expected {
+                            self.add_constraint(Constraint::equal(
+                                info.ty,
+                                InferType::Concrete(expected),
+                                info.span,
+                            ));
+                        }
+                    }
+                    InferType::Concrete(Type::UNIT)
+                } else if intrinsic_name == "byte_set" {
+                    // @byte_set(dst: ptr mut u8, byte: u8, size: u64) -> ().
+                    let ptr_ty =
+                        Type::new_ptr_mut(self.type_pool.intern_ptr_mut_from_type(Type::U8));
+                    for (i, arg_ref) in args.iter().enumerate() {
+                        let info = self.generate(*arg_ref, ctx);
+                        let expected = match i {
+                            0 => Some(ptr_ty),
+                            1 => Some(Type::U8),
+                            2 => Some(Type::U64),
+                            _ => None,
+                        };
+                        if let Some(expected) = expected {
+                            self.add_constraint(Constraint::equal(
+                                info.ty,
+                                InferType::Concrete(expected),
+                                info.span,
+                            ));
+                        }
+                    }
+                    InferType::Concrete(Type::UNIT)
                 } else if intrinsic_name == "int_to_ptr" {
                     // @int_to_ptr: returns a pointer type inferred from context
                     for arg_ref in args.iter() {

--- a/crates/rue-air/src/runtime_call.rs
+++ b/crates/rue-air/src/runtime_call.rs
@@ -8,12 +8,21 @@ use rue_runtime_abi::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RuntimeOperandOrigin {
     OutResult(AggregateShapeId),
-    ValueArgument { index: u8, ty: AbiType },
+    ValueArgument {
+        index: u8,
+        ty: AbiType,
+    },
     SignExtendedArgument(u8),
     ZeroExtendedArgument(u8),
     BoolWordArgument(u8),
     AbiExtendedIntegerArgument(u8),
-    MutablePointerArgument { index: u8, source: RuntimeAirType },
+    MutablePointerArgument {
+        index: u8,
+        source: RuntimeAirType,
+    },
+    /// A `ptr const u8` / `ptr mut u8` argument passed straight through to a
+    /// `const u8*` runtime parameter (the `@byte_copy` source, ADR-0058).
+    BytePointerArgument(u8),
     TextPointer(u8),
     TextLength(u8),
     ProjectedTextPointer(u8),
@@ -21,7 +30,10 @@ pub enum RuntimeOperandOrigin {
     ResultPointeeAlign,
     ScaledByResultPointeeSize(u8),
     PointerPointeeAlign(u8),
-    ScaledByPointerPointeeSize { pointer: u8, count: u8 },
+    ScaledByPointerPointeeSize {
+        pointer: u8,
+        count: u8,
+    },
     OptionDiscriminant(OptionVariant),
     ByteAlignment,
 }
@@ -73,7 +85,7 @@ impl RuntimeOperandOrigin {
     fn accepts(self, parameter: AbiParameter) -> bool {
         match self {
             Self::OutResult(shape) => parameter.mode == ParameterMode::OutPointer(shape),
-            Self::TextPointer(_) | Self::ProjectedTextPointer(_) => {
+            Self::TextPointer(_) | Self::ProjectedTextPointer(_) | Self::BytePointerArgument(_) => {
                 parameter.ty == AbiType::Byte && parameter.mode == ParameterMode::ConstPointer
             }
             Self::TextLength(_)
@@ -145,6 +157,8 @@ pub enum RuntimeCallKind {
     EnvCount,
     EnvPtr,
     EnvLen,
+    ByteCopy,
+    ByteSet,
 }
 
 const STR_BYTE_AT: &[RuntimeOperandOrigin] = &[
@@ -268,9 +282,31 @@ const REALLOC_BYTES: &[RuntimeOperandOrigin] = &[
     },
     RuntimeOperandOrigin::ByteAlignment,
 ];
+const BYTE_COPY: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::MutablePointerArgument {
+        index: 0,
+        source: RuntimeAirType::MutBytePointer,
+    },
+    RuntimeOperandOrigin::BytePointerArgument(1),
+    RuntimeOperandOrigin::ValueArgument {
+        index: 2,
+        ty: AbiType::U64,
+    },
+];
+const BYTE_SET: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::MutablePointerArgument {
+        index: 0,
+        source: RuntimeAirType::MutBytePointer,
+    },
+    RuntimeOperandOrigin::ZeroExtendedArgument(1),
+    RuntimeOperandOrigin::ValueArgument {
+        index: 2,
+        ty: AbiType::U64,
+    },
+];
 
 impl RuntimeCallKind {
-    pub const ALL: [Self; 38] = [
+    pub const ALL: [Self; 40] = [
         Self::StrByteAt,
         Self::StrCharScalar,
         Self::StrCharNext,
@@ -309,6 +345,8 @@ impl RuntimeCallKind {
         Self::EnvCount,
         Self::EnvPtr,
         Self::EnvLen,
+        Self::ByteCopy,
+        Self::ByteSet,
     ];
 
     pub const fn helper(self) -> RuntimeHelperId {
@@ -346,6 +384,8 @@ impl RuntimeCallKind {
             Self::EnvCount => RuntimeHelperId::EnvCount,
             Self::EnvPtr => RuntimeHelperId::EnvPtr,
             Self::EnvLen => RuntimeHelperId::EnvLen,
+            Self::ByteCopy => RuntimeHelperId::ByteCopy,
+            Self::ByteSet => RuntimeHelperId::ByteSet,
         }
     }
 
@@ -384,6 +424,8 @@ impl RuntimeCallKind {
             Self::AllocBytes => ALLOC_BYTES,
             Self::FreeBytes => FREE_BYTES,
             Self::ReallocBytes => REALLOC_BYTES,
+            Self::ByteCopy => BYTE_COPY,
+            Self::ByteSet => BYTE_SET,
         }
     }
 
@@ -564,6 +606,9 @@ impl RuntimeCallKind {
                 }
                 RuntimeOperandOrigin::TextPointer(index)
                 | RuntimeOperandOrigin::TextLength(index) => require(index, RuntimeAirType::Text),
+                RuntimeOperandOrigin::BytePointerArgument(index) => {
+                    require(index, RuntimeAirType::BytePointer)
+                }
                 RuntimeOperandOrigin::ProjectedTextPointer(index) => {
                     require(index, RuntimeAirType::BytePointer)
                 }

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -52,6 +52,8 @@ impl<'a> BodySema<'a> {
                 || name == known.free_bytes
                 || name == known.byte_read
                 || name == known.byte_write
+                || name == known.byte_copy
+                || name == known.byte_set
                 || name == known.arg_ptr
                 || name == known.env_ptr)
         {
@@ -203,6 +205,10 @@ impl<'a> BodySema<'a> {
             self.analyze_byte_read_intrinsic(air, name, &args, span, ctx)
         } else if name == known.byte_write {
             self.analyze_byte_write_intrinsic(air, name, &args, span, ctx)
+        } else if name == known.byte_copy {
+            self.analyze_byte_copy_intrinsic(air, name, &args, span, ctx)
+        } else if name == known.byte_set {
+            self.analyze_byte_set_intrinsic(air, name, &args, span, ctx)
         } else if name == known.raw {
             let raw = self.known.raw;
             self.analyze_addr_of_intrinsic(air, &args, span, ctx, false, raw, "addr_of")

--- a/crates/rue-air/src/sema/analysis/pointers.rs
+++ b/crates/rue-air/src/sema/analysis/pointers.rs
@@ -717,6 +717,85 @@ impl<'a> BodySema<'a> {
         Ok(AnalysisResult::new(air_ref, Type::UNIT))
     }
 
+    /// Analyze `@byte_copy(dst: ptr mut u8, src: ptr const u8 | ptr mut u8,
+    /// size: u64) -> ()` (ADR-0058 Phase 1, RUE-937). A memcpy-shaped bulk copy
+    /// of `size` physical bytes; `dst` and `src` must not overlap (undefined
+    /// behavior otherwise) and `size == 0` is a no-op. Lowers to the shared
+    /// `__rue_byte_copy` runtime helper.
+    pub(super) fn analyze_byte_copy_intrinsic(
+        &mut self,
+        air: &mut Air,
+        name: Spur,
+        args: &[RirCallArg],
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        self.require_preview(PreviewFeature::RawBytes, "@byte_copy intrinsic", span)?;
+        if args.len() != 3 {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "byte_copy".to_string(),
+                    expected: 3,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+        let dst = self.analyze_inst(air, args[0].value, ctx)?;
+        self.require_mut_u8_pointer("byte_copy", dst.ty, span)?;
+        let src = self.analyze_inst(air, args[1].value, ctx)?;
+        self.require_u8_pointer("byte_copy", src.ty, span)?;
+        let size = self.analyze_inst(air, args[2].value, ctx)?;
+        self.require_intrinsic_type("byte_copy", size.ty, Type::U64, span)?;
+        let air_ref = air.add_intrinsic(
+            Some(crate::RuntimeCallKind::ByteCopy),
+            name,
+            &[dst.air_ref, src.air_ref, size.air_ref],
+            Type::UNIT,
+            span,
+        )?;
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+    }
+
+    /// Analyze `@byte_set(dst: ptr mut u8, byte: u8, size: u64) -> ()`
+    /// (ADR-0058 Phase 1, RUE-937). A memset-shaped fill of `size` physical
+    /// bytes with `byte`; `size == 0` is a no-op. Lowers to the shared
+    /// `__rue_byte_set` runtime helper.
+    pub(super) fn analyze_byte_set_intrinsic(
+        &mut self,
+        air: &mut Air,
+        name: Spur,
+        args: &[RirCallArg],
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        self.require_preview(PreviewFeature::RawBytes, "@byte_set intrinsic", span)?;
+        if args.len() != 3 {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "byte_set".to_string(),
+                    expected: 3,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+        let dst = self.analyze_inst(air, args[0].value, ctx)?;
+        self.require_mut_u8_pointer("byte_set", dst.ty, span)?;
+        let byte = self.analyze_inst(air, args[1].value, ctx)?;
+        self.require_intrinsic_type("byte_set", byte.ty, Type::U8, span)?;
+        let size = self.analyze_inst(air, args[2].value, ctx)?;
+        self.require_intrinsic_type("byte_set", size.ty, Type::U64, span)?;
+        let air_ref = air.add_intrinsic(
+            Some(crate::RuntimeCallKind::ByteSet),
+            name,
+            &[dst.air_ref, byte.air_ref, size.air_ref],
+            Type::UNIT,
+            span,
+        )?;
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+    }
+
     fn require_intrinsic_type(
         &self,
         name: &str,

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -139,6 +139,10 @@ pub struct KnownSymbols {
     pub free_bytes: Spur,
     pub byte_read: Spur,
     pub byte_write: Spur,
+    /// Bulk byte primitives `@byte_copy` (memcpy) and `@byte_set` (memset),
+    /// ADR-0058 Phase 1 (RUE-937).
+    pub byte_copy: Spur,
+    pub byte_set: Spur,
 
     // Target platform intrinsics
     /// The `target_arch` intrinsic symbol - returns target CPU architecture.
@@ -205,6 +209,8 @@ impl KnownSymbols {
             free_bytes: interner.get_or_intern_static("free_bytes"),
             byte_read: interner.get_or_intern_static("byte_read"),
             byte_write: interner.get_or_intern_static("byte_write"),
+            byte_copy: interner.get_or_intern_static("byte_copy"),
+            byte_set: interner.get_or_intern_static("byte_set"),
 
             // Target platform intrinsics
             target_arch: interner.get_or_intern_static("target_arch"),
@@ -285,6 +291,8 @@ mod tests {
         assert_eq!(interner.resolve(&known.free_bytes), "free_bytes");
         assert_eq!(interner.resolve(&known.byte_read), "byte_read");
         assert_eq!(interner.resolve(&known.byte_write), "byte_write");
+        assert_eq!(interner.resolve(&known.byte_copy), "byte_copy");
+        assert_eq!(interner.resolve(&known.byte_set), "byte_set");
         assert_eq!(interner.resolve(&known.target_arch), "target_arch");
         assert_eq!(interner.resolve(&known.target_os), "target_os");
     }

--- a/crates/rue-cli-tests/cases/std_strbuf.toml
+++ b/crates/rue-cli-tests/cases/std_strbuf.toml
@@ -224,7 +224,7 @@ fn main() -> i32 {
 """ }]
 args = ["--emit", "mir", "main.rue"]
 compile_only = true
-compile_stdout_contains = ["duplicate", "byte_range", "concat_borrowed", "read_packed_byte", "write_packed_byte"]
+compile_stdout_contains = ["duplicate", "byte_range", "concat_borrowed", "copy_packed_bytes"]
 
 [[case]]
 name = "raw_pointer_helpers_are_not_associated_surface"

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1561,6 +1561,14 @@ impl<'a> CfgLower<'a> {
                 self.lower_runtime_call(plan.runtime_call.expect("realloc-bytes runtime call plan"))
                     .primary
             }
+            crate::value_plan::IntrinsicOperation::ByteCopy => {
+                self.lower_runtime_call(plan.runtime_call.expect("byte-copy runtime call plan"))
+                    .primary
+            }
+            crate::value_plan::IntrinsicOperation::ByteSet => {
+                self.lower_runtime_call(plan.runtime_call.expect("byte-set runtime call plan"))
+                    .primary
+            }
             crate::value_plan::IntrinsicOperation::ByteRead => {
                 let addr = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::AddRR {

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -290,6 +290,8 @@ pub enum IntrinsicOperation {
     ReallocBytes,
     ByteRead,
     ByteWrite,
+    ByteCopy,
+    ByteSet,
     ArgCount,
     ArgPtr,
     ArgLen,
@@ -1533,6 +1535,8 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     "realloc_bytes" => IntrinsicOperation::ReallocBytes,
                     "byte_read" => IntrinsicOperation::ByteRead,
                     "byte_write" => IntrinsicOperation::ByteWrite,
+                    "byte_copy" => IntrinsicOperation::ByteCopy,
+                    "byte_set" => IntrinsicOperation::ByteSet,
                     "arg_count" => IntrinsicOperation::ArgCount,
                     "arg_ptr" => IntrinsicOperation::ArgPtr,
                     "arg_len" => IntrinsicOperation::ArgLen,
@@ -1756,6 +1760,22 @@ fn intrinsic_runtime_call(
                 RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
                 RuntimeCallArg::value(args[1].primary, AbiType::U64),
                 RuntimeCallArg::immediate(1, AbiType::U64),
+            ],
+        ),
+        IntrinsicOperation::ByteCopy => (
+            RuntimeHelperId::ByteCopy,
+            vec![
+                RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
+                RuntimeCallArg::const_pointer(args[1].primary, AbiType::Byte),
+                RuntimeCallArg::value(args[2].primary, AbiType::U64),
+            ],
+        ),
+        IntrinsicOperation::ByteSet => (
+            RuntimeHelperId::ByteSet,
+            vec![
+                RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
+                RuntimeCallArg::extended(args[1].primary, args[1].integer_extension, AbiType::U64),
+                RuntimeCallArg::value(args[2].primary, AbiType::U64),
             ],
         ),
         IntrinsicOperation::Realloc { .. } | IntrinsicOperation::ReallocBytes => {

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1820,6 +1820,14 @@ impl<'a> CfgLower<'a> {
                 self.lower_runtime_call(plan.runtime_call.expect("realloc-bytes runtime call plan"))
                     .primary
             }
+            crate::value_plan::IntrinsicOperation::ByteCopy => {
+                self.lower_runtime_call(plan.runtime_call.expect("byte-copy runtime call plan"))
+                    .primary
+            }
+            crate::value_plan::IntrinsicOperation::ByteSet => {
+                self.lower_runtime_call(plan.runtime_call.expect("byte-set runtime call plan"))
+                    .primary
+            }
             crate::value_plan::IntrinsicOperation::ByteRead => {
                 let addr = self.mir.alloc_vreg();
                 self.mir.push(X86Inst::MovRR {

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -707,6 +707,30 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
+        "runtime.raw_bytes",
+        "byte_copy_round_trip",
+        intrinsic(UnsupportedIntrinsicKind::AllocateBytes),
+        &[],
+    ),
+    Entry::new(
+        "runtime.raw_bytes",
+        "byte_set_fills_every_byte",
+        intrinsic(UnsupportedIntrinsicKind::AllocateBytes),
+        &[],
+    ),
+    Entry::new(
+        "runtime.raw_bytes",
+        "byte_copy_size_zero_is_noop",
+        intrinsic(UnsupportedIntrinsicKind::AllocateBytes),
+        &[],
+    ),
+    Entry::new(
+        "runtime.raw_bytes",
+        "byte_copy_copies_subrange",
+        intrinsic(UnsupportedIntrinsicKind::AllocateBytes),
+        &[],
+    ),
+    Entry::new(
         "runtime.pointers",
         "field_ptr_first_field",
         intrinsic(UnsupportedIntrinsicKind::FieldPointer),

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -245,6 +245,8 @@ pub enum UnsupportedIntrinsicKind {
     ReallocateBytes,
     ByteRead,
     ByteWrite,
+    ByteCopy,
+    ByteSet,
 }
 
 /// A compiler-emitted runtime call whose deterministic semantics are not
@@ -763,6 +765,8 @@ fn unsupported_intrinsic_kind(name: &str) -> UnsupportedKind {
         }
         "byte_read" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteRead)),
         "byte_write" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteWrite)),
+        "byte_copy" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteCopy)),
+        "byte_set" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteSet)),
         "read_line" => UnsupportedKind::ExternalDependency(External::StandardInput),
         "random_u32" => UnsupportedKind::ExternalDependency(External::RandomU32),
         "random_u64" => UnsupportedKind::ExternalDependency(External::RandomU64),
@@ -1265,7 +1269,9 @@ impl<'a> Interp<'a> {
                 args.is_empty()
             }
             "ptr_write" | "ptr_offset" | "free" | "free_bytes" | "byte_read" => args.len() == 2,
-            "realloc" | "realloc_bytes" | "byte_write" => args.len() == 3,
+            "realloc" | "realloc_bytes" | "byte_write" | "byte_copy" | "byte_set" => {
+                args.len() == 3
+            }
             "syscall" => (1..=7).contains(&args.len()),
             _ => args.len() == 1,
         };
@@ -1372,6 +1378,20 @@ impl<'a> Interp<'a> {
                 self.pointer_pointee(ty(0)) == Some((Type::U8, true))
                     && ty(1) == Type::U64
                     && ty(2) == Type::U8
+                    && result_ty == Type::UNIT
+            }
+            "byte_copy" => {
+                self.pointer_pointee(ty(0)) == Some((Type::U8, true))
+                    && self
+                        .pointer_pointee(ty(1))
+                        .is_some_and(|(pointee, _)| pointee == Type::U8)
+                    && ty(2) == Type::U64
+                    && result_ty == Type::UNIT
+            }
+            "byte_set" => {
+                self.pointer_pointee(ty(0)) == Some((Type::U8, true))
+                    && ty(1) == Type::U8
+                    && ty(2) == Type::U64
                     && result_ty == Type::UNIT
             }
             "read_line" => self

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -419,6 +419,8 @@ fn every_known_unsupported_intrinsic_has_a_closed_kind() {
         ("realloc_bytes", Intrinsic::ReallocateBytes),
         ("byte_read", Intrinsic::ByteRead),
         ("byte_write", Intrinsic::ByteWrite),
+        ("byte_copy", Intrinsic::ByteCopy),
+        ("byte_set", Intrinsic::ByteSet),
     ] {
         let expected = UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(intrinsic));
         assert_eq!(unsupported_intrinsic_kind(name), expected, "@{name}");

--- a/crates/rue-runtime-abi/src/lib.rs
+++ b/crates/rue-runtime-abi/src/lib.rs
@@ -830,6 +830,24 @@ macro_rules! for_each_runtime_helper {
             result: U64_RESULT,
             safety: SafetyContract::NONE,
             returns: RETURNS
+        },
+        ByteCopy => unsafe __rue_byte_copy(dst: *mut u8, src: *const u8, size: u64) {
+            symbol: "__rue_byte_copy",
+            parameters: params![MUT_BYTE_POINTER, BYTE_VIEW, U64_VALUE],
+            result: VOID,
+            // Copies `size` bytes from `src` into the non-overlapping region at
+            // `dst`; both pointer/length ranges must describe accessible bytes.
+            safety: READABLE.union(WRITABLE),
+            returns: RETURNS
+        },
+        ByteSet => unsafe __rue_byte_set(dst: *mut u8, value: u64, size: u64) {
+            symbol: "__rue_byte_set",
+            parameters: params![MUT_BYTE_POINTER, U64_VALUE, U64_VALUE],
+            result: VOID,
+            // Writes the low byte of `value` to each of `size` bytes at `dst`,
+            // which must denote that many writable bytes.
+            safety: WRITABLE,
+            returns: RETURNS
         }
             }
     };
@@ -1274,7 +1292,7 @@ mod tests {
     #[test]
     fn manifest_is_const_valid_and_exhaustive() {
         assert_eq!(validate_manifest(), Ok(()));
-        assert_eq!(RuntimeHelperId::ALL.len(), 41);
+        assert_eq!(RuntimeHelperId::ALL.len(), 43);
         assert_eq!(RuntimeHelperId::ALL.len(), RUNTIME_HELPERS.len());
         for (index, id) in RuntimeHelperId::ALL.iter().copied().enumerate() {
             assert_eq!(id as usize, index);
@@ -1337,6 +1355,8 @@ mod tests {
             "__rue_env_count",
             "__rue_env_ptr",
             "__rue_env_len",
+            "__rue_byte_copy",
+            "__rue_byte_set",
         ];
         assert_eq!(
             RUNTIME_HELPERS.map(|helper| helper.symbol),
@@ -1348,7 +1368,7 @@ mod tests {
     #[test]
     fn every_helper_has_the_exact_accepted_signature_and_contract() {
         fn check(
-            visited: &mut [bool; 41],
+            visited: &mut [bool; 43],
             ids: &[RuntimeHelperId],
             parameters: &[AbiParameter],
             result: AbiResult,
@@ -1369,7 +1389,7 @@ mod tests {
             }
         }
 
-        let mut visited = [false; 41];
+        let mut visited = [false; 43];
         check(
             &mut visited,
             &[RuntimeHelperId::Exit],
@@ -1571,6 +1591,22 @@ mod tests {
             &[U64_VALUE],
             U64_RESULT,
             SafetyContract::NONE,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::ByteCopy],
+            &[MUT_BYTE_POINTER, BYTE_VIEW, U64_VALUE],
+            VOID,
+            READABLE.union(WRITABLE),
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::ByteSet],
+            &[MUT_BYTE_POINTER, U64_VALUE, U64_VALUE],
+            VOID,
+            WRITABLE,
             RETURNS,
         );
         assert!(visited.into_iter().all(|was_visited| was_visited));

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -197,6 +197,8 @@ macro_rules! call_runtime_helper_implementation {
     (__rue_env_count($($argument:expr),*)) => { crate::process::__rue_env_count($($argument),*) };
     (__rue_env_ptr($($argument:expr),*)) => { crate::process::__rue_env_ptr($($argument),*) };
     (__rue_env_len($($argument:expr),*)) => { crate::process::__rue_env_len($($argument),*) };
+    (__rue_byte_copy($($argument:expr),*)) => { crate::memory::__rue_byte_copy($($argument),*) };
+    (__rue_byte_set($($argument:expr),*)) => { crate::memory::__rue_byte_set($($argument),*) };
 }
 
 macro_rules! declare_runtime_helper {

--- a/crates/rue-runtime/src/memory.rs
+++ b/crates/rue-runtime/src/memory.rs
@@ -84,6 +84,32 @@ pub unsafe fn memset(dst: *mut u8, c: i32, n: usize) -> *mut u8 {
     dst
 }
 
+/// `@byte_copy(dst, src, size)` runtime helper: copy `size` bytes from `src`
+/// into the non-overlapping region at `dst` (ADR-0058, RUE-937).
+///
+/// # Safety
+///
+/// - When `size > 0`, `dst` must be valid for writes of `size` bytes and `src`
+///   valid for reads of `size` bytes; the regions must not overlap.
+/// - Either pointer may be null when `size == 0` (a no-op).
+pub unsafe fn __rue_byte_copy(dst: *mut u8, src: *const u8, size: u64) {
+    // SAFETY: the caller upholds `memcpy`'s non-overlap and validity contract.
+    unsafe { memcpy(dst, src, size as usize) };
+}
+
+/// `@byte_set(dst, value, size)` runtime helper: write the low byte of `value`
+/// to each of `size` bytes at `dst` (ADR-0058, RUE-937).
+///
+/// # Safety
+///
+/// - When `size > 0`, `dst` must be valid for writes of `size` bytes.
+/// - `dst` may be null when `size == 0` (a no-op).
+pub unsafe fn __rue_byte_set(dst: *mut u8, value: u64, size: u64) {
+    // SAFETY: the caller upholds `memset`'s validity contract. `memset` masks
+    // the fill value to its low byte, matching the intrinsic's `u8` operand.
+    unsafe { memset(dst, value as i32, size as usize) };
+}
+
 /// Compare `n` bytes of memory at `s1` and `s2`.
 ///
 /// Returns 0 if equal, negative if s1 < s2, positive if s1 > s2.

--- a/crates/rue-spec/cases/runtime/raw-bytes.toml
+++ b/crates/rue-spec/cases/runtime/raw-bytes.toml
@@ -244,6 +244,173 @@ compile_fail = true
 error_contains = "expected u8"
 
 [[case]]
+name = "byte_copy_round_trip"
+spec = ["9.2:14g", "9.2:14h"]
+preview = "raw_bytes"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    checked {
+        let src: ptr mut u8 = @alloc_bytes(3);
+        @byte_write(src, 0, 10);
+        @byte_write(src, 1, 20);
+        @byte_write(src, 2, 30);
+        let dst: ptr mut u8 = @alloc_bytes(3);
+        @byte_copy(dst, src, 3);
+        let result: i32 = @intCast(@byte_read(dst, 0))
+            + @intCast(@byte_read(dst, 1))
+            + @intCast(@byte_read(dst, 2));
+        @free_bytes(src, 3);
+        @free_bytes(dst, 3);
+        result
+    }
+}
+"""
+exit_code = 60
+
+[[case]]
+name = "byte_set_fills_every_byte"
+spec = ["9.2:14g", "9.2:14h"]
+preview = "raw_bytes"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc_bytes(4);
+        @byte_set(p, 9, 4);
+        let result: i32 = @intCast(@byte_read(p, 0))
+            + @intCast(@byte_read(p, 1))
+            + @intCast(@byte_read(p, 2))
+            + @intCast(@byte_read(p, 3));
+        @free_bytes(p, 4);
+        result
+    }
+}
+"""
+exit_code = 36
+
+[[case]]
+name = "byte_copy_size_zero_is_noop"
+spec = ["9.2:14g"]
+preview = "raw_bytes"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    checked {
+        let dst: ptr mut u8 = @alloc_bytes(2);
+        @byte_write(dst, 0, 55);
+        @byte_write(dst, 1, 11);
+        let src: ptr mut u8 = @alloc_bytes(2);
+        @byte_set(src, 99, 2);
+        @byte_copy(dst, src, 0);
+        let result: i32 = @intCast(@byte_read(dst, 0)) + @intCast(@byte_read(dst, 1));
+        @free_bytes(src, 2);
+        @free_bytes(dst, 2);
+        result
+    }
+}
+"""
+exit_code = 66
+
+[[case]]
+name = "byte_copy_copies_subrange"
+spec = ["9.2:14g"]
+preview = "raw_bytes"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    checked {
+        let src: ptr mut u8 = @alloc_bytes(4);
+        @byte_write(src, 0, 1);
+        @byte_write(src, 1, 2);
+        @byte_write(src, 2, 3);
+        @byte_write(src, 3, 4);
+        let dst: ptr mut u8 = @alloc_bytes(2);
+        @byte_set(dst, 0, 2);
+        let src_mid: ptr mut u8 = @int_to_ptr(@ptr_to_int(src) + 1);
+        @byte_copy(dst, src_mid, 2);
+        let result: i32 = @intCast(@byte_read(dst, 0)) + @intCast(@byte_read(dst, 1));
+        @free_bytes(src, 4);
+        @free_bytes(dst, 2);
+        result
+    }
+}
+"""
+exit_code = 5
+
+[[case]]
+name = "byte_copy_require_preview"
+spec = ["9.2:14h", "8.4:1"]
+source = """
+fn main() -> i32 {
+    checked {
+        let z: u64 = 0;
+        let p: ptr mut u8 = @int_to_ptr(z);
+        @byte_copy(p, p, 0);
+    };
+    0
+}
+"""
+compile_fail = true
+error_contains = "--preview raw_bytes"
+
+[[case]]
+name = "byte_copy_require_checked"
+spec = ["9.2:14h"]
+preview = "raw_bytes"
+preview_should_pass = true
+source = """
+fn use_it(p: ptr mut u8) -> i32 {
+    @byte_copy(p, p, 0);
+    0
+}
+fn main() -> i32 {
+    let p: ptr mut u8 = checked { @alloc_bytes(1) };
+    let r = use_it(p);
+    checked { @free_bytes(p, 1); };
+    r
+}
+"""
+compile_fail = true
+error_contains = "[E1300]"
+
+[[case]]
+name = "byte_set_requires_u8_value"
+spec = ["9.2:14h"]
+preview = "raw_bytes"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc_bytes(1);
+        let value: u64 = 1;
+        @byte_set(p, value, 1);
+    };
+    0
+}
+"""
+compile_fail = true
+error_contains = "expected u8"
+
+[[case]]
+name = "byte_copy_requires_mut_u8_pointer"
+spec = ["9.2:14h"]
+preview = "raw_bytes"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    checked {
+        let z: u64 = 0;
+        let p: ptr mut i32 = @int_to_ptr(z);
+        @byte_copy(p, p, 0);
+    };
+    0
+}
+"""
+compile_fail = true
+error_contains = "ptr mut u8"
+
+[[case]]
 name = "alloc_bytes_result_is_ptr_mut_u8"
 spec = ["9.2:14b", "9.2:14e"]
 preview = "raw_bytes"

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -94,6 +94,8 @@ full semantics):
 | `@realloc_bytes` | Resize physical bytes (preview `raw_bytes`) | 3 expressions (`ptr mut u8`, `u64`, `u64`) | `ptr mut u8` |
 | `@byte_read` | Read one physical byte (preview `raw_bytes`) | 2 expressions (`ptr const u8`/`ptr mut u8`, `u64`) | `u8` |
 | `@byte_write` | Write one physical byte (preview `raw_bytes`) | 3 expressions (`ptr mut u8`, `u64`, `u8`) | `()` |
+| `@byte_copy` | Copy `size` non-overlapping bytes (preview `raw_bytes`) | 3 expressions (`ptr mut u8`, `ptr const u8`/`ptr mut u8`, `u64`) | `()` |
+| `@byte_set` | Fill `size` bytes with a byte (preview `raw_bytes`) | 3 expressions (`ptr mut u8`, `u8`, `u64`) | `()` |
 | `@arg_ptr` | Pointer to argument `i`'s bytes (null out of range) | 1 expression (`u64` index) | `ptr mut u8` |
 | `@env_ptr` | Pointer to environment entry `i`'s bytes (null out of range) | 1 expression (`u64` index) | `ptr mut u8` |
 

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -158,11 +158,12 @@ fn main() -> i32 {
 
 {{ rule(id="9.2:14a", cat="normative") }}
 
-The `@alloc_bytes`, `@realloc_bytes`, `@free_bytes`, `@byte_read`, and
-`@byte_write` intrinsics provide raw access to packed physical bytes. They are
-enabled by the `raw_bytes` preview feature and may only appear inside a
-`checked` block. They do not change the element-scaled semantics of `@alloc`,
-`@realloc`, `@free`, `@ptr_offset`, `@ptr_read`, or `@ptr_write`.
+The `@alloc_bytes`, `@realloc_bytes`, `@free_bytes`, `@byte_read`,
+`@byte_write`, `@byte_copy`, and `@byte_set` intrinsics provide raw access to
+packed physical bytes. They are enabled by the `raw_bytes` preview feature and
+may only appear inside a `checked` block. They do not change the element-scaled
+semantics of `@alloc`, `@realloc`, `@free`, `@ptr_offset`, `@ptr_read`, or
+`@ptr_write`.
 
 {{ rule(id="9.2:14b", cat="dynamic-semantics") }}
 
@@ -210,6 +211,46 @@ fn main() -> i32 {
         let result: i32 = @intCast(@byte_read(p, 1));
         @free_bytes(p, 2);
         result // 66
+    }
+}
+```
+
+{{ rule(id="9.2:14g", cat="dynamic-semantics") }}
+
+`@byte_copy(dst, src, size)` copies exactly `size` physical bytes from the
+region beginning at `src` to the region beginning at `dst`, in the manner of a
+memcpy. The two regions must not overlap; a call in which `[dst, dst + size)`
+and `[src, src + size)` overlap is undefined behavior (§9.1, ADR-0028). `dst`
+must be `ptr mut u8`; `src` may be `ptr const u8` or `ptr mut u8`. `@byte_set(dst,
+byte, size)` writes the `u8` value `byte` to each of the `size` physical bytes
+beginning at `dst`, in the manner of a memset; `dst` must be `ptr mut u8`. In
+both intrinsics `size` has type `u64`, byte counts are not multiplied by Rue's
+typed-pointer slot size, and a `size` of zero performs no access and reads and
+writes no memory.
+
+{{ rule(id="9.2:14h", cat="legality-rule") }}
+
+`@byte_copy` and `@byte_set` each require both `--preview raw_bytes` and an
+enclosing `checked` block. Their destination operand is exactly `ptr mut u8`;
+the `@byte_copy` source operand is `ptr const u8` or `ptr mut u8`. The
+`@byte_set` fill operand is exactly `u8`, and every `size` operand is exactly
+`u64`. Both intrinsics evaluate to `()`.
+
+{{ rule(id="9.2:14i", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    checked {
+        let src = @alloc_bytes(3);
+        @byte_set(src, 7, 3);
+        let dst = @alloc_bytes(3);
+        @byte_copy(dst, src, 3);
+        let result: i32 = @intCast(@byte_read(dst, 0))
+            + @intCast(@byte_read(dst, 1))
+            + @intCast(@byte_read(dst, 2));
+        @free_bytes(src, 3);
+        @free_bytes(dst, 3);
+        result // 21
     }
 }
 ```

--- a/std/strbuf.rue
+++ b/std/strbuf.rue
@@ -25,12 +25,18 @@ fn copy_packed_bytes(
     destination_start: u64,
     count: u64,
 ) {
-    let mut i: u64 = 0;
-    while i < count {
-        let byte = read_packed_byte(source, source_start + i);
-        write_packed_byte(destination, destination_start + i, byte);
-        i = i + 1;
-    }
+    // A memcpy-shaped bulk copy (ADR-0058). Every StrBuf caller copies between
+    // two distinct allocations (a fresh block during grow/duplicate, a foreign
+    // buffer during append/concat), so the source and destination ranges never
+    // overlap — the non-overlapping `@byte_copy` contract holds. `@ptr_offset`
+    // cannot form the sub-range pointers because it strides by the typed-pointer
+    // slot size, so the byte offsets are folded into the addresses directly.
+    checked {
+        let source_ptr: ptr mut u8 = @int_to_ptr(@ptr_to_int(source) + source_start);
+        let destination_ptr: ptr mut u8 =
+            @int_to_ptr(@ptr_to_int(destination) + destination_start);
+        @byte_copy(destination_ptr, source_ptr, count);
+    };
 }
 
 pub struct StrBuf {


### PR DESCRIPTION
## Summary

Implements **ADR-0059 Phase 1**: the two bulk memory primitives the accepted design identified as landable now, with no canonical-layout dependency.

- **`@byte_copy(dst: ptr mut u8, src: ptr const u8 | ptr mut u8, size: u64)`** — memcpy-shaped bulk copy; overlap is UB, `size == 0` is a no-op. **`@byte_set(dst: ptr mut u8, byte: u8, size: u64)`** — memset-shaped fill. Both are `--preview raw_bytes`- and `checked {}`-gated exactly like the existing byte family, and available to std through the trusted-std carve-out.
- **Lowering** follows the alloc-family `RuntimeCallKind` pattern with new `__rue_byte_copy`/`__rue_byte_set` runtime helpers over the runtime's `memcpy`/`memset`, reusing the generic runtime-call path on **both backends** (x86-64 and AArch64 verified emitting the calls) instead of growing per-backend loop machinery. A new `BytePointerArgument` operand origin lets `@byte_copy`'s source accept `ptr const u8` or `ptr mut u8`, with AIR↔ABI manifest validation extended accordingly.
- **std port**: `StrBuf::copy_packed_bytes` now performs one `@byte_copy` instead of a per-byte loop, serving `grow`/`append_owned`/`duplicate`/`copy`/`byte_range`/`concat_borrowed`. Deliberately *not* ported: the `std.fs` marshalling loops (they bridge packed buffers and slot-based `ArrayBuf(u8)` representations that `@byte_copy` cannot bridge until the RUE-971 canonical-layout migration) and `std.mem.swap` (an in-place three-way exchange with no temp buffer).
- **Spec**: new gated paragraphs `9.2:14g`/`9.2:14h` and registry rows in `4.13:5a`; traceability 100% (764/764).
- **Tests**: 8 new raw-bytes spec cases (copy round-trip, set fill, size-0 no-op, subrange copy, plus preview/checked/wrong-type negatives); `std_strbuf` MIR assertion updated to the bulk-copy path.

## Verification

Re-verified at integration on current trunk (not just the worker branch): spec `raw_bytes` 22/22; CLI `std_strbuf` 21/21, `std_internal_raw_bytes` 3/3, `heap_intrinsics` 8/8; unit suites green; full `test.sh` green except the pre-existing unreadable-file test class, which fails only under uid 0 (reproduced on clean trunk in the same container — root bypasses `chmod 0o000`; CI runs unprivileged). End-to-end copy+set program returns the expected exit code on x86-64.

Part of RUE-937 (Phase 1 of 6; the issue remains the tracking issue through the final de-gate).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_