### PR TITLE
RUE-850: canonicalize semantic identity taxonomy

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -219,3 +219,24 @@ fn air_payload_ownership_and_validation_boundary_cannot_regress() {
     assert!(sema.contains("pub fn new_synthetic(\n        rir: &'a Rir,"));
     assert!(!sema.contains("&'a mut Rir"));
 }
+
+#[test]
+fn semantic_definition_taxonomy_has_one_enum_declaration() {
+    let canonical = include_str!("semantic_identity.rs");
+    let bindings = include_str!("sema/binding_manifest.rs");
+    let bodies = include_str!("semantic_body.rs");
+
+    assert_eq!(
+        canonical.matches("pub enum StableDefinitionKind").count(),
+        1
+    );
+    assert_eq!(
+        canonical
+            .matches("pub enum StableDefinitionNamespace")
+            .count(),
+        1
+    );
+    assert!(!bindings.contains("pub enum StableDefinitionKind"));
+    assert!(!bindings.contains("pub enum StableDefinitionNamespace"));
+    assert!(!bodies.contains("pub enum StableDefinitionKind"));
+}

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -77,13 +77,15 @@ pub use sema::{
 };
 pub use semantic_body::{
     SemanticBody, SemanticBodyAnchor, SemanticBodyCallArg, SemanticBodyCandidate,
-    SemanticBodyCandidateInstallWork, SemanticBodyDefinitionIdentity,
+    SemanticBodyCandidateInstallWork,
     SemanticBodyExport, SemanticBodyExportFailure, SemanticBodyImportFailure,
     SemanticBodyImportFailureKind, SemanticBodyInst, SemanticBodyInstData, SemanticBodyMatchArm,
-    SemanticBodyModuleIdentity, SemanticBodyPattern, SemanticBodyPlace, SemanticBodyPlaceRef,
-    SemanticBodyProjection, SemanticBodyRef, SemanticBodyWarning, SemanticImportedBody,
+    SemanticBodyPattern, SemanticBodyPlace, SemanticBodyPlaceRef, SemanticBodyProjection,
+    SemanticBodyRef, SemanticBodyWarning, SemanticDefinitionEndpoint, SemanticDefinitionToken,
+    SemanticImportedBody, SemanticModuleEndpoint, SemanticModuleToken,
     SemanticSpecializationIdentity, SemanticSpecializedBodyCandidate,
     SemanticSpecializedBodyExport, SemanticSpecializedCandidateInstallWork,
+    SemanticStableResolutionFailure,
 };
 pub use semantic_identity::{StableDefinitionKind, StableDefinitionNamespace};
 pub use semantic_import::{

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -23,6 +23,7 @@ mod runtime_call;
 mod scope;
 mod sema;
 mod semantic_body;
+mod semantic_identity;
 mod semantic_import;
 pub mod specialize;
 mod type_encoding;
@@ -67,16 +68,16 @@ pub use sema::{
     NamedConstDependencyEvent, NamedConstDependencyTargetEvent, NamedDestructorDependencyEvent,
     NamedMethodDependencyEvent, NamedMethodDependencyTargetEvent,
     OrdinaryFreeFunctionDependencyEvent, ParamSlotModes, RirDeclarationIndexWork, Sema,
-    SemaMetadata, SemaOutput, SemanticBinding, SemanticBindingKind, SemanticBindingManifest,
-    SemanticBindingManifestWork, SemanticBindingNamespace, SemanticDeclarationExport,
-    SemanticDeclarationExportWork, SemanticDeclarationPayload, SemanticDeclarationShell,
-    SemanticDeclarationShellIdentity, SemanticExportConstValue, SemanticExportFailure,
-    SemanticExportParameter, SemanticExportType, SemanticNominalIdentity, SemanticParameterMode,
-    SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
+    SemaMetadata, SemaOutput, SemanticBinding, SemanticBindingManifest,
+    SemanticBindingManifestWork, SemanticDeclarationExport, SemanticDeclarationExportWork,
+    SemanticDeclarationPayload, SemanticDeclarationShell, SemanticDeclarationShellIdentity,
+    SemanticExportConstValue, SemanticExportFailure, SemanticExportParameter, SemanticExportType,
+    SemanticNominalIdentity, SemanticParameterMode, SpecializedFreeFunctionDependencyEvent,
+    SpecializedFreeFunctionOrigin,
 };
 pub use semantic_body::{
     SemanticBody, SemanticBodyAnchor, SemanticBodyCallArg, SemanticBodyCandidate,
-    SemanticBodyCandidateInstallWork, SemanticBodyDefinitionIdentity, SemanticBodyDefinitionKind,
+    SemanticBodyCandidateInstallWork, SemanticBodyDefinitionIdentity,
     SemanticBodyExport, SemanticBodyExportFailure, SemanticBodyImportFailure,
     SemanticBodyImportFailureKind, SemanticBodyInst, SemanticBodyInstData, SemanticBodyMatchArm,
     SemanticBodyModuleIdentity, SemanticBodyPattern, SemanticBodyPlace, SemanticBodyPlaceRef,
@@ -84,6 +85,7 @@ pub use semantic_body::{
     SemanticSpecializationIdentity, SemanticSpecializedBodyCandidate,
     SemanticSpecializedBodyExport, SemanticSpecializedCandidateInstallWork,
 };
+pub use semantic_identity::{StableDefinitionKind, StableDefinitionNamespace};
 pub use semantic_import::{
     SemanticImportConstValue, SemanticImportEpoch, SemanticImportFailure, SemanticImportNominal,
     SemanticImportNominalKind, SemanticImportType, SemanticImportTypeFold,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -62,7 +62,7 @@ pub(crate) fn import_staged_body(
     >,
     body_span: Span,
 ) -> Result<crate::SemanticImportedBody, crate::SemanticBodyImportFailure> {
-    use crate::{SemanticBodyDefinitionKind as DK, SemanticBodyImportFailure as BF};
+    use crate::{SemanticBodyImportFailure as BF, StableDefinitionKind as DK};
     use crate::{
         SemanticImportFailure as F, SemanticImportNominalKind as NK, SemanticImportType as T,
     };
@@ -161,7 +161,7 @@ pub(crate) fn import_staged_body(
             .interner
             .get(identity.name.as_ref())
             .ok_or(BF::Semantic(F::MissingFunction))?;
-        if identity.kind == DK::FreeFunction {
+        if identity.kind == DK::Function {
             return sema
                 .functions_by_file_name
                 .get(&(FileId::new(identity.file_id), name))

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -56,10 +56,7 @@ pub(crate) fn analyze_all_function_bodies_with_work(
 
 pub(crate) fn import_staged_body(
     sema: &mut BodySema<'_>,
-    body: &crate::SemanticBody<
-        crate::SemanticBodyDefinitionIdentity,
-        crate::SemanticBodyModuleIdentity,
-    >,
+    body: &crate::SemanticBody<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
     body_span: Span,
 ) -> Result<crate::SemanticImportedBody, crate::SemanticBodyImportFailure> {
     use crate::{SemanticBodyImportFailure as BF, StableDefinitionKind as DK};
@@ -67,11 +64,49 @@ pub(crate) fn import_staged_body(
         SemanticImportFailure as F, SemanticImportNominalKind as NK, SemanticImportType as T,
     };
 
+    fn definition_endpoint<'a>(
+        sema: &'a BodySema<'_>,
+        token: &crate::SemanticDefinitionToken,
+    ) -> Result<&'a crate::SemanticDefinitionEndpoint, BF> {
+        if let Some(endpoint) = sema.stable_definition_endpoints.get(token) {
+            return Ok(endpoint);
+        }
+        let failure = if sema
+            .stable_definition_endpoints
+            .keys()
+            .any(|candidate| candidate.issuer() == token.issuer())
+        {
+            crate::SemanticStableResolutionFailure::Missing
+        } else {
+            crate::SemanticStableResolutionFailure::ForeignIssuer
+        };
+        Err(BF::StableResolution(failure))
+    }
+
+    fn module_endpoint<'a>(
+        sema: &'a BodySema<'_>,
+        token: &crate::SemanticModuleToken,
+    ) -> Result<&'a crate::SemanticModuleEndpoint, BF> {
+        if let Some(endpoint) = sema.stable_module_endpoints.get(token) {
+            return Ok(endpoint);
+        }
+        let failure = if sema
+            .stable_module_endpoints
+            .keys()
+            .any(|candidate| candidate.issuer() == token.issuer())
+        {
+            crate::SemanticStableResolutionFailure::Missing
+        } else {
+            crate::SemanticStableResolutionFailure::ForeignIssuer
+        };
+        Err(BF::StableResolution(failure))
+    }
+
     fn import_type(
         sema: &BodySema<'_>,
         pool: &crate::TypeInternPool,
-        value: &T<crate::SemanticBodyDefinitionIdentity, crate::SemanticBodyModuleIdentity>,
-    ) -> Result<Type, F> {
+        value: &T<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
+    ) -> Result<Type, BF> {
         Ok(match value {
             T::I8 => Type::I8,
             T::I16 => Type::I16,
@@ -111,6 +146,7 @@ pub(crate) fn import_staged_body(
                 }
             }
             T::Nominal(identity) => {
+                let identity = definition_endpoint(sema, identity)?;
                 let symbol = sema
                     .interner
                     .get(identity.name.as_ref())
@@ -119,16 +155,20 @@ pub(crate) fn import_staged_body(
                     DK::Struct => Type::new_struct(
                         *sema
                             .structs_by_file_name
-                            .get(&(FileId::new(identity.file_id), symbol))
+                            .get(&(FileId::new(identity.file), symbol))
                             .ok_or(F::MissingNominal)?,
                     ),
                     DK::Enum => Type::new_enum(
                         *sema
                             .enums_by_file_name
-                            .get(&(FileId::new(identity.file_id), symbol))
+                            .get(&(FileId::new(identity.file), symbol))
                             .ok_or(F::MissingNominal)?,
                     ),
-                    _ => return Err(F::NominalKindMismatch),
+                    _ => {
+                        return Err(BF::StableResolution(
+                            crate::SemanticStableResolutionFailure::WrongKind,
+                        ));
+                    }
                 }
             }
             T::Array { element, len } => pool
@@ -141,22 +181,26 @@ pub(crate) fn import_staged_body(
                 .try_intern_ptr_mut(import_type(sema, pool, value)?)
                 .map_err(|_| F::InvalidStructuralType)?,
             T::Module(module) => {
+                let module = module_endpoint(sema, module)?;
                 let id = (0..sema.module_registry.len())
                     .map(|i| ModuleId::new(i as u32))
                     .find(|id| {
-                        sema.module_registry.get_def(*id).file_id == FileId::new(module.file_id)
+                        sema.module_registry.get_def(*id).file_id == FileId::new(module.file)
                     })
-                    .ok_or(F::MissingModule)?;
+                    .ok_or(BF::Semantic(F::MissingModule))?;
                 Type::new_module(id)
             }
-            T::GenericParameter(_) => return Err(F::GenericParameterNeedsDeclarationContext),
+            T::GenericParameter(_) => {
+                return Err(BF::Semantic(F::GenericParameterNeedsDeclarationContext));
+            }
         })
     }
 
     fn resolve_body_function(
         sema: &BodySema<'_>,
-        identity: &crate::SemanticBodyDefinitionIdentity,
+        token: &crate::SemanticDefinitionToken,
     ) -> Result<Spur, BF> {
+        let identity = definition_endpoint(sema, token)?;
         let name = sema
             .interner
             .get(identity.name.as_ref())
@@ -164,7 +208,7 @@ pub(crate) fn import_staged_body(
         if identity.kind == DK::Function {
             return sema
                 .functions_by_file_name
-                .get(&(FileId::new(identity.file_id), name))
+                .get(&(FileId::new(identity.file), name))
                 .copied()
                 .ok_or(BF::Semantic(F::MissingFunction));
         }
@@ -175,7 +219,7 @@ pub(crate) fn import_staged_body(
             .ok_or(BF::Semantic(F::MissingFunction))?;
         let struct_id = sema
             .structs_by_file_name
-            .get(&(FileId::new(identity.file_id), owner))
+            .get(&(FileId::new(identity.file), owner))
             .copied()
             .ok_or(BF::Semantic(F::MissingFunction))?;
         let info = sema
@@ -185,7 +229,11 @@ pub(crate) fn import_staged_body(
             DK::Method => info.has_self && identity.name.as_ref() != "__drop",
             DK::AssociatedFunction => !info.has_self,
             DK::Destructor => info.has_self && identity.name.as_ref() == "__drop",
-            _ => false,
+            _ => {
+                return Err(BF::StableResolution(
+                    crate::SemanticStableResolutionFailure::WrongKind,
+                ));
+            }
         };
         if !expected {
             return Err(BF::Semantic(F::MissingFunction));
@@ -209,29 +257,35 @@ pub(crate) fn import_staged_body(
         body_span,
         &scratch,
         |value| import_type(sema, &scratch, value),
-        |identity| {
+        |token| {
+            let identity = definition_endpoint(sema, token)?;
             if identity.kind != DK::Struct {
-                return Err(BF::WrongNominalKind);
+                return Err(BF::StableResolution(
+                    crate::SemanticStableResolutionFailure::WrongKind,
+                ));
             }
             let name = sema
                 .interner
                 .get(identity.name.as_ref())
                 .ok_or(BF::Semantic(F::MissingNominal))?;
             sema.structs_by_file_name
-                .get(&(FileId::new(identity.file_id), name))
+                .get(&(FileId::new(identity.file), name))
                 .copied()
                 .ok_or(BF::Semantic(F::MissingNominal))
         },
-        |identity| {
+        |token| {
+            let identity = definition_endpoint(sema, token)?;
             if identity.kind != DK::Enum {
-                return Err(BF::WrongNominalKind);
+                return Err(BF::StableResolution(
+                    crate::SemanticStableResolutionFailure::WrongKind,
+                ));
             }
             let name = sema
                 .interner
                 .get(identity.name.as_ref())
                 .ok_or(BF::Semantic(F::MissingNominal))?;
             sema.enums_by_file_name
-                .get(&(FileId::new(identity.file_id), name))
+                .get(&(FileId::new(identity.file), name))
                 .copied()
                 .ok_or(BF::Semantic(F::MissingNominal))
         },

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -15,6 +15,7 @@ use super::{ConstValue, Sema, SemaOutput};
 use crate::types::{
     ArrayLen, PtrMutability, Type, TypeKind, parse_array_type_syntax, parse_pointer_type_syntax,
 };
+use crate::{StableDefinitionKind, StableDefinitionNamespace};
 
 /// A nominal declaration identity valid for one successful binding request.
 /// Consumers must join this identity to their own stable definition universe
@@ -23,7 +24,7 @@ use crate::types::{
 pub struct SemanticNominalIdentity {
     pub file_id: FileId,
     pub name: Arc<str>,
-    pub kind: SemanticBindingKind,
+    pub kind: StableDefinitionKind,
 }
 
 /// An owned resolved type with no `Type`, pool ID, interner symbol, or RIR handle.
@@ -194,8 +195,8 @@ impl DeclarationResolutionFailure {
 pub struct SemanticDeclarationShellIdentity {
     pub module_path: Arc<str>,
     pub is_trusted_standard_library: bool,
-    pub namespace: SemanticBindingNamespace,
-    pub kind: SemanticBindingKind,
+    pub namespace: StableDefinitionNamespace,
+    pub kind: StableDefinitionKind,
     pub name: Arc<str>,
     pub owner: Option<Arc<str>>,
 }
@@ -250,34 +251,14 @@ pub enum DeclarationInstallFailure {
     UnsupportedDeclaration,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum SemanticBindingNamespace {
-    Value,
-    Type,
-    Destructor,
-    Method,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum SemanticBindingKind {
-    Function,
-    Struct,
-    Enum,
-    ValueConst,
-    ModuleBinding,
-    Destructor,
-    Method,
-    AssociatedFunction,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SemanticBinding {
     /// Request-local source file containing this declaration.
     pub file_id: FileId,
     /// Request-local declaration location; excluded from stable identity.
     pub declaration_span: Span,
-    pub namespace: SemanticBindingNamespace,
-    pub kind: SemanticBindingKind,
+    pub namespace: StableDefinitionNamespace,
+    pub kind: StableDefinitionKind,
     pub name: Arc<str>,
     pub owner: Option<Arc<str>>,
     /// Source visibility; destructors are never public.
@@ -799,13 +780,13 @@ impl Sema<'_> {
             SemanticExportType::Nominal(nominal) => {
                 let name = self.interner.get_or_intern(nominal.name.as_ref());
                 match nominal.kind {
-                    SemanticBindingKind::Struct => Type::new_struct(
+                    StableDefinitionKind::Struct => Type::new_struct(
                         *self
                             .structs_by_file_name
                             .get(&(nominal.file_id, name))
                             .ok_or(DeclarationInstallFailure::MissingNominal)?,
                     ),
-                    SemanticBindingKind::Enum => Type::new_enum(
+                    StableDefinitionKind::Enum => Type::new_enum(
                         *self
                             .enums_by_file_name
                             .get(&(nominal.file_id, name))
@@ -1004,15 +985,15 @@ impl<'a> BoundSema<'a> {
             .iter()
             .filter_map(|binding| {
                 let kind = match binding.kind {
-                    SemanticBindingKind::Function => super::BodyOwnerKind::FreeFunction,
-                    SemanticBindingKind::Method => super::BodyOwnerKind::Method,
-                    SemanticBindingKind::AssociatedFunction => {
+                    StableDefinitionKind::Function => super::BodyOwnerKind::FreeFunction,
+                    StableDefinitionKind::Method => super::BodyOwnerKind::Method,
+                    StableDefinitionKind::AssociatedFunction => {
                         super::BodyOwnerKind::AssociatedFunction
                     }
-                    SemanticBindingKind::Destructor => super::BodyOwnerKind::Destructor,
+                    StableDefinitionKind::Destructor => super::BodyOwnerKind::Destructor,
                     _ => return None,
                 };
-                let name = if binding.kind == SemanticBindingKind::Destructor {
+                let name = if binding.kind == StableDefinitionKind::Destructor {
                     binding
                         .owner
                         .as_deref()
@@ -1021,7 +1002,7 @@ impl<'a> BoundSema<'a> {
                 } else {
                     binding.name.to_string()
                 };
-                let owner = if binding.kind == SemanticBindingKind::Destructor {
+                let owner = if binding.kind == StableDefinitionKind::Destructor {
                     Some(name.clone())
                 } else {
                     binding.owner.as_ref().map(ToString::to_string)
@@ -1125,9 +1106,9 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
             | InstData::EnumDecl { name, is_pub, .. } = &inst.data
             {
                 let kind = if matches!(inst.data, InstData::StructDecl { .. }) {
-                    SemanticBindingKind::Struct
+                    StableDefinitionKind::Struct
                 } else {
-                    SemanticBindingKind::Enum
+                    StableDefinitionKind::Enum
                 };
                 nominals.push(PendingNominalPayload {
                     shell: SemanticDeclarationShell {
@@ -1136,7 +1117,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                             is_trusted_standard_library: self
                                 .trusted_standard_library_files
                                 .contains(&inst.span.file_id),
-                            namespace: SemanticBindingNamespace::Type,
+                            namespace: StableDefinitionNamespace::Type,
                             kind,
                             name: Arc::from(self.interner.resolve(name)),
                             owner: None,
@@ -1176,9 +1157,9 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                 } if !self.declaration_index.is_anonymous_method(inst_ref) => {
                     let owner = candidate.named_method_owner;
                     let kind = match (owner, *has_self) {
-                        (Some(_), true) => SemanticBindingKind::Method,
-                        (Some(_), false) => SemanticBindingKind::AssociatedFunction,
-                        (None, _) => SemanticBindingKind::Function,
+                        (Some(_), true) => StableDefinitionKind::Method,
+                        (Some(_), false) => StableDefinitionKind::AssociatedFunction,
+                        (None, _) => StableDefinitionKind::Function,
                     };
                     let params = self.rir.params(params);
                     let names = params
@@ -1196,9 +1177,9 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                             .trusted_standard_library_files
                             .contains(&inst.span.file_id),
                         namespace: if owner.is_some() {
-                            SemanticBindingNamespace::Method
+                            StableDefinitionNamespace::Method
                         } else {
-                            SemanticBindingNamespace::Value
+                            StableDefinitionNamespace::Value
                         },
                         kind,
                         name: Arc::from(self.interner.resolve(name)),
@@ -1224,11 +1205,11 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                         is_trusted_standard_library: self
                             .trusted_standard_library_files
                             .contains(&inst.span.file_id),
-                        namespace: SemanticBindingNamespace::Value,
+                        namespace: StableDefinitionNamespace::Value,
                         // Function aliases are classified only after evaluating
                         // the initializer; their stable value identity is already
                         // complete here.
-                        kind: SemanticBindingKind::ValueConst,
+                        kind: StableDefinitionKind::ValueConst,
                         name: Arc::from(self.interner.resolve(name)),
                         owner: None,
                     },
@@ -1247,8 +1228,8 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                         is_trusted_standard_library: self
                             .trusted_standard_library_files
                             .contains(&inst.span.file_id),
-                        namespace: SemanticBindingNamespace::Destructor,
-                        kind: SemanticBindingKind::Destructor,
+                        namespace: StableDefinitionNamespace::Destructor,
+                        kind: StableDefinitionKind::Destructor,
                         name: Arc::from(self.interner.resolve(type_name)),
                         owner: Some(Arc::from(self.interner.resolve(type_name))),
                     },
@@ -1332,7 +1313,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     Ok(SemanticExportType::Nominal(SemanticNominalIdentity {
                         file_id: def.file_id,
                         name: Arc::from(def.name),
-                        kind: SemanticBindingKind::Struct,
+                        kind: StableDefinitionKind::Struct,
                     }))
                 }
             }
@@ -1348,7 +1329,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     Ok(SemanticExportType::Nominal(SemanticNominalIdentity {
                         file_id: def.file_id,
                         name: Arc::from(def.name),
-                        kind: SemanticBindingKind::Enum,
+                        kind: StableDefinitionKind::Enum,
                     }))
                 }
             }
@@ -1477,11 +1458,11 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
         for identity in manifest
             .bindings
             .iter()
-            .filter(|b| b.kind != SemanticBindingKind::ModuleBinding)
+            .filter(|b| b.kind != StableDefinitionKind::ModuleBinding)
         {
             let name = self.interner.get_or_intern(identity.name.as_ref());
             let payload = match identity.kind {
-                SemanticBindingKind::Function => {
+                StableDefinitionKind::Function => {
                     let internal = *self
                         .functions_by_file_name
                         .get(&(identity.file_id, name))
@@ -1498,7 +1479,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                         is_unchecked: info.is_unchecked,
                     }
                 }
-                SemanticBindingKind::Method | SemanticBindingKind::AssociatedFunction => {
+                StableDefinitionKind::Method | StableDefinitionKind::AssociatedFunction => {
                     let owner = self.interner.get_or_intern(
                         identity
                             .owner
@@ -1538,7 +1519,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                         is_unchecked: false,
                     }
                 }
-                SemanticBindingKind::Struct => {
+                StableDefinitionKind::Struct => {
                     let sid = *self
                         .structs_by_file_name
                         .get(&(identity.file_id, name))
@@ -1555,7 +1536,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                         is_linear: def.is_linear,
                     }
                 }
-                SemanticBindingKind::Enum => {
+                StableDefinitionKind::Enum => {
                     let eid = *self
                         .enums_by_file_name
                         .get(&(identity.file_id, name))
@@ -1578,7 +1559,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                         variants: variants.into(),
                     }
                 }
-                SemanticBindingKind::ValueConst => {
+                StableDefinitionKind::ValueConst => {
                     let info = self
                         .constants_by_file_name
                         .get(&(identity.file_id, name))
@@ -1608,8 +1589,8 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                         value,
                     }
                 }
-                SemanticBindingKind::Destructor => SemanticDeclarationPayload::Destructor,
-                SemanticBindingKind::ModuleBinding => unreachable!(),
+                StableDefinitionKind::Destructor => SemanticDeclarationPayload::Destructor,
+                StableDefinitionKind::ModuleBinding => unreachable!(),
             };
             records.push(SemanticDeclarationExport {
                 identity: identity.clone(),
@@ -1637,8 +1618,8 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
             work.rir_instructions_visited += 1;
             let mut emit = |file_id: FileId,
                             declaration_span: Span,
-                            namespace: SemanticBindingNamespace,
-                            kind: SemanticBindingKind,
+                            namespace: StableDefinitionNamespace,
+                            kind: StableDefinitionKind,
                             name: &Spur,
                             owner: Option<Arc<str>>,
                             is_public: bool| {
@@ -1665,8 +1646,8 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     emit(
                         inst.span.file_id,
                         inst.span,
-                        SemanticBindingNamespace::Value,
-                        SemanticBindingKind::Function,
+                        StableDefinitionNamespace::Value,
+                        StableDefinitionKind::Function,
                         name,
                         None,
                         *is_pub,
@@ -1687,8 +1668,8 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     emit(
                         inst.span.file_id,
                         inst.span,
-                        SemanticBindingNamespace::Type,
-                        SemanticBindingKind::Struct,
+                        StableDefinitionNamespace::Type,
+                        StableDefinitionKind::Struct,
                         name,
                         None,
                         *is_pub,
@@ -1714,11 +1695,11 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                         emit(
                             method_inst.span.file_id,
                             method_inst.span,
-                            SemanticBindingNamespace::Method,
+                            StableDefinitionNamespace::Method,
                             if *has_self {
-                                SemanticBindingKind::Method
+                                StableDefinitionKind::Method
                             } else {
-                                SemanticBindingKind::AssociatedFunction
+                                StableDefinitionKind::AssociatedFunction
                             },
                             name,
                             Some(owner.clone()),
@@ -1736,8 +1717,8 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     emit(
                         inst.span.file_id,
                         inst.span,
-                        SemanticBindingNamespace::Type,
-                        SemanticBindingKind::Enum,
+                        StableDefinitionNamespace::Type,
+                        StableDefinitionKind::Enum,
                         name,
                         None,
                         *is_pub,
@@ -1748,17 +1729,17 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     let key = (inst.span.file_id, *name);
                     let kind = if self.module_bindings.contains_key(&key) {
                         work.module_bindings_emitted += 1;
-                        SemanticBindingKind::ModuleBinding
+                        StableDefinitionKind::ModuleBinding
                     } else if self.constants_by_file_name.contains_key(&key) {
                         work.constants_emitted += 1;
-                        SemanticBindingKind::ValueConst
+                        StableDefinitionKind::ValueConst
                     } else {
                         panic!("manifest const must be a classified bound winner")
                     };
                     emit(
                         inst.span.file_id,
                         inst.span,
-                        SemanticBindingNamespace::Value,
+                        StableDefinitionNamespace::Value,
                         kind,
                         name,
                         None,
@@ -1778,8 +1759,8 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     emit(
                         inst.span.file_id,
                         inst.span,
-                        SemanticBindingNamespace::Destructor,
-                        SemanticBindingKind::Destructor,
+                        StableDefinitionNamespace::Destructor,
+                        StableDefinitionKind::Destructor,
                         type_name,
                         Some(Arc::from(self.interner.resolve(type_name))),
                         false,
@@ -2138,7 +2119,7 @@ mod tests {
         assert!(first.bindings().iter().any(|binding| {
             binding.name.as_ref() == "make"
                 && binding.owner.as_deref() == Some("Resource")
-                && binding.kind == SemanticBindingKind::AssociatedFunction
+                && binding.kind == StableDefinitionKind::AssociatedFunction
         }));
         assert!(
             first
@@ -2178,7 +2159,7 @@ mod tests {
             .unwrap();
         assert!(bound.binding_manifest().bindings().iter().any(|binding| {
             binding.name.as_ref() == "exposed"
-                && binding.kind == SemanticBindingKind::Method
+                && binding.kind == StableDefinitionKind::Method
                 && binding.is_public
         }));
     }
@@ -2201,11 +2182,11 @@ mod tests {
         )
         .unwrap();
         assert!(manifest.bindings().iter().any(|binding| {
-            binding.name.as_ref() == "value" && binding.kind == SemanticBindingKind::ValueConst
+            binding.name.as_ref() == "value" && binding.kind == StableDefinitionKind::ValueConst
         }));
         assert!(manifest.bindings().iter().any(|binding| {
             binding.name.as_ref() == "imported"
-                && binding.kind == SemanticBindingKind::ModuleBinding
+                && binding.kind == StableDefinitionKind::ModuleBinding
         }));
         assert_eq!(manifest.work().constants_emitted, 1);
         assert_eq!(manifest.work().module_bindings_emitted, 1);
@@ -2376,12 +2357,12 @@ mod tests {
         assert!(
             left[..4]
                 .iter()
-                .all(|identity| identity.namespace == SemanticBindingNamespace::Type)
+                .all(|identity| identity.namespace == StableDefinitionNamespace::Type)
         );
         assert!(
             left[4..]
                 .iter()
-                .all(|identity| identity.namespace != SemanticBindingNamespace::Type)
+                .all(|identity| identity.namespace != StableDefinitionNamespace::Type)
         );
     }
 

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -842,33 +842,86 @@ impl Sema<'_> {
 }
 
 impl<'a> BoundSema<'a> {
+    pub fn install_stable_identity_endpoints(
+        mut self,
+        definitions: &[crate::SemanticDefinitionEndpoint],
+        modules: &[crate::SemanticModuleEndpoint],
+    ) -> Result<Self, crate::SemanticStableResolutionFailure> {
+        let issuer = definitions
+            .first()
+            .map(|endpoint| endpoint.token.issuer())
+            .or_else(|| modules.first().map(|endpoint| endpoint.token.issuer()))
+            .ok_or(crate::SemanticStableResolutionFailure::Missing)?;
+        let mut definition_tokens = HashMap::new();
+        let mut definition_endpoints = HashMap::new();
+        for endpoint in definitions {
+            if endpoint.token.issuer() != issuer {
+                return Err(crate::SemanticStableResolutionFailure::ForeignIssuer);
+            }
+            if endpoint.kind.requires_owner() != endpoint.owner.is_some() {
+                return Err(crate::SemanticStableResolutionFailure::WrongKind);
+            }
+            let key = (
+                endpoint.file,
+                endpoint.name.to_string(),
+                endpoint.owner.as_deref().map(str::to_owned),
+                endpoint.kind,
+            );
+            if definition_tokens.insert(key, endpoint.token).is_some()
+                || definition_endpoints
+                    .insert(endpoint.token, endpoint.clone())
+                    .is_some()
+            {
+                return Err(crate::SemanticStableResolutionFailure::Ambiguous);
+            }
+        }
+        let mut module_tokens = HashMap::new();
+        let mut module_endpoints = HashMap::new();
+        for endpoint in modules {
+            if endpoint.token.issuer() != issuer {
+                return Err(crate::SemanticStableResolutionFailure::ForeignIssuer);
+            }
+            if module_tokens
+                .insert(FileId::new(endpoint.file), endpoint.token)
+                .is_some()
+                || module_endpoints.insert(endpoint.token, *endpoint).is_some()
+            {
+                return Err(crate::SemanticStableResolutionFailure::Ambiguous);
+            }
+        }
+        self.sema.stable_definition_tokens = definition_tokens;
+        self.sema.stable_definition_endpoints = definition_endpoints;
+        self.sema.stable_module_tokens = module_tokens;
+        self.sema.stable_module_endpoints = module_endpoints;
+        Ok(self)
+    }
+
     pub fn install_specialized_body_candidates<K, M>(
         mut self,
         candidates: Vec<crate::SemanticSpecializedBodyCandidate<K, M>>,
-        definition: impl Fn(&K) -> Option<crate::SemanticBodyDefinitionIdentity>,
-        module: impl Fn(&M) -> Option<FileId>,
+        definition: impl Fn(
+            &K,
+        ) -> Result<
+            crate::SemanticDefinitionToken,
+            crate::SemanticStableResolutionFailure,
+        >,
+        module: impl Fn(
+            &M,
+        )
+            -> Result<crate::SemanticModuleToken, crate::SemanticStableResolutionFailure>,
     ) -> (Self, crate::SemanticSpecializedCandidateInstallWork)
     where
         K: Clone + Ord,
-        M: Clone + Ord + AsRef<str>,
+        M: Clone + Ord,
     {
         let mut work = crate::SemanticSpecializedCandidateInstallWork::default();
         for candidate in candidates {
             work.attempts += 1;
-            let map_module = |key: &M| {
-                module(key)
-                    .map(|file| crate::SemanticBodyModuleIdentity {
-                        file_id: file.index(),
-                        path: std::sync::Arc::from(key.as_ref()),
-                    })
-                    .ok_or(())
-            };
-            let map_definition = |key: &K| definition(key).ok_or(());
+            let map_module = |key: &M| module(key);
+            let map_definition = |key: &K| definition(key);
             let identity = candidate
                 .identity
-                .try_map_keys(&map_definition, &|key: &M| {
-                    Ok::<_, ()>(std::sync::Arc::from(key.as_ref()))
-                });
+                .try_map_keys(&map_definition, &map_module);
             let body = candidate.body.try_map_keys(&map_definition, &map_module);
             let dependencies = candidate
                 .dependencies
@@ -899,24 +952,23 @@ impl<'a> BoundSema<'a> {
     pub fn install_ordinary_body_candidates<K, M>(
         mut self,
         candidates: Vec<crate::SemanticBodyCandidate<K, M>>,
-        definition: impl Fn(&K) -> Option<crate::SemanticBodyDefinitionIdentity>,
-        module: impl Fn(&M) -> Option<FileId>,
+        definition: impl Fn(
+            &K,
+        ) -> Result<
+            crate::SemanticDefinitionToken,
+            crate::SemanticStableResolutionFailure,
+        >,
+        module: impl Fn(
+            &M,
+        )
+            -> Result<crate::SemanticModuleToken, crate::SemanticStableResolutionFailure>,
     ) -> Self
     where
         K: Clone + Ord,
-        M: Clone + Ord + AsRef<str>,
+        M: Clone + Ord,
     {
         for candidate in candidates {
-            let mapped = candidate
-                .body
-                .try_map_keys(&|key| definition(key).ok_or(()), &|key| {
-                    module(key)
-                        .map(|file| crate::SemanticBodyModuleIdentity {
-                            file_id: file.index(),
-                            path: std::sync::Arc::from(key.as_ref()),
-                        })
-                        .ok_or(())
-                });
+            let mapped = candidate.body.try_map_keys(&definition, &module);
             if let Ok(body) = mapped {
                 self.sema.reusable_ordinary_bodies.insert(
                     candidate.owner,
@@ -1847,6 +1899,58 @@ mod tests {
         let bound =
             Sema::new_synthetic(&rir, &interner, PreviewFeatures::new()).bind_declarations()?;
         Ok(bound.binding_manifest().clone())
+    }
+
+    fn install_stable_endpoints(
+        definitions: &[crate::SemanticDefinitionEndpoint],
+        modules: &[crate::SemanticModuleEndpoint],
+    ) -> Result<(), crate::SemanticStableResolutionFailure> {
+        let (tokens, interner) = Lexer::new("fn main() {}").tokenize().unwrap();
+        let (ast, interner) = Parser::new(tokens, interner).parse().unwrap();
+        let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
+        astgen.append_items(&ast.items);
+        let rir = astgen.finish();
+        Sema::new_synthetic(&rir, &interner, PreviewFeatures::new())
+            .bind_declarations()
+            .unwrap()
+            .install_stable_identity_endpoints(definitions, modules)
+            .map(|_| ())
+    }
+
+    #[test]
+    fn stable_endpoint_install_reports_every_typed_resolution_failure() {
+        use crate::SemanticStableResolutionFailure as F;
+        let endpoint = crate::SemanticDefinitionEndpoint {
+            token: crate::SemanticDefinitionToken::new(7, 0),
+            file: 0,
+            name: Arc::from("main"),
+            kind: StableDefinitionKind::Function,
+            owner: None,
+        };
+        assert_eq!(install_stable_endpoints(&[], &[]), Err(F::Missing));
+
+        let mut duplicate = endpoint.clone();
+        duplicate.token = crate::SemanticDefinitionToken::new(7, 1);
+        assert_eq!(
+            install_stable_endpoints(&[endpoint.clone(), duplicate], &[]),
+            Err(F::Ambiguous)
+        );
+
+        let mut wrong_kind = endpoint.clone();
+        wrong_kind.kind = StableDefinitionKind::Method;
+        assert_eq!(
+            install_stable_endpoints(&[wrong_kind], &[]),
+            Err(F::WrongKind)
+        );
+
+        let foreign_module = crate::SemanticModuleEndpoint {
+            token: crate::SemanticModuleToken::new(8, 0),
+            file: 0,
+        };
+        assert_eq!(
+            install_stable_endpoints(&[endpoint], &[foreign_module]),
+            Err(F::ForeignIssuer)
+        );
     }
 
     fn lower_files(files: &[(&str, FileId)]) -> (Rir, ThreadedRodeo) {

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -236,18 +236,23 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
     pub(crate) specialized_body_exports: Vec<crate::SemanticSpecializedBodyExport>,
     pub(crate) reusable_ordinary_bodies: HashMap<
         BodyOwnerToken,
-        crate::SemanticBodyCandidate<
-            crate::SemanticBodyDefinitionIdentity,
-            crate::SemanticBodyModuleIdentity,
-        >,
+        crate::SemanticBodyCandidate<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
     >,
     pub(crate) reusable_specialized_bodies: Vec<
         crate::SemanticSpecializedBodyCandidate<
-            crate::SemanticBodyDefinitionIdentity,
-            std::sync::Arc<str>,
-            crate::SemanticBodyModuleIdentity,
+            crate::SemanticDefinitionToken,
+            crate::SemanticModuleToken,
         >,
     >,
+    pub(crate) stable_definition_tokens: HashMap<
+        (u32, String, Option<String>, crate::StableDefinitionKind),
+        crate::SemanticDefinitionToken,
+    >,
+    pub(crate) stable_definition_endpoints:
+        HashMap<crate::SemanticDefinitionToken, crate::SemanticDefinitionEndpoint>,
+    pub(crate) stable_module_tokens: HashMap<FileId, crate::SemanticModuleToken>,
+    pub(crate) stable_module_endpoints:
+        HashMap<crate::SemanticModuleToken, crate::SemanticModuleEndpoint>,
     pub(crate) body_dependency_observer: Option<AnalyzedBodyOwnerEvent>,
     pub(crate) body_owner_tokens:
         HashMap<(u32, String, Option<String>, BodyOwnerKind), BodyOwnerToken>,
@@ -390,6 +395,10 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             specialized_body_exports,
             reusable_ordinary_bodies,
             reusable_specialized_bodies,
+            stable_definition_tokens,
+            stable_definition_endpoints,
+            stable_module_tokens,
+            stable_module_endpoints,
             body_dependency_observer,
             body_owner_tokens,
             body_named_dependencies,
@@ -444,6 +453,10 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             specialized_body_exports,
             reusable_ordinary_bodies,
             reusable_specialized_bodies,
+            stable_definition_tokens,
+            stable_definition_endpoints,
+            stable_module_tokens,
+            stable_module_endpoints,
             body_dependency_observer,
             body_owner_tokens,
             body_named_dependencies,
@@ -785,6 +798,10 @@ impl<'a> Sema<'a> {
             specialized_body_exports: Vec::new(),
             reusable_ordinary_bodies: HashMap::new(),
             reusable_specialized_bodies: Vec::new(),
+            stable_definition_tokens: HashMap::new(),
+            stable_definition_endpoints: HashMap::new(),
+            stable_module_tokens: HashMap::new(),
+            stable_module_endpoints: HashMap::new(),
             body_dependency_observer: None,
             body_owner_tokens: HashMap::new(),
             body_named_dependencies: Vec::new(),

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -47,11 +47,11 @@ mod visibility;
 // Public re-exports
 pub use binding_manifest::{
     BoundSema, DeclarationBindingWork, DeclarationInstallFailure, DeclarationResolutionFailure,
-    DeclarationShells, SemanticBinding, SemanticBindingKind, SemanticBindingManifest,
-    SemanticBindingManifestWork, SemanticBindingNamespace, SemanticDeclarationExport,
-    SemanticDeclarationExportWork, SemanticDeclarationPayload, SemanticDeclarationShell,
-    SemanticDeclarationShellIdentity, SemanticExportConstValue, SemanticExportFailure,
-    SemanticExportParameter, SemanticExportType, SemanticNominalIdentity, SemanticParameterMode,
+    DeclarationShells, SemanticBinding, SemanticBindingManifest, SemanticBindingManifestWork,
+    SemanticDeclarationExport, SemanticDeclarationExportWork, SemanticDeclarationPayload,
+    SemanticDeclarationShell, SemanticDeclarationShellIdentity, SemanticExportConstValue,
+    SemanticExportFailure, SemanticExportParameter, SemanticExportType, SemanticNominalIdentity,
+    SemanticParameterMode,
 };
 pub use context::ConstValue;
 pub use declaration_index::RirDeclarationIndexWork;

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -247,8 +247,8 @@ pub enum ImplicitDropDependencySourceEvent {
     Anonymous,
     Specialization {
         identity: crate::SemanticSpecializationIdentity<
-            crate::SemanticBodyDefinitionIdentity,
-            std::sync::Arc<str>,
+            crate::SemanticDefinitionToken,
+            crate::SemanticModuleToken,
         >,
     },
     FreeFunction {

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -7,9 +7,9 @@ use rue_span::Span;
 use super::{AnalyzedFunction, BodyOwnerToken, BodySema};
 use crate::{
     AirInstData, AirPattern, AirProjection, SemanticBody, SemanticBodyAnchor, SemanticBodyCallArg,
-    SemanticBodyDefinitionIdentity, SemanticBodyExport, SemanticBodyExportFailure as F,
-    SemanticBodyInst, SemanticBodyInstData, SemanticBodyMatchArm, SemanticBodyPattern,
-    SemanticBodyPlace, SemanticBodyProjection, SemanticImportConstValue, SemanticImportType,
+    SemanticBodyExport, SemanticBodyExportFailure as F, SemanticBodyInst, SemanticBodyInstData,
+    SemanticBodyMatchArm, SemanticBodyPattern, SemanticBodyPlace, SemanticBodyProjection,
+    SemanticDefinitionToken, SemanticImportConstValue, SemanticImportType, SemanticModuleToken,
     SemanticSpecializationIdentity, SemanticSpecializedBodyExport, StableDefinitionKind, Type,
     TypeKind,
 };
@@ -26,9 +26,9 @@ impl BodySema<'_> {
         warnings: &[CompileWarning],
         specialized_calls: &HashMap<
             Spur,
-            SemanticSpecializationIdentity<SemanticBodyDefinitionIdentity, Arc<str>>,
+            SemanticSpecializationIdentity<SemanticDefinitionToken, SemanticModuleToken>,
         >,
-        dependencies: &[SemanticBodyDefinitionIdentity],
+        dependencies: &[SemanticDefinitionToken],
         dependency_boundary_complete: bool,
     ) -> Result<SemanticSpecializedBodyExport, F> {
         let source_name = self.source_function_name(base_name);
@@ -102,7 +102,7 @@ impl BodySema<'_> {
         specialized_calls: Option<
             &HashMap<
                 Spur,
-                SemanticSpecializationIdentity<SemanticBodyDefinitionIdentity, Arc<str>>,
+                SemanticSpecializationIdentity<SemanticDefinitionToken, SemanticModuleToken>,
             >,
         >,
     ) -> Result<SemanticBodyExport, F> {
@@ -515,17 +515,14 @@ impl BodySema<'_> {
         })
     }
 
-    pub(crate) fn function_identity(
-        &self,
-        symbol: Spur,
-    ) -> Result<SemanticBodyDefinitionIdentity, F> {
+    pub(crate) fn function_identity(&self, symbol: Spur) -> Result<SemanticDefinitionToken, F> {
         if let Some(info) = self.functions.get(&symbol) {
-            return Ok(SemanticBodyDefinitionIdentity {
-                file_id: info.file_id.index(),
-                name: Arc::from(self.interner.resolve(&self.source_function_name(symbol))),
-                kind: StableDefinitionKind::Function,
-                owner: None,
-            });
+            return self.stable_definition_token(
+                info.file_id.index(),
+                self.interner.resolve(&self.source_function_name(symbol)),
+                None,
+                StableDefinitionKind::Function,
+            );
         }
         let resolved = self.interner.resolve(&symbol);
         for (&(struct_id, method_name), info) in &self.methods {
@@ -537,52 +534,97 @@ impl BodySema<'_> {
             if owner.name.starts_with("__anon_struct_") {
                 return Err(F::AnonymousNominal);
             }
-            return Ok(SemanticBodyDefinitionIdentity {
-                file_id: info.span.file_id.index(),
-                name: Arc::from(method),
-                kind: if method == "__drop" {
+            return self.stable_definition_token(
+                info.span.file_id.index(),
+                method,
+                Some(owner.name.as_str()),
+                if method == "__drop" {
                     StableDefinitionKind::Destructor
                 } else if info.has_self {
                     StableDefinitionKind::Method
                 } else {
                     StableDefinitionKind::AssociatedFunction
                 },
-                owner: Some(Arc::from(owner.name.as_str())),
-            });
+            );
         }
         Err(F::UnmappedFunction)
     }
 
-    fn struct_identity(&self, id: crate::StructId) -> Result<SemanticBodyDefinitionIdentity, F> {
+    pub(crate) fn struct_identity(
+        &self,
+        id: crate::StructId,
+    ) -> Result<SemanticDefinitionToken, F> {
         let def = self.type_pool.struct_def(id);
         if def.name.starts_with("__anon_struct_") {
             return Err(F::AnonymousNominal);
         }
-        Ok(SemanticBodyDefinitionIdentity {
-            file_id: def.file_id.index(),
-            name: Arc::from(def.name.as_str()),
-            kind: StableDefinitionKind::Struct,
-            owner: None,
-        })
+        self.stable_definition_token(
+            def.file_id.index(),
+            def.name.as_str(),
+            None,
+            StableDefinitionKind::Struct,
+        )
     }
 
-    fn enum_identity(&self, id: crate::EnumId) -> Result<SemanticBodyDefinitionIdentity, F> {
+    pub(crate) fn enum_identity(&self, id: crate::EnumId) -> Result<SemanticDefinitionToken, F> {
         let def = self.type_pool.enum_def(id);
         if def.name.starts_with("__anon_enum_") {
             return Err(F::AnonymousNominal);
         }
-        Ok(SemanticBodyDefinitionIdentity {
-            file_id: def.file_id.index(),
-            name: Arc::from(def.name.as_str()),
-            kind: StableDefinitionKind::Enum,
-            owner: None,
-        })
+        self.stable_definition_token(
+            def.file_id.index(),
+            def.name.as_str(),
+            None,
+            StableDefinitionKind::Enum,
+        )
+    }
+
+    pub(crate) fn stable_definition_token(
+        &self,
+        file: u32,
+        name: &str,
+        owner: Option<&str>,
+        kind: StableDefinitionKind,
+    ) -> Result<SemanticDefinitionToken, F> {
+        let owner = owner.map(str::to_owned);
+        let key = (file, name.to_owned(), owner.clone(), kind);
+        if let Some(token) = self.stable_definition_tokens.get(&key) {
+            return Ok(*token);
+        }
+        if self.stable_definition_tokens.is_empty() {
+            // The synthetic test constructor has no compiler-issued stable
+            // universe. Keep that explicitly non-authoritative seam usable
+            // without reintroducing textual identities into exported bodies.
+            let mut slot = 2_166_136_261_u32;
+            for byte in file
+                .to_le_bytes()
+                .into_iter()
+                .chain(name.bytes())
+                .chain(owner.as_deref().unwrap_or("").bytes())
+                .chain([kind as u8])
+            {
+                slot = (slot ^ u32::from(byte)).wrapping_mul(16_777_619);
+            }
+            return Ok(SemanticDefinitionToken::new(0, slot));
+        }
+        let mut candidates = self.stable_definition_tokens.keys().filter(
+            |(candidate_file, candidate_name, candidate_owner, _)| {
+                *candidate_file == file && candidate_name == name && candidate_owner == &owner
+            },
+        );
+        let Some(_) = candidates.next() else {
+            return Err(F::MissingStableIdentity);
+        };
+        if candidates.next().is_some() {
+            return Err(F::AmbiguousStableIdentity);
+        }
+        Err(F::WrongStableIdentityKind)
     }
 
     pub(crate) fn export_body_type(
         &self,
         ty: Type,
-    ) -> Result<SemanticImportType<SemanticBodyDefinitionIdentity, Arc<str>>, F> {
+    ) -> Result<SemanticImportType<SemanticDefinitionToken, SemanticModuleToken>, F> {
         self.type_pool
             .validate_complete_type(ty)
             .map_err(|_| F::UnsupportedType)?;
@@ -637,9 +679,20 @@ impl BodySema<'_> {
             TypeKind::PtrMut(id) => SemanticImportType::PtrMut(Box::new(
                 self.export_body_type(self.type_pool.ptr_mut_def(id))?,
             )),
-            TypeKind::Module(id) => SemanticImportType::Module(Arc::from(
-                self.module_registry.get_def(id).durable_id.as_str(),
-            )),
+            TypeKind::Module(id) => {
+                let file = self.module_registry.get_def(id).file_id;
+                SemanticImportType::Module(
+                    self.stable_module_tokens
+                        .get(&file)
+                        .copied()
+                        .or_else(|| {
+                            self.stable_module_tokens
+                                .is_empty()
+                                .then(|| SemanticModuleToken::new(0, file.index()))
+                        })
+                        .ok_or(F::MissingStableIdentity)?,
+                )
+            }
             TypeKind::Error => return Err(F::UnsupportedType),
         })
     }

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -7,10 +7,10 @@ use rue_span::Span;
 use super::{AnalyzedFunction, BodyOwnerToken, BodySema};
 use crate::{
     AirInstData, AirPattern, AirProjection, SemanticBody, SemanticBodyAnchor, SemanticBodyCallArg,
-    SemanticBodyDefinitionIdentity, SemanticBodyDefinitionKind, SemanticBodyExport,
-    SemanticBodyExportFailure as F, SemanticBodyInst, SemanticBodyInstData, SemanticBodyMatchArm,
-    SemanticBodyPattern, SemanticBodyPlace, SemanticBodyProjection, SemanticImportConstValue,
-    SemanticImportType, SemanticSpecializationIdentity, SemanticSpecializedBodyExport, Type,
+    SemanticBodyDefinitionIdentity, SemanticBodyExport, SemanticBodyExportFailure as F,
+    SemanticBodyInst, SemanticBodyInstData, SemanticBodyMatchArm, SemanticBodyPattern,
+    SemanticBodyPlace, SemanticBodyProjection, SemanticImportConstValue, SemanticImportType,
+    SemanticSpecializationIdentity, SemanticSpecializedBodyExport, StableDefinitionKind, Type,
     TypeKind,
 };
 
@@ -523,7 +523,7 @@ impl BodySema<'_> {
             return Ok(SemanticBodyDefinitionIdentity {
                 file_id: info.file_id.index(),
                 name: Arc::from(self.interner.resolve(&self.source_function_name(symbol))),
-                kind: SemanticBodyDefinitionKind::FreeFunction,
+                kind: StableDefinitionKind::Function,
                 owner: None,
             });
         }
@@ -541,11 +541,11 @@ impl BodySema<'_> {
                 file_id: info.span.file_id.index(),
                 name: Arc::from(method),
                 kind: if method == "__drop" {
-                    SemanticBodyDefinitionKind::Destructor
+                    StableDefinitionKind::Destructor
                 } else if info.has_self {
-                    SemanticBodyDefinitionKind::Method
+                    StableDefinitionKind::Method
                 } else {
-                    SemanticBodyDefinitionKind::AssociatedFunction
+                    StableDefinitionKind::AssociatedFunction
                 },
                 owner: Some(Arc::from(owner.name.as_str())),
             });
@@ -561,7 +561,7 @@ impl BodySema<'_> {
         Ok(SemanticBodyDefinitionIdentity {
             file_id: def.file_id.index(),
             name: Arc::from(def.name.as_str()),
-            kind: SemanticBodyDefinitionKind::Struct,
+            kind: StableDefinitionKind::Struct,
             owner: None,
         })
     }
@@ -574,7 +574,7 @@ impl BodySema<'_> {
         Ok(SemanticBodyDefinitionIdentity {
             file_id: def.file_id.index(),
             name: Arc::from(def.name.as_str()),
-            kind: SemanticBodyDefinitionKind::Enum,
+            kind: StableDefinitionKind::Enum,
             owner: None,
         })
     }

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -346,23 +346,20 @@ mod tests {
             0
         );
 
-        let main = output
-            .ordinary_body_exports
-            .iter()
-            .find(|export| {
-                output
-                    .analyzed_body_owners
-                    .iter()
-                    .any(|owner| owner.token() == Some(export.owner))
-                    && export.body.instructions.iter().any(|inst| {
-                        matches!(
-                            &inst.data,
-                            crate::SemanticBodyInstData::Call { function, .. }
-                                if function.name.as_ref() == "leaf"
-                        )
-                    })
-            })
-            .expect("main durable body");
+        let main =
+            output
+                .ordinary_body_exports
+                .iter()
+                .find(|export| {
+                    output
+                        .analyzed_body_owners
+                        .iter()
+                        .any(|owner| owner.token() == Some(export.owner))
+                        && export.body.instructions.iter().any(|inst| {
+                            matches!(&inst.data, crate::SemanticBodyInstData::Call { .. })
+                        })
+                })
+                .expect("main durable body");
         assert!(main.body.strings.is_empty());
         assert!(
             main.body
@@ -484,8 +481,8 @@ mod tests {
             })
             .expect("warning-free main export");
         let epoch = crate::SemanticImportEpoch::<
-            crate::SemanticBodyDefinitionIdentity,
-            std::sync::Arc<str>,
+            crate::SemanticDefinitionToken,
+            crate::SemanticModuleToken,
         >::new(vec![], vec![], vec![])
         .unwrap();
         let imported = epoch.import_body(&export.body, body_span).unwrap();
@@ -560,8 +557,8 @@ mod tests {
         );
 
         let epoch = crate::SemanticImportEpoch::<
-            crate::SemanticBodyDefinitionIdentity,
-            std::sync::Arc<str>,
+            crate::SemanticDefinitionToken,
+            crate::SemanticModuleToken,
         >::new(vec![], vec![], vec![])
         .unwrap();
         let imported = epoch
@@ -637,7 +634,7 @@ mod tests {
         let [export] = output.specialized_body_exports.as_slice() else {
             panic!("one deduplicated specialization export expected");
         };
-        assert_eq!(export.identity.base.name.as_ref(), "id");
+        assert_eq!(export.identity.base.issuer(), 0);
         assert_eq!(export.identity.type_arguments.len(), 1);
         assert!(export.identity.value_arguments.is_empty());
         assert_eq!(

--- a/crates/rue-air/src/semantic_body.rs
+++ b/crates/rue-air/src/semantic_body.rs
@@ -8,20 +8,8 @@ use std::sync::Arc;
 use crate::ParamSlotModes;
 use crate::{
     AirArgMode, AirPlaceBase, BodyOwnerToken, SemanticImportConstValue, SemanticImportFailure,
-    SemanticImportType,
+    SemanticImportType, StableDefinitionKind,
 };
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum SemanticBodyDefinitionKind {
-    FreeFunction,
-    Method,
-    AssociatedFunction,
-    Destructor,
-    Struct,
-    Enum,
-    ValueConst,
-    ModuleBinding,
-}
 
 /// Request-independent textual identity used only until the compiler joins it
 /// to its authoritative stable-definition universe.
@@ -29,7 +17,7 @@ pub enum SemanticBodyDefinitionKind {
 pub struct SemanticBodyDefinitionIdentity {
     pub file_id: u32,
     pub name: Arc<str>,
-    pub kind: SemanticBodyDefinitionKind,
+    pub kind: StableDefinitionKind,
     pub owner: Option<Arc<str>>,
 }
 

--- a/crates/rue-air/src/semantic_body.rs
+++ b/crates/rue-air/src/semantic_body.rs
@@ -8,35 +8,92 @@ use std::sync::Arc;
 use crate::ParamSlotModes;
 use crate::{
     AirArgMode, AirPlaceBase, BodyOwnerToken, SemanticImportConstValue, SemanticImportFailure,
-    SemanticImportType, StableDefinitionKind,
+    SemanticImportType,
 };
 
-/// Request-independent textual identity used only until the compiler joins it
-/// to its authoritative stable-definition universe.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SemanticBodyDefinitionIdentity {
-    pub file_id: u32,
+/// Issuer-scoped snapshot authorization for one stable definition.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SemanticDefinitionToken {
+    issuer: u64,
+    slot: u32,
+}
+
+impl std::fmt::Debug for SemanticDefinitionToken {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_tuple("SemanticDefinitionToken")
+            .field(&self.slot)
+            .finish()
+    }
+}
+
+impl SemanticDefinitionToken {
+    pub fn new(issuer: u64, slot: u32) -> Self {
+        Self { issuer, slot }
+    }
+    pub fn issuer(self) -> u64 {
+        self.issuer
+    }
+    pub fn slot(self) -> u32 {
+        self.slot
+    }
+}
+
+/// Issuer-scoped snapshot authorization for one logical module.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SemanticModuleToken {
+    issuer: u64,
+    slot: u32,
+}
+
+impl std::fmt::Debug for SemanticModuleToken {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_tuple("SemanticModuleToken")
+            .field(&self.slot)
+            .finish()
+    }
+}
+
+impl SemanticModuleToken {
+    pub fn new(issuer: u64, slot: u32) -> Self {
+        Self { issuer, slot }
+    }
+    pub fn issuer(self) -> u64 {
+        self.issuer
+    }
+    pub fn slot(self) -> u32 {
+        self.slot
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticDefinitionEndpoint {
+    pub token: SemanticDefinitionToken,
+    pub file: u32,
     pub name: Arc<str>,
-    pub kind: StableDefinitionKind,
+    pub kind: crate::StableDefinitionKind,
     pub owner: Option<Arc<str>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SemanticBodyModuleIdentity {
-    pub file_id: u32,
-    pub path: Arc<str>,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SemanticModuleEndpoint {
+    pub token: SemanticModuleToken,
+    pub file: u32,
 }
 
-impl AsRef<str> for SemanticBodyModuleIdentity {
-    fn as_ref(&self) -> &str {
-        &self.path
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SemanticStableResolutionFailure {
+    Missing,
+    Ambiguous,
+    WrongKind,
+    ForeignIssuer,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SemanticBodyExport {
     pub owner: BodyOwnerToken,
-    pub body: SemanticBody<SemanticBodyDefinitionIdentity, Arc<str>>,
+    pub body: SemanticBody<SemanticDefinitionToken, SemanticModuleToken>,
 }
 
 /// Request-independent identity of one completed generic specialization.
@@ -52,9 +109,9 @@ pub struct SemanticSpecializationIdentity<K, M> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SemanticSpecializedBodyExport {
-    pub identity: SemanticSpecializationIdentity<SemanticBodyDefinitionIdentity, Arc<str>>,
-    pub body: SemanticBody<SemanticBodyDefinitionIdentity, Arc<str>>,
-    pub dependencies: Arc<[SemanticBodyDefinitionIdentity]>,
+    pub identity: SemanticSpecializationIdentity<SemanticDefinitionToken, SemanticModuleToken>,
+    pub body: SemanticBody<SemanticDefinitionToken, SemanticModuleToken>,
+    pub dependencies: Arc<[SemanticDefinitionToken]>,
     pub dependency_boundary_complete: bool,
 }
 
@@ -112,6 +169,10 @@ pub enum SemanticBodyExportFailure {
     ForeignSpan,
     UnsupportedWarningMetadata,
     SizeOverflow,
+    MissingStableIdentity,
+    AmbiguousStableIdentity,
+    WrongStableIdentityKind,
+    ForeignStableIdentityIssuer,
 }
 
 pub type SemanticBodyRef = u32;
@@ -615,6 +676,7 @@ pub struct SemanticBodyCandidateInstallWork {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SemanticBodyImportFailure {
     Semantic(super::SemanticImportFailure),
+    StableResolution(SemanticStableResolutionFailure),
     UnsupportedGenericCall,
     InvalidInstructionReference,
     ForwardInstructionReference,

--- a/crates/rue-air/src/semantic_identity.rs
+++ b/crates/rue-air/src/semantic_identity.rs
@@ -1,0 +1,80 @@
+//! Canonical semantic definition taxonomy shared by live bindings and durable keys.
+
+/// The exhaustive namespace of a semantically bound definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum StableDefinitionNamespace {
+    Value,
+    Type,
+    Destructor,
+    Method,
+}
+
+/// The exhaustive kind of a semantically bound definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum StableDefinitionKind {
+    Function,
+    Struct,
+    Enum,
+    ValueConst,
+    ModuleBinding,
+    Destructor,
+    Method,
+    AssociatedFunction,
+}
+
+impl StableDefinitionKind {
+    /// The only namespace in which this kind can be issued.
+    pub const fn namespace(self) -> StableDefinitionNamespace {
+        match self {
+            Self::Function | Self::ValueConst | Self::ModuleBinding => {
+                StableDefinitionNamespace::Value
+            }
+            Self::Struct | Self::Enum => StableDefinitionNamespace::Type,
+            Self::Destructor => StableDefinitionNamespace::Destructor,
+            Self::Method | Self::AssociatedFunction => StableDefinitionNamespace::Method,
+        }
+    }
+
+    /// Whether this definition owns an executable semantic body.
+    pub const fn owns_body(self) -> bool {
+        matches!(
+            self,
+            Self::Function | Self::Destructor | Self::Method | Self::AssociatedFunction
+        )
+    }
+
+    /// Whether this definition must name an owning nominal type.
+    pub const fn requires_owner(self) -> bool {
+        matches!(
+            self,
+            Self::Destructor | Self::Method | Self::AssociatedFunction
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn taxonomy_declares_every_kind_namespace_and_owner_shape_once() {
+        use StableDefinitionKind as K;
+        use StableDefinitionNamespace as N;
+
+        let cases = [
+            (K::Function, N::Value, true, false),
+            (K::Struct, N::Type, false, false),
+            (K::Enum, N::Type, false, false),
+            (K::ValueConst, N::Value, false, false),
+            (K::ModuleBinding, N::Value, false, false),
+            (K::Destructor, N::Destructor, true, true),
+            (K::Method, N::Method, true, true),
+            (K::AssociatedFunction, N::Method, true, true),
+        ];
+        for (kind, namespace, owns_body, requires_owner) in cases {
+            assert_eq!(kind.namespace(), namespace);
+            assert_eq!(kind.owns_body(), owns_body);
+            assert_eq!(kind.requires_owner(), requires_owner);
+        }
+    }
+}

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -275,7 +275,7 @@ pub struct SemanticImportEpoch<K: Ord, M: Ord> {
 impl<K, M> SemanticImportEpoch<K, M>
 where
     K: Clone + Ord,
-    M: Clone + Ord + AsRef<str>,
+    M: Clone + Ord,
 {
     /// Reconstruct a structured durable body without publishing partial state.
     ///
@@ -311,7 +311,10 @@ where
             body,
             body_span,
             type_pool,
-            |ty| self.import_type_local_with(ty, type_pool, None),
+            |ty| {
+                self.import_type_local_with(ty, type_pool, None)
+                    .map_err(Into::into)
+            },
             |key| match self.nominals.get(key) {
                 Some(LocalNominal::Struct(id)) => Ok(*id),
                 Some(LocalNominal::Enum(_)) => Err(SemanticBodyImportFailure::WrongNominalKind),
@@ -343,7 +346,7 @@ where
         body: &SemanticBody<K, M>,
         body_span: Span,
         type_pool: &TypeInternPool,
-        import_type: impl Fn(&SemanticImportType<K, M>) -> Result<Type, SemanticImportFailure>,
+        import_type: impl Fn(&SemanticImportType<K, M>) -> Result<Type, SemanticBodyImportFailure>,
         struct_id: impl Fn(&K) -> Result<StructId, SemanticBodyImportFailure>,
         enum_id: impl Fn(&K) -> Result<EnumId, SemanticBodyImportFailure>,
         resolve_function: impl Fn(&K) -> Result<Spur, SemanticBodyImportFailure>,
@@ -401,7 +404,7 @@ where
         {
             return Err(F::InvalidBorrowSlot);
         }
-        let return_type = import_type(&body.return_type).map_err(F::Semantic)?;
+        let return_type = import_type(&body.return_type)?;
         let mut air = Air::new(return_type);
         let inst_len = body.instructions.len();
         let place_len = body.places.len();
@@ -434,7 +437,7 @@ where
         };
         for (current, inst) in body.instructions.iter().enumerate() {
             let span = current_anchor(inst.anchor)?;
-            let ty = import_type(&inst.ty).map_err(F::Semantic)?;
+            let ty = import_type(&inst.ty)?;
             let r = |value| check_ref(value, current);
             let binary =
                 |a, b, ctor: fn(AirRef, AirRef) -> AirInstData| Ok::<_, F>(ctor(r(a)?, r(b)?));
@@ -448,9 +451,7 @@ where
                     AirInstData::StringConst(*v)
                 }
                 SemanticBodyInstData::UnitConst => AirInstData::UnitConst,
-                SemanticBodyInstData::TypeConst(v) => {
-                    AirInstData::TypeConst(import_type(v).map_err(F::Semantic)?)
-                }
+                SemanticBodyInstData::TypeConst(v) => AirInstData::TypeConst(import_type(v)?),
                 SemanticBodyInstData::Add(a, b) => binary(*a, *b, AirInstData::Add)?,
                 SemanticBodyInstData::Sub(a, b) => binary(*a, *b, AirInstData::Sub)?,
                 SemanticBodyInstData::Mul(a, b) => binary(*a, *b, AirInstData::Mul)?,
@@ -639,7 +640,7 @@ where
                 },
                 SemanticBodyInstData::IntCast { value, from_ty } => AirInstData::IntCast {
                     value: r(*value)?,
-                    from_ty: import_type(from_ty).map_err(F::Semantic)?,
+                    from_ty: import_type(from_ty)?,
                 },
                 SemanticBodyInstData::Drop { value } => AirInstData::Drop { value: r(*value)? },
                 SemanticBodyInstData::StorageLive { slot } => {
@@ -671,7 +672,7 @@ where
         // instructions. Publish the instruction stream first, then construct
         // places atomically once every index reference has an owner.
         for place in body.places.iter() {
-            let base_type = import_type(&place.base_type).map_err(F::Semantic)?;
+            let base_type = import_type(&place.base_type)?;
             let mut projections = Vec::with_capacity(place.projections.len());
             for projection in place.projections.iter() {
                 projections.push(match projection {
@@ -687,7 +688,7 @@ where
                             return Err(F::InvalidInstructionReference);
                         }
                         AirProjection::Index {
-                            array_type: import_type(array_type).map_err(F::Semantic)?,
+                            array_type: import_type(array_type)?,
                             index: AirRef::from_raw(*index),
                         }
                     }
@@ -697,7 +698,7 @@ where
         }
         let mut drops = Vec::with_capacity(body.param_drops.len());
         for (slot, ty) in body.param_drops.iter() {
-            drops.push((*slot, import_type(ty).map_err(F::Semantic)?));
+            drops.push((*slot, import_type(ty)?));
         }
         air.set_param_drops(drops);
         for slot in body.borrow_slots.iter() {
@@ -763,8 +764,8 @@ where
             );
         }
         let mut modules = BTreeMap::new();
-        for key in module_keys {
-            let path = key.as_ref().to_owned();
+        for (index, key) in module_keys.into_iter().enumerate() {
+            let path = format!("semantic-module-{index}");
             let id = module_registry.push_canonical(crate::ModuleDef::new(
                 path.clone(),
                 path.clone(),

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -91,7 +91,7 @@ struct CompletedExport {
     base_info: FunctionInfo,
     function_index: usize,
     warning_free: bool,
-    dependencies: Vec<crate::SemanticBodyDefinitionIdentity>,
+    dependencies: Vec<crate::SemanticDefinitionToken>,
     dependency_boundary_complete: bool,
 }
 
@@ -101,7 +101,7 @@ struct SpecializedBody {
     local_strings: Vec<String>,
     referenced_functions: HashSet<Spur>,
     referenced_methods: HashSet<(StructId, Spur)>,
-    dependencies: Vec<crate::SemanticBodyDefinitionIdentity>,
+    dependencies: Vec<crate::SemanticDefinitionToken>,
     dependency_boundary_complete: bool,
 }
 
@@ -128,8 +128,8 @@ impl Specializer {
         sema: &crate::sema::BodySema<'_>,
     ) -> Result<
         crate::SemanticSpecializationIdentity<
-            crate::SemanticBodyDefinitionIdentity,
-            std::sync::Arc<str>,
+            crate::SemanticDefinitionToken,
+            crate::SemanticModuleToken,
         >,
         crate::SemanticBodyExportFailure,
     > {
@@ -169,9 +169,8 @@ impl Specializer {
         sema: &mut crate::sema::BodySema<'_>,
     ) -> Option<
         crate::SemanticSpecializedBodyCandidate<
-            crate::SemanticBodyDefinitionIdentity,
-            std::sync::Arc<str>,
-            crate::SemanticBodyModuleIdentity,
+            crate::SemanticDefinitionToken,
+            crate::SemanticModuleToken,
         >,
     > {
         let identity = Self::stable_identity(key, sema).ok()?;
@@ -817,6 +816,7 @@ fn create_specialized_function(
     ) = analysis?;
 
     let mut dependencies = Vec::new();
+    let mut stable_dependency_resolution_complete = true;
     for event in &sema.body_named_dependencies[body_dependency_start..] {
         let (file_id, name, kind) = match &event.target {
             crate::sema::NamedConstDependencyTargetEvent::ValueConst { file, name } => (
@@ -848,50 +848,55 @@ fn create_specialized_function(
                 crate::StableDefinitionKind::ModuleBinding,
             ),
         };
-        dependencies.push(crate::SemanticBodyDefinitionIdentity {
-            file_id,
-            name: std::sync::Arc::from(name),
-            kind,
-            owner: None,
-        });
+        if let Ok(token) = sema.stable_definition_token(file_id, name, None, kind) {
+            dependencies.push(token);
+        } else {
+            stable_dependency_resolution_complete = false;
+        }
     }
     for event in &sema.declaration_type_dependencies[type_dependency_start..] {
-        dependencies.push(crate::SemanticBodyDefinitionIdentity {
-            file_id: event.target_file,
-            name: std::sync::Arc::from(event.target_name.as_str()),
-            kind: match event.target_kind {
-                crate::sema::DeclarationTypeDependencyTargetKind::Struct => {
-                    crate::StableDefinitionKind::Struct
-                }
-                crate::sema::DeclarationTypeDependencyTargetKind::Enum => {
-                    crate::StableDefinitionKind::Enum
-                }
-                crate::sema::DeclarationTypeDependencyTargetKind::ValueConst => {
-                    crate::StableDefinitionKind::ValueConst
-                }
-            },
-            owner: None,
-        });
+        let kind = match event.target_kind {
+            crate::sema::DeclarationTypeDependencyTargetKind::Struct => {
+                crate::StableDefinitionKind::Struct
+            }
+            crate::sema::DeclarationTypeDependencyTargetKind::Enum => {
+                crate::StableDefinitionKind::Enum
+            }
+            crate::sema::DeclarationTypeDependencyTargetKind::ValueConst => {
+                crate::StableDefinitionKind::ValueConst
+            }
+        };
+        if let Ok(token) =
+            sema.stable_definition_token(event.target_file, event.target_name.as_str(), None, kind)
+        {
+            dependencies.push(token);
+        } else {
+            stable_dependency_resolution_complete = false;
+        }
     }
     for event in &sema.declaration_type_call_head_dependencies[type_call_head_start..] {
-        dependencies.push(crate::SemanticBodyDefinitionIdentity {
-            file_id: event.callable_file,
-            name: std::sync::Arc::from(event.callable_name.as_str()),
-            kind: crate::StableDefinitionKind::Function,
-            owner: None,
-        });
+        if let Ok(token) = sema.stable_definition_token(
+            event.callable_file,
+            event.callable_name.as_str(),
+            None,
+            crate::StableDefinitionKind::Function,
+        ) {
+            dependencies.push(token);
+        } else {
+            stable_dependency_resolution_complete = false;
+        }
     }
     // Builtin type call heads are compiler-schema inputs rather than source
     // definitions; their meaning is covered by the durable schema version.
-    let dependency_boundary_complete = sema.declaration_builtin_type_call_head_dependencies
-        [builtin_call_head_start..]
-        .iter()
-        .all(|event| {
-            matches!(
-                event.builtin,
-                crate::sema::BuiltinTypeCallHead::FixedCapacityString
-            )
-        });
+    let dependency_boundary_complete = stable_dependency_resolution_complete
+        && sema.declaration_builtin_type_call_head_dependencies[builtin_call_head_start..]
+            .iter()
+            .all(|event| {
+                matches!(
+                    event.builtin,
+                    crate::sema::BuiltinTypeCallHead::FixedCapacityString
+                )
+            });
     dependencies.sort();
     dependencies.dedup();
 

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -822,32 +822,30 @@ fn create_specialized_function(
             crate::sema::NamedConstDependencyTargetEvent::ValueConst { file, name } => (
                 *file,
                 name.as_str(),
-                crate::SemanticBodyDefinitionKind::ValueConst,
+                crate::StableDefinitionKind::ValueConst,
             ),
-            crate::sema::NamedConstDependencyTargetEvent::FreeFunction { file, name } => (
-                *file,
-                name.as_str(),
-                crate::SemanticBodyDefinitionKind::FreeFunction,
-            ),
+            crate::sema::NamedConstDependencyTargetEvent::FreeFunction { file, name } => {
+                (*file, name.as_str(), crate::StableDefinitionKind::Function)
+            }
             crate::sema::NamedConstDependencyTargetEvent::NamedType { file, name, kind } => (
                 *file,
                 name.as_str(),
                 match kind {
                     crate::sema::DeclarationTypeDependencyTargetKind::Struct => {
-                        crate::SemanticBodyDefinitionKind::Struct
+                        crate::StableDefinitionKind::Struct
                     }
                     crate::sema::DeclarationTypeDependencyTargetKind::Enum => {
-                        crate::SemanticBodyDefinitionKind::Enum
+                        crate::StableDefinitionKind::Enum
                     }
                     crate::sema::DeclarationTypeDependencyTargetKind::ValueConst => {
-                        crate::SemanticBodyDefinitionKind::ValueConst
+                        crate::StableDefinitionKind::ValueConst
                     }
                 },
             ),
             crate::sema::NamedConstDependencyTargetEvent::ModuleBinding { file, name } => (
                 *file,
                 name.as_str(),
-                crate::SemanticBodyDefinitionKind::ModuleBinding,
+                crate::StableDefinitionKind::ModuleBinding,
             ),
         };
         dependencies.push(crate::SemanticBodyDefinitionIdentity {
@@ -863,13 +861,13 @@ fn create_specialized_function(
             name: std::sync::Arc::from(event.target_name.as_str()),
             kind: match event.target_kind {
                 crate::sema::DeclarationTypeDependencyTargetKind::Struct => {
-                    crate::SemanticBodyDefinitionKind::Struct
+                    crate::StableDefinitionKind::Struct
                 }
                 crate::sema::DeclarationTypeDependencyTargetKind::Enum => {
-                    crate::SemanticBodyDefinitionKind::Enum
+                    crate::StableDefinitionKind::Enum
                 }
                 crate::sema::DeclarationTypeDependencyTargetKind::ValueConst => {
-                    crate::SemanticBodyDefinitionKind::ValueConst
+                    crate::StableDefinitionKind::ValueConst
                 }
             },
             owner: None,
@@ -879,7 +877,7 @@ fn create_specialized_function(
         dependencies.push(crate::SemanticBodyDefinitionIdentity {
             file_id: event.callable_file,
             name: std::sync::Arc::from(event.callable_name.as_str()),
-            kind: crate::SemanticBodyDefinitionKind::FreeFunction,
+            kind: crate::StableDefinitionKind::Function,
             owner: None,
         });
     }

--- a/crates/rue-compiler-session-bench/src/representative.rs
+++ b/crates/rue-compiler-session-bench/src/representative.rs
@@ -335,11 +335,13 @@ fn assert_structure(scenarios: &[Value]) {
         // producer, so module reuse is represented by the query reuse below
         // rather than synthetic per-module work.
         ("no_change_query", [0, 0, 0, 0, 0, 0, 0, 1]),
-        ("leaf_edit", [1, 6, 6, 0, 6, 0, 1, 0]),
-        ("widely_depended_definition_edit", [1, 6, 6, 0, 6, 0, 1, 0]),
-        ("import_change", [2, 5, 6, 0, 6, 0, 1, 0]),
+        // Opaque bound tokens remove the old textual conversion discard, so
+        // the two semantically unchanged CFGs remain reusable.
+        ("leaf_edit", [1, 6, 6, 0, 4, 2, 1, 0]),
+        ("widely_depended_definition_edit", [1, 6, 6, 0, 4, 2, 1, 0]),
+        ("import_change", [2, 5, 6, 0, 4, 2, 1, 0]),
         ("diagnostic_error_edit", [1, 6, 5, 0, 0, 0, 1, 0]),
-        ("diagnostic_recovery", [2, 5, 6, 0, 6, 0, 1, 0]),
+        ("diagnostic_recovery", [2, 5, 6, 0, 4, 2, 1, 0]),
     ];
     for (name, counts) in expected {
         let work = &get(name)["required_vs_reused_work"];
@@ -362,19 +364,22 @@ fn assert_structure(scenarios: &[Value]) {
         "diagnostic_recovery",
     ] {
         let scenario = get(name);
+        // Stable-definition tokens resolve directly through the issuing bound
+        // definition set. Ordinary source edits therefore rebuild bodies
+        // without the former textual-join conversion discard.
         assert_eq!(
             count(
                 scenario,
                 &["semantic_work", "durable_bodies", "conversion_failures"]
             ),
-            1
+            0
         );
         assert_eq!(
             count(
                 scenario,
                 &["semantic_work", "durable_bodies", "atomic_discards"]
             ),
-            1
+            0
         );
     }
     assert_eq!(

--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -374,6 +374,99 @@ impl BoundDefinitionSet {
             .collect()
     }
 
+    pub(crate) fn semantic_definition_endpoints(&self) -> Vec<rue_air::SemanticDefinitionEndpoint> {
+        self.definitions
+            .iter()
+            .enumerate()
+            .map(|(slot, record)| {
+                let key = record.stable_key();
+                rue_air::SemanticDefinitionEndpoint {
+                    token: rue_air::SemanticDefinitionToken::new(self.issuer.id, slot as u32),
+                    file: record.declaration_span.file_id.index(),
+                    name: Arc::from(key.name()),
+                    kind: key.kind(),
+                    owner: key.owner().map(|owner| Arc::from(owner.name())),
+                }
+            })
+            .collect()
+    }
+
+    pub(crate) fn semantic_module_endpoints(
+        &self,
+        merged: &CanonicalMergedProgram,
+    ) -> Vec<rue_air::SemanticModuleEndpoint> {
+        merged
+            .ast()
+            .modules()
+            .iter()
+            .enumerate()
+            .map(|(slot, module)| rue_air::SemanticModuleEndpoint {
+                token: rue_air::SemanticModuleToken::new(self.issuer.id, slot as u32),
+                file: module.file_id().index(),
+            })
+            .collect()
+    }
+
+    pub(crate) fn semantic_token_for_key(
+        &self,
+        key: &StableDefinitionKey,
+    ) -> Result<rue_air::SemanticDefinitionToken, rue_air::SemanticStableResolutionFailure> {
+        let slot = self
+            .definitions
+            .binary_search_by(|record| record.stable_key().cmp(key))
+            .map_err(|_| rue_air::SemanticStableResolutionFailure::Missing)?;
+        Ok(rue_air::SemanticDefinitionToken::new(
+            self.issuer.id,
+            slot as u32,
+        ))
+    }
+
+    pub(crate) fn key_for_semantic_token(
+        &self,
+        token: rue_air::SemanticDefinitionToken,
+    ) -> Result<&StableDefinitionKey, rue_air::SemanticStableResolutionFailure> {
+        if token.issuer() != self.issuer.id {
+            return Err(rue_air::SemanticStableResolutionFailure::ForeignIssuer);
+        }
+        self.definitions
+            .get(token.slot() as usize)
+            .map(BoundDefinitionRecord::stable_key)
+            .ok_or(rue_air::SemanticStableResolutionFailure::Missing)
+    }
+
+    pub(crate) fn module_token_for(
+        &self,
+        merged: &CanonicalMergedProgram,
+        module: &ModuleId,
+    ) -> Result<rue_air::SemanticModuleToken, rue_air::SemanticStableResolutionFailure> {
+        let slot = merged
+            .ast()
+            .modules()
+            .iter()
+            .position(|candidate| candidate.module_id() == module)
+            .ok_or(rue_air::SemanticStableResolutionFailure::Missing)?;
+        Ok(rue_air::SemanticModuleToken::new(
+            self.issuer.id,
+            slot as u32,
+        ))
+    }
+
+    pub(crate) fn module_for_semantic_token<'a>(
+        &self,
+        merged: &'a CanonicalMergedProgram,
+        token: rue_air::SemanticModuleToken,
+    ) -> Result<&'a ModuleId, rue_air::SemanticStableResolutionFailure> {
+        if token.issuer() != self.issuer.id {
+            return Err(rue_air::SemanticStableResolutionFailure::ForeignIssuer);
+        }
+        merged
+            .ast()
+            .modules()
+            .get(token.slot() as usize)
+            .map(|module| module.module_id())
+            .ok_or(rue_air::SemanticStableResolutionFailure::Missing)
+    }
+
     pub(crate) fn key_for_body_token(
         &self,
         token: rue_air::BodyOwnerToken,

--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -1,14 +1,15 @@
 //! Stable source-definition identities issued only after semantic binding.
 
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::{
     Arc,
     atomic::{AtomicU64, Ordering},
 };
 
 use rue_air::{
-    CanonicalImportView, DeclarationBindingWork, Sema, SemanticBinding, SemanticBindingKind,
-    SemanticBindingManifestWork, SemanticBindingNamespace, SemanticDeclarationShell,
+    CanonicalImportView, DeclarationBindingWork, Sema, SemanticBinding,
+    SemanticBindingManifestWork, SemanticDeclarationShell,
 };
 use rue_error::{CompileError, CompileErrors, CompileResult, ErrorKind, MultiErrorResult};
 use rue_parser::ast::{Item, Visibility};
@@ -76,25 +77,11 @@ struct DefinitionIssuer {
 }
 static NEXT_DEFINITION_ISSUER: AtomicU64 = AtomicU64::new(1);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum StableDefinitionNamespace {
-    Value,
-    Type,
-    Destructor,
-    Method,
-}
+/// Durable-key name for the canonical semantic namespace taxonomy.
+pub type StableDefinitionNamespace = rue_air::StableDefinitionNamespace;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum StableDefinitionKind {
-    Function,
-    Struct,
-    Enum,
-    ValueConst,
-    ModuleBinding,
-    Destructor,
-    Method,
-    AssociatedFunction,
-}
+/// Durable-key name for the canonical semantic kind taxonomy.
+pub type StableDefinitionKind = rue_air::StableDefinitionKind;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StableNamedTypeKey {
@@ -165,23 +152,26 @@ impl StableDefinitionKey {
 }
 
 #[derive(Debug, Clone)]
-pub struct BoundDefinitionId {
+pub struct SnapshotBoundDefinitionId {
     key: StableDefinitionKey,
     issuer: Arc<DefinitionIssuer>,
 }
 
-impl BoundDefinitionId {
+/// Compatibility name for an issuer-scoped, snapshot-local authorization ID.
+pub type BoundDefinitionId = SnapshotBoundDefinitionId;
+
+impl SnapshotBoundDefinitionId {
     pub fn stable_key(&self) -> &StableDefinitionKey {
         &self.key
     }
 }
 
-impl PartialEq for BoundDefinitionId {
+impl PartialEq for SnapshotBoundDefinitionId {
     fn eq(&self, other: &Self) -> bool {
         self.key == other.key && Arc::ptr_eq(&self.issuer, &other.issuer)
     }
 }
-impl Eq for BoundDefinitionId {}
+impl Eq for SnapshotBoundDefinitionId {}
 
 #[derive(Debug, Clone)]
 pub struct BoundDefinitionRecord {
@@ -248,6 +238,66 @@ pub struct BoundDefinitionSet {
     definitions: Arc<[BoundDefinitionRecord]>,
     manifest_work: SemanticBindingManifestWork,
     work: BoundDefinitionWork,
+}
+
+/// Fail-closed outcomes at the snapshot-local to durable identity join.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DefinitionIdentityJoinFailure {
+    MissingSyntaxOccurrence,
+    AmbiguousSyntaxOccurrence,
+    DuplicateStableDefinition(StableDefinitionKey),
+}
+
+impl fmt::Display for DefinitionIdentityJoinFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingSyntaxOccurrence => {
+                formatter.write_str("semantic winner has no matching syntax occurrence")
+            }
+            Self::AmbiguousSyntaxOccurrence => {
+                formatter.write_str("semantic winner joins multiple syntax occurrences")
+            }
+            Self::DuplicateStableDefinition(key) => write!(
+                formatter,
+                "semantic bindings duplicate durable key {}::{:?}::{:?}::{}",
+                key.module().as_str(),
+                key.namespace(),
+                key.kind(),
+                key.name()
+            ),
+        }
+    }
+}
+
+fn join_syntax_occurrence<'a>(
+    definitions: &'a crate::DefinitionSnapshot,
+    name_key: &crate::DefinitionNameKey,
+    kind: DefinitionKind,
+) -> Result<&'a crate::DefinitionRecord, DefinitionIdentityJoinFailure> {
+    let mut matches = definitions
+        .definitions_named(name_key)
+        .filter(|record| record.kind() == kind);
+    let first = matches
+        .next()
+        .ok_or(DefinitionIdentityJoinFailure::MissingSyntaxOccurrence)?;
+    if matches.next().is_some() {
+        return Err(DefinitionIdentityJoinFailure::AmbiguousSyntaxOccurrence);
+    }
+    Ok(first)
+}
+
+fn reject_duplicate_stable_definitions(
+    records: &[BoundDefinitionRecord],
+) -> Result<(), DefinitionIdentityJoinFailure> {
+    if let Some(pair) = records
+        .windows(2)
+        .find(|pair| pair[0].stable_key() == pair[1].stable_key())
+    {
+        return Err(DefinitionIdentityJoinFailure::DuplicateStableDefinition(
+            pair[0].stable_key().clone(),
+        ));
+    }
+    Ok(())
 }
 
 impl BoundDefinitionSet {
@@ -711,7 +761,7 @@ pub(crate) fn issue_bound_definitions(
         if binding.declaration_span.file_id != binding.file_id {
             return Err(invalid("semantic binding span has a mismatched file ID"));
         }
-        let stable_kind = stable_kind(binding.kind);
+        let stable_kind = binding.kind;
         let owner = binding.owner.as_ref().map(|owner| StableNamedTypeKey {
             module: module.module_id().clone(),
             kind: StableDefinitionKind::Struct,
@@ -719,12 +769,12 @@ pub(crate) fn issue_bound_definitions(
         });
         let key = StableDefinitionKey {
             module: module.module_id().clone(),
-            namespace: stable_namespace(binding.namespace),
+            namespace: binding.namespace,
             kind: stable_kind,
             name: binding.name.clone(),
             owner,
         };
-        let (occurrence, visibility) = if binding.namespace == SemanticBindingNamespace::Method {
+        let (occurrence, visibility) = if binding.namespace == StableDefinitionNamespace::Method {
             work.named_methods_issued += 1;
             (
                 None,
@@ -736,7 +786,7 @@ pub(crate) fn issue_bound_definitions(
             )
         } else {
             let syntax_kind = syntax_kind(binding.kind);
-            let namespace = if binding.kind == SemanticBindingKind::Destructor {
+            let namespace = if binding.kind == StableDefinitionKind::Destructor {
                 DefinitionNamespace::Destructor
             } else {
                 DefinitionNamespace::ModuleItem
@@ -746,16 +796,8 @@ pub(crate) fn issue_bound_definitions(
                 namespace,
                 binding.name.as_ref(),
             );
-            let matches = merged
-                .definitions()
-                .definitions_named(&name_key)
-                .filter(|record| record.kind() == syntax_kind)
-                .collect::<Vec<_>>();
-            let [winner] = matches.as_slice() else {
-                return Err(invalid(
-                    "semantic winner does not join exactly one syntax occurrence",
-                ));
-            };
+            let winner = join_syntax_occurrence(merged.definitions(), &name_key, syntax_kind)
+                .map_err(|failure| invalid(failure.to_string()))?;
             if winner.declaration_span() != binding.declaration_span {
                 return Err(invalid(
                     "semantic winner span does not match its syntax occurrence",
@@ -763,7 +805,7 @@ pub(crate) fn issue_bound_definitions(
             }
             work.top_level_occurrences_joined += 1;
             let expected_public = winner.visibility() == Some(Visibility::Public);
-            if binding.kind != SemanticBindingKind::Destructor
+            if binding.kind != StableDefinitionKind::Destructor
                 && binding.is_public != expected_public
             {
                 return Err(invalid(
@@ -774,7 +816,7 @@ pub(crate) fn issue_bound_definitions(
         };
         let input_partition = definition_input_partition(module, binding)?;
         records.push(BoundDefinitionRecord {
-            id: BoundDefinitionId {
+            id: SnapshotBoundDefinitionId {
                 key,
                 issuer: issuer.clone(),
             },
@@ -785,14 +827,8 @@ pub(crate) fn issue_bound_definitions(
         });
     }
     records.sort_by(|left, right| left.stable_key().cmp(right.stable_key()));
-    if records
-        .windows(2)
-        .any(|pair| pair[0].stable_key() == pair[1].stable_key())
-    {
-        return Err(invalid(
-            "semantic binding produced duplicate stable definition keys",
-        ));
-    }
+    reject_duplicate_stable_definitions(&records)
+        .map_err(|failure| invalid(failure.to_string()))?;
     for record in &records {
         if let Some(owner) = record.stable_key().owner() {
             let owner_key = StableDefinitionKey {
@@ -869,7 +905,7 @@ fn definition_input_partition(
         })
     };
 
-    if binding.namespace == SemanticBindingNamespace::Method {
+    if binding.namespace == StableDefinitionNamespace::Method {
         binding
             .owner
             .as_deref()
@@ -955,22 +991,12 @@ fn partition_prefix(declaration: Span, payload: Span) -> Result<Span, CompileErr
 }
 
 fn validate_binding_shape(binding: &SemanticBinding) -> Result<(), CompileError> {
-    let valid = match (binding.namespace, binding.kind, binding.owner.as_deref()) {
-        (SemanticBindingNamespace::Value, SemanticBindingKind::Function, None)
-        | (SemanticBindingNamespace::Value, SemanticBindingKind::ValueConst, None)
-        | (SemanticBindingNamespace::Value, SemanticBindingKind::ModuleBinding, None)
-        | (SemanticBindingNamespace::Type, SemanticBindingKind::Struct, None)
-        | (SemanticBindingNamespace::Type, SemanticBindingKind::Enum, None) => true,
-        (
-            SemanticBindingNamespace::Method,
-            SemanticBindingKind::Method | SemanticBindingKind::AssociatedFunction,
-            Some(_),
-        ) => true,
-        (SemanticBindingNamespace::Destructor, SemanticBindingKind::Destructor, Some(owner)) => {
-            owner == binding.name.as_ref() && !binding.is_public
-        }
-        _ => false,
-    };
+    let owner_shape_matches = binding.owner.is_some() == binding.kind.requires_owner();
+    let destructor_shape_matches = binding.kind != StableDefinitionKind::Destructor
+        || (binding.owner.as_deref() == Some(binding.name.as_ref()) && !binding.is_public);
+    let valid = binding.namespace == binding.kind.namespace()
+        && owner_shape_matches
+        && destructor_shape_matches;
     if valid {
         Ok(())
     } else {
@@ -980,38 +1006,16 @@ fn validate_binding_shape(binding: &SemanticBinding) -> Result<(), CompileError>
     }
 }
 
-fn stable_namespace(value: SemanticBindingNamespace) -> StableDefinitionNamespace {
+fn syntax_kind(value: StableDefinitionKind) -> DefinitionKind {
     match value {
-        SemanticBindingNamespace::Value => StableDefinitionNamespace::Value,
-        SemanticBindingNamespace::Type => StableDefinitionNamespace::Type,
-        SemanticBindingNamespace::Destructor => StableDefinitionNamespace::Destructor,
-        SemanticBindingNamespace::Method => StableDefinitionNamespace::Method,
-    }
-}
-
-fn stable_kind(value: SemanticBindingKind) -> StableDefinitionKind {
-    match value {
-        SemanticBindingKind::Function => StableDefinitionKind::Function,
-        SemanticBindingKind::Struct => StableDefinitionKind::Struct,
-        SemanticBindingKind::Enum => StableDefinitionKind::Enum,
-        SemanticBindingKind::ValueConst => StableDefinitionKind::ValueConst,
-        SemanticBindingKind::ModuleBinding => StableDefinitionKind::ModuleBinding,
-        SemanticBindingKind::Destructor => StableDefinitionKind::Destructor,
-        SemanticBindingKind::Method => StableDefinitionKind::Method,
-        SemanticBindingKind::AssociatedFunction => StableDefinitionKind::AssociatedFunction,
-    }
-}
-
-fn syntax_kind(value: SemanticBindingKind) -> DefinitionKind {
-    match value {
-        SemanticBindingKind::Function => DefinitionKind::Function,
-        SemanticBindingKind::Struct => DefinitionKind::Struct,
-        SemanticBindingKind::Enum => DefinitionKind::Enum,
-        SemanticBindingKind::ValueConst | SemanticBindingKind::ModuleBinding => {
+        StableDefinitionKind::Function => DefinitionKind::Function,
+        StableDefinitionKind::Struct => DefinitionKind::Struct,
+        StableDefinitionKind::Enum => DefinitionKind::Enum,
+        StableDefinitionKind::ValueConst | StableDefinitionKind::ModuleBinding => {
             DefinitionKind::Const
         }
-        SemanticBindingKind::Destructor => DefinitionKind::Destructor,
-        SemanticBindingKind::Method | SemanticBindingKind::AssociatedFunction => {
+        StableDefinitionKind::Destructor => DefinitionKind::Destructor,
+        StableDefinitionKind::Method | StableDefinitionKind::AssociatedFunction => {
             unreachable!("methods have no top-level syntax occurrence")
         }
     }
@@ -1522,6 +1526,42 @@ mod tests {
         assert_eq!(first.source_revision(), second.source_revision());
         assert_eq!(keys(&first), keys(&second));
         assert_eq!(first.work(), second.work());
+    }
+
+    #[test]
+    fn snapshot_to_durable_join_reports_missing_ambiguous_and_duplicate_outcomes_by_type() {
+        let input = snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn repeated() {} fn repeated() {} fn main() {}",
+            )],
+            1,
+        );
+        let parsed = parse_source_snapshot_modules(&input).unwrap();
+        let definitions = crate::DefinitionSnapshot::from_parsed_modules(&parsed).unwrap();
+        let repeated = crate::DefinitionNameKey::new(
+            crate::ModuleId::from_logical_path("main.rue").unwrap(),
+            DefinitionNamespace::ModuleItem,
+            "repeated",
+        );
+        assert_eq!(
+            join_syntax_occurrence(&definitions, &repeated, DefinitionKind::Function).unwrap_err(),
+            DefinitionIdentityJoinFailure::AmbiguousSyntaxOccurrence
+        );
+        assert_eq!(
+            join_syntax_occurrence(&definitions, &repeated, DefinitionKind::Struct).unwrap_err(),
+            DefinitionIdentityJoinFailure::MissingSyntaxOccurrence
+        );
+
+        let set = bind(&snapshot(&[(7, "/one.rue", "one.rue", "fn main() {}")], 7));
+        let record = set.definitions()[0].clone();
+        let duplicate_key = record.stable_key().clone();
+        assert_eq!(
+            reject_duplicate_stable_definitions(&[record.clone(), record]).unwrap_err(),
+            DefinitionIdentityJoinFailure::DuplicateStableDefinition(duplicate_key)
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -1034,6 +1034,29 @@ fn finish_canonical_analysis(
             ),
         )
     })?;
+    let bound = bound
+        .install_stable_identity_endpoints(
+            &authoritative_definitions.semantic_definition_endpoints(),
+            &authoritative_definitions.semantic_module_endpoints(merged),
+        )
+        .map_err(|failure| {
+            CanonicalSemanticFailure::declaration(
+                crate::CompileErrors::from(crate::CompileError::without_span(
+                    rue_error::ErrorKind::InternalError(format!(
+                        "failed to install authoritative stable identity endpoints: {failure:?}"
+                    )),
+                )),
+                declaration_stage_work(
+                    declaration_index,
+                    binding,
+                    manifest_work,
+                    body_owner_tokens,
+                    BodyAnalysisWork::default(),
+                    request_stable_ids,
+                    declaration_reuse,
+                ),
+            )
+        })?;
     let token_by_key = authoritative_definitions
         .body_owner_endpoints()
         .into_iter()
@@ -1051,32 +1074,18 @@ fn finish_canonical_analysis(
             })
         })
         .collect();
-    let modules = merged
-        .ast()
-        .modules()
-        .iter()
-        .map(|module| (module.module_id().as_str().to_owned(), module.file_id()))
-        .collect::<std::collections::BTreeMap<_, _>>();
     let bound = bound.install_ordinary_body_candidates(
         air_candidates,
-        |key: &crate::StableDefinitionKey| {
-            let record = authoritative_definitions.definition_by_key(key)?;
-            let kind = key.kind();
-            if matches!(
-                kind,
-                crate::StableDefinitionKind::ValueConst
-                    | crate::StableDefinitionKind::ModuleBinding
-            ) {
-                return None;
-            }
-            Some(rue_air::SemanticBodyDefinitionIdentity {
-                file_id: record.declaration_span().file_id.index(),
-                name: std::sync::Arc::from(key.name()),
-                kind,
-                owner: key.owner().map(|owner| std::sync::Arc::from(owner.name())),
-            })
+        |key: &crate::StableDefinitionKey| authoritative_definitions.semantic_token_for_key(key),
+        |path: &Arc<str>| {
+            let module = merged
+                .ast()
+                .modules()
+                .iter()
+                .find(|module| module.module_id().as_str() == path.as_ref())
+                .ok_or(rue_air::SemanticStableResolutionFailure::Missing)?;
+            authoritative_definitions.module_token_for(merged, module.module_id())
         },
-        |module: &std::sync::Arc<str>| modules.get(module.as_ref()).copied(),
     );
     let specialized_air_candidates = durable_specialized_body_candidates
         .into_iter()
@@ -1090,17 +1099,16 @@ fn finish_canonical_analysis(
         .collect();
     let (bound, specialized_install_work) = bound.install_specialized_body_candidates(
         specialized_air_candidates,
-        |key: &crate::StableDefinitionKey| {
-            let record = authoritative_definitions.definition_by_key(key)?;
-            let kind = key.kind();
-            Some(rue_air::SemanticBodyDefinitionIdentity {
-                file_id: record.declaration_span().file_id.index(),
-                name: Arc::from(key.name()),
-                kind,
-                owner: key.owner().map(|owner| Arc::from(owner.name())),
-            })
+        |key: &crate::StableDefinitionKey| authoritative_definitions.semantic_token_for_key(key),
+        |path: &Arc<str>| {
+            let module = merged
+                .ast()
+                .modules()
+                .iter()
+                .find(|module| module.module_id().as_str() == path.as_ref())
+                .ok_or(rue_air::SemanticStableResolutionFailure::Missing)?;
+            authoritative_definitions.module_token_for(merged, module.module_id())
         },
-        |module: &Arc<str>| modules.get(module.as_ref()).copied(),
     );
     durable_body_reuse_work.specialized_mapping_attempts += specialized_install_work.attempts;
     durable_body_reuse_work.specialized_mapping_successes += specialized_install_work.successes;

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -1061,21 +1061,14 @@ fn finish_canonical_analysis(
         air_candidates,
         |key: &crate::StableDefinitionKey| {
             let record = authoritative_definitions.definition_by_key(key)?;
-            let kind = match key.kind() {
-                crate::StableDefinitionKind::Function => {
-                    rue_air::SemanticBodyDefinitionKind::FreeFunction
-                }
-                crate::StableDefinitionKind::Method => rue_air::SemanticBodyDefinitionKind::Method,
-                crate::StableDefinitionKind::AssociatedFunction => {
-                    rue_air::SemanticBodyDefinitionKind::AssociatedFunction
-                }
-                crate::StableDefinitionKind::Destructor => {
-                    rue_air::SemanticBodyDefinitionKind::Destructor
-                }
-                crate::StableDefinitionKind::Struct => rue_air::SemanticBodyDefinitionKind::Struct,
-                crate::StableDefinitionKind::Enum => rue_air::SemanticBodyDefinitionKind::Enum,
-                _ => return None,
-            };
+            let kind = key.kind();
+            if matches!(
+                kind,
+                crate::StableDefinitionKind::ValueConst
+                    | crate::StableDefinitionKind::ModuleBinding
+            ) {
+                return None;
+            }
             Some(rue_air::SemanticBodyDefinitionIdentity {
                 file_id: record.declaration_span().file_id.index(),
                 name: std::sync::Arc::from(key.name()),
@@ -1099,26 +1092,7 @@ fn finish_canonical_analysis(
         specialized_air_candidates,
         |key: &crate::StableDefinitionKey| {
             let record = authoritative_definitions.definition_by_key(key)?;
-            let kind = match key.kind() {
-                crate::StableDefinitionKind::Function => {
-                    rue_air::SemanticBodyDefinitionKind::FreeFunction
-                }
-                crate::StableDefinitionKind::Method => rue_air::SemanticBodyDefinitionKind::Method,
-                crate::StableDefinitionKind::AssociatedFunction => {
-                    rue_air::SemanticBodyDefinitionKind::AssociatedFunction
-                }
-                crate::StableDefinitionKind::Destructor => {
-                    rue_air::SemanticBodyDefinitionKind::Destructor
-                }
-                crate::StableDefinitionKind::Struct => rue_air::SemanticBodyDefinitionKind::Struct,
-                crate::StableDefinitionKind::Enum => rue_air::SemanticBodyDefinitionKind::Enum,
-                crate::StableDefinitionKind::ValueConst => {
-                    rue_air::SemanticBodyDefinitionKind::ValueConst
-                }
-                crate::StableDefinitionKind::ModuleBinding => {
-                    rue_air::SemanticBodyDefinitionKind::ModuleBinding
-                }
-            };
+            let kind = key.kind();
             Some(rue_air::SemanticBodyDefinitionIdentity {
                 file_id: record.declaration_span().file_id.index(),
                 name: Arc::from(key.name()),

--- a/crates/rue-compiler/src/definition_snapshot.rs
+++ b/crates/rue-compiler/src/definition_snapshot.rs
@@ -94,15 +94,15 @@ impl DefinitionNameKey {
 /// across source revisions or independently built snapshots, even when their
 /// numeric components happen to match.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DefinitionId {
+pub struct DefinitionOccurrenceId {
     module_index: usize,
     definition_index: usize,
 }
 
-/// Explicit name for the snapshot-local occurrence locator.
-pub type DefinitionOccurrenceId = DefinitionId;
+/// Compatibility name; occurrence IDs are always snapshot-local.
+pub type DefinitionId = DefinitionOccurrenceId;
 
-impl DefinitionId {
+impl DefinitionOccurrenceId {
     /// The issuing snapshot's logical-module index.
     #[inline]
     pub fn module_index(self) -> usize {

--- a/crates/rue-compiler/src/durable_body.rs
+++ b/crates/rue-compiler/src/durable_body.rs
@@ -4,14 +4,11 @@
 //! request-independent body algebra stored inside it. Compact live AIR remains
 //! separate and is relocated only at export and import boundaries.
 
-use std::{
-    collections::{BTreeSet, HashMap},
-    sync::Arc,
-};
+use std::{collections::BTreeSet, sync::Arc};
 
 use rue_air::{
-    SemanticBodyDefinitionIdentity, SemanticBodyDefinitionKind, SemanticBodyInstData,
-    SemanticBodyPattern, SemanticBodyProjection, SemanticImportConstValue, SemanticImportType,
+    SemanticBodyInstData, SemanticBodyPattern, SemanticBodyProjection, SemanticDefinitionToken,
+    SemanticImportConstValue, SemanticImportType, SemanticModuleToken,
 };
 
 use crate::{
@@ -259,112 +256,41 @@ pub enum DurableBodyConversionFailure {
     FingerprintUnavailable,
 }
 
-fn semantic_kind(kind: StableDefinitionKind) -> StableDefinitionKind {
-    kind
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct DefinitionJoinIdentity<'a> {
-    file_id: u32,
-    name: &'a str,
-    kind: StableDefinitionKind,
-    owner: Option<&'a str>,
-}
-
-impl<'a> From<&'a SemanticBodyDefinitionIdentity> for DefinitionJoinIdentity<'a> {
-    fn from(identity: &'a SemanticBodyDefinitionIdentity) -> Self {
-        Self {
-            file_id: identity.file_id,
-            name: &identity.name,
-            kind: identity.kind,
-            owner: identity.owner.as_deref(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-enum IndexedDefinition<'a> {
-    Unique(&'a StableDefinitionKey),
-    Ambiguous,
-}
-
 struct DefinitionJoinIndex<'a> {
-    definitions: HashMap<DefinitionJoinIdentity<'a>, IndexedDefinition<'a>>,
+    definitions: &'a BoundDefinitionSet,
 }
 
 impl<'a> DefinitionJoinIndex<'a> {
-    fn new(merged: &'a CanonicalMergedProgram, definitions: &'a BoundDefinitionSet) -> Self {
-        let module_files = merged
-            .ast()
-            .modules()
-            .iter()
-            .map(|module| (module.module_id().clone(), module.file_id().index()))
-            .collect::<HashMap<_, _>>();
-        let entries = definitions.definitions().iter().filter_map(|record| {
-            let key = record.stable_key();
-            Some((
-                DefinitionJoinIdentity {
-                    file_id: *module_files.get(key.module())?,
-                    name: key.name(),
-                    kind: semantic_kind(key.kind()),
-                    owner: key.owner().map(|owner| owner.name()),
-                },
-                key,
-            ))
-        });
-        Self::from_entries(entries)
-    }
-
-    fn from_entries(
-        entries: impl IntoIterator<Item = (DefinitionJoinIdentity<'a>, &'a StableDefinitionKey)>,
-    ) -> Self {
-        let mut definitions = HashMap::new();
-        for (identity, key) in entries {
-            definitions
-                .entry(identity)
-                .and_modify(|entry| *entry = IndexedDefinition::Ambiguous)
-                .or_insert(IndexedDefinition::Unique(key));
-        }
+    fn new(_merged: &'a CanonicalMergedProgram, definitions: &'a BoundDefinitionSet) -> Self {
         Self { definitions }
     }
 
     fn join(
         &self,
-        identity: &SemanticBodyDefinitionIdentity,
+        identity: &SemanticDefinitionToken,
         work: &mut DurableBodyWork,
     ) -> Result<&'a StableDefinitionKey, DurableBodyConversionFailure> {
         work.stable_key_joins += 1;
-        match self
-            .definitions
-            .get(&DefinitionJoinIdentity::from(identity))
-        {
-            Some(IndexedDefinition::Unique(key)) => Ok(key),
-            Some(IndexedDefinition::Ambiguous) => {
+        match self.definitions.key_for_semantic_token(*identity) {
+            Ok(key) => Ok(key),
+            Err(rue_air::SemanticStableResolutionFailure::Missing) => {
+                Err(DurableBodyConversionFailure::MissingStableDefinition)
+            }
+            Err(rue_air::SemanticStableResolutionFailure::Ambiguous) => {
                 Err(DurableBodyConversionFailure::AmbiguousStableDefinition)
             }
-            None => Err(DurableBodyConversionFailure::MissingStableDefinition),
-        }
-    }
-
-    fn join_readonly(
-        &self,
-        identity: &SemanticBodyDefinitionIdentity,
-    ) -> Result<&'a StableDefinitionKey, DurableBodyConversionFailure> {
-        match self
-            .definitions
-            .get(&DefinitionJoinIdentity::from(identity))
-        {
-            Some(IndexedDefinition::Unique(key)) => Ok(key),
-            Some(IndexedDefinition::Ambiguous) => {
-                Err(DurableBodyConversionFailure::AmbiguousStableDefinition)
+            Err(rue_air::SemanticStableResolutionFailure::WrongKind) => {
+                Err(DurableBodyConversionFailure::WrongDefinitionKind)
             }
-            None => Err(DurableBodyConversionFailure::MissingStableDefinition),
+            Err(rue_air::SemanticStableResolutionFailure::ForeignIssuer) => {
+                Err(DurableBodyConversionFailure::ForeignOwnerToken)
+            }
         }
     }
 }
 
 fn join_definition<'a>(
-    identity: &SemanticBodyDefinitionIdentity,
+    identity: &SemanticDefinitionToken,
     index: &DefinitionJoinIndex<'a>,
     work: &mut DurableBodyWork,
 ) -> Result<&'a StableDefinitionKey, DurableBodyConversionFailure> {
@@ -372,7 +298,7 @@ fn join_definition<'a>(
 }
 
 fn canonical_type(
-    ty: &SemanticImportType<SemanticBodyDefinitionIdentity, Arc<str>>,
+    ty: &SemanticImportType<SemanticDefinitionToken, SemanticModuleToken>,
     merged: &CanonicalMergedProgram,
     index: &DefinitionJoinIndex<'_>,
     work: &mut DurableBodyWork,
@@ -414,14 +340,17 @@ fn canonical_type(
         SemanticImportType::PtrMut(value) => {
             SemanticImportType::PtrMut(Box::new(canonical_type(value, merged, index, work)?))
         }
-        SemanticImportType::Module(path) => SemanticImportType::Module(
-            merged
-                .ast()
-                .modules()
-                .iter()
-                .find(|module| module.module_id().as_str() == path.as_ref())
-                .map(|module| module.module_id().clone())
-                .ok_or(DurableBodyConversionFailure::UnresolvedModule)?,
+        SemanticImportType::Module(token) => SemanticImportType::Module(
+            index
+                .definitions
+                .module_for_semantic_token(merged, *token)
+                .map_err(|failure| match failure {
+                    rue_air::SemanticStableResolutionFailure::ForeignIssuer => {
+                        DurableBodyConversionFailure::ForeignOwnerToken
+                    }
+                    _ => DurableBodyConversionFailure::UnresolvedModule,
+                })?
+                .clone(),
         ),
         SemanticImportType::GenericParameter(index) => SemanticImportType::GenericParameter(*index),
     })
@@ -442,7 +371,7 @@ fn canonical_builtin_nominal(
 }
 
 fn canonical_const_value(
-    value: &SemanticImportConstValue<SemanticBodyDefinitionIdentity, Arc<str>>,
+    value: &SemanticImportConstValue<SemanticDefinitionToken, SemanticModuleToken>,
     merged: &CanonicalMergedProgram,
     index: &DefinitionJoinIndex<'_>,
     work: &mut DurableBodyWork,
@@ -473,7 +402,10 @@ fn canonical_const_value(
 }
 
 fn durable_specialization_identity(
-    identity: &rue_air::SemanticSpecializationIdentity<SemanticBodyDefinitionIdentity, Arc<str>>,
+    identity: &rue_air::SemanticSpecializationIdentity<
+        SemanticDefinitionToken,
+        SemanticModuleToken,
+    >,
     merged: &CanonicalMergedProgram,
     index: &DefinitionJoinIndex<'_>,
     work: &mut DurableBodyWork,
@@ -503,7 +435,10 @@ fn durable_specialization_identity(
 }
 
 pub(crate) fn convert_specialization_identity(
-    identity: &rue_air::SemanticSpecializationIdentity<SemanticBodyDefinitionIdentity, Arc<str>>,
+    identity: &rue_air::SemanticSpecializationIdentity<
+        SemanticDefinitionToken,
+        SemanticModuleToken,
+    >,
     merged: &CanonicalMergedProgram,
     definitions: &BoundDefinitionSet,
     work: &mut DurableBodyWork,
@@ -650,13 +585,19 @@ pub fn attach_specialized_implicit_drop_dependencies(
             // payload to enrich.
             continue;
         };
-        let destructor = rue_air::SemanticBodyDefinitionIdentity {
-            file_id: event.target_file,
-            name: Arc::from(event.target_owner_name.as_str()),
-            kind: rue_air::StableDefinitionKind::Destructor,
-            owner: Some(Arc::from(event.target_owner_name.as_str())),
-        };
-        let destructor = join_definition(&destructor, &index, work)?.clone();
+        work.stable_key_joins += 1;
+        let destructor = definitions
+            .definitions()
+            .iter()
+            .find(|record| {
+                let key = record.stable_key();
+                key.kind() == rue_air::StableDefinitionKind::Destructor
+                    && key.owner().map(|owner| owner.name())
+                        == Some(event.target_owner_name.as_str())
+                    && record.declaration_span().file_id.index() == event.target_file
+            })
+            .map(|record| record.stable_key().clone())
+            .ok_or(DurableBodyConversionFailure::MissingStableDefinition)?;
         let mut dependencies = payload
             .dependencies
             .iter()
@@ -720,16 +661,36 @@ pub fn convert_semantic_body_exports(
                 let body = export.body.try_map_keys(
                     &|identity| {
                         stable_key_joins.set(stable_key_joins.get() + 1);
-                        join_index.join_readonly(identity).cloned()
+                        join_index
+                            .definitions
+                            .key_for_semantic_token(*identity)
+                            .cloned()
+                            .map_err(|failure| match failure {
+                                rue_air::SemanticStableResolutionFailure::Missing => {
+                                    DurableBodyConversionFailure::MissingStableDefinition
+                                }
+                                rue_air::SemanticStableResolutionFailure::Ambiguous => {
+                                    DurableBodyConversionFailure::AmbiguousStableDefinition
+                                }
+                                rue_air::SemanticStableResolutionFailure::WrongKind => {
+                                    DurableBodyConversionFailure::WrongDefinitionKind
+                                }
+                                rue_air::SemanticStableResolutionFailure::ForeignIssuer => {
+                                    DurableBodyConversionFailure::ForeignOwnerToken
+                                }
+                            })
                     },
-                    &|path| {
-                        merged
-                            .ast()
-                            .modules()
-                            .iter()
-                            .find(|module| module.module_id().as_str() == path.as_ref())
-                            .map(|module| module.module_id().clone())
-                            .ok_or(DurableBodyConversionFailure::UnresolvedModule)
+                    &|token| {
+                        join_index
+                            .definitions
+                            .module_for_semantic_token(merged, *token)
+                            .cloned()
+                            .map_err(|failure| match failure {
+                                rue_air::SemanticStableResolutionFailure::ForeignIssuer => {
+                                    DurableBodyConversionFailure::ForeignOwnerToken
+                                }
+                                _ => DurableBodyConversionFailure::UnresolvedModule,
+                            })
                     },
                 );
                 work.stable_key_joins += stable_key_joins.get();
@@ -1355,87 +1316,5 @@ mod tests {
             canonical_builtin_nominal(&Arc::from("str"), Enum),
             Err(DurableBodyConversionFailure::WrongDefinitionKind)
         );
-    }
-
-    fn join_identity<'a>(
-        file_id: u32,
-        name: &'a str,
-        kind: StableDefinitionKind,
-    ) -> DefinitionJoinIdentity<'a> {
-        DefinitionJoinIdentity {
-            file_id,
-            name,
-            kind,
-            owner: None,
-        }
-    }
-
-    fn semantic_identity(
-        file_id: u32,
-        name: &str,
-        kind: StableDefinitionKind,
-    ) -> SemanticBodyDefinitionIdentity {
-        SemanticBodyDefinitionIdentity {
-            file_id,
-            name: Arc::from(name),
-            kind,
-            owner: None,
-        }
-    }
-
-    #[test]
-    fn definition_join_index_returns_unique_definition_without_scanning() {
-        let key = StableDefinitionKey::for_test(
-            ModuleId::from_logical_path("main.rue").unwrap(),
-            StableDefinitionNamespace::Type,
-            StableDefinitionKind::Struct,
-            "Large",
-            None,
-        );
-        let index = DefinitionJoinIndex::from_entries([(
-            join_identity(7, "Large", StableDefinitionKind::Struct),
-            &key,
-        )]);
-        let mut work = DurableBodyWork::default();
-
-        assert_eq!(
-            index.join(
-                &semantic_identity(7, "Large", StableDefinitionKind::Struct),
-                &mut work,
-            ),
-            Ok(&key),
-        );
-        assert_eq!(work.stable_key_joins, 1);
-    }
-
-    #[test]
-    fn definition_join_index_preserves_ambiguous_and_missing_failures() {
-        let first = StableDefinitionKey::for_test(
-            ModuleId::from_logical_path("main.rue").unwrap(),
-            StableDefinitionNamespace::Type,
-            StableDefinitionKind::Struct,
-            "Duplicate",
-            None,
-        );
-        let second = first.clone();
-        let identity = join_identity(3, "Duplicate", StableDefinitionKind::Struct);
-        let index = DefinitionJoinIndex::from_entries([(identity, &first), (identity, &second)]);
-        let mut work = DurableBodyWork::default();
-
-        assert_eq!(
-            index.join(
-                &semantic_identity(3, "Duplicate", StableDefinitionKind::Struct),
-                &mut work,
-            ),
-            Err(DurableBodyConversionFailure::AmbiguousStableDefinition),
-        );
-        assert_eq!(
-            index.join(
-                &semantic_identity(3, "Missing", StableDefinitionKind::Struct),
-                &mut work,
-            ),
-            Err(DurableBodyConversionFailure::MissingStableDefinition),
-        );
-        assert_eq!(work.stable_key_joins, 2);
     }
 }

--- a/crates/rue-compiler/src/durable_body.rs
+++ b/crates/rue-compiler/src/durable_body.rs
@@ -259,26 +259,15 @@ pub enum DurableBodyConversionFailure {
     FingerprintUnavailable,
 }
 
-fn semantic_kind(kind: StableDefinitionKind) -> Option<SemanticBodyDefinitionKind> {
-    match kind {
-        StableDefinitionKind::Function => Some(SemanticBodyDefinitionKind::FreeFunction),
-        StableDefinitionKind::Method => Some(SemanticBodyDefinitionKind::Method),
-        StableDefinitionKind::AssociatedFunction => {
-            Some(SemanticBodyDefinitionKind::AssociatedFunction)
-        }
-        StableDefinitionKind::Destructor => Some(SemanticBodyDefinitionKind::Destructor),
-        StableDefinitionKind::Struct => Some(SemanticBodyDefinitionKind::Struct),
-        StableDefinitionKind::Enum => Some(SemanticBodyDefinitionKind::Enum),
-        StableDefinitionKind::ValueConst => Some(SemanticBodyDefinitionKind::ValueConst),
-        StableDefinitionKind::ModuleBinding => Some(SemanticBodyDefinitionKind::ModuleBinding),
-    }
+fn semantic_kind(kind: StableDefinitionKind) -> StableDefinitionKind {
+    kind
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct DefinitionJoinIdentity<'a> {
     file_id: u32,
     name: &'a str,
-    kind: SemanticBodyDefinitionKind,
+    kind: StableDefinitionKind,
     owner: Option<&'a str>,
 }
 
@@ -317,7 +306,7 @@ impl<'a> DefinitionJoinIndex<'a> {
                 DefinitionJoinIdentity {
                     file_id: *module_files.get(key.module())?,
                     name: key.name(),
-                    kind: semantic_kind(key.kind())?,
+                    kind: semantic_kind(key.kind()),
                     owner: key.owner().map(|owner| owner.name()),
                 },
                 key,
@@ -664,7 +653,7 @@ pub fn attach_specialized_implicit_drop_dependencies(
         let destructor = rue_air::SemanticBodyDefinitionIdentity {
             file_id: event.target_file,
             name: Arc::from(event.target_owner_name.as_str()),
-            kind: rue_air::SemanticBodyDefinitionKind::Destructor,
+            kind: rue_air::StableDefinitionKind::Destructor,
             owner: Some(Arc::from(event.target_owner_name.as_str())),
         };
         let destructor = join_definition(&destructor, &index, work)?.clone();
@@ -1371,7 +1360,7 @@ mod tests {
     fn join_identity<'a>(
         file_id: u32,
         name: &'a str,
-        kind: SemanticBodyDefinitionKind,
+        kind: StableDefinitionKind,
     ) -> DefinitionJoinIdentity<'a> {
         DefinitionJoinIdentity {
             file_id,
@@ -1384,7 +1373,7 @@ mod tests {
     fn semantic_identity(
         file_id: u32,
         name: &str,
-        kind: SemanticBodyDefinitionKind,
+        kind: StableDefinitionKind,
     ) -> SemanticBodyDefinitionIdentity {
         SemanticBodyDefinitionIdentity {
             file_id,
@@ -1404,14 +1393,14 @@ mod tests {
             None,
         );
         let index = DefinitionJoinIndex::from_entries([(
-            join_identity(7, "Large", SemanticBodyDefinitionKind::Struct),
+            join_identity(7, "Large", StableDefinitionKind::Struct),
             &key,
         )]);
         let mut work = DurableBodyWork::default();
 
         assert_eq!(
             index.join(
-                &semantic_identity(7, "Large", SemanticBodyDefinitionKind::Struct),
+                &semantic_identity(7, "Large", StableDefinitionKind::Struct),
                 &mut work,
             ),
             Ok(&key),
@@ -1429,20 +1418,20 @@ mod tests {
             None,
         );
         let second = first.clone();
-        let identity = join_identity(3, "Duplicate", SemanticBodyDefinitionKind::Struct);
+        let identity = join_identity(3, "Duplicate", StableDefinitionKind::Struct);
         let index = DefinitionJoinIndex::from_entries([(identity, &first), (identity, &second)]);
         let mut work = DurableBodyWork::default();
 
         assert_eq!(
             index.join(
-                &semantic_identity(3, "Duplicate", SemanticBodyDefinitionKind::Struct),
+                &semantic_identity(3, "Duplicate", StableDefinitionKind::Struct),
                 &mut work,
             ),
             Err(DurableBodyConversionFailure::AmbiguousStableDefinition),
         );
         assert_eq!(
             index.join(
-                &semantic_identity(3, "Missing", SemanticBodyDefinitionKind::Struct),
+                &semantic_identity(3, "Missing", StableDefinitionKind::Struct),
                 &mut work,
             ),
             Err(DurableBodyConversionFailure::MissingStableDefinition),

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -7,11 +7,11 @@
 use std::sync::Arc;
 
 use rue_air::{
-    SemanticBinding, SemanticBindingKind, SemanticBindingNamespace, SemanticDeclarationExport,
-    SemanticDeclarationPayload, SemanticDeclarationShell, SemanticExportConstValue,
-    SemanticExportFailure, SemanticExportType, SemanticImportConstValue, SemanticImportEpoch,
-    SemanticImportFailure, SemanticImportNominal, SemanticImportNominalKind, SemanticImportType,
-    SemanticParameterMode,
+    SemanticBinding, SemanticDeclarationExport, SemanticDeclarationPayload,
+    SemanticDeclarationShell, SemanticExportConstValue, SemanticExportFailure, SemanticExportType,
+    SemanticImportConstValue, SemanticImportEpoch, SemanticImportFailure, SemanticImportNominal,
+    SemanticImportNominalKind, SemanticImportType, SemanticParameterMode,
+    StableDefinitionNamespace,
 };
 use rue_span::FileId;
 
@@ -504,25 +504,25 @@ pub fn project_durable_declaration_semantics(
     Ok((exports.into(), work))
 }
 
-fn stable_namespace(value: SemanticBindingNamespace) -> crate::StableDefinitionNamespace {
+fn stable_namespace(value: StableDefinitionNamespace) -> crate::StableDefinitionNamespace {
     match value {
-        SemanticBindingNamespace::Value => crate::StableDefinitionNamespace::Value,
-        SemanticBindingNamespace::Type => crate::StableDefinitionNamespace::Type,
-        SemanticBindingNamespace::Destructor => crate::StableDefinitionNamespace::Destructor,
-        SemanticBindingNamespace::Method => crate::StableDefinitionNamespace::Method,
+        StableDefinitionNamespace::Value => crate::StableDefinitionNamespace::Value,
+        StableDefinitionNamespace::Type => crate::StableDefinitionNamespace::Type,
+        StableDefinitionNamespace::Destructor => crate::StableDefinitionNamespace::Destructor,
+        StableDefinitionNamespace::Method => crate::StableDefinitionNamespace::Method,
     }
 }
 
-fn stable_kind(value: SemanticBindingKind) -> Option<StableDefinitionKind> {
+fn stable_kind(value: StableDefinitionKind) -> Option<StableDefinitionKind> {
     Some(match value {
-        SemanticBindingKind::Function => StableDefinitionKind::Function,
-        SemanticBindingKind::Struct => StableDefinitionKind::Struct,
-        SemanticBindingKind::Enum => StableDefinitionKind::Enum,
-        SemanticBindingKind::ValueConst => StableDefinitionKind::ValueConst,
-        SemanticBindingKind::ModuleBinding => StableDefinitionKind::ModuleBinding,
-        SemanticBindingKind::Destructor => StableDefinitionKind::Destructor,
-        SemanticBindingKind::Method => StableDefinitionKind::Method,
-        SemanticBindingKind::AssociatedFunction => StableDefinitionKind::AssociatedFunction,
+        StableDefinitionKind::Function => StableDefinitionKind::Function,
+        StableDefinitionKind::Struct => StableDefinitionKind::Struct,
+        StableDefinitionKind::Enum => StableDefinitionKind::Enum,
+        StableDefinitionKind::ValueConst => StableDefinitionKind::ValueConst,
+        StableDefinitionKind::ModuleBinding => StableDefinitionKind::ModuleBinding,
+        StableDefinitionKind::Destructor => StableDefinitionKind::Destructor,
+        StableDefinitionKind::Method => StableDefinitionKind::Method,
+        StableDefinitionKind::AssociatedFunction => StableDefinitionKind::AssociatedFunction,
     })
 }
 
@@ -535,8 +535,8 @@ fn current_nominal(
         .definition_by_key(key)
         .ok_or(DurableSemanticProjectionFailure::MissingDefinition)?;
     let kind = match key.kind() {
-        StableDefinitionKind::Struct => SemanticBindingKind::Struct,
-        StableDefinitionKind::Enum => SemanticBindingKind::Enum,
+        StableDefinitionKind::Struct => StableDefinitionKind::Struct,
+        StableDefinitionKind::Enum => StableDefinitionKind::Enum,
         _ => return Err(DurableSemanticProjectionFailure::KindMismatch),
     };
     Ok(rue_air::SemanticNominalIdentity {
@@ -662,9 +662,9 @@ fn validate_payload_shape(
 ) -> Result<(), DurableSemanticProjectionFailure> {
     match (shell.identity.kind, payload) {
         (
-            SemanticBindingKind::Function
-            | SemanticBindingKind::Method
-            | SemanticBindingKind::AssociatedFunction,
+            StableDefinitionKind::Function
+            | StableDefinitionKind::Method
+            | StableDefinitionKind::AssociatedFunction,
             SemanticDeclarationPayload::Callable {
                 parameters,
                 has_self,
@@ -677,9 +677,9 @@ fn validate_payload_shape(
         {
             Ok(())
         }
-        (SemanticBindingKind::Struct, SemanticDeclarationPayload::Struct { .. })
-        | (SemanticBindingKind::Enum, SemanticDeclarationPayload::Enum { .. })
-        | (SemanticBindingKind::Destructor, SemanticDeclarationPayload::Destructor) => Ok(()),
+        (StableDefinitionKind::Struct, SemanticDeclarationPayload::Struct { .. })
+        | (StableDefinitionKind::Enum, SemanticDeclarationPayload::Enum { .. })
+        | (StableDefinitionKind::Destructor, SemanticDeclarationPayload::Destructor) => Ok(()),
         _ => Err(DurableSemanticProjectionFailure::KindMismatch),
     }
 }
@@ -718,16 +718,16 @@ pub(crate) fn convert_declaration_semantics(
     definitions: &BoundDefinitionSet,
     exports: &[SemanticDeclarationExport],
 ) -> Result<Arc<[DurableDeclarationSemantic]>, DurableSemanticExportFailure> {
-    fn stable_kind(kind: SemanticBindingKind) -> Option<StableDefinitionKind> {
+    fn stable_kind(kind: StableDefinitionKind) -> Option<StableDefinitionKind> {
         Some(match kind {
-            SemanticBindingKind::Function => StableDefinitionKind::Function,
-            SemanticBindingKind::Struct => StableDefinitionKind::Struct,
-            SemanticBindingKind::Enum => StableDefinitionKind::Enum,
-            SemanticBindingKind::ValueConst => StableDefinitionKind::ValueConst,
-            SemanticBindingKind::Destructor => StableDefinitionKind::Destructor,
-            SemanticBindingKind::Method => StableDefinitionKind::Method,
-            SemanticBindingKind::AssociatedFunction => StableDefinitionKind::AssociatedFunction,
-            SemanticBindingKind::ModuleBinding => return None,
+            StableDefinitionKind::Function => StableDefinitionKind::Function,
+            StableDefinitionKind::Struct => StableDefinitionKind::Struct,
+            StableDefinitionKind::Enum => StableDefinitionKind::Enum,
+            StableDefinitionKind::ValueConst => StableDefinitionKind::ValueConst,
+            StableDefinitionKind::Destructor => StableDefinitionKind::Destructor,
+            StableDefinitionKind::Method => StableDefinitionKind::Method,
+            StableDefinitionKind::AssociatedFunction => StableDefinitionKind::AssociatedFunction,
+            StableDefinitionKind::ModuleBinding => return None,
         })
     }
     let module_for_file = |file_id| {
@@ -742,10 +742,10 @@ pub(crate) fn convert_declaration_semantics(
         let module = module_for_file(file_id)?;
         let stable_kind = stable_kind(kind)?;
         let owner_is_valid = match kind {
-            SemanticBindingKind::Method | SemanticBindingKind::AssociatedFunction => {
+            StableDefinitionKind::Method | StableDefinitionKind::AssociatedFunction => {
                 owner.is_some()
             }
-            SemanticBindingKind::Destructor => owner == Some(name),
+            StableDefinitionKind::Destructor => owner == Some(name),
             _ => owner.is_none(),
         };
         if !owner_is_valid {
@@ -781,8 +781,8 @@ pub(crate) fn convert_declaration_semantics(
                 .map(|m| m.module_id())
                 .ok_or(DurableSemanticExportFailure::MissingStableNominalDefinition)?;
             let kind = match identity.kind {
-                SemanticBindingKind::Struct => StableDefinitionKind::Struct,
-                SemanticBindingKind::Enum => StableDefinitionKind::Enum,
+                StableDefinitionKind::Struct => StableDefinitionKind::Struct,
+                StableDefinitionKind::Enum => StableDefinitionKind::Enum,
                 _ => return Err(DurableSemanticExportFailure::MissingStableNominalDefinition),
             };
             definitions
@@ -911,7 +911,7 @@ pub(crate) fn convert_declaration_semantics(
                     SemanticExportConstValue::Unit => DurableConstValue::Unit,
                     SemanticExportConstValue::Function { file_id, name } => {
                         DurableConstValue::Function(
-                            key_for(*file_id, name, SemanticBindingKind::Function, None).ok_or(
+                            key_for(*file_id, name, StableDefinitionKind::Function, None).ok_or(
                                 DurableSemanticExportFailure::MissingStableFunctionDefinition,
                             )?,
                         )

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -127,7 +127,8 @@ pub use source_snapshot::{MAX_SOURCE_BYTES, SourceSnapshot};
 // Immutable query artifacts and stable identities returned by CompilerSession.
 pub use bound_definitions::{
     BoundDefinitionId, BoundDefinitionRecord, BoundDefinitionSet, BoundDefinitionWork,
-    StableDefinitionKey, StableDefinitionKind, StableDefinitionNamespace, StableNamedTypeKey,
+    SnapshotBoundDefinitionId, StableDefinitionKey, StableDefinitionKind,
+    StableDefinitionNamespace, StableNamedTypeKey,
 };
 pub use canonical_lower::{CanonicalRirOutput, CanonicalRirWork};
 pub use canonical_merge::{CanonicalMergeWork, CanonicalMergedAst, CanonicalMergedProgram};


### PR DESCRIPTION
## Summary

- define one exhaustive stable definition kind/namespace taxonomy shared by live bindings, body identities, and durable keys
- introduce explicit snapshot-local ID names and remove repeated peer-kind conversions
- resolve semantic bodies through compiler-issued, issuer-scoped definition/module endpoint tokens backed by the authoritative bound-definition set
- preserve typed missing, ambiguous, wrong-kind, and foreign-issuer join failures across export, conversion, and import
- strengthen representative incremental gates to require the improved two-CFG reuse and zero conversion failures/atomic discards

## Validation

- `scripts/rue fmt`
- typed endpoint failure test
- representative structural benchmark gate
- focused durable compiler tests (33/33)
- `scripts/rue quick` (31 targets, zero failures)
- independent cross-review

Linear: RUE-850
