### PR TITLE
RUE-960: add explicit alignment to the byte allocator intrinsics (ADR-0059 Phase 2)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1516,7 +1516,8 @@ impl<'a> ConstraintGenerator<'a> {
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)
                 } else if intrinsic_name == "alloc_bytes" {
-                    // @alloc_bytes(size: u64) -> ptr mut u8.
+                    // @alloc_bytes(size: u64, align: u64) -> ptr mut u8. Both
+                    // operands are u64 (ADR-0059 Phase 2, RUE-960).
                     for arg_ref in args.iter() {
                         let info = self.generate(*arg_ref, ctx);
                         self.add_constraint(Constraint::equal(
@@ -1553,7 +1554,8 @@ impl<'a> ConstraintGenerator<'a> {
                     }
                     result_ty
                 } else if intrinsic_name == "realloc_bytes" {
-                    // @realloc_bytes(ptr mut u8, u64, u64) -> ptr mut u8.
+                    // @realloc_bytes(ptr mut u8, u64, u64, u64) -> ptr mut u8:
+                    // (p, old_size, align, new_size) (ADR-0059 Phase 2).
                     let ptr_ty =
                         Type::new_ptr_mut(self.type_pool.intern_ptr_mut_from_type(Type::U8));
                     for (i, arg_ref) in args.iter().enumerate() {

--- a/crates/rue-air/src/runtime_call.rs
+++ b/crates/rue-air/src/runtime_call.rs
@@ -247,7 +247,12 @@ const ALLOC_BYTES: &[RuntimeOperandOrigin] = &[
         index: 0,
         ty: AbiType::U64,
     },
-    RuntimeOperandOrigin::ByteAlignment,
+    // Explicit alignment argument (ADR-0059 Phase 2, RUE-960): sourced from the
+    // intrinsic's `align` operand rather than a synthesized `ByteAlignment`.
+    RuntimeOperandOrigin::ValueArgument {
+        index: 1,
+        ty: AbiType::U64,
+    },
 ];
 // The indexed process-inventory accessors (`@arg_ptr`/`@arg_len`/`@env_ptr`/
 // `@env_len`, RUE-935) all pass a single `u64` index straight through to the
@@ -265,8 +270,16 @@ const FREE_BYTES: &[RuntimeOperandOrigin] = &[
         index: 1,
         ty: AbiType::U64,
     },
-    RuntimeOperandOrigin::ByteAlignment,
+    // Explicit alignment argument (ADR-0059 Phase 2, RUE-960).
+    RuntimeOperandOrigin::ValueArgument {
+        index: 2,
+        ty: AbiType::U64,
+    },
 ];
+// `@realloc_bytes(p, old_size, align, new_size)` maps onto the runtime helper
+// signature `__rue_realloc(ptr, old_size, new_size, align)`, so the alignment
+// operand (AIR argument 2) is passed last while `new_size` (AIR argument 3)
+// precedes it (ADR-0059 Phase 2, RUE-960).
 const REALLOC_BYTES: &[RuntimeOperandOrigin] = &[
     RuntimeOperandOrigin::MutablePointerArgument {
         index: 0,
@@ -277,10 +290,13 @@ const REALLOC_BYTES: &[RuntimeOperandOrigin] = &[
         ty: AbiType::U64,
     },
     RuntimeOperandOrigin::ValueArgument {
+        index: 3,
+        ty: AbiType::U64,
+    },
+    RuntimeOperandOrigin::ValueArgument {
         index: 2,
         ty: AbiType::U64,
     },
-    RuntimeOperandOrigin::ByteAlignment,
 ];
 const BYTE_COPY: &[RuntimeOperandOrigin] = &[
     RuntimeOperandOrigin::MutablePointerArgument {

--- a/crates/rue-air/src/sema/analysis/pointers.rs
+++ b/crates/rue-air/src/sema/analysis/pointers.rs
@@ -546,6 +546,12 @@ impl<'a> BodySema<'a> {
     /// Analyze the preview raw-byte intrinsic family (RUE-879). Unlike typed
     /// pointer operations, byte counts and offsets here are physical bytes and
     /// access operations transfer exactly one byte.
+    ///
+    /// The byte allocators carry an explicit `align: u64` byte count that must
+    /// be a power of two (ADR-0059 Phase 2, RUE-960). A comptime-constant
+    /// `align` that is zero or not a power of two is rejected here; a
+    /// non-constant `align` is a documented checked-gate contract left to the
+    /// runtime (spec 9.2:14j).
     pub(super) fn analyze_alloc_bytes_intrinsic(
         &mut self,
         air: &mut Air,
@@ -556,11 +562,11 @@ impl<'a> BodySema<'a> {
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         self.require_preview(PreviewFeature::RawBytes, "@alloc_bytes intrinsic", span)?;
-        if args.len() != 1 {
+        if args.len() != 2 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
                     name: "alloc_bytes".to_string(),
-                    expected: 1,
+                    expected: 2,
                     found: args.len(),
                 },
                 span,
@@ -568,6 +574,9 @@ impl<'a> BodySema<'a> {
         }
         let size = self.analyze_inst(air, args[0].value, ctx)?;
         self.require_intrinsic_type("alloc_bytes", size.ty, Type::U64, span)?;
+        let align = self.analyze_inst(air, args[1].value, ctx)?;
+        self.require_intrinsic_type("alloc_bytes", align.ty, Type::U64, span)?;
+        self.require_power_of_two_align("alloc_bytes", args[1].value, span, ctx)?;
         let result_ty = Type::new_ptr_mut(self.type_pool.intern_ptr_mut_from_type(Type::U8));
         if let Some(&expected) = ctx.resolved_types.get(&inst_ref)
             && expected != result_ty
@@ -579,7 +588,7 @@ impl<'a> BodySema<'a> {
         let air_ref = air.add_intrinsic(
             Some(crate::RuntimeCallKind::AllocBytes),
             name,
-            &[size.air_ref],
+            &[size.air_ref, align.air_ref],
             result_ty,
             span,
         )?;
@@ -595,11 +604,11 @@ impl<'a> BodySema<'a> {
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         self.require_preview(PreviewFeature::RawBytes, "@realloc_bytes intrinsic", span)?;
-        if args.len() != 3 {
+        if args.len() != 4 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
                     name: "realloc_bytes".to_string(),
-                    expected: 3,
+                    expected: 4,
                     found: args.len(),
                 },
                 span,
@@ -608,13 +617,21 @@ impl<'a> BodySema<'a> {
         let ptr = self.analyze_inst(air, args[0].value, ctx)?;
         self.require_mut_u8_pointer("realloc_bytes", ptr.ty, span)?;
         let old_size = self.analyze_inst(air, args[1].value, ctx)?;
-        let new_size = self.analyze_inst(air, args[2].value, ctx)?;
+        let align = self.analyze_inst(air, args[2].value, ctx)?;
+        let new_size = self.analyze_inst(air, args[3].value, ctx)?;
         self.require_intrinsic_type("realloc_bytes", old_size.ty, Type::U64, span)?;
+        self.require_intrinsic_type("realloc_bytes", align.ty, Type::U64, span)?;
         self.require_intrinsic_type("realloc_bytes", new_size.ty, Type::U64, span)?;
+        self.require_power_of_two_align("realloc_bytes", args[2].value, span, ctx)?;
         let air_ref = air.add_intrinsic(
             Some(crate::RuntimeCallKind::ReallocBytes),
             name,
-            &[ptr.air_ref, old_size.air_ref, new_size.air_ref],
+            &[
+                ptr.air_ref,
+                old_size.air_ref,
+                align.air_ref,
+                new_size.air_ref,
+            ],
             ptr.ty,
             span,
         )?;
@@ -630,11 +647,11 @@ impl<'a> BodySema<'a> {
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         self.require_preview(PreviewFeature::RawBytes, "@free_bytes intrinsic", span)?;
-        if args.len() != 2 {
+        if args.len() != 3 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
                     name: "free_bytes".to_string(),
-                    expected: 2,
+                    expected: 3,
                     found: args.len(),
                 },
                 span,
@@ -643,15 +660,45 @@ impl<'a> BodySema<'a> {
         let ptr = self.analyze_inst(air, args[0].value, ctx)?;
         self.require_mut_u8_pointer("free_bytes", ptr.ty, span)?;
         let size = self.analyze_inst(air, args[1].value, ctx)?;
+        let align = self.analyze_inst(air, args[2].value, ctx)?;
         self.require_intrinsic_type("free_bytes", size.ty, Type::U64, span)?;
+        self.require_intrinsic_type("free_bytes", align.ty, Type::U64, span)?;
+        self.require_power_of_two_align("free_bytes", args[2].value, span, ctx)?;
         let air_ref = air.add_intrinsic(
             Some(crate::RuntimeCallKind::FreeBytes),
             name,
-            &[ptr.air_ref, size.air_ref],
+            &[ptr.air_ref, size.air_ref, align.air_ref],
             Type::UNIT,
             span,
         )?;
         Ok(AnalysisResult::new(air_ref, Type::UNIT))
+    }
+
+    /// Reject a comptime-constant byte-allocator `align` argument that is zero
+    /// or not a power of two (ADR-0059 Phase 2, RUE-960). A non-constant
+    /// `align` evaluates to `None` here and is permitted: the power-of-two
+    /// contract for runtime values is documented checked-gate territory
+    /// (spec 9.2:14j), enforced by the allocator rather than the compiler.
+    fn require_power_of_two_align(
+        &mut self,
+        name: &str,
+        align_ref: InstRef,
+        span: Span,
+        ctx: &AnalysisContext,
+    ) -> CompileResult<()> {
+        if let Some(ConstValue::Integer(value)) = self.try_evaluate_const_in_fn(align_ref, ctx) {
+            let bits = value as u64;
+            if bits == 0 || !bits.is_power_of_two() {
+                return Err(CompileError::new(
+                    ErrorKind::IntrinsicAlignNotPowerOfTwo {
+                        name: name.to_string(),
+                        value: bits,
+                    },
+                    span,
+                ));
+            }
+        }
+        Ok(())
     }
 
     pub(super) fn analyze_byte_read_intrinsic(

--- a/crates/rue-cli-tests/cases/std_internal_raw_bytes.toml
+++ b/crates/rue-cli-tests/cases/std_internal_raw_bytes.toml
@@ -30,8 +30,8 @@ const std = @import("std");
 
 fn main() -> i32 {
     checked {
-        let p = @alloc_bytes(1);
-        @free_bytes(p, 1);
+        let p = @alloc_bytes(1, 1);
+        @free_bytes(p, 1, 1);
     };
     std.exit(0);
     1
@@ -46,8 +46,8 @@ description = "A user root named like a std module cannot bypass the raw-byte pr
 files = [{ path = "strbuf.rue", source = """
 fn main() -> i32 {
     checked {
-        let p = @alloc_bytes(1);
-        @free_bytes(p, 1);
+        let p = @alloc_bytes(1, 1);
+        @free_bytes(p, 1, 1);
     };
     0
 }

--- a/crates/rue-cli-tests/cases/std_strbuf.toml
+++ b/crates/rue-cli-tests/cases/std_strbuf.toml
@@ -318,7 +318,7 @@ const std = @import("std");
 const S = std.strbuf.StrBuf;
 
 fn owned(byte: u8) -> S {
-    let p: ptr mut u8 = checked { @alloc_bytes(4) };
+    let p: ptr mut u8 = checked { @alloc_bytes(4, 1) };
     checked { @byte_write(p, 0, byte); };
     std.strbuf.StrBuf { buf: p, len: 1, cap: 4 }
 }

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -3181,9 +3181,9 @@ mod tests {
         let mut preview = PreviewFeatures::new();
         preview.insert(PreviewFeature::RawBytes);
         let mir = lower_function_to_mir_with_preview(
-            "fn main() -> i32 { checked { let p = @alloc_bytes(3); \
-             @byte_write(p, 1, 255); let q = @realloc_bytes(p, 3, 5); \
-             let b = @byte_read(q, 1); @free_bytes(q, 5); \
+            "fn main() -> i32 { checked { let p = @alloc_bytes(3, 1); \
+             @byte_write(p, 1, 255); let q = @realloc_bytes(p, 3, 1, 5); \
+             let b = @byte_read(q, 1); @free_bytes(q, 5, 1); \
              @intCast(b) } }",
             "main",
             preview,

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -1743,7 +1743,8 @@ fn intrinsic_runtime_call(
             RuntimeHelperId::Alloc,
             vec![
                 RuntimeCallArg::value(args[0].primary, AbiType::U64),
-                RuntimeCallArg::immediate(1, AbiType::U64),
+                // Explicit alignment argument (ADR-0059 Phase 2, RUE-960).
+                RuntimeCallArg::value(args[1].primary, AbiType::U64),
             ],
         ),
         IntrinsicOperation::Free { element_size } => (
@@ -1759,7 +1760,8 @@ fn intrinsic_runtime_call(
             vec![
                 RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
                 RuntimeCallArg::value(args[1].primary, AbiType::U64),
-                RuntimeCallArg::immediate(1, AbiType::U64),
+                // Explicit alignment argument (ADR-0059 Phase 2, RUE-960).
+                RuntimeCallArg::value(args[2].primary, AbiType::U64),
             ],
         ),
         IntrinsicOperation::ByteCopy => (
@@ -1779,20 +1781,29 @@ fn intrinsic_runtime_call(
             ],
         ),
         IntrinsicOperation::Realloc { .. } | IntrinsicOperation::ReallocBytes => {
-            let element_size = match operation {
-                IntrinsicOperation::Realloc { element_size } => *element_size,
-                IntrinsicOperation::ReallocBytes => 1,
-                _ => unreachable!(),
-            };
-            let old = if matches!(operation, IntrinsicOperation::Realloc { .. }) {
+            // `@realloc(p, old_count, new_count)` scales element counts and
+            // passes `align = @align_of(T)` as an immediate; `@realloc_bytes(p,
+            // old_size, align, new_size)` passes byte sizes straight through
+            // with an explicit `align` value operand (ADR-0059 Phase 2).
+            let is_typed = matches!(operation, IntrinsicOperation::Realloc { .. });
+            let old = if is_typed {
                 RuntimeCallArg::scaled(args[1].primary, scale?, AbiType::U64)
             } else {
                 RuntimeCallArg::value(args[1].primary, AbiType::U64)
             };
-            let new = if matches!(operation, IntrinsicOperation::Realloc { .. }) {
+            let new = if is_typed {
                 RuntimeCallArg::scaled(args[2].primary, scale?, AbiType::U64)
             } else {
-                RuntimeCallArg::value(args[2].primary, AbiType::U64)
+                RuntimeCallArg::value(args[3].primary, AbiType::U64)
+            };
+            let align = match operation {
+                IntrinsicOperation::Realloc { element_size } => {
+                    RuntimeCallArg::immediate(*element_size, AbiType::U64)
+                }
+                IntrinsicOperation::ReallocBytes => {
+                    RuntimeCallArg::value(args[2].primary, AbiType::U64)
+                }
+                _ => unreachable!(),
             };
             (
                 RuntimeHelperId::Realloc,
@@ -1800,7 +1811,7 @@ fn intrinsic_runtime_call(
                     RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
                     old,
                     new,
-                    RuntimeCallArg::immediate(element_size, AbiType::U64),
+                    align,
                 ],
             )
         }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -3065,9 +3065,9 @@ mod tests {
         let mut preview = PreviewFeatures::new();
         preview.insert(PreviewFeature::RawBytes);
         let mir = lower_to_mir_with_preview(
-            "fn main() -> i32 { checked { let p = @alloc_bytes(3); \
-             @byte_write(p, 1, 255); let q = @realloc_bytes(p, 3, 5); \
-             let b = @byte_read(q, 1); @free_bytes(q, 5); \
+            "fn main() -> i32 { checked { let p = @alloc_bytes(3, 1); \
+             @byte_write(p, 1, 255); let q = @realloc_bytes(p, 3, 1, 5); \
+             let b = @byte_read(q, 1); @free_bytes(q, 5, 1); \
              @intCast(b) } }",
             preview,
         );

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -342,6 +342,10 @@ impl ErrorCode {
     pub const CANNOT_INFER_CAST_TARGET: Self = Self(709);
     pub const CANNOT_INFER_POINTEE_TYPE: Self = Self(710);
     pub const CONTAINER_ELEMENT_NOT_TRIVIALLY_DROPPABLE: Self = Self(711);
+    /// A comptime-constant `align` argument to a byte-allocation intrinsic
+    /// (`@alloc_bytes`/`@realloc_bytes`/`@free_bytes`, ADR-0059 Phase 2) was
+    /// zero or not a power of two. Alignment must be a power of two.
+    pub const INTRINSIC_ALIGN_NOT_POWER_OF_TWO: Self = Self(712);
 
     // ========================================================================
     // Literal/operator errors (E0800-E0899)
@@ -1444,6 +1448,11 @@ pub enum ErrorKind {
          `ptr mut T` is expected"
     )]
     CannotInferPointeeType(String),
+    #[error(
+        "the `align` argument to '@{name}' must be a power of two, but a \
+         constant value of {value} was given"
+    )]
+    IntrinsicAlignNotPowerOfTwo { name: String, value: u64 },
 
     // Module errors
     #[error("@import requires a string literal argument")]
@@ -1723,6 +1732,9 @@ impl ErrorKind {
             ErrorKind::IntrinsicTypeMismatch(_) => ErrorCode::INTRINSIC_TYPE_MISMATCH,
             ErrorKind::CannotInferCastTarget(_) => ErrorCode::CANNOT_INFER_CAST_TARGET,
             ErrorKind::CannotInferPointeeType(_) => ErrorCode::CANNOT_INFER_POINTEE_TYPE,
+            ErrorKind::IntrinsicAlignNotPowerOfTwo { .. } => {
+                ErrorCode::INTRINSIC_ALIGN_NOT_POWER_OF_TWO
+            }
             ErrorKind::ContainerElementNotTriviallyDroppable { .. } => {
                 ErrorCode::CONTAINER_ELEMENT_NOT_TRIVIALLY_DROPPABLE
             }

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -731,6 +731,18 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
+        "runtime.raw_bytes",
+        "alloc_bytes_align_one_round_trip",
+        intrinsic(UnsupportedIntrinsicKind::AllocateBytes),
+        &[],
+    ),
+    Entry::new(
+        "runtime.raw_bytes",
+        "alloc_bytes_align_eight_round_trip",
+        intrinsic(UnsupportedIntrinsicKind::AllocateBytes),
+        &[],
+    ),
+    Entry::new(
         "runtime.pointers",
         "field_ptr_first_field",
         intrinsic(UnsupportedIntrinsicKind::FieldPointer),

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -1268,10 +1268,9 @@ impl<'a> Interp<'a> {
             "read_line" | "random_u32" | "random_u64" | "arg_count" | "env_count" => {
                 args.is_empty()
             }
-            "ptr_write" | "ptr_offset" | "free" | "free_bytes" | "byte_read" => args.len() == 2,
-            "realloc" | "realloc_bytes" | "byte_write" | "byte_copy" | "byte_set" => {
-                args.len() == 3
-            }
+            "ptr_write" | "ptr_offset" | "free" | "byte_read" | "alloc_bytes" => args.len() == 2,
+            "realloc" | "byte_write" | "byte_copy" | "byte_set" | "free_bytes" => args.len() == 3,
+            "realloc_bytes" => args.len() == 4,
             "syscall" => (1..=7).contains(&args.len()),
             _ => args.len() == 1,
         };
@@ -1355,17 +1354,21 @@ impl<'a> Interp<'a> {
                     && result_ty == ty(0)
             }
             "alloc_bytes" => {
-                ty(0) == Type::U64 && self.pointer_pointee(result_ty) == Some((Type::U8, true))
+                ty(0) == Type::U64
+                    && ty(1) == Type::U64
+                    && self.pointer_pointee(result_ty) == Some((Type::U8, true))
             }
             "free_bytes" => {
                 self.pointer_pointee(ty(0)) == Some((Type::U8, true))
                     && ty(1) == Type::U64
+                    && ty(2) == Type::U64
                     && result_ty == Type::UNIT
             }
             "realloc_bytes" => {
                 self.pointer_pointee(ty(0)) == Some((Type::U8, true))
                     && ty(1) == Type::U64
                     && ty(2) == Type::U64
+                    && ty(3) == Type::U64
                     && result_ty == ty(0)
             }
             "byte_read" => {

--- a/crates/rue-spec/cases/runtime/raw-bytes.toml
+++ b/crates/rue-spec/cases/runtime/raw-bytes.toml
@@ -14,14 +14,14 @@ preview_should_pass = true
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(3);
+        let p: ptr mut u8 = @alloc_bytes(3, 1);
         @byte_write(p, 0, 11);
         @byte_write(p, 1, 22);
         @byte_write(p, 2, 33);
         let result: i32 = @intCast(@byte_read(p, 0))
             + @intCast(@byte_read(p, 1))
             + @intCast(@byte_read(p, 2));
-        @free_bytes(p, 3);
+        @free_bytes(p, 3, 1);
         result
     }
 }
@@ -36,7 +36,7 @@ preview_should_pass = true
 source = """
 fn main() -> i32 {
     checked {
-        let p = @alloc_bytes(3);
+        let p = @alloc_bytes(3, 1);
         @byte_write(p, 0, 17);
         @byte_write(p, 1, 34);
         @byte_write(p, 2, 51);
@@ -44,7 +44,7 @@ fn main() -> i32 {
         let result: i32 = @intCast(@byte_read(p, 0))
             + @intCast(@byte_read(p, 1))
             + @intCast(@byte_read(p, 2));
-        @free_bytes(p, 3);
+        @free_bytes(p, 3, 1);
         result
     }
 }
@@ -75,10 +75,10 @@ preview_should_pass = true
 source = """
 fn main() -> i32 {
     checked {
-        let p = @alloc_bytes(1);
+        let p = @alloc_bytes(1, 1);
         @byte_write(p, 0, 71);
         let result: i32 = @intCast(@byte_read(p, 0));
-        @free_bytes(p, 1);
+        @free_bytes(p, 1, 1);
         result
     }
 }
@@ -93,15 +93,15 @@ preview_should_pass = true
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(2);
+        let p: ptr mut u8 = @alloc_bytes(2, 1);
         @byte_write(p, 0, 40);
         @byte_write(p, 1, 2);
-        let q = @realloc_bytes(p, 2, 4);
+        let q = @realloc_bytes(p, 2, 1, 4);
         @byte_write(q, 2, 3);
         let result: i32 = @intCast(@byte_read(q, 0))
             + @intCast(@byte_read(q, 1))
             + @intCast(@byte_read(q, 2));
-        @free_bytes(q, 4);
+        @free_bytes(q, 4, 1);
         result
     }
 }
@@ -116,8 +116,8 @@ preview_should_pass = true
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(18446744073709551615);
-        if @ptr_to_int(p) == 0 { 0 } else { @free_bytes(p, 18446744073709551615); 1 }
+        let p: ptr mut u8 = @alloc_bytes(18446744073709551615, 1);
+        if @ptr_to_int(p) == 0 { 0 } else { @free_bytes(p, 18446744073709551615, 1); 1 }
     }
 }
 """
@@ -131,19 +131,19 @@ preview_should_pass = true
 source = """
 fn main() -> i32 {
     checked {
-        let p = @alloc_bytes(3);
+        let p = @alloc_bytes(3, 1);
         @byte_write(p, 0, 11);
         @byte_write(p, 1, 22);
         @byte_write(p, 2, 33);
-        let q = @realloc_bytes(p, 3, 18446744073709551615);
+        let q = @realloc_bytes(p, 3, 1, 18446744073709551615);
         if @ptr_to_int(q) == 0 {
             let result: i32 = @intCast(@byte_read(p, 0))
                 + @intCast(@byte_read(p, 1))
                 + @intCast(@byte_read(p, 2));
-            @free_bytes(p, 3);
+            @free_bytes(p, 3, 1);
             result
         } else {
-            @free_bytes(q, 18446744073709551615);
+            @free_bytes(q, 18446744073709551615, 1);
             1
         }
     }
@@ -159,7 +159,7 @@ preview_should_pass = true
 source = """
 fn main() -> i32 {
     checked {
-        let p = @alloc_bytes(0);
+        let p = @alloc_bytes(0, 1);
         if @ptr_to_int(p) == 0 { 0 } else { 1 }
     }
 }
@@ -174,8 +174,8 @@ preview_should_pass = true
 source = """
 fn main() -> i32 {
     checked {
-        let p = @alloc_bytes(0);
-        @free_bytes(p, 0);
+        let p = @alloc_bytes(0, 1);
+        @free_bytes(p, 0, 1);
         0
     }
 }
@@ -190,9 +190,9 @@ preview_should_pass = true
 source = """
 fn main() -> i32 {
     checked {
-        let p = @alloc_bytes(1);
+        let p = @alloc_bytes(1, 1);
         @byte_write(p, 0, 42);
-        let q = @realloc_bytes(p, 1, 0);
+        let q = @realloc_bytes(p, 1, 1, 0);
         if @ptr_to_int(q) == 0 { 0 } else { 1 }
     }
 }
@@ -204,7 +204,7 @@ name = "raw_bytes_require_preview"
 spec = ["9.2:14a", "9.2:14e", "8.4:1"]
 source = """
 fn main() -> i32 {
-    checked { let p: ptr mut u8 = @alloc_bytes(1); @free_bytes(p, 1); };
+    checked { let p: ptr mut u8 = @alloc_bytes(1, 1); @free_bytes(p, 1, 1); };
     0
 }
 """
@@ -218,7 +218,7 @@ preview = "raw_bytes"
 preview_should_pass = true
 source = """
 fn main() -> i32 {
-    let p: ptr mut u8 = @alloc_bytes(1);
+    let p: ptr mut u8 = @alloc_bytes(1, 1);
     0
 }
 """
@@ -233,7 +233,7 @@ preview_should_pass = true
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(1);
+        let p: ptr mut u8 = @alloc_bytes(1, 1);
         let value: u64 = 1;
         @byte_write(p, 0, value);
     };
@@ -251,17 +251,17 @@ preview_should_pass = true
 source = """
 fn main() -> i32 {
     checked {
-        let src: ptr mut u8 = @alloc_bytes(3);
+        let src: ptr mut u8 = @alloc_bytes(3, 1);
         @byte_write(src, 0, 10);
         @byte_write(src, 1, 20);
         @byte_write(src, 2, 30);
-        let dst: ptr mut u8 = @alloc_bytes(3);
+        let dst: ptr mut u8 = @alloc_bytes(3, 1);
         @byte_copy(dst, src, 3);
         let result: i32 = @intCast(@byte_read(dst, 0))
             + @intCast(@byte_read(dst, 1))
             + @intCast(@byte_read(dst, 2));
-        @free_bytes(src, 3);
-        @free_bytes(dst, 3);
+        @free_bytes(src, 3, 1);
+        @free_bytes(dst, 3, 1);
         result
     }
 }
@@ -276,13 +276,13 @@ preview_should_pass = true
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(4);
+        let p: ptr mut u8 = @alloc_bytes(4, 1);
         @byte_set(p, 9, 4);
         let result: i32 = @intCast(@byte_read(p, 0))
             + @intCast(@byte_read(p, 1))
             + @intCast(@byte_read(p, 2))
             + @intCast(@byte_read(p, 3));
-        @free_bytes(p, 4);
+        @free_bytes(p, 4, 1);
         result
     }
 }
@@ -297,15 +297,15 @@ preview_should_pass = true
 source = """
 fn main() -> i32 {
     checked {
-        let dst: ptr mut u8 = @alloc_bytes(2);
+        let dst: ptr mut u8 = @alloc_bytes(2, 1);
         @byte_write(dst, 0, 55);
         @byte_write(dst, 1, 11);
-        let src: ptr mut u8 = @alloc_bytes(2);
+        let src: ptr mut u8 = @alloc_bytes(2, 1);
         @byte_set(src, 99, 2);
         @byte_copy(dst, src, 0);
         let result: i32 = @intCast(@byte_read(dst, 0)) + @intCast(@byte_read(dst, 1));
-        @free_bytes(src, 2);
-        @free_bytes(dst, 2);
+        @free_bytes(src, 2, 1);
+        @free_bytes(dst, 2, 1);
         result
     }
 }
@@ -320,18 +320,18 @@ preview_should_pass = true
 source = """
 fn main() -> i32 {
     checked {
-        let src: ptr mut u8 = @alloc_bytes(4);
+        let src: ptr mut u8 = @alloc_bytes(4, 1);
         @byte_write(src, 0, 1);
         @byte_write(src, 1, 2);
         @byte_write(src, 2, 3);
         @byte_write(src, 3, 4);
-        let dst: ptr mut u8 = @alloc_bytes(2);
+        let dst: ptr mut u8 = @alloc_bytes(2, 1);
         @byte_set(dst, 0, 2);
         let src_mid: ptr mut u8 = @int_to_ptr(@ptr_to_int(src) + 1);
         @byte_copy(dst, src_mid, 2);
         let result: i32 = @intCast(@byte_read(dst, 0)) + @intCast(@byte_read(dst, 1));
-        @free_bytes(src, 4);
-        @free_bytes(dst, 2);
+        @free_bytes(src, 4, 1);
+        @free_bytes(dst, 2, 1);
         result
     }
 }
@@ -365,9 +365,9 @@ fn use_it(p: ptr mut u8) -> i32 {
     0
 }
 fn main() -> i32 {
-    let p: ptr mut u8 = checked { @alloc_bytes(1) };
+    let p: ptr mut u8 = checked { @alloc_bytes(1, 1) };
     let r = use_it(p);
-    checked { @free_bytes(p, 1); };
+    checked { @free_bytes(p, 1, 1); };
     r
 }
 """
@@ -382,7 +382,7 @@ preview_should_pass = true
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(1);
+        let p: ptr mut u8 = @alloc_bytes(1, 1);
         let value: u64 = 1;
         @byte_set(p, value, 1);
     };
@@ -418,11 +418,109 @@ preview_should_pass = true
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut i32 = @alloc_bytes(1);
-        @free_bytes(p, 1);
+        let p: ptr mut i32 = @alloc_bytes(1, 1);
+        @free_bytes(p, 1, 1);
     };
     0
 }
 """
 compile_fail = true
 error_contains = "ptr mut u8"
+
+[[case]]
+name = "alloc_bytes_align_one_round_trip"
+spec = ["9.2:14b", "9.2:14c", "9.2:14j"]
+preview = "raw_bytes"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc_bytes(4, 1);
+        @byte_write(p, 0, 20);
+        @byte_write(p, 1, 22);
+        let q = @realloc_bytes(p, 4, 1, 8);
+        @byte_write(q, 2, 3);
+        let result: i32 = @intCast(@byte_read(q, 0))
+            + @intCast(@byte_read(q, 1))
+            + @intCast(@byte_read(q, 2));
+        @free_bytes(q, 8, 1);
+        result
+    }
+}
+"""
+exit_code = 45
+
+[[case]]
+name = "alloc_bytes_align_eight_round_trip"
+spec = ["9.2:14b", "9.2:14c", "9.2:14j"]
+preview = "raw_bytes"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc_bytes(16, 8);
+        @byte_write(p, 0, 30);
+        @byte_write(p, 7, 12);
+        let q = @realloc_bytes(p, 16, 8, 32);
+        @byte_write(q, 8, 6);
+        let result: i32 = @intCast(@byte_read(q, 0))
+            + @intCast(@byte_read(q, 7))
+            + @intCast(@byte_read(q, 8));
+        @free_bytes(q, 32, 8);
+        result
+    }
+}
+"""
+exit_code = 48
+
+[[case]]
+name = "alloc_bytes_align_zero_rejected"
+spec = ["9.2:14j"]
+preview = "raw_bytes"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc_bytes(1, 0);
+        @free_bytes(p, 1, 1);
+    };
+    0
+}
+"""
+compile_fail = true
+error_contains = "[E0712]"
+
+[[case]]
+name = "realloc_bytes_align_not_power_of_two_rejected"
+spec = ["9.2:14j"]
+preview = "raw_bytes"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc_bytes(2, 1);
+        let q = @realloc_bytes(p, 2, 3, 4);
+        @free_bytes(q, 4, 1);
+    };
+    0
+}
+"""
+compile_fail = true
+error_contains = "power of two"
+
+[[case]]
+name = "free_bytes_requires_align_argument"
+spec = ["9.2:14e"]
+preview = "raw_bytes"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc_bytes(1, 1);
+        @free_bytes(p, 1);
+    };
+    0
+}
+"""
+compile_fail = true
+error_contains = "[E0701]"

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -89,9 +89,9 @@ full semantics):
 | `@alloc` | Allocate a heap block | 1 expression (`u64` count) | inferred `ptr mut T` |
 | `@free` | Free a heap block | 2 expressions (`ptr mut T`, `u64` count) | `()` |
 | `@realloc` | Resize a heap block | 3 expressions (`ptr mut T`, `u64`, `u64`) | `ptr mut T` |
-| `@alloc_bytes` | Allocate physical bytes (preview `raw_bytes`) | 1 expression (`u64`) | `ptr mut u8` |
-| `@free_bytes` | Free physical bytes (preview `raw_bytes`) | 2 expressions (`ptr mut u8`, `u64`) | `()` |
-| `@realloc_bytes` | Resize physical bytes (preview `raw_bytes`) | 3 expressions (`ptr mut u8`, `u64`, `u64`) | `ptr mut u8` |
+| `@alloc_bytes` | Allocate physical bytes with alignment (preview `raw_bytes`) | 2 expressions (`u64` size, `u64` align) | `ptr mut u8` |
+| `@free_bytes` | Free physical bytes (preview `raw_bytes`) | 3 expressions (`ptr mut u8`, `u64` size, `u64` align) | `()` |
+| `@realloc_bytes` | Resize physical bytes with alignment (preview `raw_bytes`) | 4 expressions (`ptr mut u8`, `u64` old size, `u64` align, `u64` new size) | `ptr mut u8` |
 | `@byte_read` | Read one physical byte (preview `raw_bytes`) | 2 expressions (`ptr const u8`/`ptr mut u8`, `u64`) | `u8` |
 | `@byte_write` | Write one physical byte (preview `raw_bytes`) | 3 expressions (`ptr mut u8`, `u64`, `u8`) | `()` |
 | `@byte_copy` | Copy `size` non-overlapping bytes (preview `raw_bytes`) | 3 expressions (`ptr mut u8`, `ptr const u8`/`ptr mut u8`, `u64`) | `()` |

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -167,23 +167,27 @@ semantics of `@alloc`, `@realloc`, `@free`, `@ptr_offset`, `@ptr_read`, or
 
 {{ rule(id="9.2:14b", cat="dynamic-semantics") }}
 
-`@alloc_bytes(size)` allocates `size` physical bytes of uninitialized storage
-with byte alignment and returns `ptr mut u8`. `@free_bytes(p, size)` releases a
-block returned by `@alloc_bytes` or `@realloc_bytes`; freeing a null pointer is
-permitted. All size arguments have type `u64`. Allocation failure returns null
-and does not trap. `@alloc_bytes(0)` returns null. `@free_bytes(null, 0)` is
-permitted and has no effect.
+`@alloc_bytes(size, align)` allocates `size` physical bytes of uninitialized
+storage aligned to `align` bytes and returns `ptr mut u8`. `@free_bytes(p, size,
+align)` releases a block returned by `@alloc_bytes` or `@realloc_bytes`; the
+`size` and `align` passed to `@free_bytes` must equal those used to allocate the
+block, and freeing a null pointer is permitted. All `size` and `align` arguments
+have type `u64`, and `align` must be a power of two (9.2:14j). Allocation failure
+returns null and does not trap. `@alloc_bytes(0, align)` returns null.
+`@free_bytes(null, 0, align)` is permitted and has no effect.
 
 {{ rule(id="9.2:14c", cat="dynamic-semantics") }}
 
-`@realloc_bytes(p, old_size, new_size)` resizes a raw-byte block. The first
-`min(old_size, new_size)` physical bytes are preserved. A null `p` behaves like
-`@alloc_bytes(new_size)`. On failure it returns null and leaves the original
-block allocated and unchanged.
+`@realloc_bytes(p, old_size, align, new_size)` resizes a raw-byte block. The
+first `min(old_size, new_size)` physical bytes are preserved. The `align` must
+equal the alignment used to allocate the block, and behaves as an allocation
+with that alignment; a null `p` behaves like `@alloc_bytes(new_size, align)`. On
+failure it returns null and leaves the original block allocated and unchanged.
 
-If `new_size` is zero, `@realloc_bytes(p, old_size, 0)` frees a non-null `p`
-and returns null. If `p` is null, reallocation behaves like
-`@alloc_bytes(new_size)`, including returning null when `new_size` is zero.
+If `new_size` is zero, `@realloc_bytes(p, old_size, align, 0)` frees a non-null
+`p` and returns null. If `p` is null, reallocation behaves like
+`@alloc_bytes(new_size, align)`, including returning null when `new_size` is
+zero.
 
 {{ rule(id="9.2:14d", cat="dynamic-semantics") }}
 
@@ -197,19 +201,21 @@ Offsets are not multiplied by Rue's typed-pointer slot size.
 
 Every raw-byte intrinsic requires both `--preview raw_bytes` and an enclosing
 `checked` block. Allocation and write pointers must be `ptr mut u8`; a byte
-read also accepts `ptr const u8`. Size and offset operands are exactly `u64`,
-and a byte-write value is exactly `u8`.
+read also accepts `ptr const u8`. Size, offset, and alignment operands are
+exactly `u64`, and a byte-write value is exactly `u8`. `@alloc_bytes` takes
+`(size, align)`, `@realloc_bytes` takes `(p, old_size, align, new_size)`, and
+`@free_bytes` takes `(p, size, align)`.
 
 {{ rule(id="9.2:14f", cat="example") }}
 
 ```rue
 fn main() -> i32 {
     checked {
-        let p = @alloc_bytes(2);
+        let p = @alloc_bytes(2, 1);
         @byte_write(p, 0, 65);
         @byte_write(p, 1, 66);
         let result: i32 = @intCast(@byte_read(p, 1));
-        @free_bytes(p, 2);
+        @free_bytes(p, 2, 1);
         result // 66
     }
 }
@@ -241,19 +247,28 @@ the `@byte_copy` source operand is `ptr const u8` or `ptr mut u8`. The
 ```rue
 fn main() -> i32 {
     checked {
-        let src = @alloc_bytes(3);
+        let src = @alloc_bytes(3, 1);
         @byte_set(src, 7, 3);
-        let dst = @alloc_bytes(3);
+        let dst = @alloc_bytes(3, 1);
         @byte_copy(dst, src, 3);
         let result: i32 = @intCast(@byte_read(dst, 0))
             + @intCast(@byte_read(dst, 1))
             + @intCast(@byte_read(dst, 2));
-        @free_bytes(src, 3);
-        @free_bytes(dst, 3);
+        @free_bytes(src, 3, 1);
+        @free_bytes(dst, 3, 1);
         result // 21
     }
 }
 ```
+
+{{ rule(id="9.2:14j", cat="legality-rule") }}
+
+The `align` argument to `@alloc_bytes`, `@realloc_bytes`, and `@free_bytes` is a
+byte count that must be a power of two. When `align` is a compile-time constant
+that is zero or not a power of two, the program is rejected at compile time.
+A non-constant `align` is not checked at compile time; supplying a value that is
+zero or not a power of two is then undefined behavior (§9.1, ADR-0028), like the
+other unchecked contracts of this family.
 
 ## Field Pointer Intrinsic
 

--- a/std/fs.rue
+++ b/std/fs.rue
@@ -238,7 +238,7 @@ fn _normalize_macos(e: i64) -> FileError {
 
 fn _path_to_cbuf(borrow path: strbuf.StrBuf) -> ptr mut u8 {
     let n = path.len();
-    let buf: ptr mut u8 = checked { @alloc_bytes(n + 1) };
+    let buf: ptr mut u8 = checked { @alloc_bytes(n + 1, 1) };
     if checked { @ptr_to_int(buf) } == 0 {
         @panic("out of memory");
     }
@@ -273,7 +273,7 @@ pub struct File {
         let addr: u64 = checked { @ptr_to_int(cbuf) };
         let free_len = path.len() + 1;
         let ret: i64 = checked { @syscall(_sys_openat(), _at_fdcwd(), addr, flags, mode) };
-        checked { @free_bytes(cbuf, free_len); };
+        checked { @free_bytes(cbuf, free_len, 1); };
         if ret < 0 {
             R.Err(_normalize_errno(0 - ret))
         } else {
@@ -317,7 +317,7 @@ pub struct File {
             // A full buffer is a caller error, distinct from EOF (Ok(0)).
             return R.Err(FileError.InvalidInput);
         }
-        let tmp: ptr mut u8 = checked { @alloc_bytes(want) };
+        let tmp: ptr mut u8 = checked { @alloc_bytes(want, 1) };
         if checked { @ptr_to_int(tmp) } == 0 {
             @panic("out of memory");
         }
@@ -325,7 +325,7 @@ pub struct File {
         let fd_u: u64 = @intCast(self.fd);
         let ret: i64 = checked { @syscall(_sys_read(), fd_u, addr, want) };
         if ret < 0 {
-            checked { @free_bytes(tmp, want); };
+            checked { @free_bytes(tmp, want, 1); };
             return R.Err(_normalize_errno(0 - ret));
         }
         let n: u64 = @intCast(ret);
@@ -335,7 +335,7 @@ pub struct File {
             buf.push(b);
             i = i + 1;
         }
-        checked { @free_bytes(tmp, want); };
+        checked { @free_bytes(tmp, want, 1); };
         R.Ok(n)
     }
 
@@ -349,7 +349,7 @@ pub struct File {
         if n == 0 {
             return R.Ok(0);
         }
-        let tmp: ptr mut u8 = checked { @alloc_bytes(n) };
+        let tmp: ptr mut u8 = checked { @alloc_bytes(n, 1) };
         if checked { @ptr_to_int(tmp) } == 0 {
             @panic("out of memory");
         }
@@ -361,7 +361,7 @@ pub struct File {
         let addr: u64 = checked { @ptr_to_int(tmp) };
         let fd_u: u64 = @intCast(self.fd);
         let ret: i64 = checked { @syscall(_sys_write(), fd_u, addr, n) };
-        checked { @free_bytes(tmp, n); };
+        checked { @free_bytes(tmp, n, 1); };
         if ret < 0 {
             R.Err(_normalize_errno(0 - ret))
         } else {
@@ -376,7 +376,7 @@ pub struct File {
         if n == 0 {
             return R.Ok(());
         }
-        let tmp: ptr mut u8 = checked { @alloc_bytes(n) };
+        let tmp: ptr mut u8 = checked { @alloc_bytes(n, 1) };
         if checked { @ptr_to_int(tmp) } == 0 {
             @panic("out of memory");
         }
@@ -397,20 +397,20 @@ pub struct File {
                     _ => false,
                 };
                 if !retry {
-                    checked { @free_bytes(tmp, n); };
+                    checked { @free_bytes(tmp, n, 1); };
                     return R.Err(e);
                 }
             } else {
                 let wrote: u64 = @intCast(ret);
                 if wrote == 0 {
                     // No progress on a non-error write; stop rather than spin.
-                    checked { @free_bytes(tmp, n); };
+                    checked { @free_bytes(tmp, n, 1); };
                     return R.Err(FileError.Other(0));
                 }
                 off = off + wrote;
             }
         }
-        checked { @free_bytes(tmp, n); };
+        checked { @free_bytes(tmp, n, 1); };
         R.Ok(())
     }
 

--- a/std/strbuf.rue
+++ b/std/strbuf.rue
@@ -59,7 +59,7 @@ pub struct StrBuf {
             return Self.new();
         }
         let cap = Self.initial_capacity(requested);
-        let allocation: ptr mut u8 = checked { @alloc_bytes(cap) };
+        let allocation: ptr mut u8 = checked { @alloc_bytes(cap, 1) };
         if checked { @ptr_to_int(allocation) } == 0 {
             @panic("out of memory");
         }
@@ -111,14 +111,14 @@ pub struct StrBuf {
 
         let new_cap = Self.growth_capacity(self.cap, required);
         if self.cap == 0 {
-            let replacement: ptr mut u8 = checked { @alloc_bytes(new_cap) };
+            let replacement: ptr mut u8 = checked { @alloc_bytes(new_cap, 1) };
             if checked { @ptr_to_int(replacement) } == 0 {
                 @panic("out of memory");
             }
             copy_packed_bytes(self.buf, 0, replacement, 0, self.len);
             self.buf = replacement;
         } else {
-            let replacement = checked { @realloc_bytes(self.buf, self.cap, new_cap) };
+            let replacement = checked { @realloc_bytes(self.buf, self.cap, 1, new_cap) };
             if checked { @ptr_to_int(replacement) } == 0 {
                 @panic("out of memory");
             }
@@ -293,7 +293,7 @@ pub struct StrBuf {
     // Reset after freeing so the later destructor is a no-op.
     fn free(inout self) {
         if self.cap > 0 {
-            checked { @free_bytes(self.buf, self.cap); };
+            checked { @free_bytes(self.buf, self.cap, 1); };
         }
         let zero: u64 = 0;
         self.buf = checked { @int_to_ptr(zero) };
@@ -304,6 +304,6 @@ pub struct StrBuf {
 
 drop fn StrBuf(self) {
     if self.cap > 0 {
-        checked { @free_bytes(self.buf, self.cap); };
+        checked { @free_bytes(self.buf, self.cap, 1); };
     }
 }


### PR DESCRIPTION
## Summary

Implements **ADR-0059 Phase 2** (RUE-960): the byte allocator surface gains the explicit alignment parameter the ADR-0052/0059 acceptance rulings require, fixing the alignment-1 defect ADR-0052 flagged and giving the interim surface the `(size, align)` contract the final unified `@alloc` needs.

- **New signatures** (still `--preview raw_bytes` + `checked {}`-gated; trusted-std carve-out unchanged): `@alloc_bytes(size, align)`, `@realloc_bytes(p, old_size, align, new_size)`, `@free_bytes(p, size, align)`.
- **Power-of-two rule**: `align` is a plain `u64` per the ratified ruling. Comptime-constant violations (zero or non-power-of-two) are rejected at compile time with the new **E0712** diagnostic; non-constant values carry the documented contract.
- **Operand plans**: the runtime helpers (`__rue_alloc`/`__rue_realloc`/`__rue_free`) already took `(size, align)` — the plans now source align from the intrinsic's value argument instead of the synthesized alignment-1 constant, on both backends via the generic runtime-call path, with AIR↔ABI manifest validation kept consistent.
- **std**: `strbuf.rue` and `fs.rue` pass explicit alignment 1, keeping packed-buffer behavior identical.
- **Spec**: `9.2:14b`/`14c`/`14e` updated for the new signatures; new legality rule `9.2:14j` (power-of-two); `4.13:5a` registry rows refreshed.
- **Oracle**: arity table and byte-allocator signature checks updated; two positive round-trips added to the oracle-diff ledger.

## Verification

Re-verified at integration on current trunk: spec `raw_bytes` **27/27** (five new align cases: align-1/align-8 round-trips, align-0 and align-3 rejections, missing-align arity); CLI `std_strbuf` 21/21, `std_internal_raw_bytes` 3/3, `heap_intrinsics` 8/8; full `test.sh` green except the four pre-existing uid-0 unreadable-file tests (environmental; CI runs unprivileged).

Fixes RUE-960

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_