### PR TITLE
RUE-973: route memory consumers through the layout authority (ADR-0052 phase 2)

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -630,6 +630,32 @@ impl TypeInternPoolInner {
         offset
     }
 
+    /// Byte offset of payload field `field_index` of `variant_index` within
+    /// `enum_id`. The discriminant occupies the first slot, so every payload
+    /// begins one [`SLOT_BYTES`] slot in, and each preceding payload field of
+    /// the same variant contributes its layout size. This is the same
+    /// computation [`Self::layout`] records in each entry of
+    /// [`LayoutKind::Enum`]'s `variants`; code generation's
+    /// `enum_payload_slot_offset` divides the result by [`SLOT_BYTES`] so
+    /// payload addressing agrees with the canonical layout by construction.
+    fn enum_payload_field_offset(
+        &self,
+        enum_id: EnumId,
+        variant_index: u32,
+        field_index: u32,
+    ) -> u64 {
+        let def = self.enum_def(enum_id);
+        let mut offset = SLOT_BYTES;
+        for &field_ty in def
+            .variant_payload(variant_index as usize)
+            .iter()
+            .take(field_index as usize)
+        {
+            offset = offset.saturating_add(self.layout_size(field_ty));
+        }
+        offset
+    }
+
     /// Compute the canonical physical [`Layout`] of `ty`.
     ///
     /// `size`/`stride`/`alignment` follow the flattened eight-byte slot model
@@ -1915,6 +1941,18 @@ impl FrozenTypeInternPool {
     /// `@offset_of` and field addressing during lowering.
     pub fn struct_field_offset(&self, struct_id: StructId, field_index: u32) -> u64 {
         self.inner.struct_field_offset(struct_id, field_index)
+    }
+
+    /// Byte offset of an enum variant's payload field, the shared source for
+    /// code generation's payload addressing (`enum_payload_slot_offset`).
+    pub fn enum_payload_field_offset(
+        &self,
+        enum_id: EnumId,
+        variant_index: u32,
+        field_index: u32,
+    ) -> u64 {
+        self.inner
+            .enum_payload_field_offset(enum_id, variant_index, field_index)
     }
 
     /// Validate a complete type relative to this frozen owner pool.

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -22,6 +22,7 @@
 use std::collections::HashMap;
 
 use rue_air::Type;
+use rue_air::layout::SLOT_BYTES;
 use rue_cfg::CfgValue;
 
 use crate::allocation::BoundsCheckBackend;
@@ -191,7 +192,11 @@ pub(crate) fn store_slots_through_ptr<B: SlotBackend>(
     static_byte_offset: i32,
 ) {
     for (i, val) in vals.iter().enumerate() {
-        b.emit_store_through_ptr(*val, ptr, static_byte_offset + (i as i32) * 8);
+        b.emit_store_through_ptr(
+            *val,
+            ptr,
+            static_byte_offset + (i as i32) * SLOT_BYTES as i32,
+        );
     }
 }
 
@@ -207,7 +212,7 @@ pub(crate) fn store_slots_to_sret<B: SlotBackend>(b: &mut B, vals: &[VReg]) {
     let sret_slot = b.ctx().sret_ptr_slot();
     b.emit_load_slot(ptr, sret_slot);
     for (i, val) in vals.iter().enumerate() {
-        b.emit_store_through_ptr(*val, ptr, (i as i32) * 8);
+        b.emit_store_through_ptr(*val, ptr, (i as i32) * SLOT_BYTES as i32);
     }
 }
 
@@ -251,7 +256,7 @@ fn load_through_ptr<B: SlotBackend>(b: &mut B, addr_vreg: VReg, count: u32) -> V
     let mut vregs = Vec::with_capacity(count as usize);
     for k in 0..count {
         let vreg = b.alloc_vreg();
-        b.emit_load_through_ptr(vreg, addr_vreg, (k as i32) * 8);
+        b.emit_load_through_ptr(vreg, addr_vreg, (k as i32) * SLOT_BYTES as i32);
         vregs.push(vreg);
     }
     vregs

--- a/crates/rue-codegen/src/allocation.rs
+++ b/crates/rue-codegen/src/allocation.rs
@@ -100,6 +100,21 @@ pub fn pointer_element_width(type_pool: &FrozenTypeInternPool, ptr_ty: Type) -> 
     type_width(type_pool, pointee)
 }
 
+/// Canonical byte alignment a pointer's pointee requires, from the layout
+/// authority. Companion to [`pointer_element_width`]; typed allocation passes
+/// this as the runtime allocator's `align` operand so the allocation carries the
+/// pointee's canonical `(size, alignment)` contract (ADR-0052). The defensive
+/// fallback mirrors [`pointer_element_width`]'s one-slot scalar width.
+#[inline]
+pub fn pointer_element_align(type_pool: &FrozenTypeInternPool, ptr_ty: Type) -> u64 {
+    let pointee = match ptr_ty.kind() {
+        TypeKind::PtrMut(id) => type_pool.ptr_mut_def(id),
+        TypeKind::PtrConst(id) => type_pool.ptr_const_def(id),
+        _ => return SLOT_BYTES,
+    };
+    type_pool.layout(pointee).alignment
+}
+
 /// Select the shared constant scaling operation for a byte width.
 #[inline]
 pub const fn scale_kind(bytes: u64) -> ScaleKind {

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -108,7 +108,7 @@ fn resolved_access<B: PlaceLowerBackend + ?Sized>(
         ),
         crate::value_plan::PlaceBasePlan::Param { slot, by_ref: true } => {
             let ptr = b.ensure_by_ref_param_ptr(slot);
-            let byte_offset = offsets.static_slot_offset as i32 * 8;
+            let byte_offset = offsets.static_slot_offset as i32 * allocation::SLOT_BYTES as i32;
             if let Some(dynamic) = dynamic_offset {
                 let addr = b.alloc_vreg();
                 b.emit_reg_move(addr, ptr);
@@ -255,7 +255,7 @@ fn lower_place_addr_plan_with_bounds<B: PlaceLowerBackend + ?Sized>(
         crate::value_plan::PlaceBasePlan::Param { slot, by_ref: true } => {
             let ptr = b.ensure_by_ref_param_ptr(slot);
             b.emit_reg_move(dst, ptr);
-            let byte_offset = offsets.static_slot_offset as i32 * 8;
+            let byte_offset = offsets.static_slot_offset as i32 * allocation::SLOT_BYTES as i32;
             if byte_offset != 0 {
                 b.emit_addr_add_imm(dst, byte_offset);
             }

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -180,25 +180,17 @@ fn push_leaf_types(type_pool: &FrozenTypeInternPool, ty: Type, out: &mut Vec<Typ
 
 /// Slot offset of payload field `field_index` within an enum's payload area.
 ///
-/// The discriminant occupies slot 0, so payload fields begin at slot 1. This
-/// accounts for the slot sizes of all preceding payload fields of the same
-/// variant (RUE-221).
+/// The discriminant occupies slot 0, so payload fields begin at slot 1
+/// (RUE-221). Derived from the canonical layout authority's payload byte offset
+/// divided by the slot width, so payload addressing agrees with the enum layout
+/// by construction.
 pub fn enum_payload_slot_offset(
     type_pool: &FrozenTypeInternPool,
     enum_id: EnumId,
     variant_index: u32,
     field_index: u32,
 ) -> u32 {
-    let enum_def = type_pool.enum_def(enum_id);
-    let payload = enum_def.variant_payload(variant_index as usize);
-    // 1 for the discriminant slot.
-    let mut offset = 1u32;
-    for i in 0..(field_index as usize) {
-        if let Some(&ty) = payload.get(i) {
-            offset += type_slot_count(type_pool, ty);
-        }
-    }
-    offset
+    (type_pool.enum_payload_field_offset(enum_id, variant_index, field_index) / SLOT_BYTES) as u32
 }
 
 /// Calculate the slot count for a single element of an array type.

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -277,12 +277,16 @@ pub enum IntrinsicOperation {
     PtrWrite,
     PtrOffset,
     Alloc {
+        /// The pointee's canonical byte alignment (from the layout authority),
+        /// passed as the runtime allocator's `align` operand.
         element_size: u64,
     },
     Free {
+        /// The pointee's canonical byte alignment (see [`Self::Alloc`]).
         element_size: u64,
     },
     Realloc {
+        /// The pointee's canonical byte alignment (see [`Self::Alloc`]).
         element_size: u64,
     },
     AllocBytes,
@@ -1527,9 +1531,24 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     "ptr_read" => IntrinsicOperation::PtrRead,
                     "ptr_write" => IntrinsicOperation::PtrWrite,
                     "ptr_offset" => IntrinsicOperation::PtrOffset,
-                    "alloc" => IntrinsicOperation::Alloc { element_size: 8 },
-                    "free" => IntrinsicOperation::Free { element_size: 8 },
-                    "realloc" => IntrinsicOperation::Realloc { element_size: 8 },
+                    "alloc" => IntrinsicOperation::Alloc {
+                        element_size: crate::allocation::pointer_element_align(
+                            ctx.type_pool,
+                            inst.ty,
+                        ),
+                    },
+                    "free" => IntrinsicOperation::Free {
+                        element_size: crate::allocation::pointer_element_align(
+                            ctx.type_pool,
+                            ctx.cfg.get_inst(args[0]).ty,
+                        ),
+                    },
+                    "realloc" => IntrinsicOperation::Realloc {
+                        element_size: crate::allocation::pointer_element_align(
+                            ctx.type_pool,
+                            ctx.cfg.get_inst(args[0]).ty,
+                        ),
+                    },
                     "alloc_bytes" => IntrinsicOperation::AllocBytes,
                     "free_bytes" => IntrinsicOperation::FreeBytes,
                     "realloc_bytes" => IntrinsicOperation::ReallocBytes,
@@ -1672,6 +1691,56 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
     }
 }
 
+/// Realize an allocation-family runtime call's operand list from its manifest
+/// (`RuntimeCallKind::operands()`) — the single description the AIR validator in
+/// `rue_air::runtime_call` also consumes, so the two encodings of the alloc ABI
+/// the ADR-0052 audit found are reconciled to one authority (RUE-973). Each
+/// operand's semantic origin selects how it is materialized: a size scales its
+/// count by the pointee's canonical layout size (`scale`), an alignment takes
+/// the pointee's canonical alignment (`pointee_align`, from the layout
+/// authority), a pointer passes straight through, and a plain byte-family value
+/// operand passes its AIR argument. Ordering, arity, and ABI types come from the
+/// manifest and are re-checked by `RuntimeCallPlan::expect_manifest`.
+fn realize_alloc_operands(
+    kind: rue_air::RuntimeCallKind,
+    args: &[IntrinsicArgPlan],
+    scale: Option<crate::allocation::ScalePlan>,
+    pointee_align: u64,
+) -> Vec<crate::runtime_call_plan::RuntimeCallArg> {
+    use crate::runtime_call_plan::RuntimeCallArg;
+    use rue_air::RuntimeOperandOrigin;
+    use rue_runtime_abi::AbiType;
+
+    kind.operands()
+        .iter()
+        .map(|origin| match *origin {
+            RuntimeOperandOrigin::MutablePointerArgument { index, .. } => {
+                RuntimeCallArg::mut_pointer(args[index as usize].primary, AbiType::Byte)
+            }
+            RuntimeOperandOrigin::ScaledByResultPointeeSize(index) => RuntimeCallArg::scaled(
+                args[index as usize].primary,
+                scale.expect("typed allocation size scale"),
+                AbiType::U64,
+            ),
+            RuntimeOperandOrigin::ScaledByPointerPointeeSize { count, .. } => {
+                RuntimeCallArg::scaled(
+                    args[count as usize].primary,
+                    scale.expect("typed allocation size scale"),
+                    AbiType::U64,
+                )
+            }
+            RuntimeOperandOrigin::ResultPointeeAlign
+            | RuntimeOperandOrigin::PointerPointeeAlign(_) => {
+                RuntimeCallArg::immediate(pointee_align, AbiType::U64)
+            }
+            RuntimeOperandOrigin::ValueArgument { index, ty } => {
+                RuntimeCallArg::value(args[index as usize].primary, ty)
+            }
+            other => unreachable!("unexpected allocation operand origin {other:?}"),
+        })
+        .collect()
+}
+
 fn intrinsic_runtime_call(
     operation: &IntrinsicOperation,
     args: &[IntrinsicArgPlan],
@@ -1679,6 +1748,7 @@ fn intrinsic_runtime_call(
     result_slots: u32,
 ) -> Option<crate::runtime_call_plan::RuntimeCallPlan> {
     use crate::runtime_call_plan::{RuntimeCallArg, RuntimeCallPlan};
+    use rue_air::RuntimeCallKind;
     use rue_runtime_abi::{AbiType, AggregateShapeId};
 
     let (helper, call_args) = match operation {
@@ -1734,35 +1804,19 @@ fn intrinsic_runtime_call(
         ),
         IntrinsicOperation::Alloc { element_size } => (
             RuntimeHelperId::Alloc,
-            vec![
-                RuntimeCallArg::scaled(args[0].primary, scale?, AbiType::U64),
-                RuntimeCallArg::immediate(*element_size, AbiType::U64),
-            ],
+            realize_alloc_operands(RuntimeCallKind::AllocTyped, args, scale, *element_size),
         ),
         IntrinsicOperation::AllocBytes => (
             RuntimeHelperId::Alloc,
-            vec![
-                RuntimeCallArg::value(args[0].primary, AbiType::U64),
-                // Explicit alignment argument (ADR-0059 Phase 2, RUE-960).
-                RuntimeCallArg::value(args[1].primary, AbiType::U64),
-            ],
+            realize_alloc_operands(RuntimeCallKind::AllocBytes, args, scale, 0),
         ),
         IntrinsicOperation::Free { element_size } => (
             RuntimeHelperId::Free,
-            vec![
-                RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
-                RuntimeCallArg::scaled(args[1].primary, scale?, AbiType::U64),
-                RuntimeCallArg::immediate(*element_size, AbiType::U64),
-            ],
+            realize_alloc_operands(RuntimeCallKind::FreeTyped, args, scale, *element_size),
         ),
         IntrinsicOperation::FreeBytes => (
             RuntimeHelperId::Free,
-            vec![
-                RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
-                RuntimeCallArg::value(args[1].primary, AbiType::U64),
-                // Explicit alignment argument (ADR-0059 Phase 2, RUE-960).
-                RuntimeCallArg::value(args[2].primary, AbiType::U64),
-            ],
+            realize_alloc_operands(RuntimeCallKind::FreeBytes, args, scale, 0),
         ),
         IntrinsicOperation::ByteCopy => (
             RuntimeHelperId::ByteCopy,
@@ -1780,41 +1834,14 @@ fn intrinsic_runtime_call(
                 RuntimeCallArg::value(args[2].primary, AbiType::U64),
             ],
         ),
-        IntrinsicOperation::Realloc { .. } | IntrinsicOperation::ReallocBytes => {
-            // `@realloc(p, old_count, new_count)` scales element counts and
-            // passes `align = @align_of(T)` as an immediate; `@realloc_bytes(p,
-            // old_size, align, new_size)` passes byte sizes straight through
-            // with an explicit `align` value operand (ADR-0059 Phase 2).
-            let is_typed = matches!(operation, IntrinsicOperation::Realloc { .. });
-            let old = if is_typed {
-                RuntimeCallArg::scaled(args[1].primary, scale?, AbiType::U64)
-            } else {
-                RuntimeCallArg::value(args[1].primary, AbiType::U64)
-            };
-            let new = if is_typed {
-                RuntimeCallArg::scaled(args[2].primary, scale?, AbiType::U64)
-            } else {
-                RuntimeCallArg::value(args[3].primary, AbiType::U64)
-            };
-            let align = match operation {
-                IntrinsicOperation::Realloc { element_size } => {
-                    RuntimeCallArg::immediate(*element_size, AbiType::U64)
-                }
-                IntrinsicOperation::ReallocBytes => {
-                    RuntimeCallArg::value(args[2].primary, AbiType::U64)
-                }
-                _ => unreachable!(),
-            };
-            (
-                RuntimeHelperId::Realloc,
-                vec![
-                    RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
-                    old,
-                    new,
-                    align,
-                ],
-            )
-        }
+        IntrinsicOperation::Realloc { element_size } => (
+            RuntimeHelperId::Realloc,
+            realize_alloc_operands(RuntimeCallKind::ReallocTyped, args, scale, *element_size),
+        ),
+        IntrinsicOperation::ReallocBytes => (
+            RuntimeHelperId::Realloc,
+            realize_alloc_operands(RuntimeCallKind::ReallocBytes, args, scale, 0),
+        ),
         IntrinsicOperation::Debug => {
             let arg = args.first()?;
             if arg.slots.len() >= 2 {


### PR DESCRIPTION
## Summary

Second child of the ADR-0052 canonical-layout migration (epic RUE-971): every remaining memory-observing consumer now reads the layout authority, strictly behavior-preserving.

- **Places/field access**: `place_lower`'s by-ref slot→byte conversions scale by the authority's `SLOT_BYTES`; `enum_payload_slot_offset` divides a new `enum_payload_field_offset` pool query computed beside RUE-972's `struct_field_offset` from the same per-field layout sizes.
- **Aggregate memory ops**: the `agg_slots` load/store/sret `k*8` offsets — the audit's most pervasive slot assumption — source their byte math from the authority; the walk stays slot-shaped.
- **Pointer stride**: confirmed already canonical via RUE-972's routing (`type_width`/`pointer_element_width` → `layout().size`); plan-driven on both backends, no change needed. Constants/rodata audited: no hand-computed slot bytes to route.
- **Dual alloc-ABI encodings reconciled** (the two ratification-audit discoveries): the `RuntimeCallKind` operand manifest the ABI validator consumes is now also what the emitter realizes — new `value_plan::realize_alloc_operands` maps each `RuntimeOperandOrigin` to its argument, with sizes scaled by the authority's layout size and alignments taken from the new `pointer_element_align` companion query, replacing the hardcoded `align=8` immediate and the six hand-built operand vectors. Exactly one place decides the alloc operands.
- **Behavioral footnote**: a zero-sized typed allocation would now emit the authority's alignment (1) rather than the old literal 8 — the path is unreachable today and the canonical value is correct.
- Deferred per the phase plan: stack frames (RUE-975), call-ABI classification (RUE-976), the oracle (RUE-977), raw-byte family fold-in (RUE-978).

## Verification

Re-verified at integration on current trunk (post RUE-972 merge): layout units 9/9 + 1/1; codegen units 549; CLI `abi` 55, `aggregate` 101, `heap_intrinsics` 8, `pointers` 23, `enum_payloads` 23, `arraybuf` 18; spec `raw_bytes` 27/27; oracle quick 0 disagreements; full `test.sh` green except the four pre-existing uid-0 unreadable-file tests (environmental; CI runs unprivileged). No existing test expectation modified.

Fixes RUE-973

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_