### PR TITLE
RUE-852: derive exhaustive semantic schema scaffolding

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -221,6 +221,31 @@ fn air_payload_ownership_and_validation_boundary_cannot_regress() {
 }
 
 #[test]
+fn semantic_schema_scaffolding_stays_exhaustive_and_reviewable() {
+    let body = include_str!("semantic_body.rs");
+    let import = include_str!("semantic_import.rs");
+
+    assert!(body.contains("macro_rules! semantic_body_inst_schema"));
+    assert!(body.contains("pub enum SemanticBodyInstKind"));
+    assert!(body.contains("pub fn try_map_keys<K2, M2, E>("));
+    assert!(body.contains("pub fn visit_dependencies("));
+    assert!(body.contains("pub struct SemanticBodyInstFailureContext<E>"));
+    assert!(body.contains("let data = inst.data.try_map_keys(key, module)?;"));
+    assert!(import.contains("macro_rules! semantic_import_type_schema"));
+    assert!(import.contains("macro_rules! semantic_import_const_schema"));
+    assert!(import.contains("pub enum SemanticImportTypeKind"));
+    assert!(import.contains("pub enum SemanticImportConstKind"));
+
+    let generated_kind = body
+        .split("pub const fn kind(&self) -> SemanticBodyInstKind")
+        .nth(1)
+        .and_then(|source| source.split("semantic_body_inst_schema!(").next())
+        .expect("generated semantic instruction kind implementation");
+    assert!(generated_kind.contains("match self"));
+    assert!(!generated_kind.contains("_ =>"));
+}
+
+#[test]
 fn semantic_definition_taxonomy_has_one_enum_declaration() {
     let canonical = include_str!("semantic_identity.rs");
     let bindings = include_str!("sema/binding_manifest.rs");

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -78,10 +78,11 @@ pub use sema::{
     SpecializedFreeFunctionOrigin,
 };
 pub use semantic_body::{
-    SemanticBody, SemanticBodyAnchor, SemanticBodyCallArg, SemanticBodyCandidate,
-    SemanticBodyCandidateInstallWork,
-    SemanticBodyExport, SemanticBodyExportFailure, SemanticBodyImportFailure,
-    SemanticBodyImportFailureKind, SemanticBodyInst, SemanticBodyInstData, SemanticBodyMatchArm,
+    SEMANTIC_BODY_INST_KINDS, SemanticBody, SemanticBodyAnchor, SemanticBodyCallArg,
+    SemanticBodyCandidate, SemanticBodyCandidateInstallWork, SemanticBodyExport,
+    SemanticBodyExportFailure, SemanticBodyImportFailure, SemanticBodyImportFailureKind,
+    SemanticBodyInst, SemanticBodyInstData, SemanticBodyInstDependency,
+    SemanticBodyInstFailureContext, SemanticBodyInstKind, SemanticBodyMatchArm,
     SemanticBodyPattern, SemanticBodyPlace, SemanticBodyPlaceRef, SemanticBodyProjection,
     SemanticBodyRef, SemanticBodyWarning, SemanticDefinitionEndpoint, SemanticDefinitionToken,
     SemanticImportedBody, SemanticModuleEndpoint, SemanticModuleToken,
@@ -91,8 +92,9 @@ pub use semantic_body::{
 };
 pub use semantic_identity::{StableDefinitionKind, StableDefinitionNamespace};
 pub use semantic_import::{
+    SEMANTIC_IMPORT_CONST_KINDS, SEMANTIC_IMPORT_TYPE_KINDS, SemanticImportConstKind,
     SemanticImportConstValue, SemanticImportEpoch, SemanticImportFailure, SemanticImportNominal,
-    SemanticImportNominalKind, SemanticImportType, SemanticImportTypeFold,
+    SemanticImportNominalKind, SemanticImportType, SemanticImportTypeFold, SemanticImportTypeKind,
     SemanticImportedConstValue, SemanticImportedType,
 };
 pub use types::{

--- a/crates/rue-air/src/semantic_body.rs
+++ b/crates/rue-air/src/semantic_body.rs
@@ -373,6 +373,521 @@ pub enum SemanticBodyInstData<K, M> {
     },
 }
 
+// Keep the canonical instruction's stable tag and diagnostic name in one
+// deliberately boring table. The generated `kind` match has no wildcard: a
+// newly added `SemanticBodyInstData` variant fails compilation here until its
+// schema metadata is supplied. Layout-specific export/import semantics remain
+// ordinary Rust matches at their respective boundaries.
+macro_rules! semantic_body_inst_schema {
+    ($consumer:ident) => {
+        $consumer! {
+            Const, SemanticBodyInstData::Const(..), 0, "const";
+            BoolConst, SemanticBodyInstData::BoolConst(..), 1, "bool_const";
+            StringConst, SemanticBodyInstData::StringConst(..), 2, "string_const";
+            UnitConst, SemanticBodyInstData::UnitConst, 3, "unit_const";
+            TypeConst, SemanticBodyInstData::TypeConst(..), 4, "type_const";
+            Add, SemanticBodyInstData::Add(..), 5, "add";
+            Sub, SemanticBodyInstData::Sub(..), 6, "sub";
+            Mul, SemanticBodyInstData::Mul(..), 7, "mul";
+            WrappingAdd, SemanticBodyInstData::WrappingAdd(..), 8, "wrapping_add";
+            WrappingSub, SemanticBodyInstData::WrappingSub(..), 9, "wrapping_sub";
+            WrappingMul, SemanticBodyInstData::WrappingMul(..), 10, "wrapping_mul";
+            Div, SemanticBodyInstData::Div(..), 11, "div";
+            Mod, SemanticBodyInstData::Mod(..), 12, "mod";
+            Eq, SemanticBodyInstData::Eq(..), 13, "eq";
+            Ne, SemanticBodyInstData::Ne(..), 14, "ne";
+            Lt, SemanticBodyInstData::Lt(..), 15, "lt";
+            Gt, SemanticBodyInstData::Gt(..), 16, "gt";
+            Le, SemanticBodyInstData::Le(..), 17, "le";
+            Ge, SemanticBodyInstData::Ge(..), 18, "ge";
+            And, SemanticBodyInstData::And(..), 19, "and";
+            Or, SemanticBodyInstData::Or(..), 20, "or";
+            BitAnd, SemanticBodyInstData::BitAnd(..), 21, "bit_and";
+            BitOr, SemanticBodyInstData::BitOr(..), 22, "bit_or";
+            BitXor, SemanticBodyInstData::BitXor(..), 23, "bit_xor";
+            Shl, SemanticBodyInstData::Shl(..), 24, "shl";
+            Shr, SemanticBodyInstData::Shr(..), 25, "shr";
+            Neg, SemanticBodyInstData::Neg(..), 26, "neg";
+            Not, SemanticBodyInstData::Not(..), 27, "not";
+            BitNot, SemanticBodyInstData::BitNot(..), 28, "bit_not";
+            Branch, SemanticBodyInstData::Branch { .. }, 29, "branch";
+            Loop, SemanticBodyInstData::Loop { .. }, 30, "loop";
+            InfiniteLoop, SemanticBodyInstData::InfiniteLoop { .. }, 31, "infinite_loop";
+            Match, SemanticBodyInstData::Match { .. }, 32, "match";
+            Break, SemanticBodyInstData::Break, 33, "break";
+            Continue, SemanticBodyInstData::Continue, 34, "continue";
+            Alloc, SemanticBodyInstData::Alloc { .. }, 35, "alloc";
+            Load, SemanticBodyInstData::Load { .. }, 36, "load";
+            Store, SemanticBodyInstData::Store { .. }, 37, "store";
+            ParamStore, SemanticBodyInstData::ParamStore { .. }, 38, "param_store";
+            Ret, SemanticBodyInstData::Ret(..), 39, "ret";
+            Call, SemanticBodyInstData::Call { .. }, 40, "call";
+            RuntimeCall, SemanticBodyInstData::RuntimeCall { .. }, 41, "runtime_call";
+            CallSpecialized, SemanticBodyInstData::CallSpecialized { .. }, 42, "call_specialized";
+            CallGeneric, SemanticBodyInstData::CallGeneric, 43, "call_generic";
+            Intrinsic, SemanticBodyInstData::Intrinsic { .. }, 44, "intrinsic";
+            Param, SemanticBodyInstData::Param { .. }, 45, "param";
+            Block, SemanticBodyInstData::Block { .. }, 46, "block";
+            StructInit, SemanticBodyInstData::StructInit { .. }, 47, "struct_init";
+            ArrayInit, SemanticBodyInstData::ArrayInit { .. }, 48, "array_init";
+            PlaceRead, SemanticBodyInstData::PlaceRead { .. }, 49, "place_read";
+            PlaceWrite, SemanticBodyInstData::PlaceWrite { .. }, 50, "place_write";
+            EnumVariant, SemanticBodyInstData::EnumVariant { .. }, 51, "enum_variant";
+            EnumPayloadGet, SemanticBodyInstData::EnumPayloadGet { .. }, 52, "enum_payload_get";
+            IntCast, SemanticBodyInstData::IntCast { .. }, 53, "int_cast";
+            Drop, SemanticBodyInstData::Drop { .. }, 54, "drop";
+            StorageLive, SemanticBodyInstData::StorageLive { .. }, 55, "storage_live";
+            StorageDead, SemanticBodyInstData::StorageDead { .. }, 56, "storage_dead";
+            MarkMoved, SemanticBodyInstData::MarkMoved { .. }, 57, "mark_moved";
+        }
+    };
+}
+
+macro_rules! define_semantic_body_inst_kind {
+    ($( $kind:ident, $pattern:pat, $tag:literal, $name:literal; )*) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[repr(u16)]
+        pub enum SemanticBodyInstKind {
+            $( $kind = $tag, )*
+        }
+
+        pub const SEMANTIC_BODY_INST_KINDS: &[SemanticBodyInstKind] = &[
+            $( SemanticBodyInstKind::$kind, )*
+        ];
+
+        impl SemanticBodyInstKind {
+            pub const fn schema_tag(self) -> u16 {
+                self as u16
+            }
+
+            pub const fn display_name(self) -> &'static str {
+                match self {
+                    $( Self::$kind => $name, )*
+                }
+            }
+        }
+
+        impl std::fmt::Display for SemanticBodyInstKind {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str(self.display_name())
+            }
+        }
+
+        impl<K, M> SemanticBodyInstData<K, M> {
+            pub const fn kind(&self) -> SemanticBodyInstKind {
+                match self {
+                    $( $pattern => SemanticBodyInstKind::$kind, )*
+                }
+            }
+        }
+    };
+}
+
+semantic_body_inst_schema!(define_semantic_body_inst_kind);
+
+/// Location and schema identity attached to a typed projection/import failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticBodyInstFailureContext<E> {
+    pub instruction: u32,
+    pub kind: SemanticBodyInstKind,
+    pub failure: E,
+}
+
+impl<E> SemanticBodyInstFailureContext<E> {
+    pub fn new<K, M>(instruction: u32, data: &SemanticBodyInstData<K, M>, failure: E) -> Self {
+        Self {
+            instruction,
+            kind: data.kind(),
+            failure,
+        }
+    }
+}
+
+impl<E: std::fmt::Display> std::fmt::Display for SemanticBodyInstFailureContext<E> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "instruction {} ({}, schema tag {}): {}",
+            self.instruction,
+            self.kind,
+            self.kind.schema_tag(),
+            self.failure
+        )
+    }
+}
+
+/// Borrowed dependency exposed by the canonical instruction schema. Traversal
+/// never clones keys, types, argument arrays, or specialization identities.
+#[derive(Debug, Clone, Copy)]
+pub enum SemanticBodyInstDependency<'a, K, M> {
+    Instruction(SemanticBodyRef),
+    Place(SemanticBodyPlaceRef),
+    Definition(&'a K),
+    Type(&'a SemanticImportType<K, M>),
+    String(SemanticBodyRef),
+}
+
+impl<K, M> SemanticBodyInstData<K, M> {
+    /// Project definition and module identities without cloning unchanged
+    /// dependency arrays. The exhaustive match is intentionally local to the
+    /// canonical schema so new variants produce a focused compiler error.
+    pub fn try_map_keys<K2, M2, E>(
+        &self,
+        key: &impl Fn(&K) -> Result<K2, E>,
+        module: &impl Fn(&M) -> Result<M2, E>,
+    ) -> Result<SemanticBodyInstData<K2, M2>, E> {
+        fn pattern<K, K2, E>(
+            value: &SemanticBodyPattern<K>,
+            key: &impl Fn(&K) -> Result<K2, E>,
+        ) -> Result<SemanticBodyPattern<K2>, E> {
+            Ok(match value {
+                SemanticBodyPattern::Wildcard => SemanticBodyPattern::Wildcard,
+                SemanticBodyPattern::Int(value) => SemanticBodyPattern::Int(*value),
+                SemanticBodyPattern::Bool(value) => SemanticBodyPattern::Bool(*value),
+                SemanticBodyPattern::EnumVariant {
+                    enum_key,
+                    variant_index,
+                } => SemanticBodyPattern::EnumVariant {
+                    enum_key: key(enum_key)?,
+                    variant_index: *variant_index,
+                },
+            })
+        }
+
+        use SemanticBodyInstData as D;
+        Ok(match self {
+            D::Const(v) => D::Const(*v),
+            D::BoolConst(v) => D::BoolConst(*v),
+            D::StringConst(v) => D::StringConst(*v),
+            D::UnitConst => D::UnitConst,
+            D::TypeConst(v) => D::TypeConst(v.try_map_identities(key, module)?),
+            D::Add(a, b) => D::Add(*a, *b),
+            D::Sub(a, b) => D::Sub(*a, *b),
+            D::Mul(a, b) => D::Mul(*a, *b),
+            D::WrappingAdd(a, b) => D::WrappingAdd(*a, *b),
+            D::WrappingSub(a, b) => D::WrappingSub(*a, *b),
+            D::WrappingMul(a, b) => D::WrappingMul(*a, *b),
+            D::Div(a, b) => D::Div(*a, *b),
+            D::Mod(a, b) => D::Mod(*a, *b),
+            D::Eq(a, b) => D::Eq(*a, *b),
+            D::Ne(a, b) => D::Ne(*a, *b),
+            D::Lt(a, b) => D::Lt(*a, *b),
+            D::Gt(a, b) => D::Gt(*a, *b),
+            D::Le(a, b) => D::Le(*a, *b),
+            D::Ge(a, b) => D::Ge(*a, *b),
+            D::And(a, b) => D::And(*a, *b),
+            D::Or(a, b) => D::Or(*a, *b),
+            D::BitAnd(a, b) => D::BitAnd(*a, *b),
+            D::BitOr(a, b) => D::BitOr(*a, *b),
+            D::BitXor(a, b) => D::BitXor(*a, *b),
+            D::Shl(a, b) => D::Shl(*a, *b),
+            D::Shr(a, b) => D::Shr(*a, *b),
+            D::Neg(v) => D::Neg(*v),
+            D::Not(v) => D::Not(*v),
+            D::BitNot(v) => D::BitNot(*v),
+            D::Branch {
+                cond,
+                then_value,
+                else_value,
+            } => D::Branch {
+                cond: *cond,
+                then_value: *then_value,
+                else_value: *else_value,
+            },
+            D::Loop { cond, body } => D::Loop {
+                cond: *cond,
+                body: *body,
+            },
+            D::InfiniteLoop { body } => D::InfiniteLoop { body: *body },
+            D::Match { scrutinee, arms } => D::Match {
+                scrutinee: *scrutinee,
+                arms: arms
+                    .iter()
+                    .map(|arm| {
+                        Ok(SemanticBodyMatchArm {
+                            pattern: pattern(&arm.pattern, key)?,
+                            body: arm.body,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, E>>()?
+                    .into(),
+            },
+            D::Break => D::Break,
+            D::Continue => D::Continue,
+            D::Alloc { slot, init } => D::Alloc {
+                slot: *slot,
+                init: *init,
+            },
+            D::Load { slot } => D::Load { slot: *slot },
+            D::Store { slot, value } => D::Store {
+                slot: *slot,
+                value: *value,
+            },
+            D::ParamStore { param_slot, value } => D::ParamStore {
+                param_slot: *param_slot,
+                value: *value,
+            },
+            D::Ret(v) => D::Ret(*v),
+            D::Call { function, args } => D::Call {
+                function: key(function)?,
+                args: args.clone(),
+            },
+            D::RuntimeCall { runtime, args } => D::RuntimeCall {
+                runtime: *runtime,
+                args: args.clone(),
+            },
+            D::CallSpecialized { identity, args } => D::CallSpecialized {
+                identity: identity.try_map_keys(key, module)?,
+                args: args.clone(),
+            },
+            D::CallGeneric => D::CallGeneric,
+            D::Intrinsic {
+                runtime,
+                name,
+                args,
+            } => D::Intrinsic {
+                runtime: *runtime,
+                name: name.clone(),
+                args: args.clone(),
+            },
+            D::Param { index } => D::Param { index: *index },
+            D::Block { statements, value } => D::Block {
+                statements: statements.clone(),
+                value: *value,
+            },
+            D::StructInit {
+                struct_key,
+                fields,
+                source_order,
+            } => D::StructInit {
+                struct_key: key(struct_key)?,
+                fields: fields.clone(),
+                source_order: source_order.clone(),
+            },
+            D::ArrayInit { elements } => D::ArrayInit {
+                elements: elements.clone(),
+            },
+            D::PlaceRead { place } => D::PlaceRead { place: *place },
+            D::PlaceWrite { place, value } => D::PlaceWrite {
+                place: *place,
+                value: *value,
+            },
+            D::EnumVariant {
+                enum_key,
+                variant_index,
+                payload,
+            } => D::EnumVariant {
+                enum_key: key(enum_key)?,
+                variant_index: *variant_index,
+                payload: payload.clone(),
+            },
+            D::EnumPayloadGet {
+                base,
+                enum_key,
+                variant_index,
+                field_index,
+            } => D::EnumPayloadGet {
+                base: *base,
+                enum_key: key(enum_key)?,
+                variant_index: *variant_index,
+                field_index: *field_index,
+            },
+            D::IntCast { value, from_ty } => D::IntCast {
+                value: *value,
+                from_ty: from_ty.try_map_identities(key, module)?,
+            },
+            D::Drop { value } => D::Drop { value: *value },
+            D::StorageLive { slot } => D::StorageLive { slot: *slot },
+            D::StorageDead { slot } => D::StorageDead { slot: *slot },
+            D::MarkMoved {
+                value,
+                slot,
+                is_param,
+                place,
+            } => D::MarkMoved {
+                value: *value,
+                slot: *slot,
+                is_param: *is_param,
+                place: *place,
+            },
+        })
+    }
+
+    /// Visit every dependency carried directly by this instruction. Nested
+    /// specialization types/values are exposed as their canonical roots; their
+    /// own exhaustive visitors retain responsibility for recursive identities.
+    pub fn visit_dependencies(
+        &self,
+        visitor: &mut impl FnMut(SemanticBodyInstDependency<'_, K, M>),
+    ) {
+        use SemanticBodyInstData as D;
+        fn inst<K, M>(
+            visitor: &mut impl FnMut(SemanticBodyInstDependency<'_, K, M>),
+            value: SemanticBodyRef,
+        ) {
+            visitor(SemanticBodyInstDependency::Instruction(value));
+        }
+        fn args<K, M>(
+            visitor: &mut impl FnMut(SemanticBodyInstDependency<'_, K, M>),
+            values: &[SemanticBodyCallArg],
+        ) {
+            for value in values {
+                inst(visitor, value.value);
+            }
+        }
+        match self {
+            D::Const(_)
+            | D::BoolConst(_)
+            | D::UnitConst
+            | D::Break
+            | D::Continue
+            | D::Load { .. }
+            | D::CallGeneric
+            | D::Param { .. }
+            | D::StorageLive { .. }
+            | D::StorageDead { .. } => {}
+            D::StringConst(value) => visitor(SemanticBodyInstDependency::String(*value)),
+            D::TypeConst(value) => visitor(SemanticBodyInstDependency::Type(value)),
+            D::Add(a, b)
+            | D::Sub(a, b)
+            | D::Mul(a, b)
+            | D::WrappingAdd(a, b)
+            | D::WrappingSub(a, b)
+            | D::WrappingMul(a, b)
+            | D::Div(a, b)
+            | D::Mod(a, b)
+            | D::Eq(a, b)
+            | D::Ne(a, b)
+            | D::Lt(a, b)
+            | D::Gt(a, b)
+            | D::Le(a, b)
+            | D::Ge(a, b)
+            | D::And(a, b)
+            | D::Or(a, b)
+            | D::BitAnd(a, b)
+            | D::BitOr(a, b)
+            | D::BitXor(a, b)
+            | D::Shl(a, b)
+            | D::Shr(a, b) => {
+                inst(visitor, *a);
+                inst(visitor, *b);
+            }
+            D::Neg(value) | D::Not(value) | D::BitNot(value) | D::Drop { value } => {
+                inst(visitor, *value)
+            }
+            D::Branch {
+                cond,
+                then_value,
+                else_value,
+            } => {
+                inst(visitor, *cond);
+                inst(visitor, *then_value);
+                if let Some(value) = else_value {
+                    inst(visitor, *value);
+                }
+            }
+            D::Loop { cond, body } => {
+                inst(visitor, *cond);
+                inst(visitor, *body);
+            }
+            D::InfiniteLoop { body } => inst(visitor, *body),
+            D::Match { scrutinee, arms } => {
+                inst(visitor, *scrutinee);
+                for arm in arms.iter() {
+                    if let SemanticBodyPattern::EnumVariant { enum_key, .. } = &arm.pattern {
+                        visitor(SemanticBodyInstDependency::Definition(enum_key));
+                    }
+                    inst(visitor, arm.body);
+                }
+            }
+            D::Alloc { init, .. } => inst(visitor, *init),
+            D::Store { value, .. } | D::ParamStore { value, .. } => inst(visitor, *value),
+            D::Ret(value) => {
+                if let Some(value) = value {
+                    inst(visitor, *value);
+                }
+            }
+            D::Call {
+                function,
+                args: values,
+            } => {
+                visitor(SemanticBodyInstDependency::Definition(function));
+                args(visitor, values);
+            }
+            D::RuntimeCall { args: values, .. } | D::Intrinsic { args: values, .. } => {
+                args(visitor, values)
+            }
+            D::CallSpecialized {
+                identity,
+                args: values,
+            } => {
+                visitor(SemanticBodyInstDependency::Definition(&identity.base));
+                for value in identity.type_arguments.iter() {
+                    visitor(SemanticBodyInstDependency::Type(value));
+                }
+                for value in identity.value_arguments.iter() {
+                    match value {
+                        SemanticImportConstValue::Type(value) => {
+                            visitor(SemanticBodyInstDependency::Type(value))
+                        }
+                        SemanticImportConstValue::Function(value) => {
+                            visitor(SemanticBodyInstDependency::Definition(value))
+                        }
+                        _ => {}
+                    }
+                }
+                args(visitor, values);
+            }
+            D::Block { statements, value } => {
+                for statement in statements.iter() {
+                    inst(visitor, *statement);
+                }
+                inst(visitor, *value);
+            }
+            D::StructInit {
+                struct_key, fields, ..
+            } => {
+                visitor(SemanticBodyInstDependency::Definition(struct_key));
+                for field in fields.iter() {
+                    inst(visitor, *field);
+                }
+            }
+            D::ArrayInit { elements } => {
+                for element in elements.iter() {
+                    inst(visitor, *element);
+                }
+            }
+            D::PlaceRead { place } => visitor(SemanticBodyInstDependency::Place(*place)),
+            D::PlaceWrite { place, value } => {
+                visitor(SemanticBodyInstDependency::Place(*place));
+                inst(visitor, *value);
+            }
+            D::EnumVariant {
+                enum_key, payload, ..
+            } => {
+                visitor(SemanticBodyInstDependency::Definition(enum_key));
+                for value in payload.iter() {
+                    inst(visitor, *value);
+                }
+            }
+            D::EnumPayloadGet { base, enum_key, .. } => {
+                inst(visitor, *base);
+                visitor(SemanticBodyInstDependency::Definition(enum_key));
+            }
+            D::IntCast { value, from_ty } => {
+                inst(visitor, *value);
+                visitor(SemanticBodyInstDependency::Type(from_ty));
+            }
+            D::MarkMoved { value, place, .. } => {
+                inst(visitor, *value);
+                if let Some(place) = place {
+                    visitor(SemanticBodyInstDependency::Place(*place));
+                }
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SemanticBodyWarning {
     pub code: Arc<str>,
@@ -404,24 +919,6 @@ impl<K, M> SemanticBody<K, M> {
         key: &impl Fn(&K) -> Result<K2, E>,
         module: &impl Fn(&M) -> Result<M2, E>,
     ) -> Result<SemanticBody<K2, M2>, E> {
-        fn pattern<K, K2, E>(
-            value: &SemanticBodyPattern<K>,
-            key: &impl Fn(&K) -> Result<K2, E>,
-        ) -> Result<SemanticBodyPattern<K2>, E> {
-            Ok(match value {
-                SemanticBodyPattern::Wildcard => SemanticBodyPattern::Wildcard,
-                SemanticBodyPattern::Int(value) => SemanticBodyPattern::Int(*value),
-                SemanticBodyPattern::Bool(value) => SemanticBodyPattern::Bool(*value),
-                SemanticBodyPattern::EnumVariant {
-                    enum_key,
-                    variant_index,
-                } => SemanticBodyPattern::EnumVariant {
-                    enum_key: key(enum_key)?,
-                    variant_index: *variant_index,
-                },
-            })
-        }
-
         let places = self
             .places
             .iter()
@@ -455,167 +952,11 @@ impl<K, M> SemanticBody<K, M> {
             })
             .collect::<Result<Vec<_>, E>>()?;
 
-        use SemanticBodyInstData as D;
         let instructions = self
             .instructions
             .iter()
             .map(|inst| {
-                let data = match &inst.data {
-                    D::Const(v) => D::Const(*v),
-                    D::BoolConst(v) => D::BoolConst(*v),
-                    D::StringConst(v) => D::StringConst(*v),
-                    D::UnitConst => D::UnitConst,
-                    D::TypeConst(v) => D::TypeConst(v.try_map_identities(key, module)?),
-                    D::Add(a, b) => D::Add(*a, *b),
-                    D::Sub(a, b) => D::Sub(*a, *b),
-                    D::Mul(a, b) => D::Mul(*a, *b),
-                    D::WrappingAdd(a, b) => D::WrappingAdd(*a, *b),
-                    D::WrappingSub(a, b) => D::WrappingSub(*a, *b),
-                    D::WrappingMul(a, b) => D::WrappingMul(*a, *b),
-                    D::Div(a, b) => D::Div(*a, *b),
-                    D::Mod(a, b) => D::Mod(*a, *b),
-                    D::Eq(a, b) => D::Eq(*a, *b),
-                    D::Ne(a, b) => D::Ne(*a, *b),
-                    D::Lt(a, b) => D::Lt(*a, *b),
-                    D::Gt(a, b) => D::Gt(*a, *b),
-                    D::Le(a, b) => D::Le(*a, *b),
-                    D::Ge(a, b) => D::Ge(*a, *b),
-                    D::And(a, b) => D::And(*a, *b),
-                    D::Or(a, b) => D::Or(*a, *b),
-                    D::BitAnd(a, b) => D::BitAnd(*a, *b),
-                    D::BitOr(a, b) => D::BitOr(*a, *b),
-                    D::BitXor(a, b) => D::BitXor(*a, *b),
-                    D::Shl(a, b) => D::Shl(*a, *b),
-                    D::Shr(a, b) => D::Shr(*a, *b),
-                    D::Neg(v) => D::Neg(*v),
-                    D::Not(v) => D::Not(*v),
-                    D::BitNot(v) => D::BitNot(*v),
-                    D::Branch {
-                        cond,
-                        then_value,
-                        else_value,
-                    } => D::Branch {
-                        cond: *cond,
-                        then_value: *then_value,
-                        else_value: *else_value,
-                    },
-                    D::Loop { cond, body } => D::Loop {
-                        cond: *cond,
-                        body: *body,
-                    },
-                    D::InfiniteLoop { body } => D::InfiniteLoop { body: *body },
-                    D::Match { scrutinee, arms } => D::Match {
-                        scrutinee: *scrutinee,
-                        arms: arms
-                            .iter()
-                            .map(|arm| {
-                                Ok(SemanticBodyMatchArm {
-                                    pattern: pattern(&arm.pattern, key)?,
-                                    body: arm.body,
-                                })
-                            })
-                            .collect::<Result<Vec<_>, E>>()?
-                            .into(),
-                    },
-                    D::Break => D::Break,
-                    D::Continue => D::Continue,
-                    D::Alloc { slot, init } => D::Alloc {
-                        slot: *slot,
-                        init: *init,
-                    },
-                    D::Load { slot } => D::Load { slot: *slot },
-                    D::Store { slot, value } => D::Store {
-                        slot: *slot,
-                        value: *value,
-                    },
-                    D::ParamStore { param_slot, value } => D::ParamStore {
-                        param_slot: *param_slot,
-                        value: *value,
-                    },
-                    D::Ret(v) => D::Ret(*v),
-                    D::Call { function, args } => D::Call {
-                        function: key(function)?,
-                        args: args.clone(),
-                    },
-                    D::RuntimeCall { runtime, args } => D::RuntimeCall {
-                        runtime: *runtime,
-                        args: args.clone(),
-                    },
-                    D::CallSpecialized { identity, args } => D::CallSpecialized {
-                        identity: identity.try_map_keys(key, module)?,
-                        args: args.clone(),
-                    },
-                    D::CallGeneric => D::CallGeneric,
-                    D::Intrinsic {
-                        runtime,
-                        name,
-                        args,
-                    } => D::Intrinsic {
-                        runtime: *runtime,
-                        name: name.clone(),
-                        args: args.clone(),
-                    },
-                    D::Param { index } => D::Param { index: *index },
-                    D::Block { statements, value } => D::Block {
-                        statements: statements.clone(),
-                        value: *value,
-                    },
-                    D::StructInit {
-                        struct_key,
-                        fields,
-                        source_order,
-                    } => D::StructInit {
-                        struct_key: key(struct_key)?,
-                        fields: fields.clone(),
-                        source_order: source_order.clone(),
-                    },
-                    D::ArrayInit { elements } => D::ArrayInit {
-                        elements: elements.clone(),
-                    },
-                    D::PlaceRead { place } => D::PlaceRead { place: *place },
-                    D::PlaceWrite { place, value } => D::PlaceWrite {
-                        place: *place,
-                        value: *value,
-                    },
-                    D::EnumVariant {
-                        enum_key,
-                        variant_index,
-                        payload,
-                    } => D::EnumVariant {
-                        enum_key: key(enum_key)?,
-                        variant_index: *variant_index,
-                        payload: payload.clone(),
-                    },
-                    D::EnumPayloadGet {
-                        base,
-                        enum_key,
-                        variant_index,
-                        field_index,
-                    } => D::EnumPayloadGet {
-                        base: *base,
-                        enum_key: key(enum_key)?,
-                        variant_index: *variant_index,
-                        field_index: *field_index,
-                    },
-                    D::IntCast { value, from_ty } => D::IntCast {
-                        value: *value,
-                        from_ty: from_ty.try_map_identities(key, module)?,
-                    },
-                    D::Drop { value } => D::Drop { value: *value },
-                    D::StorageLive { slot } => D::StorageLive { slot: *slot },
-                    D::StorageDead { slot } => D::StorageDead { slot: *slot },
-                    D::MarkMoved {
-                        value,
-                        slot,
-                        is_param,
-                        place,
-                    } => D::MarkMoved {
-                        value: *value,
-                        slot: *slot,
-                        is_param: *is_param,
-                        place: *place,
-                    },
-                };
+                let data = inst.data.try_map_keys(key, module)?;
                 Ok(SemanticBodyInst {
                     data,
                     ty: inst.ty.try_map_identities(key, module)?,
@@ -719,5 +1060,386 @@ impl From<super::SemanticImportFailure> for SemanticBodyImportFailure {
 impl From<crate::AirBuildError> for SemanticBodyImportFailure {
     fn from(value: crate::AirBuildError) -> Self {
         Self::AirBuild(value)
+    }
+}
+
+#[cfg(test)]
+mod schema_tests {
+    use super::*;
+
+    type Sample = SemanticBodyInstData<&'static str, &'static str>;
+
+    fn call_args(values: &[u32]) -> Arc<[SemanticBodyCallArg]> {
+        values
+            .iter()
+            .map(|value| SemanticBodyCallArg {
+                value: *value,
+                mode: AirArgMode::Normal,
+            })
+            .collect::<Vec<_>>()
+            .into()
+    }
+
+    fn instruction_samples() -> Vec<Sample> {
+        use SemanticBodyInstData as D;
+        vec![
+            D::Const(1),
+            D::BoolConst(true),
+            D::StringConst(2),
+            D::UnitConst,
+            D::TypeConst(SemanticImportType::Module("module")),
+            D::Add(1, 2),
+            D::Sub(1, 2),
+            D::Mul(1, 2),
+            D::WrappingAdd(1, 2),
+            D::WrappingSub(1, 2),
+            D::WrappingMul(1, 2),
+            D::Div(1, 2),
+            D::Mod(1, 2),
+            D::Eq(1, 2),
+            D::Ne(1, 2),
+            D::Lt(1, 2),
+            D::Gt(1, 2),
+            D::Le(1, 2),
+            D::Ge(1, 2),
+            D::And(1, 2),
+            D::Or(1, 2),
+            D::BitAnd(1, 2),
+            D::BitOr(1, 2),
+            D::BitXor(1, 2),
+            D::Shl(1, 2),
+            D::Shr(1, 2),
+            D::Neg(1),
+            D::Not(1),
+            D::BitNot(1),
+            D::Branch {
+                cond: 1,
+                then_value: 2,
+                else_value: Some(3),
+            },
+            D::Loop { cond: 1, body: 2 },
+            D::InfiniteLoop { body: 1 },
+            D::Match {
+                scrutinee: 1,
+                arms: vec![SemanticBodyMatchArm {
+                    pattern: SemanticBodyPattern::EnumVariant {
+                        enum_key: "match_enum",
+                        variant_index: 0,
+                    },
+                    body: 2,
+                }]
+                .into(),
+            },
+            D::Break,
+            D::Continue,
+            D::Alloc { slot: 0, init: 1 },
+            D::Load { slot: 0 },
+            D::Store { slot: 0, value: 1 },
+            D::ParamStore {
+                param_slot: 0,
+                value: 1,
+            },
+            D::Ret(Some(1)),
+            D::Call {
+                function: "function",
+                args: call_args(&[1, 2]),
+            },
+            D::RuntimeCall {
+                runtime: crate::RuntimeCallKind::DebugI64,
+                args: call_args(&[1]),
+            },
+            D::CallSpecialized {
+                identity: SemanticSpecializationIdentity {
+                    base: "generic",
+                    type_arguments: vec![SemanticImportType::Nominal("type_argument")].into(),
+                    value_arguments: vec![SemanticImportConstValue::Function("value_argument")]
+                        .into(),
+                },
+                args: call_args(&[1]),
+            },
+            D::CallGeneric,
+            D::Intrinsic {
+                runtime: None,
+                name: Arc::from("intrinsic"),
+                args: call_args(&[1]),
+            },
+            D::Param { index: 0 },
+            D::Block {
+                statements: vec![1, 2].into(),
+                value: 3,
+            },
+            D::StructInit {
+                struct_key: "struct",
+                fields: vec![1, 2].into(),
+                source_order: vec![1, 0].into(),
+            },
+            D::ArrayInit {
+                elements: vec![1, 2].into(),
+            },
+            D::PlaceRead { place: 4 },
+            D::PlaceWrite { place: 4, value: 1 },
+            D::EnumVariant {
+                enum_key: "enum",
+                variant_index: 1,
+                payload: vec![1, 2].into(),
+            },
+            D::EnumPayloadGet {
+                base: 1,
+                enum_key: "enum",
+                variant_index: 1,
+                field_index: 0,
+            },
+            D::IntCast {
+                value: 1,
+                from_ty: SemanticImportType::Nominal("cast_type"),
+            },
+            D::Drop { value: 1 },
+            D::StorageLive { slot: 0 },
+            D::StorageDead { slot: 0 },
+            D::MarkMoved {
+                value: 1,
+                slot: 0,
+                is_param: false,
+                place: Some(4),
+            },
+        ]
+    }
+
+    #[test]
+    fn semantic_body_instruction_schema_has_stable_unique_metadata() {
+        assert_eq!(SEMANTIC_BODY_INST_KINDS.len(), 58);
+        for (tag, kind) in SEMANTIC_BODY_INST_KINDS.iter().copied().enumerate() {
+            assert_eq!(usize::from(kind.schema_tag()), tag);
+            assert!(!kind.display_name().is_empty());
+            assert_eq!(kind.to_string(), kind.display_name());
+            assert!(
+                SEMANTIC_BODY_INST_KINDS[..tag]
+                    .iter()
+                    .all(|earlier| earlier.display_name() != kind.display_name())
+            );
+        }
+    }
+
+    #[test]
+    fn every_instruction_kind_projects_and_exposes_dependencies() {
+        let samples = instruction_samples();
+        assert_eq!(samples.len(), SEMANTIC_BODY_INST_KINDS.len());
+        for (sample, expected_kind) in samples.iter().zip(SEMANTIC_BODY_INST_KINDS) {
+            assert_eq!(sample.kind(), *expected_kind);
+            let projected = sample
+                .try_map_keys(&|key| Ok::<_, ()>(format!("mapped:{key}")), &|module| {
+                    Ok::<_, ()>(format!("mapped:{module}"))
+                })
+                .unwrap();
+            assert_eq!(projected.kind(), *expected_kind);
+            let mut dependency_count = 0;
+            sample.visit_dependencies(&mut |_| dependency_count += 1);
+            assert!(
+                dependency_count <= 8,
+                "unbounded sample for {expected_kind}"
+            );
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum SeenDependency<'a> {
+        Instruction(u32),
+        Place(u32),
+        Definition(&'a str),
+        Type(crate::SemanticImportTypeKind),
+        String(u32),
+    }
+
+    fn dependencies(sample: &Sample) -> Vec<SeenDependency<'_>> {
+        let mut seen = Vec::new();
+        sample.visit_dependencies(&mut |dependency| {
+            seen.push(match dependency {
+                SemanticBodyInstDependency::Instruction(value) => {
+                    SeenDependency::Instruction(value)
+                }
+                SemanticBodyInstDependency::Place(value) => SeenDependency::Place(value),
+                SemanticBodyInstDependency::Definition(value) => SeenDependency::Definition(value),
+                SemanticBodyInstDependency::Type(value) => SeenDependency::Type(value.kind()),
+                SemanticBodyInstDependency::String(value) => SeenDependency::String(value),
+            });
+        });
+        seen
+    }
+
+    #[test]
+    fn representative_dependency_shapes_are_exact() {
+        let samples = instruction_samples();
+        assert_eq!(dependencies(&samples[2]), [SeenDependency::String(2)]);
+        assert_eq!(
+            dependencies(&samples[5]),
+            [
+                SeenDependency::Instruction(1),
+                SeenDependency::Instruction(2)
+            ]
+        );
+        assert_eq!(
+            dependencies(&samples[29]),
+            [
+                SeenDependency::Instruction(1),
+                SeenDependency::Instruction(2),
+                SeenDependency::Instruction(3)
+            ]
+        );
+        assert_eq!(
+            dependencies(&samples[32]),
+            [
+                SeenDependency::Instruction(1),
+                SeenDependency::Definition("match_enum"),
+                SeenDependency::Instruction(2)
+            ]
+        );
+        assert_eq!(
+            dependencies(&samples[46]),
+            [
+                SeenDependency::Instruction(1),
+                SeenDependency::Instruction(2),
+                SeenDependency::Instruction(3)
+            ]
+        );
+        assert_eq!(
+            dependencies(&samples[47]),
+            [
+                SeenDependency::Definition("struct"),
+                SeenDependency::Instruction(1),
+                SeenDependency::Instruction(2)
+            ]
+        );
+        assert_eq!(dependencies(&samples[49]), [SeenDependency::Place(4)]);
+        assert_eq!(
+            dependencies(&samples[50]),
+            [SeenDependency::Place(4), SeenDependency::Instruction(1)]
+        );
+        assert_eq!(
+            dependencies(&samples[51]),
+            [
+                SeenDependency::Definition("enum"),
+                SeenDependency::Instruction(1),
+                SeenDependency::Instruction(2)
+            ]
+        );
+        assert_eq!(
+            dependencies(&samples[52]),
+            [
+                SeenDependency::Instruction(1),
+                SeenDependency::Definition("enum")
+            ]
+        );
+        assert_eq!(
+            dependencies(&samples[57]),
+            [SeenDependency::Instruction(1), SeenDependency::Place(4)]
+        );
+    }
+
+    #[test]
+    fn representative_projection_shapes_map_every_identity_domain() {
+        let samples = instruction_samples();
+        let map = |sample: &Sample| {
+            sample
+                .try_map_keys(&|key| Ok::<_, ()>(format!("mapped:{key}")), &|module| {
+                    Ok::<_, ()>(format!("mapped:{module}"))
+                })
+                .unwrap()
+        };
+        assert!(matches!(
+            map(&samples[4]),
+            SemanticBodyInstData::TypeConst(SemanticImportType::Module(module))
+                if module == "mapped:module"
+        ));
+        assert!(matches!(
+            map(&samples[32]),
+            SemanticBodyInstData::Match { arms, .. }
+                if matches!(&arms[0].pattern, SemanticBodyPattern::EnumVariant { enum_key, .. } if enum_key == "mapped:match_enum")
+        ));
+        assert!(matches!(
+            map(&samples[47]),
+            SemanticBodyInstData::StructInit { struct_key, .. } if struct_key == "mapped:struct"
+        ));
+        assert!(matches!(
+            map(&samples[51]),
+            SemanticBodyInstData::EnumVariant { enum_key, .. } if enum_key == "mapped:enum"
+        ));
+        assert!(matches!(
+            map(&samples[53]),
+            SemanticBodyInstData::IntCast {
+                from_ty: SemanticImportType::Nominal(key),
+                ..
+            } if key == "mapped:cast_type"
+        ));
+    }
+
+    #[test]
+    fn instruction_projection_and_dependency_hooks_preserve_borrowed_arrays() {
+        let args: Arc<[SemanticBodyCallArg]> = vec![SemanticBodyCallArg {
+            value: 7,
+            mode: AirArgMode::Borrow,
+        }]
+        .into();
+        let type_arguments: Arc<[SemanticImportType<&str, &str>]> =
+            vec![SemanticImportType::Nominal("T")].into();
+        let value_arguments: Arc<[SemanticImportConstValue<&str, &str>]> = vec![
+            SemanticImportConstValue::Function("helper"),
+            SemanticImportConstValue::Type(SemanticImportType::Module("module")),
+        ]
+        .into();
+        let data = SemanticBodyInstData::CallSpecialized {
+            identity: SemanticSpecializationIdentity {
+                base: "function",
+                type_arguments: type_arguments.clone(),
+                value_arguments: value_arguments.clone(),
+            },
+            args: args.clone(),
+        };
+
+        assert_eq!(data.kind(), SemanticBodyInstKind::CallSpecialized);
+        let mut definitions = Vec::new();
+        let mut instruction_refs = Vec::new();
+        let mut saw_type_argument_by_reference = false;
+        data.visit_dependencies(&mut |dependency| match dependency {
+            SemanticBodyInstDependency::Instruction(value) => instruction_refs.push(value),
+            SemanticBodyInstDependency::Definition(value) => definitions.push(*value),
+            SemanticBodyInstDependency::Type(value) => {
+                saw_type_argument_by_reference |= std::ptr::eq(value, &type_arguments[0]);
+            }
+            SemanticBodyInstDependency::Place(_) | SemanticBodyInstDependency::String(_) => {}
+        });
+        assert_eq!(definitions, ["function", "helper"]);
+        assert_eq!(instruction_refs, [7]);
+        assert!(saw_type_argument_by_reference);
+
+        let mapped = data
+            .try_map_keys(&|key| Ok::<_, ()>(format!("mapped:{key}")), &|module| {
+                Ok::<_, ()>(format!("mapped:{module}"))
+            })
+            .unwrap();
+        let SemanticBodyInstData::CallSpecialized {
+            identity,
+            args: mapped_args,
+        } = mapped
+        else {
+            panic!("projection changed instruction kind")
+        };
+        assert_eq!(identity.base, "mapped:function");
+        assert_eq!(
+            identity.type_arguments[0],
+            SemanticImportType::Nominal("mapped:T".to_owned())
+        );
+        assert!(Arc::ptr_eq(&args, &mapped_args));
+    }
+
+    #[test]
+    fn typed_failure_context_reports_instruction_and_schema_identity() {
+        let data = SemanticBodyInstData::<(), ()>::Add(0, 1);
+        let context = SemanticBodyInstFailureContext::new(12, &data, "invalid reference");
+        assert_eq!(context.instruction, 12);
+        assert_eq!(context.kind, SemanticBodyInstKind::Add);
+        assert_eq!(
+            context.to_string(),
+            "instruction 12 (add, schema tag 5): invalid reference"
+        );
     }
 }

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -65,6 +65,74 @@ pub enum SemanticImportType<K, M> {
     GenericParameter(u32),
 }
 
+macro_rules! semantic_import_type_schema {
+    ($consumer:ident) => {
+        $consumer! {
+            I8, SemanticImportType::I8, 0, "i8";
+            I16, SemanticImportType::I16, 1, "i16";
+            I32, SemanticImportType::I32, 2, "i32";
+            I64, SemanticImportType::I64, 3, "i64";
+            U8, SemanticImportType::U8, 4, "u8";
+            U16, SemanticImportType::U16, 5, "u16";
+            U32, SemanticImportType::U32, 6, "u32";
+            U64, SemanticImportType::U64, 7, "u64";
+            Bool, SemanticImportType::Bool, 8, "bool";
+            Unit, SemanticImportType::Unit, 9, "unit";
+            Never, SemanticImportType::Never, 10, "never";
+            ComptimeType, SemanticImportType::ComptimeType, 11, "comptime_type";
+            BuiltinNominal, SemanticImportType::BuiltinNominal { .. }, 12, "builtin_nominal";
+            Nominal, SemanticImportType::Nominal(..), 13, "nominal";
+            Array, SemanticImportType::Array { .. }, 14, "array";
+            PtrConst, SemanticImportType::PtrConst(..), 15, "ptr_const";
+            PtrMut, SemanticImportType::PtrMut(..), 16, "ptr_mut";
+            Module, SemanticImportType::Module(..), 17, "module";
+            GenericParameter, SemanticImportType::GenericParameter(..), 18, "generic_parameter";
+        }
+    };
+}
+
+macro_rules! define_semantic_import_type_schema {
+    ($( $kind:ident, $pattern:pat, $tag:literal, $name:literal; )*) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[repr(u8)]
+        pub enum SemanticImportTypeKind {
+            $( $kind = $tag, )*
+        }
+
+        pub const SEMANTIC_IMPORT_TYPE_KINDS: &[SemanticImportTypeKind] = &[
+            $( SemanticImportTypeKind::$kind, )*
+        ];
+
+        impl SemanticImportTypeKind {
+            pub const fn schema_tag(self) -> u8 {
+                self as u8
+            }
+
+            pub const fn display_name(self) -> &'static str {
+                match self {
+                    $( Self::$kind => $name, )*
+                }
+            }
+        }
+
+        impl std::fmt::Display for SemanticImportTypeKind {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str(self.display_name())
+            }
+        }
+
+        impl<K, M> SemanticImportType<K, M> {
+            pub const fn kind(&self) -> SemanticImportTypeKind {
+                match self {
+                    $( $pattern => SemanticImportTypeKind::$kind, )*
+                }
+            }
+        }
+    };
+}
+
+semantic_import_type_schema!(define_semantic_import_type_schema);
+
 /// One post-order step in the canonical type algebra. Recursive children have
 /// already been folded to `T`, so projection, validation, and import share one
 /// exhaustive schema traversal.
@@ -104,6 +172,60 @@ pub enum SemanticImportConstValue<K, M> {
     Function(K),
     Unit,
 }
+
+macro_rules! semantic_import_const_schema {
+    ($consumer:ident) => {
+        $consumer! {
+            Integer, SemanticImportConstValue::Integer(..), 0, "integer";
+            Bool, SemanticImportConstValue::Bool(..), 1, "bool";
+            Type, SemanticImportConstValue::Type(..), 2, "type";
+            Function, SemanticImportConstValue::Function(..), 3, "function";
+            Unit, SemanticImportConstValue::Unit, 4, "unit";
+        }
+    };
+}
+
+macro_rules! define_semantic_import_const_schema {
+    ($( $kind:ident, $pattern:pat, $tag:literal, $name:literal; )*) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[repr(u8)]
+        pub enum SemanticImportConstKind {
+            $( $kind = $tag, )*
+        }
+
+        pub const SEMANTIC_IMPORT_CONST_KINDS: &[SemanticImportConstKind] = &[
+            $( SemanticImportConstKind::$kind, )*
+        ];
+
+        impl SemanticImportConstKind {
+            pub const fn schema_tag(self) -> u8 {
+                self as u8
+            }
+
+            pub const fn display_name(self) -> &'static str {
+                match self {
+                    $( Self::$kind => $name, )*
+                }
+            }
+        }
+
+        impl std::fmt::Display for SemanticImportConstKind {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str(self.display_name())
+            }
+        }
+
+        impl<K, M> SemanticImportConstValue<K, M> {
+            pub const fn kind(&self) -> SemanticImportConstKind {
+                match self {
+                    $( $pattern => SemanticImportConstKind::$kind, )*
+                }
+            }
+        }
+    };
+}
+
+semantic_import_const_schema!(define_semantic_import_const_schema);
 
 impl<K, M> SemanticImportType<K, M> {
     /// Fold this value in post-order through the canonical schema visitor.
@@ -1289,6 +1411,31 @@ mod tests {
             kind,
             is_public: true,
             lang_item: None,
+        }
+    }
+
+    #[test]
+    fn canonical_schema_kinds_have_stable_unique_tags_and_names() {
+        assert_eq!(SEMANTIC_IMPORT_TYPE_KINDS.len(), 19);
+        for (tag, kind) in SEMANTIC_IMPORT_TYPE_KINDS.iter().copied().enumerate() {
+            assert_eq!(usize::from(kind.schema_tag()), tag);
+            assert_eq!(kind.to_string(), kind.display_name());
+            assert!(
+                SEMANTIC_IMPORT_TYPE_KINDS[..tag]
+                    .iter()
+                    .all(|earlier| earlier.display_name() != kind.display_name())
+            );
+        }
+
+        assert_eq!(SEMANTIC_IMPORT_CONST_KINDS.len(), 5);
+        for (tag, kind) in SEMANTIC_IMPORT_CONST_KINDS.iter().copied().enumerate() {
+            assert_eq!(usize::from(kind.schema_tag()), tag);
+            assert_eq!(kind.to_string(), kind.display_name());
+            assert!(
+                SEMANTIC_IMPORT_CONST_KINDS[..tag]
+                    .iter()
+                    .all(|earlier| earlier.display_name() != kind.display_name())
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- derive stable instruction, type, and const schema metadata from canonical macro tables
- centralize production instruction projection and borrowed dependency traversal with typed failure context
- add exhaustive inventory guards and bounded per-variant tests so new variants fail compilation until all hooks are supplied

## Validation

- scripts/rue fmt --check
- scripts/rue unit air schema (8/8)
- compiler durable tests (38/38)
- scripts/rue quick (31 targets)
- type architecture inventory and tests

Linear: RUE-852