### PR TITLE
RUE-949: lex @import uniformly as AT + IDENT per spec 2.5

### DIFF
--- a/crates/rue-cli-tests/cases/examples_ruelex.toml
+++ b/crates/rue-cli-tests/cases/examples_ruelex.toml
@@ -7,11 +7,10 @@
 # The whole point of ruelex is byte-for-byte agreement with the compiler's own
 # `rue --emit tokens`, so the pinned `stdout` below is exactly what that command
 # emits (token-lines section) for the same `sample.rue` — verified at authoring
-# time. The fixture is chosen to exercise the two implementation behaviors the
-# lexer deliberately mirrors (RUE-949): `@import` lexes as a single `AT_IMPORT`
-# token, and interning `import` as a side effect bumps the shared symbol counter
-# — which is why the emitted identifiers jump `sym:0` (`std`) straight to `sym:2`
-# (`add`): `sym:1` was spent on the never-emitted `import`.
+# time. The fixture pins the uniform builtin form (RUE-949): `@import` lexes as
+# `AT` + `IDENT`, interning `import` at its natural position (`sym:1`), and the
+# shared identifier/string interner gives the string literal `"std"` the same
+# `sym:0` as the identifier `std`.
 
 [section]
 id = "cli.examples_ruelex"
@@ -20,7 +19,7 @@ description = "compile examples/ruelex and tokenize a fixture, asserting the exa
 
 [[case]]
 name = "ruelex_tokenizes_fixture_matching_emit_tokens"
-description = "ruelex on a small fixture reproduces `rue --emit tokens` exactly, including the AT_IMPORT special case and its symbol-counter side effect (sym:0 -> sym:2)."
+description = "ruelex on a small fixture reproduces `rue --emit tokens` exactly, including the uniform AT + IDENT form for @import and shared ident/string interning."
 source_path = "examples/ruelex/main.rue"
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "sample.rue", source = """
@@ -33,7 +32,8 @@ stdout = """
    0..5    CONST
    6..9    IDENT(sym:0)
   10..11   EQ
-  12..19   AT_IMPORT
+  12..13   AT
+  13..19   IDENT(sym:1)
   19..20   LPAREN
   20..25   STRING(sym:0)
   25..26   RPAREN

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -115,9 +115,6 @@ pub enum TokenKind {
     At,       // @
     Question, // ?
 
-    // Builtins
-    AtImport(Spur), // @import - contains interned "import" string
-
     // Special
     Eof,
 }
@@ -206,7 +203,6 @@ impl TokenKind {
             TokenKind::Comma => "','",
             TokenKind::Dot => "'.'",
             TokenKind::At => "'@'",
-            TokenKind::AtImport(_) => "'@import'",
             TokenKind::Eof => "end of file",
         }
     }
@@ -312,7 +308,6 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Dot => write!(f, "DOT"),
             TokenKind::At => write!(f, "AT"),
             TokenKind::Question => write!(f, "QUESTION"),
-            TokenKind::AtImport(_) => write!(f, "AT_IMPORT"),
             TokenKind::Eof => write!(f, "EOF"),
         }
     }

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -458,21 +458,6 @@ pub enum LogosTokenKind {
     At,
     #[token("?")]
     Question,
-
-    // Builtins. Exactly "@import" is its own token; the regex below wins the
-    // longest-match for "@import" followed by more identifier chars (e.g.
-    // "@important"), which tokenize() splits into At + Ident. Without it,
-    // logos would fail the fused-token match and report a confusing
-    // "unexpected character: @" lex error instead of letting the parser see
-    // an ordinary @-directive. (RUE-133)
-    #[token("@import")]
-    AtImport,
-
-    // "@import" with identifier chars attached: an ordinary @-directive whose
-    // name merely starts with "import". The callback interns the name (the
-    // slice minus '@'); tokenize() emits At + Ident.
-    #[regex(r"@import[a-zA-Z0-9_]+", |lex| lex.extras.get_or_intern(&lex.slice()[1..]))]
-    AtImportPrefixedIdent(Spur),
 }
 
 use crate::{Token, TokenKind};
@@ -560,12 +545,6 @@ impl From<LogosTokenKind> for TokenKind {
             LogosTokenKind::Dot => TokenKind::Dot,
             LogosTokenKind::At => TokenKind::At,
             LogosTokenKind::Question => TokenKind::Question,
-            // AtImport is handled specially in tokenize() to provide the interned "import" Spur
-            LogosTokenKind::AtImport => unreachable!("AtImport should be handled specially"),
-            // AtImportPrefixedIdent is split into At + Ident in tokenize()
-            LogosTokenKind::AtImportPrefixedIdent(_) => {
-                unreachable!("AtImportPrefixedIdent should be handled specially")
-            }
         }
     }
 }
@@ -647,39 +626,8 @@ impl<'a> LogosLexer<'a> {
                     let span = lexer.span();
                     match result {
                         Ok(logos_kind) => {
-                            // Convert LogosTokenKind to TokenKind, handling @import specially
-                            // because it needs to carry the interned "import" symbol
-                            let token_kind = match logos_kind {
-                                LogosTokenKind::AtImport => {
-                                    let import_spur = lexer.extras.get_or_intern("import");
-                                    TokenKind::AtImport(import_spur)
-                                }
-                                LogosTokenKind::AtImportPrefixedIdent(name) => {
-                                    // An @-directive whose name starts with "import"
-                                    // (e.g. @important): split into At + Ident so the
-                                    // parser sees an ordinary directive. (RUE-133)
-                                    tokens.push(Token {
-                                        kind: TokenKind::At,
-                                        span: Span::with_file(
-                                            self.file_id,
-                                            span.start as u32,
-                                            span.start as u32 + 1,
-                                        ),
-                                    });
-                                    tokens.push(Token {
-                                        kind: TokenKind::Ident(name),
-                                        span: Span::with_file(
-                                            self.file_id,
-                                            span.start as u32 + 1,
-                                            span.end as u32,
-                                        ),
-                                    });
-                                    continue;
-                                }
-                                _ => logos_kind.into(),
-                            };
                             tokens.push(Token {
-                                kind: token_kind,
+                                kind: logos_kind.into(),
                                 span: Span::with_file(
                                     self.file_id,
                                     span.start as u32,
@@ -873,33 +821,15 @@ mod tests {
 
     #[test]
     fn test_logos_at_import_token() {
-        // @import should be recognized as a single token with interned "import" Spur
+        // @import lexes uniformly as At + Ident per spec 2.5:1-2 — no fused
+        // token, and "import" is interned at its natural position (RUE-949).
         let lexer = LogosLexer::new("@import");
         let (tokens, interner) = lexer.tokenize().unwrap();
-        if let TokenKind::AtImport(spur) = tokens[0].kind {
-            assert_eq!(interner.resolve(&spur), "import");
-        } else {
-            panic!("Expected AtImport token");
-        }
-        assert!(matches!(tokens[1].kind, TokenKind::Eof));
-    }
-
-    #[test]
-    fn test_logos_at_import_vs_at_other() {
-        // @import as single token vs @other (At + Ident)
-        let lexer = LogosLexer::new("@import @other");
-        let (tokens, interner) = lexer.tokenize().unwrap();
-        assert!(matches!(tokens[0].kind, TokenKind::AtImport(_)));
-        assert!(matches!(tokens[1].kind, TokenKind::At));
-        assert_eq!(get_ident_str(&tokens[2].kind, &interner), Some("other"));
-    }
-
-    #[test]
-    fn test_logos_at_import_span() {
-        // Verify the span covers the entire @import token
-        let lexer = LogosLexer::new("@import");
-        let (tokens, _) = lexer.tokenize().unwrap();
-        assert_eq!(tokens[0].span, Span::new(0, 7)); // "@import" is 7 chars
+        assert!(matches!(tokens[0].kind, TokenKind::At));
+        assert_eq!(tokens[0].span, Span::new(0, 1));
+        assert_eq!(get_ident_str(&tokens[1].kind, &interner), Some("import"));
+        assert_eq!(tokens[1].span, Span::new(1, 7));
+        assert!(matches!(tokens[2].kind, TokenKind::Eof));
     }
 
     #[test]
@@ -907,17 +837,17 @@ mod tests {
         // @import("path.rue") pattern
         let lexer = LogosLexer::new(r#"@import("math.rue")"#);
         let (tokens, interner) = lexer.tokenize().unwrap();
-        assert!(matches!(tokens[0].kind, TokenKind::AtImport(_)));
-        assert!(matches!(tokens[1].kind, TokenKind::LParen));
-        assert_eq!(get_string_str(&tokens[2].kind, &interner), Some("math.rue"));
-        assert!(matches!(tokens[3].kind, TokenKind::RParen));
+        assert!(matches!(tokens[0].kind, TokenKind::At));
+        assert_eq!(get_ident_str(&tokens[1].kind, &interner), Some("import"));
+        assert!(matches!(tokens[2].kind, TokenKind::LParen));
+        assert_eq!(get_string_str(&tokens[3].kind, &interner), Some("math.rue"));
+        assert!(matches!(tokens[4].kind, TokenKind::RParen));
     }
 
     #[test]
     fn test_logos_at_import_prefixed_ident_splits() {
         // A directive whose name merely starts with "import" (@importx,
-        // @important) is an ordinary @-directive: At + Ident. The word-boundary
-        // check must permit fallback to those two tokens (RUE-133).
+        // @important) is an ordinary @-directive: At + Ident (RUE-133).
         let lexer = LogosLexer::new("@importx");
         let (tokens, interner) = lexer.tokenize().unwrap();
         assert!(matches!(tokens[0].kind, TokenKind::At));

--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -1106,7 +1106,7 @@ impl Parser {
                     Ok(Expr::Ident(name))
                 }
             }
-            TokenKind::At | TokenKind::AtImport(_) => self.intrinsic(),
+            TokenKind::At => self.intrinsic(),
             TokenKind::If => self.if_expr(),
             TokenKind::While => self.while_expr(),
             TokenKind::Loop => self.loop_expr(),
@@ -1452,10 +1452,6 @@ impl Parser {
     fn intrinsic(&mut self) -> PResult<Expr> {
         let start = self.start();
         let name = match self.kind() {
-            TokenKind::AtImport(name) => {
-                let span = self.bump().span;
-                Ident { name, span }
-            }
             TokenKind::At => {
                 let at = self.bump();
                 if self.at(TokenKind::Drop) {

--- a/docs/spec/src/02-lexical-structure/01-tokens.md
+++ b/docs/spec/src/02-lexical-structure/01-tokens.md
@@ -206,3 +206,9 @@ fn main() -> i32 {
     add(xs[0], xs[1],)             // trailing comma in call arguments
 }
 ```
+
+## Symbol Interning in the Reference Token Dump
+
+{{ rule(id="2.1:25", cat="informative") }}
+
+The reference implementation's token dump (`rue --emit tokens`) prints identifier and string tokens as `IDENT(sym:N)` and `STRING(sym:N)`, where `N` indexes a single symbol table shared by identifiers and string literals and keyed by *decoded* value: the string literal `"ab"` and the identifier `ab` receive the same symbol, and an escape such as `"\t"` interns identically to a string containing a literal tab. Symbols are numbered in first-occurrence order over the token stream. Primitive type names print as `TYPE(name)` and are not interned, while `usize` and `isize` lex as ordinary identifiers. These are properties of the reference tooling's presentation, not language semantics; they are recorded here so a second implementation can reproduce the dump byte-for-byte without reverse-engineering it.

--- a/docs/spec/src/02-lexical-structure/05-builtins.md
+++ b/docs/spec/src/02-lexical-structure/05-builtins.md
@@ -22,6 +22,10 @@ builtin_arg = IDENT | expression | type ;
 
 The `@` prefix distinguishes builtins from user-defined constructs.
 
+{{ rule(id="2.5:32", cat="informative") }}
+
+Tokenization of builtins is uniform: `@` is its own token and the builtin name is an ordinary identifier token. No builtin name — including `import` — forms a fused single token, and the name is interned like any other identifier.
+
 {{ rule(id="2.5:4", cat="legality-rule") }}
 
 Using an unknown builtin name is a compile-time error.

--- a/examples/ruelex/lex.rue
+++ b/examples/ruelex/lex.rue
@@ -331,33 +331,6 @@ pub struct Lexer {
         let c = self.peek(0);
         let c1 = self.peek(1);
 
-        // `@import` is a single dedicated token in the compiler's lexer, and
-        // the word `import` is NOT interned as an identifier (empirically
-        // verified against `--emit tokens`; this is the ONLY special-cased
-        // `@name` — `@size_of`, `@syscall`, ... all lex as AT + IDENT). The
-        // language spec (2.5) says builtins are uniformly `@ IDENT`, so this
-        // is a spec-vs-compiler divergence the tool must mirror to match.
-        if c == 64 {
-            let mut e = self.pos + 1;
-            while e < self.n && is_ident_cont(@intCast(self.at(e))) {
-                e = e + 1;
-            }
-            let after = self.slice_key(self.pos + 1, e);
-            if word_eq(borrow after, "import") {
-                // The compiler still interns "import" (it bumps the symbol
-                // counter) even though it emits ONE `AT_IMPORT` token and no
-                // separate IDENT — so intern it here to keep symbol numbers in
-                // lockstep, discarding the returned index.
-                let _ = self.interner.intern(borrow after);
-                while self.pos < e {
-                    self.advance();
-                }
-                return "AT_IMPORT";
-            }
-            self.advance();
-            return "AT";
-        }
-
         if c == 45 && c1 == 62 { self.advance(); self.advance(); return "ARROW"; }
         if c == 61 && c1 == 62 { self.advance(); self.advance(); return "FATARROW"; }
         if c == 61 && c1 == 61 { self.advance(); self.advance(); return "EQEQ"; }
@@ -394,7 +367,7 @@ pub struct Lexer {
         if c == 58 { return "COLON"; }
         if c == 46 { return "DOT"; }
         if c == 63 { return "QUESTION"; }
-        // NB: `@` (c == 64) is handled at the top of this function.
+        if c == 64 { return "AT"; }
 
         fmtutil.kn("ERROR(invalid byte ", c, ")")
     }

--- a/examples/ruelex/main.rue
+++ b/examples/ruelex/main.rue
@@ -6,19 +6,10 @@
 // on 83/83 `.rue` files across the repository — every checked-in example, std
 // module, and test fixture.
 //
-// To match the reference lexer exactly, ruelex deliberately mirrors two of its
-// *implementation* behaviors that diverge from the language spec (2.5), rather
-// than the spec's uniform `@ IDENT` rule. Both are recorded as accepted
-// spec-drift in RUE-949, and both live in lex.rue `lex_op`:
-//   1. AT_IMPORT single-token special case: `@import` lexes as ONE dedicated
-//      `AT_IMPORT` token, not the general `AT` + `IDENT("import")` pair that
-//      every other builtin (`@syscall`, `@size_of`, ...) produces.
-//   2. Its interner side effect: even though no separate `import` IDENT token
-//      is emitted, the compiler still interns the word `import` (bumping the
-//      shared symbol counter). ruelex interns it too and discards the index, so
-//      subsequent `IDENT(sym:N)` numbers stay in lockstep with the reference.
-// These are mirrored intentionally — do not "fix" them to match the spec, or
-// differential agreement breaks. See RUE-949 for the drift record.
+// Builtins lex uniformly as `AT` + `IDENT` per spec 2.5 — including `@import`,
+// which the reference lexer once fused into a dedicated AT_IMPORT token with a
+// phantom intern of the word `import`. RUE-949 resolved that drift by making
+// the compiler conform to the spec, so ruelex needs no special cases.
 //
 // The modules: lex.rue (tokenizer), interner.rue (symbol numbering),
 // fmtutil.rue (StrBuf/padding helpers), this root (I/O, argv, driver).


### PR DESCRIPTION
Resolves the spec drift found by the RUE-941 spec-derived lexer: the reference lexer special-cased exactly one builtin, fusing `@import` into a dedicated `AT_IMPORT` token that also interned `import` without emitting an IDENT — shifting a spec-conforming implementation's symbol numbering from the first `@import` onward. Per the maintainer call on the issue, the lexer now conforms to the spec's uniform `"@" IDENT` form (2.5:1–2) rather than the spec documenting the accident.

## What changed

- **Lexer**: `TokenKind::AtImport` is gone, along with the `AtImportPrefixedIdent` companion workaround that RUE-133 added to keep `@important`-style names lexing. `@import` now produces `AT` + `IDENT`, interning `import` at its natural position, identical to `@size_of`, `@syscall`, etc. Net deletion — both special cases and the fused-token handling in `tokenize()`.
- **Parser**: the two `AtImport` dispatch sites collapse into the ordinary `At` intrinsic path.
- **Import discovery**: no change needed — discovery walks the parsed AST and compares the resolved intrinsic name (`parsed_modules.rs`), so the distinguishable pre-parse token the fusion existed for has no remaining consumer.
- **ruelex** (`examples/ruelex/`): drops its deliberately mirrored drift — the fused token branch and the phantom intern. The differential CLI fixture now pins the uniform form; symbol numbering downstream of `@import` is unchanged because `import` still occupies the same slot, now attached to a real token.
- **Spec**: two informative additions — 2.5:32 (builtin tokenization is uniform; no fused tokens) and 2.1:25 (the reference token dump's shared identifier/string interner keyed by decoded value, first-occurrence numbering, and non-interned `TYPE(name)` primitives), so a second implementation doesn't have to reverse-engineer these.

## Testing

- Issue repro now emits `AT` + `IDENT(sym:1)` for `@import`, uniform with `@size_of`.
- Full spec suite: 2119 passed. Import CLI tests: 54 passed. ruelex differential test passes byte-for-byte against the fixed dump. Broad suite green except two pre-existing targets whose "unreadable file" tests cannot fail under the container's root user (environmental; unrelated).

Fixes RUE-949

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTr1GrmuozXwd93nRkmPyC)_