### PR TITLE
RUE-724: report failed imports masked by struct-field type resolution

### DIFF
--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1741,15 +1741,24 @@ impl<'a> Sema<'a> {
     /// During declaration binding, resolve an indexed constant on demand.
     /// After the `BoundSema` boundary, the namespace is closed and a missing
     /// entry is an authoritative lookup miss.
+    ///
+    /// A collection failure propagates instead of degrading to a lookup miss.
+    /// Every on-demand probe sits on a path that hard-errors after a miss
+    /// (E0204/E0707/E0481), and struct fields resolve before the main const
+    /// walk in `resolve_remaining_declarations` — so a swallowed initializer
+    /// error (e.g. E0705 from a failed `@import`) was *replaced* by the
+    /// downstream miss diagnostic rather than re-reported later (RUE-724).
+    /// A name with no same-file const declaration still resolves to `Ok(None)`.
     pub(crate) fn resolve_indexed_const_binding_impl(
         &mut self,
         name: Spur,
         file_id: FileId,
-    ) -> Option<ConstValue> {
+    ) -> CompileResult<Option<ConstValue>> {
         debug_assert!(self.declaration_binding_active);
-        let _ = self.ensure_const_collected(name, file_id);
-        self.resolve_const_info_in_file(name, file_id)
-            .map(|info| info.value)
+        self.ensure_const_collected(name, file_id)?;
+        Ok(self
+            .resolve_const_info_in_file(name, file_id)
+            .map(|info| info.value))
     }
 
     fn indexed_const(&self, key: (FileId, Spur)) -> Option<PendingConst> {

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -154,7 +154,7 @@ pub trait DeclarationPhase: std::ops::Deref<Target = DeclarationNamespace> + Siz
         sema: &mut Sema<'_, Self>,
         name: Spur,
         file_id: FileId,
-    ) -> Option<ConstValue>;
+    ) -> rue_error::CompileResult<Option<ConstValue>>;
 
     fn collect_free_function_signature(
         sema: &mut Sema<'_, Self>,
@@ -168,7 +168,7 @@ impl DeclarationPhase for MutableDeclarations {
         sema: &mut Sema<'_, Self>,
         name: Spur,
         file_id: FileId,
-    ) -> Option<ConstValue> {
+    ) -> rue_error::CompileResult<Option<ConstValue>> {
         sema.resolve_indexed_const_binding_impl(name, file_id)
     }
 
@@ -186,8 +186,8 @@ impl DeclarationPhase for SourceDeclarations {
         _sema: &mut Sema<'_, Self>,
         _name: Spur,
         _file_id: FileId,
-    ) -> Option<ConstValue> {
-        None
+    ) -> rue_error::CompileResult<Option<ConstValue>> {
+        Ok(None)
     }
 
     fn collect_free_function_signature(
@@ -498,7 +498,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         &mut self,
         name: Spur,
         file_id: FileId,
-    ) -> Option<ConstValue> {
+    ) -> rue_error::CompileResult<Option<ConstValue>> {
         D::resolve_indexed_const(self, name, file_id)
     }
 

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -558,7 +558,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             .resolve_const_info_in_file(type_sym, span.file_id)
             .map(|info| info.value);
         if value.is_none() && self.declaration_binding_active {
-            value = self.try_resolve_indexed_const_during_binding(type_sym, span.file_id);
+            value = self.try_resolve_indexed_const_during_binding(type_sym, span.file_id)?;
         }
         let Some(ConstValue::Type(alias_ty)) = value else {
             return Ok(None);
@@ -923,7 +923,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
                 .get(&(file_id, member_sym))
                 .is_none()
         {
-            self.try_resolve_indexed_const_during_binding(member_sym, file_id);
+            self.try_resolve_indexed_const_during_binding(member_sym, file_id)?;
         }
         if let Some(info) = module_file_id
             .and_then(|file_id| self.constants_by_file_name.get(&(file_id, member_sym)))
@@ -1225,7 +1225,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             ));
         };
         let first_sym = self.interner.get_or_intern(first);
-        let Some(binding) = self.resolve_module_binding_in_file(root_file, first_sym) else {
+        let Some(binding) = self.resolve_module_binding_in_file(root_file, first_sym)? else {
             return Err(CompileError::new(
                 ErrorKind::UnknownType((*first).to_string()),
                 span,
@@ -1249,7 +1249,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
                     span,
                 ));
             };
-            let Some(binding) = self.resolve_module_binding_in_file(module_file_id, segment_sym)
+            let Some(binding) = self.resolve_module_binding_in_file(module_file_id, segment_sym)?
             else {
                 return Err(CompileError::new(
                     ErrorKind::UnknownModuleMember {
@@ -1293,16 +1293,16 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         &mut self,
         file_id: FileId,
         name: Spur,
-    ) -> Option<super::info::ConstInfo> {
+    ) -> CompileResult<Option<super::info::ConstInfo>> {
         if let Some(binding) = self.module_bindings.get(&(file_id, name)) {
-            return Some(binding.clone());
+            return Ok(Some(binding.clone()));
         }
         if !self.declaration_binding_active {
-            return None;
+            return Ok(None);
         }
 
-        self.try_resolve_indexed_const_during_binding(name, file_id);
-        self.module_bindings.get(&(file_id, name)).cloned()
+        self.try_resolve_indexed_const_during_binding(name, file_id)?;
+        Ok(self.module_bindings.get(&(file_id, name)).cloned())
     }
 
     /// Resolve a type-function application written directly in type position
@@ -2102,7 +2102,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
                     info.value
                 } else if self.declaration_binding_active
                     && let Some(v) =
-                        self.try_resolve_indexed_const_during_binding(sym, span.file_id)
+                        self.try_resolve_indexed_const_during_binding(sym, span.file_id)?
                 {
                     // 3. A file-level constant whose indexed declaration is
                     //    being dependency-resolved for a struct field / enum

--- a/crates/rue-ui-tests/cases/diagnostics/import-error-masking.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/import-error-masking.toml
@@ -1,0 +1,49 @@
+[section]
+id = "diagnostics.import-error-masking"
+name = "Failed imports are not masked by downstream diagnostics"
+description = "A constant initializer whose @import fails must report the import root cause even when the constant is first demanded by struct-field type resolution, which runs before the main const-collection walk (RUE-724)."
+
+# The harness strips RUE_STD_PATH and no std/ directory exists next to these
+# programs, so @import("std") fails to resolve in every case below.
+
+# The original masked repro: the failed import feeds a struct field type
+# through a const type alias. Struct fields resolve before the main const
+# walk, and the on-demand collection error used to be swallowed — the only
+# diagnostic was E0204 `unknown type 'Ints'` at the struct, hiding the E0705
+# root cause entirely.
+[[case]]
+name = "failed_std_import_reported_for_struct_field_alias"
+source = """
+const std = @import("std");
+const Ints = std.arraybuf.ArrayBuf(i64);
+struct S { xs: Ints }
+fn main() -> i32 { let s = S { xs: Ints.new() }; @intCast(s.xs.len()) }
+"""
+compile_fail = true
+error_contains = ["E0705", "standard library not found", "1:13"]
+
+# Same masking through the qualified-type-call path: the struct field names
+# the module binding directly instead of going through an alias. This used to
+# surface as E0204 `unknown type 'std'` at the field.
+[[case]]
+name = "failed_std_import_reported_for_qualified_struct_field"
+source = """
+const std = @import("std");
+struct S { xs: std.arraybuf.ArrayBuf(i64) }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0705", "standard library not found", "1:13"]
+
+# The user-module equivalent: a failed @import of an ordinary module must
+# report E0704 at the import site, not E0204 at the struct that consumes it.
+[[case]]
+name = "failed_user_import_reported_for_struct_field_alias"
+source = """
+const m = @import("missing_helper");
+const T = m.SomeType;
+struct S { x: T }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0704", "missing_helper", "1:11"]


### PR DESCRIPTION
## Problem

When `@import("std")` fails to resolve, the diagnostic depended on how the imported module was used. Through a `let` annotation the root cause surfaced correctly (`E0705: standard library not found` at the import). But when the import fed a struct field type — via a `const` type alias or a qualified type call — the only diagnostic was a misleading `E0204: unknown type` at the struct declaration, with the E0705 absent entirely.

## Mechanism

Struct fields resolve in `resolve_struct_fields`, before the main const-collection walk in `resolve_remaining_declarations`. A field type naming a const alias triggers on-demand collection of that const, and `resolve_indexed_const_binding_impl` discarded any collection error (`let _ = self.ensure_const_collected(...)`), degrading it to a lookup miss. The miss then surfaced as E0204, which aborted sema before the main const walk could re-report the initializer's real error.

The swallow's original rationale (RUE-587) was that the main pass would re-collect the const and report the error deterministically — an invariant broken by any probe whose miss diagnostic itself aborts sema first.

## Fix

`DeclarationPhase::resolve_indexed_const` now returns `CompileResult<Option<ConstValue>>` and the binding-phase impl propagates collection failures instead of swallowing them. All four on-demand probe sites (const type alias, module-member type alias, module-binding resolution for qualified types, and struct-field array lengths) propagate with `?`. Each of those sites hard-errors after a miss anyway (E0204/E0707/E0481), so the change strictly replaces a masking downstream diagnostic with the root cause; a name with no same-file const declaration still resolves to `Ok(None)` and falls through as before.

With the fix, all three shapes report the import-site root cause:

- `const Ints = std.arraybuf.ArrayBuf(i64); struct S { xs: Ints }` → E0705 at the import (was: E0204 `unknown type 'Ints'`)
- `struct S { xs: std.arraybuf.ArrayBuf(i64) }` → E0705 at the import (was: E0204 `unknown type 'std'`)
- failed user-module import feeding a field type → E0704 at the import

## Testing

- New UI cases in `crates/rue-ui-tests/cases/diagnostics/import-error-masking.toml` pin all three shapes (the harness strips `RUE_STD_PATH`, so the no-std scenario is the default).
- `scripts/rue quick`, full UI (181), spec (2053), CLI (1402) suites, the full `scripts/rue test` suite (37 targets), clippy, and fmt all pass.
- Manually verified both repro programs from the issue compile and run correctly when std is available.

Fixes RUE-724