### PR TITLE
RUE-853: add durable cache compatibility matrix

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -251,6 +251,7 @@ fn semantic_definition_taxonomy_has_one_enum_declaration() {
     let bindings = include_str!("sema/binding_manifest.rs");
     let bodies = include_str!("semantic_body.rs");
 
+    assert!(canonical.contains("macro_rules! stable_definition_kind_schema"));
     assert_eq!(
         canonical.matches("pub enum StableDefinitionKind").count(),
         1

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -90,7 +90,10 @@ pub use semantic_body::{
     SemanticSpecializedBodyExport, SemanticSpecializedCandidateInstallWork,
     SemanticStableResolutionFailure,
 };
-pub use semantic_identity::{StableDefinitionKind, StableDefinitionNamespace};
+pub use semantic_identity::{
+    STABLE_DEFINITION_KINDS, STABLE_DEFINITION_NAMESPACES, StableDefinitionKind,
+    StableDefinitionNamespace,
+};
 pub use semantic_import::{
     SEMANTIC_IMPORT_CONST_KINDS, SEMANTIC_IMPORT_TYPE_KINDS, SemanticImportConstKind,
     SemanticImportConstValue, SemanticImportEpoch, SemanticImportFailure, SemanticImportNominal,

--- a/crates/rue-air/src/semantic_identity.rs
+++ b/crates/rue-air/src/semantic_identity.rs
@@ -9,48 +9,71 @@ pub enum StableDefinitionNamespace {
     Method,
 }
 
-/// The exhaustive kind of a semantically bound definition.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum StableDefinitionKind {
-    Function,
-    Struct,
-    Enum,
-    ValueConst,
-    ModuleBinding,
-    Destructor,
-    Method,
-    AssociatedFunction,
-}
+/// Reviewable inventory of every stable semantic namespace.
+pub const STABLE_DEFINITION_NAMESPACES: &[StableDefinitionNamespace] = &[
+    StableDefinitionNamespace::Value,
+    StableDefinitionNamespace::Type,
+    StableDefinitionNamespace::Destructor,
+    StableDefinitionNamespace::Method,
+];
 
-impl StableDefinitionKind {
-    /// The only namespace in which this kind can be issued.
-    pub const fn namespace(self) -> StableDefinitionNamespace {
-        match self {
-            Self::Function | Self::ValueConst | Self::ModuleBinding => {
-                StableDefinitionNamespace::Value
-            }
-            Self::Struct | Self::Enum => StableDefinitionNamespace::Type,
-            Self::Destructor => StableDefinitionNamespace::Destructor,
-            Self::Method | Self::AssociatedFunction => StableDefinitionNamespace::Method,
+// One reviewable source generates the stable kind enum, inventory, namespace,
+// and ownership policy. Adding a kind cannot compile until all taxonomy fields
+// are supplied here.
+macro_rules! stable_definition_kind_schema {
+    ($consumer:ident) => {
+        $consumer! {
+            Function, Value, true, false;
+            Struct, Type, false, false;
+            Enum, Type, false, false;
+            ValueConst, Value, false, false;
+            ModuleBinding, Value, false, false;
+            Destructor, Destructor, true, true;
+            Method, Method, true, true;
+            AssociatedFunction, Method, true, true;
         }
-    }
-
-    /// Whether this definition owns an executable semantic body.
-    pub const fn owns_body(self) -> bool {
-        matches!(
-            self,
-            Self::Function | Self::Destructor | Self::Method | Self::AssociatedFunction
-        )
-    }
-
-    /// Whether this definition must name an owning nominal type.
-    pub const fn requires_owner(self) -> bool {
-        matches!(
-            self,
-            Self::Destructor | Self::Method | Self::AssociatedFunction
-        )
-    }
+    };
 }
+
+macro_rules! define_stable_definition_kind_schema {
+    ($( $kind:ident, $namespace:ident, $owns_body:literal, $requires_owner:literal; )*) => {
+        /// The exhaustive kind of a semantically bound definition.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub enum StableDefinitionKind {
+            $( $kind, )*
+        }
+
+        /// Reviewable inventory of every stable semantic definition kind.
+        pub const STABLE_DEFINITION_KINDS: &[StableDefinitionKind] = &[
+            $( StableDefinitionKind::$kind, )*
+        ];
+
+        impl StableDefinitionKind {
+            /// The only namespace in which this kind can be issued.
+            pub const fn namespace(self) -> StableDefinitionNamespace {
+                match self {
+                    $( Self::$kind => StableDefinitionNamespace::$namespace, )*
+                }
+            }
+
+            /// Whether this definition owns an executable semantic body.
+            pub const fn owns_body(self) -> bool {
+                match self {
+                    $( Self::$kind => $owns_body, )*
+                }
+            }
+
+            /// Whether this definition must name an owning nominal type.
+            pub const fn requires_owner(self) -> bool {
+                match self {
+                    $( Self::$kind => $requires_owner, )*
+                }
+            }
+        }
+    };
+}
+
+stable_definition_kind_schema!(define_stable_definition_kind_schema);
 
 #[cfg(test)]
 mod tests {

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -95,6 +95,7 @@ fn facade_stays_small_and_session_centered() {
         .map(|(name, _)| *name)
         .chain([
             "api_inventory",
+            "durable_compatibility_tests",
             "integration_tests",
             "pipeline_tests",
             "test_support",

--- a/crates/rue-compiler/src/durable_compatibility_tests.rs
+++ b/crates/rue-compiler/src/durable_compatibility_tests.rs
@@ -1,0 +1,987 @@
+//! Bounded compatibility matrix for every durable semantic schema family.
+//!
+//! The literal version tuple and exhaustive kind sets are deliberate review
+//! gates: any schema bump or newly introduced canonical variant must update
+//! this matrix in the same change.
+
+use std::{collections::BTreeSet, sync::Arc};
+
+use rue_air::{
+    AirArgMode, RuntimeCallKind, SEMANTIC_BODY_INST_KINDS, SEMANTIC_IMPORT_CONST_KINDS,
+    SEMANTIC_IMPORT_TYPE_KINDS, STABLE_DEFINITION_KINDS, STABLE_DEFINITION_NAMESPACES,
+    SemanticBodyCallArg, SemanticBodyInstData as D, SemanticBodyMatchArm, SemanticBodyPattern,
+    SemanticImportConstValue as C, SemanticImportNominalKind, SemanticImportType as T,
+    SemanticSpecializationIdentity,
+};
+use rue_span::FileId;
+
+use crate::*;
+
+const REVIEWED_SEMANTIC_SCHEMA: DurableSemanticSchemaVersion = DurableSemanticSchemaVersion {
+    major: 1,
+    minor: 0,
+    implementation_epoch: 1,
+};
+const REVIEWED_ORDINARY_BODY_SCHEMA: u32 = 6;
+const REVIEWED_SPECIALIZED_BODY_SCHEMA: u32 = 5;
+const REVIEWED_CFG_SCHEMA: u32 = 1;
+const REVIEWED_BODY_KINDS: usize = 58;
+const REVIEWED_TYPE_KINDS: usize = 19;
+const REVIEWED_CONST_KINDS: usize = 5;
+const REVIEWED_DECLARATION_PAYLOAD_KINDS: usize = 5;
+const REVIEWED_DEFINITION_KINDS: usize = 8;
+const REVIEWED_DEFINITION_NAMESPACES: usize = 4;
+
+fn module(path: &str) -> ModuleId {
+    ModuleId::from_logical_path(path).unwrap()
+}
+
+fn key(
+    kind: StableDefinitionKind,
+    namespace: StableDefinitionNamespace,
+    name: &str,
+) -> StableDefinitionKey {
+    StableDefinitionKey::for_test(module("pkg/main.rue"), namespace, kind, name, None)
+}
+
+fn owner() -> StableDefinitionKey {
+    key(
+        StableDefinitionKind::Function,
+        StableDefinitionNamespace::Value,
+        "main",
+    )
+}
+
+fn fingerprint(owner: StableDefinitionKey) -> StableDefinitionInputFingerprint {
+    StableDefinitionInputFingerprint {
+        schema_version: 1,
+        key: owner,
+        declaration: StableDefinitionFingerprint::for_test(1),
+        signature: StableDefinitionFingerprint::for_test(2),
+        body_or_initializer: Some(StableDefinitionFingerprint::for_test(3)),
+        precision: StableDefinitionFingerprintPrecision::SignatureAndBody,
+    }
+}
+
+fn body_payload(data: D<StableDefinitionKey, ModuleId>) -> DurableOrdinaryBodyPayload {
+    let owner = owner();
+    DurableOrdinaryBodyPayload {
+        schema_version: DURABLE_ORDINARY_BODY_SCHEMA_VERSION,
+        semantic_schema_version: DURABLE_SEMANTIC_SCHEMA_VERSION,
+        owner: owner.clone(),
+        expected_inputs: fingerprint(owner),
+        body: rue_air::SemanticBody {
+            return_type: T::Unit,
+            instructions: Arc::from([rue_air::SemanticBodyInst {
+                data,
+                ty: T::Unit,
+                anchor: rue_air::SemanticBodyAnchor { start: 0, end: 0 },
+            }]),
+            places: Arc::from([]),
+            strings: Arc::from([]),
+            param_drops: Arc::from([]),
+            borrow_slots: Arc::from([]),
+            num_locals: 0,
+            num_param_slots: 0,
+            param_by_ref: Arc::from([]),
+            param_writable: Arc::from([]),
+            allow_unreachable_code: false,
+            warnings: Arc::from([]),
+        },
+    }
+}
+
+#[test]
+fn reviewed_schema_versions_and_old_new_policy_are_explicit() {
+    assert_eq!(DURABLE_SEMANTIC_SCHEMA_VERSION, REVIEWED_SEMANTIC_SCHEMA);
+    assert_eq!(
+        DURABLE_ORDINARY_BODY_SCHEMA_VERSION,
+        REVIEWED_ORDINARY_BODY_SCHEMA
+    );
+    assert_eq!(
+        DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION,
+        REVIEWED_SPECIALIZED_BODY_SCHEMA
+    );
+    assert_eq!(
+        crate::queries::DURABLE_CFG_SCHEMA_VERSION,
+        REVIEWED_CFG_SCHEMA
+    );
+    assert_eq!(SEMANTIC_BODY_INST_KINDS.len(), REVIEWED_BODY_KINDS);
+    assert_eq!(SEMANTIC_IMPORT_TYPE_KINDS.len(), REVIEWED_TYPE_KINDS);
+    assert_eq!(SEMANTIC_IMPORT_CONST_KINDS.len(), REVIEWED_CONST_KINDS);
+    assert_eq!(STABLE_DEFINITION_KINDS.len(), REVIEWED_DEFINITION_KINDS);
+    assert_eq!(
+        STABLE_DEFINITION_NAMESPACES.len(),
+        REVIEWED_DEFINITION_NAMESPACES
+    );
+
+    let current = DURABLE_SEMANTIC_SCHEMA_VERSION;
+    assert!(current.accepts(current));
+    for candidate in [
+        DurableSemanticSchemaVersion {
+            major: current.major.saturating_sub(1),
+            ..current
+        },
+        DurableSemanticSchemaVersion {
+            major: current.major + 1,
+            ..current
+        },
+        DurableSemanticSchemaVersion {
+            minor: current.minor + 1,
+            ..current
+        },
+        DurableSemanticSchemaVersion {
+            implementation_epoch: current.implementation_epoch.saturating_sub(1),
+            ..current
+        },
+        DurableSemanticSchemaVersion {
+            implementation_epoch: current.implementation_epoch + 1,
+            ..current
+        },
+    ] {
+        assert!(
+            !current.accepts(candidate),
+            "accepted unknown schema {candidate:?}"
+        );
+    }
+
+    for version in [
+        DURABLE_ORDINARY_BODY_SCHEMA_VERSION - 1,
+        DURABLE_ORDINARY_BODY_SCHEMA_VERSION + 1,
+        u32::MAX,
+    ] {
+        let mut payload = body_payload(D::UnitConst);
+        payload.schema_version = version;
+        let mut work = DurableBodyWork::default();
+        assert_eq!(
+            payload.project_semantic_body(&mut work),
+            Err(DurableBodyProjectionFailure::SchemaVersionMismatch)
+        );
+        assert_eq!(work.projection_failures, 1);
+        assert_eq!(work.projection_completions, 0);
+    }
+}
+
+#[test]
+fn every_type_const_and_specialization_identity_round_trips_same_version() {
+    let structure = key(
+        StableDefinitionKind::Struct,
+        StableDefinitionNamespace::Type,
+        "Record",
+    );
+    let function = key(
+        StableDefinitionKind::Function,
+        StableDefinitionNamespace::Value,
+        "helper",
+    );
+    let dependency = module("pkg/dependency.rue");
+    let types = vec![
+        T::I8,
+        T::I16,
+        T::I32,
+        T::I64,
+        T::U8,
+        T::U16,
+        T::U32,
+        T::U64,
+        T::Bool,
+        T::Unit,
+        T::Never,
+        T::ComptimeType,
+        T::BuiltinNominal {
+            name: Arc::from("str"),
+            kind: SemanticImportNominalKind::Struct,
+        },
+        T::Nominal(structure.clone()),
+        T::Array {
+            element: Box::new(T::I32),
+            len: 4,
+        },
+        T::PtrConst(Box::new(T::I32)),
+        T::PtrMut(Box::new(T::I32)),
+        T::Module(dependency),
+        T::GenericParameter(0),
+    ];
+    assert_eq!(
+        types.iter().map(T::kind).collect::<BTreeSet<_>>(),
+        SEMANTIC_IMPORT_TYPE_KINDS.iter().copied().collect()
+    );
+
+    for value in &types {
+        let relocated = value
+            .try_map_identities(&|key| Ok::<_, ()>(key.clone()), &|module| {
+                Ok::<_, ()>(Arc::<str>::from(module.as_str()))
+            })
+            .unwrap();
+        let restored = relocated
+            .try_map_identities(&|key| Ok::<_, ()>(key.clone()), &|path| {
+                Ok::<_, ()>(ModuleId::from_logical_path(path).unwrap())
+            })
+            .unwrap();
+        assert_eq!(&restored, value);
+    }
+
+    let consts = vec![
+        C::Integer(i128::MAX),
+        C::Bool(true),
+        C::Type(types[14].clone()),
+        C::Function(function.clone()),
+        C::Unit,
+    ];
+    assert_eq!(
+        consts.iter().map(C::kind).collect::<BTreeSet<_>>(),
+        SEMANTIC_IMPORT_CONST_KINDS.iter().copied().collect()
+    );
+    let identity = SemanticSpecializationIdentity {
+        base: function,
+        type_arguments: types.into(),
+        value_arguments: consts.into(),
+    };
+    let relocated = identity
+        .try_map_keys(&|key| Ok::<_, ()>(key.clone()), &|module| {
+            Ok::<_, ()>(Arc::<str>::from(module.as_str()))
+        })
+        .unwrap();
+    let restored = relocated
+        .try_map_keys(&|key| Ok::<_, ()>(key.clone()), &|path| {
+            Ok::<_, ()>(ModuleId::from_logical_path(path).unwrap())
+        })
+        .unwrap();
+    assert_eq!(restored, identity);
+}
+
+#[test]
+fn every_declaration_payload_and_parameter_mode_imports_in_one_bounded_epoch() {
+    let structure = key(
+        StableDefinitionKind::Struct,
+        StableDefinitionNamespace::Type,
+        "Record",
+    );
+    let enumeration = key(
+        StableDefinitionKind::Enum,
+        StableDefinitionNamespace::Type,
+        "Choice",
+    );
+    let function = key(
+        StableDefinitionKind::Function,
+        StableDefinitionNamespace::Value,
+        "compute",
+    );
+    let constant = key(
+        StableDefinitionKind::ValueConst,
+        StableDefinitionNamespace::Value,
+        "ANSWER",
+    );
+    let destructor = key(
+        StableDefinitionKind::Destructor,
+        StableDefinitionNamespace::Destructor,
+        "Record",
+    );
+    let method = StableDefinitionKey::for_test(
+        module("pkg/main.rue"),
+        StableDefinitionNamespace::Method,
+        StableDefinitionKind::Method,
+        "read",
+        Some((StableDefinitionKind::Struct, Arc::from("Record"))),
+    );
+    let associated = StableDefinitionKey::for_test(
+        module("pkg/main.rue"),
+        StableDefinitionNamespace::Method,
+        StableDefinitionKind::AssociatedFunction,
+        "new",
+        Some((StableDefinitionKind::Struct, Arc::from("Record"))),
+    );
+    let parameters = [
+        (DurableParameterMode::Value, false),
+        (DurableParameterMode::Borrow, false),
+        (DurableParameterMode::Inout, true),
+    ]
+    .into_iter()
+    .map(|(mode, is_comptime)| DurableSemanticParameter {
+        ty: T::PtrConst(Box::new(T::Nominal(structure.clone()))),
+        mode,
+        is_comptime,
+    })
+    .collect::<Vec<_>>();
+    let declarations = vec![
+        DurableDeclarationSemantic {
+            key: function.clone(),
+            is_public: true,
+            payload: DurableDeclarationPayload::Callable {
+                parameters: parameters.into(),
+                result: T::Nominal(enumeration.clone()),
+                has_self: false,
+                is_unchecked: false,
+            },
+        },
+        DurableDeclarationSemantic {
+            key: structure.clone(),
+            is_public: true,
+            payload: DurableDeclarationPayload::Struct {
+                fields: Arc::from([(Arc::from("value"), T::I32)]),
+                is_copy: false,
+                is_linear: false,
+            },
+        },
+        DurableDeclarationSemantic {
+            key: enumeration,
+            is_public: false,
+            payload: DurableDeclarationPayload::Enum {
+                variants: Arc::from([(Arc::from("Some"), Arc::from([T::I32]))]),
+            },
+        },
+        DurableDeclarationSemantic {
+            key: constant,
+            is_public: false,
+            payload: DurableDeclarationPayload::Const {
+                ty: T::I32,
+                value: C::Integer(42),
+            },
+        },
+        DurableDeclarationSemantic {
+            key: destructor,
+            is_public: false,
+            payload: DurableDeclarationPayload::Destructor,
+        },
+        DurableDeclarationSemantic {
+            key: method,
+            is_public: false,
+            payload: DurableDeclarationPayload::Callable {
+                parameters: Arc::from([]),
+                result: T::I32,
+                has_self: true,
+                is_unchecked: false,
+            },
+        },
+        DurableDeclarationSemantic {
+            key: associated,
+            is_public: false,
+            payload: DurableDeclarationPayload::Callable {
+                parameters: Arc::from([]),
+                result: T::Nominal(structure.clone()),
+                has_self: false,
+                is_unchecked: false,
+            },
+        },
+    ];
+    let payload_kinds = declarations
+        .iter()
+        .map(|declaration| match declaration.payload {
+            DurableDeclarationPayload::Callable { .. } => "callable",
+            DurableDeclarationPayload::Struct { .. } => "struct",
+            DurableDeclarationPayload::Enum { .. } => "enum",
+            DurableDeclarationPayload::Const { .. } => "const",
+            DurableDeclarationPayload::Destructor => "destructor",
+        })
+        .collect::<BTreeSet<_>>();
+    assert_eq!(payload_kinds.len(), REVIEWED_DECLARATION_PAYLOAD_KINDS);
+    let identity_kinds = [
+        (
+            StableDefinitionKind::Function,
+            StableDefinitionNamespace::Value,
+        ),
+        (
+            StableDefinitionKind::Struct,
+            StableDefinitionNamespace::Type,
+        ),
+        (StableDefinitionKind::Enum, StableDefinitionNamespace::Type),
+        (
+            StableDefinitionKind::ValueConst,
+            StableDefinitionNamespace::Value,
+        ),
+        (
+            StableDefinitionKind::ModuleBinding,
+            StableDefinitionNamespace::Value,
+        ),
+        (
+            StableDefinitionKind::Destructor,
+            StableDefinitionNamespace::Destructor,
+        ),
+        (
+            StableDefinitionKind::Method,
+            StableDefinitionNamespace::Method,
+        ),
+        (
+            StableDefinitionKind::AssociatedFunction,
+            StableDefinitionNamespace::Method,
+        ),
+    ];
+    assert_eq!(identity_kinds.len(), REVIEWED_DEFINITION_KINDS);
+    assert_eq!(
+        identity_kinds
+            .iter()
+            .map(|(kind, _)| *kind)
+            .collect::<BTreeSet<_>>(),
+        STABLE_DEFINITION_KINDS.iter().copied().collect()
+    );
+    assert_eq!(
+        identity_kinds
+            .iter()
+            .map(|(_, namespace)| *namespace)
+            .collect::<BTreeSet<_>>(),
+        STABLE_DEFINITION_NAMESPACES.iter().copied().collect()
+    );
+    for (kind, namespace) in identity_kinds {
+        assert_eq!(kind.namespace(), namespace);
+    }
+    import_durable_declaration_semantics(&declarations).unwrap();
+}
+
+#[test]
+fn module_binding_declaration_import_is_explicitly_unsupported_and_fails_closed() {
+    let module_binding = DurableDeclarationSemantic {
+        key: key(
+            StableDefinitionKind::ModuleBinding,
+            StableDefinitionNamespace::Value,
+            "dependency",
+        ),
+        is_public: true,
+        payload: DurableDeclarationPayload::Const {
+            ty: T::Module(module("pkg/dependency.rue")),
+            value: C::Unit,
+        },
+    };
+    assert!(
+        matches!(
+            import_durable_declaration_semantics(&[module_binding]),
+            Err(rue_air::SemanticImportFailure::DeclarationKindMismatch)
+        ),
+        "module bindings have stable dependency keys but no durable declaration payload; a const-shaped payload must fail closed"
+    );
+}
+
+#[test]
+fn valid_source_order_permutations_remain_distinct_and_projectable() {
+    let structure = key(
+        StableDefinitionKind::Struct,
+        StableDefinitionNamespace::Type,
+        "Pair",
+    );
+    let payload = |source_order: Arc<[u32]>| {
+        let mut payload = body_payload(D::UnitConst);
+        payload.body.instructions = Arc::from([
+            rue_air::SemanticBodyInst {
+                data: D::UnitConst,
+                ty: T::Unit,
+                anchor: rue_air::SemanticBodyAnchor { start: 0, end: 0 },
+            },
+            rue_air::SemanticBodyInst {
+                data: D::UnitConst,
+                ty: T::Unit,
+                anchor: rue_air::SemanticBodyAnchor { start: 0, end: 0 },
+            },
+            rue_air::SemanticBodyInst {
+                data: D::StructInit {
+                    struct_key: structure.clone(),
+                    fields: Arc::from([0, 1]),
+                    source_order,
+                },
+                ty: T::Nominal(structure.clone()),
+                anchor: rue_air::SemanticBodyAnchor { start: 0, end: 0 },
+            },
+        ]);
+        payload
+    };
+    let declaration_order = payload(Arc::from([0, 1]));
+    let source_order = payload(Arc::from([1, 0]));
+    for candidate in [&declaration_order, &source_order] {
+        let mut work = DurableBodyWork::default();
+        assert!(candidate.project_semantic_body(&mut work).is_ok());
+        assert_eq!(work.projection_completions, 1);
+        assert_eq!(work.projection_failures, 0);
+    }
+    assert_ne!(declaration_order.body, source_order.body);
+}
+
+#[test]
+fn every_body_instruction_variant_preserves_kind_and_identity_on_roundtrip() {
+    let function = key(
+        StableDefinitionKind::Function,
+        StableDefinitionNamespace::Value,
+        "helper",
+    );
+    let structure = key(
+        StableDefinitionKind::Struct,
+        StableDefinitionNamespace::Type,
+        "Record",
+    );
+    let enumeration = key(
+        StableDefinitionKind::Enum,
+        StableDefinitionNamespace::Type,
+        "Choice",
+    );
+    let args: Arc<[SemanticBodyCallArg]> = Arc::from([SemanticBodyCallArg {
+        value: 0,
+        mode: AirArgMode::Borrow,
+    }]);
+    let identity = SemanticSpecializationIdentity {
+        base: function.clone(),
+        type_arguments: Arc::from([T::Module(module("pkg/dependency.rue"))]),
+        value_arguments: Arc::from([C::Function(function.clone())]),
+    };
+    let mut values = vec![
+        D::Const(1),
+        D::BoolConst(true),
+        D::StringConst(0),
+        D::UnitConst,
+        D::TypeConst(T::Nominal(structure.clone())),
+        D::Add(0, 0),
+        D::Sub(0, 0),
+        D::Mul(0, 0),
+        D::WrappingAdd(0, 0),
+        D::WrappingSub(0, 0),
+        D::WrappingMul(0, 0),
+        D::Div(0, 0),
+        D::Mod(0, 0),
+        D::Eq(0, 0),
+        D::Ne(0, 0),
+        D::Lt(0, 0),
+        D::Gt(0, 0),
+        D::Le(0, 0),
+        D::Ge(0, 0),
+        D::And(0, 0),
+        D::Or(0, 0),
+        D::BitAnd(0, 0),
+        D::BitOr(0, 0),
+        D::BitXor(0, 0),
+        D::Shl(0, 0),
+        D::Shr(0, 0),
+        D::Neg(0),
+        D::Not(0),
+        D::BitNot(0),
+        D::Branch {
+            cond: 0,
+            then_value: 0,
+            else_value: Some(0),
+        },
+        D::Loop { cond: 0, body: 0 },
+        D::InfiniteLoop { body: 0 },
+        D::Match {
+            scrutinee: 0,
+            arms: Arc::from([SemanticBodyMatchArm {
+                pattern: SemanticBodyPattern::EnumVariant {
+                    enum_key: enumeration.clone(),
+                    variant_index: 0,
+                },
+                body: 0,
+            }]),
+        },
+        D::Break,
+        D::Continue,
+        D::Alloc { slot: 0, init: 0 },
+        D::Load { slot: 0 },
+        D::Store { slot: 0, value: 0 },
+        D::ParamStore {
+            param_slot: 0,
+            value: 0,
+        },
+        D::Ret(Some(0)),
+        D::Call {
+            function: function.clone(),
+            args: args.clone(),
+        },
+        D::RuntimeCall {
+            runtime: RuntimeCallKind::ToString,
+            args: args.clone(),
+        },
+        D::CallSpecialized {
+            identity,
+            args: args.clone(),
+        },
+        D::CallGeneric,
+        D::Intrinsic {
+            runtime: None,
+            name: Arc::from("test"),
+            args: args.clone(),
+        },
+        D::Param { index: 0 },
+        D::Block {
+            statements: Arc::from([0]),
+            value: 0,
+        },
+        D::StructInit {
+            struct_key: structure.clone(),
+            fields: Arc::from([0]),
+            source_order: Arc::from([0]),
+        },
+        D::ArrayInit {
+            elements: Arc::from([0]),
+        },
+        D::PlaceRead { place: 0 },
+        D::PlaceWrite { place: 0, value: 0 },
+        D::EnumVariant {
+            enum_key: enumeration.clone(),
+            variant_index: 0,
+            payload: Arc::from([0]),
+        },
+        D::EnumPayloadGet {
+            base: 0,
+            enum_key: enumeration,
+            variant_index: 0,
+            field_index: 0,
+        },
+        D::IntCast {
+            value: 0,
+            from_ty: T::I32,
+        },
+        D::Drop { value: 0 },
+        D::StorageLive { slot: 0 },
+        D::StorageDead { slot: 0 },
+        D::MarkMoved {
+            value: 0,
+            slot: 0,
+            is_param: false,
+            place: Some(0),
+        },
+    ];
+    values.sort_by_key(D::kind);
+    assert_eq!(
+        values.iter().map(D::kind).collect::<Vec<_>>(),
+        SEMANTIC_BODY_INST_KINDS
+    );
+    for value in values {
+        let kind = value.kind();
+        let relocated = value
+            .try_map_keys(&|key| Ok::<_, ()>(key.clone()), &|module| {
+                Ok::<_, ()>(Arc::<str>::from(module.as_str()))
+            })
+            .unwrap();
+        let restored = relocated
+            .try_map_keys(&|key| Ok::<_, ()>(key.clone()), &|path| {
+                Ok::<_, ()>(ModuleId::from_logical_path(path).unwrap())
+            })
+            .unwrap();
+        assert_eq!(restored.kind(), kind);
+        assert_eq!(restored, value);
+    }
+}
+
+#[test]
+fn corrupt_truncated_unknown_and_unsupported_bodies_fail_closed_individually() {
+    let cases = [
+        (
+            D::Add(0, 0),
+            DurableBodyProjectionFailure::ForwardInstructionReference,
+        ),
+        (
+            D::StringConst(0),
+            DurableBodyProjectionFailure::InvalidStringReference,
+        ),
+        (
+            D::PlaceRead { place: 0 },
+            DurableBodyProjectionFailure::InvalidPlaceReference,
+        ),
+        (
+            D::CallGeneric,
+            DurableBodyProjectionFailure::InvalidInstructionReference,
+        ),
+        (
+            D::StructInit {
+                struct_key: key(
+                    StableDefinitionKind::Struct,
+                    StableDefinitionNamespace::Type,
+                    "S",
+                ),
+                fields: Arc::from([]),
+                source_order: Arc::from([0]),
+            },
+            DurableBodyProjectionFailure::InvalidSourceOrder,
+        ),
+    ];
+    for (data, failure) in cases {
+        let payload = body_payload(data);
+        let mut work = DurableBodyWork::default();
+        assert_eq!(payload.project_semantic_body(&mut work), Err(failure));
+        assert_eq!(work.projection_attempts, 1);
+        assert_eq!(work.projection_failures, 1);
+        assert_eq!(work.projection_completions, 0);
+    }
+
+    let mut truncated = body_payload(D::UnitConst);
+    truncated.body.num_param_slots = 1;
+    let mut work = DurableBodyWork::default();
+    assert_eq!(
+        truncated.project_semantic_body(&mut work),
+        Err(DurableBodyProjectionFailure::InvalidParameterModes)
+    );
+
+    let mut corrupt_anchor = body_payload(D::UnitConst);
+    Arc::make_mut(&mut corrupt_anchor.body.instructions)[0].anchor =
+        rue_air::SemanticBodyAnchor { start: 2, end: 1 };
+    let mut work = DurableBodyWork::default();
+    assert_eq!(
+        corrupt_anchor.project_semantic_body(&mut work),
+        Err(DurableBodyProjectionFailure::InvalidAnchor)
+    );
+}
+
+fn snapshot(entries: &[(u32, &str, &str, &str)], root: u32) -> SourceSnapshot {
+    let physical = entries
+        .iter()
+        .map(|(id, path, _, _)| (FileId::new(*id), (*path).to_owned()))
+        .collect();
+    let logical = entries
+        .iter()
+        .map(|(id, _, path, _)| (FileId::new(*id), (*path).to_owned()))
+        .collect();
+    SourceSnapshot::new(
+        SourceMetadata::new(FileId::new(root), physical, logical).unwrap(),
+        entries
+            .iter()
+            .map(|(id, _, _, source)| (FileId::new(*id), Arc::new((*source).to_owned())))
+            .collect(),
+    )
+    .unwrap()
+}
+
+#[test]
+fn relocation_file_ids_and_input_order_preserve_same_version_body_values() {
+    let original = snapshot(
+        &[
+            (
+                91,
+                "/old/main.rue",
+                "main.rue",
+                "fn left() -> i32 { 1 } fn right() -> i32 { 2 } fn main() -> i32 { left() + right() }",
+            ),
+            (92, "/old/dead.rue", "dead.rue", "fn dead() -> i32 { 0 }"),
+        ],
+        91,
+    );
+    let relocated = snapshot(
+        &[
+            (4, "/new/dead.rue", "dead.rue", "fn dead() -> i32 { 0 }"),
+            (
+                7,
+                "/new/main.rue",
+                "main.rue",
+                "fn left() -> i32 { 1 } fn right() -> i32 { 2 } fn main() -> i32 { left() + right() }",
+            ),
+        ],
+        7,
+    );
+    let options = CompileOptions::default();
+    let mut warm = CompilerSession::new();
+    warm.update(&original).into_result().unwrap();
+    warm.semantic(&options).unwrap();
+    warm.update(&relocated).into_result().unwrap();
+    let reused = warm.semantic(&options).unwrap();
+    assert_eq!(reused.work().durable_bodies.reused_bodies, 3);
+    assert_eq!(reused.work().durable_bodies.candidate_fallbacks, 0);
+    assert_eq!(reused.work().body_analysis.bodies_attempted, 0);
+
+    let mut cold = CompilerSession::new();
+    cold.update(&relocated).into_result().unwrap();
+    let fresh = cold.semantic(&options).unwrap();
+    assert_eq!(
+        format!("{:?}", reused.functions()),
+        format!("{:?}", fresh.functions())
+    );
+    assert_eq!(reused.strings(), fresh.strings());
+    assert_eq!(reused.type_pool().stats(), fresh.type_pool().stats());
+}
+
+#[test]
+fn representative_body_families_project_and_import_through_production_reuse() {
+    let cases = [
+        (
+            "scalar-control-call",
+            "fn helper(x: i32) -> i32 { if x > 0 { x + 1 } else { x - 1 } }\n\
+             fn main() -> i32 { helper(41) }",
+        ),
+        (
+            "aggregate-place-enum-string",
+            r#"
+                struct Pair { x: i32, values: [i32; 2] }
+                enum Choice { Value(i32), Empty }
+                fn mutate(inout p: Pair) { p.x = 20; p.values[0] = 2; }
+                fn read(borrow p: Pair) -> i32 { p.x + p.values[0] }
+                fn main() -> i32 {
+                    let mut p = Pair { x: 1, values: [3, 4] };
+                    mutate(inout p);
+                    let choice = Choice.Value(read(borrow p));
+                    @dbg("compatibility");
+                    match choice { Choice.Value(v) => v, Choice.Empty => 0 }
+                }
+            "#,
+        ),
+    ];
+    let options = CompileOptions::default();
+
+    for (name, source) in cases {
+        let original = snapshot(&[(71, "/old/main.rue", "main.rue", source)], 71);
+        let relocated = snapshot(&[(3, "/new/main.rue", "main.rue", source)], 3);
+        let mut warm = CompilerSession::new();
+        warm.update(&original).into_result().unwrap();
+        warm.semantic(&options).unwrap();
+        warm.update(&relocated).into_result().unwrap();
+        let reused = warm.semantic(&options).unwrap();
+        assert!(
+            reused.work().durable_bodies.projection_completions > 0,
+            "{name} never traversed durable body projection"
+        );
+        assert!(
+            reused.work().durable_bodies.import_successes > 0,
+            "{name} never traversed canonical body import"
+        );
+        assert_eq!(reused.work().durable_bodies.candidate_fallbacks, 0);
+        assert_eq!(reused.work().body_analysis.bodies_attempted, 0);
+
+        let mut cold = CompilerSession::new();
+        cold.update(&relocated).into_result().unwrap();
+        let fresh = cold.semantic(&options).unwrap();
+        assert_eq!(
+            format!("{:?}", reused.functions()),
+            format!("{:?}", fresh.functions()),
+            "{name} production import diverged from fresh analysis"
+        );
+        assert_eq!(reused.strings(), fresh.strings());
+        assert_eq!(reused.type_pool().stats(), fresh.type_pool().stats());
+    }
+}
+
+#[test]
+fn one_corrupt_body_falls_back_without_poisoning_other_semantic_or_cfg_reuse() {
+    let original = snapshot(
+        &[(
+            9,
+            "/old/main.rue",
+            "main.rue",
+            "fn first() -> i32 { 1 } fn second() -> i32 { 2 } fn stable() -> i32 { 4 } fn main() -> i32 { first() + stable() }",
+        )],
+        9,
+    );
+    let edited = snapshot(
+        &[(
+            9,
+            "/old/main.rue",
+            "main.rue",
+            "fn first() -> i32 { 1 } fn second() -> i32 { 3 } fn stable() -> i32 { 4 } fn main() -> i32 { first() + stable() }",
+        )],
+        9,
+    );
+    let options = CompileOptions {
+        opt_level: OptLevel::O1,
+        ..CompileOptions::default()
+    };
+    let mut warm = CompilerSession::new();
+    warm.update(&original).into_result().unwrap();
+    warm.semantic(&options).unwrap();
+    warm.corrupt_durable_body_schema_for_test("first", u32::MAX);
+    warm.corrupt_durable_cfg_schema_for_test("first", u32::MAX);
+    warm.update(&edited).into_result().unwrap();
+    let reused = warm.semantic(&options).unwrap();
+
+    assert_eq!(reused.work().durable_bodies.projection_failures, 1);
+    assert_eq!(reused.work().durable_bodies.candidate_fallbacks, 1);
+    assert_eq!(reused.work().durable_bodies.reused_bodies, 2);
+    assert_eq!(reused.work().body_analysis.bodies_attempted, 1);
+    assert_eq!(reused.work().cfg.cfg_schema_version_rejections, 1);
+    assert_eq!(reused.work().cfg.cfg_reuses, 2);
+    assert_eq!(reused.work().cfg.cfg_builds_attempted, 1);
+
+    let mut cold = CompilerSession::new();
+    cold.update(&edited).into_result().unwrap();
+    let fresh = cold.semantic(&options).unwrap();
+    assert_eq!(fresh.work().cfg.cfg_reuses, 0);
+    assert_eq!(fresh.work().cfg.cfg_builds_attempted, 3);
+    assert_eq!(
+        format!("{:?}", reused.functions()),
+        format!("{:?}", fresh.functions())
+    );
+    assert_eq!(reused.strings(), fresh.strings());
+    assert_eq!(
+        format!("{:?}", reused.warnings()),
+        format!("{:?}", fresh.warnings())
+    );
+    assert_eq!(reused.type_pool().stats(), fresh.type_pool().stats());
+}
+
+#[test]
+fn specialized_body_previous_current_and_future_schemas_isolate_one_candidate() {
+    let original = snapshot(
+        &[(
+            17,
+            "/old/main.rue",
+            "main.rue",
+            "fn choose(comptime n: i32) -> i32 { n }\n\
+             fn specialized_caller() -> i32 { choose(1) + choose(2) }\n\
+             fn stable() -> i32 { 40 }\n\
+             fn main() -> i32 { specialized_caller() + stable() }",
+        )],
+        17,
+    );
+    let relocated = snapshot(
+        &[(
+            3,
+            "/new/main.rue",
+            "main.rue",
+            "fn choose(comptime n: i32) -> i32 { n }\n\
+             fn specialized_caller() -> i32 { choose(1) + choose(2) }\n\
+             fn stable() -> i32 { 40 }\n\
+             fn main() -> i32 { specialized_caller() + stable() }",
+        )],
+        3,
+    );
+    let options = CompileOptions::default();
+    let versions = [
+        DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION,
+        DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION - 1,
+        DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION + 1,
+    ];
+    let mut compatible_ordinary_work = None;
+
+    for version in versions {
+        let mut warm = CompilerSession::new();
+        warm.update(&original).into_result().unwrap();
+        let baseline = warm.semantic(&options).unwrap();
+        assert_eq!(
+            baseline.work().body_analysis.specialized_bodies_attempted,
+            2
+        );
+        warm.corrupt_durable_specialized_body_schema_for_test("choose", 0, version);
+        warm.update(&relocated).into_result().unwrap();
+        let reused = warm.semantic(&options).unwrap();
+        let compatible = version == DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION;
+
+        assert_eq!(
+            reused.work().durable_bodies.candidate_fallbacks,
+            usize::from(!compatible),
+            "schema {version} must affect exactly its selected candidate"
+        );
+        assert_eq!(
+            reused.work().body_analysis.specialized_bodies_reused,
+            if compatible { 2 } else { 1 },
+            "the other specialization must remain reusable"
+        );
+        assert_eq!(
+            reused.work().body_analysis.specialized_bodies_attempted,
+            usize::from(!compatible)
+        );
+        let ordinary_work = (
+            reused.work().body_analysis.bodies_attempted,
+            reused.work().body_analysis.bodies_succeeded,
+            reused.work().body_analysis.bodies_failed,
+        );
+        if compatible {
+            compatible_ordinary_work = Some(ordinary_work);
+        } else if let Some(expected) = compatible_ordinary_work {
+            assert_eq!(ordinary_work, expected);
+        }
+
+        let mut cold = CompilerSession::new();
+        cold.update(&relocated).into_result().unwrap();
+        let fresh = cold.semantic(&options).unwrap();
+        assert_eq!(
+            format!("{:?}", reused.functions()),
+            format!("{:?}", fresh.functions())
+        );
+        assert_eq!(reused.strings(), fresh.strings());
+        assert_eq!(
+            format!("{:?}", reused.warnings()),
+            format!("{:?}", fresh.warnings())
+        );
+        assert_eq!(reused.type_pool().stats(), fresh.type_pool().stats());
+    }
+    assert_eq!(compatible_ordinary_work, Some((3, 3, 0)));
+}

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -66,6 +66,8 @@ mod pipeline_tests;
 #[cfg(test)]
 mod api_inventory;
 #[cfg(test)]
+mod durable_compatibility_tests;
+#[cfg(test)]
 mod integration_tests;
 
 // Supported source, identity, option, session, and diagnostic surface.

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -129,7 +129,7 @@ pub(crate) struct CfgFrontendOutput {
     pub(crate) durable_cfgs: std::sync::Arc<[DurableCfgArtifact]>,
 }
 
-const DURABLE_CFG_SCHEMA_VERSION: u32 = 1;
+pub(crate) const DURABLE_CFG_SCHEMA_VERSION: u32 = 1;
 
 /// Last-good, fail-closed CFG candidate retained between semantic requests.
 ///

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -8071,6 +8071,63 @@ fn continues_discovery_lifecycle(
 }
 
 #[cfg(test)]
+impl CompilerSession {
+    pub(crate) fn corrupt_durable_body_schema_for_test(
+        &mut self,
+        owner_name: &str,
+        schema_version: u32,
+    ) {
+        let cache = self
+            .last_successful_body_cache
+            .as_mut()
+            .expect("test requires a published durable body cache");
+        let mut bodies = cache.bodies.to_vec();
+        bodies
+            .iter_mut()
+            .find(|body| body.payload.owner.name() == owner_name)
+            .expect("test requires the named durable body")
+            .payload
+            .schema_version = schema_version;
+        cache.bodies = bodies.into();
+    }
+
+    pub(crate) fn corrupt_durable_specialized_body_schema_for_test(
+        &mut self,
+        owner_name: &str,
+        specialization_index: usize,
+        schema_version: u32,
+    ) {
+        let cache = self
+            .last_successful_body_cache
+            .as_mut()
+            .expect("test requires a published durable body cache");
+        let candidate = Arc::make_mut(&mut cache.specialized_bodies)
+            .iter_mut()
+            .filter(|body| body.payload.identity.base.name() == owner_name)
+            .nth(specialization_index)
+            .expect("test requires the named durable specialization");
+        candidate.payload.schema_version = schema_version;
+    }
+
+    pub(crate) fn corrupt_durable_cfg_schema_for_test(
+        &mut self,
+        owner_name: &str,
+        schema_version: u32,
+    ) {
+        let cache = Arc::make_mut(
+            self.last_successful_cfg_cache
+                .as_mut()
+                .expect("test requires a published durable CFG cache"),
+        );
+        cache
+            .iter_mut()
+            .find(|cfg| cfg.input.body.owner.name() == owner_name)
+            .expect("test requires the named durable CFG")
+            .schema_version = schema_version;
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use std::{collections::HashMap, sync::Arc};
 


### PR DESCRIPTION
## Summary

- add an exhaustive, bounded compatibility matrix across durable identity, type, declaration, ordinary-body, specialized-body, and CFG schemas
- verify same-version round trips, old/future version rejection, relocation, source ordering, malformed inputs, and unsupported fail-closed policies
- assert selective fallback preserves unaffected reuse and that reused semantic/CFG results remain equivalent to fresh compilation
- derive stable definition policy inventories from one exhaustive schema table so schema additions require explicit compatibility updates

## Validation

- scripts/rue fmt
- compiler compatibility tests (12/12)
- compiler durable tests (49/49)
- compiler architecture/API inventory (5/5)
- AIR architecture/API inventory (5/5)
- scripts/rue quick (31 targets)

Linear: RUE-853