### PR TITLE
RUE-785: Correct rue-air dependency scopes

### DIFF
--- a/crates/rue-air/BUCK
+++ b/crates/rue-air/BUCK
@@ -23,14 +23,15 @@ rue_crate(
     deps = [
         "//crates/rue-builtins:rue-builtins",
         "//crates/rue-error:rue-error",
-        "//crates/rue-lexer:rue-lexer",
-        "//crates/rue-parser:rue-parser",
         "//crates/rue-rir:rue-rir",
         "//crates/rue-runtime-abi:rue-runtime-abi",
         "//crates/rue-span:rue-span",
         "//crates/rue-target:rue-target",
         "//third-party:lasso",
-        "//third-party:rayon",
+    ],
+    test_deps = [
+        "//crates/rue-lexer:rue-lexer",
+        "//crates/rue-parser:rue-parser",
     ],
 )
 

--- a/rust-project.json
+++ b/rust-project.json
@@ -55,14 +55,6 @@
           "name": "rue_error"
         },
         {
-          "crate": 10,
-          "name": "rue_lexer"
-        },
-        {
-          "crate": 15,
-          "name": "rue_parser"
-        },
-        {
           "crate": 16,
           "name": "rue_rir"
         },
@@ -81,10 +73,6 @@
         {
           "crate": 61,
           "name": "lasso"
-        },
-        {
-          "crate": 91,
-          "name": "rayon"
         }
       ],
       "is_workspace_member": true,


### PR DESCRIPTION
## Summary

- move `rue-lexer` and `rue-parser` from `rue-air` production dependencies to test-only dependencies
- remove the unused Rayon dependency from `rue-air`
- regenerate `rust-project.json` so it no longer exposes the stale production edges

## Root cause

`crates/rue-air/BUCK` listed dependencies shared by the library and its generated test target even though lexer/parser are referenced only by tests and Rayon is not referenced by the crate. This overstated the production dependency graph and kept stale edges in generated IDE metadata.

## Impact

The production `rue-air` target now has the minimal dependency surface, while the unit-test target retains the parser dependencies it needs.

## Validation

- `./buck2 build //crates/rue-air:rue-air`
- `./buck2 test //crates/rue-air:rue-air-test` (375 passed)
- queried direct Buck deps for both targets; lexer/parser occur only on the test target and Rayon occurs on neither
- `./gen-rust-project.sh`
- `python3 scripts/validate-rust-project.py`

Linear: RUE-785
