### PR TITLE
RUE-974: compact native representation behind the aggregate_layout preview (ADR-0052 phase 3)

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -32,7 +32,7 @@ use std::sync::{Arc, PoisonError, RwLock};
 use lasso::Spur;
 use rue_span::FileId;
 
-use crate::layout::{Layout, LayoutKind, SLOT_BYTES};
+use crate::layout::{Layout, LayoutKind, PaddingRange, SLOT_BYTES};
 use crate::path_norm::{mangle_symbol_component, normalize_module_path};
 use crate::type_encoding;
 use crate::types::{
@@ -317,11 +317,73 @@ struct TypeInternPoolInner {
 
     /// Reverse index enforcing one canonical nominal for each language item.
     lang_item_structs: HashMap<LangItem, StructId>,
+
+    /// Whether the compact native physical layout (ADR-0052, the
+    /// `aggregate_layout` preview) is active for this compilation. Set once by
+    /// semantic construction from the compilation's preview features; it
+    /// therefore participates in every cache identity that already keys on
+    /// preview features. When `false` the layout authority reports today's
+    /// flattened eight-byte slot model byte-for-byte; when `true` it reports
+    /// natural scalar widths/alignments, declaration-order struct fields with
+    /// padding, ascending array stride, and tagged-enum layout. The slot
+    /// decomposition [`Self::abi_slot_count`] is unaffected either way — it is
+    /// the internal value representation, not the physical layout.
+    compact_layout: bool,
 }
 
 fn checked_pool_index(index: usize) -> Option<u32> {
     let index = u32::try_from(index).ok()?;
     (index <= type_encoding::MAX_PAYLOAD).then_some(index)
+}
+
+/// Round `offset` up to the next multiple of `align` (a power of two, always at
+/// least 1). Saturating so an already-oversized aggregate cannot wrap; the slot
+/// budget guard (`MAX_TYPE_SLOTS`) rejects genuinely oversized types earlier.
+fn align_up(offset: u64, align: u64) -> u64 {
+    debug_assert!(align >= 1, "alignment is at least 1");
+    let bump = align.saturating_sub(1);
+    offset.saturating_add(bump) & !bump
+}
+
+/// The computed compact layout of a struct: its total `size` including tail
+/// padding, its `alignment` (the maximum field alignment, minimum 1), the
+/// declaration-order byte `field_offsets`, and the interior/tail
+/// `padding_ranges`. ADR-0052 "Resolved at acceptance": `size` is rounded up to
+/// `alignment` so `stride == size`.
+struct CompactAggregateLayout {
+    size: u64,
+    alignment: u64,
+    field_offsets: Vec<u64>,
+    padding_ranges: Vec<PaddingRange>,
+}
+
+/// The computed compact layout of a tagged enum: an unsigned tag of `tag_size`
+/// (with `tag_align == tag_size`) at offset 0, the payload placed at
+/// `payload_offset` (the maximum variant alignment), the whole aggregate's
+/// `size`/`alignment`, and each variant's payload-field byte offsets relative to
+/// the aggregate base.
+struct CompactEnumLayout {
+    tag_size: u64,
+    tag_align: u64,
+    payload_offset: u64,
+    size: u64,
+    alignment: u64,
+    variants: Vec<Vec<u64>>,
+}
+
+/// The compact `(size, alignment)` of an enum's tag: the smallest unsigned
+/// integer that can represent every discriminant (ADR-0052). One variant (or
+/// zero) still needs a byte; `u8` covers up to 256 variants, `u16` up to 65536,
+/// `u32` beyond. Alignment equals size (natural scalar alignment).
+fn compact_enum_tag(variant_count: usize) -> (u64, u64) {
+    let width = if variant_count <= 256 {
+        1
+    } else if variant_count <= 65_536 {
+        2
+    } else {
+        4
+    };
+    (width, width)
 }
 
 impl TypeInternPoolInner {
@@ -611,17 +673,35 @@ impl TypeInternPoolInner {
         }
     }
 
-    /// Byte size of `ty` under the canonical layout: its slot count times
-    /// [`SLOT_BYTES`]. Zero-sized types are zero bytes.
+    /// Byte size of `ty` under the canonical layout. Zero-sized types are zero
+    /// bytes. Under the slot model this is the slot count times [`SLOT_BYTES`];
+    /// under the compact model (ADR-0052) it is the natural size including tail
+    /// padding.
     fn layout_size(&self, ty: Type) -> u64 {
-        u64::from(self.abi_slot_count(ty)) * SLOT_BYTES
+        if self.compact_layout {
+            self.compact_size_align(ty).0
+        } else {
+            u64::from(self.abi_slot_count(ty)) * SLOT_BYTES
+        }
     }
 
     /// Byte offset of the field at `field_index` within `struct_id`: the summed
-    /// sizes of every preceding field. Shared by `@offset_of` and code
-    /// generation's `struct_field_slot_offset` so field addressing agrees with
-    /// the layout intrinsic by construction.
+    /// sizes of every preceding field (slot model) or the field placement
+    /// respecting alignment and interior padding (compact model). Shared by
+    /// `@offset_of` and the layout authority so `@offset_of` and physical field
+    /// addressing agree by construction. Note that under the compact model this
+    /// physical byte offset is deliberately *not* the codegen slot offset
+    /// (`struct_field_slot_offset`), which stays a slot-count index into the
+    /// internal value representation (ADR-0052's three-representation split).
     fn struct_field_offset(&self, struct_id: StructId, field_index: u32) -> u64 {
+        if self.compact_layout {
+            return self
+                .compact_struct_layout(struct_id)
+                .field_offsets
+                .get(field_index as usize)
+                .copied()
+                .unwrap_or(0);
+        }
         let fields = &self.struct_def(struct_id).fields;
         let mut offset = 0u64;
         for field in fields.iter().take(field_index as usize) {
@@ -631,19 +711,29 @@ impl TypeInternPoolInner {
     }
 
     /// Byte offset of payload field `field_index` of `variant_index` within
-    /// `enum_id`. The discriminant occupies the first slot, so every payload
-    /// begins one [`SLOT_BYTES`] slot in, and each preceding payload field of
-    /// the same variant contributes its layout size. This is the same
-    /// computation [`Self::layout`] records in each entry of
-    /// [`LayoutKind::Enum`]'s `variants`; code generation's
-    /// `enum_payload_slot_offset` divides the result by [`SLOT_BYTES`] so
-    /// payload addressing agrees with the canonical layout by construction.
+    /// `enum_id`. Under the slot model the discriminant occupies the first slot,
+    /// so every payload begins one [`SLOT_BYTES`] slot in and each preceding
+    /// payload field contributes its layout size. Under the compact model the
+    /// payload begins at the tag-plus-alignment offset and preceding fields are
+    /// placed with natural alignment. This mirrors [`Self::layout`]'s
+    /// [`LayoutKind::Enum`] `variants`. Like `struct_field_offset`, the compact
+    /// value here is the physical byte offset, distinct from codegen's slot
+    /// offset into the value representation.
     fn enum_payload_field_offset(
         &self,
         enum_id: EnumId,
         variant_index: u32,
         field_index: u32,
     ) -> u64 {
+        if self.compact_layout {
+            let enum_layout = self.compact_enum_layout(enum_id);
+            return enum_layout
+                .variants
+                .get(variant_index as usize)
+                .and_then(|fields| fields.get(field_index as usize))
+                .copied()
+                .unwrap_or(enum_layout.payload_offset);
+        }
         let def = self.enum_def(enum_id);
         let mut offset = SLOT_BYTES;
         for &field_ty in def
@@ -656,14 +746,57 @@ impl TypeInternPoolInner {
         offset
     }
 
+    /// Slot-count offset of struct field `field_index`: the summed
+    /// [`Self::abi_slot_count`] of every preceding field. This is the *internal
+    /// value decomposition* offset (ADR-0052 representation 2), deliberately
+    /// independent of the compact-layout flag: code generation's stack/register
+    /// slot model stays slot-based (RUE-975) even when the physical layout
+    /// authority reports compact byte offsets. Under the slot model it equals
+    /// [`Self::struct_field_offset`]` / SLOT_BYTES`; under the compact model the
+    /// two intentionally diverge.
+    fn struct_field_slot_offset(&self, struct_id: StructId, field_index: u32) -> u32 {
+        let fields = &self.struct_def(struct_id).fields;
+        let mut slots = 0u32;
+        for field in fields.iter().take(field_index as usize) {
+            slots = slots.saturating_add(self.abi_slot_count(field.ty));
+        }
+        slots
+    }
+
+    /// Slot-count offset of enum payload field `field_index` of `variant_index`:
+    /// the discriminant slot (1) plus the summed [`Self::abi_slot_count`] of the
+    /// variant's preceding payload fields. Like [`Self::struct_field_slot_offset`]
+    /// this is the compact-independent internal value-decomposition offset.
+    fn enum_payload_slot_offset(
+        &self,
+        enum_id: EnumId,
+        variant_index: u32,
+        field_index: u32,
+    ) -> u32 {
+        let def = self.enum_def(enum_id);
+        let mut slots = 1u32;
+        for &field_ty in def
+            .variant_payload(variant_index as usize)
+            .iter()
+            .take(field_index as usize)
+        {
+            slots = slots.saturating_add(self.abi_slot_count(field_ty));
+        }
+        slots
+    }
+
     /// Compute the canonical physical [`Layout`] of `ty`.
     ///
-    /// `size`/`stride`/`alignment` follow the flattened eight-byte slot model
-    /// (`size == stride == abi_slot_count * SLOT_BYTES`; alignment `SLOT_BYTES`,
-    /// or `1` for a zero-sized type). `kind` records the addressing detail:
-    /// struct field byte offsets, array element layout, and enum tag/payload
-    /// placement, each derived from the same slot decomposition.
+    /// Under the slot model `size == stride == abi_slot_count * SLOT_BYTES`,
+    /// alignment is `SLOT_BYTES` (or `1` for a zero-sized type), and `kind`
+    /// records slot-derived field/element/payload offsets. Under the compact
+    /// model (ADR-0052) `size` includes tail padding, `stride == size`,
+    /// alignment is the natural alignment, and `kind` records the compact field
+    /// offsets, element stride, tag width, and payload placement.
     fn layout(&self, ty: Type) -> Layout {
+        if self.compact_layout {
+            return self.compact_layout_of(ty);
+        }
         let size = self.layout_size(ty);
         let alignment = if size == 0 { 1 } else { SLOT_BYTES };
         let stride = size;
@@ -716,6 +849,184 @@ impl TypeInternPoolInner {
                     }),
                     payload_offset,
                     variants,
+                }
+            }
+            _ => LayoutKind::Scalar,
+        };
+        Layout {
+            size,
+            alignment,
+            stride,
+            kind,
+        }
+    }
+
+    // ----- Compact native layout (ADR-0052 "Resolved at acceptance") -----
+
+    /// The compact `(size, alignment)` of `ty` under the natural LP64 table.
+    ///
+    /// Scalars use their byte width and natural alignment; `bool` is one byte;
+    /// pointers and the error-recovery scalar are eight bytes, eight-aligned.
+    /// Aggregates recurse through their struct/array/enum layout. `size` always
+    /// includes tail padding and is a multiple of `alignment`, so it doubles as
+    /// the array element stride. Any zero-sized result is normalized to
+    /// alignment 1 and stride 0 (ADR-0052's uniform zero-sized-type rule, which
+    /// includes zero-length arrays and all-zero-sized structs).
+    fn compact_size_align(&self, ty: Type) -> (u64, u64) {
+        let (size, alignment) = match ty.kind() {
+            TypeKind::I8 | TypeKind::U8 | TypeKind::Bool => (1, 1),
+            TypeKind::I16 | TypeKind::U16 => (2, 2),
+            TypeKind::I32 | TypeKind::U32 => (4, 4),
+            TypeKind::I64 | TypeKind::U64 => (8, 8),
+            TypeKind::PtrConst(_) | TypeKind::PtrMut(_) | TypeKind::Error => (8, 8),
+            TypeKind::Unit | TypeKind::Never | TypeKind::ComptimeType | TypeKind::Module(_) => {
+                (0, 1)
+            }
+            TypeKind::Struct(id) => {
+                let layout = self.compact_struct_layout(id);
+                (layout.size, layout.alignment)
+            }
+            TypeKind::Array(id) => {
+                let (element, count) = self.array_def(id);
+                let (element_size, element_align) = self.compact_size_align(element);
+                (element_size.saturating_mul(count), element_align.max(1))
+            }
+            TypeKind::Enum(id) => {
+                let layout = self.compact_enum_layout(id);
+                (layout.size, layout.alignment)
+            }
+        };
+        if size == 0 { (0, 1) } else { (size, alignment) }
+    }
+
+    /// Compact struct layout: declaration-order field byte offsets at their
+    /// natural alignment with interior and tail padding, struct alignment equal
+    /// to the maximum field alignment (minimum 1), and size rounded up to that
+    /// alignment (so `stride == size`).
+    fn compact_struct_layout(&self, struct_id: StructId) -> CompactAggregateLayout {
+        let fields = self.struct_def(struct_id).fields.clone();
+        let mut field_offsets = Vec::with_capacity(fields.len());
+        let mut padding_ranges = Vec::new();
+        let mut offset = 0u64;
+        let mut alignment = 1u64;
+        for field in &fields {
+            let (field_size, field_align) = self.compact_size_align(field.ty);
+            let placed = align_up(offset, field_align);
+            if placed > offset {
+                padding_ranges.push(PaddingRange {
+                    start: offset,
+                    end: placed,
+                });
+            }
+            field_offsets.push(placed);
+            offset = placed.saturating_add(field_size);
+            alignment = alignment.max(field_align);
+        }
+        let size = align_up(offset, alignment);
+        if size > offset {
+            padding_ranges.push(PaddingRange {
+                start: offset,
+                end: size,
+            });
+        }
+        CompactAggregateLayout {
+            size,
+            alignment,
+            field_offsets,
+            padding_ranges,
+        }
+    }
+
+    /// Pack one enum variant's payload fields like a struct starting at offset
+    /// zero, returning the field offsets (relative to the payload start), the
+    /// packed payload size, and the maximum field alignment (minimum 1).
+    fn compact_variant_payload(&self, payload: &[Type]) -> (Vec<u64>, u64, u64) {
+        let mut offsets = Vec::with_capacity(payload.len());
+        let mut offset = 0u64;
+        let mut alignment = 1u64;
+        for &field_ty in payload {
+            let (field_size, field_align) = self.compact_size_align(field_ty);
+            let placed = align_up(offset, field_align);
+            offsets.push(placed);
+            offset = placed.saturating_add(field_size);
+            alignment = alignment.max(field_align);
+        }
+        (offsets, offset, alignment)
+    }
+
+    /// Compact enum layout: a smallest-sufficient unsigned tag at offset 0, the
+    /// payload placed at the maximum variant alignment, and variant field byte
+    /// offsets relative to the aggregate base.
+    fn compact_enum_layout(&self, enum_id: EnumId) -> CompactEnumLayout {
+        let def = self.enum_def(enum_id);
+        let variant_count = def.variant_count();
+        let (tag_size, tag_align) = compact_enum_tag(variant_count);
+
+        let mut payload_align = 1u64;
+        let mut payload_size = 0u64;
+        let mut variant_local: Vec<(Vec<u64>, u64)> = Vec::with_capacity(variant_count);
+        for variant in 0..variant_count {
+            let (offsets, packed, align) =
+                self.compact_variant_payload(def.variant_payload(variant));
+            payload_align = payload_align.max(align);
+            payload_size = payload_size.max(packed);
+            variant_local.push((offsets, align));
+        }
+
+        let payload_offset = align_up(tag_size, payload_align);
+        let alignment = tag_align.max(payload_align);
+        let size = align_up(payload_offset.saturating_add(payload_size), alignment);
+        let variants = variant_local
+            .into_iter()
+            .map(|(offsets, _align)| {
+                offsets
+                    .into_iter()
+                    .map(|local| payload_offset.saturating_add(local))
+                    .collect()
+            })
+            .collect();
+
+        CompactEnumLayout {
+            tag_size,
+            tag_align,
+            payload_offset,
+            size,
+            alignment,
+            variants,
+        }
+    }
+
+    /// Build the full compact [`Layout`] of `ty`, including the per-kind
+    /// addressing detail.
+    fn compact_layout_of(&self, ty: Type) -> Layout {
+        let (size, alignment) = self.compact_size_align(ty);
+        let stride = size;
+        let kind = match ty.kind() {
+            TypeKind::Struct(id) => {
+                let layout = self.compact_struct_layout(id);
+                LayoutKind::Struct {
+                    field_offsets: layout.field_offsets,
+                    padding_ranges: layout.padding_ranges,
+                }
+            }
+            TypeKind::Array(id) => {
+                let (element, count) = self.array_def(id);
+                LayoutKind::Array {
+                    element: Box::new(self.compact_layout_of(element)),
+                    count,
+                }
+            }
+            TypeKind::Enum(id) => {
+                let layout = self.compact_enum_layout(id);
+                LayoutKind::Enum {
+                    tag: Box::new(Layout {
+                        size: layout.tag_size,
+                        alignment: layout.tag_align,
+                        stride: layout.tag_size,
+                        kind: LayoutKind::Scalar,
+                    }),
+                    payload_offset: layout.payload_offset,
+                    variants: layout.variants,
                 }
             }
             _ => LayoutKind::Scalar,
@@ -852,6 +1163,7 @@ impl TypeInternPool {
                 symbol_paths: HashMap::new(),
                 struct_lang_items: HashMap::new(),
                 lang_item_structs: HashMap::new(),
+                compact_layout: false,
             }),
         }
     }
@@ -885,6 +1197,27 @@ impl TypeInternPool {
             .write()
             .unwrap_or_else(PoisonError::into_inner)
             .symbol_paths = symbol_paths;
+    }
+
+    /// Select the physical layout model for this compilation (ADR-0052).
+    ///
+    /// Semantic construction calls this once, before any type is interned, with
+    /// whether the `aggregate_layout` preview feature is enabled. The choice is
+    /// carried through [`Self::freeze`] into the backend-facing pool so the
+    /// layout authority reports one consistent model for the whole compilation.
+    pub(crate) fn set_compact_layout(&self, compact_layout: bool) {
+        self.inner
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .compact_layout = compact_layout;
+    }
+
+    /// Whether the compact native layout (ADR-0052) is active for this pool.
+    pub fn compact_layout(&self) -> bool {
+        self.inner
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .compact_layout
     }
 
     /// Apply a type-pool mutation atomically through an isolated snapshot.
@@ -1928,6 +2261,17 @@ impl FrozenTypeInternPool {
         self.inner.abi_slot_count(ty)
     }
 
+    /// Whether the compact native layout (ADR-0052) is active for this pool.
+    ///
+    /// Code generation consults this to keep the internal slot/value/stack
+    /// model coherent while the compact-memory backends are staged: physical
+    /// pointer/heap addressing that would diverge from the slot model is
+    /// refused with a clear diagnostic rather than silently miscompiled
+    /// (RUE-975/RUE-976).
+    pub fn compact_layout(&self) -> bool {
+        self.inner.compact_layout
+    }
+
     /// Canonical physical [`Layout`] of `ty`: the one authority code generation
     /// consumes for byte size, alignment, stride, and field/element/payload
     /// offsets. Derived from [`Self::abi_slot_count`] scaled by [`SLOT_BYTES`].
@@ -1944,7 +2288,7 @@ impl FrozenTypeInternPool {
     }
 
     /// Byte offset of an enum variant's payload field, the shared source for
-    /// code generation's payload addressing (`enum_payload_slot_offset`).
+    /// `@offset_of`-style physical addressing. Distinct from the slot offset.
     pub fn enum_payload_field_offset(
         &self,
         enum_id: EnumId,
@@ -1953,6 +2297,26 @@ impl FrozenTypeInternPool {
     ) -> u64 {
         self.inner
             .enum_payload_field_offset(enum_id, variant_index, field_index)
+    }
+
+    /// Slot-count offset of a struct field: the internal value-decomposition
+    /// offset code generation's slot-based stack/register model uses, kept
+    /// independent of the compact physical layout (ADR-0052; RUE-975).
+    pub fn struct_field_slot_offset(&self, struct_id: StructId, field_index: u32) -> u32 {
+        self.inner.struct_field_slot_offset(struct_id, field_index)
+    }
+
+    /// Slot-count offset of an enum variant's payload field: the internal
+    /// value-decomposition offset (discriminant slot plus preceding payload
+    /// slots), kept independent of the compact physical layout.
+    pub fn enum_payload_slot_offset(
+        &self,
+        enum_id: EnumId,
+        variant_index: u32,
+        field_index: u32,
+    ) -> u32 {
+        self.inner
+            .enum_payload_slot_offset(enum_id, variant_index, field_index)
     }
 
     /// Validate a complete type relative to this frozen owner pool.
@@ -2193,6 +2557,7 @@ impl Clone for TypeInternPool {
                 symbol_paths: inner.symbol_paths.clone(),
                 struct_lang_items: inner.struct_lang_items.clone(),
                 lang_item_structs: inner.lang_item_structs.clone(),
+                compact_layout: inner.compact_layout,
             }),
         }
     }
@@ -3537,6 +3902,174 @@ mod tests {
                 u64::from(frozen.abi_slot_count(ty)) * SLOT_BYTES,
                 "layout size must equal abi_slot_count * SLOT_BYTES for {ty:?}"
             );
+        }
+    }
+
+    // ----- Compact native layout (ADR-0052 `aggregate_layout`) -----
+
+    #[test]
+    fn compact_layout_reports_natural_scalar_widths_and_alignments() {
+        let pool = TypeInternPool::new();
+        pool.set_compact_layout(true);
+        let ptr = Type::new_ptr_const(pool.intern_ptr_const_from_type(Type::I32));
+        let frozen = pool.freeze();
+        for (ty, size, align) in [
+            (Type::I8, 1, 1),
+            (Type::U8, 1, 1),
+            (Type::BOOL, 1, 1),
+            (Type::I16, 2, 2),
+            (Type::U16, 2, 2),
+            (Type::I32, 4, 4),
+            (Type::U32, 4, 4),
+            (Type::I64, 8, 8),
+            (Type::U64, 8, 8),
+            (ptr, 8, 8),
+        ] {
+            let layout = frozen.layout(ty);
+            assert_eq!(layout.size, size, "{ty:?} size");
+            assert_eq!(layout.alignment, align, "{ty:?} align");
+            assert_eq!(layout.stride, size, "{ty:?} stride == size");
+            assert_eq!(layout.kind, LayoutKind::Scalar, "{ty:?} kind");
+        }
+    }
+
+    #[test]
+    fn compact_layout_zero_sized_types_are_size_zero_align_one_stride_zero() {
+        let pool = TypeInternPool::new();
+        pool.set_compact_layout(true);
+        let empty_array = Type::new_array(pool.intern_array_from_type(Type::I32, 0));
+        let frozen = pool.freeze();
+        for ty in [Type::UNIT, Type::NEVER, empty_array] {
+            let layout = frozen.layout(ty);
+            assert_eq!(layout.size, 0, "{ty:?} size");
+            assert_eq!(layout.alignment, 1, "{ty:?} align");
+            assert_eq!(layout.stride, 0, "{ty:?} stride");
+        }
+    }
+
+    #[test]
+    fn compact_layout_struct_packs_fields_with_interior_and_tail_padding() {
+        // Padded { a: u8, b: i32, c: u8 }: a@0, pad[1,4), b@4, c@8, tail pad
+        // [9,12). size 12, align 4.
+        let pool = TypeInternPool::new();
+        pool.set_compact_layout(true);
+        let interner = ThreadedRodeo::default();
+        let (id, _) = pool.register_struct(
+            interner.get_or_intern("Padded"),
+            struct_def(
+                "Padded",
+                vec![
+                    StructField {
+                        name: "a".into(),
+                        ty: Type::U8,
+                    },
+                    StructField {
+                        name: "b".into(),
+                        ty: Type::I32,
+                    },
+                    StructField {
+                        name: "c".into(),
+                        ty: Type::U8,
+                    },
+                ],
+            ),
+        );
+        let frozen = pool.freeze();
+        let layout = frozen.layout(Type::new_struct(id));
+        assert_eq!(layout.size, 12);
+        assert_eq!(layout.alignment, 4);
+        assert_eq!(layout.stride, 12);
+        match &layout.kind {
+            LayoutKind::Struct {
+                field_offsets,
+                padding_ranges,
+            } => {
+                assert_eq!(field_offsets, &[0, 4, 8]);
+                assert_eq!(
+                    padding_ranges,
+                    &[
+                        PaddingRange { start: 1, end: 4 },
+                        PaddingRange { start: 9, end: 12 },
+                    ]
+                );
+            }
+            other => panic!("expected struct layout, got {other:?}"),
+        }
+        // @offset_of-facing physical offsets are compact...
+        assert_eq!(frozen.struct_field_offset(id, 1), 4);
+        // ...while the codegen slot offsets stay slot-based (representation 2).
+        assert_eq!(frozen.struct_field_slot_offset(id, 0), 0);
+        assert_eq!(frozen.struct_field_slot_offset(id, 1), 1);
+        assert_eq!(frozen.struct_field_slot_offset(id, 2), 2);
+    }
+
+    #[test]
+    fn compact_layout_array_strides_by_compact_element_size() {
+        let pool = TypeInternPool::new();
+        pool.set_compact_layout(true);
+        let array_ty = pool.try_intern_array(Type::I32, 3).unwrap();
+        let frozen = pool.freeze();
+        let layout = frozen.layout(array_ty);
+        assert_eq!(layout.size, 12);
+        assert_eq!(layout.stride, 12);
+        match layout.kind {
+            LayoutKind::Array { element, count } => {
+                assert_eq!(count, 3);
+                assert_eq!(element.size, 4);
+                assert_eq!(element.stride, 4, "compact indexing strides by 4");
+            }
+            other => panic!("expected array layout, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compact_layout_enum_uses_smallest_tag_and_max_variant_alignment() {
+        // Shape { Pair(i32, i64), One(i32) }: u8 tag@0, payload aligned to 8
+        // (the i64), so payload_offset 8. Largest payload packs i32@0,i64@8 =>
+        // 16 bytes; size = align_up(8 + 16, 8) = 24.
+        let pool = TypeInternPool::new();
+        pool.set_compact_layout(true);
+        let interner = ThreadedRodeo::default();
+        let def = EnumDef {
+            name: "Shape".to_string(),
+            variants: vec!["Pair".to_string(), "One".to_string()],
+            variant_payloads: vec![vec![Type::I32, Type::I64], vec![Type::I32]],
+            is_pub: false,
+            file_id: FileId::DEFAULT,
+        };
+        let (id, _) = pool.register_enum(interner.get_or_intern("Shape"), def);
+        let frozen = pool.freeze();
+        let layout = frozen.layout(Type::new_enum(id));
+        assert_eq!(layout.alignment, 8);
+        assert_eq!(layout.size, 24);
+        match layout.kind {
+            LayoutKind::Enum {
+                tag,
+                payload_offset,
+                variants,
+            } => {
+                assert_eq!(tag.size, 1, "smallest sufficient tag is u8");
+                assert_eq!(tag.alignment, 1);
+                assert_eq!(payload_offset, 8, "payload at max variant alignment");
+                assert_eq!(variants, vec![vec![8, 16], vec![8]]);
+            }
+            other => panic!("expected enum layout, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compact_layout_off_is_byte_for_byte_the_slot_model() {
+        // The default pool (flag off) must report exactly the slot values.
+        let pool = TypeInternPool::new();
+        let frozen = pool.freeze();
+        for (ty, size) in [
+            (Type::I8, SLOT_BYTES),
+            (Type::I32, SLOT_BYTES),
+            (Type::U64, SLOT_BYTES),
+        ] {
+            let layout = frozen.layout(ty);
+            assert_eq!(layout.size, size);
+            assert_eq!(layout.alignment, SLOT_BYTES);
         }
     }
 }

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -784,6 +784,13 @@ impl<'a> Sema<'a> {
         } = metadata;
         let type_pool = TypeInternPool::new();
         type_pool.set_symbol_paths(logical_paths.clone());
+        // Select the physical layout model for the whole compilation (ADR-0052).
+        // The choice is a pure function of the enabled preview features, which
+        // already key every compilation cache identity, so the layout authority
+        // reports one consistent model without a separate cache dimension.
+        type_pool.set_compact_layout(
+            preview_features.contains(&rue_error::PreviewFeature::AggregateLayout),
+        );
         Self {
             declarations: MutableDeclarations(DeclarationNamespace::new()),
             rir,

--- a/crates/rue-cli-tests/cases/aggregate_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout.toml
@@ -1,0 +1,173 @@
+# Compact native physical layout through the real driver (ADR-0052 phase 3,
+# RUE-974). With `--preview aggregate_layout` the canonical layout authority
+# reports the ratified compact representation: natural scalar widths and
+# alignments, declaration-order struct fields with interior/tail padding,
+# ascending array stride, a smallest-sufficient enum tag, and the uniform
+# zero-sized-type rule. The compile-time layout queries (@size_of / @align_of /
+# @offset_of) observe those values; slot-identical aggregates (all eight-byte
+# leaves) still marshal correctly through memory; and a program that would need
+# narrow (one/two/four-byte) physical memory access fails loudly rather than
+# emitting slot-shaped access against a compact layout (the narrow load/store
+# code generation is staged for RUE-975/RUE-976). Without the flag every case
+# below observes today's eight-byte slot model unchanged.
+
+[section]
+id = "cli.aggregate_layout"
+name = "Compact native layout (ADR-0052 phase 3)"
+description = "The aggregate_layout preview reports the compact physical layout in @size_of / @align_of / @offset_of; slot-identical aggregates still execute, and narrow physical access fails loudly."
+
+# Scalars take their natural LP64 width and alignment under the compact layout.
+[[case]]
+name = "compact_scalar_sizes_and_alignments"
+description = "Natural scalar widths/alignments (u8=1, i16=2, i32=4, i64=8, bool=1) under --preview aggregate_layout."
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @dbg(@size_of(u8) == 1);
+    @dbg(@size_of(i16) == 2);
+    @dbg(@size_of(i32) == 4);
+    @dbg(@size_of(i64) == 8);
+    @dbg(@size_of(bool) == 1);
+    @dbg(@align_of(i32) == 4);
+    @dbg(@align_of(u64) == 8);
+    0
+}
+""" }]
+stdout = "true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n"
+exit_code = 0
+
+# A struct is laid out in declaration order at naturally aligned offsets with
+# interior and tail padding; size rounds up to the struct alignment.
+[[case]]
+name = "compact_struct_padding_and_offsets"
+description = "Padded { a: u8, b: i32, c: u8 } -> a@0, b@4, c@8, size 12, align 4."
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Padded { a: u8, b: i32, c: u8 }
+fn main() -> i32 {
+    @dbg(@offset_of(Padded, a) == 0);
+    @dbg(@offset_of(Padded, b) == 4);
+    @dbg(@offset_of(Padded, c) == 8);
+    @dbg(@size_of(Padded) == 12);
+    @dbg(@align_of(Padded) == 4);
+    0
+}
+""" }]
+stdout = "true\ntrue\ntrue\ntrue\ntrue\n"
+exit_code = 0
+
+# Arrays are ascending with stride equal to the compact element size.
+[[case]]
+name = "compact_array_stride"
+description = "[i32; 3] has size 12; [u8; 4] has size 4 under the compact layout."
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @dbg(@size_of([i32; 3]) == 12);
+    @dbg(@size_of([u8; 4]) == 4);
+    @dbg(@size_of([i64; 2]) == 16);
+    0
+}
+""" }]
+stdout = "true\ntrue\ntrue\n"
+exit_code = 0
+
+# Zero-sized types have size 0, alignment 1, stride 0 under the compact layout
+# (the uniform rule, which includes zero-length arrays).
+[[case]]
+name = "compact_zero_sized_rules"
+description = "unit and [i32; 0] are size 0 with alignment 1."
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @dbg(@size_of(()) == 0);
+    @dbg(@align_of(()) == 1);
+    @dbg(@size_of([i32; 0]) == 0);
+    @dbg(@align_of([i32; 0]) == 1);
+    0
+}
+""" }]
+stdout = "true\ntrue\ntrue\ntrue\n"
+exit_code = 0
+
+# A slot-identical aggregate (all eight-byte leaves) has an identical compact
+# and slot layout, so field-pointer read/write through memory still executes
+# correctly under the compact layout.
+[[case]]
+name = "compact_slot_identical_field_ptr_roundtrip"
+description = "An all-i64 struct writes and reads a field through a pointer under --preview aggregate_layout."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Cell { first: i64, second: i64 }
+fn main() -> i32 {
+    let mut c = Cell { first: 40, second: 2 };
+    checked {
+        let fp: ptr mut i64 = @field_ptr(c.second);
+        @ptr_write(fp, 100);
+    };
+    @dbg(c.first);
+    @dbg(c.second);
+    @intCast(c.second)
+}
+""" }]
+stdout = "40\n100\n"
+exit_code = 100
+
+# The compact layout queries are observed identically whether or not the field
+# order forces padding; here an already-aligned all-i64 struct has no padding
+# and its size/offsets match the slot model exactly.
+[[case]]
+name = "compact_slot_identical_offsets_match_slot_model"
+description = "An all-i64 struct has offsets 0/8 and size 16 under the compact layout."
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Cell { first: i64, second: i64 }
+fn main() -> i32 {
+    @dbg(@offset_of(Cell, first) == 0);
+    @dbg(@offset_of(Cell, second) == 8);
+    @dbg(@size_of(Cell) == 16);
+    0
+}
+""" }]
+stdout = "true\ntrue\ntrue\n"
+exit_code = 0
+
+# A program that would require narrow physical memory access under the compact
+# layout is refused loudly rather than miscompiled with slot-shaped access. The
+# narrow load/store code generation is staged for RUE-975/RUE-976.
+[[case]]
+name = "compact_narrow_physical_access_fails_loudly"
+description = "Writing through a pointer into a struct with narrow i32 fields is refused, not silently miscompiled."
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Pair { a: i32, b: i32 }
+fn main() -> i32 {
+    let mut p = Pair { a: 7, b: 9 };
+    checked {
+        let fp: ptr mut i32 = @field_ptr(p.b);
+        @ptr_write(fp, 100);
+    };
+    p.b
+}
+""" }]
+compile_fail = true
+error_contains = ["aggregate_layout", "not yet implemented"]
+
+# Without the preview flag, the exact same narrow program compiles and runs
+# unchanged under today's eight-byte slot model.
+[[case]]
+name = "narrow_program_unchanged_without_the_preview"
+description = "The narrow-field program compiles and runs under the default slot model when the preview is off."
+files = [{ path = "main.rue", source = """
+struct Pair { a: i32, b: i32 }
+fn main() -> i32 {
+    let mut p = Pair { a: 7, b: 9 };
+    checked {
+        let fp: ptr mut i32 = @field_ptr(p.b);
+        @ptr_write(fp, 100);
+    };
+    p.b
+}
+""" }]
+exit_code = 100

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -371,6 +371,11 @@ impl<'a> CfgLower<'a> {
 
     /// Lower CFG to Aarch64Mir.
     pub fn lower(mut self) -> CompileResult<Aarch64Mir> {
+        crate::types::ensure_compact_layout_codegen_supported(
+            self.ctx.cfg,
+            self.ctx.type_pool,
+            self.interner,
+        )?;
         let ctx = self.ctx;
         crate::terminator_plan::lower_cfg(&ctx, &mut self, None, RET_REGS.len() as u32);
         Ok(self.mir)
@@ -381,6 +386,11 @@ impl<'a> CfgLower<'a> {
     /// This is like `lower()` but also captures detailed information about
     /// how each CFG instruction maps to MIR instructions.
     pub fn lower_with_debug(mut self) -> CompileResult<(Aarch64Mir, crate::LoweringDebugInfo)> {
+        crate::types::ensure_compact_layout_codegen_supported(
+            self.ctx.cfg,
+            self.ctx.type_pool,
+            self.interner,
+        )?;
         let mut debug_info = crate::LoweringDebugInfo {
             fn_name: self.fn_name.to_string(),
             target_arch: "aarch64".to_string(),
@@ -3030,6 +3040,72 @@ mod tests {
         )
         .lower()
         .expect("test lowering should succeed")
+    }
+
+    fn try_lower_first_fn(
+        source: &str,
+        preview: PreviewFeatures,
+    ) -> rue_error::CompileResult<Aarch64Mir> {
+        let lexer = Lexer::new(source);
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        let parser = Parser::new(tokens, interner);
+        let (ast, mut interner) = parser.parse().unwrap();
+        let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
+        astgen.append_items(&ast.items);
+        let rir = astgen.finish();
+        let output = Sema::new_synthetic(&rir, &mut interner, preview)
+            .analyze_all()
+            .unwrap();
+        let func = &output.functions[0];
+        let type_pool = &output.type_pool;
+        let cfg_output = CfgBuilder::build(
+            &func.air,
+            func.num_locals,
+            func.num_param_slots,
+            &func.name,
+            type_pool,
+            func.param_modes.clone(),
+            &interner,
+            func.allow_unreachable_code,
+        );
+        CfgLower::new(
+            cfg_output.cfg.as_ref().unwrap(),
+            type_pool,
+            &interner,
+            Target::Aarch64Linux,
+        )
+        .lower()
+    }
+
+    /// Under `aggregate_layout`, a non-slot-identical aggregate that would need
+    /// narrow physical memory codegen is refused loudly on AArch64 too, in
+    /// lockstep with x86-64 (ADR-0052 phase 3; RUE-975/RUE-976 follow-up).
+    #[test]
+    fn aggregate_layout_refuses_narrow_physical_layout_codegen() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let err = try_lower_first_fn(
+            "struct Pair { a: i32, b: i32 } fn main() -> i32 { let p = Pair { a: 7, b: 9 }; p.a }",
+            preview,
+        )
+        .expect_err("a narrow aggregate must refuse compact codegen, not miscompile");
+        assert!(
+            format!("{err:?}").contains("aggregate_layout"),
+            "refusal must name the feature, got: {err:?}"
+        );
+    }
+
+    /// A slot-identical aggregate (all eight-byte leaves) marshals correctly
+    /// under compact layout on AArch64 and is accepted.
+    #[test]
+    fn aggregate_layout_allows_slot_identical_physical_layout_codegen() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        try_lower_first_fn(
+            "struct Cell { a: i64, b: i64 } fn main() -> i32 { let c = Cell { a: 7, b: 9 }; @intCast(c.a) }",
+            preview,
+        )
+        .expect("a slot-identical aggregate must lower under compact layout");
     }
 
     fn immediate_for_operand(mir: &Aarch64Mir, operand: Operand) -> Option<i64> {

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -6,9 +6,9 @@
 //! Struct, enum, array, and pointer definitions are resolved through the
 //! canonical `FrozenTypeInternPool` (ADR-0024).
 
-use rue_air::layout::SLOT_BYTES;
+use lasso::ThreadedRodeo;
 use rue_air::{ArrayTypeId, EnumId, FrozenTypeInternPool, StructId, TypeKind};
-use rue_cfg::{CfgInstData, CfgValue, Type, ValidatedCfg};
+use rue_cfg::{Cfg, CfgInstData, CfgValue, Type, ValidatedCfg};
 use std::collections::HashMap;
 
 use crate::vreg::VReg;
@@ -181,16 +181,19 @@ fn push_leaf_types(type_pool: &FrozenTypeInternPool, ty: Type, out: &mut Vec<Typ
 /// Slot offset of payload field `field_index` within an enum's payload area.
 ///
 /// The discriminant occupies slot 0, so payload fields begin at slot 1
-/// (RUE-221). Derived from the canonical layout authority's payload byte offset
-/// divided by the slot width, so payload addressing agrees with the enum layout
-/// by construction.
+/// (RUE-221). This is the *internal value-decomposition* offset (ADR-0052
+/// representation 2), which the layout authority reports directly and keeps
+/// independent of the compact physical layout so the slot-based stack/register
+/// model is unchanged when compact byte offsets diverge from slot offsets
+/// (RUE-975). Under the slot model it equals the physical payload byte offset
+/// divided by the slot width.
 pub fn enum_payload_slot_offset(
     type_pool: &FrozenTypeInternPool,
     enum_id: EnumId,
     variant_index: u32,
     field_index: u32,
 ) -> u32 {
-    (type_pool.enum_payload_field_offset(enum_id, variant_index, field_index) / SLOT_BYTES) as u32
+    type_pool.enum_payload_slot_offset(enum_id, variant_index, field_index)
 }
 
 /// Calculate the slot count for a single element of an array type.
@@ -225,15 +228,196 @@ pub fn struct_slot_count(type_pool: &FrozenTypeInternPool, struct_id: StructId) 
 
 /// Calculate the slot offset for a field within a struct.
 ///
-/// Derived from the canonical layout authority's field byte offset (shared with
-/// `@offset_of`) divided by the slot width, so field addressing agrees with the
-/// layout intrinsic by construction.
+/// This is the *internal value-decomposition* offset (ADR-0052 representation
+/// 2), reported directly by the layout authority and kept independent of the
+/// compact physical layout so code generation's slot-based stack/register model
+/// is unchanged when compact byte offsets diverge from slot offsets (RUE-975).
+/// Under the slot model it equals the physical field byte offset (shared with
+/// `@offset_of`) divided by the slot width.
 pub fn struct_field_slot_offset(
     type_pool: &FrozenTypeInternPool,
     struct_id: StructId,
     field_index: u32,
 ) -> u32 {
-    (type_pool.struct_field_offset(struct_id, field_index) / SLOT_BYTES) as u32
+    type_pool.struct_field_slot_offset(struct_id, field_index)
+}
+
+/// Whether `ty`'s compact physical layout (ADR-0052 `aggregate_layout`) is
+/// byte-for-byte identical to the flattened eight-byte slot layout.
+///
+/// True exactly when every leaf scalar occupies a full eight bytes, so the type
+/// has no narrow fields, no interior or tail padding, and no narrowed enum tag.
+/// For such a type the compact size, alignment, stride, and field/element byte
+/// offsets all equal the slot-model values, so the slot-based memory
+/// marshalling code generation already emits is physically correct under the
+/// compact layout. When false, correct compact access requires narrow
+/// (one/two/four-byte) loads and stores at compact byte offsets, which is staged
+/// for a follow-up (see [`compact_physical_access_unsupported`]).
+pub(crate) fn is_slot_identical_layout(type_pool: &FrozenTypeInternPool, ty: Type) -> bool {
+    match ty.kind() {
+        // Eight-byte leaves and the recovery scalar: identical in both models.
+        TypeKind::I64
+        | TypeKind::U64
+        | TypeKind::PtrConst(_)
+        | TypeKind::PtrMut(_)
+        | TypeKind::Error => true,
+        // Zero-sized and compile-time-only types have identical (zero) extent.
+        TypeKind::Unit | TypeKind::Never | TypeKind::ComptimeType | TypeKind::Module(_) => true,
+        // Narrow scalars: one/two/four bytes under the compact layout.
+        TypeKind::I8
+        | TypeKind::U8
+        | TypeKind::Bool
+        | TypeKind::I16
+        | TypeKind::U16
+        | TypeKind::I32
+        | TypeKind::U32 => false,
+        TypeKind::Struct(id) => type_pool
+            .struct_def(id)
+            .fields
+            .iter()
+            .all(|field| is_slot_identical_layout(type_pool, field.ty)),
+        TypeKind::Array(id) => {
+            let (element, _length) = type_pool.array_def(id);
+            is_slot_identical_layout(type_pool, element)
+        }
+        // Enums narrow their tag (u8/u16/u32 vs an eight-byte slot).
+        TypeKind::Enum(_) => false,
+    }
+}
+
+/// The pointee of a pointer type, or the type itself when it is not a pointer.
+fn pointee_or_self(type_pool: &FrozenTypeInternPool, ty: Type) -> Type {
+    match ty.kind() {
+        TypeKind::PtrConst(id) => type_pool.ptr_const_def(id),
+        TypeKind::PtrMut(id) => type_pool.ptr_mut_def(id),
+        _ => ty,
+    }
+}
+
+/// If the compact physical layout is active and this CFG would require narrow
+/// physical memory access that code generation does not yet implement, return
+/// the first offending type so the backend can fail loudly rather than emit
+/// slot-shaped access against a compact layout (ADR-0052 phase 3, RUE-974).
+///
+/// The scan is conservative — it refuses whenever a non-slot-identical aggregate
+/// or enum is materialized as a value, a pointer to a non-slot-identical
+/// aggregate appears, a by-reference parameter is non-slot-identical, the
+/// function returns a non-slot-identical aggregate, or a typed pointer
+/// read/write or typed allocation targets a non-slot-identical pointee. Purely
+/// compile-time layout queries (`@size_of`/`@align_of`/`@offset_of`) fold to
+/// constants before code generation and introduce none of these, so they still
+/// compile and run. Slot-identical aggregates (all eight-byte leaves, e.g.
+/// `StrBuf`) marshal correctly and are allowed, as is the byte-addressed
+/// raw-byte family (`@byte_read`/`@byte_write`/`@alloc_bytes`), which is correct
+/// under any layout.
+///
+/// Returning `None` never weakens correctness: when it returns `None` every
+/// physical access the function performs is byte-for-byte identical to the slot
+/// model. The follow-up that adds narrow load/store codegen (RUE-975/RUE-976)
+/// removes the refusals this reports.
+pub(crate) fn compact_physical_access_unsupported(
+    cfg: &Cfg,
+    type_pool: &FrozenTypeInternPool,
+    interner: &ThreadedRodeo,
+) -> Option<Type> {
+    if !type_pool.compact_layout() {
+        return None;
+    }
+
+    // A value or pointer position that would place a non-slot-identical type in
+    // physical memory (aggregate value, pointer to a non-slot-identical
+    // aggregate). Narrow scalar pointers are deliberately excluded here: they
+    // are the element type of the byte-addressed raw-byte family (`ptr mut u8`
+    // in `StrBuf`) and are correct under any layout; typed reads/writes through
+    // them are caught by the operation-aware check below instead.
+    let flag_value = |ty: Type| -> bool {
+        match ty.kind() {
+            TypeKind::Struct(_) | TypeKind::Array(_) | TypeKind::Enum(_) => {
+                !is_slot_identical_layout(type_pool, ty)
+            }
+            TypeKind::PtrConst(_) | TypeKind::PtrMut(_) => {
+                let pointee = pointee_or_self(type_pool, ty);
+                matches!(
+                    pointee.kind(),
+                    TypeKind::Struct(_) | TypeKind::Array(_) | TypeKind::Enum(_)
+                ) && !is_slot_identical_layout(type_pool, pointee)
+            }
+            _ => false,
+        }
+    };
+
+    // Returned aggregates are written to the caller's sret buffer in physical
+    // memory.
+    if flag_value(cfg.return_type()) {
+        return Some(cfg.return_type());
+    }
+
+    for raw in 0..cfg.value_count() {
+        let value = CfgValue::from_raw(raw as u32);
+        let inst = cfg.get_inst(value);
+
+        if flag_value(inst.ty) {
+            return Some(inst.ty);
+        }
+
+        match &inst.data {
+            // A by-reference scalar parameter is a physical pointer dereference
+            // whose bare narrow type the value scan above does not catch.
+            CfgInstData::Param { index } => {
+                if cfg.is_param_by_ref(*index) && !is_slot_identical_layout(type_pool, inst.ty) {
+                    return Some(inst.ty);
+                }
+            }
+            // Typed pointer reads/writes and typed allocation address memory by
+            // the pointee's physical layout. The byte-addressed raw-byte family
+            // (`byte_read`/`byte_write`/`alloc_bytes`/...) is intentionally not
+            // matched here — it is correct under any layout.
+            CfgInstData::Intrinsic { name, .. } => {
+                let op = interner.resolve(name);
+                if matches!(op, "ptr_read" | "ptr_write" | "alloc" | "free" | "realloc") {
+                    let mut relevant = vec![inst.ty];
+                    for &arg in cfg.get_intrinsic_args(&inst.data) {
+                        relevant.push(cfg.get_inst(arg).ty);
+                    }
+                    for ty in relevant {
+                        let pointee = pointee_or_self(type_pool, ty);
+                        if !is_slot_identical_layout(type_pool, pointee) {
+                            return Some(pointee);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+/// Refuse code generation with a clear diagnostic when the compact physical
+/// layout is active but the function needs narrow physical memory access that is
+/// not yet implemented (see [`compact_physical_access_unsupported`]). Both
+/// backends call this at the top of lowering so the feature fails loudly rather
+/// than silently emitting slot-shaped access against a compact layout.
+pub(crate) fn ensure_compact_layout_codegen_supported(
+    cfg: &Cfg,
+    type_pool: &FrozenTypeInternPool,
+    interner: &ThreadedRodeo,
+) -> rue_error::CompileResult<()> {
+    if let Some(ty) = compact_physical_access_unsupported(cfg, type_pool, interner) {
+        let name = type_name(ty, type_pool);
+        return Err(rue_error::CompileError::without_span(
+            rue_error::ErrorKind::InternalCodegenError(format!(
+                "aggregate_layout: physical-layout code generation for type `{name}` (in function \
+                 `{}`) is not yet implemented. RUE-974 provides the compact layout authority and \
+                 the compile-time @size_of / @align_of / @offset_of queries; narrow \
+                 (one/two/four-byte) memory load and store code generation is staged for \
+                 RUE-975/RUE-976.",
+                cfg.fn_name()
+            )),
+        ));
+    }
+    Ok(())
 }
 
 /// Recursively collect all scalar vregs from an array value.

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -532,6 +532,11 @@ impl<'a> CfgLower<'a> {
 
     /// Lower CFG to X86Mir.
     pub fn lower(mut self) -> CompileResult<X86Mir> {
+        crate::types::ensure_compact_layout_codegen_supported(
+            self.ctx.cfg,
+            self.ctx.type_pool,
+            self.interner,
+        )?;
         let ctx = self.ctx;
         crate::terminator_plan::lower_cfg(&ctx, &mut self, None, RET_REGS.len() as u32);
         Ok(self.mir)
@@ -542,6 +547,11 @@ impl<'a> CfgLower<'a> {
     /// This is like `lower()` but also captures detailed information about
     /// how each CFG instruction maps to MIR instructions.
     pub fn lower_with_debug(mut self) -> CompileResult<(X86Mir, crate::LoweringDebugInfo)> {
+        crate::types::ensure_compact_layout_codegen_supported(
+            self.ctx.cfg,
+            self.ctx.type_pool,
+            self.interner,
+        )?;
         let mut debug_info = crate::LoweringDebugInfo {
             fn_name: self.fn_name.to_string(),
             target_arch: "x86_64".to_string(),
@@ -2892,6 +2902,67 @@ mod tests {
         CfgLower::new(cfg_output.cfg.as_ref().unwrap(), type_pool, &interner)
             .lower()
             .expect("test lowering should succeed")
+    }
+
+    fn try_lower_first_fn(
+        source: &str,
+        preview: PreviewFeatures,
+    ) -> rue_error::CompileResult<X86Mir> {
+        let lexer = Lexer::new(source);
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        let parser = Parser::new(tokens, interner);
+        let (ast, mut interner) = parser.parse().unwrap();
+        let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
+        astgen.append_items(&ast.items);
+        let rir = astgen.finish();
+        let output = Sema::new_synthetic(&rir, &mut interner, preview)
+            .analyze_all()
+            .unwrap();
+        let func = &output.functions[0];
+        let type_pool = &output.type_pool;
+        let cfg_output = CfgBuilder::build(
+            &func.air,
+            func.num_locals,
+            func.num_param_slots,
+            &func.name,
+            type_pool,
+            func.param_modes.clone(),
+            &interner,
+            func.allow_unreachable_code,
+        );
+        CfgLower::new(cfg_output.cfg.as_ref().unwrap(), type_pool, &interner).lower()
+    }
+
+    /// Under `aggregate_layout`, a non-slot-identical aggregate that would need
+    /// narrow physical memory codegen is refused loudly rather than miscompiled
+    /// with slot-shaped access (ADR-0052 phase 3; RUE-975/RUE-976 follow-up).
+    #[test]
+    fn aggregate_layout_refuses_narrow_physical_layout_codegen() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let err = try_lower_first_fn(
+            "struct Pair { a: i32, b: i32 } fn main() -> i32 { let p = Pair { a: 7, b: 9 }; p.a }",
+            preview,
+        )
+        .expect_err("a narrow aggregate must refuse compact codegen, not miscompile");
+        assert!(
+            format!("{err:?}").contains("aggregate_layout"),
+            "refusal must name the feature, got: {err:?}"
+        );
+    }
+
+    /// A slot-identical aggregate (all eight-byte leaves) has an identical
+    /// compact and slot layout, so its memory access marshals correctly and
+    /// compact codegen is accepted.
+    #[test]
+    fn aggregate_layout_allows_slot_identical_physical_layout_codegen() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        try_lower_first_fn(
+            "struct Cell { a: i64, b: i64 } fn main() -> i32 { let c = Cell { a: 7, b: 9 }; @intCast(c.a) }",
+            preview,
+        )
+        .expect("a slot-identical aggregate must lower under compact layout");
     }
 
     fn immediate_for_operand(mir: &X86Mir, operand: Operand) -> Option<i64> {

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -520,6 +520,15 @@ pub enum PreviewFeature {
     /// operations intentionally bypass Rue's slot-sized typed-pointer model so
     /// source-defined packed representations can use the runtime byte ABI.
     RawBytes,
+    /// Compact native physical type layout (ADR-0052). Replaces the flattened
+    /// eight-byte ABI-slot physical layout with natural scalar widths and
+    /// alignments, declaration-order struct fields with padding, ascending
+    /// array stride, and tagged-enum representation. Gated while compact-memory
+    /// code generation is staged: RUE-974 lands the layout authority and the
+    /// compile-time layout queries (`@size_of`/`@align_of`/`@offset_of`);
+    /// RUE-975/RUE-976 land the stack-and-value separation and call-ABI
+    /// classifier that compact heap/pointer code generation depends on.
+    AggregateLayout,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -542,6 +551,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra => "test_infra",
             PreviewFeature::Slices => "slices",
             PreviewFeature::RawBytes => "raw_bytes",
+            PreviewFeature::AggregateLayout => "aggregate_layout",
         }
     }
 
@@ -552,6 +562,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra => "ADR-0005",
             PreviewFeature::Slices => "ADR-0043",
             PreviewFeature::RawBytes => "RUE-879",
+            PreviewFeature::AggregateLayout => "ADR-0052",
         }
     }
 
@@ -561,6 +572,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra,
             PreviewFeature::Slices,
             PreviewFeature::RawBytes,
+            PreviewFeature::AggregateLayout,
         ]
     }
 
@@ -586,6 +598,7 @@ impl std::str::FromStr for PreviewFeature {
             "test_infra" => Ok(PreviewFeature::TestInfra),
             "slices" => Ok(PreviewFeature::Slices),
             "raw_bytes" => Ok(PreviewFeature::RawBytes),
+            "aggregate_layout" => Ok(PreviewFeature::AggregateLayout),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -2589,7 +2602,7 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(names, "test_infra, slices, raw_bytes");
+        assert_eq!(names, "test_infra, slices, raw_bytes, aggregate_layout");
     }
 
     #[test]

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -511,6 +511,21 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::FieldPointer),
         &[],
     ),
+    // ADR-0052 phase 3 (RUE-974): the compact-layout CLI cases reach a field
+    // through `@field_ptr`, which the oracle model does not model (same gap as
+    // the `offset_of_field_ptr` cases above).
+    Entry::new(
+        "cli.aggregate_layout",
+        "compact_slot_identical_field_ptr_roundtrip",
+        intrinsic(UnsupportedIntrinsicKind::FieldPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_layout",
+        "narrow_program_unchanged_without_the_preview",
+        intrinsic(UnsupportedIntrinsicKind::FieldPointer),
+        &[],
+    ),
     Entry::new(
         "cli.partial_move_depth",
         "disjoint_sibling_after_subfield_move_ok",


### PR DESCRIPTION
## Summary

Third child of the ADR-0052 migration (epic RUE-971): the layout authority can now report the ratified compact physical layout, gated behind the new `aggregate_layout` preview feature (ruling 10). Gate off, everything is byte-for-byte today's slot model and no existing test changes.

Under `--preview aggregate_layout`, per the acceptance rulings:

- **Scalars** take natural LP64 widths/alignments (u8=1/1 … i64=8/8, bool 1/1, pointers 8/8) — ruling 1.
- **Structs** lay out declaration-order fields at naturally aligned offsets with interior/tail padding; size rounds up to alignment, stride == size — ruling 2.
- **Arrays** are ascending with stride == compact element size; **enums** get the smallest-sufficient unsigned tag at offset 0 with payload at max variant alignment — ruling 4; **ZSTs** are 0/1/0 — ruling 3.
- The flag rides the intern pool, set once at semantic construction from the preview set, so it participates in the existing preview-keyed cache identity. `@size_of`/`@align_of`/`@offset_of` observe the compact values for every type.
- **Codegen** slot offsets are decoupled from the authority (ADR-0052's three-representation split: the slot-based stack model is untouched). Slot-identical aggregates (all-8-byte leaves) marshal through compact memory correctly on both backends — verified by execution, including typed `@alloc` whose RUE-973 layout-derived operands now carry compact sizes.
- **Narrow (1/2/4-byte) physical access fails loudly**: a shared pre-lowering scan on both backends refuses such programs at compile time with a staging message, rather than emitting slot-shaped access against a compact layout. Wrong answers are impossible; the refusal covers `@import("std")`'s ArrayBuf drop glue under the gate only.

Staged for the next phases (documented in the refusal message): narrow load/store codegen and the compact marshalling boundary (RUE-975/RUE-976), compact enum memory, and deterministic zero-padding (ruling 5's measure-and-revisit gate).

## Verification

Integrated on current trunk (post RUE-606/785/724). Six compact-authority unit tests, four both-backend refuse/allow codegen unit tests, eight gated CLI cases through the real driver, oracle model-gap entries for the two `@field_ptr` cases. Hand-verified by execution at integration: gated wide-alloc program runs correctly, gated narrow program is refused with the staging error, same narrow program unchanged without the flag. Full `test.sh` green on both backends except the four known uid-0 unreadable-file environmental failures. The preview registry's fourth feature required no session cache-arithmetic change (name-list assertion updated).

Fixes RUE-974

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_