### PR TITLE
RUE-957: allow const string literals and mut self receivers

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -727,6 +727,9 @@ impl ConstValueTag {
             crate::sema::ConstValue::Unit => Self::Unit,
             crate::sema::ConstValue::Type(_) => Self::Type,
             crate::sema::ConstValue::Function(_) => Self::Function,
+            crate::sema::ConstValue::String(_) => {
+                unreachable!("string const values are rejected before tag classification")
+            }
         }
     }
 
@@ -769,6 +772,17 @@ pub(crate) fn encode_const_values(
         operation: "stage",
         kind,
     };
+    // No comptime parameter has a string type, so the comptime engine never
+    // yields a string const as a specialization argument (RUE-957). Reject
+    // up front so the tag/payload scheme below stays scalar-only.
+    if values
+        .iter()
+        .any(|value| matches!(value, crate::sema::ConstValue::String(_)))
+    {
+        return Err(error(AirBuildErrorKind::ProducerInvariant(
+            "string constants are not valid comptime argument values",
+        )));
+    }
     let word_count = values.iter().try_fold(0usize, |count, value| {
         count.checked_add(1 + ConstValueTag::of(value).payload_width())
     });
@@ -801,6 +815,9 @@ pub(crate) fn encode_const_values(
                     u32::try_from(value.into_usize())
                         .map_err(|_| error(AirBuildErrorKind::ResourceLimit))?,
                 );
+            }
+            crate::sema::ConstValue::String(_) => {
+                unreachable!("string const values are rejected before encoding")
             }
         }
     }

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -315,6 +315,11 @@ pub(crate) fn import_staged_body(
                             crate::sema::ConstValue::Function(resolve_body_function(sema, value)?)
                         }
                         crate::SemanticImportConstValue::Unit => crate::sema::ConstValue::Unit,
+                        crate::SemanticImportConstValue::String(content) => {
+                            crate::sema::ConstValue::String(
+                                sema.interner.get_or_intern(content.as_ref()),
+                            )
+                        }
                     })
                 })
                 .collect::<Result<Vec<_>, BF>>()?;
@@ -1475,6 +1480,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                         method_info.struct_type,
                         &captured_values,
                         &enclosing_type_subst,
+                        method_info.self_is_mut,
                     )
                 };
 
@@ -1560,6 +1566,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                 body,
                 has_self,
                 self_mode,
+                self_is_mut,
                 ..
             } = &method_inst.data
             else {
@@ -1570,6 +1577,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
             debug_assert_eq!(method_inst.span, method_info.span);
             debug_assert_eq!(*has_self, method_info.has_self);
             debug_assert_eq!(*self_mode, method_info.self_mode);
+            debug_assert_eq!(*self_is_mut, method_info.self_is_mut);
 
             let params = sema.rir.params(params);
             let full_name = sema.method_symbol(struct_id, &method_name_str, *has_self);
@@ -1735,6 +1743,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                 method_info.struct_type,
                 *has_self,
                 *self_mode,
+                *self_is_mut,
             );
             sema.declaration_type_observer = previous_type_observer;
             sema.body_dependency_observer = previous_body_observer;

--- a/crates/rue-air/src/sema/analysis/anon_methods.rs
+++ b/crates/rue-air/src/sema/analysis/anon_methods.rs
@@ -34,6 +34,7 @@ impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
                 body,
                 has_self,
                 self_mode,
+                self_is_mut,
                 ..
             } = &method_inst.data
             {
@@ -81,6 +82,7 @@ impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
                         struct_type,
                         has_self: *has_self,
                         self_mode: *self_mode,
+                        self_is_mut: *self_is_mut,
                         params: param_range,
                         return_type: ret_type,
                         body: *body,
@@ -122,6 +124,7 @@ impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
                 body,
                 has_self,
                 self_mode,
+                self_is_mut,
                 ..
             } = &method_inst.data
             {
@@ -172,6 +175,7 @@ impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
                         struct_type,
                         has_self: *has_self,
                         self_mode: *self_mode,
+                        self_is_mut: *self_is_mut,
                         params: param_range,
                         return_type: ret_type,
                         body: *body,
@@ -270,6 +274,7 @@ impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
                 body,
                 has_self,
                 self_mode,
+                self_is_mut,
                 ..
             } = &method_inst.data
             {
@@ -336,6 +341,7 @@ impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
                         struct_type,
                         has_self: *has_self,
                         self_mode: *self_mode,
+                        self_is_mut: *self_is_mut,
                         params: param_range,
                         return_type: ret_type,
                         body: *body,

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -96,6 +96,7 @@ impl<'a> BodySema<'a> {
         struct_type: Type,
         has_self: bool,
         self_mode: RirParamMode,
+        self_is_mut: bool,
     ) -> CompileResult<(
         AnalyzedFunction,
         Vec<CompileWarning>,
@@ -155,6 +156,7 @@ impl<'a> BodySema<'a> {
             None,
             false,
             false,
+            self_is_mut,
         )?;
 
         Ok((
@@ -221,6 +223,9 @@ impl<'a> BodySema<'a> {
             None,
             /* is_destructor */ true,
             false,
+            // A destructor's `self` stays immutable; mutate via a `let mut`
+            // rebind if needed.
+            false,
         )?;
 
         reject_self_move_in_destructor(&air, full_name)?;
@@ -284,6 +289,9 @@ impl<'a> BodySema<'a> {
             None,
             false,
             allow_unused_variable,
+            // Free and associated functions have no receiver, so no binding
+            // can be a mutable by-value `self`.
+            false,
         )
     }
 
@@ -309,6 +317,7 @@ impl<'a> BodySema<'a> {
         value_subst: Option<&std::collections::HashMap<Spur, ConstValue>>,
         is_destructor: bool,
         allow_unused_variable: bool,
+        self_is_mut: bool,
     ) -> CompileResult<(
         Air,
         u32,
@@ -351,6 +360,10 @@ impl<'a> BodySema<'a> {
                 ty: *ptype,
                 mode: *mode,
                 is_comptime: *is_comptime,
+                // Only the synthetic `self` entry of a `mut self` method can
+                // be a mutable by-value binding; ordinary parameters have no
+                // `mut` form.
+                is_mut: self_is_mut && *pname == self_sym && *mode == RirParamMode::Normal,
             });
             // Inout and Borrow parameters are passed by reference.
             // Comptime parameters are VALUE params (like `comptime n: i32`), passed by value.
@@ -591,6 +604,7 @@ impl<'a> BodySema<'a> {
         body: InstRef,
         type_subst: &std::collections::HashMap<Spur, Type>,
         value_subst: &std::collections::HashMap<Spur, ConstValue>,
+        self_is_mut: bool,
     ) -> CompileResult<(
         Air,
         u32,
@@ -616,6 +630,7 @@ impl<'a> BodySema<'a> {
             Some(value_subst),
             false,
             false,
+            self_is_mut,
         )
     }
 
@@ -633,6 +648,7 @@ impl<'a> BodySema<'a> {
         self_type: Type,
         captured_comptime_values: &std::collections::HashMap<Spur, ConstValue>,
         enclosing_type_subst: &std::collections::HashMap<Spur, Type>,
+        self_is_mut: bool,
     ) -> CompileResult<(
         Air,
         u32,
@@ -661,6 +677,7 @@ impl<'a> BodySema<'a> {
             Some(captured_comptime_values),
             false,
             false,
+            self_is_mut,
         )
     }
 
@@ -720,6 +737,9 @@ impl<'a> BodySema<'a> {
             Some(&type_subst),
             Some(captured_comptime_values),
             /* is_destructor */ true,
+            false,
+            // Anonymous-struct destructors keep an immutable `self`, matching
+            // named `drop fn`.
             false,
         )?;
 

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -354,16 +354,17 @@ impl<'a> BodySema<'a> {
         // For struct parameters, the slot count is the number of fields.
         let mut next_abi_slot: u32 = 0;
         for (pname, ptype, mode, is_comptime) in params.iter() {
+            // Only the synthetic `self` entry of a `mut self` method can be a
+            // mutable by-value binding; ordinary parameters have no `mut`
+            // form.
+            let is_mut_binding = self_is_mut && *pname == self_sym && *mode == RirParamMode::Normal;
             param_vec.push(ParamInfo {
                 name: *pname,
                 abi_slot: next_abi_slot,
                 ty: *ptype,
                 mode: *mode,
                 is_comptime: *is_comptime,
-                // Only the synthetic `self` entry of a `mut self` method can
-                // be a mutable by-value binding; ordinary parameters have no
-                // `mut` form.
-                is_mut: self_is_mut && *pname == self_sym && *mode == RirParamMode::Normal,
+                is_mut: is_mut_binding,
             });
             // Inout and Borrow parameters are passed by reference.
             // Comptime parameters are VALUE params (like `comptime n: i32`), passed by value.
@@ -403,7 +404,12 @@ impl<'a> BodySema<'a> {
             };
             for _ in 0..slot_count {
                 param_by_ref.push(is_by_ref);
-                param_writable.push(*mode == RirParamMode::Inout);
+                // "Writable" means the body may store to the slot: `inout`
+                // (by-ref, written back to the caller) or a `mut self`
+                // receiver (by-value, callee-local). Optimizers and the
+                // oracle contract read this to know the slot can change
+                // between reads.
+                param_writable.push(*mode == RirParamMode::Inout || is_mut_binding);
             }
             next_abi_slot += slot_count;
         }

--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -287,6 +287,16 @@ impl<'a> BodySema<'a> {
                         },
                         inst.span,
                     )),
+                    // The engine never produces string values (string consts
+                    // are non-evaluable in comptime position, RUE-957); keep
+                    // a clean diagnostic should that ever change.
+                    Some(ConstValue::String(_)) => Err(CompileError::new(
+                        ErrorKind::ComptimeEvaluationFailed {
+                            reason: "string values are not supported in comptime blocks"
+                                .to_string(),
+                        },
+                        inst.span,
+                    )),
                     Some(ConstValue::Unit) => {
                         let ty = Type::UNIT;
                         let air_ref = air.add_inst(AirInst {
@@ -488,16 +498,7 @@ impl<'a> BodySema<'a> {
                 // Provide more specific error based on whether it's a param or local
                 match trace.base {
                     AirPlaceBase::Param(_) => {
-                        return Err(CompileError::new(
-                            ErrorKind::AssignToImmutable(root_name.clone()),
-                            span,
-                        )
-                        .with_help(format!(
-                            "consider making parameter `{}` inout: `inout {}: {}`",
-                            root_name,
-                            root_name,
-                            root_type.safe_name_with_pool(Some(&self.type_pool))
-                        )));
+                        return Err(self.immutable_param_assign_error(&root_name, root_type, span));
                     }
                     AirPlaceBase::Local(_) => {
                         return Err(CompileError::new(
@@ -658,16 +659,7 @@ impl<'a> BodySema<'a> {
                 let root_type = trace.base_type;
                 match trace.base {
                     AirPlaceBase::Param(_) => {
-                        return Err(CompileError::new(
-                            ErrorKind::AssignToImmutable(root_name.clone()),
-                            span,
-                        )
-                        .with_help(format!(
-                            "consider making parameter `{}` inout: `inout {}: {}`",
-                            root_name,
-                            root_name,
-                            root_type.safe_name_with_pool(Some(&self.type_pool))
-                        )));
+                        return Err(self.immutable_param_assign_error(&root_name, root_type, span));
                     }
                     AirPlaceBase::Local(_) => {
                         return Err(CompileError::new(

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -600,7 +600,8 @@ impl<'a> BodySema<'a> {
     /// Whether a method receiver rooted at `root` binds a mutable place, for
     /// the `inout self` mut-binding requirement (RUE-15). A `let mut` local is
     /// mutable; an `inout` parameter is mutable (it already names mutable
-    /// caller storage); everything else (`let`, `borrow` params) is not.
+    /// caller storage); a `mut self` receiver is a mutable by-value binding;
+    /// everything else (`let`, plain params, `borrow` params) is not.
     /// Mirrors `PlaceTrace::is_root_mutable`.
     pub(super) fn receiver_root_is_mutable(&self, root: Spur, ctx: &AnalysisContext) -> bool {
         // Locals shadow parameters (RUE-278): a `let mut` rebinding a param
@@ -609,7 +610,7 @@ impl<'a> BodySema<'a> {
             return local.is_mut;
         }
         if let Some(param) = ctx.params.iter().find(|p| p.name == root) {
-            return param.mode == RirParamMode::Inout;
+            return param.mode == RirParamMode::Inout || param.is_mut;
         }
         false
     }

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -184,6 +184,10 @@ impl<'a> BodySema<'a> {
                     ConstValue::Bool(_) => Type::BOOL,
                     ConstValue::Type(t) => *t,
                     ConstValue::Function(_) => Type::COMPTIME_TYPE,
+                    // No comptime parameter has a string type, so a captured
+                    // string value never occurs (RUE-957); skip rather than
+                    // fabricate a type for it.
+                    ConstValue::String(_) => continue,
                     ConstValue::Unit => Type::UNIT,
                 };
                 param_vars.entry(*name).or_insert(ParamVarInfo {
@@ -469,7 +473,8 @@ impl<'a> BodySema<'a> {
             // rejecting it as field access on a non-struct (RUE-632). A
             // constant inlines a fresh value, so no move state applies.
             if let Some(module_id) = base_type.as_module() {
-                return self.analyze_module_type_member_access(air, module_id, field, field_span);
+                return self
+                    .analyze_module_type_member_access(air, module_id, field, field_span, ctx);
             }
 
             let struct_id = match base_type.kind() {

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -333,7 +333,11 @@ impl<'a> BodySema<'a> {
                         base_type: param_info.ty,
                         projections: Vec::new(),
                         root_var: *name,
-                        is_root_mutable: matches!(param_info.mode, RirParamMode::Inout),
+                        // `inout` names mutable caller storage; a `mut self`
+                        // receiver is a mutable by-value binding (callee copy
+                        // only).
+                        is_root_mutable: matches!(param_info.mode, RirParamMode::Inout)
+                            || param_info.is_mut,
                         is_borrow_param: matches!(param_info.mode, RirParamMode::Borrow),
                     }));
                 }
@@ -2836,7 +2840,12 @@ impl<'a> BodySema<'a> {
     ///
     /// Negative integers are sign-extended into the u64 payload (two's
     /// complement), matching how comptime-block results are emitted.
-    fn materialize_const_value(value: ConstValue, ty: Type) -> (AirInstData, Type) {
+    fn materialize_const_value(
+        &mut self,
+        ctx: &mut AnalysisContext,
+        value: ConstValue,
+        ty: Type,
+    ) -> (AirInstData, Type) {
         match value {
             ConstValue::Integer(v) => (AirInstData::Const(v as u64), ty),
             ConstValue::Bool(b) => (AirInstData::BoolConst(b), Type::BOOL),
@@ -2845,6 +2854,15 @@ impl<'a> BodySema<'a> {
                 "function-valued constants are callable aliases and must not be materialized"
             ),
             ConstValue::Type(t) => (AirInstData::TypeConst(t), Type::COMPTIME_TYPE),
+            // A string constant materializes exactly like an inline string
+            // literal: its content joins the function's local string table
+            // and lowers to a `.rodata`-backed value of the declared type
+            // (always `str`, so the 2-word `{ptr, len}` shape; RUE-957).
+            ConstValue::String(content) => {
+                let content = self.interner.resolve(&content).to_string();
+                let local_id = ctx.add_local_string(content);
+                (AirInstData::StringConst(local_id), ty)
+            }
         }
     }
 
@@ -3090,6 +3108,16 @@ impl<'a> BodySema<'a> {
                         span,
                     ));
                 }
+                // No comptime parameter has a string type, so a captured
+                // string value never occurs (RUE-957).
+                ConstValue::String(_) => {
+                    return Err(CompileError::new(
+                        ErrorKind::ConstExprNotSupported {
+                            expr_kind: "a captured string value".to_string(),
+                        },
+                        span,
+                    ));
+                }
                 ConstValue::Unit => {
                     let air_ref = air.add_inst(AirInst {
                         data: AirInstData::Const(0),
@@ -3149,7 +3177,7 @@ impl<'a> BodySema<'a> {
                     span,
                 ));
             }
-            let (data, ty) = Self::materialize_const_value(const_info.value, const_info.ty);
+            let (data, ty) = self.materialize_const_value(ctx, const_info.value, const_info.ty);
             let air_ref = air.add_inst(AirInst { data, ty, span });
             return Ok(AnalysisResult::new(air_ref, ty));
         }
@@ -3185,6 +3213,32 @@ impl<'a> BodySema<'a> {
     }
 
     /// Analyze an assignment.
+    /// E0203 for a write through an immutable by-value parameter, with a
+    /// receiver-aware hint: a method's `self` should be declared `mut self`
+    /// (callee-local) or `inout self` (write-back), while an ordinary
+    /// parameter's only mutable form is `inout`.
+    pub(crate) fn immutable_param_assign_error(
+        &self,
+        name_str: &str,
+        ty: Type,
+        span: Span,
+    ) -> CompileError {
+        let error = CompileError::new(ErrorKind::AssignToImmutable(name_str.to_string()), span);
+        if name_str == "self" {
+            error.with_help(
+                "consider declaring the receiver mutable: `mut self` (mutates the callee's copy \
+                 only), or `inout self` to write back to the caller",
+            )
+        } else {
+            error.with_help(format!(
+                "consider making parameter `{}` inout: `inout {}: {}`",
+                name_str,
+                name_str,
+                ty.safe_name_with_pool(Some(&self.type_pool))
+            ))
+        }
+    }
+
     fn analyze_assign(
         &mut self,
         air: &mut Air,
@@ -3214,19 +3268,19 @@ impl<'a> BodySema<'a> {
         // against the immutable parameter with a bogus "make it inout" hint.
         if !ctx.locals.contains_key(&name) {
             if let Some(param_info) = ctx.params.iter().find(|p| p.name == name) {
-                // Check parameter mode - only inout can be assigned to
+                // Check parameter mode - inout params and `mut self` (a
+                // mutable by-value receiver binding) can be assigned to
                 match param_info.mode {
+                    RirParamMode::Normal if param_info.is_mut => {
+                        // `mut self`: assignment mutates the callee's copy
+                        // only; there is no write-back to the caller.
+                    }
                     RirParamMode::Normal => {
-                        return Err(CompileError::new(
-                            ErrorKind::AssignToImmutable(name_str.to_string()),
+                        return Err(self.immutable_param_assign_error(
+                            name_str,
+                            param_info.ty,
                             span,
-                        )
-                        .with_help(format!(
-                            "consider making parameter `{}` inout: `inout {}: {}`",
-                            name_str,
-                            name_str,
-                            param_info.ty.safe_name_with_pool(Some(&self.type_pool))
-                        )));
+                        ));
                     }
                     RirParamMode::Inout => {
                         // Inout parameters can be assigned to
@@ -3940,7 +3994,8 @@ impl<'a> BodySema<'a> {
                     // Member access is a use of the binding (`let m =
                     // @import(..); m.ANSWER` must not warn about `m`).
                     ctx.used_locals.insert(*name);
-                    return self.analyze_module_type_member_access(air, module_id, field, span);
+                    return self
+                        .analyze_module_type_member_access(air, module_id, field, span, ctx);
                 }
             }
         }
@@ -4173,7 +4228,7 @@ impl<'a> BodySema<'a> {
 
         // Handle module member access that wasn't caught above
         if let Some(module_id) = base_type.as_module() {
-            return self.analyze_module_type_member_access(air, module_id, field, span);
+            return self.analyze_module_type_member_access(air, module_id, field, span, ctx);
         }
 
         let struct_id = match base_type.as_struct() {
@@ -4304,6 +4359,7 @@ impl<'a> BodySema<'a> {
         module_id: crate::types::ModuleId,
         member_name: Spur,
         span: Span,
+        ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         let member_name_str = self.interner.resolve(&member_name).to_string();
 
@@ -4475,7 +4531,7 @@ impl<'a> BodySema<'a> {
             // A value const (e.g. `pub const ANSWER = ...`) accessed as a
             // module member: materialize the value that was evaluated at
             // declaration time, typed as declared (RUE-160).
-            let (data, ty) = Self::materialize_const_value(const_info.value, const_info.ty);
+            let (data, ty) = self.materialize_const_value(ctx, const_info.value, const_info.ty);
             let air_ref = air.add_inst(AirInst { data, ty, span });
             return Ok(AnalysisResult::new(air_ref, ty));
         }

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -80,8 +80,13 @@ pub enum SemanticExportConstValue {
     Integer(i128),
     Bool(bool),
     Type(SemanticExportType),
-    Function { file_id: FileId, name: Arc<str> },
+    Function {
+        file_id: FileId,
+        name: Arc<str>,
+    },
     Unit,
+    /// String constant content (RUE-957), carried as the literal text.
+    String(Arc<str>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -583,6 +588,7 @@ impl<'a> DeclarationShells<'a> {
                         return_type,
                         params,
                         self_mode,
+                        self_is_mut,
                         directives,
                         ..
                     } = &self.sema.rir.get(pending.declaration).data
@@ -643,6 +649,7 @@ impl<'a> DeclarationShells<'a> {
                                 struct_type: Type::new_struct(id),
                                 has_self: *has_self,
                                 self_mode: *self_mode,
+                                self_is_mut: *self_is_mut,
                                 params: range,
                                 return_type: return_type_value,
                                 body,
@@ -1623,6 +1630,9 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                             SemanticExportConstValue::Type(self.export_type(t, &mut Vec::new())?)
                         }
                         ConstValue::Unit => SemanticExportConstValue::Unit,
+                        ConstValue::String(content) => SemanticExportConstValue::String(Arc::from(
+                            self.interner.resolve(&content),
+                        )),
                         ConstValue::Function(symbol) => {
                             let fi = self
                                 .functions

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1146,6 +1146,15 @@ impl<D: DeclarationPhase> Sema<'_, D> {
                         info.is_pub,
                         span,
                     )?;
+                    // String constants stay out of the comptime engine: no
+                    // engine operation consumes them (no comptime string
+                    // params or string arithmetic), so treat a reference as
+                    // non-evaluable instead of leaking a value the arms
+                    // below would mis-type (RUE-957). Use sites materialize
+                    // string constants through the runtime path instead.
+                    if matches!(info.value, super::ConstValue::String(_)) {
+                        return Ok(None);
+                    }
                     return Ok(Some(info.value));
                 }
                 // 7. Type names used as values (e.g. `Point` in

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -303,6 +303,11 @@ pub(crate) struct ParamInfo {
     /// `RirParam::is_comptime`). Used to allow forwarding a comptime
     /// parameter to another function's comptime parameter (spec 4.14:5).
     pub is_comptime: bool,
+    /// Whether the binding is mutable in the body despite being by-value
+    /// (`mode == Normal`). Today this is only true for a `mut self`
+    /// receiver; mutations affect the callee's copy only, with no
+    /// write-back to the caller (that is `Inout`).
+    pub is_mut: bool,
 }
 
 /// How a call argument (or method receiver) loans its root variable for the
@@ -815,6 +820,14 @@ pub enum ConstValue {
     /// be used as the callee of a call expression, but cannot be materialized
     /// as ordinary runtime values.
     Function(lasso::Spur),
+    /// String value - stores the interned literal content (RUE-957).
+    ///
+    /// A string constant's use sites materialize it exactly like an inline
+    /// string literal: the content joins the function's local string table
+    /// and lowers to `.rodata`-backed `str` (`{ptr, len}`). String constants
+    /// are not usable as comptime arguments (no `comptime s: str` parameters
+    /// exist), so specialization serialization rejects them.
+    String(lasso::Spur),
     /// Unit value - the value of `()`.
     Unit,
 }
@@ -878,6 +891,12 @@ impl ConstValue {
             ConstValue::Bool(_) => Type::BOOL,
             ConstValue::Type(_) => Type::COMPTIME_TYPE,
             ConstValue::Function(_) => Type::COMPTIME_TYPE,
+            // The `str` struct type lives in the type pool, which this
+            // pool-free helper cannot reach. Both callers type-check comptime
+            // arguments, which string constants never reach (the comptime
+            // engine treats them as non-evaluable), so this arm only has to
+            // avoid colliding with a real comptime parameter type.
+            ConstValue::String(_) => Type::ERROR,
             ConstValue::Unit => Type::UNIT,
         }
     }

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1553,6 +1553,7 @@ impl<'a> Sema<'a> {
                 body,
                 has_self,
                 self_mode,
+                self_is_mut,
                 ..
             } = &method_inst.data
             {
@@ -1612,6 +1613,7 @@ impl<'a> Sema<'a> {
                         struct_type,
                         has_self: *has_self,
                         self_mode: *self_mode,
+                        self_is_mut: *self_is_mut,
                         params: param_range,
                         return_type: ret_type,
                         body: *body,
@@ -1981,14 +1983,10 @@ impl<'a> Sema<'a> {
                 }
             }
 
-            // String constants would need the String type; not supported in
-            // const context yet.
-            InstData::StringConst(_) => Err(CompileError::new(
-                ErrorKind::ConstExprNotSupported {
-                    expr_kind: "string literals".to_string(),
-                },
-                span,
-            )),
+            // A string literal is directly a constant value (RUE-957). It is
+            // stored as the interned content; use sites materialize it like
+            // an inline literal (local string table -> `.rodata` `str`).
+            InstData::StringConst(content) => Ok(ConstInit::Value(ConstValue::String(*content))),
 
             // Everything else: literals, arithmetic, comptime blocks, ... —
             // evaluated by the comptime engine.
@@ -2868,6 +2866,10 @@ impl<'a> Sema<'a> {
             }
             ConstValue::Bool(_) => Type::BOOL,
             ConstValue::Unit => Type::UNIT,
+            // A string constant is always the static view type `str`; the
+            // owning (`StrBuf`) and fixed (`Str(N)`) representations stay
+            // runtime-only (RUE-957).
+            ConstValue::String(_) => self.get_or_create_str_struct(span)?,
             ConstValue::Function(_) | ConstValue::Type(_) => Type::COMPTIME_TYPE,
         };
 

--- a/crates/rue-air/src/sema/info.rs
+++ b/crates/rue-air/src/sema/info.rs
@@ -69,6 +69,10 @@ pub struct MethodInfo {
     /// by-value, `Borrow`, or `Inout`; RUE-15). Determines how the receiver
     /// is passed at call sites (by value vs. by reference / autoref).
     pub self_mode: rue_rir::RirParamMode,
+    /// Whether the receiver is declared `mut self` (by-value receiver that
+    /// binds mutably in the method body). Body-local only: call sites and
+    /// structural identity (`AnonMethodSig`) deliberately ignore it.
+    pub self_is_mut: bool,
     /// Parameter data (names, types, modes, comptime flags) stored in arena.
     /// Access via `arena.names(params)`, `arena.types(params)`, etc.
     /// Note: This excludes `self` if present - only explicit parameters.

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -66,6 +66,12 @@ impl BodySema<'_> {
                         SemanticImportConstValue::Function(self.function_identity(*value)?)
                     }
                     super::ConstValue::Unit => SemanticImportConstValue::Unit,
+                    // Comptime parameters have no string type, so a string
+                    // specialization argument never occurs (RUE-957); export
+                    // the content faithfully regardless.
+                    super::ConstValue::String(content) => SemanticImportConstValue::String(
+                        std::sync::Arc::from(self.interner.resolve(content)),
+                    ),
                 })
             })
             .collect::<Result<Vec<_>, F>>()?;

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -1442,7 +1442,7 @@ mod tests {
             );
         }
 
-        assert_eq!(SEMANTIC_IMPORT_CONST_KINDS.len(), 5);
+        assert_eq!(SEMANTIC_IMPORT_CONST_KINDS.len(), 6);
         for (tag, kind) in SEMANTIC_IMPORT_CONST_KINDS.iter().copied().enumerate() {
             assert_eq!(usize::from(kind.schema_tag()), tag);
             assert_eq!(kind.to_string(), kind.display_name());
@@ -1593,6 +1593,7 @@ mod tests {
             SemanticImportConstValue::Type(ImportType::Module("pkg/main.rue")),
             SemanticImportConstValue::Function("callable"),
             SemanticImportConstValue::Unit,
+            SemanticImportConstValue::String(std::sync::Arc::from("hello")),
         ];
         for value in values {
             let mapped = value

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -171,6 +171,10 @@ pub enum SemanticImportConstValue<K, M> {
     Type(SemanticImportType<K, M>),
     Function(K),
     Unit,
+    /// String constant content (RUE-957). Carried as the literal text —
+    /// interner symbols are process-local and cannot cross the import
+    /// boundary.
+    String(std::sync::Arc<str>),
 }
 
 macro_rules! semantic_import_const_schema {
@@ -181,6 +185,7 @@ macro_rules! semantic_import_const_schema {
             Type, SemanticImportConstValue::Type(..), 2, "type";
             Function, SemanticImportConstValue::Function(..), 3, "function";
             Unit, SemanticImportConstValue::Unit, 4, "unit";
+            String, SemanticImportConstValue::String(..), 5, "string";
         }
     };
 }
@@ -319,6 +324,7 @@ impl<K, M> SemanticImportConstValue<K, M> {
             }
             Self::Function(value) => SemanticImportConstValue::Function(key(value)?),
             Self::Unit => SemanticImportConstValue::Unit,
+            Self::String(value) => SemanticImportConstValue::String(value.clone()),
         })
     }
 }
@@ -1166,6 +1172,12 @@ where
                     .ok_or(SemanticImportFailure::MissingFunction)?,
             ),
             SemanticImportConstValue::Unit => ConstValue::Unit,
+            // The epoch owns an isolated interner, so the content round-trips
+            // through it for validation; durable const payloads are never
+            // installed into a live Sema (install fails closed on consts).
+            SemanticImportConstValue::String(content) => {
+                ConstValue::String(self.interner.get_or_intern(content.as_ref()))
+            }
         })
     }
 
@@ -1284,6 +1296,9 @@ where
                     .ok_or(SemanticImportFailure::ForeignLocalValue)?,
             ),
             ConstValue::Unit => SemanticImportConstValue::Unit,
+            ConstValue::String(content) => {
+                SemanticImportConstValue::String(Arc::from(self.interner.resolve(&content)))
+            }
         })
     }
 

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -153,6 +153,11 @@ impl Specializer {
                         crate::SemanticImportConstValue::Function(sema.function_identity(*value)?)
                     }
                     ConstValue::Unit => crate::SemanticImportConstValue::Unit,
+                    // Comptime parameters have no string type (RUE-957);
+                    // export the content faithfully regardless.
+                    ConstValue::String(content) => crate::SemanticImportConstValue::String(
+                        std::sync::Arc::from(sema.interner.resolve(content)),
+                    ),
                 })
             })
             .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
@@ -641,6 +646,10 @@ fn mangle_const_value(value: &ConstValue) -> String {
         ConstValue::Unit => "vunit".to_string(),
         ConstValue::Type(ty) => format!("v{}", mangle_type(*ty)),
         ConstValue::Function(name) => format!("vfn{}", name.into_usize()),
+        // Comptime parameters have no string type, so strings never appear
+        // in a specialization key (RUE-957). The interner index still gives
+        // a unique, symbol-safe fragment should that ever change.
+        ConstValue::String(content) => format!("vstr{}", content.into_usize()),
     }
 }
 
@@ -801,6 +810,8 @@ fn create_specialized_function(
         base_info.body,
         &type_subst,
         &value_subst,
+        // Specialization covers free functions; they have no receiver.
+        false,
     );
     sema.body_dependency_observer = previous_body_observer;
     sema.declaration_type_observer = previous_type_observer;

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -1287,7 +1287,10 @@ impl Cfg {
             .unwrap_or(false)
     }
 
-    /// Get whether a parameter ABI slot is logically writable (`inout`).
+    /// Get whether a parameter ABI slot is logically writable: `inout`
+    /// (by-ref, written back to the caller) or a `mut self` receiver slot
+    /// (by-value, callee-local mutation only). Combine with
+    /// [`Cfg::is_param_by_ref`] to distinguish the two.
     #[inline]
     pub fn is_param_writable(&self, slot: u32) -> bool {
         self.param_modes

--- a/crates/rue-cfg/src/opt/cse.rs
+++ b/crates/rue-cfg/src/opt/cse.rs
@@ -43,12 +43,13 @@
 //! yields the identical value. A `Param { index }`'s `index` is the parameter's
 //! ABI slot (the same numbering as [`Cfg::is_param_writable`] and a
 //! `ParamStore`'s `param_slot`; both flow from sema's `abi_slot`). A slot is
-//! treated as never-written when it is (a) not logically writable by-ref
-//! (`is_param_writable(slot) == false`, i.e. `borrow` or by-value, never
-//! `inout`) and (b) receives no `ParamStore` anywhere among the block-attached
-//! instructions. By-value (`Normal`) parameters are immutable in the callee
-//! (assignment is rejected, E0203) and `borrow` parameters cannot be written, so
-//! only `inout` slots — excluded by (a) — and any slot a `ParamStore` targets —
+//! treated as never-written when it is (a) not logically writable
+//! (`is_param_writable(slot) == false`, i.e. `borrow` or plain by-value —
+//! never `inout`, and never a `mut self` receiver slot) and (b) receives no
+//! `ParamStore` anywhere among the block-attached instructions. Plain
+//! by-value (`Normal`) parameters are immutable in the callee (assignment is
+//! rejected, E0203) and `borrow` parameters cannot be written, so only
+//! writable slots — excluded by (a) — and any slot a `ParamStore` targets —
 //! excluded by (b) — are left out. (As defense in depth, a projected
 //! `PlaceWrite` whose base is a parameter slot also excludes it, though such a
 //! write only ever targets an already-excluded `inout` slot.)

--- a/crates/rue-cli-tests/cases/const_init.toml
+++ b/crates/rue-cli-tests/cases/const_init.toml
@@ -268,3 +268,40 @@ fn main() -> i32 { 0 }
 """ }]
 compile_fail = true
 error_contains = ["E0434", "not supported in const context"]
+
+# String constants (RUE-957): a top-level `const DIR: str = "..."` was E0434
+# ("string literals is not supported in const context"); the workaround was a
+# function returning the literal. Pin the runtime behavior end-to-end,
+# including the printed bytes and cross-file member access.
+[[case]]
+name = "string_const_prints_and_measures"
+files = [{ path = "main.rue", source = """
+const DIR: str = "/tmp/rue-out";
+const BANNER: str = "rue says hi";
+
+fn main() -> i32 {
+    println(BANNER);
+    println(DIR);
+    @intCast(DIR.len())
+}
+""" }]
+exit_code = 12
+stdout = "rue says hi\n/tmp/rue-out\n"
+
+[[case]]
+name = "string_const_cross_module"
+files = [
+  { path = "main.rue", source = """
+const util = @import("util.rue");
+
+fn main() -> i32 {
+    println(util.NAME);
+    @intCast(util.NAME.len())
+}
+""" },
+  { path = "util.rue", source = """
+pub const NAME: str = "rue-util";
+""" },
+]
+exit_code = 8
+stdout = "rue-util\n"

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1047,11 +1047,25 @@ impl<'a> CfgLower<'a> {
                 if value_shape.slot_count() == 0 {
                     return ValueResult::SideEffect;
                 }
-                let ptr = self.ensure_by_ref_param_ptr(param_slot);
-                if value.slots.is_empty() {
-                    self.emit_store_ptr_base(value.primary, ptr);
+                if self.ctx.cfg.is_param_by_ref(param_slot) {
+                    let ptr = self.ensure_by_ref_param_ptr(param_slot);
+                    if value.slots.is_empty() {
+                        self.emit_store_ptr_base(value.primary, ptr);
+                    } else {
+                        crate::agg_slots::store_slots_through_ptr(self, &value.slots, ptr, 0);
+                    }
                 } else {
-                    crate::agg_slots::store_slots_through_ptr(self, &value.slots, ptr, 0);
+                    // By-value slot (a `mut self` receiver): the param area
+                    // itself holds the value, so write the slots directly —
+                    // there is no pointer to chase and no caller write-back.
+                    // Mirrors the projection-free by-value Param arm of
+                    // `place_lower::lower_place_write_plan`.
+                    let vals = if value.slots.is_empty() {
+                        vec![value.primary]
+                    } else {
+                        value.slots
+                    };
+                    crate::agg_slots::store_slots(self, &vals, self.ctx.num_locals + param_slot);
                 }
                 return ValueResult::SideEffect;
             }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1271,11 +1271,25 @@ impl<'a> CfgLower<'a> {
                 if value_shape.slot_count() == 0 {
                     return ValueResult::SideEffect;
                 }
-                let ptr = self.ensure_by_ref_param_ptr(param_slot);
-                if value.slots.is_empty() {
-                    self.emit_store_ptr_base(value.primary, ptr);
+                if self.ctx.cfg.is_param_by_ref(param_slot) {
+                    let ptr = self.ensure_by_ref_param_ptr(param_slot);
+                    if value.slots.is_empty() {
+                        self.emit_store_ptr_base(value.primary, ptr);
+                    } else {
+                        crate::agg_slots::store_slots_through_ptr(self, &value.slots, ptr, 0);
+                    }
                 } else {
-                    crate::agg_slots::store_slots_through_ptr(self, &value.slots, ptr, 0);
+                    // By-value slot (a `mut self` receiver): the param area
+                    // itself holds the value, so write the slots directly —
+                    // there is no pointer to chase and no caller write-back.
+                    // Mirrors the projection-free by-value Param arm of
+                    // `place_lower::lower_place_write_plan`.
+                    let vals = if value.slots.is_empty() {
+                        vec![value.primary]
+                    } else {
+                        value.slots
+                    };
+                    crate::agg_slots::store_slots(self, &vals, self.ctx.num_locals + param_slot);
                 }
                 return ValueResult::SideEffect;
             }

--- a/crates/rue-compiler/src/durable_body.rs
+++ b/crates/rue-compiler/src/durable_body.rs
@@ -398,6 +398,7 @@ fn canonical_const_value(
             SemanticImportConstValue::Function(key.clone())
         }
         SemanticImportConstValue::Unit => SemanticImportConstValue::Unit,
+        SemanticImportConstValue::String(value) => SemanticImportConstValue::String(value.clone()),
     })
 }
 

--- a/crates/rue-compiler/src/durable_compatibility_tests.rs
+++ b/crates/rue-compiler/src/durable_compatibility_tests.rs
@@ -20,14 +20,16 @@ use crate::*;
 const REVIEWED_SEMANTIC_SCHEMA: DurableSemanticSchemaVersion = DurableSemanticSchemaVersion {
     major: 1,
     minor: 0,
-    implementation_epoch: 1,
+    // Epoch 2: const string values joined the durable const payloads
+    // (SemanticImportConstValue::String, RUE-957).
+    implementation_epoch: 2,
 };
 const REVIEWED_ORDINARY_BODY_SCHEMA: u32 = 6;
 const REVIEWED_SPECIALIZED_BODY_SCHEMA: u32 = 5;
 const REVIEWED_CFG_SCHEMA: u32 = 1;
 const REVIEWED_BODY_KINDS: usize = 58;
 const REVIEWED_TYPE_KINDS: usize = 19;
-const REVIEWED_CONST_KINDS: usize = 5;
+const REVIEWED_CONST_KINDS: usize = 6;
 const REVIEWED_DECLARATION_PAYLOAD_KINDS: usize = 5;
 const REVIEWED_DEFINITION_KINDS: usize = 8;
 const REVIEWED_DEFINITION_NAMESPACES: usize = 4;
@@ -227,6 +229,7 @@ fn every_type_const_and_specialization_identity_round_trips_same_version() {
         C::Type(types[14].clone()),
         C::Function(function.clone()),
         C::Unit,
+        C::String(Arc::from("hello")),
     ];
     assert_eq!(
         consts.iter().map(C::kind).collect::<BTreeSet<_>>(),

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -219,7 +219,9 @@ pub const DURABLE_SEMANTIC_SCHEMA_VERSION: DurableSemanticSchemaVersion =
     DurableSemanticSchemaVersion {
         major: 1,
         minor: 0,
-        implementation_epoch: 1,
+        // Epoch 2: const string values joined the durable const payloads
+        // (SemanticImportConstValue::String, RUE-957).
+        implementation_epoch: 2,
     };
 
 const DURABLE_SEMANTIC_COMPATIBLE_MINORS: &[u16] = &[0];
@@ -909,6 +911,9 @@ pub(crate) fn convert_declaration_semantics(
                         DurableConstValue::Type(ty(t, merged, definitions)?)
                     }
                     SemanticExportConstValue::Unit => DurableConstValue::Unit,
+                    SemanticExportConstValue::String(content) => {
+                        DurableConstValue::String(content.clone())
+                    }
                     SemanticExportConstValue::Function { file_id, name } => {
                         DurableConstValue::Function(
                             key_for(*file_id, name, StableDefinitionKind::Function, None).ok_or(

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -278,6 +278,12 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
+        "cli.const_init",
+        "string_const_prints_and_measures",
+        runtime_call(UnsupportedRuntimeCallKind::Println),
+        &[],
+    ),
+    Entry::new(
         "cli.differential_opt",
         "fixed_string_inout_forwarding_and_projected_lvalues_across_opt_levels",
         semantic(SemanticGapKind::InoutParameterForwarding),

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -599,6 +599,12 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
+        "items.impl-blocks",
+        "mut_self_allows_inout_method_call",
+        semantic(SemanticGapKind::InoutParameterForwarding),
+        &[],
+    ),
+    Entry::new(
         "items.unchecked",
         "ptr_ops_in_checked_ok",
         intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -218,6 +218,12 @@ pub struct Method {
 pub struct SelfParam {
     /// Receiver passing mode (`Normal` by-value, `Borrow`, or `Inout`).
     pub mode: ParamMode,
+    /// Whether the receiver is declared `mut self`: the by-value receiver
+    /// binds mutably in the method body, like `let mut`. Mutations affect
+    /// only the callee's copy — there is no write-back to the caller (that
+    /// is `inout self`). Only valid with `mode == Normal`; the parser never
+    /// produces `is_mut` together with `Borrow`/`Inout`.
+    pub is_mut: bool,
     /// Span covering the `self` keyword (and any leading mode keyword).
     pub span: Span,
 }

--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -31,6 +31,7 @@ struct PrimitiveTypeSpurs {
     u64: Spur,
     bool: Spur,
     self_type: Spur,
+    self_value: Spur,
     type_kw: Spur,
     as_kw: Spur,
     underscore: Spur,
@@ -53,6 +54,7 @@ impl PrimitiveTypeSpurs {
             u64: interner.get_or_intern("u64"),
             bool: interner.get_or_intern("bool"),
             self_type: interner.get_or_intern("Self"),
+            self_value: interner.get_or_intern("self"),
             type_kw: interner.get_or_intern("type"),
             as_kw: interner.get_or_intern("as"),
             drop_kw: interner.get_or_intern("drop"),
@@ -534,6 +536,7 @@ impl Parser {
             type_name,
             self_param: SelfParam {
                 mode: ParamMode::Normal,
+                is_mut: false,
                 span: self_tok.span,
             },
             body,
@@ -865,17 +868,24 @@ impl Parser {
         let mut params = Vec::new();
         if !self.at(TokenKind::RParen) {
             let checkpoint = self.cursor;
-            let mode = if self.eat(TokenKind::Inout) {
-                ParamMode::Inout
+            // Receiver modifiers are mutually exclusive: `inout self`,
+            // `borrow self`, or `mut self` (a by-value receiver that binds
+            // mutably in the body). If `self` doesn't follow, the cursor is
+            // reset and the tokens re-parse as an ordinary parameter list.
+            let (mode, is_mut) = if self.eat(TokenKind::Inout) {
+                (ParamMode::Inout, false)
             } else if self.eat(TokenKind::Borrow) {
-                ParamMode::Borrow
+                (ParamMode::Borrow, false)
+            } else if self.eat(TokenKind::Mut) {
+                (ParamMode::Normal, true)
             } else {
-                ParamMode::Normal
+                (ParamMode::Normal, false)
             };
             if self.at(TokenKind::SelfValue) {
                 let tok = self.bump();
                 receiver = Some(SelfParam {
                     mode,
+                    is_mut,
                     span: Span::with_file(
                         self.file_id,
                         self.tokens[checkpoint].span.start,
@@ -941,6 +951,7 @@ impl Parser {
             },
             receiver: Some(SelfParam {
                 mode: ParamMode::Normal,
+                is_mut: false,
                 span: tok.span,
             }),
             params: Vec::new(),
@@ -1935,7 +1946,7 @@ impl Parser {
                 self.expr()?
             };
             if self.eat(TokenKind::Eq) {
-                let target = expr_to_target(value).ok_or_else(|| {
+                let target = expr_to_target(value, self.syms.self_value).ok_or_else(|| {
                     self.error("invalid assignment target");
                 })?;
                 let rhs = Box::new(self.expr()?);
@@ -2223,11 +2234,17 @@ fn binary_binding(kind: TokenKind) -> Option<(u8, u8, BinaryOp)> {
     Some((p, p + 1, op))
 }
 
-fn expr_to_target(expr: Expr) -> Option<AssignTarget> {
+fn expr_to_target(expr: Expr, self_value: Spur) -> Option<AssignTarget> {
     match expr {
         Expr::Ident(id) => Some(AssignTarget::Var(id)),
         Expr::Field(field) => Some(AssignTarget::Field(field)),
         Expr::Index(index) => Some(AssignTarget::Index(index)),
+        // `self = value` targets the receiver binding; sema enforces that
+        // only a `mut self` (or shadowing `let mut`) receiver is assignable.
+        Expr::SelfExpr(se) => Some(AssignTarget::Var(Ident {
+            name: self_value,
+            span: se.span,
+        })),
         _ => None,
     }
 }

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -472,6 +472,12 @@ impl<'a> AstGen<'a> {
             Some(receiver) => self.convert_param_mode(receiver.mode),
             None => RirParamMode::Normal,
         };
+        // `mut self` (by-value receiver binding mutably in the body) is
+        // carried separately from the mode so signatures stay mode-only.
+        let self_is_mut = method
+            .receiver
+            .as_ref()
+            .is_some_and(|receiver| receiver.is_mut);
 
         // Emit methods as FnDecl instructions with has_self flag.
         // Sema uses has_self to add the implicit self parameter for methods,
@@ -490,6 +496,7 @@ impl<'a> AstGen<'a> {
                 body,
                 has_self,
                 self_mode,
+                self_is_mut,
                 method.span,
             )
             .record_failure(&mut self.payload_error);
@@ -586,6 +593,7 @@ impl<'a> AstGen<'a> {
                 body,
                 false,
                 RirParamMode::Normal,
+                false,
                 func.span,
             )
             .record_failure(&mut self.payload_error);

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -5385,6 +5385,7 @@ mod typed_payload_tests {
                 body: reference,
                 has_self: false,
                 self_mode: RirParamMode::Normal,
+                self_is_mut: false,
             },
         );
 

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -1127,6 +1127,7 @@ impl RirEditor {
         body: InstRef,
         has_self: bool,
         self_mode: RirParamMode,
+        self_is_mut: bool,
         span: Span,
     ) -> Result<InstRef, RirPayloadBuildError> {
         self.atomic(|rir| {
@@ -1143,6 +1144,7 @@ impl RirEditor {
                     body,
                     has_self,
                     self_mode,
+                    self_is_mut,
                 },
                 span,
             }))
@@ -3528,6 +3530,12 @@ pub enum InstData {
         /// by-value, `Borrow`, or `Inout`; RUE-15). Always `Normal` for
         /// associated functions and free functions.
         self_mode: RirParamMode,
+        /// Whether the receiver is declared `mut self`: a by-value receiver
+        /// that binds mutably in the method body. Body-local only — it does
+        /// not affect the method's signature, call sites, or structural
+        /// identity, and is always false unless `has_self` is true with
+        /// `self_mode == Normal`.
+        self_is_mut: bool,
     },
 
     /// Constant declaration
@@ -4260,6 +4268,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     body,
                     has_self,
                     self_mode,
+                    self_is_mut,
                 } => {
                     let pub_str = if *is_pub { "pub " } else { "" };
                     let unchecked_str = if *is_unchecked { "unchecked " } else { "" };
@@ -4269,6 +4278,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         match self_mode {
                             RirParamMode::Inout => "inout self, ",
                             RirParamMode::Borrow => "borrow self, ",
+                            RirParamMode::Normal if *self_is_mut => "mut self, ",
                             RirParamMode::Normal => "self, ",
                         }
                     } else {

--- a/crates/rue-spec/cases/items/constants.toml
+++ b/crates/rue-spec/cases/items/constants.toml
@@ -309,3 +309,89 @@ fn main() -> i32 { O.x }
 """
 compile_fail = true
 error_contains = ["E0434"]
+
+# =============================================================================
+# String constants (6.5:16)
+# =============================================================================
+
+[[case]]
+name = "string_const_basic"
+spec = ["6.5:2", "6.5:16", "6.5:17"]
+description = "A string-literal initializer declares a str constant usable like an inline literal (RUE-957)"
+source = """
+const GREETING: str = "hello";
+const EMPTY: str = "";
+
+fn main() -> i32 {
+    let g = GREETING;
+    @intCast(g.len() + GREETING.len() + EMPTY.len())
+}
+"""
+exit_code = 10
+
+[[case]]
+name = "string_const_alias"
+spec = ["6.5:16"]
+description = "A constant initialized from another string constant denotes the same value"
+source = """
+const A: str = "rue";
+const B: str = A;
+
+fn main() -> i32 {
+    @intCast(B.len() + A.len())
+}
+"""
+exit_code = 6
+
+[[case]]
+name = "string_const_module_member"
+spec = ["6.5:16"]
+description = "A pub string constant is usable through module member access"
+source = """
+const util = @import("util");
+
+fn main() -> i32 {
+    let n = util.NAME;
+    @intCast(n.len() + util.NAME.len())
+}
+"""
+aux_files = { "util.rue" = "pub const NAME: str = \"rue-util\";" }
+exit_code = 16
+
+[[case]]
+name = "unannotated_string_const_rejected"
+spec = ["6.5:4", "6.5:16"]
+description = "String constants require an annotation like every value constant; the help names str"
+source = """
+const S = "hello";
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0475", "const S: str = ...;"]
+
+[[case]]
+name = "string_const_non_str_annotation_rejected"
+spec = ["6.5:5", "6.5:16"]
+description = "A string constant's annotation must be str; other annotations are a type mismatch"
+source = """
+const S: i64 = "hello";
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0206", "expected i64, found str"]
+
+[[case]]
+name = "string_const_not_comptime_evaluable"
+spec = ["6.5:2", "6.5:16"]
+description = "String values stay outside comptime blocks"
+source = """
+const S: str = "hello";
+
+fn main() -> i32 {
+    comptime { S }
+}
+"""
+compile_fail = true
+error_contains = ["comptime"]

--- a/crates/rue-spec/cases/items/impl-blocks.toml
+++ b/crates/rue-spec/cases/items/impl-blocks.toml
@@ -637,6 +637,94 @@ fn main() -> i32 {
 }
 """
 
+[[case]]
+name = "mut_self_mutates_callee_copy"
+spec = ["6.4:35", "6.4:37"]
+description = "mut self permits field mutation and whole-receiver reassignment in the body"
+source = """
+struct Counter {
+    n: i32,
+    fn finish(mut self, bonus: i32) -> i32 {
+        self.n = self.n + bonus;
+        self.n
+    }
+    fn replace(mut self) -> i32 {
+        self = Counter { n: 40 };
+        self.n + 2
+    }
+}
+
+fn main() -> i32 {
+    let c = Counter { n: 40 };
+    let a = c.finish(2);
+    let d = Counter { n: 0 };
+    a + d.replace() - 42
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "mut_self_no_caller_writeback"
+spec = ["6.4:35"]
+description = "mut self mutates the callee's copy only; a Copy caller value is unaffected"
+source = """
+@copy
+struct P {
+    n: i32,
+    fn bump(mut self) -> i32 {
+        self.n = self.n + 1;
+        self.n
+    }
+}
+
+fn main() -> i32 {
+    let p = P { n: 20 };
+    let a = p.bump();
+    a + p.n
+}
+"""
+exit_code = 41
+
+[[case]]
+name = "mut_self_allows_inout_method_call"
+spec = ["6.4:35"]
+description = "a mut self receiver is a mutable place for inout self calls"
+source = """
+struct P {
+    n: i32,
+    fn add(inout self, v: i32) { self.n = self.n + v; }
+    fn total(mut self) -> i32 {
+        self.add(2);
+        self.add(30);
+        self.n
+    }
+}
+
+fn main() -> i32 {
+    let p = P { n: 10 };
+    p.total()
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "bare_self_mutation_rejected"
+spec = ["6.4:36"]
+compile_fail = true
+error_contains = ["E0203", "mut self"]
+description = "a bare self receiver stays immutable; the diagnostic points at mut self"
+source = """
+struct P {
+    n: i32,
+    fn poke(self) { self.n = 3; }
+}
+
+fn main() {
+    let p = P { n: 0 };
+    p.poke();
+}
+"""
+
 # =============================================================================
 # Fields and methods are separate name spaces (6.4:33) — RUE-299
 # =============================================================================

--- a/docs/spec/src/06-items/04-impl-blocks.md
+++ b/docs/spec/src/06-items/04-impl-blocks.md
@@ -19,7 +19,7 @@ method_list = method_def { method_def } ;
 method_def = [ directives ] "fn" IDENT "(" [ method_params ] ")" [ "->" type ] block ;
 method_params = method_param { "," method_param } [ "," ] ;
 method_param = receiver | ( [ "inout" | "borrow" ] IDENT ":" type ) ;
-receiver = [ "inout" | "borrow" ] "self" ;
+receiver = [ "inout" | "borrow" | "mut" ] "self" ;
 ```
 
 ## Method Definition
@@ -247,7 +247,9 @@ A receiver **MAY** be declared `borrow self` or `inout self`, mirroring the
 (copied if the struct is `Copy`, otherwise moved). A `borrow self` receiver
 grants read-only access to the receiver without taking ownership. An `inout
 self` receiver grants exclusive mutable access without taking ownership, and
-mutations to `self` are observed by the caller after the call returns.
+mutations to `self` are observed by the caller after the call returns. A
+by-value receiver **MAY** additionally be declared `mut self`, making the
+binding mutable within the method body (6.4:35).
 
 {{ rule(id="6.4:25", cat="normative") }}
 
@@ -308,5 +310,46 @@ fn main() -> i32 {
     let a = c.get();   // borrow does not consume `c`
     c.bump();
     a + c.get()        // 2 + 3 = 5
+}
+```
+
+## Mutable By-Value Receivers
+
+{{ rule(id="6.4:35", cat="normative") }}
+
+A by-value receiver **MAY** be declared `mut self`. The receiver is still
+passed by value exactly as a bare `self` receiver is — copied if the struct is
+`Copy`, otherwise moved — but the binding is mutable within the method body,
+like a `let mut` local (5.1:5): the body **MAY** assign to `self`, its fields,
+and its elements, and **MAY** call `inout self` methods on it. Mutations
+affect only the method's own value; they are never observed by the caller
+(caller write-back is `inout self`, 6.4:24). `mut` is not part of the method's
+signature: call sites are unaffected, and the caller's receiver expression is
+subject to the same rules as for a bare `self` receiver.
+
+{{ rule(id="6.4:36", cat="legality-rule") }}
+
+Assigning to `self`, a field of `self`, or an element of `self`, or calling an
+`inout self` method on `self`, inside a method whose receiver is a bare
+(non-`mut`, non-`inout`) `self` is a compile-time error. The `mut` modifier is
+only valid on a by-value receiver: `mut` cannot be combined with `borrow`
+(which grants no mutable access) or `inout` (which is already mutable).
+
+{{ rule(id="6.4:37", cat="example") }}
+
+```rue
+struct Counter {
+    n: i32,
+
+    // Consumes the receiver, mutates its own copy, returns the result.
+    fn finish(mut self, bonus: i32) -> i32 {
+        self.n = self.n + bonus;
+        self.n
+    }
+}
+
+fn main() -> i32 {
+    let c = Counter { n: 40 };
+    c.finish(2)   // 42; `c` was moved into the call
 }
 ```

--- a/docs/spec/src/06-items/05-constants.md
+++ b/docs/spec/src/06-items/05-constants.md
@@ -24,10 +24,14 @@ forms are: literals (4.14:26); the arithmetic, comparison, logical, bitwise,
 and shift operators applied to comptime-evaluable operands (4.14:27);
 `comptime` block expressions (4.14:2, 4.14:27); references to other constants
 (4.14:26); and module expressions (`@import(...)` and module member access —
-chapter 10, 6.5:10). A reference to a function item is comptime-evaluable only
-for the purpose of forming a callable alias (6.5:15). An initializer outside
-this set is a compile-time error (E0434) — the same diagnostic 4.14:29 names
-for a `const` initializer that is not comptime-evaluable.
+chapter 10, 6.5:10). Additionally, a string literal is a valid constant
+initializer (6.5:16) even though it is not in the general comptime-evaluable
+set: string values exist in constant-initializer position only, not in
+`comptime` blocks or `comptime` argument positions. A reference to a function
+item is comptime-evaluable only for the purpose of forming a callable alias
+(6.5:15). An initializer outside this set is a compile-time error (E0434) —
+the same diagnostic 4.14:29 names for a `const` initializer that is not
+comptime-evaluable.
 
 {{ rule(id="6.5:3", cat="example") }}
 
@@ -113,11 +117,40 @@ const OK: i32 = 2147483647;          // in range: fine
 {{ rule(id="6.5:14", cat="informative") }}
 
 In the current revision the compile-time-evaluable expression forms (6.5:2)
-produce only scalar values — integers and `bool` — so a value constant's type
-is in practice a scalar type. There is no const-evaluable form that yields a
-struct or an array: an aggregate initializer such as a struct literal or an
-array literal is not compile-time evaluable and is rejected (E0434). Constants
-of aggregate type may be revisited in a future revision.
+produce scalar values — integers and `bool` — plus string values from string
+literals (6.5:16), so a value constant's type is in practice a scalar type or
+`str`. There is no const-evaluable form that yields a user struct or an
+array: an aggregate initializer such as a struct literal or an array literal
+is not compile-time evaluable and is rejected (E0434). Constants of aggregate
+type may be revisited in a future revision.
+
+## String Constants
+
+{{ rule(id="6.5:16", cat="normative") }}
+
+A string-literal initializer declares a *string constant*. A string constant
+is always of type `str` — the static, copyable string view (3.7) — and its
+annotation **MUST** be `str` (the owning `StrBuf` and fixed `Str(N)`
+representations are runtime-only and do not match, 6.5:5). Like every value
+constant, a string constant requires a type annotation (6.5:4). A use of a
+string constant materializes the same value the string literal itself would
+denote at that site: string constants participate in `str` operations,
+`println`, and reads exactly like inline literals. A constant initialized
+from another string constant (`const B: str = A;`) denotes the same value.
+String values remain outside `comptime` blocks and `comptime` argument
+positions (6.5:2).
+
+{{ rule(id="6.5:17", cat="example") }}
+
+```rue
+const GREETING: str = "hello";
+const ALIAS: str = GREETING;
+
+fn main() -> i32 {
+    println(GREETING);
+    @intCast(GREETING.len() + ALIAS.len())   // 10
+}
+```
 
 ## Evaluation Order
 

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -43,7 +43,7 @@ struct_def     = directives [ "pub" ] [ "linear" ]
 struct_fields  = struct_field { "," struct_field } [ "," ] ;
 struct_field   = IDENT ":" type ;
 method         = directives "fn" IDENT
-                 "(" [ [ "inout" | "borrow" ] "self" [ "," params ] | params ] ")"
+                 "(" [ [ "inout" | "borrow" | "mut" ] "self" [ "," params ] | params ] ")"
                  [ "->" type ] "{" block "}" ;
 
 (* Enums *)

--- a/std/fs.rue
+++ b/std/fs.rue
@@ -418,11 +418,10 @@ pub struct File {
     // out of the caller's binding means the caller's scope-exit drop does not
     // fire; the sentinel (`fd = -1`) makes THIS value's own scope-exit drop a
     // no-op, so the fd is closed exactly once (ADR-0057 §4, double-close guard).
-    fn close(self) -> result.Result((), FileError) {
+    fn close(mut self) -> result.Result((), FileError) {
         let R = result.Result((), FileError);
-        let mut me = self;
-        let fd = me.fd;
-        me.fd = -1;
+        let fd = self.fd;
+        self.fd = -1;
         if fd < 0 {
             return R.Ok(());
         }


### PR DESCRIPTION
## Summary

Fixes the two mechanical items from the RUE-957 papercut bundle. The three design-decision items were split out to RUE-979 (function-local type aliases in helper signatures), RUE-980 (trapping `byte_at` companion — the RUE-602 friction ledger), and RUE-981 (struct literal defaults/partial construction), so this closes the bundle.

## Item 1 — const string literals (was E0434)

`const DIR: str = "..."` at top level now works; the workaround was a function returning the literal.

- `ConstValue::String(Spur)` carries the interned content. `eval_const_initializer` accepts `StringConst` directly; the comptime engine deliberately treats string constants as non-evaluable, so they stay out of `comptime` blocks and `comptime` argument positions (clean E0206-family diagnostics, no new value category in the engine).
- Use sites (unqualified reference and module-member `m.CONST`) materialize the value exactly like an inline literal: content joins the function-local string table and lowers to a `.rodata`-backed 2-word `str`. `const B: str = A;` aliasing and cross-module `pub const` access both work.
- Annotation rules mirror other value consts: missing annotation is E0475 (help suggests `: str`), non-`str` annotations are E0206. `StrBuf`/`Str(N)` stay runtime-only.
- The durable manifest chain (`SemanticExportConstValue` / `SemanticImportConstValue` / `DurableConstValue`) carries string content as `Arc`; the durable semantic schema `implementation_epoch` is bumped to 2 so older caches fail closed. Const payload install already fails closed to ordinary resolution, so no install-side changes were needed.

## Item 4 — `mut self` receiver (was E0203 + `let mut me = self` rebind)

A by-value receiver can be declared `mut self`: the binding is mutable in the method body — field/element writes, whole-receiver reassignment (`self = ...`), and `inout self` method calls — with **no caller write-back** (that remains `inout self`).

- The flag flows parser → RIR `FnDecl` → `MethodInfo` → the body's `ParamInfo`, and deliberately stays **out of signatures, call sites, and anonymous-struct structural identity** — like Rust's `mut self`, it is a body-local binding property.
- One real codegen bug surfaced: `ParamStore` lowering unconditionally treated the target slot as by-ref, so a whole-receiver store to a by-value slot chased a data word as a pointer (runtime crash). Both backends now branch on `is_param_by_ref` and write by-value slots directly in the frame param area, mirroring the projection-free by-value arm of `place_lower::lower_place_write_plan`. CSE/LICM already handle by-value `ParamStore` targets via their write scans.
- `std/fs.rue` `close(self)` drops the `let mut me = self;` rebind idiom that motivated the item.
- E0203 on a bare `self` receiver now suggests `mut self` (callee-local) or `inout self` (write-back) instead of the misleading `inout self: T` parameter hint.

### Preview gate

Landed ungated deliberately: ADR-0005 gates exist to merge *incomplete* multi-phase work, and AGENTS.md requires a gate "until complete" — this feature is complete in this PR (spec, grammar, parser, sema, both backends, tests), and the runtime semantics already existed via the rebind idiom. Happy to add a `mut_self` gate if you'd rather follow the `array_repeat`/`method_receivers` precedent.

## Spec

- Receiver grammar (`[ "inout" | "borrow" | "mut" ] "self"`) in Appendix A and 6.4; new rules 6.4:35 (semantics), 6.4:36 (legality), 6.4:37 (example); 6.4:24 amended.
- Constants: 6.5:2 admits string literals (initializer position only), 6.5:14 updated, new 6.5:16 (string constants) and 6.5:17 (example).

## Testing

- New spec cases: `items/impl-blocks.toml` (4 `mut self` cases: mutation+reassignment execution, Copy-caller non-write-back, `inout` call on `mut self`, bare-`self` rejection with the new hint) and `items/constants.toml` (6 string-const cases incl. module member, E0475/E0206 negatives, comptime-block rejection).
- New CLI cases in `const_init.toml` pin printed bytes and cross-module access end-to-end.
- `scripts/rue quick`, filtered spec/CLI suites, and clippy pass; x86-64 execution verified locally.
- Full-suite gate before undrafting: branch CI on head `ce77682` is green across the board — the CI workflow (full `test.sh` suite on x86-64 and ARM64) and the Sanitizer workflow both completed successfully, covering the aarch64 `ParamStore` fix.

Fixes RUE-957