### PR TITLE
RUE-725: borrow StrBuf index bases

### DIFF
--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -588,7 +588,7 @@ impl<'a> BodySema<'a> {
     }
 
     /// Resolve the type of a place without emitting AIR or recording a move.
-    pub(super) fn peek_place_type(&self, inst_ref: InstRef, ctx: &AnalysisContext) -> Option<Type> {
+    pub(crate) fn peek_place_type(&self, inst_ref: InstRef, ctx: &AnalysisContext) -> Option<Type> {
         match &self.rir.get(inst_ref).data {
             InstData::VarRef { name } => {
                 if let Some(local) = ctx.locals.get(name) {

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -5177,7 +5177,23 @@ impl<'a> BodySema<'a> {
         // String index (see below).
         let base_root = self.extract_root_variable(base);
         let base_move_state_before = base_root.and_then(|v| ctx.moved_vars.get(&v).cloned());
-        let base_result = self.analyze_inst(air, base, ctx)?;
+
+        // A byte/element index of StrBuf, str/Str(N), or a slice reads through
+        // its base place; it does not consume that place. Classify a statically
+        // typed place base before analyzing it so a StrBuf field rooted at a
+        // `borrow`/`inout` parameter is read as a borrow instead of failing the
+        // move check with E0429/E0437 before the type-specific path below can
+        // restore its move state (RUE-725). Non-place expressions still use
+        // normal value semantics and may be consumed into a temporary.
+        let borrowing_base_root = base_root.filter(|_| {
+            self.peek_place_type(base, ctx).is_some_and(|ty| {
+                self.is_strbuf(ty) || self.is_str_like(ty) || self.slice_element_type(ty).is_some()
+            })
+        });
+        let prev_byref_root = std::mem::replace(&mut ctx.byref_arg_root, borrowing_base_root);
+        let base_result = self.analyze_inst(air, base, ctx);
+        ctx.byref_arg_root = prev_byref_root;
+        let base_result = base_result?;
         let base_type = base_result.ty;
 
         // String byte indexing: `s[i]` reads the i-th BYTE of a String as `u8`

--- a/crates/rue-cli-tests/cases/string_byte_access.toml
+++ b/crates/rue-cli-tests/cases/string_byte_access.toml
@@ -114,3 +114,35 @@ fn main() -> i32 {
 """ }]
 exit_code = 0
 stdout = "195\n"
+
+[[case]]
+name = "borrow_rooted_strbuf_byte_reads"
+description = "RUE-725: StrBuf byte indexing reads through borrow/inout parameters and self-field projections without moving their roots."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+struct Lexer {
+    src: StrBuf,
+    pos: u64,
+    fn peek(borrow self) -> u8 { self.src[self.pos] }
+    fn advance(inout self) -> u8 {
+        let byte = self.src[self.pos];
+        self.pos = self.pos + 1;
+        byte
+    }
+}
+
+fn first(borrow src: StrBuf) -> u8 { src[0] }
+
+fn main() -> i32 {
+    let mut lexer = Lexer { src: "abc", pos: 0 };
+    let a = lexer.peek();
+    let b = lexer.advance();
+    let c = lexer.peek();
+    let d = first(borrow lexer.src);
+    if a == 97 && b == 97 && c == 98 && d == 97 { 7 } else { 0 }
+}
+""" }]
+exit_code = 7

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -1107,6 +1107,12 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "cli.string_byte_access",
+        "borrow_rooted_strbuf_byte_reads",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "cli.string_byte_access",
         "substring_byte_range",
         semantic(SemanticGapKind::TextProjectionRead),
         &[],


### PR DESCRIPTION
## Summary

- analyze StrBuf, str/Str(N), and slice index bases as borrowed places before move checking
- allow byte reads through `borrow`/`inout` parameters and self-field projections
- add a lexer-shaped CLI regression and register its typed oracle model gap

## Root cause

Index analysis recognized StrBuf byte access as non-consuming only after analyzing the base expression. A StrBuf field rooted at a `borrow` or `inout` parameter therefore failed the move check with E0429/E0437 before the existing move-state restoration could run.

## Impact

Natural lexer code such as `self.src[self.pos]` now works from both `borrow self` and `inout self`, and direct byte reads through borrowed StrBuf parameters remain non-consuming.

## Validation

- `scripts/rue cli string_byte_access` (7 passed)
- `scripts/rue quick` (all unit targets passed; CLI oracle audit rerun after registry update)
- `./buck2 test //crates/rue-oracle-diff:oracle-diff-test`
- hermetic rustfmt on changed Rust files
- `git diff --check upstream/trunk...HEAD`

Linear: RUE-725
