### PR TITLE
RUE-788: accept the complete type grammar in type-position intrinsics

### DIFF
--- a/crates/rue-cli-tests/cases/type_intrinsic_args.toml
+++ b/crates/rue-cli-tests/cases/type_intrinsic_args.toml
@@ -1,0 +1,38 @@
+# Type-position intrinsic grammar parity through the real driver (RUE-788).
+#
+# `@size_of`, `@align_of`, and the type position of `@offset_of` accept the
+# same type grammar annotations do. These cases exercise the forms that need
+# driver-level machinery the spec suite cannot reach: a module-qualified type
+# behind an `@import`, and the preview-gated slice type behind `--preview`.
+
+[section]
+id = "cli.type_intrinsic_args"
+name = "Type-position intrinsic arguments (RUE-788)"
+description = "Qualified and preview-gated type forms in @size_of/@offset_of through the CLI."
+
+# A module-qualified struct is a valid type argument, and @offset_of computes
+# the field offset from the imported struct's layout: 16 + 8 = 24.
+[[case]]
+name = "qualified_type_in_size_of_and_offset_of"
+files = [{ path = "geo.rue", source = """
+pub struct Point { x: i32, y: i64 }
+""" }, { path = "main.rue", source = """
+pub const geo = @import("geo.rue");
+fn main() -> i32 {
+    let size: i32 = @size_of(geo.Point);
+    let off: i32 = @intCast(@offset_of(geo.Point, y));
+    size + off
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 24
+
+# The preview-gated slice type reaches @size_of through the driver flag; the
+# slice is a two-word fat pointer.
+[[case]]
+name = "slice_type_in_size_of_with_preview"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { @size_of([i32]) }
+""" }]
+args = ["main.rue", "--preview", "slices", "-o", "prog"]
+exit_code = 16

--- a/crates/rue-parser/src/intrinsics.rs
+++ b/crates/rue-parser/src/intrinsics.rs
@@ -1,0 +1,45 @@
+//! Shared classification of intrinsic argument grammars.
+//!
+//! Most intrinsics take value expressions, but a few take types. The parser
+//! consults this policy to parse those argument positions with the canonical
+//! type grammar (the same one annotations use), and AstGen consults the same
+//! list to lower the result as a `TypeIntrinsic`/`OffsetOf`. One shared list
+//! keeps the two phases from disagreeing about which positions are types
+//! (RUE-788).
+
+/// Intrinsics whose every argument position takes a type. Each of these takes
+/// exactly one argument; arity itself is diagnosed during semantic analysis,
+/// so surplus arguments still parse as types rather than falling back to
+/// expression parsing.
+///
+/// `require_droppable` is the compile-time well-formedness gate an owning
+/// growable container (`std/arraybuf.rue`'s `ArrayBuf(T)`) uses to reject an
+/// element type it cannot yet correctly own — one with a destructor or a
+/// `linear` element (RUE-388). It takes the element type as its sole argument
+/// and evaluates to unit during comptime type-constructor reduction, so it
+/// must be lowered as a `TypeIntrinsic` (like `@size_of`), not an expression
+/// call. `require_trivially_droppable` is the analogous by-copy-read gate
+/// (RUE-651).
+pub const TYPE_INTRINSICS: &[&str] = &[
+    "size_of",
+    "align_of",
+    "require_droppable",
+    "require_trivially_droppable",
+];
+
+/// The field-offset intrinsic `@offset_of(T, field)` (RUE-301): its first
+/// argument is a type and its second names a field of that type.
+pub const OFFSET_OF_INTRINSIC: &str = "offset_of";
+
+/// How many leading arguments of `@name(...)` are parsed with the type
+/// grammar. Zero means the intrinsic is an ordinary value-position intrinsic
+/// whose arguments take the full expression grammar.
+pub fn type_argument_count(name: &str) -> usize {
+    if TYPE_INTRINSICS.contains(&name) {
+        usize::MAX
+    } else if name == OFFSET_OF_INTRINSIC {
+        1
+    } else {
+        0
+    }
+}

--- a/crates/rue-parser/src/lib.rs
+++ b/crates/rue-parser/src/lib.rs
@@ -1,6 +1,7 @@
 //! Parser and AST for the Rue programming language.
 
 pub mod ast;
+pub mod intrinsics;
 mod parser;
 mod parser_policy;
 mod validate;

--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -1480,18 +1480,41 @@ impl Parser {
             _ => unreachable!(),
         };
         self.expect(TokenKind::LParen)?;
+        // Type-position intrinsics (`@size_of`, `@align_of`, `@offset_of`'s
+        // first argument, ...) take the canonical type grammar, exactly as
+        // annotations do (RUE-788). Every other intrinsic takes the expression
+        // grammar, with a narrow carve-out for argument tokens that can only
+        // spell a type; AstGen preserves those as placeholders so semantic
+        // analysis reports the type-vs-value mismatch at the right arity.
+        let type_positions = {
+            let name_str = self.interner.resolve(&name.name);
+            crate::intrinsics::type_argument_count(name_str)
+        };
         let mut args = Vec::new();
         if !self.at(TokenKind::RParen) {
             loop {
-                let is_unambiguous_ty = self.primitive_spur(self.kind()).is_some()
-                    || (self.at(TokenKind::LBracket) && self.bracket_is_array_type())
-                    || (self.at(TokenKind::LParen) && self.nth(1) == TokenKind::RParen)
-                    || (self.at(TokenKind::Bang)
-                        && matches!(self.nth(1), TokenKind::Comma | TokenKind::RParen));
-                if is_unambiguous_ty {
-                    args.push(IntrinsicArg::Type(self.ty()?));
+                if args.len() < type_positions {
+                    match self.type_position_intrinsic_arg(name) {
+                        Ok(ty) => args.push(IntrinsicArg::Type(ty)),
+                        // The targeted diagnostic is already recorded (and any
+                        // recorded error fails the parse), so resynchronize at
+                        // the argument boundary. Keeping the enclosing call
+                        // structurally intact stops item-level recovery from
+                        // re-parsing the `@name(...)` as a directive and
+                        // cascading a second, misleading diagnostic.
+                        Err(()) => self.skip_type_position_argument(),
+                    }
                 } else {
-                    args.push(IntrinsicArg::Expr(self.expr()?));
+                    let is_unambiguous_ty = self.primitive_spur(self.kind()).is_some()
+                        || (self.at(TokenKind::LBracket) && self.bracket_is_array_type())
+                        || (self.at(TokenKind::LParen) && self.nth(1) == TokenKind::RParen)
+                        || (self.at(TokenKind::Bang)
+                            && matches!(self.nth(1), TokenKind::Comma | TokenKind::RParen));
+                    if is_unambiguous_ty {
+                        args.push(IntrinsicArg::Type(self.ty()?));
+                    } else {
+                        args.push(IntrinsicArg::Expr(self.expr()?));
+                    }
                 }
                 if !self.eat(TokenKind::Comma) {
                     break;
@@ -1511,6 +1534,56 @@ impl Parser {
             args,
             span: self.span_from(start),
         }))
+    }
+
+    /// Parse one type-position intrinsic argument with the canonical type
+    /// grammar (`ty()`), so type intrinsics accept every `TypeExpr` form an
+    /// annotation accepts: pointer, qualified, type-call, array, slice,
+    /// anonymous aggregate, unit, never, and primitive types (RUE-788).
+    ///
+    /// Expression-shaped mistakes get one targeted diagnostic here instead of
+    /// drifting through expression parsing: a `!` with an operand is a
+    /// prefix-not expression (only a bare `!` spells the never type), and a
+    /// trailing token after a complete type (`i32 + 1`, `Point { .. }`) means
+    /// the argument was a value expression.
+    fn type_position_intrinsic_arg(&mut self, intrinsic: Ident) -> PResult<TypeExpr> {
+        let intrinsic_name = self.interner.resolve(&intrinsic.name).to_string();
+        if self.at(TokenKind::Bang) && !matches!(self.nth(1), TokenKind::Comma | TokenKind::RParen)
+        {
+            self.error(format!(
+                "`@{intrinsic_name}` takes a type in this argument position, but `!` followed by \
+                 an operand is a prefix-not expression; write a bare `!` for the never type"
+            ));
+            return Err(());
+        }
+        let ty = self.ty()?;
+        if !self.at(TokenKind::Comma) && !self.at(TokenKind::RParen) {
+            self.error(format!(
+                "`@{intrinsic_name}` takes a type in this argument position, not a value \
+                 expression"
+            ));
+            return Err(());
+        }
+        Ok(ty)
+    }
+
+    /// Skip past a malformed type-position argument to its boundary: the
+    /// argument-separating `,` or the closing `)` at the intrinsic call's own
+    /// nesting level (or end of input while unterminated).
+    fn skip_type_position_argument(&mut self) {
+        let mut depth = 0usize;
+        loop {
+            match self.kind() {
+                TokenKind::Eof => return,
+                TokenKind::Comma | TokenKind::RParen if depth == 0 => return,
+                TokenKind::LParen | TokenKind::LBracket | TokenKind::LBrace => depth += 1,
+                TokenKind::RParen | TokenKind::RBracket | TokenKind::RBrace => {
+                    depth = depth.saturating_sub(1);
+                }
+                _ => {}
+            }
+            self.bump();
+        }
     }
 
     fn if_expr(&mut self) -> PResult<Expr> {
@@ -2386,6 +2459,126 @@ mod tests {
         }
         samples.sort_unstable();
         samples[samples.len() / 2]
+    }
+
+    /// Parse a function whose body is a single tail intrinsic call and return
+    /// that call's arguments.
+    fn intrinsic_args(source: &str) -> Vec<IntrinsicArg> {
+        let (ast, _) = parse_source(source).unwrap_or_else(|errors| panic!("{errors:?}\n{source}"));
+        let Item::Function(function) = &ast.items[0] else {
+            panic!("expected function in {source}");
+        };
+        let Expr::Block(body) = &function.body else {
+            panic!("expected block body in {source}");
+        };
+        let Expr::IntrinsicCall(call) = &*body.expr else {
+            panic!("expected tail intrinsic call in {source}");
+        };
+        call.args.clone()
+    }
+
+    #[test]
+    fn type_position_intrinsics_accept_the_full_type_grammar() {
+        // Parity table (RUE-788): every `TypeExpr` form an annotation accepts
+        // must parse identically in a type-position intrinsic argument.
+        // `TypeExpr::StrFixed` has no dedicated surface spelling here —
+        // `Str(8)` parses as a `TypeCall` whose canonicalization AstGen owns —
+        // and `TypeExpr::IntArg` only occurs inside a call argument list
+        // (covered by the `Buffer(2)` row).
+        let rows: &[(&str, fn(&TypeExpr) -> bool)] = &[
+            ("i32", |t| matches!(t, TypeExpr::Named(_))),
+            ("Point", |t| matches!(t, TypeExpr::Named(_))),
+            ("Self", |t| matches!(t, TypeExpr::Named(_))),
+            ("lib.geo.Point", |t| matches!(t, TypeExpr::Qualified { .. })),
+            ("()", |t| matches!(t, TypeExpr::Unit(_))),
+            ("!", |t| matches!(t, TypeExpr::Never(_))),
+            ("[i32; 4]", |t| matches!(t, TypeExpr::Array { .. })),
+            ("[i32; N]", |t| matches!(t, TypeExpr::Array { .. })),
+            ("[i32]", |t| matches!(t, TypeExpr::Slice { .. })),
+            ("[[u8; 2]; 3]", |t| matches!(t, TypeExpr::Array { .. })),
+            ("ptr const i32", |t| {
+                matches!(t, TypeExpr::PointerConst { .. })
+            }),
+            ("ptr mut ptr const u8", |t| {
+                matches!(t, TypeExpr::PointerMut { .. })
+            }),
+            ("Pair(i32, [i32; 2])", |t| {
+                matches!(t, TypeExpr::TypeCall { .. })
+            }),
+            ("Buffer(2)", |t| {
+                matches!(t, TypeExpr::TypeCall { args, .. }
+                    if matches!(args[0], TypeExpr::IntArg { value: 2, .. }))
+            }),
+            ("lib.pair.Pair(i32)", |t| {
+                matches!(t, TypeExpr::QualifiedTypeCall { .. })
+            }),
+            ("struct { x: i32, y: Pair(i32) }", |t| {
+                matches!(t, TypeExpr::AnonymousStruct { .. })
+            }),
+            ("enum { A, B(i32) }", |t| {
+                matches!(t, TypeExpr::AnonymousEnum { .. })
+            }),
+        ];
+        for (spelling, is_expected_variant) in rows {
+            for intrinsic in [
+                "size_of",
+                "align_of",
+                "require_droppable",
+                "require_trivially_droppable",
+            ] {
+                let source = format!("fn f() -> i32 {{ @{intrinsic}({spelling}) }}");
+                let args = intrinsic_args(&source);
+                assert!(
+                    matches!(&args[0], IntrinsicArg::Type(ty) if is_expected_variant(ty)),
+                    "@{intrinsic}({spelling}) parsed as {args:?}"
+                );
+            }
+            // `@offset_of` parses its first argument as a type and its second
+            // as an ordinary expression.
+            let source = format!("fn f() -> i32 {{ @offset_of({spelling}, x) }}");
+            let args = intrinsic_args(&source);
+            assert!(
+                matches!(&args[0], IntrinsicArg::Type(ty) if is_expected_variant(ty)),
+                "@offset_of({spelling}, x) parsed as {args:?}"
+            );
+            assert!(matches!(&args[1], IntrinsicArg::Expr(Expr::Ident(_))));
+        }
+    }
+
+    #[test]
+    fn type_position_intrinsics_reject_value_expressions_with_one_diagnostic() {
+        for source in [
+            "fn f() -> i32 { @size_of(1) }",
+            "fn f() -> i32 { @size_of(1 + 2) }",
+            "fn f() -> i32 { @size_of(-x) }",
+            "fn f() -> i32 { @size_of(\"s\") }",
+            "fn f() -> i32 { @size_of(x + 1) }",
+            "fn f() -> i32 { @size_of(Point { x: 1 }) }",
+            "fn f() -> i32 { @align_of(!x) }",
+            "fn f() -> i32 { @require_droppable(!true) }",
+            "fn f() -> i32 { @offset_of(1 + 2, x) }",
+        ] {
+            let errors = parse_source(source).unwrap_err();
+            assert_eq!(
+                errors.len(),
+                1,
+                "expected one targeted diagnostic for {source}, got {errors:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn value_position_intrinsics_keep_the_expression_grammar() {
+        // A value-position intrinsic still takes full expressions, with the
+        // unambiguous-type-token carve-out unchanged: a bare `!` is the never
+        // type while `!x` stays a prefix-not expression.
+        let args = intrinsic_args("fn f() -> i32 { @probe(!, !x, a + 1, (), [1, 2], Point) }");
+        assert!(matches!(&args[0], IntrinsicArg::Type(TypeExpr::Never(_))));
+        assert!(matches!(&args[1], IntrinsicArg::Expr(Expr::Unary(_))));
+        assert!(matches!(&args[2], IntrinsicArg::Expr(Expr::Binary(_))));
+        assert!(matches!(&args[3], IntrinsicArg::Type(TypeExpr::Unit(_))));
+        assert!(matches!(&args[4], IntrinsicArg::Expr(Expr::ArrayLit(_))));
+        assert!(matches!(&args[5], IntrinsicArg::Expr(Expr::Ident(_))));
     }
 
     #[test]

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -7,22 +7,8 @@
 
 use lasso::{Spur, ThreadedRodeo};
 
-/// Known type intrinsics that take a type argument rather than an expression.
-/// These intrinsics operate on types at compile time (e.g., @size_of(i32)).
-///
-/// `require_droppable` is the compile-time well-formedness gate an owning
-/// growable container (`std/arraybuf.rue`'s `ArrayBuf(T)`) uses to reject an
-/// element type it cannot yet correctly own — one with a destructor or a
-/// `linear` element (RUE-388). It takes the element type as its sole argument
-/// and evaluates to unit during comptime type-constructor reduction, so it must
-/// be lowered as a `TypeIntrinsic` (like `@size_of`), not an expression call.
-const TYPE_INTRINSICS: &[&str] = &[
-    "size_of",
-    "align_of",
-    "require_droppable",
-    "require_trivially_droppable",
-];
 use rue_parser::ast::{ConstDecl, DropFn};
+use rue_parser::intrinsics::{OFFSET_OF_INTRINSIC, TYPE_INTRINSICS};
 use rue_parser::{
     ArgMode, ArrayLength, AssignTarget, BinaryOp, CallArg, Directive, DirectiveArg, EnumDecl, Expr,
     Function, IntrinsicArg, Item, LetPattern, Method, ParamMode, Pattern, Statement, StructDecl,
@@ -814,22 +800,18 @@ impl<'a> AstGen<'a> {
                 let intrinsic_name_str = self.interner.resolve(&name);
 
                 // `@offset_of(T, field)` (RUE-301) is compiler-mediated field
-                // addressing: the first argument names a struct type and the
-                // second names one of its fields. Both spell as bare
-                // identifiers (`Point`, `x`) — the parser hands them over as
-                // `Expr::Ident` (or the first as a `Type` when it is an
-                // unambiguous type form). Lower the pair into a dedicated
-                // `OffsetOf` node so Sema can compute the offset from the
-                // layout it assigns, rather than the user hardcoding a literal.
-                if intrinsic_name_str == "offset_of" && intrinsic.args.len() == 2 {
-                    let type_arg = match &intrinsic.args[0] {
-                        IntrinsicArg::Type(ty) => Some(self.intern_type(ty)),
-                        IntrinsicArg::Expr(Expr::Ident(ident)) => Some(self.symbol(ident.name)),
-                        _ => None,
-                    };
-                    if let (Some(type_arg), IntrinsicArg::Expr(Expr::Ident(field))) =
-                        (type_arg, &intrinsic.args[1])
+                // addressing: the first argument is a type and the second
+                // names one of its fields. The parser parses the type position
+                // with the canonical type grammar (RUE-788), so the first
+                // argument always arrives as `IntrinsicArg::Type`. Lower the
+                // pair into a dedicated `OffsetOf` node so Sema can compute
+                // the offset from the layout it assigns, rather than the user
+                // hardcoding a literal.
+                if intrinsic_name_str == OFFSET_OF_INTRINSIC && intrinsic.args.len() == 2 {
+                    if let (IntrinsicArg::Type(ty), IntrinsicArg::Expr(Expr::Ident(field))) =
+                        (&intrinsic.args[0], &intrinsic.args[1])
                     {
+                        let type_arg = self.intern_type(ty);
                         return self.rir.add_inst(Inst {
                             data: InstData::OffsetOf {
                                 type_arg,
@@ -843,29 +825,19 @@ impl<'a> AstGen<'a> {
                     // during semantic analysis.
                 }
 
+                // Type intrinsics at the documented arity lower to a dedicated
+                // node; any other arity falls through so semantic analysis
+                // reports the arity error with every argument accounted for.
                 let is_type_intrinsic = TYPE_INTRINSICS.contains(&intrinsic_name_str);
-
-                if is_type_intrinsic && intrinsic.args.len() == 1 {
-                    // Handle explicit type argument
-                    if let IntrinsicArg::Type(ty) = &intrinsic.args[0] {
-                        let type_arg = self.intern_type(ty);
-                        return self.rir.add_inst(Inst {
-                            data: InstData::TypeIntrinsic { name, type_arg },
-                            span: intrinsic.span,
-                        });
-                    }
-
-                    // Handle identifier expression that should be interpreted as a type
-                    // (e.g., @size_of(Point) where Point is parsed as Ident expression)
-                    if let IntrinsicArg::Expr(Expr::Ident(ident)) = &intrinsic.args[0] {
-                        return self.rir.add_inst(Inst {
-                            data: InstData::TypeIntrinsic {
-                                name,
-                                type_arg: self.symbol(ident.name),
-                            },
-                            span: intrinsic.span,
-                        });
-                    }
+                if is_type_intrinsic
+                    && intrinsic.args.len() == 1
+                    && let IntrinsicArg::Type(ty) = &intrinsic.args[0]
+                {
+                    let type_arg = self.intern_type(ty);
+                    return self.rir.add_inst(Inst {
+                        data: InstData::TypeIntrinsic { name, type_arg },
+                        span: intrinsic.span,
+                    });
                 }
 
                 // Otherwise, treat as an expression intrinsic
@@ -1576,6 +1548,52 @@ mod tests {
             }
             _ => panic!("expected Add"),
         }
+    }
+
+    #[test]
+    fn type_intrinsics_lower_every_type_form_to_canonical_names() {
+        // Parity table (RUE-788): the parser hands every type-position
+        // intrinsic argument over as `IntrinsicArg::Type`, and lowering
+        // interns exactly the canonical spelling annotations produce — the
+        // one sema's `resolve_type` consumes.
+        for (spelling, canonical) in [
+            ("i32", "i32"),
+            ("Point", "Point"),
+            ("lib.geo.Point", "lib.geo.Point"),
+            ("()", "()"),
+            ("!", "!"),
+            ("[i32; 4]", "[i32; 4]"),
+            ("[i32]", "[i32]"),
+            ("ptr const i32", "ptr const i32"),
+            ("ptr mut ptr const u8", "ptr mut ptr const u8"),
+            ("Pair(i32, [i32; 2])", "Pair(i32, [i32; 2])"),
+            ("lib.pair.Pair(i32)", "lib.pair.Pair(i32)"),
+            ("struct { x: i32 }", "struct { x: i32 }"),
+            ("enum { A, B(i32) }", "enum { A, B(i32) }"),
+        ] {
+            let source = format!("fn f() -> i32 {{ @size_of({spelling}) }}");
+            let (rir, interner) = gen_rir(&source);
+            let type_arg = rir
+                .iter()
+                .find_map(|(_, inst)| match &inst.data {
+                    InstData::TypeIntrinsic { type_arg, .. } => Some(*type_arg),
+                    _ => None,
+                })
+                .unwrap_or_else(|| panic!("no TypeIntrinsic lowered for {spelling}"));
+            assert_eq!(interner.resolve(&type_arg), canonical);
+        }
+
+        // `@offset_of` routes its type position through the same interning.
+        let (rir, interner) = gen_rir("fn f() -> i32 { @offset_of(lib.pair.Pair(i32), second) }");
+        let (type_arg, field) = rir
+            .iter()
+            .find_map(|(_, inst)| match &inst.data {
+                InstData::OffsetOf { type_arg, field } => Some((*type_arg, *field)),
+                _ => None,
+            })
+            .expect("no OffsetOf lowered");
+        assert_eq!(interner.resolve(&type_arg), "lib.pair.Pair(i32)");
+        assert_eq!(interner.resolve(&field), "second");
     }
 
     #[test]

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -2140,3 +2140,127 @@ true
 true
 """
 exit_code = 0
+
+# =============================================================================
+# Type-position intrinsic grammar parity (RUE-788)
+#
+# `@size_of`, `@align_of`, and the type position of `@offset_of` accept the
+# same type grammar annotations do — pointer, qualified, type-call, and
+# nested forms included — not just primitives, arrays, unit, and never.
+# =============================================================================
+
+[[case]]
+name = "size_of_pointer_type"
+spec = ["4.13:12", "4.13:13"]
+description = "A pointer type is a valid @size_of argument; pointers are one 8-byte slot."
+source = """
+fn main() -> i32 {
+    @size_of(ptr const i32)
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "size_of_pointer_to_array_type"
+spec = ["4.13:12", "4.13:13"]
+description = "Nested type forms compose in intrinsic type position: a mutable pointer to an array is still one slot."
+source = """
+fn main() -> i32 {
+    @size_of(ptr mut [u8; 8])
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "size_of_array_of_pointers"
+spec = ["4.13:12", "4.13:13"]
+description = "An array whose element is itself a compound type is a valid @size_of argument."
+source = """
+fn main() -> i32 {
+    @size_of([ptr const i32; 2])
+}
+"""
+exit_code = 16
+
+[[case]]
+name = "size_of_type_call"
+spec = ["4.13:12", "4.13:13"]
+description = "A comptime type-constructor application is a valid @size_of argument and reduces to the monomorphized struct."
+source = """
+fn Pair(comptime T: type) -> type {
+    struct { first: T, second: T }
+}
+fn main() -> i32 {
+    let witness: Pair(i32) = Pair(i32) { first: 1, second: 2 };
+    @size_of(Pair(i32)) + witness.first - 1
+}
+"""
+exit_code = 16
+
+[[case]]
+name = "align_of_pointer_type"
+spec = ["4.13:18", "4.13:19", "4.13:22"]
+description = "A pointer type is a valid @align_of argument."
+source = """
+fn main() -> i32 {
+    @align_of(ptr const i32)
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "align_of_type_call"
+spec = ["4.13:18", "4.13:19", "4.13:22"]
+description = "A comptime type-constructor application is a valid @align_of argument."
+source = """
+fn Pair(comptime T: type) -> type {
+    struct { first: T, second: T }
+}
+fn main() -> i32 {
+    let witness: Pair(i32) = Pair(i32) { first: 1, second: 2 };
+    @align_of(Pair(i32)) + witness.first - 1
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "offset_of_type_call"
+spec = ["4.13:91", "4.13:92", "4.13:94"]
+description = "The type position of @offset_of accepts a type-constructor application; the offset comes from the monomorphized layout."
+source = """
+fn Pair(comptime T: type) -> type {
+    struct { first: T, second: T }
+}
+fn main() -> i32 {
+    let witness: Pair(i64) = Pair(i64) { first: 1, second: 2 };
+    let off: u64 = @offset_of(Pair(i64), second);
+    @intCast(off) + @intCast(witness.first) - 1
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "size_of_rejects_value_expression"
+spec = ["4.13:13"]
+description = "A value expression in @size_of's type position is a compile-time error, not a fallback parse."
+source = """
+fn main() -> i32 {
+    @size_of(1 + 2)
+}
+"""
+compile_fail = true
+error_contains = "expected type"
+
+[[case]]
+name = "offset_of_rejects_value_expression_type_position"
+spec = ["4.13:92"]
+description = "A value expression in @offset_of's type position is a compile-time error."
+source = """
+struct Point { x: i32 }
+fn main() -> i32 {
+    let off: u64 = @offset_of(Point { x: 1 }, x);
+    @intCast(off)
+}
+"""
+compile_fail = true
+error_contains = "takes a type in this argument position"

--- a/crates/rue-ui-tests/cases/diagnostics/parser_messages.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/parser_messages.toml
@@ -107,3 +107,49 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["expected identifier or 'drop'"]
+
+# Type-position intrinsic arguments (RUE-788): `@size_of`, `@align_of`, and
+# `@offset_of`'s first argument parse with the canonical type grammar, and an
+# expression-shaped argument gets exactly one targeted diagnostic instead of
+# drifting through expression parsing or item-level recovery.
+
+[[case]]
+name = "type_intrinsic_value_argument_names_type"
+description = "A non-type token in a type-intrinsic argument reports the type expectation once, with no cascading directive re-parse error."
+source = """
+fn main() -> i32 {
+    @size_of(1 + 2)
+}
+"""
+compile_fail = true
+expected_error = """
+error: [E0100]: expected type, found integer
+ --> test.rue:2:14
+  |
+2 |     @size_of(1 + 2)
+  |              ^
+  |
+"""
+
+[[case]]
+name = "type_intrinsic_prefix_not_is_distinguished_from_never"
+description = "`!x` in a type-intrinsic argument is called out as a prefix-not expression; a bare `!` remains the never type."
+source = """
+fn main() -> i32 {
+    @size_of(!x)
+}
+"""
+compile_fail = true
+error_contains = ["prefix-not expression", "never type"]
+
+[[case]]
+name = "type_intrinsic_trailing_expression_is_targeted"
+description = "A value expression that starts like a type (struct literal) is rejected with the type-position wording."
+source = """
+struct Point { x: i32 }
+fn main() -> i32 {
+    @align_of(Point { x: 1 })
+}
+"""
+compile_fail = true
+error_contains = ["`@align_of` takes a type in this argument position"]

--- a/crates/rue-ui-tests/cases/diagnostics/slice_preview_gate.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/slice_preview_gate.toml
@@ -90,3 +90,21 @@ fn main() -> i32 { 0 }
 """
 compile_fail = true
 error_contains = ["E0489", "can only name a function parameter"]
+
+[[case]]
+name = "slice_type_intrinsic_requires_preview"
+description = "The slice type in @size_of's type position (RUE-788) is gated like any other slice spelling: E1100 without --preview slices."
+source = """
+fn main() -> i32 { @size_of([i32]) }
+"""
+compile_fail = true
+error_contains = "requires preview feature"
+
+[[case]]
+name = "slice_type_intrinsic_sizes_the_fat_pointer"
+description = "With the preview flag, @size_of([i32]) resolves the slice's synthetic fat-pointer struct: two 8-byte words."
+preview = "slices"
+source = """
+fn main() -> i32 { @size_of([i32]) }
+"""
+exit_code = 16


### PR DESCRIPTION
## Problem

The parser classified intrinsic arguments with a narrow "unambiguous type" heuristic (primitives, arrays with a length, `()`, bare `!`), and AstGen separately recovered bare identifiers only. Valid type forms — pointer (`ptr const i32`), qualified (`geo.Point`), constructed (`Pair(i32)`), nested, and preview-gated slice (`[i32]`) types — were rejected or misclassified in `@size_of`, `@align_of`, and the type position of `@offset_of`, even though the spec (4.13:13, 4.13:19, 4.13:92) says these positions take a type.

## Change

- **One shared policy** (`rue_parser::intrinsics`): the type-position intrinsic list lives in the parser crate and AstGen consumes the same list, replacing its duplicate `TYPE_INTRINSICS` const and bare-identifier recovery.
- **Parser**: type-position arguments (`@size_of`/`@align_of`/`@require_droppable`/`@require_trivially_droppable`, and `@offset_of`'s first argument) parse with the canonical `ty()` grammar — exactly what annotations accept. Value-position intrinsics keep the full expression grammar, including the existing unambiguous-type carve-out (a bare `!` is still the never type; `!x` is still prefix-not).
- **Targeted diagnostics**: an expression-shaped argument produces exactly one diagnostic — `expected type` from the type grammar, a dedicated message distinguishing `!operand` (prefix-not) from the bare-`!` never type, and a type-not-value message for trailing expression tokens (`Point { x: 1 }`, `i32 + 1`). The parser resynchronizes at the argument boundary so the error no longer cascades into item-level recovery re-parsing the `@name(...)` as a directive.
- **AstGen**: `@offset_of` lowering now relies on the parser's `IntrinsicArg::Type` invariant; wrong-arity/shape forms still fall through to the expression-intrinsic path with placeholder preservation so sema reports them at the right arity.

Sema needed no changes: `resolve_type` already consumes every canonical spelling (`ptr const T`, `[T]`, `Name(args)`, `a.b.C`), so the widened forms flow straight through, including preview gating (`@size_of([i32])` is E1100 without `--preview slices`, and sizes the fat pointer with it). Anonymous aggregate types parse and lower in these positions and then report the same E0204 annotations report — exact parity with the shared limitation.

## Coverage (parser/RIR/sema/CLI parity)

- Parser unit tables over every `TypeExpr` variant in all type-position intrinsics, negative expression cases pinned to exactly one diagnostic, and the value-position never/not distinction.
- RIR table asserting each form lowers to the same canonical interned name annotations produce, plus `@offset_of` routing.
- Spec cases: pointer, pointer-to-array, array-of-pointers, and type-call forms in `@size_of`/`@align_of`/`@offset_of`; negative value-expression cases.
- UI cases: golden no-cascade diagnostic, prefix-not wording, type-not-value wording, and slice preview gating in intrinsic position.
- CLI cases: module-qualified type behind `@import`, and the slice form behind `--preview slices`, through the real driver.

Full spec (2128), UI (191), and CLI (1520) suites pass locally.

Fixes RUE-788

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTr1GrmuozXwd93nRkmPyC)_