### PR TITLE
RUE-946: return oversized payload enums via sret

### DIFF
--- a/crates/rue-cli-tests/cases/aggregate_abi_matrix.toml
+++ b/crates/rue-cli-tests/cases/aggregate_abi_matrix.toml
@@ -624,3 +624,92 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "17\n"
+
+# by-value return at each backend's return-register budget (RUE-946). An enum
+# is 1 discriminant slot + widest payload, so an N-i32 payload is N+1 slots.
+# The register budget is 6 on x86-64 and 8 on aarch64; oversized returns must
+# switch to sret instead of indexing past the return-register array. The
+# divergent middle sizes (7 and 8 slots) are registers on one backend and sret
+# on the other, so both policy arms run on every CI platform. Each case prints
+# a position-weighted payload sum, so any single dropped or misrouted slot
+# changes the output.
+
+# 6 slots: at the x86-64 budget, registers on both backends.
+[[case]]
+name = "enum_return_at_x86_budget"
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum E { V(i32, i32, i32, i32, i32), Empty }
+fn make() -> E { E.V(1, 2, 3, 4, 5) }
+fn weighted(e: E) -> i32 {
+    match e {
+        E.V(a, b, c, d, e) => a * 1 + b * 2 + c * 3 + d * 4 + e * 5,
+        E.Empty => -1,
+    }
+}
+fn main() -> i32 {
+    @dbg(weighted(make()));
+    0
+}
+""" }]
+stdout = "55\n"
+
+# 7 slots: sret on x86-64, registers on aarch64.
+[[case]]
+name = "enum_return_above_x86_budget"
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum E { V(i32, i32, i32, i32, i32, i32), Empty }
+fn make() -> E { E.V(1, 2, 3, 4, 5, 6) }
+fn weighted(e: E) -> i32 {
+    match e {
+        E.V(a, b, c, d, e, f) => a * 1 + b * 2 + c * 3 + d * 4 + e * 5 + f * 6,
+        E.Empty => -1,
+    }
+}
+fn main() -> i32 {
+    @dbg(weighted(make()));
+    0
+}
+""" }]
+stdout = "91\n"
+
+# 8 slots: sret on x86-64, at the aarch64 budget in registers.
+[[case]]
+name = "enum_return_at_aarch64_budget"
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum E { V(i32, i32, i32, i32, i32, i32, i32), Empty }
+fn make() -> E { E.V(1, 2, 3, 4, 5, 6, 7) }
+fn weighted(e: E) -> i32 {
+    match e {
+        E.V(a, b, c, d, e, f, g) => a * 1 + b * 2 + c * 3 + d * 4 + e * 5 + f * 6 + g * 7,
+        E.Empty => -1,
+    }
+}
+fn main() -> i32 {
+    @dbg(weighted(make()));
+    0
+}
+""" }]
+stdout = "140\n"
+
+# 9 slots: above both budgets, sret on every backend (the RUE-946 ICE repro).
+[[case]]
+name = "enum_return_above_all_budgets"
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum E { V(i32, i32, i32, i32, i32, i32, i32, i32), Empty }
+fn make() -> E { E.V(1, 2, 3, 4, 5, 6, 7, 8) }
+fn weighted(e: E) -> i32 {
+    match e {
+        E.V(a, b, c, d, e, f, g, h) => a * 1 + b * 2 + c * 3 + d * 4 + e * 5 + f * 6 + g * 7 + h * 8,
+        E.Empty => -1,
+    }
+}
+fn main() -> i32 {
+    @dbg(weighted(make()));
+    0
+}
+""" }]
+stdout = "204\n"

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -284,7 +284,9 @@ pub fn type_uses_sret_return(
             }
             types::type_slot_count(type_pool, ty) > ret_reg_budget
         }
-        TypeKind::Array(_) => types::type_slot_count(type_pool, ty) > ret_reg_budget,
+        TypeKind::Array(_) | TypeKind::Enum(_) => {
+            types::type_slot_count(type_pool, ty) > ret_reg_budget
+        }
         _ => false,
     }
 }

--- a/docs/notes/ffi-abi-conformance-audit.md
+++ b/docs/notes/ffi-abi-conformance-audit.md
@@ -164,9 +164,11 @@ The target-C runtime subset had no conformance defect within its current
 surface. The audit did find one native return-classification defect:
 
 - [RUE-946](https://linear.app/rue/issue/RUE-946/large-payload-enum-returns-exceed-the-register-budget-and-ice-instead)
-  tracks large payload enums. Enum returns are currently excluded from indirect
+  tracked large payload enums. Enum returns were excluded from indirect
   return classification, so a payload wider than six x86-64 slots or eight
-  AArch64 slots indexes beyond the backend's return-register table and panics.
+  AArch64 slots indexed beyond the backend's return-register table and
+  panicked. The fix routes oversized enum returns through the same sret policy
+  as structs and arrays.
 
 RUE-946 owns the compiler repair and regression cases. Keeping it separate
 prevents an investigative ABI audit from silently becoming a cross-backend


### PR DESCRIPTION
`type_uses_sret_return` selected sret for oversized structs and arrays but not enums, so a payload enum wider than the return-register budget still built a `ReturnPlan::Registers` plan and each backend indexed past its fixed return-register table (`len is 6 but the index is 6` on x86-64, `len is 8 but the index is 8` on AArch64).

The fix adds `TypeKind::Enum` to the slot-count arm of the one canonical sret policy. Every downstream path — hidden-pointer materialization, callee `store_slots_to_sret`, caller sret readback — is already slot-generic and enum-aware (`is_multislot_aggregate` includes payload enums), so callers and callees agree on the hidden pointer and every discriminant/payload slot with no per-backend work. Discriminant-only enums remain 1-slot scalars and are unaffected.

Coverage: four new aggregate-ABI-matrix cases pin payload-enum returns at 6, 7, 8, and 9 slots — at, above, and between the 6-register x86-64 and 8-register AArch64 budgets. The divergent 7- and 8-slot sizes take registers on one backend and sret on the other, so both policy arms execute on every CI platform. Each case prints a position-weighted payload sum, so any dropped or misrouted slot changes stdout.

Verified locally: the pre-fix compiler aborts on the 9-slot repro; post-fix, `--emit asm` succeeds for x86-64 Linux, AArch64 Linux, and AArch64 macOS, native x86-64 execution round-trips the high payload slot, and the codegen unit suite plus the full `aggregate_abi_matrix` and `enum_payloads` CLI suites pass. Also updated the FFI ABI audit note to past tense.

Fixes RUE-946

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTr1GrmuozXwd93nRkmPyC)_