### PR TITLE
RUE-975: byte-based stack frames via the layout authority (ADR-0052 phase 4)

### DIFF
--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -428,10 +428,10 @@ impl<'a> Emitter<'a> {
     /// Calculate the total stack space used by callee-saved registers.
     ///
     /// On AArch64, registers are saved in pairs (16 bytes per pair), rounded up.
+    /// This is the callee-saved GPR area only (the FP/LR pair is separate);
+    /// sourced from the frame-layout authority so it cannot drift.
     fn callee_saved_stack_size(&self) -> i32 {
-        let num_regs = self.callee_saved.len();
-        let pairs = (num_regs + 1) / 2;
-        (pairs * 16) as i32
+        crate::frame_layout::aarch64_callee_saved_pairs_bytes(self.callee_saved.len()) as i32
     }
 
     /// Adjust an FP-relative offset to account for callee-saved registers.
@@ -557,7 +557,9 @@ impl<'a> Emitter<'a> {
         // sret pointer slot, if any.
         let total_slots = self.num_locals + self.num_params + self.has_sret as u32;
         if total_slots > 0 {
-            let stack_size = ((total_slots as i32 * 8 + 15) / 16) * 16;
+            let stack_size = crate::frame_layout::align_frame_size(
+                crate::frame_layout::slot_region_bytes(total_slots),
+            );
             if stack_size > 0 {
                 self.begin_inst();
                 self.emit_sub_imm(Reg::Sp, Reg::Sp, stack_size as u32);
@@ -599,7 +601,7 @@ impl<'a> Emitter<'a> {
             // pre-spill count. (RUE-129)
             let slot = self.num_locals_original + i;
             // Skip past callee-saved registers in the offset calculation
-            let offset = -callee_saved_size - ((slot as i32 + 1) * 8);
+            let offset = -callee_saved_size + crate::frame_layout::slot_offset_pre_saved(slot);
             let abi_index = (i + abi_shift) as usize;
 
             if abi_index < param_regs.len() {
@@ -623,7 +625,7 @@ impl<'a> Emitter<'a> {
         // loads it back to store the result through.
         if self.has_sret {
             let slot = self.num_locals_original + self.num_params;
-            let offset = -callee_saved_size - ((slot as i32 + 1) * 8);
+            let offset = -callee_saved_size + crate::frame_layout::slot_offset_pre_saved(slot);
             self.begin_inst();
             self.emit_str(param_regs[0], Reg::Fp, offset);
             end_inst!(self, "str {}, [x29, #{}] ; sret ptr", param_regs[0], offset);
@@ -1330,7 +1332,9 @@ impl<'a> Emitter<'a> {
             // Must mirror the prologue's allocation exactly: locals + ALL
             // params + the sret pointer slot.
             let total_slots = self.num_locals + self.num_params + self.has_sret as u32;
-            let stack_size = ((total_slots as i32 * 8 + 15) / 16) * 16;
+            let stack_size = crate::frame_layout::align_frame_size(
+                crate::frame_layout::slot_region_bytes(total_slots),
+            );
             if stack_size > 0 {
                 self.begin_inst();
                 self.emit_add_imm(Reg::Sp, Reg::Sp, stack_size as u32);

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -413,8 +413,10 @@ impl<'a> CfgLowerContext<'a> {
     /// Calculate the stack offset for a local variable slot.
     ///
     /// Local variables are stored at negative offsets from the frame pointer.
+    /// The offset is a byte-based product of the frame-layout authority (before
+    /// the backend's saved-register adjustment), not a re-derived `* 8`.
     pub fn local_offset(&self, slot: u32) -> i32 {
-        -((slot as i32 + 1) * 8)
+        crate::frame_layout::slot_offset_pre_saved(slot)
     }
 
     /// Check if a slot corresponds to a parameter ABI slot.

--- a/crates/rue-codegen/src/frame_layout.rs
+++ b/crates/rue-codegen/src/frame_layout.rs
@@ -1,0 +1,210 @@
+//! Byte-based stack-frame layout authority (ADR-0052 phase 4).
+//!
+//! Stack frames, register-allocator spill slots, and temporaries are a
+//! byte-based product of the canonical layout authority rather than a literal
+//! `* 8` re-derived independently at every frame-arithmetic site. The per-slot
+//! storage width and the call-boundary frame alignment are sourced here from
+//! the layout authority's [`SLOT_BYTES`], so `cfg_lower`'s local addressing,
+//! both backends' prologue/epilogue sizing, both spill allocators, and the
+//! `--emit stackframe` reporter cannot drift apart.
+//!
+//! ADR-0052 keeps three representations separate. Frame *layout* is physical:
+//! each cell has a byte offset, size, and alignment. The internal *value
+//! decomposition* stays slot-shaped — a spilled or stack-homed value fragment
+//! still occupies exactly one [`SLOT_BYTES`] cell — so every frame cell is one
+//! `SLOT_BYTES` cell today and the gate-off frame is byte-for-byte identical to
+//! the historical slot model. A future narrow-frame phase varies the per-cell
+//! width without disturbing the consumers that read offsets and sizes from this
+//! authority; conversion between a slot-shaped value and narrow memory happens
+//! at explicit pack/unpack boundaries, not in frame arithmetic.
+
+use rue_air::layout::SLOT_BYTES;
+
+/// Call-boundary stack alignment. Both supported targets keep the frame
+/// 16-byte aligned at calls.
+pub const STACK_FRAME_ALIGNMENT: u64 = 16;
+
+/// Byte size of one frame storage cell holding a slot-shaped value fragment.
+///
+/// Sourced from the canonical layout authority so the frame cannot drift from
+/// the physical slot width. Every local, parameter home, sret pointer cell, and
+/// register-allocator spill slot is one such cell today (the internal value
+/// decomposition keeps slot-shaped fragments); a narrow-frame phase later
+/// varies this per cell.
+#[inline]
+pub const fn frame_cell_bytes() -> u64 {
+    SLOT_BYTES
+}
+
+/// FP-relative byte offset of frame slot `slot`, before the saved-register area
+/// (callee-saved registers, and the FP/LR pair on AArch64) is accounted for.
+///
+/// Slot 0 is the cell immediately below the frame pointer; slots descend. With
+/// uniform [`frame_cell_bytes`] cells this is `-((slot + 1) * cell_bytes)`; the
+/// backends add the saved-register offset via their own adjustment.
+#[inline]
+pub fn slot_offset_pre_saved(slot: u32) -> i32 {
+    -(frame_cell_bytes() as i32 * (slot as i32 + 1))
+}
+
+/// Total byte span of `num_slots` contiguous frame cells.
+#[inline]
+pub fn slot_region_bytes(num_slots: u32) -> i32 {
+    frame_cell_bytes() as i32 * num_slots as i32
+}
+
+/// Round a frame byte size up to [`STACK_FRAME_ALIGNMENT`].
+#[inline]
+pub fn align_frame_size(bytes: i32) -> i32 {
+    let align = STACK_FRAME_ALIGNMENT as i32;
+    ((bytes + align - 1) / align) * align
+}
+
+/// How a target saves the registers that sit between the frame pointer and the
+/// slot region. Their total byte span shifts every frame-slot offset down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SavedRegScheme {
+    /// x86-64: each saved GPR is one 8-byte push; the saved RBP and return
+    /// address sit *above* the frame pointer and are not part of this area.
+    X86_64,
+    /// AArch64: a 16-byte FP/LR pair at the top of the frame, then callee-saved
+    /// registers stored in 16-byte pairs (rounded up).
+    Aarch64,
+}
+
+/// Bytes AArch64 uses to store `num_callee_saved` callee-saved GPRs, saved in
+/// 16-byte pairs (rounded up). This excludes the separate FP/LR pair.
+#[inline]
+pub fn aarch64_callee_saved_pairs_bytes(num_callee_saved: usize) -> u64 {
+    let pairs = (num_callee_saved + 1) / 2;
+    pairs as u64 * STACK_FRAME_ALIGNMENT
+}
+
+impl SavedRegScheme {
+    /// Bytes reserved for saved registers between the frame pointer and the
+    /// slot region, given `num_callee_saved` saved general-purpose registers.
+    pub fn saved_area_bytes(self, num_callee_saved: usize) -> u64 {
+        match self {
+            SavedRegScheme::X86_64 => num_callee_saved as u64 * frame_cell_bytes(),
+            // FP/LR pair plus the paired callee-saved registers.
+            SavedRegScheme::Aarch64 => {
+                STACK_FRAME_ALIGNMENT + aarch64_callee_saved_pairs_bytes(num_callee_saved)
+            }
+        }
+    }
+}
+
+/// A byte-based description of one function's stack frame: the saved-register
+/// area followed by a run of slot cells (locals, parameter homes, the optional
+/// sret pointer cell, and register-allocator spill slots).
+///
+/// This is the single authority the reporter and the backends share so the
+/// frame arithmetic is computed once.
+#[derive(Debug, Clone, Copy)]
+pub struct FrameLayout {
+    scheme: SavedRegScheme,
+    saved_area_bytes: u64,
+    num_slots: u32,
+}
+
+impl FrameLayout {
+    /// Build a frame layout for `num_slots` slot cells sitting below the saved
+    /// registers described by `scheme`.
+    pub fn new(scheme: SavedRegScheme, num_callee_saved: usize, num_slots: u32) -> Self {
+        Self {
+            scheme,
+            saved_area_bytes: scheme.saved_area_bytes(num_callee_saved),
+            num_slots,
+        }
+    }
+
+    /// Bytes reserved for saved registers between the frame pointer and the
+    /// slot region.
+    #[inline]
+    pub fn saved_area_bytes(&self) -> i32 {
+        self.saved_area_bytes as i32
+    }
+
+    /// FP-relative byte offset of frame slot `slot`, past the saved-register
+    /// area.
+    #[inline]
+    pub fn slot_offset(&self, slot: u32) -> i32 {
+        -self.saved_area_bytes() + slot_offset_pre_saved(slot)
+    }
+
+    /// Byte size of frame slot `slot`. Uniform [`frame_cell_bytes`] today.
+    #[inline]
+    pub fn slot_size(&self, _slot: u32) -> u64 {
+        frame_cell_bytes()
+    }
+
+    /// Total frame size in bytes, including the saved-register area and the
+    /// 16-byte-aligned slot region.
+    pub fn frame_size(&self) -> u64 {
+        let slots = slot_region_bytes(self.num_slots);
+        match self.scheme {
+            // The saved GPR pushes are not 16-aligned on x86-64, so the whole
+            // (saved + slots) span is rounded together.
+            SavedRegScheme::X86_64 => align_frame_size(self.saved_area_bytes() + slots) as u64,
+            // The AArch64 saved area is already a multiple of 16, so only the
+            // slot region is rounded before adding it.
+            SavedRegScheme::Aarch64 => self.saved_area_bytes + align_frame_size(slots) as u64,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slot_offsets_match_the_historical_slot_model() {
+        // -((slot + 1) * 8) for every slot, gate-off byte-for-byte.
+        assert_eq!(slot_offset_pre_saved(0), -8);
+        assert_eq!(slot_offset_pre_saved(1), -16);
+        assert_eq!(slot_offset_pre_saved(5), -48);
+    }
+
+    #[test]
+    fn align_frame_size_rounds_up_to_sixteen() {
+        assert_eq!(align_frame_size(0), 0);
+        assert_eq!(align_frame_size(1), 16);
+        assert_eq!(align_frame_size(8), 16);
+        assert_eq!(align_frame_size(16), 16);
+        assert_eq!(align_frame_size(17), 32);
+    }
+
+    #[test]
+    fn x86_64_saved_area_is_eight_per_register() {
+        assert_eq!(SavedRegScheme::X86_64.saved_area_bytes(0), 0);
+        assert_eq!(SavedRegScheme::X86_64.saved_area_bytes(1), 8);
+        assert_eq!(SavedRegScheme::X86_64.saved_area_bytes(3), 24);
+    }
+
+    #[test]
+    fn aarch64_saved_area_pairs_and_reserves_fp_lr() {
+        // FP/LR pair (16) plus paired callee-saved registers (16 per pair).
+        assert_eq!(SavedRegScheme::Aarch64.saved_area_bytes(0), 16);
+        assert_eq!(SavedRegScheme::Aarch64.saved_area_bytes(1), 32);
+        assert_eq!(SavedRegScheme::Aarch64.saved_area_bytes(2), 32);
+        assert_eq!(SavedRegScheme::Aarch64.saved_area_bytes(3), 48);
+    }
+
+    #[test]
+    fn frame_size_matches_prior_x86_64_rounding() {
+        // round16(callee_saved_size + total_slots * 8).
+        let layout = FrameLayout::new(SavedRegScheme::X86_64, 1, 2);
+        // saved = 8, slots = 16 -> round16(24) = 32.
+        assert_eq!(layout.frame_size(), 32);
+        assert_eq!(layout.slot_offset(0), -8 - 8);
+    }
+
+    #[test]
+    fn frame_size_matches_prior_aarch64_rounding() {
+        // fp_lr(16) + callee_saved_pairs*16 + round16(total_slots * 8).
+        let layout = FrameLayout::new(SavedRegScheme::Aarch64, 1, 3);
+        // saved = 16 + 16 = 32, slots = 24 -> round16(24) = 32; total = 64.
+        assert_eq!(layout.frame_size(), 64);
+        assert_eq!(layout.slot_offset(0), -32 - 8);
+    }
+}

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -58,6 +58,7 @@ pub mod aggregate_eq;
 mod api_inventory;
 pub mod byref_args;
 pub mod cfg_lower;
+pub mod frame_layout;
 pub mod index_map;
 pub mod liveness;
 pub mod place_lower;

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -845,7 +845,10 @@ impl SpillSlotAllocator {
         Self {
             slots: Vec::new(),
             min_slot_end: None,
-            base_offset: -((existing_locals as i32 + 1) * 8),
+            // Spill slots continue the frame's slot region after the existing
+            // locals/params, so the first spill homes at the same offset the
+            // frame-layout authority gives slot `existing_locals`.
+            base_offset: crate::frame_layout::slot_offset_pre_saved(existing_locals),
         }
     }
 
@@ -890,9 +893,10 @@ impl SpillSlotAllocator {
         self.offset_for_slot(slot_index)
     }
 
-    /// Get the stack offset for a given slot index.
+    /// Get the stack offset for a given spill slot index (each spill cell is
+    /// one frame cell below the previous, continuing the slot region).
     fn offset_for_slot(&self, slot_index: usize) -> i32 {
-        self.base_offset - (slot_index as i32 * 8)
+        self.base_offset - crate::frame_layout::slot_region_bytes(slot_index as u32)
     }
 
     /// Get the number of unique spill slots used.

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -293,38 +293,34 @@ fn generate_x86_64_stack_frame(
     let (_mir, num_spills, used_callee_saved) =
         RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
 
-    // Calculate stack layout (ALL params get frame slots: the prologue copies
-    // stack-passed args into the frame param area)
-    let callee_saved_size = used_callee_saved.len() * 8;
+    // Calculate stack layout through the byte-based frame-layout authority
+    // (ALL params get frame slots: the prologue copies stack-passed args into
+    // the frame param area). Every slot cell is one frame cell today.
+    use crate::frame_layout::{FrameLayout, SavedRegScheme, frame_cell_bytes};
     let total_slots = num_locals + num_spills + num_params + sret_slots;
-    let needed_bytes = total_slots as i32 * 8;
-    let current_offset = callee_saved_size as i32;
-    let total_needed = current_offset + needed_bytes;
-    let stack_size = ((total_needed + 15) / 16) * 16;
+    let frame = FrameLayout::new(SavedRegScheme::X86_64, used_callee_saved.len(), total_slots);
+    let stack_size = frame.frame_size() as i32;
 
     let mut slots = Vec::new();
 
-    // Add callee-saved registers
+    // Add callee-saved registers (each an 8-byte push just below rbp).
     for (i, reg) in used_callee_saved.iter().enumerate() {
-        let offset = -((i as i32 + 1) * 8);
+        let offset = crate::frame_layout::slot_offset_pre_saved(i as u32);
         slots.push(StackSlot {
             name: Some(format!("saved {}", reg)),
             offset,
-            size: 8,
+            size: frame_cell_bytes() as usize,
             ty: "i64".to_string(),
             kind: StackSlotKind::CalleeSaved,
         });
     }
 
-    let callee_saved_size_i32 = callee_saved_size as i32;
-
     // Add local variables
     for i in 0..num_locals {
-        let slot_offset = -callee_saved_size_i32 - ((i as i32 + 1) * 8);
         slots.push(StackSlot {
             name: None, // We don't have variable names from CFG yet
-            offset: slot_offset,
-            size: 8,
+            offset: frame.slot_offset(i),
+            size: frame.slot_size(i) as usize,
             ty: "i64".to_string(), // Generic - we don't track types at CFG level
             kind: StackSlotKind::Local,
         });
@@ -332,15 +328,12 @@ fn generate_x86_64_stack_frame(
 
     // Add parameter spill slots (ALL params: stack-passed args are copied
     // into the frame param area by the prologue)
-    #[allow(unused_variables)]
-    let arg_regs = ["rdi", "rsi", "rdx", "rcx", "r8", "r9"];
     for i in 0..num_params {
         let slot = num_locals + i;
-        let slot_offset = -callee_saved_size_i32 - ((slot as i32 + 1) * 8);
         slots.push(StackSlot {
             name: None, // We don't have param names from CFG yet
-            offset: slot_offset,
-            size: 8,
+            offset: frame.slot_offset(slot),
+            size: frame.slot_size(slot) as usize,
             ty: "i64".to_string(),
             kind: StackSlotKind::Parameter,
         });
@@ -349,11 +342,10 @@ fn generate_x86_64_stack_frame(
     // Add the sret pointer slot (one past the param area)
     if has_sret {
         let slot = num_locals + num_params;
-        let slot_offset = -callee_saved_size_i32 - ((slot as i32 + 1) * 8);
         slots.push(StackSlot {
             name: Some("sret ptr".to_string()),
-            offset: slot_offset,
-            size: 8,
+            offset: frame.slot_offset(slot),
+            size: frame.slot_size(slot) as usize,
             ty: "ptr".to_string(),
             kind: StackSlotKind::Parameter,
         });
@@ -362,15 +354,17 @@ fn generate_x86_64_stack_frame(
     // Add spill slots
     for i in 0..num_spills {
         let slot = num_locals + num_params + sret_slots + i;
-        let slot_offset = -callee_saved_size_i32 - ((slot as i32 + 1) * 8);
         slots.push(StackSlot {
             name: None,
-            offset: slot_offset,
-            size: 8,
+            offset: frame.slot_offset(slot),
+            size: frame.slot_size(slot) as usize,
             ty: "i64".to_string(),
             kind: StackSlotKind::Spill,
         });
     }
+
+    #[allow(unused_variables)]
+    let arg_regs = ["rdi", "rsi", "rdx", "rcx", "r8", "r9"];
 
     // Build argument locations (the hidden sret pointer occupies the first
     // ABI slot when present, shifting user args by one)
@@ -441,21 +435,21 @@ fn generate_aarch64_stack_frame(
     let (_mir, num_spills, used_callee_saved) =
         RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
 
-    // Calculate stack layout for AArch64
-    // Callee-saved registers are saved in pairs (16 bytes per pair)
-    let num_callee_regs = used_callee_saved.len();
-    let callee_saved_pairs = (num_callee_regs + 1) / 2;
-    let callee_saved_size = callee_saved_pairs * 16;
-
-    // FP and LR are saved separately (16 bytes)
-    let fp_lr_size = 16;
-
-    // ALL params get frame slots: the prologue copies stack-passed args into
-    // the frame param area
+    // Calculate stack layout for AArch64 through the byte-based frame-layout
+    // authority. Callee-saved registers are saved in pairs (16 bytes per pair)
+    // and the FP/LR pair (16 bytes) sits above them; ALL params get frame slots
+    // (the prologue copies stack-passed args into the frame param area).
+    use crate::frame_layout::{FrameLayout, SavedRegScheme};
     let total_slots = num_locals + num_spills + num_params + sret_slots;
-    let locals_size = ((total_slots as i32 * 8 + 15) / 16) * 16;
+    let frame = FrameLayout::new(
+        SavedRegScheme::Aarch64,
+        used_callee_saved.len(),
+        total_slots,
+    );
+    let frame_size = frame.frame_size() as usize;
 
-    let frame_size = fp_lr_size + callee_saved_size + locals_size as usize;
+    // FP and LR are saved separately (16 bytes) at the very top of the frame.
+    let fp_lr_size = 16;
 
     let mut slots = Vec::new();
 
@@ -493,15 +487,12 @@ fn generate_aarch64_stack_frame(
         });
     }
 
-    let locals_base_offset = -(fp_lr_size as i32 + callee_saved_size as i32);
-
     // Add local variables
     for i in 0..num_locals {
-        let slot_offset = locals_base_offset - ((i as i32 + 1) * 8);
         slots.push(StackSlot {
             name: None,
-            offset: slot_offset,
-            size: 8,
+            offset: frame.slot_offset(i),
+            size: frame.slot_size(i) as usize,
             ty: "i64".to_string(),
             kind: StackSlotKind::Local,
         });
@@ -511,11 +502,10 @@ fn generate_aarch64_stack_frame(
     // into the frame param area by the prologue)
     for i in 0..num_params {
         let slot = num_locals + i;
-        let slot_offset = locals_base_offset - ((slot as i32 + 1) * 8);
         slots.push(StackSlot {
             name: None,
-            offset: slot_offset,
-            size: 8,
+            offset: frame.slot_offset(slot),
+            size: frame.slot_size(slot) as usize,
             ty: "i64".to_string(),
             kind: StackSlotKind::Parameter,
         });
@@ -524,11 +514,10 @@ fn generate_aarch64_stack_frame(
     // Add the sret pointer slot (one past the param area)
     if has_sret {
         let slot = num_locals + num_params;
-        let slot_offset = locals_base_offset - ((slot as i32 + 1) * 8);
         slots.push(StackSlot {
             name: Some("sret ptr".to_string()),
-            offset: slot_offset,
-            size: 8,
+            offset: frame.slot_offset(slot),
+            size: frame.slot_size(slot) as usize,
             ty: "ptr".to_string(),
             kind: StackSlotKind::Parameter,
         });
@@ -537,11 +526,10 @@ fn generate_aarch64_stack_frame(
     // Add spill slots
     for i in 0..num_spills {
         let slot = num_locals + num_params + sret_slots + i;
-        let slot_offset = locals_base_offset - ((slot as i32 + 1) * 8);
         slots.push(StackSlot {
             name: None,
-            offset: slot_offset,
-            size: 8,
+            offset: frame.slot_offset(slot),
+            size: frame.slot_size(slot) as usize,
             ty: "i64".to_string(),
             kind: StackSlotKind::Spill,
         });

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -317,9 +317,10 @@ impl<'a> Emitter<'a> {
 
     /// Calculate the total stack space used by callee-saved registers.
     ///
-    /// On x86-64, each register is pushed individually (8 bytes each).
+    /// On x86-64, each register is pushed individually (8 bytes each). Sourced
+    /// from the frame-layout authority's saved-register scheme.
     fn callee_saved_size(&self) -> i32 {
-        self.callee_saved.len() as i32 * 8
+        crate::frame_layout::SavedRegScheme::X86_64.saved_area_bytes(self.callee_saved.len()) as i32
     }
 
     /// Adjust an RBP-relative offset to account for callee-saved registers.
@@ -464,17 +465,16 @@ impl<'a> Emitter<'a> {
         //   args are copied into the frame param area below so the body can
         //   address every param slot uniformly)
         // - one slot for the incoming sret pointer, if any
-        // Each slot is 8 bytes, total aligned to 16
+        // Each slot is one frame cell; the total (including callee-saved
+        // pushes) is 16-byte aligned by the frame-layout authority.
         let total_slots = self.num_locals + self.num_params + self.has_sret as u32;
-        let needed_bytes = total_slots as i32 * 8;
-        // Account for callee-saved pushes for alignment calculation
-        let pushes_so_far = callee_saved.len() as i32;
-        // We need total stack usage (including callee-saved) to be 16-byte aligned
-        // At this point: rbp is set, callee_saved are pushed
-        // After sub rsp, N: rsp should be 16-byte aligned
-        let current_offset = pushes_so_far * 8;
-        let total_needed = current_offset + needed_bytes;
-        let stack_size = ((total_needed + 15) / 16) * 16 - current_offset;
+        let needed_bytes = crate::frame_layout::slot_region_bytes(total_slots);
+        // Account for callee-saved pushes for alignment calculation.
+        // At this point: rbp is set, callee_saved are pushed.
+        // After sub rsp, N: rsp should be 16-byte aligned.
+        let current_offset = self.callee_saved_size();
+        let stack_size =
+            crate::frame_layout::align_frame_size(current_offset + needed_bytes) - current_offset;
 
         if stack_size > 0 {
             // sub rsp, imm32: 48 81 EC imm32
@@ -510,7 +510,7 @@ impl<'a> Emitter<'a> {
             // because CfgLower generates param offsets based on the original count
             let slot = self.num_locals_original + i;
             // Skip past callee-saved registers in the offset calculation
-            let offset = -callee_saved_size - ((slot as i32 + 1) * 8);
+            let offset = -callee_saved_size + crate::frame_layout::slot_offset_pre_saved(slot);
             let abi_index = i + abi_shift;
 
             if (abi_index as usize) < ARG_REGS.len() {
@@ -536,7 +536,7 @@ impl<'a> Emitter<'a> {
         // loads it back to store the result through.
         if self.has_sret {
             let slot = self.num_locals_original + self.num_params;
-            let offset = -callee_saved_size - ((slot as i32 + 1) * 8);
+            let offset = -callee_saved_size + crate::frame_layout::slot_offset_pre_saved(slot);
             self.begin_inst();
             self.emit_mov_mr(Reg::Rbp, offset, ARG_REGS[0]);
             end_inst!(self, "mov [rbp{}], {} ; sret ptr", offset, ARG_REGS[0]);


### PR DESCRIPTION
## Summary

Fourth child of the ADR-0052 migration (epic RUE-971): stack and value separation. A new `frame_layout.rs` authority makes frames, spill slots, and parameter/sret homes a byte-based product of the layout authority, owned in one place with a target-parameterized `SavedRegScheme`/`FrameLayout`.

The audit's four independent re-derivations of frame arithmetic now consume it instead of computing `*8` locally:

- `cfg_lower`'s `local_offset` (`-((slot+1)*8)`), which grounded all local/parameter stack addressing in both backends;
- the shared regalloc `SpillSlotAllocator`;
- both backends' prologue/epilogue and param/sret homing in `emit.rs`;
- the `--emit stackframe` reporter, which previously recomputed the entire frame per backend.

Per ADR-0052's three-representation split, frame **layout** is byte-based while the internal value decomposition stays slot-shaped — CFG temporary sizing is deliberately unchanged, so generated code is **byte-identical gate-off** (every frame cell one `SLOT_BYTES` cell at `SLOT_BYTES` alignment, same 16-byte rounding). Under `aggregate_layout` the frame is also unchanged and RUE-974's loud refusal of narrow physical access remains in force; narrow load/store marshalling and outgoing call-arg sizing stay staged for RUE-976.

## Verification

Integrated and re-verified on current trunk: six new `frame_layout` unit tests; codegen units 560; CLI `abi` 55, `aggregate` 109, `aggregate_layout` 8; oracle quick 0 disagreements; full `test.sh` green except the four known uid-0 unreadable-file environmental failures — including the encoding-exact, reproducibility, and stackframe golden tests unmodified, which is the byte-identical claim tested directly. Gated and ungated execution re-verified by hand at integration.

Fixes RUE-975

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_