### PR TITLE
RUE-983: add blocking Linux TCP listener and stream to std.net

### DIFF
--- a/crates/rue-cli-tests/cases/std_net_tcp.toml
+++ b/crates/rue-cli-tests/cases/std_net_tcp.toml
@@ -1,0 +1,201 @@
+# std.net blocking TCP v1 (RUE-983, ADR-0060) — real sockets over loopback.
+#
+# The Linux cases run the whole blocking client/server surface in one process:
+# bind on an ephemeral port (port 0 + local_addr, so no fixed port is
+# assumed), connect against the listen backlog, accept, byte round trip,
+# shutdown(Write) observed as EOF by the peer, and explicit consuming closes.
+# Deterministic RUE-984 multi-process loopback coverage extends this.
+#
+# macOS is the fail-closed unsupported platform until RUE-986: constructors
+# return NetworkError.Unsupported before any socket syscall, asserted by the
+# macOS-only case.
+
+[section]
+id = "cli.std_net_tcp"
+name = "Standard library v1 — std.net blocking TCP (RUE-983)"
+description = "TcpListener/TcpStream over loopback: connect/accept/read/write/shutdown/close."
+
+[[case]]
+name = "tcp_loopback_round_trip"
+description = "bind(0)+local_addr, connect, accept, write_all->read, shutdown->EOF, closes."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+only_on = ["x86-64-linux", "aarch64-linux"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn fail(code: i32) -> i32 {
+    @dbg(code);
+    1
+}
+
+fn main() -> i32 {
+    let RL = std.result.Result(std.net.TcpListener, std.net.NetworkError);
+    let RS = std.result.Result(std.net.TcpStream, std.net.NetworkError);
+    let RA = std.result.Result(std.net.SockAddr, std.net.NetworkError);
+    let RU = std.result.Result(u64, std.net.NetworkError);
+    let RUnit = std.result.Result((), std.net.NetworkError);
+
+    // Ephemeral bind: never assume a fixed free port.
+    let bind_addr = std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), 0);
+    let mut listener = match std.net.TcpListener.bind(bind_addr) {
+        RL.Ok(l) => l,
+        RL.Err(e) => { return fail(101); },
+    };
+    let port: u16 = match listener.local_addr() {
+        RA.Ok(a) => a.port,
+        RA.Err(e) => { return fail(102); },
+    };
+    if port == 0 { return fail(103); }
+    @dbg(1);
+
+    // connect completes against the backlog before accept runs.
+    let mut client = match std.net.TcpStream.connect(std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), port)) {
+        RS.Ok(s) => s,
+        RS.Err(e) => { return fail(104); },
+    };
+    let mut server = match listener.accept() {
+        RS.Ok(s) => s,
+        RS.Err(e) => { return fail(105); },
+    };
+    @dbg(2);
+
+    // client -> server byte round trip.
+    let mut out = std.arraybuf.ArrayBuf(u8).new();
+    out.push(104); out.push(105); out.push(33);
+    match client.write_all(borrow out) {
+        RUnit.Ok(u) => {},
+        RUnit.Err(e) => { return fail(106); },
+    }
+    let mut inbuf = std.arraybuf.ArrayBuf(u8).with_capacity(16);
+    let got = match server.read(inout inbuf) {
+        RU.Ok(n) => n,
+        RU.Err(e) => { return fail(107); },
+    };
+    if got != 3 { return fail(108); }
+    @dbg(inbuf.get_or(0, 0)); @dbg(inbuf.get_or(1, 0)); @dbg(inbuf.get_or(2, 0));
+
+    // Peer half-close: after client shutdown(Write), server read is EOF and
+    // nothing else (Ok(0)).
+    match client.shutdown(std.net.Shutdown.Write) {
+        RUnit.Ok(u) => {},
+        RUnit.Err(e) => { return fail(109); },
+    }
+    let mut eofbuf = std.arraybuf.ArrayBuf(u8).with_capacity(8);
+    match server.read(inout eofbuf) {
+        RU.Ok(n) => { if n == 0 { @dbg(3); } else { return fail(110); } },
+        RU.Err(e) => { return fail(111); },
+    }
+
+    // Server -> client still flows after the client's write shutdown.
+    let mut reply = std.arraybuf.ArrayBuf(u8).new();
+    reply.push(111); reply.push(107);
+    match server.write_all(borrow reply) {
+        RUnit.Ok(u) => {},
+        RUnit.Err(e) => { return fail(112); },
+    }
+    let mut back = std.arraybuf.ArrayBuf(u8).with_capacity(8);
+    match client.read(inout back) {
+        RU.Ok(n) => { if n == 2 { @dbg(back.get_or(0, 0)); } else { return fail(113); } },
+        RU.Err(e) => { return fail(114); },
+    }
+
+    // Consuming closes; the sentinel keeps each drop from double-closing.
+    match client.close() { RUnit.Ok(u) => {}, RUnit.Err(e) => { return fail(115); } }
+    match server.close() { RUnit.Ok(u) => {}, RUnit.Err(e) => { return fail(116); } }
+    match listener.close() { RUnit.Ok(u) => {}, RUnit.Err(e) => { return fail(117); } }
+    @dbg(4);
+    0
+}
+""" }]
+stdout = "1\n2\n104\n105\n33\n3\n111\n4\n"
+
+# Connecting to a just-released ephemeral port is refused, exercising errno
+# normalization (ECONNREFUSED -> ConnectionRefused) through a real syscall.
+[[case]]
+name = "tcp_connection_refused"
+description = "connect() to a closed loopback port normalizes to ConnectionRefused."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+only_on = ["x86-64-linux", "aarch64-linux"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn fail(code: i32) -> i32 {
+    @dbg(code);
+    1
+}
+
+fn main() -> i32 {
+    let RL = std.result.Result(std.net.TcpListener, std.net.NetworkError);
+    let RS = std.result.Result(std.net.TcpStream, std.net.NetworkError);
+    let RA = std.result.Result(std.net.SockAddr, std.net.NetworkError);
+    let RUnit = std.result.Result((), std.net.NetworkError);
+
+    // Learn an ephemeral port, then free it so nothing listens there.
+    let bind_addr = std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), 0);
+    let mut listener = match std.net.TcpListener.bind(bind_addr) {
+        RL.Ok(l) => l,
+        RL.Err(e) => { return fail(101); },
+    };
+    let port: u16 = match listener.local_addr() {
+        RA.Ok(a) => a.port,
+        RA.Err(e) => { return fail(102); },
+    };
+    match listener.close() { RUnit.Ok(u) => {}, RUnit.Err(e) => { return fail(103); } }
+
+    match std.net.TcpStream.connect(std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), port)) {
+        RS.Ok(s) => {
+            let ignored = s.close();
+            return fail(104);
+        },
+        RS.Err(e) => {
+            match e {
+                std.net.NetworkError.ConnectionRefused => { @dbg(1); },
+                _ => { return fail(105); },
+            }
+        },
+    }
+    0
+}
+""" }]
+stdout = "1\n"
+
+# The fail-closed platform boundary: macOS constructors report Unsupported
+# without issuing a socket syscall (ADR-0060 §7, real Darwin ABI is RUE-986).
+[[case]]
+name = "tcp_macos_unsupported"
+description = "bind and connect return NetworkError.Unsupported on macOS."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+only_on = ["aarch64-macos"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let RL = std.result.Result(std.net.TcpListener, std.net.NetworkError);
+    let RS = std.result.Result(std.net.TcpStream, std.net.NetworkError);
+    let addr = std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), 0);
+    match std.net.TcpListener.bind(addr) {
+        RL.Ok(l) => { let ignored = l.close(); @dbg(0); },
+        RL.Err(e) => {
+            match e {
+                std.net.NetworkError.Unsupported => { @dbg(1); },
+                _ => { @dbg(0); },
+            }
+        },
+    }
+    let addr2 = std.net.SockAddr.v4(std.net.Ipv4Addr.localhost(), 1);
+    match std.net.TcpStream.connect(addr2) {
+        RS.Ok(s) => { let ignored = s.close(); @dbg(0); },
+        RS.Err(e) => {
+            match e {
+                std.net.NetworkError.Unsupported => { @dbg(2); },
+                _ => { @dbg(0); },
+            }
+        },
+    }
+    0
+}
+""" }]
+stdout = "1\n2\n"

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -1028,6 +1028,18 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
+        "cli.std_net_tcp",
+        "tcp_connection_refused",
+        external(ExternalDependencyKind::SystemCall),
+        &["aarch64-linux", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.std_net_tcp",
+        "tcp_loopback_round_trip",
+        external(ExternalDependencyKind::SystemCall),
+        &["aarch64-linux", "x86-64-linux"],
+    ),
+    Entry::new(
         "cli.std_strbuf",
         "aliased_three_word_layout_and_scope_drop",
         intrinsic(UnsupportedIntrinsicKind::IntToPointer),

--- a/docs/designs/0060-network-io-v1.md
+++ b/docs/designs/0060-network-io-v1.md
@@ -207,7 +207,7 @@ The implementation dependency chain is exact:
 
 - [x] **Reusable explicit-endian helpers** — RUE-970
 - [x] **IPv4 and `SockAddr` types plus Linux marshalling** — RUE-982, blocked by RUE-970
-- [ ] **Blocking `TcpListener`/`TcpStream` operations** — RUE-983, blocked by RUE-982
+- [x] **Blocking `TcpListener`/`TcpStream` operations** — RUE-983, blocked by RUE-982
 - [ ] **Deterministic real-binary Linux loopback coverage** — RUE-984, blocked by RUE-983
 
 RUE-984 may narrowly extend the CLI harness to coordinate two processes. Tests

--- a/std/net.rue
+++ b/std/net.rue
@@ -23,6 +23,7 @@
 
 const binary = @import("binary.rue");
 const option = @import("option.rue");
+const result = @import("result.rue");
 
 // The AF_INET address-family value shared by both v1 Linux targets.
 fn _af_inet() -> u16 {
@@ -120,5 +121,537 @@ pub struct SockAddr {
         let port = binary.u16_from_be_bytes([b[2], b[3]]);
         let ip = Ipv4Addr.new(b[4], b[5], b[6], b[7]);
         O.Some(SockAddr.v4(ip, port))
+    }
+}
+
+// ===========================================================================
+// Blocking TCP v1 (RUE-983, ADR-0060 §1/§5/§6/§7).
+//
+// Pure Rue over `@syscall`, Linux x86-64 and aarch64 only. Constructors are
+// the fail-closed platform boundary: on macOS they return
+// `NetworkError.Unsupported` BEFORE any socket syscall (no guessed Darwin
+// numbers; real Darwin support is RUE-986). Because no constructor succeeds
+// off-Linux, every method and drop below runs only over Linux descriptors,
+// so the syscall tables carry Linux numbers keyed by architecture alone.
+//
+// Descriptor ownership follows ADR-0057 §4 exactly as std.fs.File: scope exit
+// closes a live fd via `drop fn`; consuming `close(self)` first swaps in the
+// `-1` sentinel so the moved-from value's drop is a no-op and the fd closes
+// exactly once. File/TcpStream IO names stay parallel (`read`, `write`,
+// `write_all`, `close`) without a trait abstraction (ADR-0060 §5).
+// ===========================================================================
+
+const arraybuf = @import("arraybuf.rue");
+
+// A normalized, target-independent network error (ADR-0060 §6). Useful stable
+// categories are mapped; everything else falls through to `Other(i64)` with
+// the raw errno, so no error is ever lost.
+pub enum NetworkError {
+    Unsupported,          // not a v1 platform (macOS until RUE-986)
+    PermissionDenied,     // EACCES, EPERM
+    AddressInUse,         // EADDRINUSE
+    AddressNotAvailable,  // EADDRNOTAVAIL
+    ConnectionRefused,    // ECONNREFUSED
+    ConnectionReset,      // ECONNRESET
+    ConnectionAborted,    // ECONNABORTED
+    NotConnected,         // ENOTCONN
+    TimedOut,             // ETIMEDOUT
+    Interrupted,          // EINTR
+    WouldBlock,           // EAGAIN / EWOULDBLOCK
+    InvalidInput,         // EINVAL, EBADF
+    Other(i64),           // any other raw errno
+}
+
+// How `TcpStream.shutdown` disables the connection's directions.
+pub enum Shutdown {
+    Read,   // SHUT_RD: further receives return EOF
+    Write,  // SHUT_WR: sends are done; the peer's read sees EOF
+    Both,   // SHUT_RDWR
+}
+
+// Whether this target runs real v1 network syscalls. The single fail-closed
+// platform gate (ADR-0060 §7): macOS waits for RUE-986.
+fn _net_supported() -> bool {
+    match @target_os() {
+        Os.Linux => true,
+        Os.Macos => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Linux socket syscall numbers, keyed by architecture. These are only issued
+// behind `_net_supported()` (see the section comment), so no Darwin numbers
+// appear here.
+// ---------------------------------------------------------------------------
+
+fn _sys_socket() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => 41,
+        Arch.Aarch64 => 198,
+    }
+}
+
+fn _sys_connect() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => 42,
+        Arch.Aarch64 => 203,
+    }
+}
+
+fn _sys_accept() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => 43,
+        Arch.Aarch64 => 202,
+    }
+}
+
+fn _sys_bind() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => 49,
+        Arch.Aarch64 => 200,
+    }
+}
+
+fn _sys_listen() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => 50,
+        Arch.Aarch64 => 201,
+    }
+}
+
+fn _sys_getsockname() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => 51,
+        Arch.Aarch64 => 204,
+    }
+}
+
+fn _sys_shutdown() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => 48,
+        Arch.Aarch64 => 210,
+    }
+}
+
+fn _sys_net_read() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => 0,
+        Arch.Aarch64 => 63,
+    }
+}
+
+fn _sys_net_write() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => 1,
+        Arch.Aarch64 => 64,
+    }
+}
+
+fn _sys_net_close() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => 3,
+        Arch.Aarch64 => 57,
+    }
+}
+
+// Linux socket constants, identical on both v1 architectures.
+fn _sock_stream() -> u64 { 1 }
+fn _default_backlog() -> u64 { 128 }
+
+// Normalize a POSITIVE Linux errno into `NetworkError` (asm-generic values,
+// same on x86-64 and aarch64).
+fn _normalize_net_errno(e: i64) -> NetworkError {
+    // EPERM=1 EINTR=4 EBADF=9 EAGAIN=11 EACCES=13 EINVAL=22 EADDRINUSE=98
+    // EADDRNOTAVAIL=99 ECONNABORTED=103 ECONNRESET=104 ENOTCONN=107
+    // ETIMEDOUT=110 ECONNREFUSED=111
+    if e == 1 {
+        NetworkError.PermissionDenied
+    } else if e == 13 {
+        NetworkError.PermissionDenied
+    } else if e == 98 {
+        NetworkError.AddressInUse
+    } else if e == 99 {
+        NetworkError.AddressNotAvailable
+    } else if e == 111 {
+        NetworkError.ConnectionRefused
+    } else if e == 104 {
+        NetworkError.ConnectionReset
+    } else if e == 103 {
+        NetworkError.ConnectionAborted
+    } else if e == 107 {
+        NetworkError.NotConnected
+    } else if e == 110 {
+        NetworkError.TimedOut
+    } else if e == 4 {
+        NetworkError.Interrupted
+    } else if e == 11 {
+        NetworkError.WouldBlock
+    } else if e == 22 {
+        NetworkError.InvalidInput
+    } else if e == 9 {
+        NetworkError.InvalidInput
+    } else {
+        NetworkError.Other(e)
+    }
+}
+
+// Serialize a marshalled sockaddr_in value into a kernel-addressable 16-byte
+// heap buffer. A `[u8; 16]` VALUE lives in 8-byte logical slots (ADR-0040),
+// so its storage is not the contiguous byte image the kernel needs; this is
+// the one copy from value space into byte space. Caller frees with
+// `@free_bytes(buf, sockaddr_in_len(), 1)`.
+fn _sockaddr_to_kernel_buf(b: [u8; 16]) -> ptr mut u8 {
+    let buf: ptr mut u8 = checked { @alloc_bytes(sockaddr_in_len(), 1) };
+    if checked { @ptr_to_int(buf) } == 0 {
+        @panic("out of memory");
+    }
+    let mut i: u64 = 0;
+    while i < 16 {
+        checked { @byte_write(buf, i, b[i]); };
+        i = i + 1;
+    }
+    buf
+}
+
+// Create an AF_INET SOCK_STREAM socket, or the normalized error.
+fn _new_stream_socket() -> result.Result(i32, NetworkError) {
+    let R = result.Result(i32, NetworkError);
+    let af: u64 = @intCast(_af_inet());
+    let proto: u64 = 0;
+    let ret: i64 = checked { @syscall(_sys_socket(), af, _sock_stream(), proto) };
+    if ret < 0 {
+        R.Err(_normalize_net_errno(0 - ret))
+    } else {
+        let fd: i32 = @intCast(ret);
+        R.Ok(fd)
+    }
+}
+
+// Close a raw fd on an error path where no owned value exists yet. The error
+// (if any) is unobservable by design, like drop-close.
+fn _close_raw(fd: i32) {
+    if fd >= 0 {
+        let fd_u: u64 = @intCast(fd);
+        checked { @syscall(_sys_net_close(), fd_u); };
+    }
+}
+
+// A connected TCP stream: an owned socket descriptor (ADR-0060 §5).
+//
+// `read`/`write`/`write_all` mirror `std.fs.File` byte-for-byte in shape:
+// read appends into the buffer's spare capacity and `Ok(0)` means the peer
+// closed (EOF, including after the peer's `shutdown(Write)`); write may be
+// short; `write_all` loops over short writes and retries EINTR.
+pub struct TcpStream {
+    fd: i32,
+
+    // Connect to `addr`, blocking until established or failed.
+    fn connect(addr: SockAddr) -> result.Result(TcpStream, NetworkError) {
+        let R = result.Result(TcpStream, NetworkError);
+        if !_net_supported() {
+            return R.Err(NetworkError.Unsupported);
+        }
+        let RS = result.Result(i32, NetworkError);
+        let fd = match _new_stream_socket() {
+            RS.Ok(fd) => fd,
+            RS.Err(e) => { return R.Err(e); },
+        };
+        let buf = _sockaddr_to_kernel_buf(addr.to_sockaddr_in());
+        let baddr: u64 = checked { @ptr_to_int(buf) };
+        let fd_u: u64 = @intCast(fd);
+        let ret: i64 = checked { @syscall(_sys_connect(), fd_u, baddr, sockaddr_in_len()) };
+        checked { @free_bytes(buf, sockaddr_in_len(), 1); };
+        if ret < 0 {
+            _close_raw(fd);
+            return R.Err(_normalize_net_errno(0 - ret));
+        }
+        R.Ok(TcpStream { fd: fd })
+    }
+
+    // Read up to the buffer's spare capacity, appending to `buf`; the count
+    // is returned. `Ok(0)` means the peer closed this direction (EOF) and
+    // nothing else: a spare-capacity-free buffer is the caller error
+    // `Err(InvalidInput)`, exactly as `File.read` (ADR-0057 §5).
+    fn read(inout self, inout buf: arraybuf.ArrayBuf(u8)) -> result.Result(u64, NetworkError) {
+        let R = result.Result(u64, NetworkError);
+        let want = buf.capacity() - buf.len();
+        if want == 0 {
+            return R.Err(NetworkError.InvalidInput);
+        }
+        let tmp: ptr mut u8 = checked { @alloc_bytes(want, 1) };
+        if checked { @ptr_to_int(tmp) } == 0 {
+            @panic("out of memory");
+        }
+        let addr: u64 = checked { @ptr_to_int(tmp) };
+        let fd_u: u64 = @intCast(self.fd);
+        let ret: i64 = checked { @syscall(_sys_net_read(), fd_u, addr, want) };
+        if ret < 0 {
+            checked { @free_bytes(tmp, want, 1); };
+            return R.Err(_normalize_net_errno(0 - ret));
+        }
+        let n: u64 = @intCast(ret);
+        let mut i: u64 = 0;
+        while i < n {
+            let b = checked { @byte_read(tmp, i) };
+            buf.push(b);
+            i = i + 1;
+        }
+        checked { @free_bytes(tmp, want, 1); };
+        R.Ok(n)
+    }
+
+    // Send the bytes of `buf` in a single write(2); may send fewer than
+    // `buf.len()` (the count is returned). Use `write_all` for the
+    // whole-buffer guarantee.
+    fn write(inout self, borrow buf: arraybuf.ArrayBuf(u8)) -> result.Result(u64, NetworkError) {
+        let R = result.Result(u64, NetworkError);
+        let n = buf.len();
+        if n == 0 {
+            return R.Ok(0);
+        }
+        let tmp: ptr mut u8 = checked { @alloc_bytes(n, 1) };
+        if checked { @ptr_to_int(tmp) } == 0 {
+            @panic("out of memory");
+        }
+        let mut i: u64 = 0;
+        while i < n {
+            checked { @byte_write(tmp, i, buf.get_or(i, 0)); };
+            i = i + 1;
+        }
+        let addr: u64 = checked { @ptr_to_int(tmp) };
+        let fd_u: u64 = @intCast(self.fd);
+        let ret: i64 = checked { @syscall(_sys_net_write(), fd_u, addr, n) };
+        checked { @free_bytes(tmp, n, 1); };
+        if ret < 0 {
+            R.Err(_normalize_net_errno(0 - ret))
+        } else {
+            R.Ok(@intCast(ret))
+        }
+    }
+
+    // Send every byte of `buf`, looping over short writes and retrying EINTR.
+    fn write_all(inout self, borrow buf: arraybuf.ArrayBuf(u8)) -> result.Result((), NetworkError) {
+        let R = result.Result((), NetworkError);
+        let n = buf.len();
+        if n == 0 {
+            return R.Ok(());
+        }
+        let tmp: ptr mut u8 = checked { @alloc_bytes(n, 1) };
+        if checked { @ptr_to_int(tmp) } == 0 {
+            @panic("out of memory");
+        }
+        let mut i: u64 = 0;
+        while i < n {
+            checked { @byte_write(tmp, i, buf.get_or(i, 0)); };
+            i = i + 1;
+        }
+        let base: u64 = checked { @ptr_to_int(tmp) };
+        let fd_u: u64 = @intCast(self.fd);
+        let mut off: u64 = 0;
+        while off < n {
+            let ret: i64 = checked { @syscall(_sys_net_write(), fd_u, base + off, n - off) };
+            if ret < 0 {
+                let e = _normalize_net_errno(0 - ret);
+                let retry = match e {
+                    NetworkError.Interrupted => true,
+                    _ => false,
+                };
+                if !retry {
+                    checked { @free_bytes(tmp, n, 1); };
+                    return R.Err(e);
+                }
+            } else {
+                let wrote: u64 = @intCast(ret);
+                if wrote == 0 {
+                    // No progress on a non-error write; stop rather than spin.
+                    checked { @free_bytes(tmp, n, 1); };
+                    return R.Err(NetworkError.Other(0));
+                }
+                off = off + wrote;
+            }
+        }
+        checked { @free_bytes(tmp, n, 1); };
+        R.Ok(())
+    }
+
+    // Disable one or both directions of the connection. After
+    // `shutdown(Write)`, the peer's read observes EOF (`Ok(0)`) once it
+    // drains buffered data; this value still owns the fd and must be closed.
+    fn shutdown(inout self, how: Shutdown) -> result.Result((), NetworkError) {
+        let R = result.Result((), NetworkError);
+        let mode: u64 = match how {
+            Shutdown.Read => 0,   // SHUT_RD
+            Shutdown.Write => 1,  // SHUT_WR
+            Shutdown.Both => 2,   // SHUT_RDWR
+        };
+        let fd_u: u64 = @intCast(self.fd);
+        let ret: i64 = checked { @syscall(_sys_shutdown(), fd_u, mode) };
+        if ret < 0 {
+            R.Err(_normalize_net_errno(0 - ret))
+        } else {
+            R.Ok(())
+        }
+    }
+
+    // Consuming close (ADR-0057 §4): the sentinel makes the moved-from
+    // value's drop a no-op, so the fd closes exactly once.
+    fn close(self) -> result.Result((), NetworkError) {
+        let R = result.Result((), NetworkError);
+        let mut me = self;
+        let fd = me.fd;
+        me.fd = -1;
+        if fd < 0 {
+            return R.Ok(());
+        }
+        let fd_u: u64 = @intCast(fd);
+        let ret: i64 = checked { @syscall(_sys_net_close(), fd_u) };
+        if ret < 0 {
+            R.Err(_normalize_net_errno(0 - ret))
+        } else {
+            R.Ok(())
+        }
+    }
+}
+
+// Scope-exit close, guarded by the consuming-close sentinel (ADR-0057 §4).
+drop fn TcpStream(self) {
+    if self.fd >= 0 {
+        let fd_u: u64 = @intCast(self.fd);
+        checked { @syscall(_sys_net_close(), fd_u); };
+    }
+}
+
+// A listening TCP socket: an owned descriptor distinct from `TcpStream`
+// (ADR-0060 §5) — a listener accepts connections, a stream transfers bytes.
+pub struct TcpListener {
+    fd: i32,
+
+    // Bind to `addr` and start listening (socket + bind + listen). Bind with
+    // port 0 to let the kernel choose an ephemeral port, then recover it with
+    // `local_addr`.
+    fn bind(addr: SockAddr) -> result.Result(TcpListener, NetworkError) {
+        let R = result.Result(TcpListener, NetworkError);
+        if !_net_supported() {
+            return R.Err(NetworkError.Unsupported);
+        }
+        let RS = result.Result(i32, NetworkError);
+        let fd = match _new_stream_socket() {
+            RS.Ok(fd) => fd,
+            RS.Err(e) => { return R.Err(e); },
+        };
+        let buf = _sockaddr_to_kernel_buf(addr.to_sockaddr_in());
+        let baddr: u64 = checked { @ptr_to_int(buf) };
+        let fd_u: u64 = @intCast(fd);
+        let bret: i64 = checked { @syscall(_sys_bind(), fd_u, baddr, sockaddr_in_len()) };
+        checked { @free_bytes(buf, sockaddr_in_len(), 1); };
+        if bret < 0 {
+            _close_raw(fd);
+            return R.Err(_normalize_net_errno(0 - bret));
+        }
+        let lret: i64 = checked { @syscall(_sys_listen(), fd_u, _default_backlog()) };
+        if lret < 0 {
+            _close_raw(fd);
+            return R.Err(_normalize_net_errno(0 - lret));
+        }
+        R.Ok(TcpListener { fd: fd })
+    }
+
+    // The local address this listener is bound to, decoded from the kernel
+    // via getsockname. This is how a port-0 bind learns its ephemeral port.
+    // The kernel-filled family and length are validated before decoding
+    // (ADR-0060 §3).
+    fn local_addr(inout self) -> result.Result(SockAddr, NetworkError) {
+        let R = result.Result(SockAddr, NetworkError);
+        let abuf: ptr mut u8 = checked { @alloc_bytes(sockaddr_in_len(), 1) };
+        if checked { @ptr_to_int(abuf) } == 0 {
+            @panic("out of memory");
+        }
+        // socklen_t in/out argument: starts at 16, kernel writes the actual
+        // length back (little-endian u32 on both v1 targets).
+        let lbuf: ptr mut u8 = checked { @alloc_bytes(4, 1) };
+        if checked { @ptr_to_int(lbuf) } == 0 {
+            @panic("out of memory");
+        }
+        checked { @byte_write(lbuf, 0, 16); };
+        checked { @byte_write(lbuf, 1, 0); };
+        checked { @byte_write(lbuf, 2, 0); };
+        checked { @byte_write(lbuf, 3, 0); };
+        let aaddr: u64 = checked { @ptr_to_int(abuf) };
+        let laddr: u64 = checked { @ptr_to_int(lbuf) };
+        let fd_u: u64 = @intCast(self.fd);
+        let ret: i64 = checked { @syscall(_sys_getsockname(), fd_u, aaddr, laddr) };
+        if ret < 0 {
+            checked { @free_bytes(abuf, sockaddr_in_len(), 1); };
+            checked { @free_bytes(lbuf, 4, 1); };
+            return R.Err(_normalize_net_errno(0 - ret));
+        }
+        let l0 = checked { @byte_read(lbuf, 0) };
+        let l1 = checked { @byte_read(lbuf, 1) };
+        let l2 = checked { @byte_read(lbuf, 2) };
+        let l3 = checked { @byte_read(lbuf, 3) };
+        checked { @free_bytes(lbuf, 4, 1); };
+        let written_len = binary.u32_from_le_bytes([l0, l1, l2, l3]);
+        if written_len != 16 {
+            checked { @free_bytes(abuf, sockaddr_in_len(), 1); };
+            return R.Err(NetworkError.InvalidInput);
+        }
+        let b0 = checked { @byte_read(abuf, 0) };
+        let b1 = checked { @byte_read(abuf, 1) };
+        let b2 = checked { @byte_read(abuf, 2) };
+        let b3 = checked { @byte_read(abuf, 3) };
+        let b4 = checked { @byte_read(abuf, 4) };
+        let b5 = checked { @byte_read(abuf, 5) };
+        let b6 = checked { @byte_read(abuf, 6) };
+        let b7 = checked { @byte_read(abuf, 7) };
+        checked { @free_bytes(abuf, sockaddr_in_len(), 1); };
+        let bytes: [u8; 16] = [b0, b1, b2, b3, b4, b5, b6, b7, 0, 0, 0, 0, 0, 0, 0, 0];
+        let O = option.Option(SockAddr);
+        match SockAddr.from_sockaddr_in(bytes) {
+            O.Some(a) => R.Ok(a),
+            O.None => R.Err(NetworkError.InvalidInput),
+        }
+    }
+
+    // Block until a connection arrives and return its stream. v1 does not
+    // expose the peer address (the kernel address arguments are null); a
+    // later peer_addr can add it without reshaping accept (ADR-0060 §3).
+    fn accept(inout self) -> result.Result(TcpStream, NetworkError) {
+        let R = result.Result(TcpStream, NetworkError);
+        let fd_u: u64 = @intCast(self.fd);
+        // Null kernel address arguments: v1 does not expose the peer address.
+        let null_ptr: u64 = 0;
+        let ret: i64 = checked { @syscall(_sys_accept(), fd_u, null_ptr, null_ptr) };
+        if ret < 0 {
+            R.Err(_normalize_net_errno(0 - ret))
+        } else {
+            let fd: i32 = @intCast(ret);
+            R.Ok(TcpStream { fd: fd })
+        }
+    }
+
+    // Consuming close (ADR-0057 §4), as `TcpStream.close`.
+    fn close(self) -> result.Result((), NetworkError) {
+        let R = result.Result((), NetworkError);
+        let mut me = self;
+        let fd = me.fd;
+        me.fd = -1;
+        if fd < 0 {
+            return R.Ok(());
+        }
+        let fd_u: u64 = @intCast(fd);
+        let ret: i64 = checked { @syscall(_sys_net_close(), fd_u) };
+        if ret < 0 {
+            R.Err(_normalize_net_errno(0 - ret))
+        } else {
+            R.Ok(())
+        }
+    }
+}
+
+// Scope-exit close, guarded by the consuming-close sentinel (ADR-0057 §4).
+drop fn TcpListener(self) {
+    if self.fd >= 0 {
+        let fd_u: u64 = @intCast(self.fd);
+        checked { @syscall(_sys_net_close(), fd_u); };
     }
 }


### PR DESCRIPTION
**Stacked on #1768 → #1770 → #1771**; the last commit is the RUE-983 change. Rebase/merge in order.

Implements blocking TCP v1 per ADR-0060 as pure Rue over `@syscall`:

- **`TcpStream`**: `connect`, `read` (appends into spare capacity; `Ok(0)` is peer-close/EOF and nothing else), `write` (may be short), `write_all` (loops short writes, retries EINTR, refuses zero-progress spins), `shutdown` with an explicit `Shutdown.Read/Write/Both` mode, consuming `close`, and drop-close. IO method names stay parallel with `File`, no trait invented (§5).
- **`TcpListener`**: `bind` (socket+bind+listen, backlog 128), `accept` (returns `TcpStream`, null peer-address arguments per §3), `local_addr` (getsockname with family and length validated before decode — how a port-0 bind learns its ephemeral port, which RUE-984's loopback tests need), consuming `close`, drop-close.
- Both types reuse the ADR-0057 owned-fd contract exactly: `-1` sentinel on consuming close so drop never double-closes.
- **`NetworkError`** matches the §6 enum, mapping asm-generic errno (identical on both v1 architectures) with `Other(i64)` fallback so no error is lost.
- **Fail-closed platform boundary (§7)**: constructors return `Unsupported` on macOS before any socket syscall; no guessed Darwin numbers exist in the module, so the syscall tables are Linux values keyed by architecture alone. Real Darwin support stays RUE-986; IPv6 stays RUE-985.

Coverage (`cli.std_net_tcp`): a full single-process loopback round trip on both Linux targets — ephemeral bind + `local_addr`, connect completing against the backlog, accept, client→server bytes, `shutdown(Write)` observed by the peer as `Ok(0)` EOF while server→client still flows, and consuming closes; a `ConnectionRefused` normalization case through a real failed connect; and an `only_on = ["aarch64-macos"]` case asserting `Unsupported` on macOS. The two syscall-driven Linux cases are registered in the oracle model-gap table (the oracle interprets the macOS case fully, so it correctly needs no entry). Full `std_` CLI suite, oracle-diff suite, and quick suite pass locally.

Fixes RUE-983

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTr1GrmuozXwd93nRkmPyC)_