### PR TITLE
RUE-988: align manifest scenario CFG counters with bound-token reuse

### DIFF
--- a/benchmarks/manifest.toml
+++ b/benchmarks/manifest.toml
@@ -38,11 +38,14 @@ not_runtime = "Measures compiler build/query latency and cache behavior, not gen
 target = "host-default"
 scenarios = [
   { name = "no_change_query", modules = [0, 0], semantic_bodies = [0, 0], cfgs = [0, 0], semantic_queries = [0, 1] },
-  { name = "leaf_edit", modules = [1, 6], semantic_bodies = [6, 0], cfgs = [6, 0], semantic_queries = [1, 0] },
-  { name = "widely_depended_definition_edit", modules = [1, 6], semantic_bodies = [6, 0], cfgs = [6, 0], semantic_queries = [1, 0] },
-  { name = "import_change", modules = [2, 5], semantic_bodies = [6, 0], cfgs = [6, 0], semantic_queries = [1, 0] },
+  # Bound tokens (RUE-850) removed the textual conversion discard, so the two
+  # semantically unchanged CFGs stay reusable on ordinary source edits; these
+  # rows mirror assert_structure in rue-compiler-session-bench.
+  { name = "leaf_edit", modules = [1, 6], semantic_bodies = [6, 0], cfgs = [4, 2], semantic_queries = [1, 0] },
+  { name = "widely_depended_definition_edit", modules = [1, 6], semantic_bodies = [6, 0], cfgs = [4, 2], semantic_queries = [1, 0] },
+  { name = "import_change", modules = [2, 5], semantic_bodies = [6, 0], cfgs = [4, 2], semantic_queries = [1, 0] },
   { name = "diagnostic_error_edit", modules = [1, 6], semantic_bodies = [5, 0], cfgs = [0, 0], semantic_queries = [1, 0] },
-  { name = "diagnostic_recovery", modules = [2, 5], semantic_bodies = [6, 0], cfgs = [6, 0], semantic_queries = [1, 0] },
+  { name = "diagnostic_recovery", modules = [2, 5], semantic_bodies = [6, 0], cfgs = [4, 2], semantic_queries = [1, 0] },
 ]
 
 [[benchmark]]


### PR DESCRIPTION
The Benchmarks workflow has failed on every trunk push since RUE-850 landed (last green: run 1649 at `ba55053`). All three platforms fail in `scripts/validate-benchmark.py` with `representative scenario '…' structural work does not match manifest` for `leaf_edit`, `widely_depended_definition_edit`, `import_change`, and `diagnostic_recovery`.

RUE-850 (`36da639`) intentionally removed the textual conversion discard, so the two semantically unchanged CFGs now stay reusable on ordinary source edits. It updated the harness assertions in `crates/rue-compiler-session-bench/src/representative.rs` from `cfgs = [6, 0]` to `[4, 2]` for those four scenarios, but not the matching declarations in `benchmarks/manifest.toml` — and the CI validator checks results against the manifest.

This mirrors the harness in the manifest (`cfgs = [4, 2]` for the four edit scenarios) with a comment pointing at the source of truth.

Verification:
- Reconstructed the exact `results.json` from failing run 29630901356 (Linux x86-64) out of the job log; `scripts/validate-benchmark.py` reproduced the four CI errors against the old manifest and passes with this change.
- `scripts/test-benchmark-tools.py`: 110 tests pass (its scenario expectations derive from the manifest, so it stays consistent).

Same failure mode as RUE-908.

Fixes RUE-988

---
_Generated by [Claude Code](https://claude.ai/code/session_01BN98CBtNF5BKTAdZ2mx9R4)_