### PR TITLE
RUE-726: stop top-level recovery inside a failed item's braces

### DIFF
--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -2066,22 +2066,41 @@ impl Parser {
         if self.recover_reserved_let_keywords() || self.recover_missing_item_name() {
             return start;
         }
+        // Track brace depth across the skipped tokens so synchronization only
+        // happens at top level: an item prefix inside the failed item's own
+        // braces (a struct's later methods, say) is part of the failed item,
+        // and re-parsing it as a fresh top-level item emits phantom errors at
+        // valid lines (RUE-726). A stray close brace clamps to zero so text
+        // after an over-closed item still synchronizes.
+        let mut brace_depth: usize = 0;
         if !self.at(TokenKind::Eof) {
             debug_assert_eq!(
                 recovery::item_recovery_action(
                     recovery::ItemRecoveryPosition::Initial,
-                    &self.kind()
+                    &self.kind(),
+                    brace_depth,
                 ),
                 recovery::ItemRecoveryAction::Consume
             );
+            match self.kind() {
+                TokenKind::LBrace => brace_depth += 1,
+                TokenKind::RBrace => {}
+                _ => {}
+            }
             self.bump();
         }
         while !self.at(TokenKind::Eof)
             && recovery::item_recovery_action(
                 recovery::ItemRecoveryPosition::AfterProgress,
                 &self.kind(),
+                brace_depth,
             ) == recovery::ItemRecoveryAction::Consume
         {
+            match self.kind() {
+                TokenKind::LBrace => brace_depth += 1,
+                TokenKind::RBrace => brace_depth = brace_depth.saturating_sub(1),
+                _ => {}
+            }
             self.bump();
         }
         start
@@ -2355,6 +2374,19 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![8, 29, 50]
         );
+    }
+
+    #[test]
+    fn struct_body_error_does_not_reparse_sibling_methods() {
+        // RUE-726: one real error inside a method body must not resynchronize
+        // at the struct's remaining methods and re-report them as malformed
+        // free functions at earlier, valid lines.
+        let source = "struct S {\n    n: i64,\n    fn a(borrow self) -> i64 { self.n }\n    \
+                      fn b(borrow self) -> i64 {\n        match self.n {\n            \
+                      Some(x) => x,\n            _ => 0,\n        }\n    }\n}\n\
+                      fn main() -> i32 { 0 }";
+        let errors = parse_source(source).unwrap_err();
+        assert_eq!(errors.len(), 1, "expected only the real error: {errors:?}");
     }
 
     #[test]

--- a/crates/rue-parser/src/parser_policy/recovery.rs
+++ b/crates/rue-parser/src/parser_policy/recovery.rs
@@ -22,10 +22,15 @@ pub(crate) enum ItemRecoveryAction {
 /// the next item. Every recovery consumes its first token, even when it looks
 /// like an item prefix, because stopping before progress would retry the same
 /// failed parse forever. Once progress is established, item keywords,
-/// modifiers, and directives are preserved as synchronization points.
+/// modifiers, and directives are preserved as synchronization points — but
+/// only at brace depth zero. An item prefix nested inside the failed item's
+/// braces is one of that item's own members: synchronizing there re-parses a
+/// struct's remaining methods as free functions, emitting phantom errors at
+/// valid lines before the real one (RUE-726).
 pub(crate) fn item_recovery_action(
     position: ItemRecoveryPosition,
     token: &TokenKind,
+    brace_depth: usize,
 ) -> ItemRecoveryAction {
     let starts_item = matches!(
         token,
@@ -39,7 +44,7 @@ pub(crate) fn item_recovery_action(
             | TokenKind::Unchecked
             | TokenKind::At
     );
-    match (position, starts_item) {
+    match (position, starts_item && brace_depth == 0) {
         (ItemRecoveryPosition::AfterProgress, true) => ItemRecoveryAction::Synchronize,
         _ => ItemRecoveryAction::Consume,
     }
@@ -63,29 +68,35 @@ mod tests {
             TokenKind::At,
         ] {
             assert_eq!(
-                item_recovery_action(ItemRecoveryPosition::AfterProgress, &token),
+                item_recovery_action(ItemRecoveryPosition::AfterProgress, &token, 0),
                 ItemRecoveryAction::Synchronize,
                 "{token:?}"
             );
         }
         assert_eq!(
-            item_recovery_action(ItemRecoveryPosition::AfterProgress, &TokenKind::Let),
+            item_recovery_action(ItemRecoveryPosition::AfterProgress, &TokenKind::Let, 0),
             ItemRecoveryAction::Consume
         );
         assert_eq!(
-            item_recovery_action(ItemRecoveryPosition::AfterProgress, &TokenKind::If),
+            item_recovery_action(ItemRecoveryPosition::AfterProgress, &TokenKind::If, 0),
             ItemRecoveryAction::Consume
         );
     }
 
     #[test]
-    fn initial_position_always_makes_progress() {
-        for token in [TokenKind::Fn, TokenKind::At, TokenKind::Let] {
+    fn nested_item_prefixes_are_not_synchronization_points() {
+        // A method's `fn` inside a failed struct's body must be consumed, not
+        // treated as the start of a new top-level item (RUE-726).
+        for depth in [1usize, 2, 7] {
             assert_eq!(
-                item_recovery_action(ItemRecoveryPosition::Initial, &token),
+                item_recovery_action(ItemRecoveryPosition::AfterProgress, &TokenKind::Fn, depth),
                 ItemRecoveryAction::Consume,
-                "{token:?}"
+                "depth {depth}"
             );
         }
+        assert_eq!(
+            item_recovery_action(ItemRecoveryPosition::Initial, &TokenKind::Fn, 0),
+            ItemRecoveryAction::Consume
+        );
     }
 }

--- a/crates/rue-ui-tests/cases/diagnostics/parser_recovery.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/parser_recovery.toml
@@ -1,0 +1,63 @@
+# Top-level parse recovery (RUE-726).
+#
+# A parse error inside a method body used to rewind to the struct's start and
+# resynchronize at the next `fn` — which is the struct's own next method — so
+# every remaining sibling method was re-parsed as a free function, emitting
+# phantom E0100 errors ("methods take `self` as the first parameter") at
+# perfectly valid earlier lines, positioned BEFORE the real error. Recovery is
+# now brace-depth aware: item prefixes inside the failed item's braces are
+# consumed, not synchronized on.
+
+[section]
+id = "diagnostics.parser_recovery"
+name = "Top-level recovery does not re-parse a failed item's members"
+description = "One method-body error reports once; sibling methods emit no phantom errors (RUE-726)."
+
+# The exact-golden assertion pins the whole (summary-stripped) error output
+# to the single real error at the real site, so a reappearing phantom — any
+# extra error, at any position — fails the case.
+[[case]]
+name = "method_body_error_no_phantom_siblings"
+source = """
+struct S {
+    n: i64,
+    fn a(borrow self) -> i64 { self.n }
+    fn b(borrow self) -> i64 {
+        match self.n {
+            Some(x) => x,
+            _ => 0,
+        }
+    }
+}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+expected_error = """
+error: [E0100]: expected '.', found '=>'
+ --> test.rue:6:21
+  |
+6 |             Some(x) => x,
+  |                     ^^
+  |
+"""
+
+# Recovery still finds the next real top-level item after skipping the whole
+# failed struct: the later free-standing parse error is reported too, at its
+# own site, with nothing in between.
+[[case]]
+name = "recovery_still_synchronizes_after_failed_struct"
+source = """
+struct S {
+    n: i64,
+    fn a(borrow self) -> i64 {
+        match self.n {
+            Some(x) => x,
+            _ => 0,
+        }
+    }
+}
+fn broken( -> i32 { 0 }
+fn ok() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["expected '.', found '=>'", "found '->'"]


### PR DESCRIPTION
Independent of the M8 stack — based directly on trunk.

One parse error inside a method body produced phantom E0100 errors at earlier, valid sibling methods (with the actively wrong "methods take `self` as the first parameter" help), positioned *before* the real error. Mechanism, confirmed against the issue's hypothesis: when a struct item fails, the top-level loop rewinds the cursor to the struct's start and `recover_item` skips forward — synchronizing at the first `fn` it meets, which is the struct's *own next method*. Each sibling then re-parses as a free function where `self` is illegal, fails, and recovery repeats down the struct.

The fix makes recovery brace-depth aware, in the `parser_policy::recovery` policy: item-prefix tokens are synchronization points only at brace depth zero; inside the failed item's braces they're consumed as part of the skip. A stray close brace clamps depth to zero so text after an over-closed item still synchronizes. (`recover_reserved_let_keywords` already tracks depth this way, so this follows existing precedent.)

On the repro, the compiler now emits exactly one error at the real site (`6:21`) — previously three. Coverage:

- policy unit test: nested item prefixes are consumed at depth ≥ 1, still synchronized at depth 0;
- parser unit test: the struct repro yields exactly one error;
- UI exact-golden pinning the full error output of the repro (any reappearing phantom fails the case), plus a case proving recovery still finds and reports a *later* real top-level error after skipping the whole failed struct.

Full spec (2119), CLI (1518), UI (188), and quick suites pass locally.

Fixes RUE-726

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTr1GrmuozXwd93nRkmPyC)_