### PR TITLE
RUE-775: pin canonical/presentation switching as distinct diagnostic identities

### DIFF
--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -9523,6 +9523,63 @@ mod tests {
     }
 
     #[test]
+    fn switching_update_modes_is_a_distinct_diagnostic_identity() {
+        // RUE-775: canonical `update()` and `update_for_presentation()` over
+        // one byte-identical snapshot must not reuse each other's merge
+        // diagnostics — the presentation provenance is part of the attempt
+        // key — while returning to an already-computed mode reuses it.
+        let source = snapshot(
+            &[
+                (
+                    1,
+                    "/p/main.rue",
+                    "main.rue",
+                    "fn same() {} fn same() {} fn main() {}",
+                ),
+                (2, "/p/a.rue", "a.rue", "fn a() {}"),
+            ],
+            1,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        session.merge().unwrap_err();
+        session
+            .update_for_presentation(&source)
+            .into_result()
+            .unwrap();
+        session.merge().unwrap_err();
+        assert_eq!(session.work().merge.executions, 2);
+
+        let identities = session
+            .queries
+            .merge
+            .attempt_history()
+            .filter(|attempt| attempt.execution == QueryAttemptExecution::Computed)
+            .map(|attempt| {
+                (
+                    attempt.key.source.revision.clone(),
+                    attempt.key.presentation.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(identities.len(), 2);
+        assert_eq!(identities[0].0, identities[1].0);
+        assert!(identities[0].1.is_none(), "canonical attempt has no order");
+        assert!(identities[1].1.is_some(), "presentation attempt has order");
+
+        // Returning to each already-attempted mode reuses its own result
+        // instead of recomputing or crossing modes.
+        session.update(&source).into_result().unwrap();
+        session.merge().unwrap_err();
+        session
+            .update_for_presentation(&source)
+            .into_result()
+            .unwrap();
+        session.merge().unwrap_err();
+        assert_eq!(session.work().merge.executions, 2);
+    }
+
+    #[test]
     fn root_relocation_file_id_and_logical_changes_invalidate_correctly() {
         let base = snapshot(
             &[


### PR DESCRIPTION
Test-only change. Verifying RUE-775 against current source per the evidence rules: the reported mechanism no longer exists. `same_attempt()` is gone; `DiagnosticAttemptProvenance` (Canonical vs. Presentation with the caller's order) is part of `ParseQueryKey` and the merge attempt identity, so the hidden-state reuse the issue describes cannot occur. Of the issue's acceptance criteria, reordering identical multi-error snapshots is already pinned by `failed_merge_attempt_identity_includes_presentation_order`; the one uncovered criterion was **switching `update()` ↔ `update_for_presentation()` on one session**.

This adds that regression test: over one byte-identical snapshot, each mode computes its own merge attempt (same source revision; canonical attempt carries no presentation order, presentation attempt carries one), and returning to each already-attempted mode reuses that mode's own result with no recomputation and no cross-mode reuse — which also pins that order-independent artifact reuse is preserved.

All 583 `rue-compiler` tests pass locally.

Fixes RUE-775

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTr1GrmuozXwd93nRkmPyC)_