### PR TITLE
RUE-976: canonical call-ABI classifier (ADR-0052 phase 5)

### DIFF
--- a/crates/rue-air/src/call_abi.rs
+++ b/crates/rue-air/src/call_abi.rs
@@ -1,0 +1,356 @@
+//! Canonical native call-ABI classifier (ADR-0052 phase 5).
+//!
+//! One authority that answers a single question: *how does a value of a given
+//! type cross a call boundary on this target* — returned in registers, returned
+//! indirectly through caller storage (sret), passed by value across argument
+//! slots, or passed as one by-reference pointer. ADR-0052's third
+//! representation ("call ABI classification") is deliberately separate from the
+//! physical slot *count*: today the two coincide (an aggregate return uses sret
+//! exactly when its flattened slot count exceeds the return-register budget, and
+//! an argument occupies one slot per leaf), and this authority reproduces that
+//! decision byte-for-byte. Its value is that both code-generation backends, the
+//! sret/return-budget decision sites, and the oracle's model of the call
+//! contract consult *one* place instead of each rediscovering
+//! `slot_count > budget`.
+//!
+//! [`CallAbi`] is the extensibility seam ADR-0052 requires. The preserved native
+//! Rue convention is the first and only implementation; the guaranteed target C
+//! ABI (RUE-742 / RUE-745, SysV / AAPCS) will add further variants to this
+//! authority rather than embedding a peer FFI calculator inside a backend.
+//!
+//! ## Memory-first transitional rule (ADR-0052 ratified ruling 9)
+//!
+//! The preserved slot call convention stays in force unchanged while memory
+//! layout migrates. Under the compact layout preview an aggregate whose compact
+//! representation is *not* slot-identical cannot be expressed by the preserved
+//! register convention, so this classifier rules it **indirect** (by-reference /
+//! sret). That composes with RUE-974's loud refusal: a compact aggregate
+//! crossing a call is either expressible slot-identically (classified and
+//! marshaled exactly as today), passed indirectly (this rule), or refused
+//! loudly by code generation because the narrow indirect marshaling is not yet
+//! implemented — never silently wrong. With the gate off `compact_layout()` is
+//! false, the rule never fires, and every classification is byte-for-byte the
+//! historical slot decision.
+
+use crate::{FrozenTypeInternPool, Type, TypeKind};
+
+/// Which calling convention governs a boundary.
+///
+/// The seam ADR-0052 requires so the future guaranteed target C classifier
+/// extends this authority instead of adding a peer path. Only the native
+/// convention is implemented today.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallAbi {
+    /// The preserved native Rue convention (RUE-106): a by-value aggregate is
+    /// returned one flattened ABI slot per return register, or via sret when it
+    /// does not fit; canonical `StrBuf` always returns via sret; a by-reference
+    /// `inout` / `borrow` argument is one pointer slot; a by-value argument
+    /// occupies one slot per leaf.
+    Native,
+}
+
+/// How a by-value return value crosses the call boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReturnClass {
+    /// Zero-sized: no return register and no caller storage.
+    ZeroSized,
+    /// A single scalar returned in the target's primary return register.
+    Scalar,
+    /// A complete aggregate returned one flattened slot per return register.
+    Registers {
+        /// Number of flattened return slots.
+        slot_count: u32,
+    },
+    /// A complete aggregate written to caller-provided storage, whose address
+    /// is passed as a hidden first argument (sret).
+    Indirect {
+        /// Number of flattened return slots the callee writes.
+        slot_count: u32,
+    },
+}
+
+impl ReturnClass {
+    /// Number of flattened return slots represented by this classification.
+    pub const fn slot_count(self) -> u32 {
+        match self {
+            Self::ZeroSized => 0,
+            Self::Scalar => 1,
+            Self::Registers { slot_count } | Self::Indirect { slot_count } => slot_count,
+        }
+    }
+
+    /// Whether the return crosses indirectly through caller storage (sret).
+    pub const fn uses_sret(self) -> bool {
+        matches!(self, Self::Indirect { .. })
+    }
+}
+
+/// How an argument is presented at the source level, before ABI classification.
+///
+/// The classifier only needs to distinguish a by-value argument from a
+/// by-reference one; callers map their own argument-mode enum (`CfgArgMode`)
+/// onto this so the classifier does not depend on the CFG crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArgConvention {
+    /// A normal by-value argument; its physical layout crosses directly.
+    ByValue,
+    /// An `inout` or `borrow` argument, represented by one caller pointer.
+    ByReference,
+}
+
+/// How one argument crosses the call boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArgClass {
+    /// Occupies no ABI slot (a zero-sized by-value argument).
+    Omitted,
+    /// Passed by value across `slot_count` flattened ABI slots: the first
+    /// `arg_reg_budget` in argument registers, the remainder on the stack.
+    Direct {
+        /// Number of flattened ABI slots the value occupies.
+        slot_count: u32,
+    },
+    /// Passed as one caller-provided pointer slot: a by-reference `inout` /
+    /// `borrow`, or — transitionally under the compact layout — a by-value
+    /// aggregate the preserved slot convention cannot express directly (see the
+    /// module memory-first rule).
+    Indirect,
+}
+
+impl ArgClass {
+    /// Number of ABI *crossing* slots this classification presents: a direct
+    /// value's slot count, one pointer for indirect, none when omitted.
+    ///
+    /// This is the representation-3 crossing width. The physical
+    /// value-decomposition width the CFG and the oracle track is
+    /// [`NativeCallAbi::arg_slot_width`], which is unaffected by the compact
+    /// transitional rule.
+    pub const fn crossing_slots(self) -> u32 {
+        match self {
+            Self::Omitted => 0,
+            Self::Direct { slot_count } => slot_count,
+            Self::Indirect => 1,
+        }
+    }
+}
+
+/// The native call-ABI classifier: the [`CallAbi::Native`] implementation.
+///
+/// Consumes the canonical slot decomposition and the target's return-register
+/// budget. Argument register partitioning is a downstream concern of the
+/// per-backend lowerer (it counts materialized ABI slots against
+/// `arg_reg_budget`), so the budget is not stored here.
+#[derive(Debug, Clone, Copy)]
+pub struct NativeCallAbi<'a> {
+    type_pool: &'a FrozenTypeInternPool,
+    ret_reg_budget: u32,
+}
+
+impl<'a> NativeCallAbi<'a> {
+    /// Build the native classifier for a target whose return-register budget is
+    /// `ret_reg_budget` (6 on x86-64, 8 on AArch64).
+    pub fn new(type_pool: &'a FrozenTypeInternPool, ret_reg_budget: u32) -> Self {
+        Self {
+            type_pool,
+            ret_reg_budget,
+        }
+    }
+
+    /// Build the native classifier for argument-side queries only
+    /// ([`classify_arg`](Self::classify_arg) and
+    /// [`arg_slot_width`](Self::arg_slot_width)), which do not depend on the
+    /// return-register budget.
+    ///
+    /// The target-independent oracle uses this to model the native call
+    /// contract without knowing a target's return registers; calling a
+    /// return-classification method on the result is not meaningful.
+    pub fn for_arguments(type_pool: &'a FrozenTypeInternPool) -> Self {
+        // The return-register budget is never read by the argument-side
+        // queries, so a sentinel is sound here.
+        Self {
+            type_pool,
+            ret_reg_budget: 0,
+        }
+    }
+
+    /// The convention this classifier implements.
+    pub const fn abi(&self) -> CallAbi {
+        CallAbi::Native
+    }
+
+    /// Classify how a by-value return of `ty` crosses the boundary.
+    ///
+    /// Reproduces the historical decision exactly: zero-sized returns nothing;
+    /// canonical `StrBuf` and any aggregate whose flattened slot count exceeds
+    /// the return-register budget use sret; a smaller aggregate returns in
+    /// registers; everything else is a scalar. Under the compact layout a
+    /// non-slot-identical aggregate is forced indirect (memory-first rule).
+    pub fn classify_return(&self, ty: Type) -> ReturnClass {
+        let slot_count = self.type_pool.abi_slot_count(ty);
+        if slot_count == 0 {
+            return ReturnClass::ZeroSized;
+        }
+        if self.return_uses_sret(ty, slot_count)
+            || self.crosses_indirectly_under_compact(ty, slot_count)
+        {
+            return ReturnClass::Indirect { slot_count };
+        }
+        if self.is_multislot_aggregate(ty, slot_count) {
+            ReturnClass::Registers { slot_count }
+        } else {
+            ReturnClass::Scalar
+        }
+    }
+
+    /// Whether a by-value return of `ty` uses the sret convention. Thin
+    /// predicate over [`classify_return`] for the decision sites that only need
+    /// the boolean.
+    pub fn return_is_sret(&self, ty: Type) -> bool {
+        self.classify_return(ty).uses_sret()
+    }
+
+    /// Classify how one argument crosses the boundary.
+    ///
+    /// A by-reference `inout` / `borrow` is one pointer slot. A by-value
+    /// argument is omitted when zero-sized, otherwise passed directly across its
+    /// flattened slots — except that under the compact layout a non-slot-
+    /// identical aggregate is forced indirect (memory-first rule).
+    pub fn classify_arg(&self, ty: Type, convention: ArgConvention) -> ArgClass {
+        match convention {
+            ArgConvention::ByReference => ArgClass::Indirect,
+            ArgConvention::ByValue => {
+                let slot_count = self.type_pool.abi_slot_count(ty);
+                if slot_count == 0 {
+                    ArgClass::Omitted
+                } else if self.crosses_indirectly_under_compact(ty, slot_count) {
+                    // Memory-first transitional rule: the preserved slot
+                    // convention cannot pass this compact aggregate by value.
+                    // Code generation refuses it loudly until the indirect
+                    // marshaling lands; the authority still records the intent.
+                    ArgClass::Indirect
+                } else {
+                    ArgClass::Direct { slot_count }
+                }
+            }
+        }
+    }
+
+    /// Physical parameter-slot width of one argument: the value-decomposition
+    /// count the CFG parameter layout and the oracle's call contract track.
+    ///
+    /// A by-reference argument is one pointer slot; a by-value argument is its
+    /// flattened slot count. This is representation 2 in ADR-0052 terms and is
+    /// deliberately independent of the compact transitional classification: the
+    /// callee's parameter slots stay slot-shaped even for a compact aggregate,
+    /// which is precisely why code generation refuses the not-yet-implemented
+    /// indirect marshaling rather than silently disagreeing about slot counts.
+    pub fn arg_slot_width(&self, ty: Type, convention: ArgConvention) -> u32 {
+        match convention {
+            ArgConvention::ByReference => 1,
+            ArgConvention::ByValue => self.type_pool.abi_slot_count(ty),
+        }
+    }
+
+    /// The historical `type_uses_sret_return` predicate: strbuf, or a
+    /// struct/array/payload-enum whose slot count exceeds the budget
+    /// (oversized enums route through the same slot-count policy per RUE-946;
+    /// discriminant-only enums are single-slot and stay scalar).
+    fn return_uses_sret(&self, ty: Type, slot_count: u32) -> bool {
+        match ty.kind() {
+            TypeKind::Struct(struct_id) => {
+                self.type_pool.is_strbuf(struct_id) || slot_count > self.ret_reg_budget
+            }
+            TypeKind::Array(_) | TypeKind::Enum(_) => slot_count > self.ret_reg_budget,
+            _ => false,
+        }
+    }
+
+    /// Whether `ty` needs a complete aggregate slot representation rather than a
+    /// single primary vreg. Discriminant-only enums stay scalar.
+    fn is_multislot_aggregate(&self, ty: Type, slot_count: u32) -> bool {
+        matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_))
+            || (ty.is_enum() && slot_count > 1)
+    }
+
+    /// The memory-first transitional rule (ADR-0052 ruling 9): under the compact
+    /// layout, an aggregate whose compact representation is not slot-identical
+    /// cannot cross the preserved register convention and must go indirect.
+    ///
+    /// Always false with the gate off (`compact_layout()` is false), so every
+    /// classification is byte-for-byte the historical slot decision.
+    fn crosses_indirectly_under_compact(&self, ty: Type, slot_count: u32) -> bool {
+        self.type_pool.compact_layout()
+            && self.is_multislot_aggregate(ty, slot_count)
+            && !is_slot_identical_layout(self.type_pool, ty)
+    }
+}
+
+/// Whether the compact physical layout of `ty` is byte-for-byte identical to
+/// the flattened eight-byte slot layout, so slot-shaped marshaling is exactly
+/// correct for it (ADR-0052).
+///
+/// True for eight-byte leaves (`i64`/`u64`/pointers, the recovery scalar) and
+/// zero-sized / compile-time-only types, and for aggregates built entirely from
+/// slot-identical leaves. Narrow scalars (one/two/four bytes) and enums (narrow
+/// tag) are not slot-identical. This is the single authority both the compact
+/// call-ABI transitional rule above and code generation's narrow-access refusal
+/// (RUE-974) consult, so they cannot disagree about which types the compact
+/// layout leaves unchanged.
+pub fn is_slot_identical_layout(type_pool: &FrozenTypeInternPool, ty: Type) -> bool {
+    match ty.kind() {
+        // Eight-byte leaves and the recovery scalar: identical in both models.
+        TypeKind::I64
+        | TypeKind::U64
+        | TypeKind::PtrConst(_)
+        | TypeKind::PtrMut(_)
+        | TypeKind::Error => true,
+        // Zero-sized and compile-time-only types have identical (zero) extent.
+        TypeKind::Unit | TypeKind::Never | TypeKind::ComptimeType | TypeKind::Module(_) => true,
+        // Narrow scalars: one/two/four bytes under the compact layout.
+        TypeKind::I8
+        | TypeKind::U8
+        | TypeKind::Bool
+        | TypeKind::I16
+        | TypeKind::U16
+        | TypeKind::I32
+        | TypeKind::U32 => false,
+        TypeKind::Struct(id) => type_pool
+            .struct_def(id)
+            .fields
+            .iter()
+            .all(|field| is_slot_identical_layout(type_pool, field.ty)),
+        TypeKind::Array(id) => {
+            let (element, _length) = type_pool.array_def(id);
+            is_slot_identical_layout(type_pool, element)
+        }
+        // Enums narrow their tag (u8/u16/u32 vs an eight-byte slot).
+        TypeKind::Enum(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Behavioral coverage that exercises the classifier against a real type
+    // pool lives with the backend ABI/oracle suites (which own program
+    // fixtures); these unit checks pin the pure classification algebra.
+
+    #[test]
+    fn return_class_slot_count_and_sret_predicate_agree() {
+        assert_eq!(ReturnClass::ZeroSized.slot_count(), 0);
+        assert_eq!(ReturnClass::Scalar.slot_count(), 1);
+        assert_eq!(ReturnClass::Registers { slot_count: 3 }.slot_count(), 3);
+        assert_eq!(ReturnClass::Indirect { slot_count: 9 }.slot_count(), 9);
+        assert!(!ReturnClass::Registers { slot_count: 3 }.uses_sret());
+        assert!(ReturnClass::Indirect { slot_count: 9 }.uses_sret());
+    }
+
+    #[test]
+    fn arg_class_crossing_width_matches_the_slot_contract() {
+        assert_eq!(ArgClass::Omitted.crossing_slots(), 0);
+        assert_eq!(ArgClass::Direct { slot_count: 4 }.crossing_slots(), 4);
+        // A by-reference argument and a transitional indirect aggregate both
+        // cross as one pointer.
+        assert_eq!(ArgClass::Indirect.crossing_slots(), 1);
+    }
+}

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -12,6 +12,7 @@
 
 #[cfg(test)]
 mod api_inventory;
+pub mod call_abi;
 mod canonical_imports;
 mod inference;
 mod inst;
@@ -32,6 +33,9 @@ mod type_encoding;
 mod type_properties;
 mod types;
 
+pub use call_abi::{
+    ArgClass, ArgConvention, CallAbi, NativeCallAbi, ReturnClass, is_slot_identical_layout,
+};
 pub use canonical_imports::CanonicalImportView;
 pub use inference::{
     Constraint, ConstraintContext, ConstraintGenerator, ExprInfo, FunctionSig, InferType,

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -5,11 +5,10 @@
 //! lowerers consume the normalized slot vector and only choose how to marshal
 //! those slots for their ABI.
 
-use rue_air::FrozenTypeInternPool;
+use rue_air::{FrozenTypeInternPool, NativeCallAbi, ReturnClass};
 use rue_cfg::{Cfg, CfgArgMode, CfgCallArg, Type};
 use rue_runtime_abi::{ReservedExportClass, ReservedExportId};
 
-use crate::cfg_lower::type_uses_sret_return;
 use crate::types;
 use crate::vreg::VReg;
 
@@ -410,21 +409,21 @@ impl CallPlan {
     }
 }
 
-/// The one shared return policy.  In particular, sret selection remains
-/// delegated to `type_uses_sret_return` rather than being inferred by a caller.
+/// The one shared return policy.  Return classification (scalar / registers /
+/// sret) is delegated to the canonical call-ABI classifier
+/// [`NativeCallAbi::classify_return`]; this function only maps its result onto
+/// the codegen [`ReturnPlan`], adding the caller-storage byte size that sret
+/// needs. Keeping the classification in the shared authority is what makes both
+/// backends and the oracle agree by construction.
 pub fn return_plan(type_pool: &FrozenTypeInternPool, ty: Type, ret_reg_budget: u32) -> ReturnPlan {
-    let slot_count = types::type_slot_count(type_pool, ty);
-    if slot_count == 0 {
-        ReturnPlan::ZeroSized
-    } else if type_uses_sret_return(type_pool, ty, ret_reg_budget) {
-        ReturnPlan::Sret {
+    match NativeCallAbi::new(type_pool, ret_reg_budget).classify_return(ty) {
+        ReturnClass::ZeroSized => ReturnPlan::ZeroSized,
+        ReturnClass::Scalar => ReturnPlan::Scalar,
+        ReturnClass::Registers { slot_count } => ReturnPlan::Registers { slot_count },
+        ReturnClass::Indirect { slot_count } => ReturnPlan::Sret {
             slot_count,
             storage_bytes: align_up(slot_count * 8, 16),
-        }
-    } else if types::is_multislot_aggregate(type_pool, ty) {
-        ReturnPlan::Registers { slot_count }
-    } else {
-        ReturnPlan::Scalar
+        },
     }
 }
 

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -20,7 +20,7 @@
 use std::fmt;
 
 use lasso::{Key, ThreadedRodeo};
-use rue_air::{FrozenTypeInternPool, StructId, TypeKind};
+use rue_air::{FrozenTypeInternPool, NativeCallAbi, StructId, TypeKind};
 use rue_cfg::{BlockId, Cfg, CfgValue, Type};
 
 use crate::types;
@@ -272,23 +272,16 @@ fn format_cfg_inst_data_impl(
 ///   slot through that pointer before returning. (RUE-13/78/91)
 ///
 /// Scalars and unit never use sret.
+///
+/// The decision itself is owned by the canonical call-ABI classifier
+/// [`rue_air::NativeCallAbi`] (ADR-0052 phase 5); this is the thin boolean
+/// predicate the sret decision sites and both backends consult.
 pub fn type_uses_sret_return(
     type_pool: &FrozenTypeInternPool,
     ty: Type,
     ret_reg_budget: u32,
 ) -> bool {
-    match ty.kind() {
-        TypeKind::Struct(struct_id) => {
-            if type_pool.is_strbuf(struct_id) {
-                return true;
-            }
-            types::type_slot_count(type_pool, ty) > ret_reg_budget
-        }
-        TypeKind::Array(_) | TypeKind::Enum(_) => {
-            types::type_slot_count(type_pool, ty) > ret_reg_budget
-        }
-        _ => false,
-    }
+    NativeCallAbi::new(type_pool, ret_reg_budget).return_is_sret(ty)
 }
 
 /// Does this function return its value via the sret convention?

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -253,36 +253,13 @@ pub fn struct_field_slot_offset(
 /// compact layout. When false, correct compact access requires narrow
 /// (one/two/four-byte) loads and stores at compact byte offsets, which is staged
 /// for a follow-up (see [`compact_physical_access_unsupported`]).
+///
+/// Delegates to the canonical layout authority `rue_air::is_slot_identical_layout`
+/// so the compact call-ABI classifier's transitional indirect rule (RUE-976) and
+/// this narrow-access refusal cannot disagree about which types the compact
+/// layout leaves unchanged.
 pub(crate) fn is_slot_identical_layout(type_pool: &FrozenTypeInternPool, ty: Type) -> bool {
-    match ty.kind() {
-        // Eight-byte leaves and the recovery scalar: identical in both models.
-        TypeKind::I64
-        | TypeKind::U64
-        | TypeKind::PtrConst(_)
-        | TypeKind::PtrMut(_)
-        | TypeKind::Error => true,
-        // Zero-sized and compile-time-only types have identical (zero) extent.
-        TypeKind::Unit | TypeKind::Never | TypeKind::ComptimeType | TypeKind::Module(_) => true,
-        // Narrow scalars: one/two/four bytes under the compact layout.
-        TypeKind::I8
-        | TypeKind::U8
-        | TypeKind::Bool
-        | TypeKind::I16
-        | TypeKind::U16
-        | TypeKind::I32
-        | TypeKind::U32 => false,
-        TypeKind::Struct(id) => type_pool
-            .struct_def(id)
-            .fields
-            .iter()
-            .all(|field| is_slot_identical_layout(type_pool, field.ty)),
-        TypeKind::Array(id) => {
-            let (element, _length) = type_pool.array_def(id);
-            is_slot_identical_layout(type_pool, element)
-        }
-        // Enums narrow their tag (u8/u16/u32 vs an eight-byte slot).
-        TypeKind::Enum(_) => false,
-    }
+    rue_air::is_slot_identical_layout(type_pool, ty)
 }
 
 /// The pointee of a pointer type, or the type itself when it is not a pointer.

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -1656,10 +1656,17 @@ impl<'a> Interp<'a> {
     /// views to `Normal`, while real `borrow` / `inout` arguments carry one
     /// pointer regardless of the pointee's logical width.
     fn call_arg_slot_width(&self, ty: Type, mode: CfgArgMode) -> usize {
-        match mode {
-            CfgArgMode::Normal => self.state.type_pool.abi_slot_count(ty) as usize,
-            CfgArgMode::Inout | CfgArgMode::Borrow => 1,
-        }
+        // Consume the canonical native call-ABI classifier (ADR-0052 phase 5)
+        // so the oracle's model of the argument contract agrees with the
+        // compiler by construction rather than by coincidence. This is the
+        // physical value-decomposition width (representation 2): by-value is
+        // one slot per leaf, a physical `borrow` / `inout` is one pointer.
+        let convention = match mode {
+            CfgArgMode::Normal => rue_air::ArgConvention::ByValue,
+            CfgArgMode::Inout | CfgArgMode::Borrow => rue_air::ArgConvention::ByReference,
+        };
+        rue_air::NativeCallAbi::for_arguments(&self.state.type_pool).arg_slot_width(ty, convention)
+            as usize
     }
 
     /// Validate the caller's complete physical argument layout against the


### PR DESCRIPTION
## Summary

Fifth child of the ADR-0052 migration (epic RUE-971): the canonical native call-ABI classifier. `crates/rue-air/src/call_abi.rs` is now the single authority for how a value crosses a call boundary — `classify_return` (ZeroSized/Scalar/Registers/Indirect), `classify_arg` (Omitted/Direct/Indirect), `arg_slot_width`, `return_is_sret` — consuming type layout + target ABI instead of the audit's "classification IS slot count" coupling. `CallAbi` is the extensibility seam for the future C ABI classification (RUE-742/745).

- Consumers routed through it: `cfg_lower::type_uses_sret_return`, `call_plan::return_plan`, and the **oracle's** `call_arg_slot_width` — oracle and codegen now agree on the call contract structurally, not by mirroring.
- `is_slot_identical_layout` moves to rue-air as the one layout-identity authority both the classifier and RUE-974's narrow-access refusal consult, so they cannot diverge on which types compact layout leaves unchanged.
- **RUE-946 folded in at integration**: the oversized-payload-enum sret rule landed on trunk mid-flight and semantically conflicted with the classifier extraction; resolved by teaching the classifier the new rule (struct/array/enum over the return-register budget → sret, discriminant-only enums scalar). RUE-946's 111-case ABI boundary matrix passes through the classifier unmodified.
- Under `aggregate_layout`, the memory-first transitional rule (ruling 9) classifies non-slot-identical compact aggregates indirect for returns and by-value args; every such type is also caught by RUE-974's loud pre-lowering refusal, so nothing can silently disagree about marshaling until narrow load/store codegen lands (staged next).

Gate off, generated code is byte-identical — encoding-exact ABI, oracle, and golden tests pass unmodified.

## Verification

Two new `call_abi` unit tests; codegen units 560; CLI `abi` 55, `aggregate_abi_matrix` 111, `aggregate` 109, `aggregate_layout` 8; oracle quick 0 disagreements; full `test.sh` green except the four known uid-0 unreadable-file environmental failures. Gated execution re-verified by hand at integration.

Fixes RUE-976

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_