### PR TITLE
RUE-977: language integration for the canonical layout migration (ADR-0052 phase 6)

### DIFF
--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -66,6 +66,14 @@ impl Entry {
 /// Entries are generated from unknown-gap diagnostics emitted by the real
 /// production classifier, then reviewed into this typed list. Dynamic
 /// `Unsupported::detail` text is intentionally absent from the policy key.
+///
+/// Clusters marked `slot-model-default` cover corpus cases that pin the current
+/// default eight-byte slot layout (byte offsets, per-slot sizes, aggregate
+/// widths). The gap *reasons* here are layout-independent (they are unmodeled
+/// raw-pointer / `@field_ptr` intrinsics), but the cases' expected values move
+/// when the ratified compact layout (ADR-0052, `aggregate_layout`) becomes the
+/// default, so the stabilization sweep (RUE-987) greps `slot-model-default` to
+/// enumerate every ledger entry it must re-verify after the flip.
 const ENTRIES: &[Entry] = &[
     Entry::new(
         "array_literal_string",
@@ -97,6 +105,7 @@ const ENTRIES: &[Entry] = &[
         implementation_defined(ImplementationDefinedKind::StringCapacityValue),
         &[],
     ),
+    // slot-model-default: the aggregate ABI matrix pins per-slot byte layout.
     Entry::new(
         "cli.aggregate_abi_matrix",
         "aos_ptr_rw",
@@ -145,6 +154,7 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
         &[],
     ),
+    // slot-model-default: ascending-layout cases assert "slot k at base + k*8".
     Entry::new(
         "cli.aggregate_ascending_layout",
         "heap_multislot_roundtrip_no_clobber",
@@ -157,6 +167,7 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
         &[],
     ),
+    // slot-model-default: aggregate_slots pins per-slot 8-byte field layout.
     Entry::new(
         "cli.aggregate_slots",
         "dbg_string_from_field",
@@ -493,6 +504,8 @@ const ENTRIES: &[Entry] = &[
         semantic(SemanticGapKind::InoutParameterForwarding),
         &[],
     ),
+    // slot-model-default: offset_of_field_ptr pins @offset_of byte values
+    // (0/8/16/24) and their @field_ptr agreement.
     Entry::new(
         "cli.offset_of_field_ptr",
         "field_ptr_on_param_struct",
@@ -520,6 +533,8 @@ const ENTRIES: &[Entry] = &[
     // ADR-0052 phase 3 (RUE-974): the compact-layout CLI cases reach a field
     // through `@field_ptr`, which the oracle model does not model (same gap as
     // the `offset_of_field_ptr` cases above).
+    // slot-model-default: aggregate_layout contrasts the default slot layout
+    // with the compact preview, so its expected values track the flip.
     Entry::new(
         "cli.aggregate_layout",
         "compact_slot_identical_field_ptr_roundtrip",

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -609,7 +609,11 @@ enum Value {
     /// `String`/`StrBuf` occupies three slots (`ptr`, `len`, `cap`), while
     /// `str`/`Str(N)` occupies two (`ptr`, `len`). Keeping the width on
     /// the value prevents a `str` parameter from shifting later parameters as if
-    /// it were a growable string.
+    /// it were a growable string. Every width here is the compiler's
+    /// `abi_slot_count` for the corresponding text type; `string_literal_value`
+    /// and `text_struct_slots` derive it from that authority, and the type-free
+    /// constructors below carry the same values (slot-model-default) for the
+    /// sites that have no type in hand.
     Str {
         bytes: Vec<u8>,
         slots: usize,
@@ -621,6 +625,10 @@ impl Value {
         Self::string_bytes(text.into().into_bytes())
     }
 
+    /// slot-model-default: the owned-`StrBuf` width `abi_slot_count(StrBuf) == 3`
+    /// ({ptr, len, cap}). Used by the type-free sites (the `@to_string` result,
+    /// which is always a `StrBuf`, and test fixtures); the type-aware paths
+    /// derive the same value from the compiler authority.
     fn string_bytes(bytes: impl Into<Vec<u8>>) -> Self {
         Self::Str {
             bytes: bytes.into(),
@@ -628,10 +636,16 @@ impl Value {
         }
     }
 
+    #[cfg(test)]
     fn str_view(text: impl Into<String>) -> Self {
         Self::str_view_bytes(text.into().into_bytes())
     }
 
+    /// slot-model-default: the `str`/`Str(N)` view width
+    /// `abi_slot_count(str) == 2` ({ptr, len}). The interpreter's live path
+    /// (`string_literal_value`) now derives the width from the compiler
+    /// authority, so this explicit two-slot constructor is a test fixture only.
+    #[cfg(test)]
     fn str_view_bytes(bytes: impl Into<Vec<u8>>) -> Self {
         Self::Str {
             bytes: bytes.into(),
@@ -839,11 +853,27 @@ enum WritebackPlace<'a> {
 
 impl<'a> Interp<'a> {
     fn string_literal_value(&self, text: String, ty: Type) -> Value {
-        if self.is_str_like_type(ty) {
-            Value::str_view(text)
-        } else {
-            Value::string(text)
+        // slot-model-default: derive the text value's ABI slot width from the
+        // compiler's `abi_slot_count` authority instead of hardcoding
+        // str/Str(N) = 2 and StrBuf = 3. A str/Str(N) view is two slots
+        // ({ptr, len}); an owned StrBuf is three ({ptr, len, cap}). The
+        // value-slot decomposition is preserved across the ADR-0052 migration
+        // (only the physical byte layout compacts), so these widths are stable.
+        Value::Str {
+            bytes: text.into_bytes(),
+            slots: self.text_value_slot_width(ty),
         }
+    }
+
+    /// ABI value-slot width the interpreter carries for a text value of type
+    /// `ty`, taken from the compiler's `abi_slot_count` authority. A non-struct
+    /// `ty` never reaches a string literal; it defaults to the owned-string
+    /// width so a malformed value is still shaped like a header rather than a
+    /// view.
+    fn text_value_slot_width(&self, ty: Type) -> usize {
+        ty.as_struct()
+            .map(|id| self.state.type_pool.abi_slot_count(Type::new_struct(id)) as usize)
+            .unwrap_or(3)
     }
 
     fn is_str_like_type(&self, ty: Type) -> bool {
@@ -865,10 +895,12 @@ impl<'a> Interp<'a> {
     }
 
     fn text_struct_slots(&self, struct_id: rue_air::StructId) -> Option<usize> {
-        if self.is_str_like_struct(struct_id) {
-            Some(2)
-        } else if self.is_owned_string_struct(struct_id) {
-            Some(3)
+        // slot-model-default: a str/Str(N) view certifies two ABI slots and an
+        // owned StrBuf three. Derive the width from `abi_slot_count` rather than
+        // carrying the 2/3 literals independently; the guard keeps this `None`
+        // for every non-text struct.
+        if self.is_str_like_struct(struct_id) || self.is_owned_string_struct(struct_id) {
+            Some(self.text_value_slot_width(Type::new_struct(struct_id)))
         } else {
             None
         }

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -500,13 +500,16 @@ fn main() -> i32 {
 """
 exit_code = 8
 
+# slot-model-default: observes 8-byte alignment under the current default
+# layout (4.13:22, now observe-only). RUE-987 re-golds these values when the
+# compact layout (ADR-0052) becomes the default.
 [[case]]
 name = "align_of_all_types_8"
 spec = ["4.13:22"]
 source = """
 struct Point { x: i32, y: i32 }
 fn main() -> i32 {
-    // All types currently have 8-byte alignment
+    // All types currently observe 8-byte alignment under the default layout.
     if @align_of(i8) != 8 { return 1; }
     if @align_of(i64) != 8 { return 2; }
     if @align_of(bool) != 8 { return 3; }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,15 @@ Use `rue --emit <stage>` to inspect `tokens`, `ast`, `rir`, `air`, `cfg`,
 `lowering`, `mir`, `liveness`, `regalloc`, `asm`, or `stackframe`. The option
 can be repeated to request several views.
 
+The `stackframe` view reports each frame's byte-based layout — per-slot offsets
+and sizes, callee-saved registers, and the 16-byte-aligned total — from the
+single frame-layout authority (`rue-codegen`'s `frame_layout`, RUE-975), the
+same byte product both backends' prologue/epilogue and spill allocators consume,
+rather than re-deriving `slot * 8` arithmetic per backend. Physical stack layout
+is one representation produced by the ADR-0052 canonical layout authority; the
+internal value decomposition stays slot-shaped, so under the default layout the
+reported offsets are unchanged.
+
 ## Frontend and semantic IRs
 
 - **`rue-lexer`** tokenizes source and records byte spans and interned names.

--- a/docs/notes/ffi-abi-conformance-audit.md
+++ b/docs/notes/ffi-abi-conformance-audit.md
@@ -48,6 +48,15 @@ slots. Scalars occupy one slot, each aggregate leaf occupies one slot, zero-size
 value parameters occupy none, and `borrow`/`inout` parameters occupy one pointer
 slot. This is a compiler representation, not the target C layout algorithm.
 
+This logical 8-byte slot flattening is the *call-ABI value decomposition*, which
+ADR-0052 deliberately separates from the *physical memory layout* of a type. The
+call convention is preserved unchanged while memory layout migrates to the
+compact representation (previewed by the `aggregate_layout` feature; the
+canonical native classifier is RUE-976), so the slot counts above stay valid
+even after `@size_of`, field offsets, and stack frames adopt natural byte
+widths. Physical layout alone never certifies that a value can be passed by
+value through this convention.
+
 For a multi-slot value, the call planner reverses that value's slots before
 assigning argument locations. The callee reconstructs logical field order. This
 means that even an aggregate small enough to remain in registers is not passed

--- a/docs/spec/src/03-types/06-struct-types.md
+++ b/docs/spec/src/03-types/06-struct-types.md
@@ -71,6 +71,21 @@ Under the current implementation, every non-zero-sized value occupies one or mor
 
 It follows that, under the current implementation, the size of a struct is the sum of the sizes of all its fields, with no padding between fields or at the end (a zero-sized field contributes nothing). A future version that packed scalars or reordered fields would change this observation.
 
+{{ rule(id="3.6:10a", cat="informative") }}
+
+The ratified direction (ADR-0052) replaces the eight-byte slot model with a
+*compact* native layout, already selectable behind the `aggregate_layout`
+preview feature. Under it each scalar uses its natural byte width and alignment
+(for example `i32` is four bytes, four-aligned; `bool` is one byte), struct
+fields are placed in declaration order at offsets satisfying their alignment
+with explicit interior and tail padding, a type's size includes that tail
+padding and equals its array element stride (`stride == size`), enums use the
+smallest sufficient unsigned tag, and a zero-sized type has size `0`, alignment
+`1`, and stride `0`. This too is a documented observation, not a guarantee:
+whichever layout is in effect, only the properties of 3.6:8 are portable, and
+`@size_of`, `@align_of`, `@offset_of`, and `@field_ptr` continue to report the
+chosen layout so compiler-mediated code stays correct across the change.
+
 {{ rule(id="3.6:11") }}
 
 ```rue

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -214,7 +214,7 @@ The value returned by `@size_of` is determined at compile time.
 
 ```rue
 fn main() -> i32 {
-    @size_of(i32)     // 8 (one 8-byte slot)
+    @size_of(i32)     // 8 (one 8-byte slot, observed under the current default layout)
 }
 ```
 
@@ -224,7 +224,9 @@ fn main() -> i32 {
 struct Point { x: i32, y: i32 }
 
 fn main() -> i32 {
-    @size_of(Point)   // 16 (two 8-byte slots)
+    // 16 under the current default layout (two 8-byte slots); the ratified
+    // compact layout (ADR-0052) would observe 8 (two 4-byte i32 fields).
+    @size_of(Point)   // 16
 }
 ```
 
@@ -246,15 +248,23 @@ The return type of `@align_of` is `i32`.
 
 The value returned by `@align_of` is determined at compile time.
 
-{{ rule(id="4.13:22", cat="normative") }}
+{{ rule(id="4.13:22", cat="informative") }}
 
-All types in Rue currently have 8-byte alignment.
+`@align_of(T)` reports the alignment the implementation has chosen for `T`
+under the layout in effect for the compilation (1.3:6, 3.6:12); it *observes*
+that choice and does not guarantee a particular value. Under the current
+default layout every type observes 8-byte alignment. The ratified compact
+layout (ADR-0052, previewed by the `aggregate_layout` feature) instead gives
+each scalar its natural alignment — `@align_of(i32)` would then observe `4` and
+`@align_of(bool)` `1` — so a portable program must not assume the value `8`.
+Whichever layout is in effect, the size of a type is always a multiple of its
+alignment (3.6:8).
 
 {{ rule(id="4.13:23") }}
 
 ```rue
 fn main() -> i32 {
-    @align_of(i32)    // 8
+    @align_of(i32)    // 8 (observed under the current default layout)
 }
 ```
 
@@ -295,8 +305,8 @@ struct Mixed { a: i32, b: i64, c: bool }
 
 fn main() -> i32 {
     let off_a: u64 = @offset_of(Mixed, a);   // 0
-    let off_b: u64 = @offset_of(Mixed, b);   // 8  (a occupies one 8-byte slot)
-    let off_c: u64 = @offset_of(Mixed, c);   // 16 (a and b occupy two slots)
+    let off_b: u64 = @offset_of(Mixed, b);   // 8  (observed under the current default layout)
+    let off_c: u64 = @offset_of(Mixed, c);   // 16 (observed under the current default layout)
     let sum: u64 = off_a + off_b + off_c;    // 24
     @intCast(sum)
 }


### PR DESCRIPTION
## Summary

Sixth child of the ADR-0052 migration (epic RUE-971): everything that states or tests slot facts becomes either observe-only wording or authority-derived values — with **no observed value changing** while the `aggregate_layout` gate is off.

- **Spec**: the audit's anchor guarantee (4.13 "All types in Rue currently have 8-byte alignment") becomes an informative observe-only rule per RUE-288's observe-vs-guarantee model; a new informative section in 3.6 documents the ratified compact layout and the preview flag; layout-intrinsic examples are relabeled "observed under the current default layout". Traceability stays 100% normative, no orphans.
- **Oracle**: the hardcoded str=2/StrBuf=3 slot literals in `string_literal_value`/`text_struct_slots` now derive from the compiler's `abi_slot_count` authority (extending the RUE-976 pattern); the two-slot str-view constructors become `cfg(test)`. The single remaining hardcoded width (`@to_string`'s type-free result site) is documented and stable under ADR-0052's preserved value decomposition.
- **Ledger/tooling**: a grep-able `slot-model-default` marker annotates the five slot-model CLI corpus clusters in the oracle-diff ledger plus the oracle text sites and the spec align_of case, giving the RUE-987 stabilization sweep a mechanical enumeration of every default-mode-dependent entry. `--emit stackframe` docs reflect RUE-975's byte-based frame authority; the FFI ABI note points at ADR-0052's call-ABI/physical-layout separation.

## Verification

No test expectation changed. Spec suite 2128 with the traceability gate green (764/764 normative, no orphans); oracle-diff 0 disagreements; full `test.sh` green except the four known uid-0 unreadable-file environmental failures.

Fixes RUE-977

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_