### PR TITLE
RUE-942: extend ruelex into a stage-1 frontend

### DIFF
--- a/crates/rue-cli-tests/cases/examples_rueparse.toml
+++ b/crates/rue-cli-tests/cases/examples_rueparse.toml
@@ -1,0 +1,74 @@
+# The Rue stage-1 frontend (RUE-942): a recursive-descent + Pratt parser
+# implemented in Rue on top of examples/ruelex. These cases execute the real
+# compiled program, not a Rust-side model of it.
+
+[section]
+id = "cli.examples_rueparse"
+name = "Rue parser written in Rue (rueparse)"
+description = "compile the 1.9K-line Rue frontend and exercise its arena AST, full expression ladder, generic patterns, anonymous types, and recovery"
+
+[[case]]
+name = "rueparse_covers_real_frontend_grammar"
+description = "parse constructs used by current std but missing from the older normative grammar: anonymous enums, anonymous-struct drop fns, and generic qualified patterns"
+source_path = "examples/ruelex/main.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "sample.rue", source = """
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None, }
+}
+
+fn Buffer(comptime T: type) -> type {
+    struct {
+        value: T,
+        fn get(borrow self) -> T { self.value }
+        drop fn(self) {}
+    }
+}
+
+fn classify(x: R) -> i32 {
+    match x {
+        pkg.Result(i32, E).Ok(v) => v,
+        pkg.Result(i32, E).Err(e) => 0 - e,
+    }
+}
+
+fn main() -> i32 {
+    let x = 1 + 2 * 3;
+    if x == 7 { x } else { 0 }
+}
+""" }]
+program_args = ["--ast", "sample.rue"]
+exit_code = 0
+stdout_contains = [
+    "(program v=0",
+    "(anon-enum-type",
+    "(anon-struct-type",
+    "(drop-fn",
+    "(type-call",
+    "(pattern",
+    "(binary v=62",
+]
+
+[[case]]
+name = "rueparse_reports_and_recovers_from_syntax_error"
+description = "malformed input returns nonzero while still producing diagnostics and a deterministic recovery tree"
+source_path = "examples/ruelex/main.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "bad.rue", source = """
+fn main() -> i32 {
+    let x = ;
+    x
+}
+""" }]
+program_args = ["--ast", "bad.rue"]
+exit_code = 1
+stdout_contains = ["parse error at byte", "(program v="]
+
+[[case]]
+name = "rueparse_missing_input_is_an_io_error"
+description = "an unreadable input is not silently accepted as an empty program"
+source_path = "examples/ruelex/main.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+program_args = ["--ast", "missing.rue"]
+exit_code = 1
+stdout = "ruelex: cannot read missing.rue\n"

--- a/examples/ruelex/ast.rue
+++ b/examples/ruelex/ast.rue
@@ -1,0 +1,200 @@
+// Arena representation for the Rue parser written in Rue.
+//
+// Every node is POD: textual names remain lexer interner ids and child links
+// are u64 arena indices. This makes trees traversable despite Rue's current
+// restriction on repeated reads from ArrayBuf elements that require drop glue.
+
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const Nodes = std.arraybuf.ArrayBuf(Node);
+
+pub const NONE: u64 = 0;
+pub const PROGRAM: u64 = 1;
+pub const LIST: u64 = 2;
+pub const ERROR: u64 = 3;
+pub const IDENT: u64 = 4;
+pub const INT: u64 = 5;
+pub const STRING: u64 = 6;
+pub const BOOL: u64 = 7;
+pub const UNIT: u64 = 8;
+pub const TYPE: u64 = 9;
+pub const TYPE_CALL: u64 = 10;
+pub const ARRAY_TYPE: u64 = 11;
+pub const PTR_TYPE: u64 = 12;
+pub const ANON_STRUCT_TYPE: u64 = 13;
+pub const BINARY: u64 = 14;
+pub const UNARY: u64 = 15;
+pub const CALL: u64 = 16;
+pub const ARG: u64 = 17;
+pub const FIELD: u64 = 18;
+pub const METHOD_CALL: u64 = 19;
+pub const INDEX: u64 = 20;
+pub const TRY: u64 = 21;
+pub const STRUCT_LITERAL: u64 = 22;
+pub const FIELD_INIT: u64 = 23;
+pub const ARRAY_LITERAL: u64 = 24;
+pub const REPEAT_ARRAY: u64 = 25;
+pub const INTRINSIC: u64 = 26;
+pub const BLOCK: u64 = 27;
+pub const COMPTIME_BLOCK: u64 = 28;
+pub const CHECKED_BLOCK: u64 = 29;
+pub const IF: u64 = 30;
+pub const MATCH: u64 = 31;
+pub const ARM: u64 = 32;
+pub const PATTERN: u64 = 33;
+pub const WHILE: u64 = 34;
+pub const LOOP: u64 = 35;
+pub const FOR: u64 = 36;
+pub const BREAK: u64 = 37;
+pub const CONTINUE: u64 = 38;
+pub const RETURN: u64 = 39;
+pub const LET: u64 = 40;
+pub const ASSIGN: u64 = 41;
+pub const EXPR_STMT: u64 = 42;
+pub const DIRECTIVE: u64 = 43;
+pub const FUNCTION: u64 = 44;
+pub const PARAM: u64 = 45;
+pub const STRUCT_DEF: u64 = 46;
+pub const FIELD_DEF: u64 = 47;
+pub const METHOD: u64 = 48;
+pub const ENUM_DEF: u64 = 49;
+pub const VARIANT: u64 = 50;
+pub const DROP_FN: u64 = 51;
+pub const CONST_DECL: u64 = 52;
+pub const ANON_ENUM_TYPE: u64 = 53;
+
+pub struct Node {
+    kind: u64,
+    value: u64,
+    aux: u64,
+    start: u64,
+    end: u64,
+    a: u64,
+    b: u64,
+    c: u64,
+    d: u64,
+}
+
+pub struct Arena {
+    nodes: Nodes,
+
+    fn new() -> Self {
+        let mut nodes = Nodes.new();
+        nodes.push(Node { kind: NONE, value: 0, aux: 0, start: 0, end: 0, a: 0, b: 0, c: 0, d: 0 });
+        Self { nodes: nodes }
+    }
+
+    fn add(inout self, kind: u64, value: u64, start: u64, end: u64, a: u64, b: u64, c: u64) -> u64 {
+        let id = self.nodes.len();
+        self.nodes.push(Node { kind: kind, value: value, aux: 0, start: start, end: end, a: a, b: b, c: c, d: 0 });
+        id
+    }
+
+    fn add_meta(inout self, kind: u64, value: u64, aux: u64, start: u64, end: u64, a: u64, b: u64, c: u64, d: u64) -> u64 {
+        let id = self.nodes.len();
+        self.nodes.push(Node { kind: kind, value: value, aux: aux, start: start, end: end, a: a, b: b, c: c, d: d });
+        id
+    }
+
+    fn list(inout self, list: u64, item: u64, start: u64, end: u64) -> u64 {
+        self.add(LIST, 0, start, end, list, item, 0)
+    }
+
+    fn at(borrow self, id: u64) -> Node {
+        self.nodes.get_or(id, Node { kind: ERROR, value: 0, aux: 0, start: 0, end: 0, a: 0, b: 0, c: 0, d: 0 })
+    }
+
+    fn len(borrow self) -> u64 { self.nodes.len() }
+
+    fn append_u(inout out: StrBuf, value: u64) {
+        out.push_str(@to_string(value));
+    }
+
+    fn kind_name(kind: u64) -> StrBuf {
+        if kind == PROGRAM { "program" }
+        else if kind == LIST { "list" }
+        else if kind == ERROR { "error" }
+        else if kind == IDENT { "ident" }
+        else if kind == INT { "int" }
+        else if kind == STRING { "string" }
+        else if kind == BOOL { "bool" }
+        else if kind == UNIT { "unit" }
+        else if kind == TYPE { "type" }
+        else if kind == TYPE_CALL { "type-call" }
+        else if kind == ARRAY_TYPE { "array-type" }
+        else if kind == PTR_TYPE { "ptr-type" }
+        else if kind == ANON_STRUCT_TYPE { "anon-struct-type" }
+        else if kind == ANON_ENUM_TYPE { "anon-enum-type" }
+        else if kind == BINARY { "binary" }
+        else if kind == UNARY { "unary" }
+        else if kind == CALL { "call" }
+        else if kind == ARG { "arg" }
+        else if kind == FIELD { "field" }
+        else if kind == METHOD_CALL { "method-call" }
+        else if kind == INDEX { "index" }
+        else if kind == TRY { "try" }
+        else if kind == STRUCT_LITERAL { "struct-literal" }
+        else if kind == FIELD_INIT { "field-init" }
+        else if kind == ARRAY_LITERAL { "array" }
+        else if kind == REPEAT_ARRAY { "repeat-array" }
+        else if kind == INTRINSIC { "intrinsic" }
+        else if kind == BLOCK { "block" }
+        else if kind == COMPTIME_BLOCK { "comptime" }
+        else if kind == CHECKED_BLOCK { "checked" }
+        else if kind == IF { "if" }
+        else if kind == MATCH { "match" }
+        else if kind == ARM { "arm" }
+        else if kind == PATTERN { "pattern" }
+        else if kind == WHILE { "while" }
+        else if kind == LOOP { "loop" }
+        else if kind == FOR { "for" }
+        else if kind == BREAK { "break" }
+        else if kind == CONTINUE { "continue" }
+        else if kind == RETURN { "return" }
+        else if kind == LET { "let" }
+        else if kind == ASSIGN { "assign" }
+        else if kind == EXPR_STMT { "expr-stmt" }
+        else if kind == DIRECTIVE { "directive" }
+        else if kind == FUNCTION { "function" }
+        else if kind == PARAM { "param" }
+        else if kind == STRUCT_DEF { "struct" }
+        else if kind == FIELD_DEF { "field-def" }
+        else if kind == METHOD { "method" }
+        else if kind == ENUM_DEF { "enum" }
+        else if kind == VARIANT { "variant" }
+        else if kind == DROP_FN { "drop-fn" }
+        else { "const" }
+    }
+
+    fn dump_node(borrow self, id: u64, inout out: StrBuf) {
+        if id == NONE {
+            out.push_str("_");
+            return;
+        }
+        let n = self.at(id);
+        out.push_str("(");
+        out.push_str(Self.kind_name(n.kind));
+        out.push_str(" v=");
+        Self.append_u(inout out, n.value);
+        if n.aux != 0 {
+            out.push_str(" x=");
+            Self.append_u(inout out, n.aux);
+        }
+        out.push_str(" @");
+        Self.append_u(inout out, n.start);
+        out.push_str("..");
+        Self.append_u(inout out, n.end);
+        if n.a != NONE { out.push_str(" "); self.dump_node(n.a, inout out); }
+        if n.b != NONE { out.push_str(" "); self.dump_node(n.b, inout out); }
+        if n.c != NONE { out.push_str(" "); self.dump_node(n.c, inout out); }
+        if n.d != NONE { out.push_str(" "); self.dump_node(n.d, inout out); }
+        out.push_str(")");
+    }
+
+    fn dump(borrow self, root: u64) -> StrBuf {
+        let mut out = StrBuf.new();
+        self.dump_node(root, inout out);
+        out.push_str("\n");
+        out
+    }
+}

--- a/examples/ruelex/lex.rue
+++ b/examples/ruelex/lex.rue
@@ -14,6 +14,7 @@
 const std = @import("std");
 const fmtutil = @import("fmtutil.rue");
 const interner = @import("interner.rue");
+const token = @import("token.rue");
 const StrBuf = std.strbuf.StrBuf;
 const Bytes = std.arraybuf.ArrayBuf(u8);
 
@@ -83,6 +84,8 @@ pub struct Lexer {
     col: u64,
     interner: interner.Interner,
     pretty: bool,
+    last_kind: u64,
+    last_value: u64,
 
     fn new(src: Bytes, pretty: bool) -> Self {
         let mut lx = Self {
@@ -93,6 +96,8 @@ pub struct Lexer {
             col: 1,
             interner: interner.Interner.new(),
             pretty: pretty,
+            last_kind: token.UNKNOWN,
+            last_value: 0,
         };
         lx.n = lx.src.len();
         lx
@@ -219,6 +224,8 @@ pub struct Lexer {
         if word_eq(borrow key, "type") { return "TYPE(type)"; }
 
         let sym = self.interner.intern(borrow key);
+        self.last_kind = token.IDENT;
+        self.last_value = sym;
         fmtutil.kn("IDENT(sym:", sym, ")")
     }
 
@@ -247,6 +254,8 @@ pub struct Lexer {
                 break;
             }
         }
+        self.last_kind = token.INT;
+        self.last_value = val;
         fmtutil.kn("INT(", val, ")")
     }
 
@@ -277,8 +286,11 @@ pub struct Lexer {
             }
         }
         if !any {
+            self.last_kind = token.ERROR;
             return "ERROR(empty base literal)";
         }
+        self.last_kind = token.INT;
+        self.last_value = val;
         fmtutil.kn("INT(", val, ")")
     }
 
@@ -287,10 +299,12 @@ pub struct Lexer {
         let mut key = StrBuf.new();
         loop {
             if self.pos >= self.n {
+                self.last_kind = token.ERROR;
                 return "ERROR(unterminated string)";
             }
             let c = self.peek(0);
             if c == 10 {
+                self.last_kind = token.ERROR;
                 return "ERROR(unterminated string)";
             }
             if c == 34 {
@@ -300,15 +314,18 @@ pub struct Lexer {
             if c == 92 {
                 self.advance(); // backslash
                 if self.pos >= self.n {
+                    self.last_kind = token.ERROR;
                     return "ERROR(unterminated string)";
                 }
                 let e = self.peek(0);
                 if e == 10 {
+                    self.last_kind = token.ERROR;
                     return "ERROR(unterminated string)";
                 }
                 let dec = decode_escape(e);
                 if dec == 256 {
                     self.advance();
+                    self.last_kind = token.ERROR;
                     return "ERROR(invalid escape)";
                 }
                 let db: u8 = @intCast(dec);
@@ -321,6 +338,8 @@ pub struct Lexer {
             }
         }
         let sym = self.interner.intern(borrow key);
+        self.last_kind = token.STRING;
+        self.last_value = sym;
         fmtutil.kn("STRING(sym:", sym, ")")
     }
 
@@ -397,7 +416,7 @@ pub struct Lexer {
 
     // Tokenize the whole input, appending one line per token to `out`, ending
     // with an EOF token whose span is (n, n).
-    fn run(inout self, inout out: StrBuf) {
+    fn run(inout self, inout out: StrBuf, inout tokens: token.Tokens) {
         loop {
             self.skip_trivia();
             if self.pos >= self.n {
@@ -407,6 +426,8 @@ pub struct Lexer {
             let sl = self.line;
             let sc = self.col;
             let c = self.peek(0);
+            self.last_kind = token.UNKNOWN;
+            self.last_value = 0;
             let kind = if is_ident_start(c) {
                 self.lex_ident(start)
             } else if is_digit(c) {
@@ -417,8 +438,25 @@ pub struct Lexer {
                 self.lex_op(start)
             };
             let end = self.pos;
+            let compact_kind = if self.last_kind == token.UNKNOWN {
+                token.kind_from_name(borrow kind)
+            } else {
+                self.last_kind
+            };
+            tokens.push(token.Token {
+                kind: compact_kind,
+                start: start,
+                end: end,
+                value: self.last_value,
+            });
             self.emit(inout out, start, end, sl, sc, kind);
         }
+        tokens.push(token.Token {
+            kind: token.EOF,
+            start: self.n,
+            end: self.n,
+            value: 0,
+        });
         self.emit(inout out, self.n, self.n, self.line, self.col, "EOF");
     }
 }
@@ -426,7 +464,19 @@ pub struct Lexer {
 // Tokenize `src`, returning the full formatted dump. Consumes `src`.
 pub fn tokenize(src: Bytes, pretty: bool) -> StrBuf {
     let mut out = StrBuf.new();
+    let mut tokens = token.Tokens.new();
     let mut lx = Lexer.new(src, pretty);
-    lx.run(inout out);
+    lx.run(inout out, inout tokens);
     out
+}
+
+// Tokenize `src` into a compact POD stream for rueparse. The formatted output
+// is intentionally discarded; both public entry points execute the same
+// recognizers so differential lexer coverage also protects parser input.
+pub fn scan(src: Bytes) -> token.Tokens {
+    let mut out = StrBuf.new();
+    let mut tokens = token.Tokens.new();
+    let mut lx = Lexer.new(src, false);
+    lx.run(inout out, inout tokens);
+    tokens
 }

--- a/examples/ruelex/main.rue
+++ b/examples/ruelex/main.rue
@@ -1,4 +1,5 @@
-// ruelex — the Rue lexer, written in Rue. Dogfooding maturity rung 3 (RUE-941).
+// ruelex — the Rue stage-1 frontend, written in Rue. Dogfooding maturity
+// rungs 3 and 4 (RUE-941 / RUE-942).
 //
 // This is a self-hosting milestone: a lexer for Rue, implemented in Rue, that
 // reproduces the reference compiler's own `--emit tokens` dump byte-for-byte.
@@ -11,54 +12,72 @@
 // phantom intern of the word `import`. RUE-949 resolved that drift by making
 // the compiler conform to the spec, so ruelex needs no special cases.
 //
-// The modules: lex.rue (tokenizer), interner.rue (symbol numbering),
-// fmtutil.rue (StrBuf/padding helpers), this root (I/O, argv, driver).
+// The `--ast` mode extends that lexer with a recursive-descent + Pratt parser
+// for the current Rue grammar. It stores a traversable tree in a POD arena and
+// prints a deterministic S-expression containing symbols and byte spans.
+// Native corpus validation covers all 117 valid `.rue` files in examples,
+// std, benchmarks, and reproducibility fixtures, including deep nesting.
 //
-// Usage:  ruelex [--pretty] <file.rue> [<file.rue> ...]
+// The modules: token.rue (POD tokens), lex.rue (tokenizer), interner.rue
+// (symbol numbering), ast.rue (POD arena), parse.rue (grammar + recovery),
+// fmtutil.rue (formatting helpers), this root (I/O, argv, driver).
+//
+// Usage:  ruelex [--pretty|--ast] <file.rue> [<file.rue> ...]
 //
 // For each file argument, tokenizes the entire file and prints one line per
 // token. The default output reproduces the Rue compiler's own `--emit tokens`
 // dump — `{start:>4}..{end:<3}  KIND` with 0-based byte offsets — so the two
-// can be diffed. `--pretty` prints `LINE:COL KIND` with 1-based spans instead.
+// can be diffed. `--pretty` prints `LINE:COL KIND` with 1-based spans instead;
+// `--ast` parses and prints the arena tree, returning nonzero on syntax errors.
 //
 // Reading uses std.fs (open + chunked read loop); argv comes from std.env;
 // output goes to stdout via the `print` builtin (which writes a borrowed StrBuf
 // with nothing appended — the token dump already carries its own trailing
 // newlines, so `print` keeps the bytes identical to `--emit tokens`). The lexer
-// itself lives in lex.rue / interner.rue / fmtutil.rue.
+// itself lives in the modules listed above.
 
 const std = @import("std");
 const lex = @import("lex.rue");
+const parse = @import("parse.rue");
 const StrBuf = std.strbuf.StrBuf;
 const Bytes = std.arraybuf.ArrayBuf(u8);
 const OptStr = std.option.Option(StrBuf);
 const FileRes = std.result.Result(std.fs.File, std.fs.FileError);
 const ReadRes = std.result.Result(u64, std.fs.FileError);
 
-// Read the whole file at `path` into a byte buffer. On open/read error the
-// bytes read so far (possibly empty) are returned; the diagnostic is the
-// caller's concern.
-fn read_file(borrow path: StrBuf) -> Bytes {
+struct FileInput {
+    data: Bytes,
+    ok: bool,
+}
+
+// Read the whole file at `path` into a byte buffer. Open/read failures retain
+// any bytes acquired so ownership stays simple, but `ok` makes the driver
+// reject the input instead of silently parsing a partial or empty program.
+fn read_file(borrow path: StrBuf) -> FileInput {
     let mut data = Bytes.new();
     let mut f = match std.fs.File.open(borrow path) {
         FileRes.Ok(file) => file,
         FileRes.Err(e) => {
-            return data;
+            return FileInput { data: data, ok: false };
         },
     };
+    let mut ok = true;
     let chunk: u64 = 65536;
     loop {
         data.reserve(chunk);
         let n = match f.read(inout data) {
             ReadRes.Ok(k) => k,
-            ReadRes.Err(e) => 0,
+            ReadRes.Err(e) => {
+                ok = false;
+                0
+            },
         };
         if n == 0 {
             break;
         }
     }
     let _ = f.close();
-    data
+    FileInput { data: data, ok: ok }
 }
 
 // Whether StrBuf `a` equals `flag`. `flag` is taken by value so a string
@@ -69,7 +88,7 @@ fn str_eq(borrow a: StrBuf, flag: StrBuf) -> bool {
 
 // Tokenize one file and print its dump. When `with_header`, precede it with a
 // `=== <path> ===` banner so multi-file output stays navigable.
-fn process_file(borrow path: StrBuf, pretty: bool, with_header: bool) {
+fn process_file(borrow path: StrBuf, pretty: bool, ast_mode: bool, with_header: bool) -> bool {
     if with_header {
         let mut h = StrBuf.new();
         h.push_str("=== ");
@@ -77,9 +96,31 @@ fn process_file(borrow path: StrBuf, pretty: bool, with_header: bool) {
         h.push_str(" ===\n");
         print(h);
     }
-    let data = read_file(borrow path);
-    let dump = lex.tokenize(data, pretty);
-    print(dump);
+    let input = read_file(borrow path);
+    if !input.ok {
+        let mut message = StrBuf.new();
+        message.push_str("ruelex: cannot read ");
+        message.push_str(path.clone());
+        message.push_str("\n");
+        print(message);
+        return false;
+    }
+    let data = input.data;
+    if ast_mode {
+        let result = parse.parse(lex.scan(data));
+        if result.errors.len() != 0 {
+            print(result.errors);
+            print(result.dump);
+            false
+        } else {
+            print(result.dump);
+            true
+        }
+    } else {
+        let dump = lex.tokenize(data, pretty);
+        print(dump);
+        true
+    }
 }
 
 fn main() -> i32 {
@@ -87,6 +128,7 @@ fn main() -> i32 {
 
     // First pass: pick up flags and count file arguments.
     let mut pretty = false;
+    let mut ast_mode = false;
     let mut nfiles: u64 = 0;
     let mut i: u64 = 1;
     while i < argc {
@@ -94,6 +136,8 @@ fn main() -> i32 {
             OptStr.Some(a) => {
                 if str_eq(borrow a, "--pretty") {
                     pretty = true;
+                } else if str_eq(borrow a, "--ast") {
+                    ast_mode = true;
                 } else {
                     nfiles = nfiles + 1;
                 }
@@ -114,14 +158,19 @@ fn main() -> i32 {
     let with_header = nfiles > 1;
 
     // Second pass: process each file argument in order.
+    let mut ok = true;
     i = 1;
     while i < argc {
         match std.env.arg(i) {
             OptStr.Some(a) => {
                 if str_eq(borrow a, "--pretty") {
                     // flag, skip
+                } else if str_eq(borrow a, "--ast") {
+                    // flag, skip
                 } else {
-                    process_file(borrow a, pretty, with_header);
+                    if !process_file(borrow a, pretty, ast_mode, with_header) {
+                        ok = false;
+                    }
                 }
             },
             OptStr.None => {},
@@ -129,11 +178,11 @@ fn main() -> i32 {
         i = i + 1;
     }
 
-    0
+    if ok { 0 } else { 1 }
 }
 
 fn usage_text() -> StrBuf {
     let mut u = StrBuf.new();
-    u.push_str("usage: ruelex [--pretty] <file.rue> [<file.rue> ...]\n");
+    u.push_str("usage: ruelex [--pretty|--ast] <file.rue> [<file.rue> ...]\n");
     u
 }

--- a/examples/ruelex/parse.rue
+++ b/examples/ruelex/parse.rue
@@ -1,0 +1,793 @@
+// Recursive-descent and Pratt parser for Rue, written in Rue.
+//
+// This follows the normative grammar in spec appendix A. The output is a POD
+// arena with byte spans and interner ids, dumped as deterministic S-expressions
+// for differential testing against the Rust frontend.
+
+const std = @import("std");
+const token = @import("token.rue");
+const ast = @import("ast.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub struct ParseOutput {
+    dump: StrBuf,
+    errors: StrBuf,
+    node_count: u64,
+}
+
+pub struct Parser {
+    tokens: token.Tokens,
+    pos: u64,
+    arena: ast.Arena,
+    errors: StrBuf,
+    error_count: u64,
+
+    fn new(tokens: token.Tokens) -> Self {
+        Self {
+            tokens: tokens,
+            pos: 0,
+            arena: ast.Arena.new(),
+            errors: StrBuf.new(),
+            error_count: 0,
+        }
+    }
+
+    fn fallback() -> token.Token {
+        token.Token { kind: token.EOF, start: 0, end: 0, value: 0 }
+    }
+
+    fn current(borrow self) -> token.Token {
+        self.tokens.get_or(self.pos, Self.fallback())
+    }
+
+    fn kind_at(borrow self, pos: u64) -> u64 {
+        self.tokens.get_or(pos, Self.fallback()).kind
+    }
+
+    fn previous(borrow self) -> token.Token {
+        if self.pos == 0 { Self.fallback() }
+        else { self.tokens.get_or(self.pos - 1, Self.fallback()) }
+    }
+
+    fn kind(borrow self) -> u64 { self.current().kind }
+    fn at(borrow self, kind: u64) -> bool { self.kind() == kind }
+    fn eof(borrow self) -> bool { self.at(token.EOF) }
+
+    fn bump(inout self) -> token.Token {
+        let t = self.current();
+        if t.kind != token.EOF { self.pos = self.pos + 1; }
+        t
+    }
+
+    fn eat(inout self, kind: u64) -> bool {
+        if self.at(kind) { let _ = self.bump(); true } else { false }
+    }
+
+    fn report(inout self, expected: u64) {
+        let got = self.current();
+        self.errors.push_str("parse error at byte ");
+        self.errors.push_str(@to_string(got.start));
+        self.errors.push_str(": expected token ");
+        self.errors.push_str(@to_string(expected));
+        self.errors.push_str(", got ");
+        self.errors.push_str(@to_string(got.kind));
+        self.errors.push_str("\n");
+        self.error_count = self.error_count + 1;
+    }
+
+    fn expect(inout self, kind: u64) -> token.Token {
+        if self.at(kind) { self.bump() }
+        else {
+            self.report(kind);
+            let t = self.current();
+            if !self.eof() { let _ = self.bump(); }
+            t
+        }
+    }
+
+    fn add(inout self, kind: u64, value: u64, start: u64, end: u64, a: u64, b: u64, c: u64) -> u64 {
+        self.arena.add(kind, value, start, end, a, b, c)
+    }
+
+    fn add_meta(inout self, kind: u64, value: u64, aux: u64, start: u64, end: u64, a: u64, b: u64, c: u64, d: u64) -> u64 {
+        self.arena.add_meta(kind, value, aux, start, end, a, b, c, d)
+    }
+
+    fn append(inout self, list: u64, item: u64) -> u64 {
+        let n = self.arena.at(item);
+        self.arena.list(list, item, n.start, n.end)
+    }
+
+    // Binding power is ordered from loose to tight. Zero means non-infix.
+    fn binding_power(kind: u64) -> u64 {
+        if kind == token.PIPEPIPE { 1 }
+        else if kind == token.AMPAMP { 2 }
+        else if kind == token.EQEQ || kind == token.BANGEQ || kind == token.LT || kind == token.GT || kind == token.LTEQ || kind == token.GTEQ { 3 }
+        else if kind == token.PIPE { 4 }
+        else if kind == token.CARET { 5 }
+        else if kind == token.AMP { 6 }
+        else if kind == token.LTLT || kind == token.GTGT { 7 }
+        else if kind == token.PLUS || kind == token.MINUS { 8 }
+        else if kind == token.STAR || kind == token.SLASH || kind == token.PERCENT { 9 }
+        else { 0 }
+    }
+
+    fn parse_expr(inout self, min_bp: u64, allow_struct: bool) -> u64 {
+        let mut lhs = self.parse_prefix(allow_struct);
+        loop {
+            let op = self.kind();
+            let bp = Self.binding_power(op);
+            if bp == 0 || bp <= min_bp { break; }
+            let _ = self.bump();
+            let rhs = self.parse_expr(bp, allow_struct);
+            let l = self.arena.at(lhs);
+            let r = self.arena.at(rhs);
+            lhs = self.add(ast.BINARY, op, l.start, r.end, lhs, rhs, 0);
+        }
+        lhs
+    }
+
+    fn parse_prefix(inout self, allow_struct: bool) -> u64 {
+        let t = self.current();
+        let mut base = if t.kind == token.INT {
+            let _ = self.bump();
+            self.add(ast.INT, t.value, t.start, t.end, 0, 0, 0)
+        } else if t.kind == token.STRING {
+            let _ = self.bump();
+            self.add(ast.STRING, t.value, t.start, t.end, 0, 0, 0)
+        } else if t.kind == token.TRUE || t.kind == token.FALSE {
+            let _ = self.bump();
+            let v: u64 = if t.kind == token.TRUE { 1 } else { 0 };
+            self.add(ast.BOOL, v, t.start, t.end, 0, 0, 0)
+        } else if t.kind == token.IDENT || t.kind == token.SELF {
+            self.parse_ident_primary(allow_struct)
+        } else if t.kind == token.SELFTYPE {
+            self.parse_self_type_primary(allow_struct)
+        } else if Self.is_primitive(t.kind) {
+            let _ = self.bump();
+            self.add(ast.TYPE, t.kind, t.start, t.end, 0, 0, 0)
+        } else if t.kind == token.LPAREN {
+            self.parse_paren()
+        } else if t.kind == token.LBRACKET {
+            self.parse_array()
+        } else if t.kind == token.LBRACE {
+            self.parse_block()
+        } else if t.kind == token.COMPTIME {
+            let start = self.bump().start;
+            let body = self.parse_block();
+            let end = self.arena.at(body).end;
+            self.add(ast.COMPTIME_BLOCK, 0, start, end, body, 0, 0)
+        } else if t.kind == token.CHECKED {
+            let start = self.bump().start;
+            let body = self.parse_block();
+            let end = self.arena.at(body).end;
+            self.add(ast.CHECKED_BLOCK, 0, start, end, body, 0, 0)
+        } else if t.kind == token.IF {
+            self.parse_if()
+        } else if t.kind == token.MATCH {
+            self.parse_match()
+        } else if t.kind == token.WHILE {
+            self.parse_while()
+        } else if t.kind == token.LOOP {
+            self.parse_loop()
+        } else if t.kind == token.FOR {
+            self.parse_for()
+        } else if t.kind == token.BREAK {
+            self.parse_break()
+        } else if t.kind == token.CONTINUE {
+            let x = self.bump();
+            self.add(ast.CONTINUE, 0, x.start, x.end, 0, 0, 0)
+        } else if t.kind == token.RETURN {
+            self.parse_return()
+        } else if t.kind == token.AT {
+            self.parse_intrinsic()
+        } else if t.kind == token.MINUS || t.kind == token.BANG || t.kind == token.TILDE {
+            let op = self.bump();
+            let inner = self.parse_prefix(allow_struct);
+            let end = self.arena.at(inner).end;
+            self.add(ast.UNARY, op.kind, op.start, end, inner, 0, 0)
+        } else if t.kind == token.STRUCT {
+            self.parse_anon_struct_type(true)
+        } else if t.kind == token.ENUM {
+            self.parse_anon_enum_type()
+        } else {
+            self.report(token.IDENT);
+            let bad = self.bump();
+            self.add(ast.ERROR, bad.kind, bad.start, bad.end, 0, 0, 0)
+        };
+        base = self.parse_postfix(base, allow_struct);
+        base
+    }
+
+    fn parse_ident_primary(inout self, allow_struct: bool) -> u64 {
+        let name = self.bump();
+        let ident = self.add(ast.IDENT, name.value, name.start, name.end, 0, 0, 0);
+        if self.at(token.LPAREN) {
+            let args = self.parse_call_args();
+            let end = self.previous().end;
+            self.add(ast.CALL, 0, name.start, end, ident, args, 0)
+        } else if allow_struct && self.at(token.LBRACE) {
+            let fields = self.parse_field_inits();
+            let end = self.previous().end;
+            self.add(ast.STRUCT_LITERAL, 0, name.start, end, ident, fields, 0)
+        } else { ident }
+    }
+
+    fn parse_self_type_primary(inout self, allow_struct: bool) -> u64 {
+        let name = self.bump();
+        let ty = self.add(ast.TYPE, token.SELFTYPE, name.start, name.end, 0, 0, 0);
+        if allow_struct && self.at(token.LBRACE) {
+            let fields = self.parse_field_inits();
+            self.add(ast.STRUCT_LITERAL, 0, name.start, self.previous().end, ty, fields, 0)
+        } else { ty }
+    }
+
+    fn parse_postfix(inout self, seed: u64, allow_struct: bool) -> u64 {
+        let mut base = seed;
+        loop {
+            if self.eat(token.DOT) {
+                let name = self.expect(token.IDENT);
+                if self.at(token.LPAREN) {
+                    let args = self.parse_call_args();
+                    let begin = self.arena.at(base).start;
+                    base = self.add(ast.METHOD_CALL, name.value, begin, self.previous().end, base, args, 0);
+                } else if allow_struct && self.at(token.LBRACE) {
+                    let field = self.add(ast.FIELD, name.value, self.arena.at(base).start, name.end, base, 0, 0);
+                    let fields = self.parse_field_inits();
+                    base = self.add(ast.STRUCT_LITERAL, 0, self.arena.at(field).start, self.previous().end, field, fields, 0);
+                } else {
+                    let begin = self.arena.at(base).start;
+                    base = self.add(ast.FIELD, name.value, begin, name.end, base, 0, 0);
+                }
+            } else if self.eat(token.LBRACKET) {
+                let idx = self.parse_expr(0, true);
+                let close = self.expect(token.RBRACKET);
+                let begin = self.arena.at(base).start;
+                base = self.add(ast.INDEX, 0, begin, close.end, base, idx, 0);
+            } else if self.eat(token.QUESTION) {
+                let begin = self.arena.at(base).start;
+                base = self.add(ast.TRY, 0, begin, self.previous().end, base, 0, 0);
+            } else { break; }
+        }
+        base
+    }
+
+    fn parse_call_args(inout self) -> u64 {
+        let _ = self.expect(token.LPAREN);
+        let mut args: u64 = 0;
+        while !self.at(token.RPAREN) && !self.eof() {
+            let start = self.current().start;
+            let mode: u64 = if self.eat(token.INOUT) { token.INOUT }
+                else if self.eat(token.BORROW) { token.BORROW }
+                else { 0 };
+            let value = self.parse_expr(0, true);
+            let arg = self.add(ast.ARG, mode, start, self.arena.at(value).end, value, 0, 0);
+            args = self.append(args, arg);
+            if !self.eat(token.COMMA) { break; }
+        }
+        let _ = self.expect(token.RPAREN);
+        args
+    }
+
+    fn parse_field_inits(inout self) -> u64 {
+        let _ = self.expect(token.LBRACE);
+        let mut fields: u64 = 0;
+        while !self.at(token.RBRACE) && !self.eof() {
+            let name = self.expect(token.IDENT);
+            let shorthand = if self.eat(token.COLON) { 0 } else { 1 };
+            let value = if shorthand == 1 {
+                self.add(ast.IDENT, name.value, name.start, name.end, 0, 0, 0)
+            } else { self.parse_expr(0, true) };
+            let field = self.add_meta(ast.FIELD_INIT, name.value, shorthand, name.start, self.arena.at(value).end, value, 0, 0, 0);
+            fields = self.append(fields, field);
+            if !self.eat(token.COMMA) { break; }
+        }
+        let _ = self.expect(token.RBRACE);
+        fields
+    }
+
+    fn parse_paren(inout self) -> u64 {
+        let open = self.bump();
+        if self.eat(token.RPAREN) {
+            self.add(ast.UNIT, 0, open.start, self.previous().end, 0, 0, 0)
+        } else {
+            let inner = self.parse_expr(0, true);
+            let _ = self.expect(token.RPAREN);
+            inner
+        }
+    }
+
+    fn parse_array(inout self) -> u64 {
+        let open = self.bump();
+        if self.eat(token.RBRACKET) {
+            return self.add(ast.ARRAY_LITERAL, 0, open.start, self.previous().end, 0, 0, 0);
+        }
+        let first = self.parse_expr(0, true);
+        if self.eat(token.SEMI) {
+            let count = self.parse_expr(0, true);
+            let close = self.expect(token.RBRACKET);
+            return self.add(ast.REPEAT_ARRAY, 0, open.start, close.end, first, count, 0);
+        }
+        let mut elems = self.append(0, first);
+        while self.eat(token.COMMA) && !self.at(token.RBRACKET) {
+            elems = self.append(elems, self.parse_expr(0, true));
+        }
+        let close = self.expect(token.RBRACKET);
+        self.add(ast.ARRAY_LITERAL, 0, open.start, close.end, elems, 0, 0)
+    }
+
+    fn parse_intrinsic(inout self) -> u64 {
+        let at = self.bump();
+        let name = if self.at(token.IDENT) || self.at(token.DROP) { self.bump() } else { self.expect(token.IDENT) };
+        let args = self.parse_call_args();
+        self.add_meta(ast.INTRINSIC, name.value, name.kind, at.start, self.previous().end, args, 0, 0, 0)
+    }
+
+    fn parse_if(inout self) -> u64 {
+        let start = self.bump().start;
+        let cond = self.parse_expr(0, false);
+        let then_part = self.parse_block();
+        let mut else_part: u64 = 0;
+        if self.eat(token.ELSE) {
+            else_part = if self.at(token.IF) { self.parse_if() } else { self.parse_block() };
+        }
+        let end = if else_part != 0 { self.arena.at(else_part).end } else { self.arena.at(then_part).end };
+        self.add(ast.IF, 0, start, end, cond, then_part, else_part)
+    }
+
+    fn parse_match(inout self) -> u64 {
+        let start = self.bump().start;
+        let value = self.parse_expr(0, false);
+        let _ = self.expect(token.LBRACE);
+        let mut arms: u64 = 0;
+        while !self.at(token.RBRACE) && !self.eof() {
+            let pat = self.parse_pattern();
+            let _ = self.expect(token.FATARROW);
+            let body = self.parse_expr(0, true);
+            let arm = self.add(ast.ARM, 0, self.arena.at(pat).start, self.arena.at(body).end, pat, body, 0);
+            arms = self.append(arms, arm);
+            if !self.eat(token.COMMA) { break; }
+        }
+        let close = self.expect(token.RBRACE);
+        self.add(ast.MATCH, 0, start, close.end, value, arms, 0)
+    }
+
+    fn parse_pattern(inout self) -> u64 {
+        let start = self.current().start;
+        let mut negative: u64 = 0;
+        if self.eat(token.MINUS) { negative = 1; }
+        if self.at(token.INT) {
+            let n = self.bump();
+            return self.add_meta(ast.PATTERN, n.value, negative, start, n.end, 0, 0, 0, 0);
+        }
+        if self.at(token.TRUE) || self.at(token.FALSE) || self.at(token.UNDERSCORE) {
+            let p = self.bump();
+            return self.add(ast.PATTERN, p.kind, start, p.end, 0, 0, 0);
+        }
+        let first = self.expect(token.IDENT);
+        let mut path = self.add(ast.IDENT, first.value, first.start, first.end, 0, 0, 0);
+        loop {
+            if self.at(token.LPAREN) && self.paren_followed_by_dot() {
+                let args = self.parse_type_args();
+                path = self.add(ast.TYPE_CALL, 0, first.start, self.previous().end, path, args, 0);
+            } else if self.eat(token.DOT) {
+                let seg = self.expect(token.IDENT);
+                path = self.add(ast.FIELD, seg.value, first.start, seg.end, path, 0, 0);
+            } else { break; }
+        }
+        let mut binds: u64 = 0;
+        if self.eat(token.LPAREN) {
+            while !self.at(token.RPAREN) && !self.eof() {
+                let b = self.expect(token.IDENT);
+                binds = self.append(binds, self.add(ast.IDENT, b.value, b.start, b.end, 0, 0, 0));
+                if !self.eat(token.COMMA) { break; }
+            }
+            let _ = self.expect(token.RPAREN);
+        }
+        self.add(ast.PATTERN, 0, start, self.previous().end, path, binds, 0)
+    }
+
+    fn paren_followed_by_dot(borrow self) -> bool {
+        if !self.at(token.LPAREN) { return false; }
+        let mut p = self.pos;
+        let mut depth: u64 = 0;
+        loop {
+            let k = self.kind_at(p);
+            if k == token.EOF { return false; }
+            if k == token.LPAREN { depth = depth + 1; }
+            else if k == token.RPAREN {
+                depth = depth - 1;
+                if depth == 0 { return self.kind_at(p + 1) == token.DOT; }
+            }
+            p = p + 1;
+        }
+    }
+
+    fn parse_while(inout self) -> u64 {
+        let start = self.bump().start;
+        let cond = self.parse_expr(0, false);
+        let body = self.parse_block();
+        self.add(ast.WHILE, 0, start, self.arena.at(body).end, cond, body, 0)
+    }
+
+    fn parse_loop(inout self) -> u64 {
+        let start = self.bump().start;
+        let body = self.parse_block();
+        self.add(ast.LOOP, 0, start, self.arena.at(body).end, body, 0, 0)
+    }
+
+    fn parse_for(inout self) -> u64 {
+        let start = self.bump().start;
+        let name = if self.at(token.IDENT) || self.at(token.UNDERSCORE) { self.bump() } else { self.expect(token.IDENT) };
+        let _ = self.expect(token.IN);
+        let iter = self.parse_expr(0, false);
+        let body = self.parse_block();
+        self.add_meta(ast.FOR, name.value, name.kind, start, self.arena.at(body).end, iter, body, 0, 0)
+    }
+
+    fn expression_starts(kind: u64) -> bool {
+        kind == token.INT || kind == token.STRING || kind == token.TRUE || kind == token.FALSE ||
+        kind == token.IDENT || kind == token.SELF || kind == token.SELFTYPE ||
+        kind == token.LPAREN || kind == token.LBRACKET || kind == token.LBRACE ||
+        kind == token.COMPTIME || kind == token.CHECKED || kind == token.IF ||
+        kind == token.MATCH || kind == token.WHILE || kind == token.LOOP ||
+        kind == token.FOR || kind == token.BREAK || kind == token.CONTINUE ||
+        kind == token.RETURN || kind == token.AT || kind == token.MINUS ||
+        kind == token.BANG || kind == token.TILDE || kind == token.STRUCT || kind == token.ENUM || Self.is_primitive(kind)
+    }
+
+    fn parse_break(inout self) -> u64 {
+        let start = self.bump().start;
+        let value = if Self.expression_starts(self.kind()) && !self.at(token.RBRACE) && !self.at(token.COMMA) { self.parse_expr(0, true) } else { 0 };
+        let end = if value == 0 { self.previous().end } else { self.arena.at(value).end };
+        self.add(ast.BREAK, 0, start, end, value, 0, 0)
+    }
+
+    fn parse_return(inout self) -> u64 {
+        let start = self.bump().start;
+        let value = if Self.expression_starts(self.kind()) && !self.at(token.RBRACE) && !self.at(token.COMMA) { self.parse_expr(0, true) } else { 0 };
+        let end = if value == 0 { self.previous().end } else { self.arena.at(value).end };
+        self.add(ast.RETURN, 0, start, end, value, 0, 0)
+    }
+
+    fn parse_block(inout self) -> u64 {
+        let open = self.expect(token.LBRACE);
+        let mut stmts: u64 = 0;
+        let mut tail: u64 = 0;
+        while !self.at(token.RBRACE) && !self.eof() {
+            if self.at(token.LET) || self.directives_before_let() {
+                let directives = self.parse_directives();
+                let s = self.parse_let(directives);
+                stmts = self.append(stmts, s);
+                continue;
+            }
+            let start = self.current().start;
+            let expr = self.parse_expr(0, true);
+            if self.eat(token.EQ) {
+                let rhs = self.parse_expr(0, true);
+                let semi = self.expect(token.SEMI);
+                let s = self.add(ast.ASSIGN, 0, start, semi.end, expr, rhs, 0);
+                stmts = self.append(stmts, s);
+            } else if self.eat(token.SEMI) {
+                let s = self.add(ast.EXPR_STMT, 0, start, self.previous().end, expr, 0, 0);
+                stmts = self.append(stmts, s);
+            } else if self.at(token.RBRACE) {
+                tail = expr;
+                break;
+            } else if Self.can_omit_semi(self.arena.at(expr).kind) {
+                let s = self.add(ast.EXPR_STMT, 0, start, self.arena.at(expr).end, expr, 0, 0);
+                stmts = self.append(stmts, s);
+            } else {
+                self.report(token.SEMI);
+                if !self.eof() { let _ = self.bump(); }
+            }
+        }
+        let close = self.expect(token.RBRACE);
+        self.add(ast.BLOCK, 0, open.start, close.end, stmts, tail, 0)
+    }
+
+    fn can_omit_semi(kind: u64) -> bool {
+        kind == ast.BLOCK || kind == ast.IF || kind == ast.MATCH || kind == ast.WHILE ||
+        kind == ast.LOOP || kind == ast.FOR || kind == ast.BREAK || kind == ast.CONTINUE || kind == ast.RETURN
+    }
+
+    // Directives and intrinsics share the same `@ IDENT (...)` prefix. Scan
+    // without producing diagnostics so an expression statement such as
+    // `@dbg(f(i));` is not damaged by speculative directive parsing.
+    fn directives_before_let(borrow self) -> bool {
+        if !self.at(token.AT) { return false; }
+        let mut p = self.pos;
+        loop {
+            if self.kind_at(p) != token.AT { break; }
+            p = p + 1;
+            if self.kind_at(p) != token.IDENT { return false; }
+            p = p + 1;
+            if self.kind_at(p) == token.LPAREN {
+                p = p + 1;
+                while self.kind_at(p) != token.RPAREN && self.kind_at(p) != token.EOF {
+                    p = p + 1;
+                }
+                if self.kind_at(p) != token.RPAREN { return false; }
+                p = p + 1;
+            }
+        }
+        self.kind_at(p) == token.LET
+    }
+
+    fn parse_let(inout self, directives: u64) -> u64 {
+        let start = self.expect(token.LET).start;
+        let mutable: u64 = if self.eat(token.MUT) { 1 } else { 0 };
+        let name = if self.at(token.IDENT) || self.at(token.UNDERSCORE) { self.bump() } else { self.expect(token.IDENT) };
+        let ty = if self.eat(token.COLON) { self.parse_type() } else { 0 };
+        let _ = self.expect(token.EQ);
+        let value = self.parse_expr(0, true);
+        let semi = self.expect(token.SEMI);
+        let flags = mutable + name.kind * 256;
+        self.add_meta(ast.LET, name.value, flags, start, semi.end, directives, ty, value, 0)
+    }
+
+    fn is_primitive(kind: u64) -> bool { kind >= token.TYPE_I8 && kind <= token.TYPE_TYPE }
+
+    fn parse_type(inout self) -> u64 {
+        let t = self.current();
+        if Self.is_primitive(t.kind) || t.kind == token.SELFTYPE {
+            let _ = self.bump();
+            return self.add(ast.TYPE, t.kind, t.start, t.end, 0, 0, 0);
+        }
+        if t.kind == token.BANG {
+            let _ = self.bump();
+            return self.add(ast.TYPE, token.BANG, t.start, t.end, 0, 0, 0);
+        }
+        if t.kind == token.LPAREN {
+            let start = self.bump().start;
+            let close = self.expect(token.RPAREN);
+            return self.add(ast.TYPE, token.LPAREN, start, close.end, 0, 0, 0);
+        }
+        if t.kind == token.LBRACKET {
+            let start = self.bump().start;
+            let elem = self.parse_type();
+            let _ = self.expect(token.SEMI);
+            let len = self.parse_expr(0, true);
+            let close = self.expect(token.RBRACKET);
+            return self.add(ast.ARRAY_TYPE, 0, start, close.end, elem, len, 0);
+        }
+        if t.kind == token.PTR {
+            let start = self.bump().start;
+            let mode = if self.eat(token.CONST) { token.CONST } else if self.eat(token.MUT) { token.MUT } else { self.report(token.CONST); 0 };
+            let inner = self.parse_type();
+            return self.add(ast.PTR_TYPE, mode, start, self.arena.at(inner).end, inner, 0, 0);
+        }
+        if t.kind == token.STRUCT { return self.parse_anon_struct_type(false); }
+        if t.kind == token.ENUM { return self.parse_anon_enum_type(); }
+        let name = self.expect(token.IDENT);
+        let mut path = self.add(ast.IDENT, name.value, name.start, name.end, 0, 0, 0);
+        while self.eat(token.DOT) {
+            let seg = self.expect(token.IDENT);
+            path = self.add(ast.FIELD, seg.value, name.start, seg.end, path, 0, 0);
+        }
+        if self.at(token.LPAREN) {
+            let args = self.parse_type_args();
+            self.add(ast.TYPE_CALL, 0, name.start, self.previous().end, path, args, 0)
+        } else { self.add(ast.TYPE, token.IDENT, name.start, self.arena.at(path).end, path, 0, 0) }
+    }
+
+    fn parse_type_args(inout self) -> u64 {
+        let _ = self.expect(token.LPAREN);
+        let mut args: u64 = 0;
+        while !self.at(token.RPAREN) && !self.eof() {
+            let arg = if Self.is_primitive(self.kind()) || self.at(token.SELFTYPE) || self.at(token.LBRACKET) || self.at(token.PTR) || self.at(token.STRUCT) || self.at(token.ENUM) {
+                self.parse_type()
+            } else if self.at(token.MINUS) || self.at(token.INT) {
+                self.parse_expr(0, true)
+            } else { self.parse_type() };
+            args = self.append(args, arg);
+            if !self.eat(token.COMMA) { break; }
+        }
+        let _ = self.expect(token.RPAREN);
+        args
+    }
+
+    fn parse_directives(inout self) -> u64 {
+        let mut list: u64 = 0;
+        while self.at(token.AT) {
+            let start = self.bump().start;
+            let name = self.expect(token.IDENT);
+            let mut args: u64 = 0;
+            if self.eat(token.LPAREN) {
+                while !self.at(token.RPAREN) && !self.eof() {
+                    let a = self.expect(token.IDENT);
+                    args = self.append(args, self.add(ast.IDENT, a.value, a.start, a.end, 0, 0, 0));
+                    if !self.eat(token.COMMA) { break; }
+                }
+                let _ = self.expect(token.RPAREN);
+            }
+            let d = self.add(ast.DIRECTIVE, name.value, start, self.previous().end, args, 0, 0);
+            list = self.append(list, d);
+        }
+        list
+    }
+
+    fn parse_params(inout self, method: bool) -> u64 {
+        let _ = self.expect(token.LPAREN);
+        let mut params: u64 = 0;
+        let receiver = self.at(token.SELF) ||
+            ((self.at(token.INOUT) || self.at(token.BORROW) || self.at(token.MUT)) && self.kind_at(self.pos + 1) == token.SELF);
+        if method && receiver {
+            let start = self.current().start;
+            let mode = if self.at(token.SELF) { 0 } else { self.bump().kind };
+            let receiver = self.expect(token.SELF);
+            let p = self.add_meta(ast.PARAM, receiver.value, mode, start, receiver.end, 0, 0, 0, 0);
+            params = self.append(params, p);
+            let _ = self.eat(token.COMMA);
+        }
+        while !self.at(token.RPAREN) && !self.eof() {
+            let start = self.current().start;
+            let mode = if self.at(token.COMPTIME) || self.at(token.INOUT) || self.at(token.BORROW) { self.bump().kind } else { 0 };
+            let name = self.expect(token.IDENT);
+            let _ = self.expect(token.COLON);
+            let ty = self.parse_type();
+            let p = self.add_meta(ast.PARAM, name.value, mode, start, self.arena.at(ty).end, ty, 0, 0, 0);
+            params = self.append(params, p);
+            if !self.eat(token.COMMA) { break; }
+        }
+        let _ = self.expect(token.RPAREN);
+        params
+    }
+
+    fn parse_function(inout self, directives: u64, flags: u64, method: bool) -> u64 {
+        let start = self.expect(token.FN).start;
+        let name = self.expect(token.IDENT);
+        let params = self.parse_params(method);
+        let ret = if self.eat(token.ARROW) { self.parse_type() } else { 0 };
+        let body = self.parse_block();
+        let kind = if method { ast.METHOD } else { ast.FUNCTION };
+        self.add_meta(kind, name.value, flags, start, self.arena.at(body).end, directives, params, ret, body)
+    }
+
+    fn parse_struct(inout self, directives: u64, flags: u64) -> u64 {
+        let start = self.expect(token.STRUCT).start;
+        let name = self.expect(token.IDENT);
+        let _ = self.expect(token.LBRACE);
+        let mut members: u64 = 0;
+        while !self.at(token.RBRACE) && !self.eof() {
+            let dirs = self.parse_directives();
+            if self.at(token.FN) {
+                members = self.append(members, self.parse_function(dirs, 0, true));
+            } else if self.at(token.DROP) {
+                members = self.append(members, self.parse_drop(true));
+            } else {
+                let field = self.expect(token.IDENT);
+                let _ = self.expect(token.COLON);
+                let ty = self.parse_type();
+                members = self.append(members, self.add(ast.FIELD_DEF, field.value, field.start, self.arena.at(ty).end, ty, dirs, 0));
+                let _ = self.eat(token.COMMA);
+            }
+        }
+        let close = self.expect(token.RBRACE);
+        self.add_meta(ast.STRUCT_DEF, name.value, flags, start, close.end, directives, members, 0, 0)
+    }
+
+    fn parse_anon_struct_type(inout self, with_methods: bool) -> u64 {
+        let start = self.expect(token.STRUCT).start;
+        let _ = self.expect(token.LBRACE);
+        let mut members: u64 = 0;
+        while !self.at(token.RBRACE) && !self.eof() {
+            let dirs = self.parse_directives();
+            if with_methods && self.at(token.FN) {
+                members = self.append(members, self.parse_function(dirs, 0, true));
+            } else if with_methods && self.at(token.DROP) {
+                members = self.append(members, self.parse_drop(true));
+            } else {
+                let field = self.expect(token.IDENT);
+                let _ = self.expect(token.COLON);
+                let ty = self.parse_type();
+                members = self.append(members, self.add(ast.FIELD_DEF, field.value, field.start, self.arena.at(ty).end, ty, dirs, 0));
+                let _ = self.eat(token.COMMA);
+            }
+        }
+        let close = self.expect(token.RBRACE);
+        self.add(ast.ANON_STRUCT_TYPE, 0, start, close.end, members, 0, 0)
+    }
+
+    fn parse_anon_enum_type(inout self) -> u64 {
+        let start = self.expect(token.ENUM).start;
+        let _ = self.expect(token.LBRACE);
+        let mut variants: u64 = 0;
+        while !self.at(token.RBRACE) && !self.eof() {
+            let v = self.expect(token.IDENT);
+            let mut payload: u64 = 0;
+            if self.eat(token.LPAREN) {
+                while !self.at(token.RPAREN) && !self.eof() {
+                    payload = self.append(payload, self.parse_type());
+                    if !self.eat(token.COMMA) { break; }
+                }
+                let _ = self.expect(token.RPAREN);
+            }
+            variants = self.append(variants, self.add(ast.VARIANT, v.value, v.start, self.previous().end, payload, 0, 0));
+            if !self.eat(token.COMMA) { break; }
+        }
+        let close = self.expect(token.RBRACE);
+        self.add(ast.ANON_ENUM_TYPE, 0, start, close.end, variants, 0, 0)
+    }
+
+    fn parse_enum(inout self, flags: u64) -> u64 {
+        let start = self.expect(token.ENUM).start;
+        let name = self.expect(token.IDENT);
+        let _ = self.expect(token.LBRACE);
+        let mut variants: u64 = 0;
+        while !self.at(token.RBRACE) && !self.eof() {
+            let v = self.expect(token.IDENT);
+            let mut payload: u64 = 0;
+            if self.eat(token.LPAREN) {
+                while !self.at(token.RPAREN) && !self.eof() {
+                    payload = self.append(payload, self.parse_type());
+                    if !self.eat(token.COMMA) { break; }
+                }
+                let _ = self.expect(token.RPAREN);
+            }
+            variants = self.append(variants, self.add(ast.VARIANT, v.value, v.start, self.previous().end, payload, 0, 0));
+            if !self.eat(token.COMMA) { break; }
+        }
+        let close = self.expect(token.RBRACE);
+        self.add_meta(ast.ENUM_DEF, name.value, flags, start, close.end, variants, 0, 0, 0)
+    }
+
+    fn parse_const(inout self, directives: u64, flags: u64) -> u64 {
+        let start = self.expect(token.CONST).start;
+        let name = self.expect(token.IDENT);
+        let ty = if self.eat(token.COLON) { self.parse_type() } else { 0 };
+        let _ = self.expect(token.EQ);
+        let value = self.parse_expr(0, true);
+        let semi = self.expect(token.SEMI);
+        self.add_meta(ast.CONST_DECL, name.value, flags, start, semi.end, directives, ty, value, 0)
+    }
+
+    fn parse_drop(inout self, anonymous: bool) -> u64 {
+        let start = self.expect(token.DROP).start;
+        let _ = self.expect(token.FN);
+        let name = if anonymous { Self.fallback() } else { self.expect(token.IDENT) };
+        let _ = self.expect(token.LPAREN);
+        let _ = self.expect(token.SELF);
+        let _ = self.expect(token.RPAREN);
+        let body = self.parse_block();
+        self.add(ast.DROP_FN, name.value, start, self.arena.at(body).end, body, 0, 0)
+    }
+
+    fn parse_item(inout self) -> u64 {
+        let directives = self.parse_directives();
+        let mut flags: u64 = 0;
+        if self.eat(token.PUB) { flags = flags + 1; }
+        if self.eat(token.UNCHECKED) { flags = flags + 2; }
+        if self.eat(token.LINEAR) { flags = flags + 4; }
+        if self.at(token.FN) { self.parse_function(directives, flags, false) }
+        else if self.at(token.STRUCT) { self.parse_struct(directives, flags) }
+        else if self.at(token.ENUM) { self.parse_enum(flags) }
+        else if self.at(token.DROP) { self.parse_drop(false) }
+        else if self.at(token.CONST) { self.parse_const(directives, flags) }
+        else {
+            self.report(token.FN);
+            let bad = self.bump();
+            self.add(ast.ERROR, bad.kind, bad.start, bad.end, directives, 0, 0)
+        }
+    }
+
+    fn parse_program(inout self) -> u64 {
+        let start = self.current().start;
+        let mut items: u64 = 0;
+        while !self.eof() {
+            items = self.append(items, self.parse_item());
+        }
+        self.add(ast.PROGRAM, self.error_count, start, self.current().end, items, 0, 0)
+    }
+
+    fn finish(mut self) -> ParseOutput {
+        let root = self.parse_program();
+        let count = self.arena.len();
+        let dump = self.arena.dump(root);
+        ParseOutput { dump: dump, errors: self.errors, node_count: count }
+    }
+}
+
+pub fn parse(tokens: token.Tokens) -> ParseOutput {
+    Parser.new(tokens).finish()
+}

--- a/examples/ruelex/token.rue
+++ b/examples/ruelex/token.rue
@@ -1,0 +1,191 @@
+// POD token representation shared by the Rue lexer and parser.
+//
+// Token kinds are integers rather than a payload enum so a whole token stream
+// can live in ArrayBuf(Token) and be indexed repeatedly while parsing. `value`
+// is the interned symbol for IDENT/STRING and the decoded value for INT.
+
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+pub const EOF: u64 = 0;
+pub const ERROR: u64 = 1;
+pub const IDENT: u64 = 2;
+pub const INT: u64 = 3;
+pub const STRING: u64 = 4;
+
+pub const BORROW: u64 = 10;
+pub const FN: u64 = 11;
+pub const INOUT: u64 = 12;
+pub const LET: u64 = 13;
+pub const LINEAR: u64 = 14;
+pub const MUT: u64 = 15;
+pub const IF: u64 = 16;
+pub const ELSE: u64 = 17;
+pub const WHILE: u64 = 18;
+pub const LOOP: u64 = 19;
+pub const FOR: u64 = 20;
+pub const IN: u64 = 21;
+pub const MATCH: u64 = 22;
+pub const RETURN: u64 = 23;
+pub const BREAK: u64 = 24;
+pub const COMPTIME: u64 = 25;
+pub const CONTINUE: u64 = 26;
+pub const TRUE: u64 = 27;
+pub const FALSE: u64 = 28;
+pub const STRUCT: u64 = 29;
+pub const ENUM: u64 = 30;
+pub const IMPL: u64 = 31;
+pub const SELF: u64 = 32;
+pub const SELFTYPE: u64 = 33;
+pub const DROP: u64 = 34;
+pub const PUB: u64 = 35;
+pub const CONST: u64 = 36;
+pub const CHECKED: u64 = 37;
+pub const UNCHECKED: u64 = 38;
+pub const PTR: u64 = 39;
+
+pub const TYPE_I8: u64 = 40;
+pub const TYPE_I16: u64 = 41;
+pub const TYPE_I32: u64 = 42;
+pub const TYPE_I64: u64 = 43;
+pub const TYPE_U8: u64 = 44;
+pub const TYPE_U16: u64 = 45;
+pub const TYPE_U32: u64 = 46;
+pub const TYPE_U64: u64 = 47;
+pub const TYPE_BOOL: u64 = 48;
+pub const TYPE_TYPE: u64 = 49;
+
+pub const PLUS: u64 = 60;
+pub const MINUS: u64 = 61;
+pub const STAR: u64 = 62;
+pub const SLASH: u64 = 63;
+pub const PERCENT: u64 = 64;
+pub const EQ: u64 = 65;
+pub const BANG: u64 = 66;
+pub const LT: u64 = 67;
+pub const GT: u64 = 68;
+pub const AMP: u64 = 69;
+pub const PIPE: u64 = 70;
+pub const CARET: u64 = 71;
+pub const TILDE: u64 = 72;
+pub const LPAREN: u64 = 73;
+pub const RPAREN: u64 = 74;
+pub const LBRACE: u64 = 75;
+pub const RBRACE: u64 = 76;
+pub const LBRACKET: u64 = 77;
+pub const RBRACKET: u64 = 78;
+pub const COMMA: u64 = 79;
+pub const SEMI: u64 = 80;
+pub const COLON: u64 = 81;
+pub const DOT: u64 = 82;
+pub const QUESTION: u64 = 83;
+pub const AT: u64 = 84;
+pub const ARROW: u64 = 85;
+pub const FATARROW: u64 = 86;
+pub const EQEQ: u64 = 87;
+pub const BANGEQ: u64 = 88;
+pub const LTEQ: u64 = 89;
+pub const GTEQ: u64 = 90;
+pub const LTLT: u64 = 91;
+pub const GTGT: u64 = 92;
+pub const AMPAMP: u64 = 93;
+pub const PIPEPIPE: u64 = 94;
+pub const UNDERSCORE: u64 = 95;
+pub const UNKNOWN: u64 = 255;
+
+pub struct Token {
+    kind: u64,
+    start: u64,
+    end: u64,
+    value: u64,
+}
+
+pub const Tokens = std.arraybuf.ArrayBuf(Token);
+
+fn eq(borrow name: StrBuf, expected: StrBuf) -> bool {
+    StrBuf.equals_borrowed(borrow name, borrow expected)
+}
+
+// Map the stable text used by `--emit tokens` to the compact parser tag.
+// IDENT/INT/STRING are set directly by the recognizer because their labels
+// include payload text and therefore are not exact static names.
+pub fn kind_from_name(borrow name: StrBuf) -> u64 {
+    if eq(borrow name, "EOF") { return EOF; }
+    if eq(borrow name, "BORROW") { return BORROW; }
+    if eq(borrow name, "FN") { return FN; }
+    if eq(borrow name, "INOUT") { return INOUT; }
+    if eq(borrow name, "LET") { return LET; }
+    if eq(borrow name, "LINEAR") { return LINEAR; }
+    if eq(borrow name, "MUT") { return MUT; }
+    if eq(borrow name, "IF") { return IF; }
+    if eq(borrow name, "ELSE") { return ELSE; }
+    if eq(borrow name, "WHILE") { return WHILE; }
+    if eq(borrow name, "LOOP") { return LOOP; }
+    if eq(borrow name, "FOR") { return FOR; }
+    if eq(borrow name, "IN") { return IN; }
+    if eq(borrow name, "MATCH") { return MATCH; }
+    if eq(borrow name, "RETURN") { return RETURN; }
+    if eq(borrow name, "BREAK") { return BREAK; }
+    if eq(borrow name, "COMPTIME") { return COMPTIME; }
+    if eq(borrow name, "CONTINUE") { return CONTINUE; }
+    if eq(borrow name, "TRUE") { return TRUE; }
+    if eq(borrow name, "FALSE") { return FALSE; }
+    if eq(borrow name, "STRUCT") { return STRUCT; }
+    if eq(borrow name, "ENUM") { return ENUM; }
+    if eq(borrow name, "IMPL") { return IMPL; }
+    if eq(borrow name, "SELF") { return SELF; }
+    if eq(borrow name, "SELFTYPE") { return SELFTYPE; }
+    if eq(borrow name, "DROP") { return DROP; }
+    if eq(borrow name, "PUB") { return PUB; }
+    if eq(borrow name, "CONST") { return CONST; }
+    if eq(borrow name, "CHECKED") { return CHECKED; }
+    if eq(borrow name, "UNCHECKED") { return UNCHECKED; }
+    if eq(borrow name, "PTR") { return PTR; }
+    if eq(borrow name, "TYPE(i8)") { return TYPE_I8; }
+    if eq(borrow name, "TYPE(i16)") { return TYPE_I16; }
+    if eq(borrow name, "TYPE(i32)") { return TYPE_I32; }
+    if eq(borrow name, "TYPE(i64)") { return TYPE_I64; }
+    if eq(borrow name, "TYPE(u8)") { return TYPE_U8; }
+    if eq(borrow name, "TYPE(u16)") { return TYPE_U16; }
+    if eq(borrow name, "TYPE(u32)") { return TYPE_U32; }
+    if eq(borrow name, "TYPE(u64)") { return TYPE_U64; }
+    if eq(borrow name, "TYPE(bool)") { return TYPE_BOOL; }
+    if eq(borrow name, "TYPE(type)") { return TYPE_TYPE; }
+    if eq(borrow name, "PLUS") { return PLUS; }
+    if eq(borrow name, "MINUS") { return MINUS; }
+    if eq(borrow name, "STAR") { return STAR; }
+    if eq(borrow name, "SLASH") { return SLASH; }
+    if eq(borrow name, "PERCENT") { return PERCENT; }
+    if eq(borrow name, "EQ") { return EQ; }
+    if eq(borrow name, "BANG") { return BANG; }
+    if eq(borrow name, "LT") { return LT; }
+    if eq(borrow name, "GT") { return GT; }
+    if eq(borrow name, "AMP") { return AMP; }
+    if eq(borrow name, "PIPE") { return PIPE; }
+    if eq(borrow name, "CARET") { return CARET; }
+    if eq(borrow name, "TILDE") { return TILDE; }
+    if eq(borrow name, "LPAREN") { return LPAREN; }
+    if eq(borrow name, "RPAREN") { return RPAREN; }
+    if eq(borrow name, "LBRACE") { return LBRACE; }
+    if eq(borrow name, "RBRACE") { return RBRACE; }
+    if eq(borrow name, "LBRACKET") { return LBRACKET; }
+    if eq(borrow name, "RBRACKET") { return RBRACKET; }
+    if eq(borrow name, "COMMA") { return COMMA; }
+    if eq(borrow name, "SEMI") { return SEMI; }
+    if eq(borrow name, "COLON") { return COLON; }
+    if eq(borrow name, "DOT") { return DOT; }
+    if eq(borrow name, "QUESTION") { return QUESTION; }
+    if eq(borrow name, "AT") { return AT; }
+    if eq(borrow name, "ARROW") { return ARROW; }
+    if eq(borrow name, "FATARROW") { return FATARROW; }
+    if eq(borrow name, "EQEQ") { return EQEQ; }
+    if eq(borrow name, "BANGEQ") { return BANGEQ; }
+    if eq(borrow name, "LTEQ") { return LTEQ; }
+    if eq(borrow name, "GTEQ") { return GTEQ; }
+    if eq(borrow name, "LTLT") { return LTLT; }
+    if eq(borrow name, "GTGT") { return GTGT; }
+    if eq(borrow name, "AMPAMP") { return AMPAMP; }
+    if eq(borrow name, "PIPEPIPE") { return PIPEPIPE; }
+    if eq(borrow name, "UNDERSCORE") { return UNDERSCORE; }
+    ERROR
+}


### PR DESCRIPTION
## Summary

- expose the existing Rue lexer as a compact POD token stream without changing its byte-for-byte token dump
- add a recursive-descent and Pratt parser with spans, recovery, and a traversable POD arena
- add an --ast mode and end-to-end coverage for real grammar forms, malformed input, and I/O failure

The frontend is 1,992 lines of Rue and parses all 117 valid Rue files under examples, std, benchmarks, and reproducibility fixtures, including the deep-nesting stress source. This is a mergeable RUE-942 milestone; the issue remains open for AST normalization and automated structural oracle comparison with the Rust frontend.

## Performance

Five fresh -j1 O0 compiler processes after warmup:

- before: 4,761 transitive lines / 24,430 tokens; 147.9 ms compiler median
- after: 6,044 transitive lines / 37,371 tokens; 464.8 ms compiler median
- after phases: parser 7.6 ms, sema 135.0 ms, CFG 25.3 ms, codegen 224.2 ms
- after process median 480.6 ms; peak RSS median 42.7 MiB

## Validation

- scripts/rue cli examples_rueparse
- scripts/rue cli examples_ruelex
- scripts/rue cli (1,543 cases)
- scripts/rue quick
- native corpus parse: 117/117
- x86-64-linux, aarch64-linux, and aarch64-macos cross-compiles

Relates to RUE-942