### PR TITLE
RUE-989: narrow physical access codegen under aggregate_layout (ADR-0052 phase 5.5)

### DIFF
--- a/crates/rue-cli-tests/cases/aggregate_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout.toml
@@ -1,15 +1,18 @@
-# Compact native physical layout through the real driver (ADR-0052 phase 3,
-# RUE-974). With `--preview aggregate_layout` the canonical layout authority
+# Compact native physical layout through the real driver (ADR-0052, RUE-974 +
+# RUE-989). With `--preview aggregate_layout` the canonical layout authority
 # reports the ratified compact representation: natural scalar widths and
 # alignments, declaration-order struct fields with interior/tail padding,
 # ascending array stride, a smallest-sufficient enum tag, and the uniform
 # zero-sized-type rule. The compile-time layout queries (@size_of / @align_of /
 # @offset_of) observe those values; slot-identical aggregates (all eight-byte
-# leaves) still marshal correctly through memory; and a program that would need
-# narrow (one/two/four-byte) physical memory access fails loudly rather than
-# emitting slot-shaped access against a compact layout (the narrow load/store
-# code generation is staged for RUE-975/RUE-976). Without the flag every case
-# below observes today's eight-byte slot model unchanged.
+# leaves) marshal correctly through memory; and RUE-989 lowers narrow
+# (one/two/four-byte) scalar access through typed pointers with the correct
+# zero/sign extension, so narrow heap round-trips, compact struct field access,
+# and heap arrays of narrow scalars compile and execute. A program that would
+# still need unimplemented whole-aggregate marshalling through a pointer or
+# across a call (or compact enum memory) fails loudly rather than emitting
+# slot-shaped access against a compact layout. Without the flag every case below
+# observes today's eight-byte slot model unchanged.
 
 [section]
 id = "cli.aggregate_layout"
@@ -133,12 +136,14 @@ fn main() -> i32 {
 stdout = "true\ntrue\ntrue\n"
 exit_code = 0
 
-# A program that would require narrow physical memory access under the compact
-# layout is refused loudly rather than miscompiled with slot-shaped access. The
-# narrow load/store code generation is staged for RUE-975/RUE-976.
+# RUE-989: writing a narrow i32 field through a `@field_ptr` pointer now lowers
+# and executes under the compact layout. The frame stores the field in an
+# eight-byte slot; `@field_ptr` addresses that slot, and the narrow four-byte
+# store hits its low bytes (little-endian), so the round-trip is correct.
 [[case]]
-name = "compact_narrow_physical_access_fails_loudly"
-description = "Writing through a pointer into a struct with narrow i32 fields is refused, not silently miscompiled."
+name = "compact_struct_field_narrow_roundtrip"
+description = "Writing a narrow i32 field through a pointer round-trips under --preview aggregate_layout (RUE-989)."
+differential_opt = true
 args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Pair { a: i32, b: i32 }
@@ -148,14 +153,15 @@ fn main() -> i32 {
         let fp: ptr mut i32 = @field_ptr(p.b);
         @ptr_write(fp, 100);
     };
+    @dbg(p.a);
     p.b
 }
 """ }]
-compile_fail = true
-error_contains = ["aggregate_layout", "not yet implemented"]
+stdout = "7\n"
+exit_code = 100
 
-# Without the preview flag, the exact same narrow program compiles and runs
-# unchanged under today's eight-byte slot model.
+# The same narrow-field program also compiles and runs under the default slot
+# model when the preview is off (byte-identical gate-off behavior).
 [[case]]
 name = "narrow_program_unchanged_without_the_preview"
 description = "The narrow-field program compiles and runs under the default slot model when the preview is off."
@@ -171,3 +177,132 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 100
+
+# RUE-989: narrow scalar heap round-trips through @alloc/@ptr_write/@ptr_read
+# for i32, i16 (signed, storing -1 and reading it back), u16 (zero-extended),
+# and u8. The load extends the narrow physical value into its slot per the
+# scalar's signedness.
+[[case]]
+name = "narrow_heap_roundtrip_scalars"
+description = "i32/i16/u16/u8 heap round-trips with correct sign/zero extension under --preview aggregate_layout (RUE-989)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    checked {
+        let pi: ptr mut i32 = @alloc(1);
+        @ptr_write(pi, 10);
+        @dbg(@ptr_read(pi));
+        @free(pi, 1);
+        let ps: ptr mut i16 = @alloc(1);
+        let neg: i16 = -1;
+        @ptr_write(ps, neg);
+        @dbg(@ptr_read(ps));
+        @free(ps, 1);
+        let pu: ptr mut u16 = @alloc(1);
+        let big: u16 = 65535;
+        @ptr_write(pu, big);
+        @dbg(@ptr_read(pu));
+        @free(pu, 1);
+        let pb: ptr mut u8 = @alloc(1);
+        let by: u8 = 200;
+        @ptr_write(pb, by);
+        @dbg(@ptr_read(pb));
+        @free(pb, 1);
+    };
+    0
+}
+""" }]
+stdout = "10\n-1\n65535\n200\n"
+exit_code = 0
+
+# RUE-989: heap arrays of narrow scalars walked with @ptr_offset at the compact
+# stride (u8 stride 1, i16 stride 2, i32 stride 4), covering signed negatives.
+[[case]]
+name = "narrow_heap_array_walk"
+description = "Walk heap [u8;4], [i16;3] (with negatives), [i32;3] at compact stride under --preview aggregate_layout (RUE-989)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    checked {
+        let pa: ptr mut u8 = @alloc(4);
+        let v0: u8 = 10; let v1: u8 = 20; let v2: u8 = 30; let v3: u8 = 40;
+        @ptr_write(@ptr_offset(pa, 0), v0);
+        @ptr_write(@ptr_offset(pa, 1), v1);
+        @ptr_write(@ptr_offset(pa, 2), v2);
+        @ptr_write(@ptr_offset(pa, 3), v3);
+        @dbg(@ptr_read(@ptr_offset(pa, 0)));
+        @dbg(@ptr_read(@ptr_offset(pa, 3)));
+        @free(pa, 4);
+        let ph: ptr mut i16 = @alloc(3);
+        let h0: i16 = -5; let h1: i16 = 6; let h2: i16 = -7;
+        @ptr_write(@ptr_offset(ph, 0), h0);
+        @ptr_write(@ptr_offset(ph, 1), h1);
+        @ptr_write(@ptr_offset(ph, 2), h2);
+        @dbg(@ptr_read(@ptr_offset(ph, 0)));
+        @dbg(@ptr_read(@ptr_offset(ph, 2)));
+        @free(ph, 3);
+        let pw: ptr mut i32 = @alloc(3);
+        @ptr_write(@ptr_offset(pw, 0), 100);
+        @ptr_write(@ptr_offset(pw, 1), 200);
+        @ptr_write(@ptr_offset(pw, 2), 300);
+        @dbg(@ptr_read(@ptr_offset(pw, 2)));
+        @free(pw, 3);
+    };
+    0
+}
+""" }]
+stdout = "10\n40\n-5\n-7\n300\n"
+exit_code = 0
+
+# RUE-989: mixed struct { a: u8, b: i32, c: u8 } field round-trips through
+# @field_ptr, each field written and read at its own narrow width.
+[[case]]
+name = "mixed_struct_field_roundtrip"
+description = "Round-trip every field of { a: u8, b: i32, c: u8 } through narrow field pointers (RUE-989)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Mixed { a: u8, b: i32, c: u8 }
+fn main() -> i32 {
+    let mut m = Mixed { a: 1, b: 2, c: 3 };
+    checked {
+        let pa: ptr mut u8 = @field_ptr(m.a);
+        let av: u8 = 250;
+        @ptr_write(pa, av);
+        let pb: ptr mut i32 = @field_ptr(m.b);
+        @ptr_write(pb, -12345);
+        let pc: ptr mut u8 = @field_ptr(m.c);
+        let cv: u8 = 99;
+        @ptr_write(pc, cv);
+    };
+    @dbg(m.a);
+    @dbg(m.b);
+    @dbg(m.c);
+    0
+}
+""" }]
+stdout = "250\n-12345\n99\n"
+exit_code = 0
+
+# A whole non-slot-identical aggregate marshalled through a pointer as a single
+# value is still refused loudly: that marshalling (and the frame-versus-heap
+# pointer provenance it depends on) is unimplemented. RUE-989 lifts the refusal
+# only for narrow SCALAR access.
+[[case]]
+name = "narrow_aggregate_through_pointer_still_fails"
+description = "Writing a whole narrow struct through a pointer is still refused, not silently miscompiled."
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Pair { a: i32, b: i32 }
+fn main() -> i32 {
+    checked {
+        let p: ptr mut Pair = @alloc(1);
+        @ptr_write(p, Pair { a: 1, b: 2 });
+    };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["aggregate_layout", "not yet implemented"]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1484,10 +1484,22 @@ impl<'a> CfgLower<'a> {
                 } else {
                     let dst = self.mir.alloc_vreg();
                     if count != 0 {
-                        self.mir.push(Aarch64Inst::LdrIndexed {
-                            dst: Operand::Virtual(dst),
-                            base: ptr,
-                        });
+                        // A narrow scalar pointee reads 1/2/4 physical bytes and
+                        // extends into the slot-shaped vreg (RUE-989); a full-slot
+                        // pointee keeps the eight-byte load.
+                        if let Some(narrow) = plan.narrow_access {
+                            self.mir.push(Aarch64Inst::NarrowLoadIndexed {
+                                dst: Operand::Virtual(dst),
+                                base: ptr,
+                                width: narrow.width,
+                                signed: narrow.signed,
+                            });
+                        } else {
+                            self.mir.push(Aarch64Inst::LdrIndexed {
+                                dst: Operand::Virtual(dst),
+                                base: ptr,
+                            });
+                        }
                     }
                     if count != 0 {
                         slots.push(dst);
@@ -1502,6 +1514,13 @@ impl<'a> CfgLower<'a> {
                     // Zero-sized values have no bytes to write.
                 } else if !value.slots.is_empty() {
                     crate::agg_slots::store_slots_through_ptr(self, &value.slots, ptr, 0);
+                } else if let Some(narrow) = plan.narrow_access {
+                    // A narrow scalar truncates to 1/2/4 physical bytes (RUE-989).
+                    self.mir.push(Aarch64Inst::NarrowStoreIndexed {
+                        src: Operand::Virtual(value.primary),
+                        base: ptr,
+                        width: narrow.width,
+                    });
                 } else {
                     self.mir.push(Aarch64Inst::StrIndexed {
                         src: Operand::Virtual(value.primary),
@@ -3091,21 +3110,62 @@ mod tests {
         .lower()
     }
 
-    /// Under `aggregate_layout`, a non-slot-identical aggregate that would need
-    /// narrow physical memory codegen is refused loudly on AArch64 too, in
-    /// lockstep with x86-64 (ADR-0052 phase 3; RUE-975/RUE-976 follow-up).
+    /// Under `aggregate_layout`, a non-slot-identical **array** value is still
+    /// refused loudly on AArch64 too, in lockstep with x86-64 (ADR-0052; RUE-989
+    /// narrows the refusal to aggregates through pointers/calls, arrays, enums).
     #[test]
-    fn aggregate_layout_refuses_narrow_physical_layout_codegen() {
+    fn aggregate_layout_refuses_unimplemented_aggregate_codegen() {
         let mut preview = PreviewFeatures::new();
         preview.insert(PreviewFeature::AggregateLayout);
         let err = try_lower_first_fn(
-            "struct Pair { a: i32, b: i32 } fn main() -> i32 { let p = Pair { a: 7, b: 9 }; p.a }",
+            "fn main() -> i32 { let a: [i32; 3] = [1, 2, 3]; a[0] }",
             preview,
         )
-        .expect_err("a narrow aggregate must refuse compact codegen, not miscompile");
+        .expect_err("a narrow array value must refuse compact codegen, not miscompile");
         assert!(
             format!("{err:?}").contains("aggregate_layout"),
             "refusal must name the feature, got: {err:?}"
+        );
+    }
+
+    /// RUE-989: under `aggregate_layout`, narrow scalar access through a typed
+    /// pointer lowers on AArch64 in lockstep with x86-64, emitting the narrow
+    /// pseudos (`ldrsw`/`str w`) instead of the eight-byte `Ldr`/`Str`. Gate-off,
+    /// the same program keeps the eight-byte indexed access.
+    #[test]
+    fn aggregate_layout_allows_narrow_scalar_physical_access() {
+        let source = "fn main() -> i32 { checked { let p: ptr mut i32 = @alloc(1); \
+                      @ptr_write(p, 5); @dbg(@ptr_read(p)); @free(p, 1); }; 0 }";
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let mir = try_lower_first_fn(source, preview)
+            .expect("a narrow scalar through a typed pointer must lower under compact layout");
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::NarrowStoreIndexed { width: 4, .. })),
+            "a narrow i32 @ptr_write must emit a 4-byte narrow store"
+        );
+        assert!(
+            mir.instructions().iter().any(|inst| matches!(
+                inst,
+                Aarch64Inst::NarrowLoadIndexed {
+                    width: 4,
+                    signed: true,
+                    ..
+                }
+            )),
+            "a narrow i32 @ptr_read must emit a sign-extending 4-byte narrow load"
+        );
+
+        let off = try_lower_first_fn(source, PreviewFeatures::new())
+            .expect("the same program lowers under the default slot model");
+        assert!(
+            off.instructions().iter().all(|inst| !matches!(
+                inst,
+                Aarch64Inst::NarrowStoreIndexed { .. } | Aarch64Inst::NarrowLoadIndexed { .. }
+            )),
+            "gate-off must not emit any narrow access"
         );
     }
 

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -59,7 +59,10 @@
 
 use rue_error::{CompileError, CompileResult, ErrorKind, ice_error};
 
-use super::mir::{Aarch64Inst, Aarch64Mir, BLOCK_LABEL_BASE, Cond, LabelId, Reg};
+use super::mir::{
+    Aarch64Inst, Aarch64Mir, BLOCK_LABEL_BASE, Cond, LabelId, Reg, narrow_load_mnemonic,
+    narrow_store_mnemonic,
+};
 use crate::{EmittedCode, EmittedInst, EmittedRelocation};
 
 // ========== AArch64 Instruction Encoding Constants ==========
@@ -486,6 +489,8 @@ impl<'a> Emitter<'a> {
                     | Aarch64Inst::StrbIndexed { .. }
                     | Aarch64Inst::LdrIndexedOffset { .. }
                     | Aarch64Inst::StrIndexedOffset { .. }
+                    | Aarch64Inst::NarrowLoadIndexed { .. }
+                    | Aarch64Inst::NarrowStoreIndexed { .. }
             ) {
                 return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
                     format!(
@@ -680,6 +685,50 @@ impl<'a> Emitter<'a> {
                 self.begin_inst();
                 self.emit_strb(rs, *base, adjusted_offset);
                 end_inst!(self, "strb {}, [{}, #{}]", rs.as_w(), base, adjusted_offset);
+            }
+
+            Aarch64Inst::NarrowLoad {
+                dst,
+                base,
+                width,
+                signed,
+            } => {
+                let rd = dst.as_physical();
+                self.begin_inst();
+                self.emit_narrow_load(rd, *base, *width, *signed);
+                // A sign-extending load targets the 64-bit X register; a
+                // zero-extending load targets the 32-bit W register (which
+                // implicitly clears the upper half).
+                if *signed {
+                    end_inst!(
+                        self,
+                        "{} {}, [{}]",
+                        narrow_load_mnemonic(*width, *signed),
+                        rd,
+                        base
+                    );
+                } else {
+                    end_inst!(
+                        self,
+                        "{} {}, [{}]",
+                        narrow_load_mnemonic(*width, *signed),
+                        rd.as_w(),
+                        base
+                    );
+                }
+            }
+
+            Aarch64Inst::NarrowStore { src, base, width } => {
+                let rs = src.as_physical();
+                self.begin_inst();
+                self.emit_narrow_store(rs, *base, *width);
+                end_inst!(
+                    self,
+                    "{} {}, [{}]",
+                    narrow_store_mnemonic(*width),
+                    rs.as_w(),
+                    base
+                );
             }
 
             Aarch64Inst::AddRR { dst, src1, src2 } => {
@@ -1211,7 +1260,9 @@ impl<'a> Emitter<'a> {
             | Aarch64Inst::LdrbIndexed { .. }
             | Aarch64Inst::StrbIndexed { .. }
             | Aarch64Inst::LdrIndexedOffset { .. }
-            | Aarch64Inst::StrIndexedOffset { .. } => {
+            | Aarch64Inst::StrIndexedOffset { .. }
+            | Aarch64Inst::NarrowLoadIndexed { .. }
+            | Aarch64Inst::NarrowStoreIndexed { .. } => {
                 unreachable!(
                     "LdrIndexed/StrIndexed variants should be caught by emit() verification"
                 )
@@ -1642,6 +1693,38 @@ impl<'a> Emitter<'a> {
             | ((offset as u32) << 10)
             | ((base.encoding() as u32) << 5)
             | rs.encoding() as u32;
+        self.emit_u32(inst);
+    }
+
+    /// Emit a narrow (1/2/4-byte) load of `[base]` extended into the 64-bit `rd`
+    /// (RUE-989). The address is fully materialized in `base` (imm12 = 0), so
+    /// there is no offset to scale. The unsigned forms (`ldrb`/`ldrh`/`ldr w`)
+    /// zero-extend into the X register; the signed forms
+    /// (`ldrsb`/`ldrsh`/`ldrsw`, 64-bit variant) sign-extend into it.
+    fn emit_narrow_load(&mut self, rd: Reg, base: Reg, width: u8, signed: bool) {
+        let base_opcode: u32 = match (width, signed) {
+            (1, false) => 0x3940_0000, // ldrb  w, [base]
+            (1, true) => 0x3980_0000,  // ldrsb x, [base]
+            (2, false) => 0x7940_0000, // ldrh  w, [base]
+            (2, true) => 0x7980_0000,  // ldrsh x, [base]
+            (4, false) => 0xB940_0000, // ldr   w, [base]  (zero-extends)
+            (4, true) => 0xB980_0000,  // ldrsw x, [base]
+            _ => unreachable!("narrow load width must be 1, 2, or 4: {width}"),
+        };
+        let inst = base_opcode | ((base.encoding() as u32) << 5) | rd.encoding() as u32;
+        self.emit_u32(inst);
+    }
+
+    /// Emit a narrow (1/2/4-byte) store of the low `width` bytes of `rs` to
+    /// `[base]` (RUE-989), the address fully materialized in `base` (imm12 = 0).
+    fn emit_narrow_store(&mut self, rs: Reg, base: Reg, width: u8) {
+        let base_opcode: u32 = match width {
+            1 => 0x3900_0000, // strb w, [base]
+            2 => 0x7900_0000, // strh w, [base]
+            4 => 0xB900_0000, // str  w, [base]
+            _ => unreachable!("narrow store width must be 1, 2, or 4: {width}"),
+        };
+        let inst = base_opcode | ((base.encoding() as u32) << 5) | rs.encoding() as u32;
         self.emit_u32(inst);
     }
 
@@ -2540,6 +2623,46 @@ mod tests {
             }),
             vec![0x62, 0x00, 0x00, 0x39]
         );
+    }
+
+    /// RUE-989: the narrow physical load through a pointer selects
+    /// ldrb/ldrsb/ldrh/ldrsh/ldr(w)/ldrsw per width and signedness, extending
+    /// into the 64-bit destination. dst X0, base X1, imm12 0 (address fully in
+    /// base).
+    #[test]
+    fn test_narrow_load_encoding() {
+        let word = |width, signed| {
+            let code = emit_single(Aarch64Inst::NarrowLoad {
+                dst: Operand::Physical(Reg::X0),
+                base: Reg::X1,
+                width,
+                signed,
+            });
+            u32::from_le_bytes(code[0..4].try_into().unwrap())
+        };
+        assert_eq!(word(1, false), 0x3940_0020); // ldrb  w0, [x1]
+        assert_eq!(word(1, true), 0x3980_0020); // ldrsb x0, [x1]
+        assert_eq!(word(2, false), 0x7940_0020); // ldrh  w0, [x1]
+        assert_eq!(word(2, true), 0x7980_0020); // ldrsh x0, [x1]
+        assert_eq!(word(4, false), 0xB940_0020); // ldr   w0, [x1]
+        assert_eq!(word(4, true), 0xB980_0020); // ldrsw x0, [x1]
+    }
+
+    /// RUE-989: the narrow physical store through a pointer selects
+    /// strb/strh/str(w) per width. src X2, base X3.
+    #[test]
+    fn test_narrow_store_encoding() {
+        let word = |width| {
+            let code = emit_single(Aarch64Inst::NarrowStore {
+                src: Operand::Physical(Reg::X2),
+                base: Reg::X3,
+                width,
+            });
+            u32::from_le_bytes(code[0..4].try_into().unwrap())
+        };
+        assert_eq!(word(1), 0x3900_0062); // strb w2, [x3]
+        assert_eq!(word(2), 0x7900_0062); // strh w2, [x3]
+        assert_eq!(word(4), 0xB900_0062); // str  w2, [x3]
     }
 
     #[test]

--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -131,10 +131,12 @@ fn uses(inst: &Aarch64Inst) -> Vec<VReg> {
         Aarch64Inst::MovRR { src, .. } => {
             add_if_virtual(src, &mut result);
         }
-        Aarch64Inst::Ldr { .. } | Aarch64Inst::Ldrb { .. } => {
+        Aarch64Inst::Ldr { .. } | Aarch64Inst::Ldrb { .. } | Aarch64Inst::NarrowLoad { .. } => {
             // Reads from memory via base (physical register)
         }
-        Aarch64Inst::Str { src, .. } | Aarch64Inst::Strb { src, .. } => {
+        Aarch64Inst::Str { src, .. }
+        | Aarch64Inst::Strb { src, .. }
+        | Aarch64Inst::NarrowStore { src, .. } => {
             add_if_virtual(src, &mut result);
         }
         Aarch64Inst::AddRR { src1, src2, .. }
@@ -220,11 +222,15 @@ fn uses(inst: &Aarch64Inst) -> Vec<VReg> {
         Aarch64Inst::LdpPost { .. } => {
             // Only defines
         }
-        Aarch64Inst::LdrIndexed { base, .. } | Aarch64Inst::LdrbIndexed { base, .. } => {
+        Aarch64Inst::LdrIndexed { base, .. }
+        | Aarch64Inst::LdrbIndexed { base, .. }
+        | Aarch64Inst::NarrowLoadIndexed { base, .. } => {
             // base is a VReg directly, not an Operand
             result.push(*base);
         }
-        Aarch64Inst::StrIndexed { src, base } | Aarch64Inst::StrbIndexed { src, base } => {
+        Aarch64Inst::StrIndexed { src, base }
+        | Aarch64Inst::StrbIndexed { src, base }
+        | Aarch64Inst::NarrowStoreIndexed { src, base, .. } => {
             add_if_virtual(src, &mut result);
             result.push(*base);
         }
@@ -280,10 +286,12 @@ fn defs(inst: &Aarch64Inst) -> Vec<VReg> {
         Aarch64Inst::MovRR { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
-        Aarch64Inst::Ldr { dst, .. } | Aarch64Inst::Ldrb { dst, .. } => {
+        Aarch64Inst::Ldr { dst, .. }
+        | Aarch64Inst::Ldrb { dst, .. }
+        | Aarch64Inst::NarrowLoad { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
-        Aarch64Inst::Str { .. } | Aarch64Inst::Strb { .. } => {
+        Aarch64Inst::Str { .. } | Aarch64Inst::Strb { .. } | Aarch64Inst::NarrowStore { .. } => {
             // Writes to memory
         }
         Aarch64Inst::AddRR { dst, .. }
@@ -350,10 +358,14 @@ fn defs(inst: &Aarch64Inst) -> Vec<VReg> {
             add_if_virtual(dst1, &mut result);
             add_if_virtual(dst2, &mut result);
         }
-        Aarch64Inst::LdrIndexed { dst, .. } | Aarch64Inst::LdrbIndexed { dst, .. } => {
+        Aarch64Inst::LdrIndexed { dst, .. }
+        | Aarch64Inst::LdrbIndexed { dst, .. }
+        | Aarch64Inst::NarrowLoadIndexed { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
-        Aarch64Inst::StrIndexed { .. } | Aarch64Inst::StrbIndexed { .. } => {
+        Aarch64Inst::StrIndexed { .. }
+        | Aarch64Inst::StrbIndexed { .. }
+        | Aarch64Inst::NarrowStoreIndexed { .. } => {
             // Writes to memory
         }
         Aarch64Inst::LdrIndexedOffset { dst, .. } => {

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -461,6 +461,44 @@ pub enum Aarch64Inst {
         base: VReg,
     },
 
+    /// Pre-register-allocation narrow (1/2/4-byte) load through a virtual
+    /// address, extended into the 64-bit `dst` (ADR-0052, RUE-989). `signed`
+    /// selects `ldrsb`/`ldrsh`/`ldrsw` (sign-extend) versus `ldrb`/`ldrh`/`ldr w`
+    /// (zero-extend). The address is fully materialized in `base`, so no offset
+    /// is encoded. Register allocation lowers this to [`Aarch64Inst::NarrowLoad`].
+    NarrowLoadIndexed {
+        dst: Operand,
+        base: VReg,
+        width: u8,
+        signed: bool,
+    },
+
+    /// Pre-register-allocation narrow (1/2/4-byte) store of the low `width` bytes
+    /// of `src` through a virtual address (`strb`/`strh`/`str w`). Register
+    /// allocation lowers this to [`Aarch64Inst::NarrowStore`].
+    NarrowStoreIndexed {
+        src: Operand,
+        base: VReg,
+        width: u8,
+    },
+
+    /// Narrow (1/2/4-byte) load of `[base]` extended into the 64-bit `dst`, the
+    /// physical-base form of [`Aarch64Inst::NarrowLoadIndexed`].
+    NarrowLoad {
+        dst: Operand,
+        base: Reg,
+        width: u8,
+        signed: bool,
+    },
+
+    /// Narrow (1/2/4-byte) store of the low `width` bytes of `src` to `[base]`,
+    /// the physical-base form of [`Aarch64Inst::NarrowStoreIndexed`].
+    NarrowStore {
+        src: Operand,
+        base: Reg,
+        width: u8,
+    },
+
     /// `ldr dst, [base, #offset]` - Load from memory via register with offset.
     LdrIndexedOffset {
         dst: Operand,
@@ -962,6 +1000,31 @@ impl Aarch64Inst {
     }
 }
 
+/// The load mnemonic for a narrow access width and extension, used in the
+/// textual MIR dump of the narrow load instructions.
+pub(crate) fn narrow_load_mnemonic(width: u8, signed: bool) -> &'static str {
+    match (width, signed) {
+        (1, false) => "ldrb",
+        (1, true) => "ldrsb",
+        (2, false) => "ldrh",
+        (2, true) => "ldrsh",
+        (4, false) => "ldr",
+        (4, true) => "ldrsw",
+        _ => "ldr?",
+    }
+}
+
+/// The store mnemonic for a narrow access width, used in the textual MIR dump of
+/// the narrow store instructions.
+pub(crate) fn narrow_store_mnemonic(width: u8) -> &'static str {
+    match width {
+        1 => "strb",
+        2 => "strh",
+        4 => "str",
+        _ => "str?",
+    }
+}
+
 impl fmt::Display for Aarch64Inst {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -991,6 +1054,36 @@ impl fmt::Display for Aarch64Inst {
             Aarch64Inst::StrIndexed { src, base } => write!(f, "str {}, [{}]", src, base),
             Aarch64Inst::LdrbIndexed { dst, base } => write!(f, "ldrb {}, [{}]", dst, base),
             Aarch64Inst::StrbIndexed { src, base } => write!(f, "strb {}, [{}]", src, base),
+            Aarch64Inst::NarrowLoadIndexed {
+                dst,
+                base,
+                width,
+                signed,
+            } => write!(
+                f,
+                "{} {}, [{}]",
+                narrow_load_mnemonic(*width, *signed),
+                dst,
+                base
+            ),
+            Aarch64Inst::NarrowStoreIndexed { src, base, width } => {
+                write!(f, "{} {}, [{}]", narrow_store_mnemonic(*width), src, base)
+            }
+            Aarch64Inst::NarrowLoad {
+                dst,
+                base,
+                width,
+                signed,
+            } => write!(
+                f,
+                "{} {}, [{}]",
+                narrow_load_mnemonic(*width, *signed),
+                dst,
+                base
+            ),
+            Aarch64Inst::NarrowStore { src, base, width } => {
+                write!(f, "{} {}, [{}]", narrow_store_mnemonic(*width), src, base)
+            }
             Aarch64Inst::LdrIndexedOffset { dst, base, offset } => {
                 if *offset == 0 {
                     write!(f, "ldr {}, [{}]", dst, base)

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -808,6 +808,56 @@ impl RegAlloc {
                 });
             }
 
+            Aarch64Inst::NarrowLoadIndexed {
+                dst,
+                base,
+                width,
+                signed,
+            } => {
+                let base_reg = Self::load_operand(context, mir, Operand::Virtual(base), Reg::X9)?;
+                let base_phys = base_reg.as_physical();
+                match Self::get_allocation(context, dst) {
+                    Some(Allocation::Register(reg)) => mir.push(Aarch64Inst::NarrowLoad {
+                        dst: Operand::Physical(reg),
+                        base: base_phys,
+                        width,
+                        signed,
+                    }),
+                    Some(Allocation::Spill(offset)) => {
+                        mir.push(Aarch64Inst::NarrowLoad {
+                            dst: Operand::Physical(Reg::X10),
+                            base: base_phys,
+                            width,
+                            signed,
+                        });
+                        mir.push_after(Aarch64Inst::Str {
+                            src: Operand::Physical(Reg::X10),
+                            base: Reg::Fp,
+                            offset,
+                        });
+                    }
+                    Some(Allocation::Rematerialize(_)) => {
+                        unreachable!("destination cannot be rematerializable")
+                    }
+                    None => mir.push(Aarch64Inst::NarrowLoad {
+                        dst,
+                        base: base_phys,
+                        width,
+                        signed,
+                    }),
+                }
+            }
+
+            Aarch64Inst::NarrowStoreIndexed { src, base, width } => {
+                let src_op = Self::load_operand(context, mir, src, Reg::X9)?;
+                let base_reg = Self::load_operand(context, mir, Operand::Virtual(base), Reg::X10)?;
+                mir.push(Aarch64Inst::NarrowStore {
+                    src: src_op,
+                    base: base_reg.as_physical(),
+                    width,
+                });
+            }
+
             Aarch64Inst::LdrIndexedOffset { dst, base, offset } => {
                 // Load base vreg into scratch, then emit load with offset
                 let base_op = Operand::Virtual(base);
@@ -984,6 +1034,23 @@ impl RegAlloc {
             Aarch64Inst::Ret => mir.push(Aarch64Inst::Ret),
             Aarch64Inst::Brk => mir.push(Aarch64Inst::Brk),
             Aarch64Inst::Svc { imm } => mir.push(Aarch64Inst::Svc { imm }),
+            // The physical-base narrow forms are produced by this pass from the
+            // indexed pseudos above with already-allocated operands; they never
+            // appear in the pre-allocation input, so pass them through unchanged.
+            Aarch64Inst::NarrowLoad {
+                dst,
+                base,
+                width,
+                signed,
+            } => mir.push(Aarch64Inst::NarrowLoad {
+                dst,
+                base,
+                width,
+                signed,
+            }),
+            Aarch64Inst::NarrowStore { src, base, width } => {
+                mir.push(Aarch64Inst::NarrowStore { src, base, width })
+            }
         }
         Ok(())
     }

--- a/crates/rue-codegen/src/aarch64/schedule.rs
+++ b/crates/rue-codegen/src/aarch64/schedule.rs
@@ -85,6 +85,8 @@ fn get_latency(inst: &Aarch64Inst) -> u32 {
         | Aarch64Inst::LdrIndexed { .. }
         | Aarch64Inst::LdrbIndexed { .. }
         | Aarch64Inst::LdrIndexedOffset { .. }
+        | Aarch64Inst::NarrowLoad { .. }
+        | Aarch64Inst::NarrowLoadIndexed { .. }
         | Aarch64Inst::LdpPost { .. } => 4,
 
         // Memory stores: 1 cycle to retire (store buffer)
@@ -93,6 +95,8 @@ fn get_latency(inst: &Aarch64Inst) -> u32 {
         | Aarch64Inst::StrIndexed { .. }
         | Aarch64Inst::StrbIndexed { .. }
         | Aarch64Inst::StrIndexedOffset { .. }
+        | Aarch64Inst::NarrowStore { .. }
+        | Aarch64Inst::NarrowStoreIndexed { .. }
         | Aarch64Inst::StpPre { .. } => 1,
 
         // Simple arithmetic: 1 cycle
@@ -231,6 +235,10 @@ fn accesses_memory(inst: &Aarch64Inst) -> bool {
             | Aarch64Inst::Strb { .. }
             | Aarch64Inst::LdrbIndexed { .. }
             | Aarch64Inst::StrbIndexed { .. }
+            | Aarch64Inst::NarrowLoad { .. }
+            | Aarch64Inst::NarrowStore { .. }
+            | Aarch64Inst::NarrowLoadIndexed { .. }
+            | Aarch64Inst::NarrowStoreIndexed { .. }
     )
 }
 
@@ -247,8 +255,12 @@ fn regs_read(inst: &Aarch64Inst) -> Vec<Reg> {
     match inst {
         Aarch64Inst::MovImm { .. } => {}
         Aarch64Inst::MovRR { src, .. } => add_if_phys(src, &mut result),
-        Aarch64Inst::Ldr { base, .. } | Aarch64Inst::Ldrb { base, .. } => result.push(*base),
-        Aarch64Inst::Str { src, base, .. } | Aarch64Inst::Strb { src, base, .. } => {
+        Aarch64Inst::Ldr { base, .. }
+        | Aarch64Inst::Ldrb { base, .. }
+        | Aarch64Inst::NarrowLoad { base, .. } => result.push(*base),
+        Aarch64Inst::Str { src, base, .. }
+        | Aarch64Inst::Strb { src, base, .. }
+        | Aarch64Inst::NarrowStore { src, base, .. } => {
             add_if_phys(src, &mut result);
             result.push(*base);
         }
@@ -332,14 +344,16 @@ fn regs_read(inst: &Aarch64Inst) -> Vec<Reg> {
         }
         Aarch64Inst::LdrIndexed { .. }
         | Aarch64Inst::LdrbIndexed { .. }
-        | Aarch64Inst::LdrIndexedOffset { .. } => {
+        | Aarch64Inst::LdrIndexedOffset { .. }
+        | Aarch64Inst::NarrowLoadIndexed { .. } => {
             // Pre-regalloc indexed load. The scheduler runs after regalloc,
             // which rewrites this variant; the virtual base has no physical
             // register to record here.
         }
         Aarch64Inst::StrIndexed { src, .. }
         | Aarch64Inst::StrbIndexed { src, .. }
-        | Aarch64Inst::StrIndexedOffset { src, .. } => {
+        | Aarch64Inst::StrIndexedOffset { src, .. }
+        | Aarch64Inst::NarrowStoreIndexed { src, .. } => {
             // Pre-regalloc indexed store. The scheduler runs after regalloc,
             // which rewrites this variant; the virtual base has no physical
             // register to record here.
@@ -427,6 +441,8 @@ fn regs_written(inst: &Aarch64Inst) -> Vec<Reg> {
         | Aarch64Inst::LdrIndexed { dst, .. }
         | Aarch64Inst::LdrbIndexed { dst, .. }
         | Aarch64Inst::LdrIndexedOffset { dst, .. }
+        | Aarch64Inst::NarrowLoad { dst, .. }
+        | Aarch64Inst::NarrowLoadIndexed { dst, .. }
         | Aarch64Inst::StringConstPtr { dst, .. }
         | Aarch64Inst::StringConstLen { dst, .. }
         | Aarch64Inst::StringConstCap { dst, .. } => {
@@ -441,7 +457,9 @@ fn regs_written(inst: &Aarch64Inst) -> Vec<Reg> {
         | Aarch64Inst::Strb { .. }
         | Aarch64Inst::StrIndexed { .. }
         | Aarch64Inst::StrbIndexed { .. }
-        | Aarch64Inst::StrIndexedOffset { .. } => {
+        | Aarch64Inst::StrIndexedOffset { .. }
+        | Aarch64Inst::NarrowStore { .. }
+        | Aarch64Inst::NarrowStoreIndexed { .. } => {
             // Writes to memory, not registers
         }
         Aarch64Inst::StpPre { .. } => {

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -262,6 +262,56 @@ pub(crate) fn is_slot_identical_layout(type_pool: &FrozenTypeInternPool, ty: Typ
     rue_air::is_slot_identical_layout(type_pool, ty)
 }
 
+/// Physical width (1/2/4 bytes) and extension of a narrow scalar accessed
+/// through a pointer under the compact layout (ADR-0052, RUE-989).
+///
+/// A load extends the narrow physical value into its slot-shaped virtual
+/// register — zero-extend for unsigned integers and `bool` (whose 0/1 validity
+/// is preserved, ruling 1), sign-extend for signed integers — and a store
+/// truncates the slot value to the narrow width. This is the explicit
+/// pack/unpack at the slot-value ↔ physical-memory boundary of ADR-0052's
+/// three-representation split.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NarrowScalar {
+    /// Physical byte width: 1, 2, or 4.
+    pub width: u8,
+    /// Whether a load sign-extends (`true`) or zero-extends (`false`).
+    pub signed: bool,
+}
+
+/// The narrow-access description for a scalar accessed through a pointer, or
+/// `None` when the value occupies a full eight-byte slot (`i64`/`u64`/pointers)
+/// or the compact layout is inactive. When `None`, the existing eight-byte
+/// slot-shaped load/store is byte-for-byte correct, so gate-off behavior is
+/// unchanged.
+///
+/// Only scalar leaves narrow: aggregates crossing the pointer boundary as whole
+/// values remain refused by [`compact_physical_access_unsupported`].
+pub(crate) fn narrow_scalar_access(
+    type_pool: &FrozenTypeInternPool,
+    ty: Type,
+) -> Option<NarrowScalar> {
+    if !type_pool.compact_layout() {
+        return None;
+    }
+    let (width, signed) = match ty.kind() {
+        TypeKind::I8 => (1, true),
+        TypeKind::U8 | TypeKind::Bool => (1, false),
+        TypeKind::I16 => (2, true),
+        TypeKind::U16 => (2, false),
+        TypeKind::I32 => (4, true),
+        TypeKind::U32 => (4, false),
+        // i64/u64/pointers occupy a full slot; aggregates never take this path.
+        _ => return None,
+    };
+    debug_assert_eq!(
+        u64::from(width),
+        type_pool.layout(ty).size,
+        "narrow scalar width must equal the compact physical size"
+    );
+    Some(NarrowScalar { width, signed })
+}
+
 /// The pointee of a pointer type, or the type itself when it is not a pointer.
 fn pointee_or_self(type_pool: &FrozenTypeInternPool, ty: Type) -> Type {
     match ty.kind() {
@@ -271,27 +321,43 @@ fn pointee_or_self(type_pool: &FrozenTypeInternPool, ty: Type) -> Type {
     }
 }
 
-/// If the compact physical layout is active and this CFG would require narrow
-/// physical memory access that code generation does not yet implement, return
-/// the first offending type so the backend can fail loudly rather than emit
-/// slot-shaped access against a compact layout (ADR-0052 phase 3, RUE-974).
+/// If the compact physical layout is active and this CFG would require physical
+/// memory access that code generation does not yet implement, return the first
+/// offending type so the backend can fail loudly rather than emit slot-shaped
+/// access against a compact layout (ADR-0052, RUE-974 refusal narrowed by
+/// RUE-989).
 ///
-/// The scan is conservative — it refuses whenever a non-slot-identical aggregate
-/// or enum is materialized as a value, a pointer to a non-slot-identical
-/// aggregate appears, a by-reference parameter is non-slot-identical, the
-/// function returns a non-slot-identical aggregate, or a typed pointer
-/// read/write or typed allocation targets a non-slot-identical pointee. Purely
-/// compile-time layout queries (`@size_of`/`@align_of`/`@offset_of`) fold to
-/// constants before code generation and introduce none of these, so they still
-/// compile and run. Slot-identical aggregates (all eight-byte leaves, e.g.
-/// `StrBuf`) marshal correctly and are allowed, as is the byte-addressed
-/// raw-byte family (`@byte_read`/`@byte_write`/`@alloc_bytes`), which is correct
-/// under any layout.
+/// RUE-989 implements narrow (one/two/four-byte) **scalar** access through typed
+/// pointers with the correct zero/sign extension, so a narrow scalar
+/// `@ptr_read`/`@ptr_write`/`@alloc`/`@free`/`@realloc` (including a scalar
+/// struct field reached with `@field_ptr` or a scalar heap element reached with
+/// `@ptr_offset`) now compiles and executes. A non-slot-identical **struct**
+/// value may also exist in the slot-based frame, because its field access uses
+/// static slot offsets and its scalar fields are reached with narrow access.
 ///
-/// Returning `None` never weakens correctness: when it returns `None` every
-/// physical access the function performs is byte-for-byte identical to the slot
-/// model. The follow-up that adds narrow load/store codegen (RUE-975/RUE-976)
-/// removes the refusals this reports.
+/// The scan still refuses what remains unimplemented, always consulting the
+/// canonical [`is_slot_identical_layout`] authority rather than a parallel local
+/// judgment:
+///
+/// - a non-slot-identical **array** or **enum** value (dynamic array indexing
+///   strides by the compact element size while the slot-based frame stores
+///   elements at the slot stride, and compact enum memory is unimplemented);
+/// - a **pointer to a non-slot-identical aggregate** (whole-aggregate
+///   marshalling through a pointer is unimplemented, and frame-versus-heap
+///   pointer provenance is ambiguous, so `@raw`/`@field_ptr` of an aggregate and
+///   an aggregate-pointee `@alloc` are refused);
+/// - a **by-reference non-slot-identical aggregate** parameter;
+/// - a non-slot-identical aggregate that **crosses a call boundary** as an
+///   argument or as the **return value** (RUE-976's transitional indirect rule).
+///
+/// Purely compile-time layout queries (`@size_of`/`@align_of`/`@offset_of`) fold
+/// to constants before code generation. Slot-identical aggregates (all
+/// eight-byte leaves, e.g. `StrBuf`) marshal correctly, as does the
+/// byte-addressed raw-byte family (`@byte_read`/`@byte_write`/`@alloc_bytes`).
+///
+/// Returning `None` never weakens correctness: every remaining physical access
+/// is either byte-for-byte identical to the slot model or a narrow scalar access
+/// RUE-989 lowers correctly.
 pub(crate) fn compact_physical_access_unsupported(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,
@@ -301,31 +367,20 @@ pub(crate) fn compact_physical_access_unsupported(
         return None;
     }
 
-    // A value or pointer position that would place a non-slot-identical type in
-    // physical memory (aggregate value, pointer to a non-slot-identical
-    // aggregate). Narrow scalar pointers are deliberately excluded here: they
-    // are the element type of the byte-addressed raw-byte family (`ptr mut u8`
-    // in `StrBuf`) and are correct under any layout; typed reads/writes through
-    // them are caught by the operation-aware check below instead.
-    let flag_value = |ty: Type| -> bool {
-        match ty.kind() {
-            TypeKind::Struct(_) | TypeKind::Array(_) | TypeKind::Enum(_) => {
-                !is_slot_identical_layout(type_pool, ty)
-            }
-            TypeKind::PtrConst(_) | TypeKind::PtrMut(_) => {
-                let pointee = pointee_or_self(type_pool, ty);
-                matches!(
-                    pointee.kind(),
-                    TypeKind::Struct(_) | TypeKind::Array(_) | TypeKind::Enum(_)
-                ) && !is_slot_identical_layout(type_pool, pointee)
-            }
-            _ => false,
-        }
+    // A non-slot-identical aggregate (struct/array/enum) whose whole-value
+    // marshalling across a memory or call boundary RUE-989 does not implement.
+    // Narrow SCALAR access through typed pointers IS implemented, so scalars
+    // never trigger a refusal here.
+    let unimplemented_aggregate = |ty: Type| -> bool {
+        matches!(
+            ty.kind(),
+            TypeKind::Struct(_) | TypeKind::Array(_) | TypeKind::Enum(_)
+        ) && !is_slot_identical_layout(type_pool, ty)
     };
 
     // Returned aggregates are written to the caller's sret buffer in physical
-    // memory.
-    if flag_value(cfg.return_type()) {
+    // memory (RUE-976's transitional indirect rule; unimplemented).
+    if unimplemented_aggregate(cfg.return_type()) {
         return Some(cfg.return_type());
     }
 
@@ -333,22 +388,54 @@ pub(crate) fn compact_physical_access_unsupported(
         let value = CfgValue::from_raw(raw as u32);
         let inst = cfg.get_inst(value);
 
-        if flag_value(inst.ty) {
+        // A non-slot-identical ARRAY or ENUM value is refused outright: dynamic
+        // array indexing strides by the compact element size while the frame is
+        // slot-based, and compact enum memory is unimplemented. A non-slot-
+        // identical STRUCT value, by contrast, is allowed to exist in the frame
+        // (static slot-offset field access, narrow scalar field pointers); the
+        // boundary checks below still refuse a struct that crosses a pointer,
+        // call, return, or by-ref boundary.
+        if matches!(inst.ty.kind(), TypeKind::Array(_) | TypeKind::Enum(_))
+            && !is_slot_identical_layout(type_pool, inst.ty)
+        {
             return Some(inst.ty);
         }
 
+        // A pointer to a non-slot-identical aggregate: whole-aggregate
+        // marshalling through a pointer is unimplemented and the pointer's
+        // frame-versus-heap provenance is ambiguous.
+        if matches!(inst.ty.kind(), TypeKind::PtrConst(_) | TypeKind::PtrMut(_)) {
+            let pointee = pointee_or_self(type_pool, inst.ty);
+            if unimplemented_aggregate(pointee) {
+                return Some(pointee);
+            }
+        }
+
         match &inst.data {
-            // A by-reference scalar parameter is a physical pointer dereference
-            // whose bare narrow type the value scan above does not catch.
+            // A by-reference aggregate parameter is a pointer into the caller's
+            // slot-based frame; whole-aggregate compact access is unimplemented.
+            // A by-reference narrow scalar reads/writes its eight-byte slot
+            // through the pointer and is correct, so scalars are allowed.
             CfgInstData::Param { index } => {
-                if cfg.is_param_by_ref(*index) && !is_slot_identical_layout(type_pool, inst.ty) {
+                if cfg.is_param_by_ref(*index) && unimplemented_aggregate(inst.ty) {
                     return Some(inst.ty);
                 }
             }
+            // A non-slot-identical aggregate passed by value crosses the call
+            // boundary indirectly (RUE-976); that marshalling is unimplemented.
+            CfgInstData::Call { .. } => {
+                for arg in cfg.get_call_args(&inst.data) {
+                    let arg_ty = cfg.get_inst(arg.value).ty;
+                    if unimplemented_aggregate(arg_ty) {
+                        return Some(arg_ty);
+                    }
+                }
+            }
             // Typed pointer reads/writes and typed allocation address memory by
-            // the pointee's physical layout. The byte-addressed raw-byte family
-            // (`byte_read`/`byte_write`/`alloc_bytes`/...) is intentionally not
-            // matched here — it is correct under any layout.
+            // the pointee's physical layout. A narrow scalar pointee is now
+            // lowered correctly; a non-slot-identical aggregate pointee is
+            // refused. The byte-addressed raw-byte family is not matched here —
+            // it is correct under any layout.
             CfgInstData::Intrinsic { name, .. } => {
                 let op = interner.resolve(name);
                 if matches!(op, "ptr_read" | "ptr_write" | "alloc" | "free" | "realloc") {
@@ -358,7 +445,7 @@ pub(crate) fn compact_physical_access_unsupported(
                     }
                     for ty in relevant {
                         let pointee = pointee_or_self(type_pool, ty);
-                        if !is_slot_identical_layout(type_pool, pointee) {
+                        if unimplemented_aggregate(pointee) {
                             return Some(pointee);
                         }
                     }
@@ -386,10 +473,10 @@ pub(crate) fn ensure_compact_layout_codegen_supported(
         return Err(rue_error::CompileError::without_span(
             rue_error::ErrorKind::InternalCodegenError(format!(
                 "aggregate_layout: physical-layout code generation for type `{name}` (in function \
-                 `{}`) is not yet implemented. RUE-974 provides the compact layout authority and \
-                 the compile-time @size_of / @align_of / @offset_of queries; narrow \
-                 (one/two/four-byte) memory load and store code generation is staged for \
-                 RUE-975/RUE-976.",
+                 `{}`) is not yet implemented. RUE-989 lowers narrow (one/two/four-byte) scalar \
+                 access through typed pointers, but whole-aggregate marshalling through pointers \
+                 and across call boundaries, and compact enum memory, are still staged for a \
+                 follow-up.",
                 cfg.fn_name()
             )),
         ));

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -318,6 +318,12 @@ pub struct IntrinsicPlan {
     pub result_ty: Type,
     pub result_slots: u32,
     pub scale: Option<crate::allocation::ScalePlan>,
+    /// For a typed `@ptr_read`/`@ptr_write` of a narrow scalar under the compact
+    /// layout, the physical width and extension of the memory access (RUE-989).
+    /// `None` for a full eight-byte slot access or when the compact layout is
+    /// inactive, so both backends fall back to their existing slot-shaped
+    /// load/store and gate-off behavior is unchanged.
+    pub narrow_access: Option<crate::types::NarrowScalar>,
 }
 
 /// Place with every dynamic index already materialized. The plan contains no
@@ -1587,6 +1593,22 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                 };
                 let result_slots = ctx.type_slot_count(inst.ty);
                 let runtime_call = intrinsic_runtime_call(&operation, &values, scale, result_slots);
+                // A narrow-scalar `@ptr_read`/`@ptr_write` under the compact
+                // layout accesses 1/2/4 physical bytes with the pointee's
+                // extension (RUE-989). The read's pointee is its result type; the
+                // write's pointee is the value operand's type. Every other
+                // operation, a full-slot scalar, or the gate being off yields
+                // `None`, preserving the slot-shaped path.
+                let narrow_access = match operation {
+                    IntrinsicOperation::PtrRead => {
+                        crate::types::narrow_scalar_access(ctx.type_pool, inst.ty)
+                    }
+                    IntrinsicOperation::PtrWrite => crate::types::narrow_scalar_access(
+                        ctx.type_pool,
+                        ctx.cfg.get_inst(args[1]).ty,
+                    ),
+                    _ => None,
+                };
                 let result = adapter.emit_intrinsic(IntrinsicPlan {
                     operation,
                     runtime_call,
@@ -1594,6 +1616,7 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     result_ty: inst.ty,
                     result_slots,
                     scale,
+                    narrow_access,
                 });
                 cache_result(adapter, value, result);
                 Some(ValueKind::Intrinsic)

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1738,11 +1738,23 @@ impl<'a> CfgLower<'a> {
                 } else {
                     let dst = self.mir.alloc_vreg();
                     if count != 0 {
-                        self.mir.push(X86Inst::MovRMIndexed {
-                            dst: Operand::Virtual(dst),
-                            base: ptr,
-                            offset: 0,
-                        });
+                        // A narrow scalar pointee reads 1/2/4 physical bytes and
+                        // extends into the slot-shaped vreg (RUE-989); a full-slot
+                        // pointee keeps the eight-byte load.
+                        if let Some(narrow) = plan.narrow_access {
+                            self.mir.push(X86Inst::NarrowLoadIndexed {
+                                dst: Operand::Virtual(dst),
+                                base: ptr,
+                                width: narrow.width,
+                                signed: narrow.signed,
+                            });
+                        } else {
+                            self.mir.push(X86Inst::MovRMIndexed {
+                                dst: Operand::Virtual(dst),
+                                base: ptr,
+                                offset: 0,
+                            });
+                        }
                     }
                     if count != 0 {
                         slots.push(dst);
@@ -1757,6 +1769,13 @@ impl<'a> CfgLower<'a> {
                     // Zero-sized values have no bytes to write.
                 } else if !value.slots.is_empty() {
                     crate::agg_slots::store_slots_through_ptr(self, &value.slots, ptr, 0);
+                } else if let Some(narrow) = plan.narrow_access {
+                    // A narrow scalar truncates to 1/2/4 physical bytes (RUE-989).
+                    self.mir.push(X86Inst::NarrowStoreIndexed {
+                        base: ptr,
+                        src: Operand::Virtual(value.primary),
+                        width: narrow.width,
+                    });
                 } else {
                     self.mir.push(X86Inst::MovMRIndexed {
                         base: ptr,
@@ -2947,21 +2966,65 @@ mod tests {
         CfgLower::new(cfg_output.cfg.as_ref().unwrap(), type_pool, &interner).lower()
     }
 
-    /// Under `aggregate_layout`, a non-slot-identical aggregate that would need
-    /// narrow physical memory codegen is refused loudly rather than miscompiled
-    /// with slot-shaped access (ADR-0052 phase 3; RUE-975/RUE-976 follow-up).
+    /// Under `aggregate_layout`, a non-slot-identical **array** value is still
+    /// refused loudly rather than miscompiled: dynamic indexing strides by the
+    /// compact element size while the slot-based frame stores elements at the
+    /// slot stride (ADR-0052; RUE-989 narrows the refusal to what remains
+    /// unimplemented — aggregates through pointers/calls, arrays, and enums).
     #[test]
-    fn aggregate_layout_refuses_narrow_physical_layout_codegen() {
+    fn aggregate_layout_refuses_unimplemented_aggregate_codegen() {
         let mut preview = PreviewFeatures::new();
         preview.insert(PreviewFeature::AggregateLayout);
         let err = try_lower_first_fn(
-            "struct Pair { a: i32, b: i32 } fn main() -> i32 { let p = Pair { a: 7, b: 9 }; p.a }",
+            "fn main() -> i32 { let a: [i32; 3] = [1, 2, 3]; a[0] }",
             preview,
         )
-        .expect_err("a narrow aggregate must refuse compact codegen, not miscompile");
+        .expect_err("a narrow array value must refuse compact codegen, not miscompile");
         assert!(
             format!("{err:?}").contains("aggregate_layout"),
             "refusal must name the feature, got: {err:?}"
+        );
+    }
+
+    /// RUE-989: under `aggregate_layout`, narrow scalar access through a typed
+    /// pointer now lowers, emitting the narrow (1/2/4-byte) load/store pseudos
+    /// instead of a full eight-byte slot access. Gate-off, the same program uses
+    /// the eight-byte `MovRMIndexed`/`MovMRIndexed`.
+    #[test]
+    fn aggregate_layout_allows_narrow_scalar_physical_access() {
+        let source = "fn main() -> i32 { checked { let p: ptr mut i32 = @alloc(1); \
+                      @ptr_write(p, 5); @dbg(@ptr_read(p)); @free(p, 1); }; 0 }";
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let mir = try_lower_first_fn(source, preview)
+            .expect("a narrow scalar through a typed pointer must lower under compact layout");
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::NarrowStoreIndexed { width: 4, .. })),
+            "a narrow i32 @ptr_write must emit a 4-byte narrow store"
+        );
+        assert!(
+            mir.instructions().iter().any(|inst| matches!(
+                inst,
+                X86Inst::NarrowLoadIndexed {
+                    width: 4,
+                    signed: true,
+                    ..
+                }
+            )),
+            "a narrow i32 @ptr_read must emit a sign-extending 4-byte narrow load"
+        );
+
+        // Gate-off, the identical program keeps the eight-byte slot access.
+        let off = try_lower_first_fn(source, PreviewFeatures::new())
+            .expect("the same program lowers under the default slot model");
+        assert!(
+            off.instructions().iter().all(|inst| !matches!(
+                inst,
+                X86Inst::NarrowStoreIndexed { .. } | X86Inst::NarrowLoadIndexed { .. }
+            )),
+            "gate-off must not emit any narrow access"
         );
     }
 

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -115,6 +115,17 @@ use super::mir::{LabelId, Reg, X86Inst, X86Mir};
 use crate::vreg::BLOCK_LABEL_BASE;
 use crate::{EmittedCode, EmittedInst, EmittedRelocation, format_offset};
 
+/// The assembly operand-size keyword for a narrow memory access width, used only
+/// in the textual disassembly listing of the narrow load/store instructions.
+fn narrow_width_keyword(width: u8) -> &'static str {
+    match width {
+        1 => "byte ",
+        2 => "word ",
+        4 => "dword ",
+        _ => "",
+    }
+}
+
 /// Kind of jump fixup.
 ///
 /// We always use rel32 encoding to support jumps of any size within a function.
@@ -375,6 +386,8 @@ impl<'a> Emitter<'a> {
                     | X86Inst::MovMRIndexed { .. }
                     | X86Inst::Movzx8RMIndexed { .. }
                     | X86Inst::MovMR8Indexed { .. }
+                    | X86Inst::NarrowLoadIndexed { .. }
+                    | X86Inst::NarrowStoreIndexed { .. }
             ) {
                 return Err(ice_error!(
                     "post-regalloc verification failed",
@@ -685,6 +698,35 @@ impl<'a> Emitter<'a> {
                     "mov byte [{}{}], {}",
                     base,
                     format_offset(adjusted_offset),
+                    src.as_physical()
+                );
+            }
+            X86Inst::NarrowLoadRM {
+                dst,
+                base,
+                width,
+                signed,
+            } => {
+                self.begin_inst();
+                self.emit_narrow_load_rm(dst.as_physical(), *base, *width, *signed);
+                let ext = if *signed { "movsx" } else { "movzx" };
+                end_inst!(
+                    self,
+                    "{} {}, {}[{}]",
+                    ext,
+                    dst.as_physical(),
+                    narrow_width_keyword(*width),
+                    base
+                );
+            }
+            X86Inst::NarrowStoreMR { base, src, width } => {
+                self.begin_inst();
+                self.emit_narrow_store_mr(*base, src.as_physical(), *width);
+                end_inst!(
+                    self,
+                    "mov {}[{}], {}",
+                    narrow_width_keyword(*width),
+                    base,
                     src.as_physical()
                 );
             }
@@ -1127,10 +1169,12 @@ impl<'a> Emitter<'a> {
             X86Inst::MovRMIndexed { .. }
             | X86Inst::MovMRIndexed { .. }
             | X86Inst::Movzx8RMIndexed { .. }
-            | X86Inst::MovMR8Indexed { .. } => {
-                // Regalloc lowers these into MovRM/MovMR, and
-                // emit_internal() verifies none survive before this dispatch loop runs,
-                // returning an ICE instead of ever reaching this arm.
+            | X86Inst::MovMR8Indexed { .. }
+            | X86Inst::NarrowLoadIndexed { .. }
+            | X86Inst::NarrowStoreIndexed { .. } => {
+                // Regalloc lowers these into MovRM/MovMR/NarrowLoadRM/NarrowStoreMR,
+                // and emit_internal() verifies none survive before this dispatch loop
+                // runs, returning an ICE instead of ever reaching this arm.
                 unreachable!("indexed memory pseudo rejected by pre-emission verification")
             }
 
@@ -1427,6 +1471,70 @@ impl<'a> Emitter<'a> {
         self.code.push(rex);
         self.code.push(0x88);
         self.emit_modrm_memory(src.encoding(), base.encoding(), offset);
+    }
+
+    /// Emit a narrow (1/2/4-byte) load of `[base]` extended into the 64-bit
+    /// `dst` (RUE-989). The address is fully materialized in `base`, so no
+    /// displacement is encoded.
+    ///
+    /// - width 1, zero: `movzx r64, byte [m]`  = REX.W 0F B6 /r
+    /// - width 1, sign: `movsx r64, byte [m]`  = REX.W 0F BE /r
+    /// - width 2, zero: `movzx r64, word [m]`  = REX.W 0F B7 /r
+    /// - width 2, sign: `movsx r64, word [m]`  = REX.W 0F BF /r
+    /// - width 4, zero: `mov r32, dword [m]`   = 8B /r (no REX.W; zero-extends)
+    /// - width 4, sign: `movsxd r64, dword [m]`= REX.W 63 /r
+    fn emit_narrow_load_rm(&mut self, dst: Reg, base: Reg, width: u8, signed: bool) {
+        if width == 4 && !signed {
+            // 32-bit `mov` writes the low dword and zeroes the upper dword of the
+            // 64-bit destination, so no REX.W (a bare REX only if a high register
+            // is referenced).
+            let rex =
+                if dst.needs_rex() { 0x04 } else { 0 } | if base.needs_rex() { 0x01 } else { 0 };
+            if rex != 0 {
+                self.code.push(0x40 | rex);
+            }
+            self.code.push(0x8b);
+            self.emit_modrm_memory(dst.encoding(), base.encoding(), 0);
+            return;
+        }
+        let rex =
+            0x48 | if dst.needs_rex() { 0x04 } else { 0 } | if base.needs_rex() { 0x01 } else { 0 };
+        self.code.push(rex);
+        match (width, signed) {
+            (1, false) => self.code.extend_from_slice(&[0x0f, 0xb6]),
+            (1, true) => self.code.extend_from_slice(&[0x0f, 0xbe]),
+            (2, false) => self.code.extend_from_slice(&[0x0f, 0xb7]),
+            (2, true) => self.code.extend_from_slice(&[0x0f, 0xbf]),
+            (4, true) => self.code.push(0x63),
+            _ => unreachable!("narrow load width must be 1, 2, or 4: {width}"),
+        }
+        self.emit_modrm_memory(dst.encoding(), base.encoding(), 0);
+    }
+
+    /// Emit a narrow (1/2/4-byte) store of the low `width` bytes of `src` to
+    /// `[base]` (RUE-989).
+    ///
+    /// - width 1: `mov byte [m], r8`   = [REX] 88 /r
+    /// - width 2: `mov word [m], r16`  = 66 [REX] 89 /r
+    /// - width 4: `mov dword [m], r32` = [REX] 89 /r
+    fn emit_narrow_store_mr(&mut self, base: Reg, src: Reg, width: u8) {
+        match width {
+            1 => self.emit_mov_mr8(base, 0, src),
+            2 | 4 => {
+                if width == 2 {
+                    // 16-bit operand-size override; must precede any REX prefix.
+                    self.code.push(0x66);
+                }
+                let rex = if src.needs_rex() { 0x04 } else { 0 }
+                    | if base.needs_rex() { 0x01 } else { 0 };
+                if rex != 0 {
+                    self.code.push(0x40 | rex);
+                }
+                self.code.push(0x89);
+                self.emit_modrm_memory(src.encoding(), base.encoding(), 0);
+            }
+            _ => unreachable!("narrow store width must be 1, 2, or 4: {width}"),
+        }
     }
 
     /// Emit `mov dst, [base + index*scale + disp]` - Load with SIB addressing.
@@ -3796,6 +3904,53 @@ mod tests {
         });
         // movzx rax, cx -> 48 0F B7 C1 (REX.W 0F B7 /r)
         assert_eq!(code, vec![0x48, 0x0F, 0xB7, 0xC1]);
+    }
+
+    /// RUE-989: the narrow physical load through a pointer encodes the correct
+    /// movzx/movsx/movsxd/`mov r32` per width and signedness, extending into the
+    /// 64-bit destination. Base Rbx (no REX), dst Rax; the address carries no
+    /// displacement (offset 0 -> mod=01 disp8=0, as in the byte forms).
+    #[test]
+    fn test_narrow_load_encoding() {
+        let load = |width, signed| {
+            emit_single(X86Inst::NarrowLoadRM {
+                dst: Operand::Physical(Reg::Rax),
+                base: Reg::Rbx,
+                width,
+                signed,
+            })
+        };
+        // movzx rax, byte [rbx] -> REX.W 0F B6
+        assert_eq!(load(1, false), vec![0x48, 0x0f, 0xb6, 0x43, 0x00]);
+        // movsx rax, byte [rbx] -> REX.W 0F BE
+        assert_eq!(load(1, true), vec![0x48, 0x0f, 0xbe, 0x43, 0x00]);
+        // movzx rax, word [rbx] -> REX.W 0F B7
+        assert_eq!(load(2, false), vec![0x48, 0x0f, 0xb7, 0x43, 0x00]);
+        // movsx rax, word [rbx] -> REX.W 0F BF
+        assert_eq!(load(2, true), vec![0x48, 0x0f, 0xbf, 0x43, 0x00]);
+        // mov eax, dword [rbx] -> 8B (no REX.W; zero-extends into rax)
+        assert_eq!(load(4, false), vec![0x8b, 0x43, 0x00]);
+        // movsxd rax, dword [rbx] -> REX.W 63
+        assert_eq!(load(4, true), vec![0x48, 0x63, 0x43, 0x00]);
+    }
+
+    /// RUE-989: the narrow physical store through a pointer truncates the source
+    /// to 1/2/4 bytes. Base Rbx (no REX), src Rcx.
+    #[test]
+    fn test_narrow_store_encoding() {
+        let store = |width| {
+            emit_single(X86Inst::NarrowStoreMR {
+                base: Reg::Rbx,
+                src: Operand::Physical(Reg::Rcx),
+                width,
+            })
+        };
+        // mov byte [rbx], cl -> [REX] 88
+        assert_eq!(store(1), vec![0x40, 0x88, 0x4b, 0x00]);
+        // mov word [rbx], cx -> 66 89 (operand-size prefix, no REX needed)
+        assert_eq!(store(2), vec![0x66, 0x89, 0x4b, 0x00]);
+        // mov dword [rbx], ecx -> 89 (no prefix, no REX needed)
+        assert_eq!(store(4), vec![0x89, 0x4b, 0x00]);
     }
 
     // --- Add with immediate ---

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -133,10 +133,12 @@ pub fn uses(inst: &X86Inst) -> Vec<VReg> {
         X86Inst::MovRR { src, .. } => {
             add_if_virtual(src, &mut result);
         }
-        X86Inst::MovRM { .. } | X86Inst::Movzx8RM { .. } => {
+        X86Inst::MovRM { .. } | X86Inst::Movzx8RM { .. } | X86Inst::NarrowLoadRM { .. } => {
             // Reads from memory (base is physical), defines dst
         }
-        X86Inst::MovMR { src, .. } | X86Inst::MovMR8 { src, .. } => {
+        X86Inst::MovMR { src, .. }
+        | X86Inst::MovMR8 { src, .. }
+        | X86Inst::NarrowStoreMR { src, .. } => {
             add_if_virtual(src, &mut result);
         }
         X86Inst::AddRR { dst, src }
@@ -248,11 +250,15 @@ pub fn uses(inst: &X86Inst) -> Vec<VReg> {
             add_if_virtual(dst, &mut result);
             add_if_virtual(count, &mut result);
         }
-        X86Inst::MovRMIndexed { base, .. } | X86Inst::Movzx8RMIndexed { base, .. } => {
+        X86Inst::MovRMIndexed { base, .. }
+        | X86Inst::Movzx8RMIndexed { base, .. }
+        | X86Inst::NarrowLoadIndexed { base, .. } => {
             // base is a VReg
             result.push(*base);
         }
-        X86Inst::MovMRIndexed { base, src, .. } | X86Inst::MovMR8Indexed { base, src, .. } => {
+        X86Inst::MovMRIndexed { base, src, .. }
+        | X86Inst::MovMR8Indexed { base, src, .. }
+        | X86Inst::NarrowStoreIndexed { base, src, .. } => {
             result.push(*base);
             add_if_virtual(src, &mut result);
         }
@@ -316,10 +322,12 @@ pub fn defs(inst: &X86Inst) -> Vec<VReg> {
         X86Inst::MovRR { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
-        X86Inst::MovRM { dst, .. } | X86Inst::Movzx8RM { dst, .. } => {
+        X86Inst::MovRM { dst, .. }
+        | X86Inst::Movzx8RM { dst, .. }
+        | X86Inst::NarrowLoadRM { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
-        X86Inst::MovMR { .. } | X86Inst::MovMR8 { .. } => {
+        X86Inst::MovMR { .. } | X86Inst::MovMR8 { .. } | X86Inst::NarrowStoreMR { .. } => {
             // Writes to memory, not to a register
         }
         X86Inst::AddRR { dst, .. }
@@ -405,10 +413,14 @@ pub fn defs(inst: &X86Inst) -> Vec<VReg> {
         X86Inst::Shl { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
-        X86Inst::MovRMIndexed { dst, .. } | X86Inst::Movzx8RMIndexed { dst, .. } => {
+        X86Inst::MovRMIndexed { dst, .. }
+        | X86Inst::Movzx8RMIndexed { dst, .. }
+        | X86Inst::NarrowLoadIndexed { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
-        X86Inst::MovMRIndexed { .. } | X86Inst::MovMR8Indexed { .. } => {
+        X86Inst::MovMRIndexed { .. }
+        | X86Inst::MovMR8Indexed { .. }
+        | X86Inst::NarrowStoreIndexed { .. } => {
             // Writes to memory
         }
         X86Inst::MovRMSib { dst, .. } => {

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -499,6 +499,38 @@ pub enum X86Inst {
         src: Operand,
     },
 
+    /// Pre-register-allocation narrow (1/2/4-byte) load of `[base]` extended
+    /// into the 64-bit `dst` (ADR-0052, RUE-989). `signed` selects `movsx`
+    /// (sign-extend) versus `movzx`/`mov r32` (zero-extend). The pointer address
+    /// is fully materialized in `base`, so no displacement is encoded. Register
+    /// allocation lowers this to [`X86Inst::NarrowLoadRM`].
+    NarrowLoadIndexed {
+        dst: Operand,
+        base: VReg,
+        width: u8,
+        signed: bool,
+    },
+
+    /// Pre-register-allocation narrow (1/2/4-byte) store of the low `width`
+    /// bytes of `src` to `[base]` (ADR-0052, RUE-989). Register allocation lowers
+    /// this to [`X86Inst::NarrowStoreMR`].
+    NarrowStoreIndexed { base: VReg, src: Operand, width: u8 },
+
+    /// Narrow (1/2/4-byte) load of `[base]` extended into the 64-bit `dst`
+    /// (`movzx`/`movsx`/`movsxd`/`mov r32`), the physical-base form of
+    /// [`X86Inst::NarrowLoadIndexed`].
+    NarrowLoadRM {
+        dst: Operand,
+        base: Reg,
+        width: u8,
+        signed: bool,
+    },
+
+    /// Narrow (1/2/4-byte) store of the low `width` bytes of `src` to `[base]`
+    /// (`mov byte/word/dword [m], r`), the physical-base form of
+    /// [`X86Inst::NarrowStoreIndexed`].
+    NarrowStoreMR { base: Reg, src: Operand, width: u8 },
+
     /// `mov dst, [base + index*scale + disp]` - Load from memory with SIB addressing.
     ///
     /// This instruction uses x86-64 SIB (Scale-Index-Base) addressing mode for
@@ -571,6 +603,17 @@ impl X86Inst {
             // All other instructions don't clobber additional registers
             _ => &[],
         }
+    }
+}
+
+/// The assembly operand-size keyword for a narrow memory access width, used in
+/// the textual MIR dump of the narrow load/store instructions.
+fn mem_width_keyword(width: u8) -> &'static str {
+    match width {
+        1 => "byte ",
+        2 => "word ",
+        4 => "dword ",
+        _ => "",
     }
 }
 
@@ -708,6 +751,44 @@ impl fmt::Display for X86Inst {
             }
             X86Inst::MovMR8Indexed { base, offset, src } => {
                 write!(f, "mov byte [{}+{}], {}", base, offset, src)
+            }
+            X86Inst::NarrowLoadIndexed {
+                dst,
+                base,
+                width,
+                signed,
+            } => {
+                let ext = if *signed { "movsx" } else { "movzx" };
+                write!(
+                    f,
+                    "{} {}, {}[{}]",
+                    ext,
+                    dst,
+                    mem_width_keyword(*width),
+                    base
+                )
+            }
+            X86Inst::NarrowStoreIndexed { base, src, width } => {
+                write!(f, "mov {}[{}], {}", mem_width_keyword(*width), base, src)
+            }
+            X86Inst::NarrowLoadRM {
+                dst,
+                base,
+                width,
+                signed,
+            } => {
+                let ext = if *signed { "movsx" } else { "movzx" };
+                write!(
+                    f,
+                    "{} {}, {}[{}]",
+                    ext,
+                    dst,
+                    mem_width_keyword(*width),
+                    base
+                )
+            }
+            X86Inst::NarrowStoreMR { base, src, width } => {
+                write!(f, "mov {}[{}], {}", mem_width_keyword(*width), base, src)
             }
             X86Inst::MovRMSib {
                 dst,

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -770,6 +770,56 @@ impl RegAlloc {
                 });
             }
 
+            X86Inst::NarrowLoadIndexed {
+                dst,
+                base,
+                width,
+                signed,
+            } => {
+                let base_reg = Self::load_operand(context, mir, Operand::Virtual(base), Reg::Rax)?;
+                let base_phys = base_reg.as_physical();
+                match Self::get_allocation(context, dst) {
+                    Some(Allocation::Register(reg)) => mir.push(X86Inst::NarrowLoadRM {
+                        dst: Operand::Physical(reg),
+                        base: base_phys,
+                        width,
+                        signed,
+                    }),
+                    Some(Allocation::Spill(spill_off)) => {
+                        mir.push(X86Inst::NarrowLoadRM {
+                            dst: Operand::Physical(Reg::Rdx),
+                            base: base_phys,
+                            width,
+                            signed,
+                        });
+                        mir.push_after(X86Inst::MovMR {
+                            base: Reg::Rbp,
+                            offset: spill_off,
+                            src: Operand::Physical(Reg::Rdx),
+                        });
+                    }
+                    Some(Allocation::Rematerialize(_)) => {
+                        unreachable!("destination cannot be rematerializable")
+                    }
+                    None => mir.push(X86Inst::NarrowLoadRM {
+                        dst,
+                        base: base_phys,
+                        width,
+                        signed,
+                    }),
+                }
+            }
+
+            X86Inst::NarrowStoreIndexed { base, src, width } => {
+                let src_op = Self::load_operand(context, mir, src, Reg::Rdx)?;
+                let base_reg = Self::load_operand(context, mir, Operand::Virtual(base), Reg::Rax)?;
+                mir.push(X86Inst::NarrowStoreMR {
+                    base: base_reg.as_physical(),
+                    src: src_op,
+                    width,
+                });
+            }
+
             X86Inst::MovRMSib {
                 dst,
                 base,
@@ -909,6 +959,23 @@ impl RegAlloc {
             X86Inst::Syscall => mir.push(X86Inst::Syscall),
             X86Inst::Ret => mir.push(X86Inst::Ret),
             X86Inst::Ud2 => mir.push(X86Inst::Ud2),
+            // The physical-base narrow forms are produced by this pass from the
+            // indexed pseudos above with already-allocated operands; they never
+            // appear in the pre-allocation input, so pass them through unchanged.
+            X86Inst::NarrowLoadRM {
+                dst,
+                base,
+                width,
+                signed,
+            } => mir.push(X86Inst::NarrowLoadRM {
+                dst,
+                base,
+                width,
+                signed,
+            }),
+            X86Inst::NarrowStoreMR { base, src, width } => {
+                mir.push(X86Inst::NarrowStoreMR { base, src, width })
+            }
         }
         Ok(())
     }

--- a/crates/rue-codegen/src/x86_64/schedule.rs
+++ b/crates/rue-codegen/src/x86_64/schedule.rs
@@ -85,14 +85,18 @@ fn get_latency(inst: &X86Inst) -> u32 {
         | X86Inst::MovRMIndexed { .. }
         | X86Inst::MovRMSib { .. }
         | X86Inst::Movzx8RM { .. }
-        | X86Inst::Movzx8RMIndexed { .. } => 4,
+        | X86Inst::Movzx8RMIndexed { .. }
+        | X86Inst::NarrowLoadRM { .. }
+        | X86Inst::NarrowLoadIndexed { .. } => 4,
 
         // Memory stores: 1 cycle to retire (store buffer)
         X86Inst::MovMR { .. }
         | X86Inst::MovMRIndexed { .. }
         | X86Inst::MovMRSib { .. }
         | X86Inst::MovMR8 { .. }
-        | X86Inst::MovMR8Indexed { .. } => 1,
+        | X86Inst::MovMR8Indexed { .. }
+        | X86Inst::NarrowStoreMR { .. }
+        | X86Inst::NarrowStoreIndexed { .. } => 1,
 
         // Simple arithmetic: 1 cycle
         X86Inst::AddRR { .. }
@@ -247,6 +251,10 @@ fn accesses_memory(inst: &X86Inst) -> bool {
             | X86Inst::MovMR8 { .. }
             | X86Inst::Movzx8RMIndexed { .. }
             | X86Inst::MovMR8Indexed { .. }
+            | X86Inst::NarrowLoadRM { .. }
+            | X86Inst::NarrowStoreMR { .. }
+            | X86Inst::NarrowLoadIndexed { .. }
+            | X86Inst::NarrowStoreIndexed { .. }
             | X86Inst::Push { .. }
             | X86Inst::Pop { .. }
     )
@@ -265,8 +273,12 @@ fn regs_read(inst: &X86Inst) -> Vec<Reg> {
     match inst {
         X86Inst::MovRI32 { .. } | X86Inst::MovRI64 { .. } => {}
         X86Inst::MovRR { src, .. } => add_if_phys(src, &mut result),
-        X86Inst::MovRM { base, .. } | X86Inst::Movzx8RM { base, .. } => result.push(*base),
-        X86Inst::MovMR { base, src, .. } | X86Inst::MovMR8 { base, src, .. } => {
+        X86Inst::MovRM { base, .. }
+        | X86Inst::Movzx8RM { base, .. }
+        | X86Inst::NarrowLoadRM { base, .. } => result.push(*base),
+        X86Inst::MovMR { base, src, .. }
+        | X86Inst::MovMR8 { base, src, .. }
+        | X86Inst::NarrowStoreMR { base, src, .. } => {
             result.push(*base);
             add_if_phys(src, &mut result);
         }
@@ -367,12 +379,16 @@ fn regs_read(inst: &X86Inst) -> Vec<Reg> {
             add_if_phys(dst, &mut result);
             add_if_phys(count, &mut result);
         }
-        X86Inst::MovRMIndexed { .. } | X86Inst::Movzx8RMIndexed { .. } => {
+        X86Inst::MovRMIndexed { .. }
+        | X86Inst::Movzx8RMIndexed { .. }
+        | X86Inst::NarrowLoadIndexed { .. } => {
             // Pre-regalloc indexed load. The scheduler runs after regalloc,
             // which rewrites this variant; the virtual base has no physical
             // register to record here.
         }
-        X86Inst::MovMRIndexed { src, .. } | X86Inst::MovMR8Indexed { src, .. } => {
+        X86Inst::MovMRIndexed { src, .. }
+        | X86Inst::MovMR8Indexed { src, .. }
+        | X86Inst::NarrowStoreIndexed { src, .. } => {
             // Pre-regalloc indexed store. The scheduler runs after regalloc,
             // which rewrites this variant; the virtual base has no physical
             // register to record here.
@@ -427,10 +443,11 @@ fn regs_written(inst: &X86Inst) -> Vec<Reg> {
         | X86Inst::MovRI64 { dst, .. }
         | X86Inst::MovRR { dst, .. }
         | X86Inst::MovRM { dst, .. }
-        | X86Inst::Movzx8RM { dst, .. } => {
+        | X86Inst::Movzx8RM { dst, .. }
+        | X86Inst::NarrowLoadRM { dst, .. } => {
             add_if_phys(dst, &mut result);
         }
-        X86Inst::MovMR { .. } | X86Inst::MovMR8 { .. } => {}
+        X86Inst::MovMR { .. } | X86Inst::MovMR8 { .. } | X86Inst::NarrowStoreMR { .. } => {}
         X86Inst::AddRR { dst, .. }
         | X86Inst::AddRR64 { dst, .. }
         | X86Inst::AddRI { dst, .. }
@@ -504,10 +521,12 @@ fn regs_written(inst: &X86Inst) -> Vec<Reg> {
         }
         X86Inst::Lea { dst, .. } => add_if_phys(dst, &mut result),
         X86Inst::Shl { dst, .. } => add_if_phys(dst, &mut result),
-        X86Inst::MovRMIndexed { dst, .. } | X86Inst::Movzx8RMIndexed { dst, .. } => {
-            add_if_phys(dst, &mut result)
-        }
-        X86Inst::MovMRIndexed { .. } | X86Inst::MovMR8Indexed { .. } => {}
+        X86Inst::MovRMIndexed { dst, .. }
+        | X86Inst::Movzx8RMIndexed { dst, .. }
+        | X86Inst::NarrowLoadIndexed { dst, .. } => add_if_phys(dst, &mut result),
+        X86Inst::MovMRIndexed { .. }
+        | X86Inst::MovMR8Indexed { .. }
+        | X86Inst::NarrowStoreIndexed { .. } => {}
         X86Inst::MovRMSib { dst, .. } => add_if_phys(dst, &mut result),
         X86Inst::MovMRSib { .. } => {} // Store doesn't write to register (only memory)
         X86Inst::CallRel { .. } | X86Inst::Syscall => {

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -547,6 +547,33 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::FieldPointer),
         &[],
     ),
+    // ADR-0052 phase 5.5 (RUE-989): the narrow-access execution cases reach
+    // memory through `@field_ptr` and `@alloc`, both outside the oracle model
+    // (same gaps as the entries above and the heap_intrinsics corpus).
+    Entry::new(
+        "cli.aggregate_layout",
+        "compact_struct_field_narrow_roundtrip",
+        intrinsic(UnsupportedIntrinsicKind::FieldPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_layout",
+        "mixed_struct_field_roundtrip",
+        intrinsic(UnsupportedIntrinsicKind::FieldPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_layout",
+        "narrow_heap_array_walk",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_layout",
+        "narrow_heap_roundtrip_scalars",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
     Entry::new(
         "cli.partial_move_depth",
         "disjoint_sibling_after_subfield_move_ok",


### PR DESCRIPTION
## Summary

Tier 1 of the narrow-memory work RUE-974 staged behind its loud refusal: **1/2/4-byte loads and stores on both backends**, lifting the `aggregate_layout` refusal for narrow scalars through typed pointers, compact struct fields, and narrow array walks. Gate off, code generation is byte-identical (every narrow decision is `None` without the preview).

- Loads extend into the slot-shaped vreg (zero-extend unsigned/bool, sign-extend signed); stores truncate — the explicit pack/unpack at ADR-0052's slot-value ↔ physical-memory boundary. Width/signedness decided once in `value_plan::narrow_scalar_access` from the layout authority.
- Both backends in lockstep across the full checklist (MIR variants, display, liveness, regalloc rewrite, scheduling, encoding, CFG lowering, tests): `movzx`/`movsx`/`movsxd` + 8/16/32-bit stores on x86-64; `ldrb`/`ldrsb`/`ldrh`/`ldrsh`/`ldr`-w/`ldrsw` + `strb`/`strh`/`str`-w on AArch64.
- The refusal scan — still consulting `is_slot_identical_layout`, never a parallel judgment — now covers exactly what remains: non-slot-identical array/enum values, pointers to non-slot-identical aggregates, by-ref aggregate params, aggregates crossing calls (RUE-976's transitional indirect rule), and aggregate pointees of typed pointer ops. Compact enum memory and std-under-gate stay staged (RUE-987 prerequisites).

## Verification

Verified by execution at integration: the RUE-974 seam program (`@alloc` i32 / `@ptr_write` / `@ptr_read`) prints 10 under the gate; i16 sign-extension (−1) and u16 zero-extension (65535) round-trips; mixed `{u8,i32,u8}` struct field round-trips via `@field_ptr`; narrow heap array walks at compact stride; same programs unchanged ungated. Ten new codegen unit tests (allow + still-refuse, both backends); five new gated CLI execution cases (`aggregate_layout` 12); `abi` 59, `aggregate_abi_matrix` 37, `heap_intrinsics` 8; oracle quick 0 disagreements; full `test.sh` green except the four known uid-0 environmental failures.

Fixes RUE-989

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_