### PR TITLE
RUE-866: Internalize compiler query records

### DIFF
--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -5,14 +5,14 @@
 use std::{collections::HashMap, env, process, sync::Arc, time::Instant};
 
 use rue_air::{FrozenTypeInternPool, TypeKind};
+use rue_compiler::unstable::{
+    DependencyBaseline, DependencyIncompleteReason, DependencySurface, FullInvalidationReason,
+    InvalidationMetrics, InvalidationScope, MetricsSnapshot, ParseMetrics,
+};
 use rue_compiler::{
     AcceptedReadManifestEntry, CanonicalSemanticOutput, CompileOptions, CompilerSession,
-    CompilerSessionWork, DiscoverySourceAssembler, DurableBodyWork,
-    FRONTEND_DIAGNOSTIC_RETENTION_LIMIT, FRONTEND_INVALIDATION_PLAN_RETENTION_LIMIT,
-    FileMetadataFingerprint, FrontendDiagnosticSnapshot, ImportDiscoveryContext,
-    ImportObservationLedger, OptLevel, ParsedModulesWork, PhysicalFileIdentity,
-    SemanticDependencyIncompleteReason, SemanticDependencyInputManifest, SemanticDependencySurface,
-    SemanticFullInvalidationReason, SemanticInvalidationPlan, SemanticInvalidationScope,
+    DiscoverySourceAssembler, FileMetadataFingerprint, FrontendDiagnosticSnapshot,
+    ImportDiscoveryContext, ImportObservationLedger, OptLevel, PhysicalFileIdentity,
     SourceMetadata, SourceSnapshot,
 };
 use rue_span::FileId;
@@ -59,29 +59,30 @@ struct QueryCounts {
 }
 
 impl QueryCounts {
-    fn from(work: &CompilerSessionWork) -> Self {
+    fn from(work: &MetricsSnapshot) -> Self {
         Self {
-            merge_executions: work.merge.executions,
-            merge_reuses: work.merge.reuses,
-            rir_executions: work.rir.executions,
-            rir_reuses: work.rir.reuses,
-            semantic_executions: work.semantic.executions,
-            semantic_reuses: work.semantic.reuses,
-            definition_executions: work.definitions.executions,
-            definition_reuses: work.definitions.reuses,
-            downstream_invalidations: work.downstream_invalidations,
-            semantic_entries_invalidated: work.semantic_entries_invalidated,
-            definition_entries_invalidated: work.definition_entries_invalidated,
-            dependency_manifest_executions: work.dependency_manifests.executions,
-            dependency_manifest_reuses: work.dependency_manifests.reuses,
-            invalidation_plan_executions: work.invalidation_plans.executions,
-            invalidation_plan_reuses: work.invalidation_plans.reuses,
-            declaration_reuse_plans: work.declaration_reuse_plans,
-            durable_records_compared: work.durable_records_compared,
-            durable_records_reused: work.durable_records_reused,
-            ordinary_declaration_resolutions_skipped: work.ordinary_declaration_resolutions_skipped,
-            durable_installs: work.durable_installs,
-            declaration_reuse_fallbacks: work.declaration_reuse_fallbacks,
+            merge_executions: work.merge().executions,
+            merge_reuses: work.merge().reuses,
+            rir_executions: work.rir().executions,
+            rir_reuses: work.rir().reuses,
+            semantic_executions: work.semantic().executions,
+            semantic_reuses: work.semantic().reuses,
+            definition_executions: work.definitions().executions,
+            definition_reuses: work.definitions().reuses,
+            downstream_invalidations: work.downstream_invalidations(),
+            semantic_entries_invalidated: work.semantic_entries_invalidated(),
+            definition_entries_invalidated: work.definition_entries_invalidated(),
+            dependency_manifest_executions: work.dependency_manifests().executions,
+            dependency_manifest_reuses: work.dependency_manifests().reuses,
+            invalidation_plan_executions: work.invalidation_plans().executions,
+            invalidation_plan_reuses: work.invalidation_plans().reuses,
+            declaration_reuse_plans: work.declaration_reuse_plans(),
+            durable_records_compared: work.durable_records_compared(),
+            durable_records_reused: work.durable_records_reused(),
+            ordinary_declaration_resolutions_skipped: work
+                .ordinary_declaration_resolutions_skipped(),
+            durable_installs: work.durable_installs(),
+            declaration_reuse_fallbacks: work.declaration_reuse_fallbacks(),
         }
     }
 
@@ -386,12 +387,12 @@ fn snapshot(modules: usize, variant: Variant) -> SourceSnapshot {
     SourceSnapshot::new(metadata, sources).unwrap()
 }
 
-fn parse_json(work: ParsedModulesWork) -> Value {
+fn parse_json(work: ParseMetrics) -> Value {
     json!({
-        "lexer_invocations": work.syntax.lexer_invocations,
-        "parser_invocations": work.syntax.parser_invocations,
-        "lexed_bytes": work.syntax.lexed_bytes,
-        "tokens": work.syntax.tokens,
+        "lexer_invocations": work.lexer_invocations,
+        "parser_invocations": work.parser_invocations,
+        "lexed_bytes": work.lexed_bytes,
+        "tokens": work.tokens,
         "modules_considered": work.modules_considered,
         "modules_reused": work.modules_reused,
         "modules_rebound": work.modules_rebound,
@@ -401,216 +402,49 @@ fn parse_json(work: ParsedModulesWork) -> Value {
     })
 }
 
-fn durable_body_work_json(work: DurableBodyWork) -> Value {
-    json!({
-        "candidate_comparisons": work.candidate_comparisons,
-        "candidate_fallbacks": work.candidate_fallbacks,
-        "specialized_mapping_attempts": work.specialized_mapping_attempts,
-        "specialized_mapping_successes": work.specialized_mapping_successes,
-        "specialized_mapping_failures": work.specialized_mapping_failures,
-        "export_attempts": work.export_attempts,
-        "export_successes": work.export_successes,
-        "export_rejections": work.export_rejections,
-        "instructions_exported": work.instructions_exported,
-        "places_exported": work.places_exported,
-        "strings_exported": work.strings_exported,
-        "conversion_attempts": work.conversion_attempts,
-        "conversion_completions": work.conversion_completions,
-        "conversion_failures": work.conversion_failures,
-        "stable_key_joins": work.stable_key_joins,
-        "finalization_attempts": work.finalization_attempts,
-        "finalization_completions": work.finalization_completions,
-        "finalization_failures": work.finalization_failures,
-        "projection_attempts": work.projection_attempts,
-        "projection_completions": work.projection_completions,
-        "projection_failures": work.projection_failures,
-        "instructions_projected": work.instructions_projected,
-        "places_projected": work.places_projected,
-        "strings_projected": work.strings_projected,
-        "import_attempts": work.import_attempts,
-        "import_successes": work.import_successes,
-        "import_failures": work.import_failures,
-        "installed_instructions": work.installed_instructions,
-        "installed_places": work.installed_places,
-        "installed_strings": work.installed_strings,
-        "atomic_discards": work.atomic_discards,
-        "reused_bodies": work.reused_bodies,
-        "skipped_body_analyses": work.skipped_body_analyses,
-    })
+fn semantic_work_json(work: &MetricsSnapshot, from: usize) -> Value {
+    work.semantic_work_json(from)
 }
 
-fn semantic_work_json(work: &CompilerSessionWork, from: usize) -> Value {
-    let records = &work.semantic_records[from..];
-    json!({
-        "failed_requests": records.iter().filter(|record| record.failure.is_some()).count(),
-        "failure_phases": {
-            "declaration": records.iter().filter(|record| matches!(record.failure.map(|failure| failure.phase), Some(rue_compiler::CanonicalSemanticFailurePhase::Declaration))).count(),
-            "body_analysis": records.iter().filter(|record| matches!(record.failure.map(|failure| failure.phase), Some(rue_compiler::CanonicalSemanticFailurePhase::BodyAnalysis))).count(),
-            "cfg_construction": records.iter().filter(|record| matches!(record.failure.map(|failure| failure.phase), Some(rue_compiler::CanonicalSemanticFailurePhase::CfgConstruction))).count(),
-        },
-        "bind_invocations": records.iter().map(|record| record.work.binding.bind_invocations).sum::<usize>(),
-        "declaration_resolution_invocations": records.iter().map(|record| record.work.binding.declaration_resolution_invocations).sum::<usize>(),
-        "declaration_resolution_failures": records.iter().map(|record| record.work.binding.declaration_resolution_failures).sum::<usize>(),
-        "body_readiness_finalization_invocations": records.iter().map(|record| record.work.binding.body_readiness_finalization_invocations).sum::<usize>(),
-        "body_free_function_lookups": records.iter().map(|record| record.work.body_analysis.free_function_record_lookups).sum::<usize>(),
-        "bodies_attempted": records.iter().map(|record| record.work.body_analysis.bodies_attempted).sum::<usize>(),
-        "bodies_succeeded": records.iter().map(|record| record.work.body_analysis.bodies_succeeded).sum::<usize>(),
-        "bodies_failed": records.iter().map(|record| record.work.body_analysis.bodies_failed).sum::<usize>(),
-        "air_instructions_produced": records.iter().map(|record| record.work.body_analysis.air_instructions_produced).sum::<usize>(),
-        "body_dependency_air_instructions_observed": records.iter().map(|record| record.work.body_analysis.body_dependency_air_instructions_observed).sum::<usize>(),
-        "local_strings_produced": records.iter().map(|record| record.work.body_analysis.local_strings_produced).sum::<usize>(),
-        "string_ids_remapped": records.iter().map(|record| record.work.body_analysis.string_ids_remapped).sum::<usize>(),
-        "specialization_air_instructions_scanned": records.iter().map(|record| record.work.body_analysis.specialization_air_instructions_scanned).sum::<usize>(),
-        "generic_calls_observed": records.iter().map(|record| record.work.body_analysis.generic_calls_observed).sum::<usize>(),
-        "specialization_requests_unique": records.iter().map(|record| record.work.body_analysis.specialization_requests_unique).sum::<usize>(),
-        "specialization_requests_duplicate": records.iter().map(|record| record.work.body_analysis.specialization_requests_duplicate).sum::<usize>(),
-        "specialization_rewrites": records.iter().map(|record| record.work.body_analysis.specialization_rewrites).sum::<usize>(),
-        "specialization_rounds": records.iter().map(|record| record.work.body_analysis.specialization_rounds).sum::<usize>(),
-        "specialization_driver_failures": records.iter().map(|record| record.work.body_analysis.specialization_driver_failures).sum::<usize>(),
-        "specialized_bodies_attempted": records.iter().map(|record| record.work.body_analysis.specialized_bodies_attempted).sum::<usize>(),
-        "specialized_bodies_succeeded": records.iter().map(|record| record.work.body_analysis.specialized_bodies_succeeded).sum::<usize>(),
-        "specialized_bodies_failed": records.iter().map(|record| record.work.body_analysis.specialized_bodies_failed).sum::<usize>(),
-        "durable_bodies": {
-            "candidate_comparisons": records.iter().map(|record| record.work.durable_bodies.candidate_comparisons).sum::<usize>(),
-            "candidate_fallbacks": records.iter().map(|record| record.work.durable_bodies.candidate_fallbacks).sum::<usize>(),
-            "specialized_mapping_attempts": records.iter().map(|record| record.work.durable_bodies.specialized_mapping_attempts).sum::<usize>(),
-            "specialized_mapping_successes": records.iter().map(|record| record.work.durable_bodies.specialized_mapping_successes).sum::<usize>(),
-            "specialized_mapping_failures": records.iter().map(|record| record.work.durable_bodies.specialized_mapping_failures).sum::<usize>(),
-            "export_attempts": records.iter().map(|record| record.work.durable_bodies.export_attempts).sum::<usize>(),
-            "export_successes": records.iter().map(|record| record.work.durable_bodies.export_successes).sum::<usize>(),
-            "export_rejections": records.iter().map(|record| record.work.durable_bodies.export_rejections).sum::<usize>(),
-            "instructions_exported": records.iter().map(|record| record.work.durable_bodies.instructions_exported).sum::<usize>(),
-            "places_exported": records.iter().map(|record| record.work.durable_bodies.places_exported).sum::<usize>(),
-            "strings_exported": records.iter().map(|record| record.work.durable_bodies.strings_exported).sum::<usize>(),
-            "conversion_attempts": records.iter().map(|record| record.work.durable_bodies.conversion_attempts).sum::<usize>(),
-            "conversion_completions": records.iter().map(|record| record.work.durable_bodies.conversion_completions).sum::<usize>(),
-            "conversion_failures": records.iter().map(|record| record.work.durable_bodies.conversion_failures).sum::<usize>(),
-            "finalization_attempts": records.iter().map(|record| record.work.durable_bodies.finalization_attempts).sum::<usize>(),
-            "finalization_completions": records.iter().map(|record| record.work.durable_bodies.finalization_completions).sum::<usize>(),
-            "finalization_failures": records.iter().map(|record| record.work.durable_bodies.finalization_failures).sum::<usize>(),
-            "stable_key_joins": records.iter().map(|record| record.work.durable_bodies.stable_key_joins).sum::<usize>(),
-            "projection_attempts": records.iter().map(|record| record.work.durable_bodies.projection_attempts).sum::<usize>(),
-            "projection_completions": records.iter().map(|record| record.work.durable_bodies.projection_completions).sum::<usize>(),
-            "projection_failures": records.iter().map(|record| record.work.durable_bodies.projection_failures).sum::<usize>(),
-            "instructions_projected": records.iter().map(|record| record.work.durable_bodies.instructions_projected).sum::<usize>(),
-            "places_projected": records.iter().map(|record| record.work.durable_bodies.places_projected).sum::<usize>(),
-            "strings_projected": records.iter().map(|record| record.work.durable_bodies.strings_projected).sum::<usize>(),
-            "import_attempts": records.iter().map(|record| record.work.durable_bodies.import_attempts).sum::<usize>(),
-            "import_successes": records.iter().map(|record| record.work.durable_bodies.import_successes).sum::<usize>(),
-            "import_failures": records.iter().map(|record| record.work.durable_bodies.import_failures).sum::<usize>(),
-            "installed_instructions": records.iter().map(|record| record.work.durable_bodies.installed_instructions).sum::<usize>(),
-            "installed_places": records.iter().map(|record| record.work.durable_bodies.installed_places).sum::<usize>(),
-            "installed_strings": records.iter().map(|record| record.work.durable_bodies.installed_strings).sum::<usize>(),
-            "atomic_discards": records.iter().map(|record| record.work.durable_bodies.atomic_discards).sum::<usize>(),
-            "reused_bodies": records.iter().map(|record| record.work.durable_bodies.reused_bodies).sum::<usize>(),
-            "skipped_body_analyses": records.iter().map(|record| record.work.durable_bodies.skipped_body_analyses).sum::<usize>(),
-        },
-        "cfg": {
-            "drop_glue_functions_synthesized": records.iter().map(|record| record.work.cfg.drop_glue_functions_synthesized).sum::<usize>(),
-            "functions_considered": records.iter().map(|record| record.work.cfg.functions_considered).sum::<usize>(),
-            "comptime_functions_filtered": records.iter().map(|record| record.work.cfg.comptime_functions_filtered).sum::<usize>(),
-            "builds_attempted": records.iter().map(|record| record.work.cfg.cfg_builds_attempted).sum::<usize>(),
-            "builds_succeeded": records.iter().map(|record| record.work.cfg.cfg_builds_succeeded).sum::<usize>(),
-            "builds_failed": records.iter().map(|record| record.work.cfg.cfg_builds_failed).sum::<usize>(),
-            "air_instructions_consumed": records.iter().map(|record| record.work.cfg.air_instructions_consumed).sum::<usize>(),
-            "optimization_attempts": records.iter().map(|record| record.work.cfg.optimization_attempts).sum::<usize>(),
-            "optimization_completions": records.iter().map(|record| record.work.cfg.optimization_completions).sum::<usize>(),
-            "optimized_level_attempts": records.iter().map(|record| record.work.cfg.optimized_level_attempts).sum::<usize>(),
-            "warnings_emitted": records.iter().map(|record| record.work.cfg.cfg_warnings_emitted).sum::<usize>(),
-            "implicit_destructor_targets_emitted": records.iter().map(|record| record.work.cfg.implicit_destructor_targets_emitted).sum::<usize>(),
-            "reuse_candidates": records.iter().map(|record| record.work.cfg.cfg_reuse_candidates).sum::<usize>(),
-            "import_attempts": records.iter().map(|record| record.work.cfg.cfg_import_attempts).sum::<usize>(),
-            "import_successes": records.iter().map(|record| record.work.cfg.cfg_import_successes).sum::<usize>(),
-            "import_failures": records.iter().map(|record| record.work.cfg.cfg_import_failures).sum::<usize>(),
-            "reuses": records.iter().map(|record| record.work.cfg.cfg_reuses).sum::<usize>(),
-            "fallbacks": records.iter().map(|record| record.work.cfg.cfg_fallbacks).sum::<usize>(),
-            "warnings_reused": records.iter().map(|record| record.work.cfg.cfg_warnings_reused).sum::<usize>(),
-            "implicit_destructor_targets_reused": records.iter().map(|record| record.work.cfg.implicit_destructor_targets_reused).sum::<usize>(),
-            "export_attempts": records.iter().map(|record| record.work.cfg.cfg_export_attempts).sum::<usize>(),
-            "export_successes": records.iter().map(|record| record.work.cfg.cfg_export_successes).sum::<usize>(),
-            "export_rejections": records.iter().map(|record| record.work.cfg.cfg_export_rejections).sum::<usize>(),
-        },
-        "ordinary_free_function_dependency_events": records.iter().map(|record| record.work.body_analysis.ordinary_free_function_dependency_events).sum::<usize>(),
-        "specialized_origin_records": records.iter().map(|record| record.work.body_analysis.specialized_origin_records).sum::<usize>(),
-        "specialized_free_function_dependency_events": records.iter().map(|record| record.work.body_analysis.specialized_free_function_dependency_events).sum::<usize>(),
-        "named_method_dependency_events": records.iter().map(|record| record.work.body_analysis.named_method_dependency_events).sum::<usize>(),
-        "named_destructor_dependency_events": records.iter().map(|record| record.work.body_analysis.named_destructor_dependency_events).sum::<usize>(),
-        "declaration_type_dependency_events": records.iter().map(|record| record.work.body_analysis.declaration_type_dependency_events).sum::<usize>(),
-        "declaration_type_call_head_dependency_events": records.iter().map(|record| record.work.body_analysis.declaration_type_call_head_dependency_events).sum::<usize>(),
-        "named_const_dependency_events": records.iter().map(|record| record.work.body_analysis.named_const_dependency_events).sum::<usize>(),
-        "manifest_build_invocations": records.iter().map(|record| record.work.manifest.build_invocations).sum::<usize>(),
-        "body_owner_tokens": {
-            "provisional_slots": records.iter().map(|record| record.work.body_owner_tokens.provisional_slots).sum::<usize>(),
-            "authoritative_slots": records.iter().map(|record| record.work.body_owner_tokens.authoritative_slots).sum::<usize>(),
-            "slots_validated": records.iter().map(|record| record.work.body_owner_tokens.slots_validated).sum::<usize>(),
-            "tokens_installed": records.iter().map(|record| record.work.body_owner_tokens.tokens_installed).sum::<usize>(),
-            "validation_failures": records.iter().map(|record| record.work.body_owner_tokens.validation_failures).sum::<usize>(),
-        },
-        "declaration_reuse": {
-            "plan_executions": records.iter().map(|record| record.work.declaration_reuse.plan_executions).sum::<usize>(),
-            "durable_records_compared": records.iter().map(|record| record.work.declaration_reuse.durable_records_compared).sum::<usize>(),
-            "durable_records_reused": records.iter().map(|record| record.work.declaration_reuse.durable_records_reused).sum::<usize>(),
-            "ordinary_declaration_resolutions_skipped": records.iter().map(|record| record.work.declaration_reuse.ordinary_declaration_resolutions_skipped).sum::<usize>(),
-            "install_invocations": records.iter().map(|record| record.work.declaration_reuse.install_invocations).sum::<usize>(),
-            "fallbacks": records.iter().map(|record| record.work.declaration_reuse.fallbacks).sum::<usize>(),
-            "semantic_epochs_started": records.iter().map(|record| record.work.declaration_reuse.semantic_epochs_started).sum::<usize>(),
-            "declaration_indexes_built": records.iter().map(|record| record.work.declaration_reuse.declaration_indexes_built).sum::<usize>(),
-            "shell_predeclaration_epochs": records.iter().map(|record| record.work.declaration_reuse.shell_predeclaration_epochs).sum::<usize>(),
-            "durable_cache_population_exports": records.iter().map(|record| record.work.declaration_reuse.durable_cache_population_exports).sum::<usize>(),
-            "fallback_epochs_started": records.iter().map(|record| record.work.declaration_reuse.fallback_epochs_started).sum::<usize>(),
-        },
-        "semantic_epochs_started": records.iter().map(|record| record.work.declaration_reuse.semantic_epochs_started).sum::<usize>(),
-        "declaration_indexes_built": records.iter().map(|record| record.work.declaration_reuse.declaration_indexes_built).sum::<usize>(),
-        "shell_predeclaration_epochs": records.iter().map(|record| record.work.declaration_reuse.shell_predeclaration_epochs).sum::<usize>(),
-        "durable_cache_population_exports": records.iter().map(|record| record.work.declaration_reuse.durable_cache_population_exports).sum::<usize>(),
-        "fallback_epochs_started": records.iter().map(|record| record.work.declaration_reuse.fallback_epochs_started).sum::<usize>(),
-    })
+fn definition_work_json(work: &MetricsSnapshot, from: usize) -> Value {
+    work.definition_work_json(from)
 }
 
-fn definition_work_json(work: &CompilerSessionWork, from: usize) -> Value {
-    let records = &work.definition_records[from..];
+fn retention_json(work: &MetricsSnapshot) -> Value {
     json!({
-        "bind_invocations": records.iter().map(|record| record.binding.bind_invocations).sum::<usize>(),
-        "manifest_build_invocations": records.iter().map(|record| record.manifest.build_invocations).sum::<usize>(),
-        "manifest_bindings_visited": records.iter().map(|record| record.issuance.manifest_bindings_visited).sum::<usize>(),
-        "ids_issued": records.iter().map(|record| record.issuance.ids_issued).sum::<usize>(),
-    })
-}
-
-fn retention_json(work: &CompilerSessionWork) -> Value {
-    json!({
-        "diagnostic_entries": work.retention.diagnostic_entries,
-        "diagnostic_source_attempts": work.retention.diagnostic_source_attempts,
-        "diagnostic_source_bytes": work.retention.diagnostic_source_bytes,
-        "dependency_manifests": work.retention.dependency_manifests,
-        "invalidation_plans": work.retention.invalidation_plans,
+        "diagnostic_entries": work.retention().diagnostic_entries,
+        "diagnostic_source_attempts": work.retention().diagnostic_source_attempts,
+        "diagnostic_source_bytes": work.retention().diagnostic_source_bytes,
+        "dependency_manifests": work.retention().dependency_manifests,
+        "invalidation_plans": work.retention().invalidation_plans,
     })
 }
 
 fn measure<F>(session: &mut CompilerSession, operation: F) -> Value
 where
-    F: FnOnce(&mut CompilerSession) -> ParsedModulesWork,
+    F: FnOnce(&mut CompilerSession) -> ParseMetrics,
 {
-    let before = QueryCounts::from(session.work());
-    let semantic_records = session.work().semantic_records.len();
-    let definition_records = session.work().definition_records.len();
+    let before_metrics = session.unstable_metrics();
+    let before = QueryCounts::from(&before_metrics);
+    let semantic_records = before_metrics.semantic_record_count();
+    let definition_records = before_metrics.definition_record_count();
     let started = Instant::now();
     let parse = operation(session);
     let elapsed = started.elapsed();
-    let work = session.work();
-    let query_delta = QueryCounts::from(work).delta(before);
+    let work = session.unstable_metrics();
+    let query_delta = QueryCounts::from(&work).delta(before);
     // Successful updates replace the current-revision record vectors. Treat
     // that reset as a new zero-based measurement window.
-    let semantic_records = if work.semantic_records.len() < semantic_records
-        || (query_delta.semantic_executions > 0 && work.semantic_records.len() <= semantic_records)
+    let semantic_records = if work.semantic_record_count() < semantic_records
+        || (query_delta.semantic_executions > 0 && work.semantic_record_count() <= semantic_records)
     {
         0
     } else {
         semantic_records
     };
-    let definition_records = if work.definition_records.len() < definition_records
+    let definition_records = if work.definition_record_count() < definition_records
         || (query_delta.definition_executions > 0
-            && work.definition_records.len() <= definition_records)
+            && work.definition_record_count() <= definition_records)
     {
         0
     } else {
@@ -621,39 +455,35 @@ where
         "parse": parse_json(parse),
         "queries": query_delta.json(),
         "merge_work": {
-            "definition_shards_indexed": work.last_merge.definition_shards_indexed,
-            "definition_shards_reused": work.last_merge.definition_shards_reused,
-            "definition_shards_rebuilt": work.last_merge.definition_shards_rebuilt,
+            "definition_shards_indexed": work.merge_metrics().definition_shards_indexed,
+            "definition_shards_reused": work.merge_metrics().definition_shards_reused,
+            "definition_shards_rebuilt": work.merge_metrics().definition_shards_rebuilt,
         },
-        "semantic_work": semantic_work_json(work, semantic_records),
-        "definition_work": definition_work_json(work, definition_records),
-        "retention": retention_json(work),
+        "semantic_work": semantic_work_json(&work, semantic_records),
+        "definition_work": definition_work_json(&work, definition_records),
+        "retention": retention_json(&work),
     })
 }
 
-fn invalidation_plan_json(plan: &SemanticInvalidationPlan) -> Value {
+fn invalidation_plan_json(plan: &InvalidationMetrics) -> Value {
     let mut dependency_blockers = Vec::new();
     let (scope, reasons) = match plan.scope() {
-        SemanticInvalidationScope::Full { reasons } => (
+        InvalidationScope::Full { reasons } => (
             "full",
             reasons
                 .iter()
                 .map(|reason| match reason {
-                    SemanticFullInvalidationReason::RootChanged => "root_changed",
-                    SemanticFullInvalidationReason::ModuleImportsChanged => {
-                        "module_imports_changed"
-                    }
-                    SemanticFullInvalidationReason::TargetChanged => "target_changed",
-                    SemanticFullInvalidationReason::PreviewFeaturesChanged => {
-                        "preview_features_changed"
-                    }
-                    SemanticFullInvalidationReason::IncompleteDefinitionUniverse => {
+                    FullInvalidationReason::RootChanged => "root_changed",
+                    FullInvalidationReason::ModuleImportsChanged => "module_imports_changed",
+                    FullInvalidationReason::TargetChanged => "target_changed",
+                    FullInvalidationReason::PreviewFeaturesChanged => "preview_features_changed",
+                    FullInvalidationReason::IncompleteDefinitionUniverse => {
                         "incomplete_definition_universe"
                     }
-                    SemanticFullInvalidationReason::IncompleteDependencyGraph(blockers) => {
+                    FullInvalidationReason::IncompleteDependencyGraph(blockers) => {
                         dependency_blockers.extend(blockers.iter().map(|blocker| {
                             json!({
-                                "owner": blocker.owner().map(|owner| owner.name()),
+                                "owner": blocker.owner(),
                                 "surface": dependency_surface_name(blocker.surface()),
                                 "reason": dependency_reason_name(blocker.reason()),
                             })
@@ -663,7 +493,7 @@ fn invalidation_plan_json(plan: &SemanticInvalidationPlan) -> Value {
                 })
                 .collect::<Vec<_>>(),
         ),
-        SemanticInvalidationScope::Incremental => ("incremental", Vec::new()),
+        InvalidationScope::Incremental => ("incremental", Vec::new()),
     };
     let work = plan.work();
     json!({
@@ -684,73 +514,70 @@ fn invalidation_plan_json(plan: &SemanticInvalidationPlan) -> Value {
     })
 }
 
-fn dependency_surface_name(surface: SemanticDependencySurface) -> &'static str {
+fn dependency_surface_name(surface: DependencySurface) -> &'static str {
     match surface {
-        SemanticDependencySurface::BodyOwner => "body_owner",
-        SemanticDependencySurface::FreeFunctionCall => "free_function_call",
-        SemanticDependencySurface::NonGenericNamedMethodCall => "non_generic_named_method_call",
-        SemanticDependencySurface::GenericNamedMethodCall => "generic_named_method_call",
-        SemanticDependencySurface::NamedDestructorCall => "named_destructor_call",
-        SemanticDependencySurface::ImplicitNamedDestructor => "implicit_named_destructor",
-        SemanticDependencySurface::DeclarationType => "declaration_type",
-        SemanticDependencySurface::DeclarationTypeCallHead => "declaration_type_call_head",
-        SemanticDependencySurface::SupportedTypeCallHead => "supported_type_call_head",
-        SemanticDependencySurface::NamedValueConst => "named_value_const",
+        DependencySurface::BodyOwner => "body_owner",
+        DependencySurface::FreeFunctionCall => "free_function_call",
+        DependencySurface::NonGenericNamedMethodCall => "non_generic_named_method_call",
+        DependencySurface::GenericNamedMethodCall => "generic_named_method_call",
+        DependencySurface::NamedDestructorCall => "named_destructor_call",
+        DependencySurface::ImplicitNamedDestructor => "implicit_named_destructor",
+        DependencySurface::DeclarationType => "declaration_type",
+        DependencySurface::DeclarationTypeCallHead => "declaration_type_call_head",
+        DependencySurface::SupportedTypeCallHead => "supported_type_call_head",
+        DependencySurface::NamedValueConst => "named_value_const",
     }
 }
 
-fn dependency_reason_name(reason: SemanticDependencyIncompleteReason) -> &'static str {
+fn dependency_reason_name(reason: DependencyIncompleteReason) -> &'static str {
     match reason {
-        SemanticDependencyIncompleteReason::AnonymousBodyOwnerUnavailable => {
+        DependencyIncompleteReason::AnonymousBodyOwnerUnavailable => {
             "anonymous_body_owner_unavailable"
         }
-        SemanticDependencyIncompleteReason::CallerEndpointUnavailable => {
-            "caller_endpoint_unavailable"
-        }
-        SemanticDependencyIncompleteReason::GenericSubstitutionIdentityUnavailable => {
+        DependencyIncompleteReason::CallerEndpointUnavailable => "caller_endpoint_unavailable",
+        DependencyIncompleteReason::GenericSubstitutionIdentityUnavailable => {
             "generic_substitution_identity_unavailable"
         }
-        SemanticDependencyIncompleteReason::DestructorEndpointUnavailable => {
+        DependencyIncompleteReason::DestructorEndpointUnavailable => {
             "destructor_endpoint_unavailable"
         }
-        SemanticDependencyIncompleteReason::AnonymousDropOwnerUnavailable => {
+        DependencyIncompleteReason::AnonymousDropOwnerUnavailable => {
             "anonymous_drop_owner_unavailable"
         }
-        SemanticDependencyIncompleteReason::ResolvedTypeIdentityUnavailable => {
+        DependencyIncompleteReason::ResolvedTypeIdentityUnavailable => {
             "resolved_type_identity_unavailable"
         }
-        SemanticDependencyIncompleteReason::TypeCallHeadIdentityUnavailable => {
+        DependencyIncompleteReason::TypeCallHeadIdentityUnavailable => {
             "type_call_head_identity_unavailable"
         }
-        SemanticDependencyIncompleteReason::UnsupportedDynamicTypeCallHead => {
+        DependencyIncompleteReason::UnsupportedDynamicTypeCallHead => {
             "unsupported_dynamic_type_call_head"
         }
-        SemanticDependencyIncompleteReason::ConstEndpointUnavailable => {
-            "const_endpoint_unavailable"
-        }
+        DependencyIncompleteReason::ConstEndpointUnavailable => "const_endpoint_unavailable",
     }
 }
 
 fn measure_manifest_plan(
     session: &mut CompilerSession,
     source: &SourceSnapshot,
-    previous: Option<&Arc<SemanticDependencyInputManifest>>,
+    previous: Option<&Arc<DependencyBaseline>>,
     options: &CompileOptions,
-) -> (Value, Arc<SemanticDependencyInputManifest>) {
-    let before = QueryCounts::from(session.work());
+) -> (Value, Arc<DependencyBaseline>) {
+    let before = QueryCounts::from(&session.unstable_metrics());
     let update = session.update(source);
-    let parse = update.work();
+    let parse = update.unstable_metrics();
     update.into_result().unwrap();
     let manifest_started = Instant::now();
-    let current = session.semantic_dependency_inputs(options, None).unwrap();
+    let current = session.unstable_dependency_baseline(options, None).unwrap();
     let manifest_elapsed = manifest_started.elapsed();
-    let manifest_work = current.work();
-    let after_manifest = QueryCounts::from(session.work());
+    let manifest_work = current.unstable_metrics();
+    let after_manifest = QueryCounts::from(&session.unstable_metrics());
     let plan_started = Instant::now();
-    let plan = session.semantic_invalidation_plan(previous.unwrap_or(&current), &current);
+    let plan = session
+        .unstable_invalidation_metrics(previous.unwrap_or(&current), &current)
+        .unwrap();
     let plan_elapsed = plan_started.elapsed();
-    let after_plan = QueryCounts::from(session.work());
-    let durable_body_work = durable_body_work_json(manifest_work.durable_bodies);
+    let after_plan = QueryCounts::from(&session.unstable_metrics());
     (
         json!({
             "manifest_wall_time_ns": manifest_elapsed.as_nanos(),
@@ -762,11 +589,11 @@ fn measure_manifest_plan(
                 "body_named_events_translated": manifest_work.body_named_events_translated,
                 "body_dependency_records_built": manifest_work.body_dependency_records_built,
                 "extra_rir_instructions_visited": manifest_work.extra_rir_instructions_visited,
-                "durable_bodies": durable_body_work,
+                "durable_bodies": manifest_work.durable_bodies,
             },
             "planner_queries": after_plan.delta(after_manifest).json(),
             "plan": invalidation_plan_json(&plan),
-            "retention": retention_json(session.work()),
+            "retention": retention_json(&session.unstable_metrics()),
         }),
         current,
     )
@@ -780,7 +607,7 @@ fn measured_semantic(
     let mut output = None;
     let value = measure(session, |session| {
         let update = session.update(source);
-        let parse = update.work();
+        let parse = update.unstable_metrics();
         update.into_result().unwrap();
         output = Some(session.semantic(options).unwrap());
         parse
@@ -863,7 +690,7 @@ where
     cold_session.update(source).into_result().unwrap();
     prepare_semantic(&mut cold_session, source);
     let cold = cold_session.semantic(options).unwrap();
-    let cold_semantic_work = semantic_work_json(cold_session.work(), 0);
+    let cold_semantic_work = semantic_work_json(&cold_session.unstable_metrics(), 0);
     let cold_count = |path: &[&str]| count(&cold_semantic_work, path);
     assert!(cold_count(&["bodies_attempted"]) > 0);
     assert_eq!(
@@ -882,7 +709,7 @@ where
         format!("{:?}", reused.functions()),
         format!("{:?}", cold.functions())
     );
-    assert_eq!(reused.input(), cold.input());
+    assert_eq!(reused.unstable_input_debug(), cold.unstable_input_debug());
     assert_eq!(reused.type_pool().stats(), cold.type_pool().stats());
     assert_eq!(
         type_pool_snapshot(reused.type_pool()),
@@ -935,8 +762,8 @@ where
         format!("{:?}", cold.specialized_free_function_dependencies())
     );
     assert_eq!(
-        reused.durable_specialized_body_payloads(),
-        cold.durable_specialized_body_payloads()
+        reused.unstable_durable_artifact_status(),
+        cold.unstable_durable_artifact_status()
     );
     assert_eq!(
         reused.ordinary_free_function_dependencies_complete(),
@@ -980,10 +807,10 @@ where
     );
 
     let reused_manifest = reused_session
-        .semantic_dependency_inputs(options, std_dir)
+        .unstable_dependency_baseline(options, std_dir)
         .unwrap();
     let cold_manifest = cold_session
-        .semantic_dependency_inputs(options, std_dir)
+        .unstable_dependency_baseline(options, std_dir)
         .unwrap();
     // Dependency queries may publish import-stage diagnostics on only the
     // cold side when the reused side already retained the manifest. Re-query
@@ -1032,8 +859,8 @@ where
     assert_manifest_field!(body_dependency_blockers);
     assert_manifest_field!(dependency_blockers);
     assert_eq!(
-        reused_manifest.durable_ordinary_bodies(),
-        cold_manifest.durable_ordinary_bodies()
+        reused_manifest.unstable_durable_artifact_status(),
+        cold_manifest.unstable_durable_artifact_status()
     );
     assert_eq!(
         reused_manifest.free_function_caller_dependencies_complete(),
@@ -1252,7 +1079,7 @@ fn completion_workloads(functions: usize) -> Vec<Value> {
     measured_semantic(&mut recovery, &fixture.direct, &o1);
     let failed = measure(&mut recovery, |session| {
         let update = session.update(&fixture.semantic_error);
-        let parse = update.work();
+        let parse = update.unstable_metrics();
         update.into_result().unwrap();
         session.semantic(&o1).unwrap_err();
         parse
@@ -1283,7 +1110,7 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
     scenarios.push(named(
         "cold",
         measure(&mut session, |session| {
-            let parse = session.update(&fixture.base).work();
+            let parse = session.update(&fixture.base).unstable_metrics();
             session.merge().unwrap();
             session.rir().unwrap();
             session.semantic(&options).unwrap();
@@ -1293,7 +1120,7 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
     scenarios.push(named(
         "exact_noop",
         measure(&mut session, |session| {
-            let parse = session.update(&fixture.base).work();
+            let parse = session.update(&fixture.base).unstable_metrics();
             session.merge().unwrap();
             session.rir().unwrap();
             session.semantic(&options).unwrap();
@@ -1305,7 +1132,7 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
         measure(&mut session, |session| {
             let update = session.update(&fixture.reachable_root_body_edit);
             assert!(update.downstream_invalidated());
-            let parse = update.work();
+            let parse = update.unstable_metrics();
             update.into_result().unwrap();
             session.merge().unwrap();
             session.rir().unwrap();
@@ -1318,7 +1145,7 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
         measure(&mut session, |session| {
             let update = session.update(&fixture.identity_edit);
             assert!(update.downstream_invalidated());
-            let parse = update.work();
+            let parse = update.unstable_metrics();
             update.into_result().unwrap();
             session.merge().unwrap();
             session.rir().unwrap();
@@ -1331,7 +1158,7 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
         measure(&mut session, |session| {
             let update = session.update(&fixture.syntax_error);
             assert!(update.result().is_err());
-            let parse = update.work();
+            let parse = update.unstable_metrics();
             session.merge().unwrap();
             session.rir().unwrap();
             session.semantic(&options).unwrap();
@@ -1341,7 +1168,7 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
     scenarios.push(named(
         "syntax_recovery",
         measure(&mut session, |session| {
-            let parse = session.update(&fixture.identity_edit).work();
+            let parse = session.update(&fixture.identity_edit).unstable_metrics();
             session.merge().unwrap();
             session.rir().unwrap();
             session.semantic(&options).unwrap();
@@ -1353,7 +1180,7 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
         measure(&mut session, |session| {
             let update = session.update(&fixture.semantic_error);
             assert!(update.downstream_invalidated());
-            let parse = update.work();
+            let parse = update.unstable_metrics();
             update.into_result().unwrap();
             session.semantic(&options).unwrap_err();
             parse
@@ -1362,7 +1189,7 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
     scenarios.push(named(
         "semantic_recovery",
         measure(&mut session, |session| {
-            let parse = session.update(&fixture.identity_edit).work();
+            let parse = session.update(&fixture.identity_edit).unstable_metrics();
             session.semantic(&options).unwrap();
             parse
         }),
@@ -1372,7 +1199,7 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
     scenarios.push(named(
         "stable_definitions_cold",
         measure(&mut stable, |session| {
-            let parse = session.update(&fixture.base).work();
+            let parse = session.update(&fixture.base).unstable_metrics();
             session.stable_definitions(&options).unwrap();
             parse
         }),
@@ -1381,7 +1208,7 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
         "stable_definitions_reuse",
         measure(&mut stable, |session| {
             session.stable_definitions(&options).unwrap();
-            ParsedModulesWork::default()
+            ParseMetrics::default()
         }),
     ));
     let mut planner = CompilerSession::new();
@@ -1430,17 +1257,11 @@ fn count(value: &Value, path: &[&str]) -> u64 {
 
 fn assert_structure(scenarios: &[Value], modules: usize) {
     for scenario in scenarios {
-        assert!(
-            count(scenario, &["retention", "diagnostic_entries"])
-                <= FRONTEND_DIAGNOSTIC_RETENTION_LIMIT as u64
-        );
-        assert!(
-            count(scenario, &["retention", "invalidation_plans"])
-                <= FRONTEND_INVALIDATION_PLAN_RETENTION_LIMIT as u64
-        );
+        assert!(count(scenario, &["retention", "diagnostic_entries"]) < scenarios.len() as u64);
+        assert!(count(scenario, &["retention", "invalidation_plans"]) < scenarios.len() as u64);
         assert!(
             count(scenario, &["retention", "dependency_manifests"])
-                <= (FRONTEND_INVALIDATION_PLAN_RETENTION_LIMIT * 2 + 1) as u64
+                <= (scenarios.len() * 2 + 1) as u64
         );
     }
     let get = |name: &str| {

--- a/crates/rue-compiler-session-bench/src/representative.rs
+++ b/crates/rue-compiler-session-bench/src/representative.rs
@@ -187,7 +187,7 @@ fn measured_project_semantic(
     let mut output = None;
     let value = measure(session, |session| {
         let update = session.update(source);
-        let parse = update.work();
+        let parse = update.unstable_metrics();
         update.into_result().unwrap();
         close_discovery(session, source);
         output = Some(session.semantic(options).unwrap());
@@ -223,7 +223,7 @@ fn successful_edit(name: &str, target: &SourceSnapshot) -> Value {
     let mut session = CompilerSession::new();
     measured_project_semantic(&mut session, &base, &options);
     session
-        .semantic_dependency_inputs(&options, Some("/bench/std"))
+        .unstable_dependency_baseline(&options, Some("/bench/std"))
         .unwrap();
     let (mut value, output) = measured_project_semantic(&mut session, target, &options);
     let parity = assert_cold_reused_parity_with_discovery(
@@ -248,12 +248,12 @@ fn diagnostic_and_recovery() -> (Value, Value) {
     let mut session = CompilerSession::new();
     measured_project_semantic(&mut session, &base, &options);
     session
-        .semantic_dependency_inputs(&options, Some("/bench/std"))
+        .unstable_dependency_baseline(&options, Some("/bench/std"))
         .unwrap();
     let last_good = session.last_good_semantic_diagnostics().unwrap().clone();
     let mut failed = measure(&mut session, |session| {
         let update = session.update(&failed_source);
-        let parse = update.work();
+        let parse = update.unstable_metrics();
         update.into_result().unwrap();
         close_discovery(session, &failed_source);
         session.semantic(&options).unwrap_err();

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -36,6 +36,7 @@ const PRODUCTION_MODULES: &[(&str, &str)] = &[
     ("source_snapshot", include_str!("source_snapshot.rs")),
     ("syntax", include_str!("syntax.rs")),
     ("typed_query_store", include_str!("typed_query_store.rs")),
+    ("unstable", include_str!("unstable.rs")),
 ];
 
 fn code_identifiers(source: &str) -> Vec<&str> {
@@ -76,6 +77,138 @@ fn public_compile_functions(source: &str) -> Vec<String> {
     names
 }
 
+const RUE_866_INTERNAL_VOCABULARY: &[&str] = &[
+    "CompilerSessionWork",
+    "FrontendQueryWork",
+    "FrontendRetentionMetrics",
+    "FRONTEND_DIAGNOSTIC_RETENTION_LIMIT",
+    "FRONTEND_INVALIDATION_PLAN_RETENTION_LIMIT",
+    "DefinitionQueryRecord",
+    "SemanticQueryRecord",
+    "ImportDiagnosticInputDescriptor",
+    "ImportGraphInputDescriptor",
+    "ImportDiscoveryRevisionArtifact",
+    "ImportDiscoveryRevisionStatus",
+    "FrontendDiagnosticIdentity",
+    "ResolvedCodegenRevision",
+    "ResolvedLinkRevision",
+    "ResolvedProgramRevision",
+    "SemanticDependencyBlocker",
+    "SemanticDependencyIncompleteReason",
+    "SemanticDependencyInputManifest",
+    "SemanticDependencyManifestWork",
+    "SemanticDependencySurface",
+    "SemanticFullInvalidationReason",
+    "SemanticInvalidationPlan",
+    "SemanticInvalidationScope",
+    "SemanticInvalidationWork",
+    "StableBodyDependencyInputRecord",
+    "StableBuiltinTypeCallHeadInput",
+    "StableDeclarationTypeCallHeadDependency",
+    "StableDeclarationTypeDependency",
+    "StableDefinitionFingerprint",
+    "StableDefinitionFingerprintPrecision",
+    "StableDefinitionInputFingerprint",
+    "StableFreeFunctionDependency",
+    "StableModuleImportDependency",
+    "StableNamedConstDependency",
+    "StableNamedConstDependencyTarget",
+    "StableNamedDestructorDependency",
+    "StableNamedMethodDependency",
+    "StableNamedMethodDependencyTarget",
+    "CodegenInputDescriptor",
+    "LinkInputDescriptor",
+    "SemanticInputDescriptor",
+    "ModuleResolutionInput",
+    "ModuleResolutionInputs",
+    "SourceStore",
+    "StableLinkerInput",
+    "StableOptLevel",
+    "StablePreviewFeatures",
+    "ParseInvalidationSummary",
+    "ParsedAstPresentationWork",
+    "ParsedModulesWork",
+    "CanonicalMergeWork",
+    "CanonicalRirWork",
+    "CanonicalSemanticFailurePhase",
+    "CanonicalSemanticFailureWork",
+    "CanonicalSemanticWork",
+    "PipelineWork",
+    "SourceStats",
+];
+
+fn public_signatures(source: &str) -> String {
+    let mut result = String::new();
+    let mut collecting = false;
+    for line in source.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("pub ") && !trimmed.starts_with("pub(crate)") {
+            collecting = true;
+        }
+        if collecting {
+            result.push_str(line);
+            result.push('\n');
+            if line.contains('{') || line.contains(';') {
+                collecting = false;
+            }
+        }
+    }
+    result
+}
+
+fn public_use_declarations(source: &str) -> Vec<String> {
+    let mut declarations = Vec::new();
+    let mut declaration = String::new();
+    for line in source.lines() {
+        let code = line.split_once("//").map_or(line, |(code, _)| code);
+        if declaration.is_empty() && !code.trim_start().starts_with("pub use ") {
+            continue;
+        }
+        declaration.push_str(code);
+        declaration.push('\n');
+        if code.contains(';') {
+            declarations.push(std::mem::take(&mut declaration));
+        }
+    }
+    declarations
+}
+
+fn assert_no_public_use_globs(source: &str) {
+    for declaration in public_use_declarations(source) {
+        assert!(
+            !public_use_is_glob(&declaration),
+            "public glob reexports bypass the supported facade inventory: {declaration}"
+        );
+    }
+}
+
+fn public_use_is_glob(declaration: &str) -> bool {
+    declaration
+        .split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_' || ch == '*'))
+        .filter(|token| !token.is_empty())
+        .any(|token| token == "*")
+}
+
+fn inherent_impl<'a>(source: &'a str, owner: &str) -> &'a str {
+    let marker = format!("impl {owner} {{");
+    let start = source.find(&marker).expect("reviewed owner impl exists");
+    let rest = &source[start..];
+    let mut depth = 0usize;
+    for (offset, byte) in rest.bytes().enumerate() {
+        match byte {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &rest[..=offset];
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("reviewed owner impl is balanced")
+}
+
 #[test]
 fn facade_stays_small_and_session_centered() {
     let facade = include_str!("lib.rs");
@@ -86,7 +219,11 @@ fn facade_stays_small_and_session_centered() {
 
     let mut declared_modules = facade
         .lines()
-        .filter_map(|line| line.trim().strip_prefix("mod "))
+        .filter_map(|line| {
+            line.trim()
+                .strip_prefix("mod ")
+                .or_else(|| line.trim().strip_prefix("pub mod "))
+        })
         .filter_map(|module| module.strip_suffix(';'))
         .collect::<Vec<_>>();
     declared_modules.sort_unstable();
@@ -173,6 +310,113 @@ fn orphaned_backend_inspection_exports_cannot_return() {
         assert!(
             !code_identifiers(backend).contains(&name),
             "orphaned backend inspection path returned: {name}"
+        );
+    }
+}
+
+#[test]
+fn query_engine_records_cannot_return_to_the_supported_root() {
+    let facade = include_str!("lib.rs");
+    let mut supported_exports = String::new();
+    let mut in_supported_export = false;
+    for line in facade.lines() {
+        if line.trim_start().starts_with("pub use ") {
+            in_supported_export = true;
+        }
+        if in_supported_export {
+            supported_exports.push_str(line);
+            supported_exports.push('\n');
+            if line.contains(';') {
+                in_supported_export = false;
+            }
+        }
+    }
+    for forbidden in RUE_866_INTERNAL_VOCABULARY {
+        assert!(
+            !supported_exports.contains(forbidden),
+            "query-engine implementation record returned to the supported root: {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn unstable_views_do_not_alias_query_engine_records() {
+    let unstable = include_str!("unstable.rs");
+    assert!(
+        !unstable.contains("pub use crate::"),
+        "unstable views must own their projections instead of aliasing compiler records"
+    );
+    assert!(!unstable.contains("pub type "));
+    assert!(!unstable.contains("pub use "));
+
+    let facade = include_str!("lib.rs");
+    assert_no_public_use_globs(facade);
+    let public_modules = facade
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("pub mod "))
+        .collect::<Vec<_>>();
+    assert_eq!(public_modules, ["unstable;"]);
+
+    let session = include_str!("session.rs");
+    let diagnostic = include_str!("diagnostic_attempt_store.rs");
+    let reviewed_public = [
+        public_signatures(inherent_impl(session, "CompilerSession")),
+        public_signatures(inherent_impl(session, "CompilerSessionUpdate")),
+        public_signatures(inherent_impl(diagnostic, "FrontendDiagnosticSnapshot")),
+        public_signatures(inherent_impl(include_str!("queries.rs"), "CompileOutput")),
+        public_signatures(inherent_impl(
+            include_str!("canonical_semantic.rs"),
+            "CanonicalSemanticOutput",
+        )),
+        public_signatures(inherent_impl(session, "CanonicalImportGraphOutput")),
+    ]
+    .concat();
+    for forbidden in RUE_866_INTERNAL_VOCABULARY {
+        assert!(
+            !reviewed_public.contains(forbidden),
+            "internal vocabulary leaked through a supported public signature or field: {forbidden}"
+        );
+    }
+    for line in unstable
+        .lines()
+        .map(str::trim_start)
+        .filter(|line| line.starts_with("pub "))
+    {
+        for forbidden in RUE_866_INTERNAL_VOCABULARY {
+            assert!(
+                !line.contains(forbidden),
+                "unstable public item directly exposes internal vocabulary: {line}"
+            );
+        }
+    }
+    assert!(reviewed_public.contains("pub fn stage(&self) -> DiagnosticStage"));
+
+    for forbidden in [
+        "pub fn work(&self) -> CompilerSessionWork",
+        "pub fn semantic_dependency_inputs",
+        "pub fn discovery_attempt(&self) -> Option<&Arc<ImportDiscoveryRevisionArtifact>>",
+        "pub fn last_good_discovery(&self) -> Option<&Arc<ImportDiscoveryRevisionArtifact>>",
+        "pub fn committed_import_discovery(&self) -> Option<&Arc<ImportDiscoveryRevisionArtifact>>",
+    ] {
+        assert!(
+            !session.contains(forbidden),
+            "session implementation record leaked through a public signature: {forbidden}"
+        );
+    }
+
+    let queries = include_str!("queries.rs");
+    assert!(!queries.contains("pub source_stats: SourceStats"));
+    assert!(!queries.contains("pub work: PipelineWork"));
+}
+
+#[test]
+fn qualified_public_globs_are_rejected() {
+    for fixture in ["pub use session::*;", "pub use unstable::{Metrics, *};"] {
+        assert!(
+            public_use_declarations(fixture)
+                .iter()
+                .any(|declaration| public_use_is_glob(declaration)),
+            "qualified glob fixture escaped the public-use guard: {fixture}"
         );
     }
 }

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -450,8 +450,12 @@ impl CanonicalSemanticOutput {
     }
 
     /// Exact semantic and optimization identity of this output.
-    pub fn input(&self) -> &CodegenInputDescriptor {
+    pub(crate) fn input(&self) -> &CodegenInputDescriptor {
         &self.input
+    }
+    /// Debug-only identity projection for differential and benchmark tooling.
+    pub fn unstable_input_debug(&self) -> String {
+        format!("{:?}", self.input)
     }
     /// Analyzed functions paired with optimized CFGs in machine-symbol order.
     pub fn functions(&self) -> &[FunctionWithCfg] {
@@ -560,9 +564,17 @@ impl CanonicalSemanticOutput {
     pub fn durable_specialized_body_payloads(&self) -> &[crate::DurableSpecializedBodyPayload] {
         &self.durable_specialized_body_payloads
     }
+    /// Explicitly unstable equality status for durable-cache instrumentation.
+    pub fn unstable_durable_artifact_status(&self) -> crate::unstable::DurableArtifactStatus {
+        crate::unstable::DurableArtifactStatus::from_debug(&self.durable_specialized_body_payloads)
+    }
     /// Structural work performed by this request.
-    pub fn work(&self) -> CanonicalSemanticWork {
+    pub(crate) fn work(&self) -> CanonicalSemanticWork {
         self.work
+    }
+    /// Return an owned snapshot of explicitly unstable semantic work metrics.
+    pub fn unstable_metrics(&self) -> crate::unstable::SemanticMetrics {
+        crate::unstable::SemanticMetrics::from_work(self.work)
     }
 }
 

--- a/crates/rue-compiler/src/dependency_envelope.rs
+++ b/crates/rue-compiler/src/dependency_envelope.rs
@@ -128,7 +128,19 @@ pub struct DependencyAcceptedRead {
 impl DependencyEnvelope {
     /// Project the compiler-owned graph and ledgers without rediscovering an
     /// import edge or consulting semantic analysis.
-    pub fn from_closed_revision(artifact: &ImportDiscoveryRevisionArtifact) -> Option<Self> {
+    #[cfg(not(test))]
+    pub fn from_closed_revision(
+        revision: &crate::unstable::ImportDiscoveryRevision,
+    ) -> Option<Self> {
+        Self::from_artifact(&revision.inner)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_closed_revision(artifact: &ImportDiscoveryRevisionArtifact) -> Option<Self> {
+        Self::from_artifact(artifact)
+    }
+
+    fn from_artifact(artifact: &ImportDiscoveryRevisionArtifact) -> Option<Self> {
         let graph = artifact.graph()?;
         let status = match artifact.status() {
             ImportDiscoveryRevisionStatus::ClosedValid if graph.validation().is_valid() => {

--- a/crates/rue-compiler/src/diagnostic_attempt_store.rs
+++ b/crates/rue-compiler/src/diagnostic_attempt_store.rs
@@ -22,7 +22,7 @@ use crate::{
 pub const FRONTEND_DIAGNOSTIC_RETENTION_LIMIT: usize = 16;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum FrontendDiagnosticStage {
+pub(crate) enum FrontendDiagnosticIdentity {
     Syntax,
     Import(ImportDiagnosticInputDescriptor),
     Merge,
@@ -30,12 +30,34 @@ pub enum FrontendDiagnosticStage {
     Semantic(ResolvedCodegenRevision),
 }
 
+/// Stable diagnostic phase projection with query identity removed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DiagnosticStage {
+    Syntax,
+    Import,
+    Merge,
+    Rir,
+    Semantic,
+}
+
+impl FrontendDiagnosticIdentity {
+    fn phase(&self) -> DiagnosticStage {
+        match self {
+            Self::Syntax => DiagnosticStage::Syntax,
+            Self::Import(_) => DiagnosticStage::Import,
+            Self::Merge => DiagnosticStage::Merge,
+            Self::Rir(_) => DiagnosticStage::Rir,
+            Self::Semantic(_) => DiagnosticStage::Semantic,
+        }
+    }
+}
+
 /// Exact immutable inputs to one canonical import-diagnostic projection.
 ///
 /// Keeping the plan and observation ledger in the descriptor makes reuse an
 /// exact attempted-revision property rather than merely a source-text match.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ImportDiagnosticInputDescriptor {
+pub(crate) struct ImportDiagnosticInputDescriptor {
     pub(crate) source: SourceRevision,
     pub(crate) context: Option<ImportDiscoveryContext>,
     pub(crate) plan: Option<ImportDiscoveryPlan>,
@@ -44,19 +66,23 @@ pub struct ImportDiagnosticInputDescriptor {
 }
 
 impl ImportDiagnosticInputDescriptor {
-    pub fn source_revision(&self) -> &SourceRevision {
+    pub(crate) fn source_revision(&self) -> &SourceRevision {
         &self.source
     }
-    pub fn context(&self) -> Option<&ImportDiscoveryContext> {
+    #[cfg(test)]
+    pub(crate) fn context(&self) -> Option<&ImportDiscoveryContext> {
         self.context.as_ref()
     }
-    pub fn plan(&self) -> Option<&ImportDiscoveryPlan> {
+    #[cfg(test)]
+    pub(crate) fn plan(&self) -> Option<&ImportDiscoveryPlan> {
         self.plan.as_ref()
     }
-    pub fn ledger(&self) -> &ImportObservationLedger {
+    #[cfg(test)]
+    pub(crate) fn ledger(&self) -> &ImportObservationLedger {
         &self.ledger
     }
-    pub fn accepted_read_manifest(&self) -> &[crate::AcceptedReadManifestEntry] {
+    #[cfg(test)]
+    pub(crate) fn accepted_read_manifest(&self) -> &[crate::AcceptedReadManifestEntry] {
         &self.accepted_reads
     }
 }
@@ -65,7 +91,7 @@ impl ImportDiagnosticInputDescriptor {
 #[derive(Debug, Clone)]
 pub struct FrontendDiagnosticSnapshot {
     pub(crate) source: SourceSnapshot,
-    pub(crate) stage: FrontendDiagnosticStage,
+    pub(crate) stage: FrontendDiagnosticIdentity,
     pub(crate) provenance: DiagnosticAttemptProvenance,
     pub(crate) errors: Arc<[CompileError]>,
     pub(crate) warnings: Arc<[CompileWarning]>,
@@ -86,7 +112,10 @@ impl FrontendDiagnosticSnapshot {
     pub fn source_revision(&self) -> &SourceRevision {
         self.source.source_revision()
     }
-    pub fn stage(&self) -> &FrontendDiagnosticStage {
+    pub fn stage(&self) -> DiagnosticStage {
+        self.stage.phase()
+    }
+    pub(crate) fn identity(&self) -> &FrontendDiagnosticIdentity {
         &self.stage
     }
     pub fn errors(&self) -> &[CompileError] {
@@ -136,21 +165,22 @@ pub(crate) struct DiagnosticAttemptStore {
 }
 
 impl DiagnosticAttemptStore {
-    pub fn find(
+    #[cfg(test)]
+    pub(crate) fn find(
         &self,
         source: &SourceSnapshot,
-        stage: &FrontendDiagnosticStage,
+        stage: &FrontendDiagnosticIdentity,
     ) -> Option<&Arc<FrontendDiagnosticSnapshot>> {
         self.latest
             .and_then(|latest| self.entries.iter().find(|entry| entry.id == latest))
             .filter(|entry| {
                 snapshot_matches_source_attempt(entry.snapshot(), source)
-                    && entry.snapshot().stage() == stage
+                    && entry.snapshot().identity() == stage
             })
             .or_else(|| {
                 self.entries.iter().rev().find(|entry| {
                     snapshot_matches_source_attempt(entry.snapshot(), source)
-                        && entry.snapshot().stage() == stage
+                        && entry.snapshot().identity() == stage
                 })
             })
             .map(IndexedDiagnosticAttempt::snapshot)
@@ -159,7 +189,7 @@ impl DiagnosticAttemptStore {
     pub fn find_exact(
         &self,
         source: &SourceSnapshot,
-        stage: &FrontendDiagnosticStage,
+        stage: &FrontendDiagnosticIdentity,
         provenance: &DiagnosticAttemptProvenance,
     ) -> Option<&Arc<FrontendDiagnosticSnapshot>> {
         self.entries
@@ -167,7 +197,7 @@ impl DiagnosticAttemptStore {
             .rev()
             .find(|entry| {
                 snapshot_matches_source_attempt(entry.snapshot(), source)
-                    && entry.snapshot().stage() == stage
+                    && entry.snapshot().identity() == stage
                     && &entry.snapshot().provenance == provenance
             })
             .map(IndexedDiagnosticAttempt::snapshot)
@@ -222,7 +252,7 @@ impl DiagnosticAttemptStore {
             .diagnostics()
             .expect("indexed diagnostic attempt owns a batch");
         debug_assert!(
-            self.find_exact(snapshot.source(), snapshot.stage(), &snapshot.provenance)
+            self.find_exact(snapshot.source(), snapshot.identity(), &snapshot.provenance)
                 .is_none(),
             "diagnostic attempt keys are published once"
         );
@@ -269,7 +299,7 @@ impl DiagnosticAttemptStore {
         self.latest = Some(id);
         if snapshot.is_success() {
             self.latest_successful = Some(id);
-            if matches!(snapshot.stage(), FrontendDiagnosticStage::Semantic(_)) {
+            if matches!(snapshot.identity(), FrontendDiagnosticIdentity::Semantic(_)) {
                 self.last_good_semantic = Some(id);
             }
         }
@@ -440,7 +470,7 @@ mod tests {
 
     fn snapshot(
         source: &SourceSnapshot,
-        stage: FrontendDiagnosticStage,
+        stage: FrontendDiagnosticIdentity,
         success: bool,
     ) -> Arc<FrontendDiagnosticSnapshot> {
         Arc::new(FrontendDiagnosticSnapshot {
@@ -461,10 +491,10 @@ mod tests {
     #[test]
     fn exact_attempt_keys_and_selectors_are_independent() {
         let valid_source = source("fn main() {}");
-        let syntax = snapshot(&valid_source, FrontendDiagnosticStage::Syntax, true);
+        let syntax = snapshot(&valid_source, FrontendDiagnosticIdentity::Syntax, true);
         let semantic = snapshot(
             &valid_source,
-            FrontendDiagnosticStage::Semantic(crate::ResolvedCodegenRevision::new(
+            FrontendDiagnosticIdentity::Semantic(crate::ResolvedCodegenRevision::new(
                 crate::ResolvedProgramRevision::new(
                     crate::SemanticInputDescriptor::new(
                         &valid_source,
@@ -490,7 +520,7 @@ mod tests {
             true,
         );
         let failure_source = source("fn main( {");
-        let failure = snapshot(&failure_source, FrontendDiagnosticStage::Syntax, false);
+        let failure = snapshot(&failure_source, FrontendDiagnosticIdentity::Syntax, false);
         let mut store = DiagnosticAttemptStore::default();
         store.insert(indexed(syntax.clone()));
         store.insert(indexed(semantic.clone()));
@@ -501,7 +531,7 @@ mod tests {
         assert!(Arc::ptr_eq(store.last_good_semantic().unwrap(), &semantic));
         assert!(Arc::ptr_eq(
             store
-                .find(&valid_source, &FrontendDiagnosticStage::Syntax)
+                .find(&valid_source, &FrontendDiagnosticIdentity::Syntax)
                 .unwrap(),
             &syntax
         ));
@@ -511,20 +541,20 @@ mod tests {
     fn eviction_is_bounded_and_reselection_reindexes_without_copying_batch() {
         let mut store = DiagnosticAttemptStore::default();
         let pinned_source = source("fn main() -> i32 { 0 }");
-        let pinned = snapshot(&pinned_source, FrontendDiagnosticStage::Syntax, true);
+        let pinned = snapshot(&pinned_source, FrontendDiagnosticIdentity::Syntax, true);
         store.insert(indexed(pinned.clone()));
         for revision in 0..=FRONTEND_DIAGNOSTIC_RETENTION_LIMIT {
             let current = source(&format!("fn main() -> i32 {{ {revision} }}"));
             store.insert(indexed(snapshot(
                 &current,
-                FrontendDiagnosticStage::Merge,
+                FrontendDiagnosticIdentity::Merge,
                 true,
             )));
         }
         assert!(store.retention_metrics().entries <= FRONTEND_DIAGNOSTIC_RETENTION_LIMIT);
         assert!(
             store
-                .find(&pinned_source, &FrontendDiagnosticStage::Syntax)
+                .find(&pinned_source, &FrontendDiagnosticIdentity::Syntax)
                 .is_none()
         );
 
@@ -532,7 +562,7 @@ mod tests {
         assert!(Arc::ptr_eq(store.latest().unwrap(), &pinned));
         assert!(Arc::ptr_eq(
             store
-                .find(&pinned_source, &FrontendDiagnosticStage::Syntax)
+                .find(&pinned_source, &FrontendDiagnosticIdentity::Syntax)
                 .unwrap(),
             &pinned
         ));
@@ -575,7 +605,7 @@ mod tests {
         let attempt = |source: &SourceSnapshot, provenance| {
             Arc::new(FrontendDiagnosticSnapshot {
                 source: source.clone(),
-                stage: FrontendDiagnosticStage::Syntax,
+                stage: FrontendDiagnosticIdentity::Syntax,
                 provenance,
                 errors: Arc::from([]),
                 warnings: Arc::from([]),
@@ -599,7 +629,7 @@ mod tests {
 
         assert!(Arc::ptr_eq(
             store
-                .find(&reverse, &FrontendDiagnosticStage::Syntax)
+                .find(&reverse, &FrontendDiagnosticIdentity::Syntax)
                 .unwrap(),
             &reverse_attempt
         ));

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -2387,7 +2387,7 @@ mod tests {
             .unwrap_err();
         let second = session.import_diagnostics().unwrap();
         assert!(!Arc::ptr_eq(&first, &second));
-        let crate::FrontendDiagnosticStage::Import(input) = second.stage() else {
+        let crate::FrontendDiagnosticIdentity::Import(input) = second.identity() else {
             panic!("failed discovery must publish the import diagnostic stage")
         };
         assert_eq!(input.source_revision(), source.source_revision());
@@ -2433,10 +2433,10 @@ mod tests {
             .unwrap_err();
         let second = session.import_diagnostics().unwrap();
         assert!(!Arc::ptr_eq(&first, &second));
-        let crate::FrontendDiagnosticStage::Import(first_input) = first.stage() else {
+        let crate::FrontendDiagnosticIdentity::Import(first_input) = first.identity() else {
             unreachable!()
         };
-        let crate::FrontendDiagnosticStage::Import(second_input) = second.stage() else {
+        let crate::FrontendDiagnosticIdentity::Import(second_input) = second.identity() else {
             unreachable!()
         };
         assert_ne!(first_input.context(), second_input.context());
@@ -2464,7 +2464,7 @@ mod tests {
         session.close_import_discovery(partial.clone()).unwrap_err();
         let third = session.import_diagnostics().unwrap();
         assert!(!Arc::ptr_eq(&second, &third));
-        let crate::FrontendDiagnosticStage::Import(third_input) = third.stage() else {
+        let crate::FrontendDiagnosticIdentity::Import(third_input) = third.identity() else {
             unreachable!()
         };
         assert_eq!(second_input.context(), third_input.context());
@@ -2607,7 +2607,7 @@ mod tests {
         assert!(Arc::ptr_eq(&first, &second));
         assert_eq!(session.work().import_diagnostics.executions, 1);
         assert_eq!(session.work().import_diagnostics.reuses, 2);
-        let crate::FrontendDiagnosticStage::Import(input) = first.stage() else {
+        let crate::FrontendDiagnosticIdentity::Import(input) = first.identity() else {
             panic!("direct batch import preflight must use the import diagnostic stage")
         };
         assert!(input.context().is_none());

--- a/crates/rue-compiler/src/import_graph.rs
+++ b/crates/rue-compiler/src/import_graph.rs
@@ -7,12 +7,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
-use crate::{
-    CompileOptions, ModuleId, ModuleResolutionInputs, SemanticInputDescriptor, StableLinkerInput,
-    StableOptLevel,
-};
+use crate::{ModuleId, ModuleResolutionInputs, SemanticInputDescriptor, StableOptLevel};
 use rue_air::normalize_module_path;
-use rue_error::{CompileError, CompileResult, ErrorKind};
 
 /// One valid import call, identified independently of request-local file IDs.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -255,7 +251,7 @@ impl CanonicalImportGraphValidation {
 
 /// Complete downstream semantic identity after import resolution.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ResolvedProgramRevision {
+pub(crate) struct ResolvedProgramRevision {
     semantic: SemanticInputDescriptor,
     imports: CanonicalImportGraph,
 }
@@ -266,106 +262,37 @@ impl ResolvedProgramRevision {
     /// The canonical graph itself ignores physical relocation, while this
     /// complete revision intentionally retains the explicit physical
     /// resolution inputs embedded in `semantic`.
-    pub fn new(semantic: SemanticInputDescriptor, imports: CanonicalImportGraph) -> Self {
+    pub(crate) fn new(semantic: SemanticInputDescriptor, imports: CanonicalImportGraph) -> Self {
         Self { semantic, imports }
     }
 
-    pub fn semantic(&self) -> &SemanticInputDescriptor {
-        &self.semantic
-    }
-
-    pub fn imports(&self) -> &CanonicalImportGraph {
+    #[cfg(test)]
+    pub(crate) fn imports(&self) -> &CanonicalImportGraph {
         &self.imports
     }
 }
 
 /// Complete code-generation identity after canonical import resolution.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ResolvedCodegenRevision {
+pub(crate) struct ResolvedCodegenRevision {
     program: ResolvedProgramRevision,
     opt_level: StableOptLevel,
 }
 
 impl ResolvedCodegenRevision {
-    pub fn new(program: ResolvedProgramRevision, opt_level: StableOptLevel) -> Self {
+    pub(crate) fn new(program: ResolvedProgramRevision, opt_level: StableOptLevel) -> Self {
         Self { program, opt_level }
     }
 
-    /// Add code-generation options to an already-resolved program revision.
-    ///
-    /// Requiring `program` prevents this path from omitting canonical imports.
-    pub fn from_compile_options(
-        program: ResolvedProgramRevision,
-        options: &CompileOptions,
-    ) -> CompileResult<Self> {
-        validate_resolved_compile_options(&program, options)?;
-        Ok(Self::new(program, options.opt_level.into()))
-    }
-
-    pub fn program(&self) -> &ResolvedProgramRevision {
+    #[cfg(test)]
+    pub(crate) fn program(&self) -> &ResolvedProgramRevision {
         &self.program
     }
 
-    pub fn opt_level(&self) -> StableOptLevel {
+    #[cfg(test)]
+    pub(crate) fn opt_level(&self) -> StableOptLevel {
         self.opt_level
     }
-}
-
-/// Complete link identity after canonical import resolution and code generation.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ResolvedLinkRevision {
-    codegen: ResolvedCodegenRevision,
-    linker: StableLinkerInput,
-}
-
-impl ResolvedLinkRevision {
-    pub fn new(codegen: ResolvedCodegenRevision, linker: StableLinkerInput) -> Self {
-        Self { codegen, linker }
-    }
-
-    /// Add code-generation and linker options to an already-resolved program.
-    pub fn from_compile_options(
-        program: ResolvedProgramRevision,
-        options: &CompileOptions,
-    ) -> CompileResult<Self> {
-        Ok(Self::new(
-            ResolvedCodegenRevision::from_compile_options(program, options)?,
-            (&options.linker).into(),
-        ))
-    }
-
-    pub fn codegen(&self) -> &ResolvedCodegenRevision {
-        &self.codegen
-    }
-
-    pub fn linker(&self) -> &StableLinkerInput {
-        &self.linker
-    }
-}
-
-fn validate_resolved_compile_options(
-    program: &ResolvedProgramRevision,
-    options: &CompileOptions,
-) -> CompileResult<()> {
-    if program.semantic().target != options.target {
-        return Err(provenance_error(format!(
-            "resolved program target {} does not match compile options target {}",
-            program.semantic().target,
-            options.target
-        )));
-    }
-    let features = crate::StablePreviewFeatures::new(&options.preview_features);
-    if program.semantic().preview_features != features {
-        return Err(provenance_error(
-            "resolved program preview features do not match compile options preview features"
-                .to_string(),
-        ));
-    }
-    Ok(())
-}
-
-fn provenance_error(message: String) -> CompileError {
-    CompileError::without_span(ErrorKind::InvalidCompilerInput(message))
 }
 
 /// Validate a canonical graph against the explicit resolved module set.

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Rue's embeddable compiler facade.
 //!
 //! Compilation starts with an owned [`SourceSnapshot`]. A [`CompilerSession`]
@@ -54,6 +56,7 @@ mod source_metadata;
 mod source_snapshot;
 mod syntax;
 mod typed_query_store;
+pub mod unstable;
 
 #[cfg(test)]
 mod test_support;
@@ -80,6 +83,9 @@ pub use diagnostic::{
     ColorChoice, DiagnosticFormatter, JsonDiagnostic, JsonDiagnosticFormatter, JsonSpan,
     JsonSuggestion, MultiFileFormatter, MultiFileJsonFormatter, SourceInfo,
 };
+#[cfg(test)]
+pub(crate) use diagnostic_attempt_store::FrontendDiagnosticIdentity;
+pub use diagnostic_attempt_store::{DiagnosticStage, FrontendDiagnosticSnapshot};
 pub use import_discovery::{
     AcceptedImportSource, AcceptedReadManifestEntry, DiscoverySourceAssembler,
     FileMetadataFingerprint, IMPORT_DISCOVERY_POLICY_VERSION, ImportCandidateRole,
@@ -89,26 +95,52 @@ pub use import_discovery::{
 pub use import_graph::{
     CanonicalImportCycle, CanonicalImportGraph, CanonicalImportGraphProblem,
     CanonicalImportGraphValidation, CanonicalImportRecord, CanonicalImportResolution,
-    ImportDirective, ImportDirectives, ResolvedCodegenRevision, ResolvedLinkRevision,
-    ResolvedProgramRevision,
+    ImportDirective, ImportDirectives,
 };
+pub(crate) use import_graph::{ResolvedCodegenRevision, ResolvedProgramRevision};
 pub use parsed_modules::{
-    InvalidImportShape, ParseInvalidationSummary, ParsedAstPresentation, ParsedAstPresentationWork,
-    ParsedInvalidImport, ParsedModulesWork, ParsedProgram,
+    InvalidImportShape, ParsedAstPresentation, ParsedInvalidImport, ParsedProgram,
     parse_source_snapshot_for_ast_presentation,
 };
 pub use queries::{
-    CompileOptions, CompileOutput, FunctionWithCfg, LinkerMode, PipelineWork, SourceStats,
-    SourceView, compile_snapshot,
+    CompileOptions, CompileOutput, FunctionWithCfg, LinkerMode, SourceView, compile_snapshot,
 };
-pub use session::{
-    CanonicalImportGraphOutput, CompilerSession, CompilerSessionUpdate, CompilerSessionWork,
-    DefinitionQueryRecord, DifferentialOracleFault, FRONTEND_DIAGNOSTIC_RETENTION_LIMIT,
-    FRONTEND_INVALIDATION_PLAN_RETENTION_LIMIT, FrontendDiagnosticSnapshot,
-    FrontendDiagnosticStage, FrontendQueryWork, FrontendRetentionMetrics,
-    ImportDiagnosticInputDescriptor, ImportDiscoveryRevisionArtifact,
-    ImportDiscoveryRevisionStatus, ImportGraphInputDescriptor, SemanticDependencyBlocker,
-    SemanticDependencyIncompleteReason, SemanticDependencyInputManifest,
+pub use session::{CanonicalImportGraphOutput, CompilerSession, CompilerSessionUpdate};
+pub use source_identity::{ModuleId, ModuleRevision, SourceId, SourceIdVersion, SourceRevision};
+pub use source_metadata::SourceMetadata;
+pub use source_snapshot::{MAX_SOURCE_BYTES, SourceSnapshot};
+
+// Query keys, invalidation records, dependency manifests, fingerprints, and
+// work records are compiler implementation. Keep crate-local paths available
+// while the session remains their sole owner, without publishing them through
+// the supported facade.
+#[allow(unused_imports)]
+pub(crate) use bound_definitions::BoundDefinitionWork;
+#[allow(unused_imports)]
+pub(crate) use canonical_lower::CanonicalRirWork;
+#[allow(unused_imports)]
+pub(crate) use canonical_merge::CanonicalMergeWork;
+#[allow(unused_imports)]
+pub(crate) use canonical_semantic::{
+    CanonicalSemanticFailurePhase, CanonicalSemanticFailureWork, CanonicalSemanticWork,
+};
+#[allow(unused_imports)]
+pub(crate) use definition_snapshot::DefinitionShardWork;
+#[allow(unused_imports)]
+pub(crate) use durable_body::DurableBodyWork;
+#[allow(unused_imports)]
+pub(crate) use parsed_modules::{
+    ParseInvalidationSummary, ParsedAstPresentationWork, ParsedModulesWork,
+};
+pub(crate) use queries::{PipelineWork, SourceStats};
+#[allow(unused_imports)]
+pub(crate) use semantic_symbols::SemanticTranslationWork;
+#[allow(unused_imports)]
+pub(crate) use session::{
+    CompilerSessionWork, DefinitionQueryRecord, FRONTEND_DIAGNOSTIC_RETENTION_LIMIT,
+    FRONTEND_INVALIDATION_PLAN_RETENTION_LIMIT, FrontendQueryWork, FrontendRetentionMetrics,
+    ImportDiscoveryRevisionArtifact, ImportDiscoveryRevisionStatus, ImportGraphInputDescriptor,
+    SemanticDependencyBlocker, SemanticDependencyIncompleteReason, SemanticDependencyInputManifest,
     SemanticDependencyManifestWork, SemanticDependencySurface, SemanticFullInvalidationReason,
     SemanticInvalidationPlan, SemanticInvalidationScope, SemanticInvalidationWork,
     SemanticQueryRecord, StableBodyDependencyInputRecord, StableBuiltinTypeCallHeadInput,
@@ -118,36 +150,32 @@ pub use session::{
     StableNamedConstDependency, StableNamedConstDependencyTarget, StableNamedDestructorDependency,
     StableNamedMethodDependency, StableNamedMethodDependencyTarget,
 };
-pub use source_identity::{
-    CodegenInputDescriptor, LinkInputDescriptor, ModuleId, ModuleResolutionInput,
-    ModuleResolutionInputs, ModuleRevision, SemanticInputDescriptor, SourceId, SourceIdVersion,
-    SourceRevision, SourceStore, StableLinkerInput, StableOptLevel, StablePreviewFeatures,
+#[cfg(test)]
+pub(crate) use source_identity::LinkInputDescriptor;
+#[allow(unused_imports)]
+pub(crate) use source_identity::{
+    CodegenInputDescriptor, ModuleResolutionInput, ModuleResolutionInputs, SemanticInputDescriptor,
+    SourceStore, StableOptLevel, StablePreviewFeatures,
 };
-pub use source_metadata::SourceMetadata;
-pub use source_snapshot::{MAX_SOURCE_BYTES, SourceSnapshot};
 
 // Immutable query artifacts and stable identities returned by CompilerSession.
 pub use bound_definitions::{
-    BoundDefinitionId, BoundDefinitionRecord, BoundDefinitionSet, BoundDefinitionWork,
-    SnapshotBoundDefinitionId, StableDefinitionKey, StableDefinitionKind,
-    StableDefinitionNamespace, StableNamedTypeKey,
+    BoundDefinitionId, BoundDefinitionRecord, BoundDefinitionSet, SnapshotBoundDefinitionId,
+    StableDefinitionKey, StableDefinitionKind, StableDefinitionNamespace, StableNamedTypeKey,
 };
-pub use canonical_lower::{CanonicalRirOutput, CanonicalRirWork};
-pub use canonical_merge::{CanonicalMergeWork, CanonicalMergedAst, CanonicalMergedProgram};
-pub use canonical_semantic::{
-    CanonicalSemanticFailurePhase, CanonicalSemanticFailureWork, CanonicalSemanticOutput,
-    CanonicalSemanticWork,
-};
+pub use canonical_lower::CanonicalRirOutput;
+pub use canonical_merge::{CanonicalMergedAst, CanonicalMergedProgram};
+pub use canonical_semantic::CanonicalSemanticOutput;
 pub use definition_snapshot::{
     DefinitionId, DefinitionKind, DefinitionNameKey, DefinitionNamespace, DefinitionOccurrenceId,
-    DefinitionRecord, DefinitionShard, DefinitionShardWork, DefinitionSnapshot, ModuleDefinition,
+    DefinitionRecord, DefinitionShard, DefinitionSnapshot, ModuleDefinition,
 };
 pub use durable_body::{
     DURABLE_ORDINARY_BODY_SCHEMA_VERSION, DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION, DurableAirInst,
     DurableAirInstData, DurableAirRef, DurableBodyAnchor, DurableBodyConversionFailure,
-    DurableBodyProjectionFailure, DurableBodyWork, DurableCallArg, DurableMatchArm,
-    DurableOrdinaryBody, DurableOrdinaryBodyPayload, DurablePattern, DurablePlace, DurablePlaceRef,
-    DurableProjection, DurableSpecializedBody, DurableSpecializedBodyPayload,
+    DurableBodyProjectionFailure, DurableCallArg, DurableMatchArm, DurableOrdinaryBody,
+    DurableOrdinaryBodyPayload, DurablePattern, DurablePlace, DurablePlaceRef, DurableProjection,
+    DurableSpecializedBody, DurableSpecializedBodyPayload,
     convert_semantic_specialized_body_exports,
 };
 pub use durable_semantics::{
@@ -195,7 +223,7 @@ pub(crate) use parsed_modules::CanonicalParseUpdate;
 pub(crate) use queries::build_functions_and_cfgs;
 #[cfg(test)]
 pub(crate) use rue_parser::Item;
-pub use semantic_symbols::{SemanticSymbol, SemanticSymbolUniverse, SemanticTranslationWork};
+pub use semantic_symbols::{SemanticSymbol, SemanticSymbolUniverse};
 pub(crate) use syntax::SyntaxWork;
 
 pub use lasso::ThreadedRodeo;

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -261,7 +261,7 @@ mod tests {
         ));
         assert!(Arc::ptr_eq(
             session
-                .most_recent_diagnostics_for(&reverse, &FrontendDiagnosticStage::Syntax)
+                .most_recent_diagnostics_for(&reverse, &FrontendDiagnosticIdentity::Syntax)
                 .unwrap(),
             &reverse_diagnostics
         ));

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -500,9 +500,17 @@ pub struct CompileOutput {
     /// Warnings generated during compilation.
     pub warnings: Vec<CompileWarning>,
     /// Source volume measured while executing the session queries.
-    pub source_stats: SourceStats,
+    pub(crate) source_stats: SourceStats,
     /// Structural work performed by the session query graph.
-    pub work: PipelineWork,
+    pub(crate) work: PipelineWork,
+}
+
+impl CompileOutput {
+    /// Return instrumentation from this one-shot compilation without exposing
+    /// query-engine work records.
+    pub fn unstable_metrics(&self) -> crate::unstable::OneShotMetrics {
+        crate::unstable::OneShotMetrics::new(self.source_stats, self.work)
+    }
 }
 
 /// Compile an immutable owned source snapshot through a one-shot canonical
@@ -569,7 +577,7 @@ impl CompilerSession {
 
     fn committed_snapshot_for_executable(&self) -> MultiErrorResult<SourceSnapshot> {
         let snapshot = self
-            .committed_import_discovery()
+            .committed_import_discovery_artifact()
             .ok_or_else(|| {
                 CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
                     "compilation requires a closed-valid import discovery revision".into(),

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -30,10 +30,10 @@ use crate::{
     validate_canonical_import_graph,
 };
 
-use crate::diagnostic_attempt_store::{DiagnosticAttemptProvenance, DiagnosticAttemptStore};
-pub use crate::diagnostic_attempt_store::{
-    FRONTEND_DIAGNOSTIC_RETENTION_LIMIT, FrontendDiagnosticSnapshot, FrontendDiagnosticStage,
-    ImportDiagnosticInputDescriptor,
+pub(crate) use crate::diagnostic_attempt_store::FRONTEND_DIAGNOSTIC_RETENTION_LIMIT;
+use crate::diagnostic_attempt_store::{
+    DiagnosticAttemptProvenance, DiagnosticAttemptStore, FrontendDiagnosticIdentity,
+    FrontendDiagnosticSnapshot, ImportDiagnosticInputDescriptor,
 };
 use crate::typed_query_store::{
     AbortedQueryReason, AttemptExecution as QueryAttemptExecution, AttemptView,
@@ -1413,8 +1413,13 @@ impl SemanticDependencyInputManifest {
     /// Durable candidates published by this successful dependency manifest.
     /// Production reuse consumes the session's last-successful canonical body
     /// baseline; this accessor exposes the same stable artifacts to planners.
-    pub fn durable_ordinary_bodies(&self) -> &[crate::DurableOrdinaryBody] {
+    #[cfg(test)]
+    pub(crate) fn durable_ordinary_bodies(&self) -> &[crate::DurableOrdinaryBody] {
         &self.durable_ordinary_bodies
+    }
+    /// Explicitly unstable equality status for durable-cache instrumentation.
+    pub fn unstable_durable_artifact_status(&self) -> crate::unstable::DurableArtifactStatus {
+        crate::unstable::DurableArtifactStatus::from_debug(&self.durable_ordinary_bodies)
     }
     pub fn body_dependency_blockers(&self) -> &[SemanticDependencyBlocker] {
         self.durable_body_candidate_state.blockers()
@@ -1434,8 +1439,13 @@ impl SemanticDependencyInputManifest {
             SemanticDefinitionUniverseState::Complete
         )
     }
-    pub fn work(&self) -> SemanticDependencyManifestWork {
+    #[cfg(test)]
+    pub(crate) fn work(&self) -> SemanticDependencyManifestWork {
         self.work
+    }
+    /// Return owned counters for unstable dependency-manifest instrumentation.
+    pub fn unstable_metrics(&self) -> crate::unstable::DependencyManifestMetrics {
+        crate::unstable::DependencyManifestMetrics::from_work(self.work)
     }
 
     fn surface_complete(&self, surface: SemanticDependencySurface) -> bool {
@@ -1508,10 +1518,10 @@ impl SemanticInvalidationPlan {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ImportGraphInputDescriptor {
-    pub sources: SourceRevision,
-    pub resolution: ModuleResolutionInputs,
-    pub std_dir: Option<Arc<str>>,
+pub(crate) struct ImportGraphInputDescriptor {
+    pub(crate) sources: SourceRevision,
+    pub(crate) resolution: ModuleResolutionInputs,
+    pub(crate) std_dir: Option<Arc<str>>,
 }
 
 #[derive(Debug, Clone)]
@@ -1522,7 +1532,7 @@ pub struct CanonicalImportGraphOutput {
 }
 
 impl CanonicalImportGraphOutput {
-    pub fn input(&self) -> &ImportGraphInputDescriptor {
+    pub(crate) fn input(&self) -> &ImportGraphInputDescriptor {
         &self.input
     }
     pub fn graph(&self) -> &CanonicalImportGraph {
@@ -1554,30 +1564,21 @@ pub struct DefinitionQueryRecord {
 pub struct CompilerSessionUpdate {
     result: Result<Arc<ParsedProgram>, CompileErrors>,
     work: ParsedModulesWork,
+    #[cfg(test)]
     invalidation: ParseInvalidationSummary,
     downstream_invalidated: bool,
     diagnostics: Arc<FrontendDiagnosticSnapshot>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ImportDiscoveryRevisionStatus {
+pub(crate) enum ImportDiscoveryRevisionStatus {
     Open,
     ClosedAttempted,
     ClosedValid,
 }
 
-/// Deliberate retained-state corruptions used only to prove the differential
-/// oracle detects missing dependency edges and stale reuse.
-#[doc(hidden)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DifferentialOracleFault {
-    Semantic,
-    Diagnostic,
-    Import,
-}
-
 #[derive(Debug, Clone)]
-pub struct ImportDiscoveryRevisionArtifact {
+pub(crate) struct ImportDiscoveryRevisionArtifact {
     status: ImportDiscoveryRevisionStatus,
     source_revision: SourceRevision,
     context: crate::ImportDiscoveryContext,
@@ -1593,16 +1594,16 @@ pub struct ImportDiscoveryRevisionArtifact {
 }
 
 impl ImportDiscoveryRevisionArtifact {
-    pub fn status(&self) -> ImportDiscoveryRevisionStatus {
+    pub(crate) fn status(&self) -> ImportDiscoveryRevisionStatus {
         self.status
     }
-    pub fn source_revision(&self) -> &SourceRevision {
+    pub(crate) fn source_revision(&self) -> &SourceRevision {
         &self.source_revision
     }
-    pub fn context(&self) -> &crate::ImportDiscoveryContext {
+    pub(crate) fn context(&self) -> &crate::ImportDiscoveryContext {
         &self.context
     }
-    pub fn snapshot(&self) -> &SourceSnapshot {
+    pub(crate) fn snapshot(&self) -> &SourceSnapshot {
         &self.snapshot
     }
     #[cfg(test)]
@@ -1610,28 +1611,29 @@ impl ImportDiscoveryRevisionArtifact {
         self.program.as_ref()
     }
     /// Exact parse work performed by this bounded discovery lifecycle.
-    pub fn parse_work(&self) -> ParsedModulesWork {
+    pub(crate) fn parse_work(&self) -> ParsedModulesWork {
         self.parse_work
     }
-    pub fn plan(&self) -> Option<&crate::ImportDiscoveryPlan> {
+    #[cfg(test)]
+    pub(crate) fn plan(&self) -> Option<&crate::ImportDiscoveryPlan> {
         self.plan.as_ref()
     }
-    pub fn ledger(&self) -> &crate::ImportObservationLedger {
+    pub(crate) fn ledger(&self) -> &crate::ImportObservationLedger {
         &self.ledger
     }
-    pub fn accepted_read_manifest(&self) -> &[crate::AcceptedReadManifestEntry] {
+    pub(crate) fn accepted_read_manifest(&self) -> &[crate::AcceptedReadManifestEntry] {
         &self.accepted_reads
     }
-    pub fn graph(&self) -> Option<&Arc<CanonicalImportGraphOutput>> {
+    pub(crate) fn graph(&self) -> Option<&Arc<CanonicalImportGraphOutput>> {
         self.graph.as_ref()
     }
-    pub fn diagnostics(&self) -> &CompileErrors {
+    pub(crate) fn diagnostics(&self) -> &CompileErrors {
         &self.diagnostics
     }
     /// Revision-labeled canonical diagnostic batch for this attempted import
     /// revision. An ordinary open iteration has none; an I/O/policy failure
     /// publishes its batch without pretending that a graph closed.
-    pub fn diagnostic_snapshot(&self) -> Option<&Arc<FrontendDiagnosticSnapshot>> {
+    pub(crate) fn diagnostic_snapshot(&self) -> Option<&Arc<FrontendDiagnosticSnapshot>> {
         self.diagnostic_snapshot.as_ref()
     }
 }
@@ -1643,10 +1645,16 @@ impl CompilerSessionUpdate {
     pub fn into_result(self) -> Result<Arc<ParsedProgram>, CompileErrors> {
         self.result
     }
-    pub fn work(&self) -> ParsedModulesWork {
+    #[cfg(test)]
+    pub(crate) fn work(&self) -> ParsedModulesWork {
         self.work
     }
-    pub fn invalidation(&self) -> &ParseInvalidationSummary {
+    /// Return the explicitly unstable parse-work metrics for this update.
+    pub fn unstable_metrics(&self) -> crate::unstable::ParseMetrics {
+        crate::unstable::ParseMetrics::from_work(self.work)
+    }
+    #[cfg(test)]
+    pub(crate) fn invalidation(&self) -> &ParseInvalidationSummary {
         &self.invalidation
     }
     pub fn downstream_invalidated(&self) -> bool {
@@ -1659,6 +1667,7 @@ impl CompilerSessionUpdate {
 
 #[derive(Debug, Default)]
 pub struct CompilerSession {
+    identity: Arc<()>,
     /// Protocol context only while the typed import-closure query is open.
     /// Closed attempts live exclusively in their plan or closure terminal.
     open_discovery: Option<Arc<ImportDiscoveryRevisionArtifact>>,
@@ -1870,7 +1879,7 @@ impl TypedQueryFamily for ParseQuery {
                 Err(_) => true,
             }
             && record.diagnostics.source_revision() == &record.key.source.revision
-            && record.diagnostics.stage() == &FrontendDiagnosticStage::Syntax
+            && record.diagnostics.identity() == &FrontendDiagnosticIdentity::Syntax
             && record.diagnostics.provenance == record.key.presentation
     }
 }
@@ -2104,7 +2113,7 @@ impl TypedQueryFamily for MergeQuery {
         };
         artifact_matches
             && record.diagnostics.source_revision() == &record.key.source.revision
-            && record.diagnostics.stage() == &FrontendDiagnosticStage::Merge
+            && record.diagnostics.identity() == &FrontendDiagnosticIdentity::Merge
     }
 }
 
@@ -2173,8 +2182,8 @@ impl TypedQueryFamily for RirQuery {
             Ok(output) => output.source_revision() == &record.key.source,
             Err(_) => true,
         }) && record.diagnostics.source_revision() == &record.key.source
-            && record.diagnostics.stage()
-                == &FrontendDiagnosticStage::Rir(record.key.source.clone())
+            && record.diagnostics.identity()
+                == &FrontendDiagnosticIdentity::Rir(record.key.source.clone())
             && record
                 .merged
                 .as_ref()
@@ -2224,7 +2233,8 @@ impl TypedQueryFamily for ImportDiagnosticQuery {
 
     fn record_is_consistent(record: &Self::Record) -> bool {
         record.diagnostics.source_revision() == record.key.source_revision()
-            && record.diagnostics.stage() == &FrontendDiagnosticStage::Import(record.key.clone())
+            && record.diagnostics.identity()
+                == &FrontendDiagnosticIdentity::Import(record.key.clone())
     }
 }
 
@@ -2296,14 +2306,14 @@ impl TypedQueryFamily for SemanticQuery {
             Ok(output) => output.input() == &record.key.input,
             Err(_) => true,
         };
-        let expected_stage = FrontendDiagnosticStage::Semantic(semantic_diagnostic_input(
+        let expected_stage = FrontendDiagnosticIdentity::Semantic(semantic_diagnostic_input(
             &record.key.input,
             record.key.imports.clone(),
         ));
         record.key.input.semantic.sources.root() == record.key.imports.root()
             && (artifact_matches || record.oracle_injected)
             && record.diagnostics.source_revision() == &record.key.input.semantic.sources
-            && record.diagnostics.stage() == &expected_stage
+            && record.diagnostics.identity() == &expected_stage
     }
 }
 
@@ -2563,9 +2573,12 @@ impl CompilerSession {
     /// oracle. This is deliberately typed and narrow; production callers have
     /// no reason to use it.
     #[doc(hidden)]
-    pub fn inject_stale_query_for_oracle(&mut self, fault: DifferentialOracleFault) -> bool {
+    pub fn inject_stale_query_for_oracle(
+        &mut self,
+        fault: crate::unstable::DifferentialOracleFault,
+    ) -> bool {
         match fault {
-            DifferentialOracleFault::Semantic => {
+            crate::unstable::DifferentialOracleFault::Semantic => {
                 let records = self.queries.semantic.records().cloned().collect::<Vec<_>>();
                 let Some(current) = records.last().cloned() else {
                     return false;
@@ -2591,7 +2604,7 @@ impl CompilerSession {
                 );
                 true
             }
-            DifferentialOracleFault::Diagnostic => {
+            crate::unstable::DifferentialOracleFault::Diagnostic => {
                 let Some(latest) = self.diagnostics.latest().cloned() else {
                     return false;
                 };
@@ -2610,7 +2623,7 @@ impl CompilerSession {
                 self.diagnostics.select_snapshot(&stale);
                 true
             }
-            DifferentialOracleFault::Import => {
+            crate::unstable::DifferentialOracleFault::Import => {
                 let Some(current) = self
                     .queries
                     .import_closures
@@ -2836,7 +2849,23 @@ impl CompilerSession {
         })?;
         crate::ImportDiscoveryPlan::new(program, context)
     }
-    pub fn discovery_attempt(&self) -> Option<&Arc<ImportDiscoveryRevisionArtifact>> {
+    #[cfg(not(test))]
+    pub fn discovery_attempt(&self) -> Option<Arc<crate::unstable::ImportDiscoveryRevision>> {
+        self.discovery_attempt_artifact().map(|artifact| {
+            Arc::new(crate::unstable::ImportDiscoveryRevision::new(
+                artifact.clone(),
+            ))
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn discovery_attempt(&self) -> Option<&Arc<ImportDiscoveryRevisionArtifact>> {
+        self.discovery_attempt_artifact()
+    }
+
+    pub(crate) fn discovery_attempt_artifact(
+        &self,
+    ) -> Option<&Arc<ImportDiscoveryRevisionArtifact>> {
         self.open_discovery
             .as_ref()
             .or_else(|| {
@@ -2852,7 +2881,23 @@ impl CompilerSession {
                     .map(|record| &record.artifact)
             })
     }
-    pub fn last_good_discovery(&self) -> Option<&Arc<ImportDiscoveryRevisionArtifact>> {
+    #[cfg(not(test))]
+    pub fn last_good_discovery(&self) -> Option<Arc<crate::unstable::ImportDiscoveryRevision>> {
+        self.last_good_discovery_artifact().map(|artifact| {
+            Arc::new(crate::unstable::ImportDiscoveryRevision::new(
+                artifact.clone(),
+            ))
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn last_good_discovery(&self) -> Option<&Arc<ImportDiscoveryRevisionArtifact>> {
+        self.last_good_discovery_artifact()
+    }
+
+    pub(crate) fn last_good_discovery_artifact(
+        &self,
+    ) -> Option<&Arc<ImportDiscoveryRevisionArtifact>> {
         self.queries
             .import_closures
             .last_good_record()
@@ -2864,7 +2909,20 @@ impl CompilerSession {
     /// Downstream compilation must consume this artifact (or queries that
     /// delegate to it), rather than reconstructing import or standard-library
     /// resolution from the source snapshot alone.
-    pub fn committed_import_discovery(&self) -> Option<&Arc<ImportDiscoveryRevisionArtifact>> {
+    #[cfg(not(test))]
+    pub fn committed_import_discovery(
+        &self,
+    ) -> Option<Arc<crate::unstable::ImportDiscoveryRevision>> {
+        self.committed_import_discovery_artifact().map(|artifact| {
+            Arc::new(crate::unstable::ImportDiscoveryRevision::new(
+                artifact.clone(),
+            ))
+        })
+    }
+
+    pub(crate) fn committed_import_discovery_artifact(
+        &self,
+    ) -> Option<&Arc<ImportDiscoveryRevisionArtifact>> {
         let source = self.published.as_ref()?.source_revision();
         self.queries
             .import_closures
@@ -2876,7 +2934,7 @@ impl CompilerSession {
     /// Return the canonical graph and captured resolution context adopted for
     /// the current compiler revision.
     pub fn committed_import_graph(&self) -> Result<Arc<CanonicalImportGraphOutput>, CompileErrors> {
-        let committed = self.committed_import_discovery().ok_or_else(|| {
+        let committed = self.committed_import_discovery_artifact().ok_or_else(|| {
             CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
                 "no closed-valid import discovery revision is committed".into(),
             )))
@@ -2918,7 +2976,7 @@ impl CompilerSession {
         execution: &mut QueryAttemptExecution,
         origin: &mut Option<AttemptId>,
     ) -> Result<Arc<FrontendDiagnosticSnapshot>, CompileErrors> {
-        let diagnostics = if let Some(attempt) = self.discovery_attempt() {
+        let diagnostics = if let Some(attempt) = self.discovery_attempt_artifact() {
             let diagnostics = attempt.diagnostic_snapshot.as_ref().ok_or_else(|| {
                 CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
                     "open import discovery work has no canonical diagnostic batch".into(),
@@ -2956,7 +3014,7 @@ impl CompilerSession {
                 guard.started();
                 let diagnostics = self.publish_diagnostics(
                     &source,
-                    FrontendDiagnosticStage::Import(input.clone()),
+                    FrontendDiagnosticIdentity::Import(input.clone()),
                     Some(&errors),
                     &[],
                 );
@@ -3197,7 +3255,24 @@ impl CompilerSession {
     /// Close the current staging revision. Missing, ambiguous, and malformed
     /// imports retain a closed attempted artifact; only a diagnostic-free graph
     /// is atomically adopted as the committed compiler revision.
+    #[cfg(not(test))]
     pub fn close_import_discovery(
+        &mut self,
+        ledger: crate::ImportObservationLedger,
+    ) -> Result<Arc<crate::unstable::ImportDiscoveryRevision>, CompileErrors> {
+        self.close_import_discovery_artifact(ledger)
+            .map(|artifact| Arc::new(crate::unstable::ImportDiscoveryRevision::new(artifact)))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn close_import_discovery(
+        &mut self,
+        ledger: crate::ImportObservationLedger,
+    ) -> Result<Arc<ImportDiscoveryRevisionArtifact>, CompileErrors> {
+        self.close_import_discovery_artifact(ledger)
+    }
+
+    fn close_import_discovery_artifact(
         &mut self,
         ledger: crate::ImportObservationLedger,
     ) -> Result<Arc<ImportDiscoveryRevisionArtifact>, CompileErrors> {
@@ -3430,7 +3505,7 @@ impl CompilerSession {
 
     fn require_closed_discovery(&self) -> Result<(), CompileErrors> {
         if self
-            .discovery_attempt()
+            .discovery_attempt_artifact()
             .is_some_and(|attempt| attempt.status != ImportDiscoveryRevisionStatus::ClosedValid)
         {
             return Err(CompileErrors::from(CompileError::without_span(
@@ -3442,8 +3517,15 @@ impl CompilerSession {
         }
         Ok(())
     }
-    pub fn work(&self) -> &CompilerSessionWork {
+    pub(crate) fn work(&self) -> &CompilerSessionWork {
         self.metrics.work()
+    }
+    /// Return an owned snapshot of explicitly unstable compiler metrics.
+    ///
+    /// The snapshot cannot be installed back into this or another session and
+    /// therefore grants no access to query ownership or invalidation state.
+    pub fn unstable_metrics(&self) -> crate::unstable::MetricsSnapshot {
+        crate::unstable::MetricsSnapshot::new(self.metrics.work().clone())
     }
     /// Diagnostic snapshot from the most recently attempted query, whether it
     /// succeeded or failed.
@@ -3469,10 +3551,11 @@ impl CompilerSession {
     /// public stage. When the current selection matches, this returns that
     /// exact batch; otherwise it returns the most recently indexed match.
     /// Clone the `Arc` when the artifact must outlive index eviction.
-    pub fn most_recent_diagnostics_for(
+    #[cfg(test)]
+    pub(crate) fn most_recent_diagnostics_for(
         &self,
         source: &SourceSnapshot,
-        stage: &FrontendDiagnosticStage,
+        stage: &FrontendDiagnosticIdentity,
     ) -> Option<&Arc<FrontendDiagnosticSnapshot>> {
         self.diagnostics.find(source, stage)
     }
@@ -3482,10 +3565,11 @@ impl CompilerSession {
     /// This is not an exact lookup when canonical and presentation provenance
     /// share a public stage; it follows the selection contract documented by
     /// `most_recent_diagnostics_for`.
-    pub fn diagnostics_for(
+    #[cfg(test)]
+    pub(crate) fn diagnostics_for(
         &self,
         source: &SourceSnapshot,
-        stage: &FrontendDiagnosticStage,
+        stage: &FrontendDiagnosticIdentity,
     ) -> Option<&Arc<FrontendDiagnosticSnapshot>> {
         self.most_recent_diagnostics_for(source, stage)
     }
@@ -3493,27 +3577,27 @@ impl CompilerSession {
     fn publish_diagnostics(
         &mut self,
         source: &SourceSnapshot,
-        stage: FrontendDiagnosticStage,
+        stage: FrontendDiagnosticIdentity,
         errors: Option<&CompileErrors>,
         warnings: &[CompileWarning],
     ) -> Arc<FrontendDiagnosticSnapshot> {
         let provenance = match &stage {
-            FrontendDiagnosticStage::Syntax => self
+            FrontendDiagnosticIdentity::Syntax => self
                 .batch_diagnostic_order
                 .as_ref()
                 .map_or(DiagnosticAttemptProvenance::Canonical, |order| {
                     DiagnosticAttemptProvenance::Presentation(order.clone().into())
                 }),
-            FrontendDiagnosticStage::Merge if errors.is_some() => self
+            FrontendDiagnosticIdentity::Merge if errors.is_some() => self
                 .batch_diagnostic_order
                 .as_ref()
                 .map_or(DiagnosticAttemptProvenance::Canonical, |order| {
                     DiagnosticAttemptProvenance::Presentation(order.clone().into())
                 }),
-            FrontendDiagnosticStage::Merge => DiagnosticAttemptProvenance::Canonical,
-            FrontendDiagnosticStage::Import(_)
-            | FrontendDiagnosticStage::Rir(_)
-            | FrontendDiagnosticStage::Semantic(_) => DiagnosticAttemptProvenance::Canonical,
+            FrontendDiagnosticIdentity::Merge => DiagnosticAttemptProvenance::Canonical,
+            FrontendDiagnosticIdentity::Import(_)
+            | FrontendDiagnosticIdentity::Rir(_)
+            | FrontendDiagnosticIdentity::Semantic(_) => DiagnosticAttemptProvenance::Canonical,
         };
         if let Some(existing) = self
             .diagnostics
@@ -3565,7 +3649,7 @@ impl CompilerSession {
         };
         self.publish_diagnostics(
             source,
-            FrontendDiagnosticStage::Import(input),
+            FrontendDiagnosticIdentity::Import(input),
             Some(errors),
             &[],
         )
@@ -3800,7 +3884,7 @@ impl CompilerSession {
         } else {
             self.publish_diagnostics(
                 snapshot,
-                FrontendDiagnosticStage::Syntax,
+                FrontendDiagnosticIdentity::Syntax,
                 result.as_ref().err(),
                 &[],
             )
@@ -3988,7 +4072,7 @@ impl CompilerSession {
         } else {
             self.publish_diagnostics(
                 snapshot,
-                FrontendDiagnosticStage::Syntax,
+                FrontendDiagnosticIdentity::Syntax,
                 result.as_ref().err(),
                 &[],
             )
@@ -4041,6 +4125,7 @@ impl CompilerSession {
                     CompilerSessionUpdate {
                         result: Ok(self.published.as_ref().unwrap().clone()),
                         work: parse_work,
+                        #[cfg(test)]
                         invalidation,
                         downstream_invalidated: false,
                         diagnostics,
@@ -4057,6 +4142,7 @@ impl CompilerSession {
                     CompilerSessionUpdate {
                         result: Ok(candidate),
                         work: parse_work,
+                        #[cfg(test)]
                         invalidation,
                         downstream_invalidated,
                         diagnostics,
@@ -4066,6 +4152,7 @@ impl CompilerSession {
             Err(errors) => CompilerSessionUpdate {
                 result: Err(errors),
                 work: parse_work,
+                #[cfg(test)]
                 invalidation,
                 downstream_invalidated: false,
                 diagnostics,
@@ -4108,7 +4195,7 @@ impl CompilerSession {
         execution: &mut QueryAttemptExecution,
     ) -> Result<Arc<CanonicalImportGraphOutput>, CompileErrors> {
         self.require_closed_discovery()?;
-        if let Some(committed) = self.committed_import_discovery() {
+        if let Some(committed) = self.committed_import_discovery_artifact() {
             let graph = committed
                 .graph()
                 .expect("closed-valid discovery revisions retain their canonical graph");
@@ -4374,7 +4461,7 @@ impl CompilerSession {
             .expect("published program retains source snapshot");
         let diagnostics = self.publish_diagnostics(
             &source,
-            FrontendDiagnosticStage::Merge,
+            FrontendDiagnosticIdentity::Merge,
             merged.as_ref().err(),
             &[],
         );
@@ -4494,7 +4581,7 @@ impl CompilerSession {
             .expect("RIR query retains its exact source snapshot");
         let diagnostics = Arc::new(FrontendDiagnosticSnapshot {
             source: source_snapshot,
-            stage: FrontendDiagnosticStage::Rir(source.clone()),
+            stage: FrontendDiagnosticIdentity::Rir(source.clone()),
             provenance: DiagnosticAttemptProvenance::Canonical,
             errors: result
                 .as_ref()
@@ -4679,7 +4766,7 @@ impl CompilerSession {
                 *attempt_record = Some(record);
                 let diagnostics = self.publish_diagnostics(
                     &source,
-                    FrontendDiagnosticStage::Semantic(semantic_diagnostic_input(
+                    FrontendDiagnosticIdentity::Semantic(semantic_diagnostic_input(
                         &input,
                         imports.clone(),
                     )),
@@ -5012,7 +5099,7 @@ impl CompilerSession {
         let diagnostic_input = semantic_diagnostic_input(&input, imports.clone());
         let diagnostics = self.publish_diagnostics(
             &source,
-            FrontendDiagnosticStage::Semantic(diagnostic_input),
+            FrontendDiagnosticIdentity::Semantic(diagnostic_input),
             result.as_ref().err(),
             result
                 .as_ref()
@@ -5357,7 +5444,7 @@ impl CompilerSession {
     /// flags and stable blockers make incomplete capture fail closed. The query
     /// shares the import and stable-definition inputs and performs no additional
     /// RIR traversal.
-    pub fn semantic_dependency_inputs(
+    pub(crate) fn semantic_dependency_inputs(
         &mut self,
         options: &CompileOptions,
         std_dir: Option<&str>,
@@ -5420,6 +5507,18 @@ impl CompilerSession {
         guard.finish(execution, origin, &result, structural);
         self.metrics.synchronize();
         result
+    }
+
+    pub fn unstable_dependency_baseline(
+        &mut self,
+        options: &CompileOptions,
+        std_dir: Option<&str>,
+    ) -> Result<Arc<crate::unstable::DependencyBaseline>, CompileErrors> {
+        self.semantic_dependency_inputs(options, std_dir)
+            .map(|manifest| {
+                crate::unstable::DependencyBaseline::new(manifest, self.identity.clone())
+            })
+            .map(Arc::new)
     }
 
     fn semantic_dependency_inputs_attempt(
@@ -6405,7 +6504,7 @@ impl CompilerSession {
     /// Supported production manifests with complete dependency capture can produce
     /// an incremental invalidation plan. Unsupported dependency surfaces, incomplete
     /// capture, and global semantic-input changes fail closed to full invalidation.
-    pub fn semantic_invalidation_plan(
+    pub(crate) fn semantic_invalidation_plan(
         &mut self,
         previous: &Arc<SemanticDependencyInputManifest>,
         current: &Arc<SemanticDependencyInputManifest>,
@@ -6470,6 +6569,22 @@ impl CompilerSession {
         guard.finish(execution, origin, &Ok::<(), ()>(()), structural);
         self.metrics.synchronize();
         plan
+    }
+
+    pub fn unstable_invalidation_metrics(
+        &mut self,
+        previous: &crate::unstable::DependencyBaseline,
+        current: &crate::unstable::DependencyBaseline,
+    ) -> Result<crate::unstable::InvalidationMetrics, CompileErrors> {
+        if !previous.belongs_to(&self.identity) || !current.belongs_to(&self.identity) {
+            return Err(CompileErrors::from(CompileError::without_span(
+                ErrorKind::InvalidCompilerInput(
+                    "dependency baselines belong to a different compiler session".into(),
+                ),
+            )));
+        }
+        let plan = self.semantic_invalidation_plan(&previous.inner, &current.inner);
+        Ok(crate::unstable::InvalidationMetrics::from_plan(&plan))
     }
 }
 
@@ -8281,8 +8396,8 @@ mod tests {
             &diagnostics
         ));
         assert!(matches!(
-            session.latest_diagnostics().unwrap().stage(),
-            FrontendDiagnosticStage::Rir(_)
+            session.latest_diagnostics().unwrap().identity(),
+            FrontendDiagnosticIdentity::Rir(_)
         ));
         assert!(session.queries.merge.len() > merge_terminals);
         assert!(session.queries.rir.len() > rir_terminals);
@@ -8355,7 +8470,7 @@ mod tests {
             );
             let snapshot = Arc::new(FrontendDiagnosticSnapshot {
                 source,
-                stage: FrontendDiagnosticStage::Syntax,
+                stage: FrontendDiagnosticIdentity::Syntax,
                 provenance: DiagnosticAttemptProvenance::Canonical,
                 errors: Arc::from([]),
                 warnings: Arc::from([]),
@@ -10414,7 +10529,7 @@ mod tests {
         let failed_source = session.published_snapshot.clone().unwrap();
         let failed_diagnostics = session.publish_diagnostics(
             &failed_source,
-            FrontendDiagnosticStage::Semantic(semantic_diagnostic_input(
+            FrontendDiagnosticIdentity::Semantic(semantic_diagnostic_input(
                 &failed_input,
                 failed_imports.clone(),
             )),
@@ -12572,7 +12687,7 @@ mod tests {
         assert!(Arc::ptr_eq(session.published().unwrap(), &published));
         assert!(Arc::ptr_eq(
             session
-                .diagnostics_for(&syntax_bad, &FrontendDiagnosticStage::Syntax)
+                .diagnostics_for(&syntax_bad, &FrontendDiagnosticIdentity::Syntax)
                 .unwrap(),
             &syntax_diagnostics
         ));
@@ -12597,7 +12712,7 @@ mod tests {
                 .map(ToString::to_string)
                 .collect::<Vec<_>>()
         );
-        let FrontendDiagnosticStage::Semantic(input) = first.stage() else {
+        let FrontendDiagnosticIdentity::Semantic(input) = first.identity() else {
             panic!("semantic diagnostic stage");
         };
         assert_eq!(input.opt_level(), crate::StableOptLevel::O0);
@@ -12666,7 +12781,10 @@ mod tests {
         session.merge().unwrap_err();
         let second = session.latest_diagnostics().unwrap().clone();
         assert!(Arc::ptr_eq(&first, &second));
-        assert!(matches!(first.stage(), FrontendDiagnosticStage::Merge));
+        assert!(matches!(
+            first.identity(),
+            FrontendDiagnosticIdentity::Merge
+        ));
         assert_eq!(session.work().merge.executions, 1);
         assert_eq!(session.work().diagnostic_reuses, 1);
     }
@@ -12680,7 +12798,7 @@ mod tests {
         evict_diagnostic_index(&mut session);
         assert!(
             session
-                .most_recent_diagnostics_for(&source, &FrontendDiagnosticStage::Syntax)
+                .most_recent_diagnostics_for(&source, &FrontendDiagnosticIdentity::Syntax)
                 .is_none()
         );
         let publications = session.work().diagnostic_publications;
@@ -12698,7 +12816,7 @@ mod tests {
         assert_eq!(session.work().diagnostic_reuses, reuses + 1);
         assert!(Arc::ptr_eq(
             session
-                .most_recent_diagnostics_for(&source, &FrontendDiagnosticStage::Syntax)
+                .most_recent_diagnostics_for(&source, &FrontendDiagnosticIdentity::Syntax)
                 .unwrap(),
             &origin
         ));
@@ -12716,7 +12834,7 @@ mod tests {
         evict_diagnostic_index(&mut session);
         assert!(
             session
-                .most_recent_diagnostics_for(&source, &FrontendDiagnosticStage::Syntax)
+                .most_recent_diagnostics_for(&source, &FrontendDiagnosticIdentity::Syntax)
                 .is_none()
         );
         let publications = session.work().diagnostic_publications;
@@ -12734,7 +12852,7 @@ mod tests {
         assert_eq!(session.work().diagnostic_reuses, reuses + 1);
         assert!(Arc::ptr_eq(
             session
-                .most_recent_diagnostics_for(&source, &FrontendDiagnosticStage::Syntax)
+                .most_recent_diagnostics_for(&source, &FrontendDiagnosticIdentity::Syntax)
                 .unwrap(),
             &origin
         ));
@@ -12786,7 +12904,7 @@ mod tests {
         evict_diagnostic_index(&mut session);
         assert!(
             session
-                .most_recent_diagnostics_for(&source, &FrontendDiagnosticStage::Merge)
+                .most_recent_diagnostics_for(&source, &FrontendDiagnosticIdentity::Merge)
                 .is_none()
         );
         let publications = session.work().diagnostic_publications;
@@ -12801,7 +12919,7 @@ mod tests {
         assert_eq!(session.work().diagnostic_reuses, reuses + 1);
         assert!(Arc::ptr_eq(
             session
-                .most_recent_diagnostics_for(&source, &FrontendDiagnosticStage::Merge)
+                .most_recent_diagnostics_for(&source, &FrontendDiagnosticIdentity::Merge)
                 .unwrap(),
             &origin
         ));
@@ -12813,7 +12931,7 @@ mod tests {
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
         let origin = session.import_diagnostics().unwrap();
-        let stage = origin.stage().clone();
+        let stage = origin.identity().clone();
 
         evict_diagnostic_index(&mut session);
         assert!(
@@ -12850,7 +12968,7 @@ mod tests {
         session.update(&source).into_result().unwrap();
         let first_errors = session.semantic(&options).unwrap_err();
         let origin = session.latest_diagnostics().unwrap().clone();
-        let stage = origin.stage().clone();
+        let stage = origin.identity().clone();
 
         evict_diagnostic_index(&mut session);
         assert!(
@@ -12946,10 +13064,10 @@ fn main() -> i32 { selected.value() }"#,
         let diagnostics_b = session.latest_diagnostics().unwrap().clone();
 
         assert!(!Arc::ptr_eq(&diagnostics_a, &diagnostics_b));
-        let FrontendDiagnosticStage::Semantic(input_a) = diagnostics_a.stage() else {
+        let FrontendDiagnosticIdentity::Semantic(input_a) = diagnostics_a.identity() else {
             panic!("semantic diagnostics");
         };
-        let FrontendDiagnosticStage::Semantic(input_b) = diagnostics_b.stage() else {
+        let FrontendDiagnosticIdentity::Semantic(input_b) = diagnostics_b.identity() else {
             panic!("semantic diagnostics");
         };
         assert_eq!(input_a.program().imports(), &graph_a);
@@ -13022,7 +13140,7 @@ fn main() -> i32 { selected.value() }"#,
                 session
                     .diagnostics_for(
                         &valid,
-                        &FrontendDiagnosticStage::Semantic(semantic_diagnostic_input(
+                        &FrontendDiagnosticIdentity::Semantic(semantic_diagnostic_input(
                             recovered.input(),
                             session.accepted_semantic_import_graph().unwrap(),
                         ))
@@ -13040,7 +13158,7 @@ fn main() -> i32 { selected.value() }"#,
         );
         assert!(
             session
-                .diagnostics_for(&first_bad, &FrontendDiagnosticStage::Syntax)
+                .diagnostics_for(&first_bad, &FrontendDiagnosticIdentity::Syntax)
                 .is_none(),
             "unpinned old cache entry should be evicted"
         );

--- a/crates/rue-compiler/src/source_identity.rs
+++ b/crates/rue-compiler/src/source_identity.rs
@@ -12,7 +12,11 @@ use rue_error::{CompileError, CompileResult, ErrorKind, PreviewFeatures};
 use rue_target::Target;
 use sha2::{Digest, Sha256};
 
-use crate::{CompileOptions, LinkerMode, SourceMetadata, SourceSnapshot};
+#[cfg(test)]
+use crate::CompileOptions;
+#[cfg(test)]
+use crate::LinkerMode;
+use crate::{SourceMetadata, SourceSnapshot};
 
 const SOURCE_DOMAIN_V1: &[u8] = b"rue.source\0v1\0sha256\0";
 
@@ -470,10 +474,12 @@ impl From<OptLevel> for StableOptLevel {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg(test)]
 pub enum StableLinkerInput {
     Internal,
     System(Arc<str>),
 }
+#[cfg(test)]
 impl From<&LinkerMode> for StableLinkerInput {
     fn from(value: &LinkerMode) -> Self {
         match value {
@@ -505,10 +511,12 @@ pub struct CodegenInputDescriptor {
     pub opt_level: StableOptLevel,
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg(test)]
 pub struct LinkInputDescriptor {
     pub codegen: CodegenInputDescriptor,
     pub linker: StableLinkerInput,
 }
+#[cfg(test)]
 impl LinkInputDescriptor {
     pub fn from_compile_options(snapshot: &SourceSnapshot, options: &CompileOptions) -> Self {
         Self {

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1,0 +1,909 @@
+//! Explicitly unstable compiler instrumentation and test-support views.
+//!
+//! Nothing in this module is covered by the supported facade's compatibility
+//! policy. These owned snapshots and opaque session products cannot be
+//! installed into a session or used as query keys.
+
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+
+use crate::canonical_semantic::CanonicalSemanticFailurePhase as SemanticFailurePhase;
+
+/// Opaque equality status for session-owned durable artifacts.
+///
+/// The fingerprint is instrumentation, not a cache key or durable schema. It
+/// deliberately has no import/install operation.
+#[derive(Clone, PartialEq, Eq)]
+pub struct DurableArtifactStatus {
+    count: usize,
+    fingerprint: [u8; 32],
+}
+
+impl std::fmt::Debug for DurableArtifactStatus {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("DurableArtifactStatus")
+            .field("count", &self.count)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Owned dependency-manifest counters. No manifest records or cache payloads
+/// are retained by this snapshot.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DependencyManifestMetrics {
+    pub body_owner_events_translated: usize,
+    pub body_named_events_translated: usize,
+    pub body_dependency_records_built: usize,
+    pub extra_rir_instructions_visited: usize,
+    pub durable_bodies: DurableBodyMetrics,
+}
+
+/// Durable-body reuse counters without the durable cache records themselves.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
+pub struct DurableBodyMetrics {
+    pub candidate_comparisons: usize,
+    pub candidate_fallbacks: usize,
+    pub specialized_mapping_attempts: usize,
+    pub specialized_mapping_successes: usize,
+    pub specialized_mapping_failures: usize,
+    pub export_attempts: usize,
+    pub export_successes: usize,
+    pub export_rejections: usize,
+    pub instructions_exported: usize,
+    pub places_exported: usize,
+    pub strings_exported: usize,
+    pub conversion_attempts: usize,
+    pub conversion_completions: usize,
+    pub conversion_failures: usize,
+    pub stable_key_joins: usize,
+    pub finalization_attempts: usize,
+    pub finalization_completions: usize,
+    pub finalization_failures: usize,
+    pub projection_attempts: usize,
+    pub projection_completions: usize,
+    pub projection_failures: usize,
+    pub instructions_projected: usize,
+    pub places_projected: usize,
+    pub strings_projected: usize,
+    pub import_attempts: usize,
+    pub import_successes: usize,
+    pub import_failures: usize,
+    pub installed_instructions: usize,
+    pub installed_places: usize,
+    pub installed_strings: usize,
+    pub atomic_discards: usize,
+    pub reused_bodies: usize,
+    pub skipped_body_analyses: usize,
+}
+
+impl From<crate::DurableBodyWork> for DurableBodyMetrics {
+    fn from(work: crate::DurableBodyWork) -> Self {
+        Self {
+            candidate_comparisons: work.candidate_comparisons,
+            candidate_fallbacks: work.candidate_fallbacks,
+            specialized_mapping_attempts: work.specialized_mapping_attempts,
+            specialized_mapping_successes: work.specialized_mapping_successes,
+            specialized_mapping_failures: work.specialized_mapping_failures,
+            export_attempts: work.export_attempts,
+            export_successes: work.export_successes,
+            export_rejections: work.export_rejections,
+            instructions_exported: work.instructions_exported,
+            places_exported: work.places_exported,
+            strings_exported: work.strings_exported,
+            conversion_attempts: work.conversion_attempts,
+            conversion_completions: work.conversion_completions,
+            conversion_failures: work.conversion_failures,
+            stable_key_joins: work.stable_key_joins,
+            finalization_attempts: work.finalization_attempts,
+            finalization_completions: work.finalization_completions,
+            finalization_failures: work.finalization_failures,
+            projection_attempts: work.projection_attempts,
+            projection_completions: work.projection_completions,
+            projection_failures: work.projection_failures,
+            instructions_projected: work.instructions_projected,
+            places_projected: work.places_projected,
+            strings_projected: work.strings_projected,
+            import_attempts: work.import_attempts,
+            import_successes: work.import_successes,
+            import_failures: work.import_failures,
+            installed_instructions: work.installed_instructions,
+            installed_places: work.installed_places,
+            installed_strings: work.installed_strings,
+            atomic_discards: work.atomic_discards,
+            reused_bodies: work.reused_bodies,
+            skipped_body_analyses: work.skipped_body_analyses,
+        }
+    }
+}
+
+impl DependencyManifestMetrics {
+    pub(crate) fn from_work(work: crate::session::SemanticDependencyManifestWork) -> Self {
+        let durable = work.durable_bodies;
+        Self {
+            body_owner_events_translated: work.body_owner_events_translated,
+            body_named_events_translated: work.body_named_events_translated,
+            body_dependency_records_built: work.body_dependency_records_built,
+            extra_rir_instructions_visited: work.extra_rir_instructions_visited,
+            durable_bodies: durable.into(),
+        }
+    }
+}
+
+impl DurableArtifactStatus {
+    pub fn count(&self) -> usize {
+        self.count
+    }
+
+    pub(crate) fn from_debug<T: std::fmt::Debug>(artifacts: &[T]) -> Self {
+        let mut hasher = Sha256::new();
+        for artifact in artifacts {
+            hasher.update(format!("{artifact:?}").as_bytes());
+            hasher.update([0]);
+        }
+        Self {
+            count: artifacts.len(),
+            fingerprint: hasher.finalize().into(),
+        }
+    }
+}
+
+/// Query lifecycle counters contained in [`MetricsSnapshot`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct QueryMetrics {
+    pub calls: usize,
+    pub executions: usize,
+    pub reuses: usize,
+}
+
+impl From<crate::session::FrontendQueryWork> for QueryMetrics {
+    fn from(work: crate::session::FrontendQueryWork) -> Self {
+        Self {
+            calls: work.calls,
+            executions: work.executions,
+            reuses: work.reuses,
+        }
+    }
+}
+
+/// Retention gauges contained in [`MetricsSnapshot`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RetentionMetrics {
+    pub diagnostic_entries: usize,
+    pub diagnostic_source_attempts: usize,
+    pub diagnostic_source_bytes: usize,
+    pub dependency_manifests: usize,
+    pub invalidation_plans: usize,
+}
+
+/// Merge counters used by the in-tree benchmark.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MergeMetrics {
+    pub definition_shards_indexed: usize,
+    pub definition_shards_reused: usize,
+    pub definition_shards_rebuilt: usize,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ParseMetrics {
+    pub lexer_invocations: usize,
+    pub parser_invocations: usize,
+    pub lexed_bytes: usize,
+    pub tokens: usize,
+    pub modules_considered: usize,
+    pub modules_reused: usize,
+    pub modules_rebound: usize,
+    pub modules_reparsed: usize,
+    pub source_text_clones: usize,
+    pub source_bytes_rehashed: usize,
+}
+
+impl ParseMetrics {
+    pub(crate) fn from_work(work: crate::ParsedModulesWork) -> Self {
+        Self {
+            lexer_invocations: work.syntax.lexer_invocations,
+            parser_invocations: work.syntax.parser_invocations,
+            lexed_bytes: work.syntax.lexed_bytes,
+            tokens: work.syntax.tokens,
+            modules_considered: work.modules_considered,
+            modules_reused: work.modules_reused,
+            modules_rebound: work.modules_rebound,
+            modules_reparsed: work.modules_reparsed,
+            source_text_clones: work.source_text_clones,
+            source_bytes_rehashed: work.source_bytes_rehashed,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LowerMetrics {
+    pub parser_invocations: usize,
+    pub ast_payload_clones: usize,
+}
+
+impl LowerMetrics {
+    pub(crate) fn from_work(work: crate::CanonicalRirWork) -> Self {
+        Self {
+            parser_invocations: work.parser_invocations,
+            ast_payload_clones: work.ast_payload_clones,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SemanticBindingMetrics {
+    pub bind_invocations: usize,
+}
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SemanticManifestMetrics {
+    pub build_invocations: usize,
+}
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SemanticCfgMetrics {
+    pub cfg_builds_attempted: usize,
+    pub cfg_builds_succeeded: usize,
+    pub cfg_builds_failed: usize,
+}
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SemanticMetrics {
+    pub binding: SemanticBindingMetrics,
+    pub manifest: SemanticManifestMetrics,
+    pub cfg: SemanticCfgMetrics,
+}
+
+impl SemanticMetrics {
+    pub(crate) fn from_work(work: crate::CanonicalSemanticWork) -> Self {
+        Self {
+            binding: SemanticBindingMetrics {
+                bind_invocations: work.binding.bind_invocations,
+            },
+            manifest: SemanticManifestMetrics {
+                build_invocations: work.manifest.build_invocations,
+            },
+            cfg: SemanticCfgMetrics {
+                cfg_builds_attempted: work.cfg.cfg_builds_attempted,
+                cfg_builds_succeeded: work.cfg.cfg_builds_succeeded,
+                cfg_builds_failed: work.cfg.cfg_builds_failed,
+            },
+        }
+    }
+}
+
+/// Metrics captured by the one-shot compilation adapter.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct OneShotMetrics {
+    pub files: usize,
+    pub bytes: usize,
+    pub lines: usize,
+    pub tokens: usize,
+    pub parsed: ParseMetrics,
+    pub lowered: LowerMetrics,
+    pub semantic: SemanticMetrics,
+}
+
+impl OneShotMetrics {
+    pub(crate) fn new(stats: crate::SourceStats, work: crate::PipelineWork) -> Self {
+        Self {
+            files: stats.files,
+            bytes: stats.bytes,
+            lines: stats.lines,
+            tokens: stats.tokens,
+            parsed: ParseMetrics::from_work(work.parsed),
+            lowered: LowerMetrics::from_work(work.lowered),
+            semantic: SemanticMetrics::from_work(work.semantic),
+        }
+    }
+}
+
+/// Owned compiler metrics snapshot with query records and inputs projected out.
+#[derive(Debug, Clone)]
+pub struct MetricsSnapshot {
+    inner: crate::session::CompilerSessionWork,
+}
+
+impl MetricsSnapshot {
+    pub(crate) fn new(inner: crate::session::CompilerSessionWork) -> Self {
+        Self { inner }
+    }
+    pub fn updates(&self) -> usize {
+        self.inner.updates
+    }
+    pub fn merge(&self) -> QueryMetrics {
+        self.inner.merge.into()
+    }
+    pub fn rir(&self) -> QueryMetrics {
+        self.inner.rir.into()
+    }
+    pub fn semantic(&self) -> QueryMetrics {
+        self.inner.semantic.into()
+    }
+    pub fn definitions(&self) -> QueryMetrics {
+        self.inner.definitions.into()
+    }
+    pub fn dependency_manifests(&self) -> QueryMetrics {
+        self.inner.dependency_manifests.into()
+    }
+    pub fn invalidation_plans(&self) -> QueryMetrics {
+        self.inner.invalidation_plans.into()
+    }
+    pub fn downstream_invalidations(&self) -> usize {
+        self.inner.downstream_invalidations
+    }
+    pub fn semantic_entries_invalidated(&self) -> usize {
+        self.inner.semantic_entries_invalidated
+    }
+    pub fn definition_entries_invalidated(&self) -> usize {
+        self.inner.definition_entries_invalidated
+    }
+    pub fn declaration_reuse_plans(&self) -> usize {
+        self.inner.declaration_reuse_plans
+    }
+    pub fn durable_records_compared(&self) -> usize {
+        self.inner.durable_records_compared
+    }
+    pub fn durable_records_reused(&self) -> usize {
+        self.inner.durable_records_reused
+    }
+    pub fn ordinary_declaration_resolutions_skipped(&self) -> usize {
+        self.inner.ordinary_declaration_resolutions_skipped
+    }
+    pub fn durable_installs(&self) -> usize {
+        self.inner.durable_installs
+    }
+    pub fn declaration_reuse_fallbacks(&self) -> usize {
+        self.inner.declaration_reuse_fallbacks
+    }
+    pub fn semantic_record_count(&self) -> usize {
+        self.inner.semantic_records.len()
+    }
+    pub fn definition_record_count(&self) -> usize {
+        self.inner.definition_records.len()
+    }
+    pub fn merge_metrics(&self) -> MergeMetrics {
+        MergeMetrics {
+            definition_shards_indexed: self.inner.last_merge.definition_shards_indexed,
+            definition_shards_reused: self.inner.last_merge.definition_shards_reused,
+            definition_shards_rebuilt: self.inner.last_merge.definition_shards_rebuilt,
+        }
+    }
+    pub fn parse_metrics(&self) -> ParseMetrics {
+        ParseMetrics::from_work(self.inner.last_parse)
+    }
+    pub fn lower_metrics(&self) -> LowerMetrics {
+        LowerMetrics {
+            parser_invocations: self.inner.last_rir.parser_invocations,
+            ast_payload_clones: self.inner.last_rir.ast_payload_clones,
+        }
+    }
+    pub fn retention(&self) -> RetentionMetrics {
+        RetentionMetrics {
+            diagnostic_entries: self.inner.retention.diagnostic_entries,
+            diagnostic_source_attempts: self.inner.retention.diagnostic_source_attempts,
+            diagnostic_source_bytes: self.inner.retention.diagnostic_source_bytes,
+            dependency_manifests: self.inner.retention.dependency_manifests,
+            invalidation_plans: self.inner.retention.invalidation_plans,
+        }
+    }
+    pub fn semantic_work_json(&self, from: usize) -> Value {
+        semantic_work_json(&self.inner, from)
+    }
+    pub fn definition_work_json(&self, from: usize) -> Value {
+        definition_work_json(&self.inner, from)
+    }
+}
+
+fn semantic_work_json(work: &crate::session::CompilerSessionWork, from: usize) -> Value {
+    let records = &work.semantic_records[from..];
+    json!({
+        "failed_requests": records.iter().filter(|record| record.failure.is_some()).count(),
+        "failure_phases": {
+            "declaration": records.iter().filter(|record| matches!(record.failure.map(|failure| failure.phase), Some(SemanticFailurePhase::Declaration))).count(),
+            "body_analysis": records.iter().filter(|record| matches!(record.failure.map(|failure| failure.phase), Some(SemanticFailurePhase::BodyAnalysis))).count(),
+            "cfg_construction": records.iter().filter(|record| matches!(record.failure.map(|failure| failure.phase), Some(SemanticFailurePhase::CfgConstruction))).count(),
+        },
+        "bind_invocations": records.iter().map(|record| record.work.binding.bind_invocations).sum::<usize>(),
+        "declaration_resolution_invocations": records.iter().map(|record| record.work.binding.declaration_resolution_invocations).sum::<usize>(),
+        "declaration_resolution_failures": records.iter().map(|record| record.work.binding.declaration_resolution_failures).sum::<usize>(),
+        "body_readiness_finalization_invocations": records.iter().map(|record| record.work.binding.body_readiness_finalization_invocations).sum::<usize>(),
+        "body_free_function_lookups": records.iter().map(|record| record.work.body_analysis.free_function_record_lookups).sum::<usize>(),
+        "bodies_attempted": records.iter().map(|record| record.work.body_analysis.bodies_attempted).sum::<usize>(),
+        "bodies_succeeded": records.iter().map(|record| record.work.body_analysis.bodies_succeeded).sum::<usize>(),
+        "bodies_failed": records.iter().map(|record| record.work.body_analysis.bodies_failed).sum::<usize>(),
+        "air_instructions_produced": records.iter().map(|record| record.work.body_analysis.air_instructions_produced).sum::<usize>(),
+        "body_dependency_air_instructions_observed": records.iter().map(|record| record.work.body_analysis.body_dependency_air_instructions_observed).sum::<usize>(),
+        "local_strings_produced": records.iter().map(|record| record.work.body_analysis.local_strings_produced).sum::<usize>(),
+        "string_ids_remapped": records.iter().map(|record| record.work.body_analysis.string_ids_remapped).sum::<usize>(),
+        "specialization_air_instructions_scanned": records.iter().map(|record| record.work.body_analysis.specialization_air_instructions_scanned).sum::<usize>(),
+        "generic_calls_observed": records.iter().map(|record| record.work.body_analysis.generic_calls_observed).sum::<usize>(),
+        "specialization_requests_unique": records.iter().map(|record| record.work.body_analysis.specialization_requests_unique).sum::<usize>(),
+        "specialization_requests_duplicate": records.iter().map(|record| record.work.body_analysis.specialization_requests_duplicate).sum::<usize>(),
+        "specialization_rewrites": records.iter().map(|record| record.work.body_analysis.specialization_rewrites).sum::<usize>(),
+        "specialization_rounds": records.iter().map(|record| record.work.body_analysis.specialization_rounds).sum::<usize>(),
+        "specialization_driver_failures": records.iter().map(|record| record.work.body_analysis.specialization_driver_failures).sum::<usize>(),
+        "specialized_bodies_attempted": records.iter().map(|record| record.work.body_analysis.specialized_bodies_attempted).sum::<usize>(),
+        "specialized_bodies_succeeded": records.iter().map(|record| record.work.body_analysis.specialized_bodies_succeeded).sum::<usize>(),
+        "specialized_bodies_failed": records.iter().map(|record| record.work.body_analysis.specialized_bodies_failed).sum::<usize>(),
+        "durable_bodies": {
+            "candidate_comparisons": records.iter().map(|record| record.work.durable_bodies.candidate_comparisons).sum::<usize>(),
+            "candidate_fallbacks": records.iter().map(|record| record.work.durable_bodies.candidate_fallbacks).sum::<usize>(),
+            "specialized_mapping_attempts": records.iter().map(|record| record.work.durable_bodies.specialized_mapping_attempts).sum::<usize>(),
+            "specialized_mapping_successes": records.iter().map(|record| record.work.durable_bodies.specialized_mapping_successes).sum::<usize>(),
+            "specialized_mapping_failures": records.iter().map(|record| record.work.durable_bodies.specialized_mapping_failures).sum::<usize>(),
+            "export_attempts": records.iter().map(|record| record.work.durable_bodies.export_attempts).sum::<usize>(),
+            "export_successes": records.iter().map(|record| record.work.durable_bodies.export_successes).sum::<usize>(),
+            "export_rejections": records.iter().map(|record| record.work.durable_bodies.export_rejections).sum::<usize>(),
+            "instructions_exported": records.iter().map(|record| record.work.durable_bodies.instructions_exported).sum::<usize>(),
+            "places_exported": records.iter().map(|record| record.work.durable_bodies.places_exported).sum::<usize>(),
+            "strings_exported": records.iter().map(|record| record.work.durable_bodies.strings_exported).sum::<usize>(),
+            "conversion_attempts": records.iter().map(|record| record.work.durable_bodies.conversion_attempts).sum::<usize>(),
+            "conversion_completions": records.iter().map(|record| record.work.durable_bodies.conversion_completions).sum::<usize>(),
+            "conversion_failures": records.iter().map(|record| record.work.durable_bodies.conversion_failures).sum::<usize>(),
+            "finalization_attempts": records.iter().map(|record| record.work.durable_bodies.finalization_attempts).sum::<usize>(),
+            "finalization_completions": records.iter().map(|record| record.work.durable_bodies.finalization_completions).sum::<usize>(),
+            "finalization_failures": records.iter().map(|record| record.work.durable_bodies.finalization_failures).sum::<usize>(),
+            "stable_key_joins": records.iter().map(|record| record.work.durable_bodies.stable_key_joins).sum::<usize>(),
+            "projection_attempts": records.iter().map(|record| record.work.durable_bodies.projection_attempts).sum::<usize>(),
+            "projection_completions": records.iter().map(|record| record.work.durable_bodies.projection_completions).sum::<usize>(),
+            "projection_failures": records.iter().map(|record| record.work.durable_bodies.projection_failures).sum::<usize>(),
+            "instructions_projected": records.iter().map(|record| record.work.durable_bodies.instructions_projected).sum::<usize>(),
+            "places_projected": records.iter().map(|record| record.work.durable_bodies.places_projected).sum::<usize>(),
+            "strings_projected": records.iter().map(|record| record.work.durable_bodies.strings_projected).sum::<usize>(),
+            "import_attempts": records.iter().map(|record| record.work.durable_bodies.import_attempts).sum::<usize>(),
+            "import_successes": records.iter().map(|record| record.work.durable_bodies.import_successes).sum::<usize>(),
+            "import_failures": records.iter().map(|record| record.work.durable_bodies.import_failures).sum::<usize>(),
+            "installed_instructions": records.iter().map(|record| record.work.durable_bodies.installed_instructions).sum::<usize>(),
+            "installed_places": records.iter().map(|record| record.work.durable_bodies.installed_places).sum::<usize>(),
+            "installed_strings": records.iter().map(|record| record.work.durable_bodies.installed_strings).sum::<usize>(),
+            "atomic_discards": records.iter().map(|record| record.work.durable_bodies.atomic_discards).sum::<usize>(),
+            "reused_bodies": records.iter().map(|record| record.work.durable_bodies.reused_bodies).sum::<usize>(),
+            "skipped_body_analyses": records.iter().map(|record| record.work.durable_bodies.skipped_body_analyses).sum::<usize>(),
+        },
+        "cfg": {
+            "drop_glue_functions_synthesized": records.iter().map(|record| record.work.cfg.drop_glue_functions_synthesized).sum::<usize>(),
+            "functions_considered": records.iter().map(|record| record.work.cfg.functions_considered).sum::<usize>(),
+            "comptime_functions_filtered": records.iter().map(|record| record.work.cfg.comptime_functions_filtered).sum::<usize>(),
+            "builds_attempted": records.iter().map(|record| record.work.cfg.cfg_builds_attempted).sum::<usize>(),
+            "builds_succeeded": records.iter().map(|record| record.work.cfg.cfg_builds_succeeded).sum::<usize>(),
+            "builds_failed": records.iter().map(|record| record.work.cfg.cfg_builds_failed).sum::<usize>(),
+            "air_instructions_consumed": records.iter().map(|record| record.work.cfg.air_instructions_consumed).sum::<usize>(),
+            "optimization_attempts": records.iter().map(|record| record.work.cfg.optimization_attempts).sum::<usize>(),
+            "optimization_completions": records.iter().map(|record| record.work.cfg.optimization_completions).sum::<usize>(),
+            "optimized_level_attempts": records.iter().map(|record| record.work.cfg.optimized_level_attempts).sum::<usize>(),
+            "warnings_emitted": records.iter().map(|record| record.work.cfg.cfg_warnings_emitted).sum::<usize>(),
+            "implicit_destructor_targets_emitted": records.iter().map(|record| record.work.cfg.implicit_destructor_targets_emitted).sum::<usize>(),
+            "reuse_candidates": records.iter().map(|record| record.work.cfg.cfg_reuse_candidates).sum::<usize>(),
+            "import_attempts": records.iter().map(|record| record.work.cfg.cfg_import_attempts).sum::<usize>(),
+            "import_successes": records.iter().map(|record| record.work.cfg.cfg_import_successes).sum::<usize>(),
+            "import_failures": records.iter().map(|record| record.work.cfg.cfg_import_failures).sum::<usize>(),
+            "reuses": records.iter().map(|record| record.work.cfg.cfg_reuses).sum::<usize>(),
+            "fallbacks": records.iter().map(|record| record.work.cfg.cfg_fallbacks).sum::<usize>(),
+            "warnings_reused": records.iter().map(|record| record.work.cfg.cfg_warnings_reused).sum::<usize>(),
+            "implicit_destructor_targets_reused": records.iter().map(|record| record.work.cfg.implicit_destructor_targets_reused).sum::<usize>(),
+            "export_attempts": records.iter().map(|record| record.work.cfg.cfg_export_attempts).sum::<usize>(),
+            "export_successes": records.iter().map(|record| record.work.cfg.cfg_export_successes).sum::<usize>(),
+            "export_rejections": records.iter().map(|record| record.work.cfg.cfg_export_rejections).sum::<usize>(),
+        },
+        "ordinary_free_function_dependency_events": records.iter().map(|record| record.work.body_analysis.ordinary_free_function_dependency_events).sum::<usize>(),
+        "specialized_origin_records": records.iter().map(|record| record.work.body_analysis.specialized_origin_records).sum::<usize>(),
+        "specialized_free_function_dependency_events": records.iter().map(|record| record.work.body_analysis.specialized_free_function_dependency_events).sum::<usize>(),
+        "named_method_dependency_events": records.iter().map(|record| record.work.body_analysis.named_method_dependency_events).sum::<usize>(),
+        "named_destructor_dependency_events": records.iter().map(|record| record.work.body_analysis.named_destructor_dependency_events).sum::<usize>(),
+        "declaration_type_dependency_events": records.iter().map(|record| record.work.body_analysis.declaration_type_dependency_events).sum::<usize>(),
+        "declaration_type_call_head_dependency_events": records.iter().map(|record| record.work.body_analysis.declaration_type_call_head_dependency_events).sum::<usize>(),
+        "named_const_dependency_events": records.iter().map(|record| record.work.body_analysis.named_const_dependency_events).sum::<usize>(),
+        "manifest_build_invocations": records.iter().map(|record| record.work.manifest.build_invocations).sum::<usize>(),
+        "body_owner_tokens": {
+            "provisional_slots": records.iter().map(|record| record.work.body_owner_tokens.provisional_slots).sum::<usize>(),
+            "authoritative_slots": records.iter().map(|record| record.work.body_owner_tokens.authoritative_slots).sum::<usize>(),
+            "slots_validated": records.iter().map(|record| record.work.body_owner_tokens.slots_validated).sum::<usize>(),
+            "tokens_installed": records.iter().map(|record| record.work.body_owner_tokens.tokens_installed).sum::<usize>(),
+            "validation_failures": records.iter().map(|record| record.work.body_owner_tokens.validation_failures).sum::<usize>(),
+        },
+        "declaration_reuse": {
+            "plan_executions": records.iter().map(|record| record.work.declaration_reuse.plan_executions).sum::<usize>(),
+            "durable_records_compared": records.iter().map(|record| record.work.declaration_reuse.durable_records_compared).sum::<usize>(),
+            "durable_records_reused": records.iter().map(|record| record.work.declaration_reuse.durable_records_reused).sum::<usize>(),
+            "ordinary_declaration_resolutions_skipped": records.iter().map(|record| record.work.declaration_reuse.ordinary_declaration_resolutions_skipped).sum::<usize>(),
+            "install_invocations": records.iter().map(|record| record.work.declaration_reuse.install_invocations).sum::<usize>(),
+            "fallbacks": records.iter().map(|record| record.work.declaration_reuse.fallbacks).sum::<usize>(),
+            "semantic_epochs_started": records.iter().map(|record| record.work.declaration_reuse.semantic_epochs_started).sum::<usize>(),
+            "declaration_indexes_built": records.iter().map(|record| record.work.declaration_reuse.declaration_indexes_built).sum::<usize>(),
+            "shell_predeclaration_epochs": records.iter().map(|record| record.work.declaration_reuse.shell_predeclaration_epochs).sum::<usize>(),
+            "durable_cache_population_exports": records.iter().map(|record| record.work.declaration_reuse.durable_cache_population_exports).sum::<usize>(),
+            "fallback_epochs_started": records.iter().map(|record| record.work.declaration_reuse.fallback_epochs_started).sum::<usize>(),
+        },
+        "semantic_epochs_started": records.iter().map(|record| record.work.declaration_reuse.semantic_epochs_started).sum::<usize>(),
+        "declaration_indexes_built": records.iter().map(|record| record.work.declaration_reuse.declaration_indexes_built).sum::<usize>(),
+        "shell_predeclaration_epochs": records.iter().map(|record| record.work.declaration_reuse.shell_predeclaration_epochs).sum::<usize>(),
+        "durable_cache_population_exports": records.iter().map(|record| record.work.declaration_reuse.durable_cache_population_exports).sum::<usize>(),
+        "fallback_epochs_started": records.iter().map(|record| record.work.declaration_reuse.fallback_epochs_started).sum::<usize>(),
+    })
+}
+
+fn definition_work_json(work: &crate::session::CompilerSessionWork, from: usize) -> Value {
+    let records = &work.definition_records[from..];
+    json!({
+        "bind_invocations": records.iter().map(|record| record.binding.bind_invocations).sum::<usize>(),
+        "manifest_build_invocations": records.iter().map(|record| record.manifest.build_invocations).sum::<usize>(),
+        "manifest_bindings_visited": records.iter().map(|record| record.issuance.manifest_bindings_visited).sum::<usize>(),
+        "ids_issued": records.iter().map(|record| record.issuance.ids_issued).sum::<usize>(),
+    })
+}
+
+/// Opaque import-discovery product retained by the session.
+#[derive(Debug, Clone)]
+pub struct ImportDiscoveryRevision {
+    pub(crate) inner: Arc<crate::session::ImportDiscoveryRevisionArtifact>,
+}
+
+/// Read-only status of an import-discovery product.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportDiscoveryStatus {
+    Open,
+    ClosedAttempted,
+    ClosedValid,
+}
+
+impl ImportDiscoveryRevision {
+    #[cfg(not(test))]
+    pub(crate) fn new(inner: Arc<crate::session::ImportDiscoveryRevisionArtifact>) -> Self {
+        Self { inner }
+    }
+
+    pub fn status(&self) -> ImportDiscoveryStatus {
+        match self.inner.status() {
+            crate::session::ImportDiscoveryRevisionStatus::Open => ImportDiscoveryStatus::Open,
+            crate::session::ImportDiscoveryRevisionStatus::ClosedAttempted => {
+                ImportDiscoveryStatus::ClosedAttempted
+            }
+            crate::session::ImportDiscoveryRevisionStatus::ClosedValid => {
+                ImportDiscoveryStatus::ClosedValid
+            }
+        }
+    }
+
+    pub fn source_revision(&self) -> &crate::SourceRevision {
+        self.inner.source_revision()
+    }
+
+    pub fn diagnostics(&self) -> &crate::CompileErrors {
+        self.inner.diagnostics()
+    }
+
+    pub fn diagnostic_snapshot(&self) -> Option<&Arc<crate::FrontendDiagnosticSnapshot>> {
+        self.inner.diagnostic_snapshot()
+    }
+
+    pub fn unstable_metrics(&self) -> ParseMetrics {
+        ParseMetrics::from_work(self.inner.parse_work())
+    }
+
+    pub fn graph_input_debug(&self) -> Option<String> {
+        self.inner
+            .graph()
+            .map(|graph| format!("{:?}", graph.input()))
+    }
+
+    pub fn accepted_reads_debug(&self) -> String {
+        format!("{:?}", self.inner.accepted_read_manifest())
+    }
+
+    pub fn observation_ledger_debug(&self) -> String {
+        format!("{:?}", self.inner.ledger())
+    }
+}
+
+/// Deliberate fault selection for the differential incremental oracle.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DifferentialOracleFault {
+    Semantic,
+    Diagnostic,
+    Import,
+}
+
+/// Opaque dependency baseline used only by unstable invalidation benchmarks.
+#[derive(Debug, Clone)]
+pub struct DependencyBaseline {
+    pub(crate) inner: std::sync::Arc<crate::SemanticDependencyInputManifest>,
+    owner: Arc<()>,
+}
+
+impl DependencyBaseline {
+    pub(crate) fn new(
+        inner: std::sync::Arc<crate::SemanticDependencyInputManifest>,
+        owner: Arc<()>,
+    ) -> Self {
+        Self { inner, owner }
+    }
+    pub(crate) fn belongs_to(&self, owner: &Arc<()>) -> bool {
+        Arc::ptr_eq(&self.owner, owner)
+    }
+    pub fn unstable_metrics(&self) -> DependencyManifestMetrics {
+        self.inner.unstable_metrics()
+    }
+    pub fn unstable_durable_artifact_status(&self) -> DurableArtifactStatus {
+        self.inner.unstable_durable_artifact_status()
+    }
+    pub fn input(&self) -> String {
+        format!("{:?}", self.inner.input())
+    }
+    pub fn imports(&self) -> String {
+        format!("{:?}", self.inner.imports())
+    }
+    pub fn definitions(&self) -> String {
+        format!("{:?}", self.inner.definitions())
+    }
+    pub fn definition_fingerprints(&self) -> String {
+        format!("{:?}", self.inner.definition_fingerprints())
+    }
+    pub fn module_imports(&self) -> String {
+        format!("{:?}", self.inner.module_imports())
+    }
+    pub fn free_function_dependencies(&self) -> String {
+        format!("{:?}", self.inner.free_function_dependencies())
+    }
+    pub fn named_method_dependencies(&self) -> String {
+        format!("{:?}", self.inner.named_method_dependencies())
+    }
+    pub fn named_destructor_dependencies(&self) -> String {
+        format!("{:?}", self.inner.named_destructor_dependencies())
+    }
+    pub fn implicit_named_destructor_dependencies(&self) -> String {
+        format!("{:?}", self.inner.implicit_named_destructor_dependencies())
+    }
+    pub fn declaration_type_dependencies(&self) -> String {
+        format!("{:?}", self.inner.declaration_type_dependencies())
+    }
+    pub fn declaration_type_call_head_dependencies(&self) -> String {
+        format!("{:?}", self.inner.declaration_type_call_head_dependencies())
+    }
+    pub fn builtin_type_call_head_inputs(&self) -> String {
+        format!("{:?}", self.inner.builtin_type_call_head_inputs())
+    }
+    pub fn named_const_dependencies(&self) -> String {
+        format!("{:?}", self.inner.named_const_dependencies())
+    }
+    pub fn body_dependencies(&self) -> String {
+        format!("{:?}", self.inner.body_dependencies())
+    }
+    pub fn body_dependency_blockers(&self) -> String {
+        format!("{:?}", self.inner.body_dependency_blockers())
+    }
+    pub fn dependency_blockers(&self) -> String {
+        format!("{:?}", self.inner.dependency_blockers())
+    }
+    pub fn free_function_caller_dependencies_complete(&self) -> bool {
+        self.inner.free_function_caller_dependencies_complete()
+    }
+    pub fn non_generic_named_method_dependencies_complete(&self) -> bool {
+        self.inner.non_generic_named_method_dependencies_complete()
+    }
+    pub fn generic_named_method_dependencies_complete(&self) -> bool {
+        self.inner.generic_named_method_dependencies_complete()
+    }
+    pub fn named_destructor_dependencies_complete(&self) -> bool {
+        self.inner.named_destructor_dependencies_complete()
+    }
+    pub fn implicit_named_destructor_dependencies_complete(&self) -> bool {
+        self.inner.implicit_named_destructor_dependencies_complete()
+    }
+    pub fn declaration_type_dependencies_complete(&self) -> bool {
+        self.inner.declaration_type_dependencies_complete()
+    }
+    pub fn declaration_type_call_head_dependencies_complete(&self) -> bool {
+        self.inner
+            .declaration_type_call_head_dependencies_complete()
+    }
+    pub fn supported_type_call_heads_complete(&self) -> bool {
+        self.inner.supported_type_call_heads_complete()
+    }
+    pub fn named_value_const_dependencies_complete(&self) -> bool {
+        self.inner.named_value_const_dependencies_complete()
+    }
+    pub fn semantic_dependency_graph_complete(&self) -> bool {
+        self.inner.semantic_dependency_graph_complete()
+    }
+    pub fn definition_universe_complete(&self) -> bool {
+        self.inner.definition_universe_complete()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DependencySurface {
+    BodyOwner,
+    FreeFunctionCall,
+    NonGenericNamedMethodCall,
+    GenericNamedMethodCall,
+    NamedDestructorCall,
+    ImplicitNamedDestructor,
+    DeclarationType,
+    DeclarationTypeCallHead,
+    SupportedTypeCallHead,
+    NamedValueConst,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DependencyIncompleteReason {
+    AnonymousBodyOwnerUnavailable,
+    CallerEndpointUnavailable,
+    GenericSubstitutionIdentityUnavailable,
+    DestructorEndpointUnavailable,
+    AnonymousDropOwnerUnavailable,
+    ResolvedTypeIdentityUnavailable,
+    TypeCallHeadIdentityUnavailable,
+    UnsupportedDynamicTypeCallHead,
+    ConstEndpointUnavailable,
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DependencyBlocker {
+    owner: Option<String>,
+    surface: DependencySurface,
+    reason: DependencyIncompleteReason,
+}
+impl DependencyBlocker {
+    pub fn owner(&self) -> Option<&str> {
+        self.owner.as_deref()
+    }
+    pub fn surface(&self) -> DependencySurface {
+        self.surface
+    }
+    pub fn reason(&self) -> DependencyIncompleteReason {
+        self.reason
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FullInvalidationReason {
+    RootChanged,
+    ModuleImportsChanged,
+    TargetChanged,
+    PreviewFeaturesChanged,
+    IncompleteDefinitionUniverse,
+    IncompleteDependencyGraph(std::sync::Arc<[DependencyBlocker]>),
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InvalidationScope {
+    Full {
+        reasons: std::sync::Arc<[FullInvalidationReason]>,
+    },
+    Incremental,
+}
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct InvalidationWorkMetrics {
+    pub definition_fingerprints_compared: usize,
+    pub dependency_edges_visited: usize,
+    pub reverse_closure_nodes_visited: usize,
+    pub extra_rir_instructions_visited: usize,
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidationMetrics {
+    scope: InvalidationScope,
+    added: Vec<()>,
+    removed: Vec<()>,
+    changed: Vec<()>,
+    invalidated: Vec<()>,
+    reusable: Vec<()>,
+    work: InvalidationWorkMetrics,
+}
+impl InvalidationMetrics {
+    pub(crate) fn from_plan(plan: &crate::SemanticInvalidationPlan) -> Self {
+        fn surface(value: crate::SemanticDependencySurface) -> DependencySurface {
+            use crate::SemanticDependencySurface as S;
+            match value {
+                S::BodyOwner => DependencySurface::BodyOwner,
+                S::FreeFunctionCall => DependencySurface::FreeFunctionCall,
+                S::NonGenericNamedMethodCall => DependencySurface::NonGenericNamedMethodCall,
+                S::GenericNamedMethodCall => DependencySurface::GenericNamedMethodCall,
+                S::NamedDestructorCall => DependencySurface::NamedDestructorCall,
+                S::ImplicitNamedDestructor => DependencySurface::ImplicitNamedDestructor,
+                S::DeclarationType => DependencySurface::DeclarationType,
+                S::DeclarationTypeCallHead => DependencySurface::DeclarationTypeCallHead,
+                S::SupportedTypeCallHead => DependencySurface::SupportedTypeCallHead,
+                S::NamedValueConst => DependencySurface::NamedValueConst,
+            }
+        }
+        fn reason(value: crate::SemanticDependencyIncompleteReason) -> DependencyIncompleteReason {
+            use crate::SemanticDependencyIncompleteReason as R;
+            match value {
+                R::AnonymousBodyOwnerUnavailable => {
+                    DependencyIncompleteReason::AnonymousBodyOwnerUnavailable
+                }
+                R::CallerEndpointUnavailable => {
+                    DependencyIncompleteReason::CallerEndpointUnavailable
+                }
+                R::GenericSubstitutionIdentityUnavailable => {
+                    DependencyIncompleteReason::GenericSubstitutionIdentityUnavailable
+                }
+                R::DestructorEndpointUnavailable => {
+                    DependencyIncompleteReason::DestructorEndpointUnavailable
+                }
+                R::AnonymousDropOwnerUnavailable => {
+                    DependencyIncompleteReason::AnonymousDropOwnerUnavailable
+                }
+                R::ResolvedTypeIdentityUnavailable => {
+                    DependencyIncompleteReason::ResolvedTypeIdentityUnavailable
+                }
+                R::TypeCallHeadIdentityUnavailable => {
+                    DependencyIncompleteReason::TypeCallHeadIdentityUnavailable
+                }
+                R::UnsupportedDynamicTypeCallHead => {
+                    DependencyIncompleteReason::UnsupportedDynamicTypeCallHead
+                }
+                R::ConstEndpointUnavailable => DependencyIncompleteReason::ConstEndpointUnavailable,
+            }
+        }
+        let scope = match plan.scope() {
+            crate::SemanticInvalidationScope::Incremental => InvalidationScope::Incremental,
+            crate::SemanticInvalidationScope::Full { reasons } => InvalidationScope::Full {
+                reasons: reasons
+                    .iter()
+                    .map(|value| match value {
+                        crate::SemanticFullInvalidationReason::RootChanged => {
+                            FullInvalidationReason::RootChanged
+                        }
+                        crate::SemanticFullInvalidationReason::ModuleImportsChanged => {
+                            FullInvalidationReason::ModuleImportsChanged
+                        }
+                        crate::SemanticFullInvalidationReason::TargetChanged => {
+                            FullInvalidationReason::TargetChanged
+                        }
+                        crate::SemanticFullInvalidationReason::PreviewFeaturesChanged => {
+                            FullInvalidationReason::PreviewFeaturesChanged
+                        }
+                        crate::SemanticFullInvalidationReason::IncompleteDefinitionUniverse => {
+                            FullInvalidationReason::IncompleteDefinitionUniverse
+                        }
+                        crate::SemanticFullInvalidationReason::IncompleteDependencyGraph(
+                            blockers,
+                        ) => FullInvalidationReason::IncompleteDependencyGraph(
+                            blockers
+                                .iter()
+                                .map(|b| DependencyBlocker {
+                                    owner: b.owner().map(|o| o.name().to_owned()),
+                                    surface: surface(b.surface()),
+                                    reason: reason(b.reason()),
+                                })
+                                .collect(),
+                        ),
+                    })
+                    .collect(),
+            },
+        };
+        let work = plan.work();
+        Self {
+            scope,
+            added: vec![(); plan.added().len()],
+            removed: vec![(); plan.removed().len()],
+            changed: vec![(); plan.changed().len()],
+            invalidated: vec![(); plan.invalidated().len()],
+            reusable: vec![(); plan.reusable().len()],
+            work: InvalidationWorkMetrics {
+                definition_fingerprints_compared: work.definition_fingerprints_compared,
+                dependency_edges_visited: work.dependency_edges_visited,
+                reverse_closure_nodes_visited: work.reverse_closure_nodes_visited,
+                extra_rir_instructions_visited: work.extra_rir_instructions_visited,
+            },
+        }
+    }
+    pub fn scope(&self) -> &InvalidationScope {
+        &self.scope
+    }
+    pub fn added(&self) -> &[()] {
+        &self.added
+    }
+    pub fn removed(&self) -> &[()] {
+        &self.removed
+    }
+    pub fn changed(&self) -> &[()] {
+        &self.changed
+    }
+    pub fn invalidated(&self) -> &[()] {
+        &self.invalidated
+    }
+    pub fn reusable(&self) -> &[()] {
+        &self.reusable
+    }
+    pub fn work(&self) -> InvalidationWorkMetrics {
+        self.work
+    }
+}

--- a/crates/rue-compiler/tests/differential_oracle.rs
+++ b/crates/rue-compiler/tests/differential_oracle.rs
@@ -11,13 +11,12 @@
 use std::{collections::HashMap, fmt::Write as _, sync::Arc};
 
 use rue_cfg::OptLevel;
+use rue_compiler::unstable::DifferentialOracleFault;
 use rue_compiler::{
     AcceptedImportSource, AcceptedReadManifestEntry, CompileOptions, CompilerSession,
-    DifferentialOracleFault, DiscoverySourceAssembler, FRONTEND_DIAGNOSTIC_RETENTION_LIMIT,
-    FRONTEND_INVALIDATION_PLAN_RETENTION_LIMIT, FileMetadataFingerprint,
-    FrontendDiagnosticSnapshot, ImportDiscoveryContext, ImportObservation, ImportObservationLedger,
-    PhysicalFileIdentity, PreviewFeature, PreviewFeatures, SourceMetadata, SourceSnapshot,
-    generate_emitted_asm,
+    DiscoverySourceAssembler, FileMetadataFingerprint, FrontendDiagnosticSnapshot,
+    ImportDiscoveryContext, ImportObservation, ImportObservationLedger, PhysicalFileIdentity,
+    PreviewFeature, PreviewFeatures, SourceMetadata, SourceSnapshot, generate_emitted_asm,
 };
 use rue_span::FileId;
 use rue_target::Target;
@@ -172,9 +171,9 @@ fn close_discovery(session: &mut CompilerSession, step: &Step) -> String {
         Ok(artifact) => format!(
             "status={:?};input={:?};reads={:?};ledger={:?}",
             artifact.status(),
-            artifact.graph().map(|graph| graph.input()),
-            artifact.accepted_read_manifest(),
-            artifact.ledger()
+            artifact.graph_input_debug(),
+            artifact.accepted_reads_debug(),
+            artifact.observation_ledger_debug()
         ),
         Err(errors) => format!("close-error:{errors:?}"),
     }
@@ -187,9 +186,9 @@ fn render_selected_import(session: &CompilerSession) -> String {
     format!(
         "status={:?};input={:?};reads={:?};ledger={:?}",
         artifact.status(),
-        artifact.graph().map(|graph| graph.input()),
-        artifact.accepted_read_manifest(),
-        artifact.ledger()
+        artifact.graph_input_debug(),
+        artifact.accepted_reads_debug(),
+        artifact.observation_ledger_debug()
     )
 }
 
@@ -249,7 +248,7 @@ fn observe_with_fault(
                 format!(
                     "source={:?};codegen={:?}",
                     step.snapshot.source_revision(),
-                    output.input()
+                    output.unstable_input_debug()
                 ),
             )
         }
@@ -266,7 +265,7 @@ fn observe_with_fault(
     // Capture the semantic request's selected batch before the manifest query
     // performs its own supporting diagnostic work.
     let diagnostics = normalize_diagnostics(session.latest_diagnostics());
-    let manifest = match session.semantic_dependency_inputs(&step.options, None) {
+    let manifest = match session.unstable_dependency_baseline(&step.options, None) {
         Ok(manifest) => format!(
             "input={:?};imports={:?};definitions={:?};fingerprints={:?};module-imports={:?};free={:?};methods={:?};destructors={:?};implicit={:?};decl-types={:?};call-heads={:?};builtins={:?};consts={:?};bodies={:?};blockers={:?};complete={}",
             manifest.input(),
@@ -559,12 +558,12 @@ fn option_leaves_reuse_source_terminals_and_restore_exact_semantic_variants() {
     session.semantic(&optimized).unwrap();
     session.semantic(&preview).unwrap();
 
-    assert_eq!(session.work().merge.executions, 1);
-    assert_eq!(session.work().rir.executions, 1);
-    assert_eq!(session.work().semantic.executions, 4);
+    assert_eq!(session.unstable_metrics().merge().executions, 1);
+    assert_eq!(session.unstable_metrics().rir().executions, 1);
+    assert_eq!(session.unstable_metrics().semantic().executions, 4);
     assert!(Arc::ptr_eq(&first, &session.semantic(&default).unwrap()));
-    assert_eq!(session.work().semantic.executions, 4);
-    assert_eq!(session.work().semantic.reuses, 1);
+    assert_eq!(session.unstable_metrics().semantic().executions, 4);
+    assert_eq!(session.unstable_metrics().semantic().reuses, 1);
 }
 
 #[test]
@@ -604,10 +603,9 @@ fn failure_recovery_and_bounded_eviction_match_fresh_sessions() {
     for step in &steps {
         observe(&mut session, step);
     }
-    assert!(session.work().retention.diagnostic_entries <= FRONTEND_DIAGNOSTIC_RETENTION_LIMIT);
-    assert!(
-        session.work().retention.invalidation_plans <= FRONTEND_INVALIDATION_PLAN_RETENTION_LIMIT
-    );
+    let metrics = session.unstable_metrics();
+    assert!(metrics.retention().diagnostic_entries < steps.len());
+    assert!(metrics.retention().invalidation_plans < steps.len());
 }
 
 #[test]

--- a/crates/rue-compiler/tests/public_api.rs
+++ b/crates/rue-compiler/tests/public_api.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
+use rue_compiler::unstable::MetricsSnapshot;
 use rue_compiler::{
     CanonicalRirOutput, CanonicalSemanticOutput, CompileOptions, CompileOutput, CompilerSession,
-    CompilerSessionUpdate, CompilerSessionWork, FileId, FrontendDiagnosticSnapshot,
-    MultiErrorResult, SourceMetadata, SourceSnapshot, SourceView, compile_snapshot,
+    CompilerSessionUpdate, DiagnosticStage, FileId, FrontendDiagnosticSnapshot, MultiErrorResult,
+    SourceMetadata, SourceSnapshot, SourceView, compile_snapshot,
 };
 
 #[test]
@@ -16,17 +17,38 @@ fn curated_facade_compiles_for_an_external_consumer() {
     let rir: Arc<CanonicalRirOutput> = session.rir().unwrap();
     let semantic: Arc<CanonicalSemanticOutput> =
         session.semantic(&CompileOptions::default()).unwrap();
-    let work: &CompilerSessionWork = session.work();
+    let work: MetricsSnapshot = session.unstable_metrics();
     let diagnostics: Option<&Arc<FrontendDiagnosticSnapshot>> = session.latest_diagnostics();
     let views: Vec<SourceView<'_>> = snapshot.files().collect();
     assert_eq!(views[0].file_id, FileId::DEFAULT);
     let _rir_view = rir.rir();
     assert_eq!(semantic.functions().len(), 1);
-    assert_eq!(work.updates, 1);
+    assert_eq!(work.updates(), 1);
     assert!(diagnostics.is_some());
+    assert_eq!(diagnostics.unwrap().stage(), DiagnosticStage::Semantic);
 
     let adapter: fn(&SourceSnapshot, &CompileOptions) -> MultiErrorResult<CompileOutput> =
         compile_snapshot;
     let _ = adapter;
     let _metadata: &SourceMetadata = snapshot.metadata();
+}
+
+#[test]
+fn dependency_baselines_cannot_cross_session_ownership() {
+    let snapshot = SourceSnapshot::single("main.rue", "fn main() -> i32 { 0 }").unwrap();
+    let options = CompileOptions::default();
+    let mut first = CompilerSession::new();
+    let mut second = CompilerSession::new();
+    first.update(&snapshot).into_result().unwrap();
+    second.update(&snapshot).into_result().unwrap();
+    let first_baseline = first.unstable_dependency_baseline(&options, None).unwrap();
+    let second_baseline = second.unstable_dependency_baseline(&options, None).unwrap();
+    let before = first.unstable_metrics().invalidation_plans();
+
+    assert!(
+        first
+            .unstable_invalidation_metrics(&first_baseline, &second_baseline)
+            .is_err()
+    );
+    assert_eq!(first.unstable_metrics().invalidation_plans(), before);
 }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -18,18 +18,20 @@ mod allocation;
 mod timing;
 
 #[cfg(test)]
-use rue_compiler::CompilerSessionWork;
+use rue_compiler::unstable::MetricsSnapshot;
+use rue_compiler::unstable::{
+    ImportDiscoveryRevision, ImportDiscoveryStatus, LowerMetrics, ParseMetrics, SemanticMetrics,
+};
 use rue_compiler::{
     AcceptedImportSource, Ast, CanonicalRirOutput, CanonicalSemanticOutput, CompileError,
     CompileErrors, CompileOptions, CompileWarning, CompilerSession, DependencyEnvelope,
     DependencyEnvelopeStatus, DiscoverySourceAssembler, ErrorKind, FileId, FileMetadataFingerprint,
-    FrozenTypeInternPool, ImportDiscoveryContext, ImportDiscoveryRevisionArtifact,
-    ImportDiscoveryRevisionStatus, ImportObservation, ImportObservationLedger,
+    FrozenTypeInternPool, ImportDiscoveryContext, ImportObservation, ImportObservationLedger,
     ImportObservationStatus, Lexer, LinkerMode, MultiFileFormatter, MultiFileJsonFormatter,
-    OptLevel, PhysicalFileIdentity, PipelineWork, PreviewFeature, PreviewFeatures, SourceInfo,
-    SourceMetadata, SourceSnapshot, Token, configure_thread_pool, generate_emitted_asm,
-    generate_liveness_info, generate_lowering_info, generate_mir, generate_regalloc_info,
-    generate_stack_frame_info, parse_source_snapshot_for_ast_presentation,
+    OptLevel, PhysicalFileIdentity, PreviewFeature, PreviewFeatures, SourceInfo, SourceMetadata,
+    SourceSnapshot, Token, configure_thread_pool, generate_emitted_asm, generate_liveness_info,
+    generate_lowering_info, generate_mir, generate_regalloc_info, generate_stack_frame_info,
+    parse_source_snapshot_for_ast_presentation,
 };
 use rue_rir::RirPrinter;
 use rue_target::Target;
@@ -67,9 +69,16 @@ struct EmitFrontend {
     parsed: Arc<rue_compiler::ParsedProgram>,
     rir: Arc<CanonicalRirOutput>,
     semantic: Arc<CanonicalSemanticOutput>,
-    work: PipelineWork,
+    work: EmitWork,
     #[cfg(test)]
-    session_work: CompilerSessionWork,
+    session_work: MetricsSnapshot,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct EmitWork {
+    parsed: ParseMetrics,
+    lowered: LowerMetrics,
+    semantic: SemanticMetrics,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -116,16 +125,15 @@ fn build_emit_frontend_in_session(
         session.rir()?
     };
     let semantic = session.semantic(&options)?;
-    let session_work = session.work().clone();
+    let session_work = session.unstable_metrics();
     Ok(EmitFrontend {
         parsed,
         rir,
         semantic: semantic.clone(),
-        work: PipelineWork {
-            parsed: session_work.last_parse,
-            merged: session_work.last_merge,
-            lowered: session_work.last_rir,
-            semantic: semantic.work(),
+        work: EmitWork {
+            parsed: session_work.parse_metrics(),
+            lowered: session_work.lower_metrics(),
+            semantic: semantic.unstable_metrics(),
         },
         #[cfg(test)]
         session_work,
@@ -169,7 +177,7 @@ impl EmitFrontend {
         self.semantic.warnings()
     }
 
-    fn query_work(&self) -> PipelineWork {
+    fn query_work(&self) -> EmitWork {
         self.work
     }
 }
@@ -1560,7 +1568,7 @@ fn validate_manifest_allows_source(
 #[derive(Debug)]
 struct ImportDiscoveryResult {
     source_snapshot: SourceSnapshot,
-    revision: Arc<ImportDiscoveryRevisionArtifact>,
+    revision: Arc<ImportDiscoveryRevision>,
     session: CompilerSession,
 }
 
@@ -1941,7 +1949,7 @@ fn main() {
         return;
     }
 
-    if import_discovery.revision.status() != ImportDiscoveryRevisionStatus::ClosedValid {
+    if import_discovery.revision.status() != ImportDiscoveryStatus::ClosedValid {
         diagnostics.print_errors(import_discovery.revision.diagnostics());
         std::process::exit(1);
     }
@@ -2106,7 +2114,7 @@ fn main() {
                 options.benchmark_json,
                 &options.target,
                 options.benchmark_json.then(|| {
-                    let source_stats = output.source_stats;
+                    let source_stats = output.unstable_metrics();
                     timing::SourceMetrics {
                         files: source_stats.files,
                         bytes: source_stats.bytes,
@@ -2222,7 +2230,7 @@ fn handle_emit_multi_file(
         diagnostics.print_warnings(state.warnings());
         let work = state.query_work();
         debug_assert_eq!(state.parsed.modules().len(), source_snapshot.len());
-        debug_assert!(work.parsed.syntax.parser_invocations <= source_snapshot.len());
+        debug_assert!(work.parsed.parser_invocations <= source_snapshot.len());
         debug_assert_eq!(work.lowered.parser_invocations, 0);
         debug_assert_eq!(work.semantic.binding.bind_invocations, 1);
         debug_assert_eq!(work.semantic.manifest.build_invocations, 1);
@@ -2927,8 +2935,8 @@ mod tests {
         let frontend = build_emit_frontend(&snapshot, CompileOptions::default()).unwrap();
         let work = frontend.work;
 
-        assert_eq!(work.parsed.syntax.lexer_invocations, 2);
-        assert_eq!(work.parsed.syntax.parser_invocations, 2);
+        assert_eq!(work.parsed.lexer_invocations, 2);
+        assert_eq!(work.parsed.parser_invocations, 2);
         assert_eq!(work.lowered.parser_invocations, 0);
         assert_eq!(work.lowered.ast_payload_clones, 0);
         assert_eq!(work.semantic.binding.bind_invocations, 1);
@@ -2937,10 +2945,10 @@ mod tests {
         assert_eq!(work.semantic.cfg.cfg_builds_succeeded, 1);
         assert_eq!(work.semantic.cfg.cfg_builds_failed, 0);
         let session_work = &frontend.session_work;
-        assert_eq!(session_work.updates, 1);
-        assert_eq!(session_work.merge.executions, 1);
-        assert_eq!(session_work.rir.executions, 1);
-        assert_eq!(session_work.semantic.executions, 1);
+        assert_eq!(session_work.updates(), 1);
+        assert_eq!(session_work.merge().executions, 1);
+        assert_eq!(session_work.rir().executions, 1);
+        assert_eq!(session_work.semantic().executions, 1);
 
         let presentation = parse_source_snapshot_for_ast_presentation(&snapshot).unwrap();
         assert_eq!(


### PR DESCRIPTION
## Summary

- remove query keys/records, invalidation plans, dependency manifests, fingerprints, retention internals, input descriptors, and work records from the supported compiler root
- expose only owned projections and opaque session products through the explicitly unstable metrics/debug namespace
- project diagnostic stage without query identity, bind invalidation baselines to their owning session, and reject cross-session use before query publication
- migrate CLI, compiler-session benchmarks, and the differential oracle to the canonical session-owned views
- add an exhaustive facade guard for forbidden vocabulary, public signatures/fields/modules, aliases, and qualified or nested glob reexports

Independent adversarial review found and verified fixes for a transitive diagnostic identity leak, cross-session baseline injection, an incomplete inventory guard, accidental digest authority, and dead production paths.

## Validation

- `scripts/rue quick`
- `./buck2 test //crates/rue-compiler/...`
- `./buck2 test //crates/rue-compiler:rue-compiler-public-api-test`
- compiler-session benchmark smoke run
- compiler, CLI, and benchmark production builds
- `scripts/rue fmt`
- `git diff --check`

Fixes RUE-866
