### PR TITLE
RUE-942: gate ruelex against the production frontend

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -58,6 +58,29 @@ filegroup(
     srcs = glob(["examples/**"]),
 )
 
+# Syntax-valid, checked-in Rue programs compared by the independent stage-1
+# frontend differential. Keeping the selection explicit excludes intentionally
+# malformed UI/spec/CLI fixtures without a filename heuristic.
+filegroup(
+    name = "frontend-diff-corpus",
+    srcs = dict([(path, path) for path in glob([
+        "benchmarks/**/*.rue",
+        "examples/**/*.rue",
+        "reproducibility/**/*.rue",
+        "std/**/*.rue",
+    ])] + [
+        ("benchmarks/scenarios/representative/labels.rue", "//benchmarks/scenarios/representative:labels.rue"),
+        ("benchmarks/scenarios/representative/labels_alt.rue", "//benchmarks/scenarios/representative:labels_alt.rue"),
+        ("benchmarks/scenarios/representative/main.rue", "//benchmarks/scenarios/representative:main.rue"),
+        ("benchmarks/scenarios/representative/model.rue", "//benchmarks/scenarios/representative:model.rue"),
+        ("benchmarks/scenarios/representative/report.rue", "//benchmarks/scenarios/representative:report.rue"),
+        ("benchmarks/scenarios/representative/std/_std.rue", "//benchmarks/scenarios/representative:std_root.rue"),
+        ("benchmarks/scenarios/representative/std/math.rue", "//benchmarks/scenarios/representative:std_math.rue"),
+        ("benchmarks/scenarios/representative/worker.rue", "//benchmarks/scenarios/representative:worker.rue"),
+    ]),
+    visibility = ["PUBLIC"],
+)
+
 # Checked-in repo-relative source_path fixtures for the CLI integration tests.
 filegroup(
     name = "cli-test-fixtures",

--- a/crates/rue-frontend-diff/BUCK
+++ b/crates/rue-frontend-diff/BUCK
@@ -1,0 +1,22 @@
+load("//crates:defs.bzl", "rue_binary")
+
+rue_binary(
+    name = "rue-frontend-diff",
+    deps = [
+        "//crates/rue-lexer:rue-lexer",
+        "//crates/rue-parser:rue-parser",
+        "//crates/rue-test-runner:rue-test-runner",
+        "//third-party:lasso",
+        "//third-party:tempfile",
+    ],
+)
+
+sh_test(
+    name = "frontend-diff-test",
+    test = ":rue-frontend-diff",
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_FRONTEND_DIFF_CORPUS": "$(location root//:frontend-diff-corpus)",
+        "RUE_STD_PATH": "$(location root//:std)/std",
+    },
+)

--- a/crates/rue-frontend-diff/src/main.rs
+++ b/crates/rue-frontend-diff/src/main.rs
@@ -1,0 +1,1192 @@
+//! Paired token and structural differential for the production frontend and
+//! `examples/ruelex`. Every source must first match the production token dump
+//! byte-for-byte; only then is its lexeme-erased AST shape accepted.
+
+use lasso::ThreadedRodeo;
+use rue_lexer::Lexer;
+use rue_parser::Parser;
+use rue_parser::ast::*;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+use std::time::Duration;
+
+const BORROW: u64 = 10;
+const INOUT: u64 = 12;
+const MUT: u64 = 15;
+const COMPTIME: u64 = 25;
+const IDENT_TOKEN: u64 = 2;
+const UNDERSCORE: u64 = 95;
+const EXPECTED_CORPUS_FILES: usize = 117;
+const PROCESS_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_CAPTURE_BYTES: usize = 16 * 1024 * 1024;
+const SYNTAX_PROBES: &[(&str, &str)] = &[
+    (
+        "intrinsic-placeholders.rue",
+        "fn f(x: bool) { @probe(!, !x, (), [u8]); }",
+    ),
+    (
+        "slice-types.rue",
+        "fn f(borrow bytes: [u8]) -> u64 { @size_of([u8]) }",
+    ),
+];
+
+fn node(kind: &str, meta: &str, a: String, b: String, c: String, d: String) -> String {
+    format!("({kind}{meta} {a} {b} {c} {d})")
+}
+
+fn leaf(kind: &str) -> String {
+    node(kind, "", "_".into(), "_".into(), "_".into(), "_".into())
+}
+
+fn list<I: IntoIterator<Item = String>>(items: I) -> String {
+    items.into_iter().fold("_".to_owned(), |head, item| {
+        node("list", "", head, item, "_".into(), "_".into())
+    })
+}
+
+struct Shapes<'a> {
+    interner: &'a ThreadedRodeo,
+}
+
+impl Shapes<'_> {
+    fn ident(&self) -> String {
+        leaf("ident")
+    }
+
+    fn directives(&self, directives: &[Directive]) -> String {
+        list(directives.iter().map(|d| {
+            node(
+                "directive",
+                "",
+                list(d.args.iter().map(|arg| match arg {
+                    DirectiveArg::Ident(_) => self.ident(),
+                })),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            )
+        }))
+    }
+
+    fn param_mode(mode: ParamMode) -> u64 {
+        match mode {
+            ParamMode::Normal => 0,
+            ParamMode::Inout => INOUT,
+            ParamMode::Borrow => BORROW,
+            ParamMode::Comptime => COMPTIME,
+        }
+    }
+
+    fn arg_mode(mode: ArgMode) -> u64 {
+        match mode {
+            ArgMode::Normal => 0,
+            ArgMode::Inout => INOUT,
+            ArgMode::Borrow => BORROW,
+        }
+    }
+
+    fn param(&self, param: &Param) -> String {
+        node(
+            "param",
+            &format!(" mode={}", Self::param_mode(param.mode)),
+            self.ty(&param.ty),
+            "_".into(),
+            "_".into(),
+            "_".into(),
+        )
+    }
+
+    fn receiver(&self, receiver: &SelfParam) -> String {
+        let mode = if receiver.is_mut {
+            MUT
+        } else {
+            Self::param_mode(receiver.mode)
+        };
+        node(
+            "param",
+            &format!(" mode={mode}"),
+            "_".into(),
+            "_".into(),
+            "_".into(),
+            "_".into(),
+        )
+    }
+
+    fn args(&self, args: &[CallArg]) -> String {
+        list(args.iter().map(|arg| {
+            node(
+                "arg",
+                &format!(" mode={}", Self::arg_mode(arg.mode)),
+                self.expr(&arg.expr),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            )
+        }))
+    }
+
+    fn array_length(&self, length: &ArrayLength) -> String {
+        match length {
+            ArrayLength::Literal(_) => leaf("int"),
+            ArrayLength::Named(_) => self.ident(),
+            ArrayLength::Call { args, .. } => node(
+                "call",
+                "",
+                self.ident(),
+                list(args.iter().map(|a| {
+                    node(
+                        "arg",
+                        " mode=0",
+                        self.array_length(a),
+                        "_".into(),
+                        "_".into(),
+                        "_".into(),
+                    )
+                })),
+                "_".into(),
+                "_".into(),
+            ),
+        }
+    }
+
+    fn qualified(&self, count: usize) -> String {
+        (1..count).fold(self.ident(), |base, _| {
+            node("field", "", base, "_".into(), "_".into(), "_".into())
+        })
+    }
+
+    fn ty(&self, ty: &TypeExpr) -> String {
+        match ty {
+            TypeExpr::Named(name) => {
+                let spelling = self.interner.resolve(&name.name);
+                let child = if matches!(
+                    spelling,
+                    "i8" | "i16"
+                        | "i32"
+                        | "i64"
+                        | "u8"
+                        | "u16"
+                        | "u32"
+                        | "u64"
+                        | "bool"
+                        | "type"
+                        | "Self"
+                ) {
+                    "_".into()
+                } else {
+                    self.ident()
+                };
+                node(
+                    "type",
+                    " form=named",
+                    child,
+                    "_".into(),
+                    "_".into(),
+                    "_".into(),
+                )
+            }
+            TypeExpr::Qualified { segments, .. } => node(
+                "type",
+                " form=named",
+                self.qualified(segments.len()),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            TypeExpr::Unit(_) => node(
+                "type",
+                " form=unit",
+                "_".into(),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            TypeExpr::Never(_) => node(
+                "type",
+                " form=never",
+                "_".into(),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            TypeExpr::Array {
+                element, length, ..
+            } => node(
+                "array-type",
+                "",
+                self.ty(element),
+                self.array_length(length),
+                "_".into(),
+                "_".into(),
+            ),
+            TypeExpr::Slice { element, .. } => node(
+                "slice-type",
+                "",
+                self.ty(element),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            TypeExpr::AnonymousStruct {
+                fields, methods, ..
+            } => {
+                let members = fields
+                    .iter()
+                    .map(|field| {
+                        node(
+                            "field-def",
+                            "",
+                            self.ty(&field.ty),
+                            "_".into(),
+                            "_".into(),
+                            "_".into(),
+                        )
+                    })
+                    .chain(methods.iter().map(|method| self.method(method)));
+                node(
+                    "anon-struct-type",
+                    "",
+                    list(members),
+                    "_".into(),
+                    "_".into(),
+                    "_".into(),
+                )
+            }
+            TypeExpr::AnonymousEnum { variants, .. } => node(
+                "anon-enum-type",
+                "",
+                self.variants(variants),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            TypeExpr::PointerConst { pointee, .. } => node(
+                "ptr-type",
+                " mode=36",
+                self.ty(pointee),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            TypeExpr::PointerMut { pointee, .. } => node(
+                "ptr-type",
+                " mode=15",
+                self.ty(pointee),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            TypeExpr::TypeCall { args, .. } | TypeExpr::QualifiedTypeCall { args, .. } => {
+                let path = match ty {
+                    TypeExpr::TypeCall { .. } => self.ident(),
+                    TypeExpr::QualifiedTypeCall { segments, .. } => self.qualified(segments.len()),
+                    _ => unreachable!(),
+                };
+                node(
+                    "type-call",
+                    "",
+                    path,
+                    list(args.iter().map(|a| self.ty(a))),
+                    "_".into(),
+                    "_".into(),
+                )
+            }
+            TypeExpr::StrFixed { .. } => node(
+                "type-call",
+                "",
+                self.ident(),
+                list([leaf("int")]),
+                "_".into(),
+                "_".into(),
+            ),
+            TypeExpr::IntArg { .. } => leaf("int"),
+        }
+    }
+
+    fn variants(&self, variants: &[EnumVariant]) -> String {
+        list(variants.iter().map(|variant| {
+            node(
+                "variant",
+                "",
+                list(variant.payload.iter().map(|ty| self.ty(ty))),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            )
+        }))
+    }
+
+    fn block(&self, block: &BlockExpr) -> String {
+        let tail = match block.expr.as_ref() {
+            Expr::Unit(unit) if unit.span.end == block.span.end => "_".into(),
+            other => self.expr(other),
+        };
+        node(
+            "block",
+            "",
+            list(block.statements.iter().map(|s| self.statement(s))),
+            tail,
+            "_".into(),
+            "_".into(),
+        )
+    }
+
+    fn bin_op(op: BinaryOp) -> u64 {
+        match op {
+            BinaryOp::Add => 60,
+            BinaryOp::Sub => 61,
+            BinaryOp::Mul => 62,
+            BinaryOp::Div => 63,
+            BinaryOp::Mod => 64,
+            BinaryOp::Eq => 87,
+            BinaryOp::Ne => 88,
+            BinaryOp::Lt => 67,
+            BinaryOp::Gt => 68,
+            BinaryOp::Le => 89,
+            BinaryOp::Ge => 90,
+            BinaryOp::And => 93,
+            BinaryOp::Or => 94,
+            BinaryOp::BitAnd => 69,
+            BinaryOp::BitOr => 70,
+            BinaryOp::BitXor => 71,
+            BinaryOp::Shl => 91,
+            BinaryOp::Shr => 92,
+        }
+    }
+
+    fn unary_op(op: UnaryOp) -> u64 {
+        match op {
+            UnaryOp::Neg => 61,
+            UnaryOp::Not => 66,
+            UnaryOp::BitNot => 72,
+        }
+    }
+
+    fn expr(&self, expr: &Expr) -> String {
+        match expr {
+            Expr::Int(_) => leaf("int"),
+            Expr::String(_) => leaf("string"),
+            Expr::Bool(v) => node(
+                "bool",
+                &format!(" value={}", u8::from(v.value)),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            Expr::Unit(_) => leaf("unit"),
+            Expr::Ident(name) => {
+                if self.interner.resolve(&name.name) == "Self" {
+                    node(
+                        "type",
+                        " form=named",
+                        "_".into(),
+                        "_".into(),
+                        "_".into(),
+                        "_".into(),
+                    )
+                } else {
+                    self.ident()
+                }
+            }
+            Expr::SelfExpr(_) => self.ident(),
+            Expr::Binary(v) => node(
+                "binary",
+                &format!(" op={}", Self::bin_op(v.op)),
+                self.expr(&v.left),
+                self.expr(&v.right),
+                "_".into(),
+                "_".into(),
+            ),
+            Expr::Unary(v) => node(
+                "unary",
+                &format!(" op={}", Self::unary_op(v.op)),
+                self.expr(&v.operand),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            Expr::Paren(v) => self.expr(&v.inner),
+            Expr::Block(v) => self.block(v),
+            Expr::If(v) => {
+                // The production AST represents `else if` as a synthetic
+                // zero-statement block whose tail is the nested if. ruelex
+                // keeps the grammar edge directly; erase only that wrapper.
+                let else_shape = v.else_block.as_ref().map_or("_".into(), |b| {
+                    if b.statements.is_empty()
+                        && matches!(b.expr.as_ref(), Expr::If(_))
+                        && b.span == b.expr.span()
+                    {
+                        self.expr(&b.expr)
+                    } else {
+                        self.block(b)
+                    }
+                });
+                node(
+                    "if",
+                    "",
+                    self.expr(&v.cond),
+                    self.block(&v.then_block),
+                    else_shape,
+                    "_".into(),
+                )
+            }
+            Expr::Match(v) => node(
+                "match",
+                "",
+                self.expr(&v.scrutinee),
+                list(v.arms.iter().map(|a| {
+                    node(
+                        "arm",
+                        "",
+                        self.pattern(&a.pattern),
+                        self.expr(&a.body),
+                        "_".into(),
+                        "_".into(),
+                    )
+                })),
+                "_".into(),
+                "_".into(),
+            ),
+            Expr::While(v) => node(
+                "while",
+                "",
+                self.expr(&v.cond),
+                self.block(&v.body),
+                "_".into(),
+                "_".into(),
+            ),
+            Expr::Loop(v) => node(
+                "loop",
+                "",
+                self.block(&v.body),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            Expr::For(v) => node(
+                "for",
+                &format!(
+                    " binder={}",
+                    match v.binder {
+                        LetPattern::Ident(_) => IDENT_TOKEN,
+                        LetPattern::Wildcard(_) => UNDERSCORE,
+                    }
+                ),
+                self.expr(&v.iterable),
+                self.block(&v.body),
+                "_".into(),
+                "_".into(),
+            ),
+            Expr::Call(v) => node(
+                "call",
+                "",
+                self.ident(),
+                self.args(&v.args),
+                "_".into(),
+                "_".into(),
+            ),
+            Expr::Break(v) => node(
+                "break",
+                "",
+                v.value.as_ref().map_or("_".into(), |e| self.expr(e)),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            Expr::Continue(_) => leaf("continue"),
+            Expr::Return(v) => node(
+                "return",
+                "",
+                v.value.as_ref().map_or("_".into(), |e| self.expr(e)),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            Expr::StructLit(v) => {
+                let mut head = v.base.as_ref().map_or_else(
+                    || {
+                        if self.interner.resolve(&v.name.name) == "Self" {
+                            node(
+                                "type",
+                                " form=named",
+                                "_".into(),
+                                "_".into(),
+                                "_".into(),
+                                "_".into(),
+                            )
+                        } else {
+                            self.ident()
+                        }
+                    },
+                    |base| {
+                        node(
+                            "field",
+                            "",
+                            self.expr(base),
+                            "_".into(),
+                            "_".into(),
+                            "_".into(),
+                        )
+                    },
+                );
+                if let Some(args) = &v.ctor_args {
+                    head = node("call", "", head, self.args(args), "_".into(), "_".into());
+                }
+                node(
+                    "struct-literal",
+                    "",
+                    head,
+                    list(v.fields.iter().map(|f| {
+                        node(
+                            "field-init",
+                            &format!(" shorthand={}", u8::from(f.shorthand)),
+                            self.expr(&f.value),
+                            "_".into(),
+                            "_".into(),
+                            "_".into(),
+                        )
+                    })),
+                    "_".into(),
+                    "_".into(),
+                )
+            }
+            Expr::Field(v) => node(
+                "field",
+                "",
+                self.expr(&v.base),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            Expr::MethodCall(v) => node(
+                "method-call",
+                "",
+                self.expr(&v.receiver),
+                self.args(&v.args),
+                "_".into(),
+                "_".into(),
+            ),
+            Expr::Try(v) => node(
+                "try",
+                "",
+                self.expr(&v.operand),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            Expr::IntrinsicCall(v) => node(
+                "intrinsic",
+                "",
+                list(v.args.iter().map(|a| {
+                    let value = match a {
+                        IntrinsicArg::Expr(e) => self.expr(e),
+                        IntrinsicArg::Type(t) => self.ty(t),
+                    };
+                    node("arg", " mode=0", value, "_".into(), "_".into(), "_".into())
+                })),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            Expr::ArrayLit(v) => {
+                if let Some(repeat) = &v.repeat {
+                    node(
+                        "repeat-array",
+                        "",
+                        self.expr(&v.elements[0]),
+                        self.array_length(repeat),
+                        "_".into(),
+                        "_".into(),
+                    )
+                } else {
+                    node(
+                        "array",
+                        "",
+                        list(v.elements.iter().map(|e| self.expr(e))),
+                        "_".into(),
+                        "_".into(),
+                        "_".into(),
+                    )
+                }
+            }
+            Expr::Index(v) => node(
+                "index",
+                "",
+                self.expr(&v.base),
+                self.expr(&v.index),
+                "_".into(),
+                "_".into(),
+            ),
+            Expr::Path(v) => {
+                let base = v.base.as_ref().map_or_else(
+                    || self.ident(),
+                    |e| {
+                        node(
+                            "field",
+                            "",
+                            self.expr(e),
+                            "_".into(),
+                            "_".into(),
+                            "_".into(),
+                        )
+                    },
+                );
+                node("field", "", base, "_".into(), "_".into(), "_".into())
+            }
+            Expr::Comptime(v) => node(
+                "comptime",
+                "",
+                self.expr(&v.expr),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            Expr::Checked(v) => node(
+                "checked",
+                "",
+                self.expr(&v.expr),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            Expr::TypeLit(v) => self.ty(&v.type_expr),
+            Expr::Error(_) => leaf("error"),
+        }
+    }
+
+    fn pattern(&self, pattern: &Pattern) -> String {
+        match pattern {
+            Pattern::Wildcard(_) => node(
+                "pattern",
+                " form=wildcard",
+                "_".into(),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            Pattern::Int(_) => node(
+                "pattern",
+                " form=int",
+                "_".into(),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            Pattern::NegInt(_) => node(
+                "pattern",
+                " form=neg-int",
+                "_".into(),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            Pattern::Bool(v) => node(
+                "pattern",
+                if v.value { " form=true" } else { " form=false" },
+                "_".into(),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            Pattern::Path(v) => {
+                let mut path = v.base.as_ref().map_or_else(
+                    || self.ident(),
+                    |e| {
+                        node(
+                            "field",
+                            "",
+                            self.expr(e),
+                            "_".into(),
+                            "_".into(),
+                            "_".into(),
+                        )
+                    },
+                );
+                if let Some(args) = &v.ctor_args {
+                    path = node(
+                        "type-call",
+                        "",
+                        path,
+                        list(args.iter().map(|a| {
+                            // Qualified generic-pattern heads use CallArg in the
+                            // production AST even though named arguments occupy
+                            // type grammar positions. ruelex retains that type
+                            // wrapper; reconstruct it from the interned spelling.
+                            match &a.expr {
+                                Expr::Ident(_) => node(
+                                    "type",
+                                    " form=named",
+                                    self.ident(),
+                                    "_".into(),
+                                    "_".into(),
+                                    "_".into(),
+                                ),
+                                Expr::Unit(_) => node(
+                                    "type",
+                                    " form=unit",
+                                    "_".into(),
+                                    "_".into(),
+                                    "_".into(),
+                                    "_".into(),
+                                ),
+                                other => self.expr(other),
+                            }
+                        })),
+                        "_".into(),
+                        "_".into(),
+                    );
+                }
+                path = node("field", "", path, "_".into(), "_".into(), "_".into());
+                node(
+                    "pattern",
+                    " form=path",
+                    path,
+                    list(v.bindings.iter().map(|_| self.ident())),
+                    "_".into(),
+                    "_".into(),
+                )
+            }
+        }
+    }
+
+    fn statement(&self, statement: &Statement) -> String {
+        match statement {
+            Statement::Let(v) => node(
+                "let",
+                &format!(
+                    " flags={}",
+                    u64::from(v.is_mut)
+                        + match v.pattern {
+                            LetPattern::Ident(_) => IDENT_TOKEN * 256,
+                            LetPattern::Wildcard(_) => UNDERSCORE * 256,
+                        }
+                ),
+                self.directives(&v.directives),
+                v.ty.as_ref().map_or("_".into(), |t| self.ty(t)),
+                self.expr(&v.init),
+                "_".into(),
+            ),
+            Statement::Assign(v) => node(
+                "assign",
+                "",
+                match &v.target {
+                    AssignTarget::Var(_) => self.ident(),
+                    AssignTarget::Field(e) => self.expr(&Expr::Field(e.clone())),
+                    AssignTarget::Index(e) => self.expr(&Expr::Index(e.clone())),
+                },
+                self.expr(&v.value),
+                "_".into(),
+                "_".into(),
+            ),
+            Statement::Expr(v) => node(
+                "expr-stmt",
+                "",
+                self.expr(v),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+        }
+    }
+
+    fn method(&self, method: &Method) -> String {
+        if self.interner.resolve(&method.name.name) == "__drop" {
+            return node(
+                "drop-fn",
+                "",
+                self.expr(&method.body),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            );
+        }
+        let params = method
+            .receiver
+            .iter()
+            .map(|r| self.receiver(r))
+            .chain(method.params.iter().map(|p| self.param(p)));
+        node(
+            "method",
+            "",
+            self.directives(&method.directives),
+            list(params),
+            method
+                .return_type
+                .as_ref()
+                .map_or("_".into(), |t| self.ty(t)),
+            self.expr(&method.body),
+        )
+    }
+
+    fn function(&self, function: &Function) -> String {
+        let flags = u64::from(function.visibility == Visibility::Public)
+            + 2 * u64::from(function.is_unchecked);
+        node(
+            "function",
+            &format!(" flags={flags}"),
+            self.directives(&function.directives),
+            list(function.params.iter().map(|p| self.param(p))),
+            function
+                .return_type
+                .as_ref()
+                .map_or("_".into(), |t| self.ty(t)),
+            self.expr(&function.body),
+        )
+    }
+
+    fn item(&self, item: &Item) -> String {
+        match item {
+            Item::Function(v) => self.function(v),
+            Item::Struct(v) => {
+                let flags =
+                    u64::from(v.visibility == Visibility::Public) + 4 * u64::from(v.is_linear);
+                let members = v
+                    .fields
+                    .iter()
+                    .map(|f| {
+                        (
+                            f.span.start,
+                            node(
+                                "field-def",
+                                "",
+                                self.ty(&f.ty),
+                                "_".into(),
+                                "_".into(),
+                                "_".into(),
+                            ),
+                        )
+                    })
+                    .chain(v.methods.iter().map(|m| (m.span.start, self.method(m))));
+                let mut members: Vec<_> = members.collect();
+                members.sort_by_key(|m| m.0);
+                node(
+                    "struct",
+                    &format!(" flags={flags}"),
+                    self.directives(&v.directives),
+                    list(members.into_iter().map(|m| m.1)),
+                    "_".into(),
+                    "_".into(),
+                )
+            }
+            Item::Enum(v) => node(
+                "enum",
+                &format!(" flags={}", u8::from(v.visibility == Visibility::Public)),
+                self.variants(&v.variants),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            Item::DropFn(v) => node(
+                "drop-fn",
+                "",
+                self.expr(&v.body),
+                "_".into(),
+                "_".into(),
+                "_".into(),
+            ),
+            Item::Const(v) => node(
+                "const",
+                &format!(" flags={}", u8::from(v.visibility == Visibility::Public)),
+                self.directives(&v.directives),
+                v.ty.as_ref().map_or("_".into(), |t| self.ty(t)),
+                self.expr(&v.init),
+                "_".into(),
+            ),
+            Item::Error(_) => leaf("error"),
+        }
+    }
+
+    fn ast(&self, ast: &Ast) -> String {
+        format!(
+            "{}\n",
+            node(
+                "program",
+                "",
+                list(ast.items.iter().map(|i| self.item(i))),
+                "_".into(),
+                "_".into(),
+                "_".into()
+            )
+        )
+    }
+}
+
+struct ReferenceOutputs {
+    tokens: String,
+    shape: String,
+}
+
+fn rust_outputs(source: &str) -> Result<ReferenceOutputs, String> {
+    let (tokens, interner) = Lexer::new(source)
+        .tokenize()
+        .map_err(|e| format!("lexer rejected source: {e:?}"))?;
+    let token_dump = tokens.iter().map(|token| format!("{token}\n")).collect();
+    let (ast, interner) = Parser::new(tokens, interner)
+        .parse()
+        .map_err(|e| format!("parser rejected source: {e:?}"))?;
+    Ok(ReferenceOutputs {
+        tokens: token_dump,
+        shape: Shapes {
+            interner: &interner,
+        }
+        .ast(&ast),
+    })
+}
+
+#[cfg(test)]
+fn rust_shape(source: &str) -> Result<String, String> {
+    Ok(rust_outputs(source)?.shape)
+}
+
+fn collect_rue_files(root: &Path, files: &mut Vec<PathBuf>) -> Result<(), String> {
+    for entry in fs::read_dir(root).map_err(|e| format!("read {}: {e}", root.display()))? {
+        let path = entry.map_err(|e| e.to_string())?.path();
+        if path.is_dir() {
+            collect_rue_files(&path, files)?;
+        } else if path.extension().is_some_and(|e| e == "rue") {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn mismatch(kind: &str, path: &Path, expected: &str, actual: &str) -> String {
+    let at = expected
+        .bytes()
+        .zip(actual.bytes())
+        .position(|(a, b)| a != b)
+        .unwrap_or(expected.len().min(actual.len()));
+    let start = at.saturating_sub(100);
+    let end_e = (at + 180).min(expected.len());
+    let end_a = (at + 180).min(actual.len());
+    format!(
+        "{}: first {kind} mismatch at byte {at}\nproduction: ...{}...\nruelex:    ...{}...",
+        path.display(),
+        &expected[start..end_e],
+        &actual[start..end_a]
+    )
+}
+
+fn bounded_run(command: Command, label: &str) -> Result<std::process::Output, String> {
+    rue_test_runner::run_with_timeout_and_output_limit(
+        command,
+        PROCESS_TIMEOUT,
+        None,
+        MAX_CAPTURE_BYTES,
+    )
+    .map_err(|error| format!("{label}: {error}"))
+}
+
+fn frontend_output(frontend: &Path, path: &Path, shape: bool) -> Result<String, String> {
+    let mut command = Command::new(frontend);
+    if shape {
+        command.arg("--ast-shape");
+    }
+    command.arg(path);
+    let phase = if shape { "AST shape" } else { "token dump" };
+    let output = bounded_run(command, &format!("ruelex {phase} for {}", path.display()))?;
+    if !output.status.success() {
+        return Err(format!(
+            "ruelex {phase} rejected {} ({}):\nstdout:\n{}\nstderr:\n{}",
+            path.display(),
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    String::from_utf8(output.stdout).map_err(|error| {
+        format!(
+            "ruelex {phase} for {} was not UTF-8: {error}",
+            path.display()
+        )
+    })
+}
+
+fn compare_source(frontend: &Path, path: &Path, source: &str) -> Result<(), String> {
+    let production = rust_outputs(source)?;
+    let ruelex_tokens = frontend_output(frontend, path, false)?;
+    if production.tokens != ruelex_tokens {
+        return Err(mismatch(
+            "token/lexeme",
+            path,
+            &production.tokens,
+            &ruelex_tokens,
+        ));
+    }
+    let ruelex_shape = frontend_output(frontend, path, true)?;
+    if production.shape != ruelex_shape {
+        return Err(mismatch(
+            "AST shape",
+            path,
+            &production.shape,
+            &ruelex_shape,
+        ));
+    }
+    Ok(())
+}
+
+fn run() -> Result<usize, String> {
+    let compiler = env::var_os("RUE_BINARY").ok_or("RUE_BINARY is not set")?;
+    let corpus =
+        PathBuf::from(env::var_os("RUE_FRONTEND_DIFF_CORPUS").unwrap_or_else(|| ".".into()));
+    let root = corpus.join("examples/ruelex/main.rue");
+    if !root.is_file() {
+        return Err(format!(
+            "corpus root {} does not contain examples/ruelex/main.rue",
+            corpus.display()
+        ));
+    }
+    let temp = tempfile::tempdir().map_err(|e| e.to_string())?;
+    let frontend = temp.path().join("ruelex");
+    let mut compile = Command::new(compiler);
+    compile.arg(&root).arg("-o").arg(&frontend);
+    let compile = bounded_run(compile, "compile ruelex")?;
+    if !compile.status.success() {
+        return Err(format!(
+            "compiling {} failed with {}:\nstdout:\n{}\nstderr:\n{}",
+            root.display(),
+            compile.status,
+            String::from_utf8_lossy(&compile.stdout),
+            String::from_utf8_lossy(&compile.stderr)
+        ));
+    }
+    let mut files = Vec::new();
+    collect_rue_files(&corpus, &mut files)?;
+    files.sort();
+    if files.len() != EXPECTED_CORPUS_FILES {
+        return Err(format!(
+            "declared corpus contains {} .rue files, expected {EXPECTED_CORPUS_FILES}; update the explicit corpus and audited count together",
+            files.len()
+        ));
+    }
+    for path in &files {
+        let source =
+            fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+        compare_source(&frontend, path, &source)?;
+    }
+    for (name, source) in SYNTAX_PROBES {
+        let path = temp.path().join(name);
+        fs::write(&path, source).map_err(|error| format!("write {}: {error}", path.display()))?;
+        compare_source(&frontend, &path, source)?;
+    }
+    Ok(files.len())
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(count) => {
+            println!(
+                "frontend token + structural differential: {count}/{count} corpus files and {} syntax probes agree",
+                SYNTAX_PROBES.len()
+            );
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("frontend structural differential failed: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    fn fake_frontend(tokens: &str, shape: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
+        use std::os::unix::fs::PermissionsExt;
+
+        fn shell_quote(value: &str) -> String {
+            format!("'{}'", value.replace('\'', "'\"'\"'"))
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("probe.rue");
+        fs::write(&source, "fn main() {}").unwrap();
+        let executable = temp.path().join("fake-ruelex");
+        fs::write(
+            &executable,
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = --ast-shape ]; then printf %s {}; else printf %s {}; fi\n",
+                shell_quote(shape),
+                shell_quote(tokens)
+            ),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&executable).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&executable, permissions).unwrap();
+        (temp, executable, source)
+    }
+
+    #[test]
+    fn normalization_covers_items_params_types_statements_control_flow_and_postfix() {
+        let source = "pub unchecked fn f(comptime T: type, inout x: i32, borrow y: [u8; 4], borrow s: [u8]) -> i32 { let mut z: i32 = x; while z < 3 { z = z + 1; } if true { z } else { y[0] } }";
+        let shape = rust_shape(source).unwrap();
+        for needle in [
+            "(function flags=3",
+            "(param mode=25",
+            "(array-type",
+            "(slice-type",
+            "(let flags=513",
+            "(while",
+            "(if",
+            "(index",
+            "(binary op=67",
+        ] {
+            assert!(shape.contains(needle), "missing {needle} in {shape}");
+        }
+    }
+
+    #[test]
+    fn normalization_covers_items_and_patterns() {
+        let source = "pub struct S { x: i32, fn get(borrow self) -> i32 { self.x } } pub enum E { A, B(i32) } fn f(e: E) -> i32 { match e { E.A => 0, E.B(x) => x } }";
+        let shape = rust_shape(source).unwrap();
+        for needle in [
+            "(struct flags=1",
+            "(method ",
+            "(enum flags=1",
+            "(variant",
+            "form=path",
+            "(field",
+        ] {
+            assert!(shape.contains(needle), "missing {needle} in {shape}");
+        }
+    }
+
+    #[test]
+    fn mismatch_reports_first_difference_with_context() {
+        let report = mismatch(
+            "AST shape",
+            Path::new("x.rue"),
+            "(program (int))",
+            "(program (bool))",
+        );
+        assert!(report.contains("x.rue: first AST shape mismatch at byte 10"));
+        assert!(report.contains("production:"));
+        assert!(report.contains("ruelex:"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn combined_oracle_rejects_mutated_token_output_even_when_shape_matches() {
+        let source_text = "fn main() {}";
+        let reference = rust_outputs(source_text).unwrap();
+        let (_temp, frontend, source) = fake_frontend("mutated token dump\n", &reference.shape);
+        let error = compare_source(&frontend, &source, source_text).unwrap_err();
+        assert!(error.contains("token/lexeme mismatch"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn combined_oracle_rejects_mutated_shape_after_exact_tokens() {
+        let source_text = "fn main() {}";
+        let reference = rust_outputs(source_text).unwrap();
+        let (_temp, frontend, source) = fake_frontend(&reference.tokens, "(mutated)\n");
+        let error = compare_source(&frontend, &source, source_text).unwrap_err();
+        assert!(error.contains("AST shape mismatch"), "{error}");
+    }
+}

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -1735,7 +1735,57 @@ fn run_golden_ir_test(
 
 enum DrainMessage {
     Bytes(Vec<u8>),
+    Overflow,
     Done,
+}
+
+struct PipeDrain {
+    rx: mpsc::Receiver<DrainMessage>,
+    bytes: Vec<u8>,
+    done: bool,
+    overflowed: bool,
+}
+
+impl PipeDrain {
+    fn poll(&mut self) {
+        // Bound work per child-status poll. An unbounded producer must not keep
+        // the timeout loop inside `try_recv` forever.
+        for _ in 0..64 {
+            match self.rx.try_recv() {
+                Ok(message) => self.handle(message),
+                Err(mpsc::TryRecvError::Empty) => return,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    self.done = true;
+                    return;
+                }
+            }
+        }
+    }
+
+    fn finish(&mut self, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        while !self.done {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return;
+            }
+            match self.rx.recv_timeout(remaining) {
+                Ok(message) => self.handle(message),
+                Err(_) => {
+                    self.done = true;
+                    return;
+                }
+            }
+        }
+    }
+
+    fn handle(&mut self, message: DrainMessage) {
+        match message {
+            DrainMessage::Bytes(chunk) => self.bytes.extend(chunk),
+            DrainMessage::Overflow => self.overflowed = true,
+            DrainMessage::Done => self.done = true,
+        }
+    }
 }
 
 /// How long `run_with_timeout` waits for pipe-drain helpers after the child has
@@ -1753,17 +1803,36 @@ const PIPE_DRAIN_FINISH_TIMEOUT: Duration = Duration::from_millis(500);
 /// because a daemonized descendant inherited the write end, the caller can
 /// still recover the bytes that were already read instead of blocking on a
 /// thread join.
-fn spawn_pipe_drain<R: IoRead + Send + 'static>(pipe: Option<R>) -> mpsc::Receiver<DrainMessage> {
+fn spawn_pipe_drain<R: IoRead + Send + 'static>(
+    pipe: Option<R>,
+    output_limit: Option<usize>,
+) -> PipeDrain {
     let (tx, rx) = mpsc::channel();
     std::thread::spawn(move || {
         if let Some(mut reader) = pipe {
             let mut buf = [0; 8192];
+            let mut retained = 0usize;
+            let mut overflowed = false;
             loop {
                 match reader.read(&mut buf) {
                     Ok(0) => break,
                     Ok(n) => {
-                        if tx.send(DrainMessage::Bytes(buf[..n].to_vec())).is_err() {
-                            return;
+                        if !overflowed {
+                            let keep = output_limit
+                                .map(|limit| n.min(limit.saturating_sub(retained)))
+                                .unwrap_or(n);
+                            if keep > 0
+                                && tx.send(DrainMessage::Bytes(buf[..keep].to_vec())).is_err()
+                            {
+                                return;
+                            }
+                            retained += keep;
+                            if keep < n {
+                                overflowed = true;
+                                if tx.send(DrainMessage::Overflow).is_err() {
+                                    return;
+                                }
+                            }
                         }
                     }
                     Err(_) => break,
@@ -1772,24 +1841,11 @@ fn spawn_pipe_drain<R: IoRead + Send + 'static>(pipe: Option<R>) -> mpsc::Receiv
         }
         let _ = tx.send(DrainMessage::Done);
     });
-    rx
-}
-
-fn collect_drained_bytes(rx: mpsc::Receiver<DrainMessage>, timeout: Duration) -> Vec<u8> {
-    let deadline = Instant::now() + timeout;
-    let mut bytes = Vec::new();
-
-    loop {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            return bytes;
-        }
-
-        match rx.recv_timeout(remaining) {
-            Ok(DrainMessage::Bytes(chunk)) => bytes.extend(chunk),
-            Ok(DrainMessage::Done) | Err(mpsc::RecvTimeoutError::Disconnected) => return bytes,
-            Err(mpsc::RecvTimeoutError::Timeout) => return bytes,
-        }
+    PipeDrain {
+        rx,
+        bytes: Vec::new(),
+        done: false,
+        overflowed: false,
     }
 }
 
@@ -1875,9 +1931,35 @@ fn kill_process_group(child: &mut std::process::Child) {
 ///   A timeout error is prefixed with [`TIMEOUT_PREFIX`] so callers can report
 ///   it as a distinct failure class.
 pub fn run_with_timeout(
+    cmd: Command,
+    timeout: Duration,
+    stdin_input: Option<&str>,
+) -> TestResult<Output> {
+    run_with_timeout_impl(cmd, timeout, stdin_input, None)
+}
+
+/// Run a command with a timeout while retaining at most `output_limit` bytes
+/// from each of stdout and stderr.
+///
+/// Unlike checking [`Output`] after [`run_with_timeout`] returns, this limit is
+/// enforced by the pipe-drain threads as bytes arrive. Once either stream
+/// exceeds the limit, further bytes are discarded, the process group is
+/// killed, and the function returns a fatal failure identifying the stream.
+/// The limit applies independently to stdout and stderr.
+pub fn run_with_timeout_and_output_limit(
+    cmd: Command,
+    timeout: Duration,
+    stdin_input: Option<&str>,
+    output_limit: usize,
+) -> TestResult<Output> {
+    run_with_timeout_impl(cmd, timeout, stdin_input, Some(output_limit))
+}
+
+fn run_with_timeout_impl(
     mut cmd: Command,
     timeout: Duration,
     stdin_input: Option<&str>,
+    output_limit: Option<usize>,
 ) -> TestResult<Output> {
     configure_process_group(&mut cmd);
     let mut child = cmd
@@ -1896,8 +1978,8 @@ pub fn run_with_timeout(
     // The drains send chunks over channels instead of being joined directly:
     // if a descendant process inherits a pipe fd and keeps it open after the
     // direct child exits, a reader thread can block forever waiting for EOF.
-    let stdout_rx = spawn_pipe_drain(child.stdout.take());
-    let stderr_rx = spawn_pipe_drain(child.stderr.take());
+    let mut stdout_drain = spawn_pipe_drain(child.stdout.take(), output_limit);
+    let mut stderr_drain = spawn_pipe_drain(child.stderr.take(), output_limit);
 
     // Feed stdin on its own thread so a large input can't block the drain (and
     // vice versa). A program may exit without reading all of its input; a broken
@@ -1913,17 +1995,45 @@ pub fn run_with_timeout(
     let start = Instant::now();
 
     loop {
+        stdout_drain.poll();
+        stderr_drain.poll();
+        if stdout_drain.overflowed || stderr_drain.overflowed {
+            kill_process_group(&mut child);
+            let stream = match (stdout_drain.overflowed, stderr_drain.overflowed) {
+                (true, true) => "stdout and stderr",
+                (true, false) => "stdout",
+                (false, true) => "stderr",
+                (false, false) => unreachable!(),
+            };
+            return Err(TestFailure::fatal(format!(
+                "OUTPUT LIMIT: {stream} exceeded the {}-byte capture limit (process group killed)",
+                output_limit.expect("overflow requires an output limit")
+            )));
+        }
+
         match child.try_wait() {
             Ok(Some(status)) => {
                 // Process finished: collect any fully-drained output, but do
                 // not wait forever if a descendant inherited a pipe fd.
-                let stdout = collect_drained_bytes(stdout_rx, PIPE_DRAIN_FINISH_TIMEOUT);
-                let stderr = collect_drained_bytes(stderr_rx, PIPE_DRAIN_FINISH_TIMEOUT);
+                stdout_drain.finish(PIPE_DRAIN_FINISH_TIMEOUT);
+                stderr_drain.finish(PIPE_DRAIN_FINISH_TIMEOUT);
                 drop(stdin_writer);
+                if stdout_drain.overflowed || stderr_drain.overflowed {
+                    let stream = match (stdout_drain.overflowed, stderr_drain.overflowed) {
+                        (true, true) => "stdout and stderr",
+                        (true, false) => "stdout",
+                        (false, true) => "stderr",
+                        (false, false) => unreachable!(),
+                    };
+                    return Err(TestFailure::fatal(format!(
+                        "OUTPUT LIMIT: {stream} exceeded the {}-byte capture limit",
+                        output_limit.expect("overflow requires an output limit")
+                    )));
+                }
                 return Ok(Output {
                     status,
-                    stdout,
-                    stderr,
+                    stdout: stdout_drain.bytes,
+                    stderr: stderr_drain.bytes,
                 });
             }
             Ok(None) => {
@@ -1933,8 +2043,8 @@ pub fn run_with_timeout(
                     // drain helpers already captured without waiting forever
                     // for EOF from an escaped descendant.
                     kill_process_group(&mut child);
-                    let _stdout = collect_drained_bytes(stdout_rx, PIPE_DRAIN_FINISH_TIMEOUT);
-                    let _stderr = collect_drained_bytes(stderr_rx, PIPE_DRAIN_FINISH_TIMEOUT);
+                    stdout_drain.finish(PIPE_DRAIN_FINISH_TIMEOUT);
+                    stderr_drain.finish(PIPE_DRAIN_FINISH_TIMEOUT);
                     drop(stdin_writer);
                     return Err(TestFailure::fatal(format!(
                         "{} test execution timed out after {} ms (process group killed)",
@@ -3803,6 +3913,19 @@ chmod +x "$output"
         assert!(output.status.success());
         assert_eq!(output.stdout.len(), 200_000);
         assert_eq!(output.stderr.len(), 200_000);
+    }
+
+    #[test]
+    fn test_run_with_timeout_output_limit_rejects_overflow_while_draining() {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("head -c 200000 /dev/zero");
+        let error =
+            run_with_timeout_and_output_limit(cmd, Duration::from_secs(10), None, 16 * 1024)
+                .expect_err("stdout beyond the retention limit must fail");
+
+        assert!(error.is_fatal());
+        assert!(error.contains("OUTPUT LIMIT: stdout exceeded"));
+        assert!(error.contains("16384-byte capture limit"));
     }
 
     #[test]

--- a/examples/ruelex/ast.rue
+++ b/examples/ruelex/ast.rue
@@ -62,6 +62,7 @@ pub const VARIANT: u64 = 50;
 pub const DROP_FN: u64 = 51;
 pub const CONST_DECL: u64 = 52;
 pub const ANON_ENUM_TYPE: u64 = 53;
+pub const SLICE_TYPE: u64 = 54;
 
 pub struct Node {
     kind: u64,
@@ -122,6 +123,7 @@ pub struct Arena {
         else if kind == TYPE { "type" }
         else if kind == TYPE_CALL { "type-call" }
         else if kind == ARRAY_TYPE { "array-type" }
+        else if kind == SLICE_TYPE { "slice-type" }
         else if kind == PTR_TYPE { "ptr-type" }
         else if kind == ANON_STRUCT_TYPE { "anon-struct-type" }
         else if kind == ANON_ENUM_TYPE { "anon-enum-type" }
@@ -194,6 +196,96 @@ pub struct Arena {
     fn dump(borrow self, root: u64) -> StrBuf {
         let mut out = StrBuf.new();
         self.dump_node(root, inout out);
+        out.push_str("\n");
+        out
+    }
+
+    // Structural oracle form. Names, literal payloads, spans, and interner ids
+    // are intentionally absent: the same harness co-runs the default token
+    // dump byte-for-byte before accepting this structural comparison.
+    // Every arena edge remains explicit (including absent optional children),
+    // while grammar-bearing modes, flags, and operators are retained.
+    fn shape_meta(borrow self, borrow n: Node, inout out: StrBuf) {
+        if n.kind == BINARY || n.kind == UNARY {
+            out.push_str(" op=");
+            Self.append_u(inout out, n.value);
+        } else if n.kind == TYPE {
+            out.push_str(" form=");
+            if n.value == 66 { out.push_str("never"); }
+            else if n.value == 73 { out.push_str("unit"); }
+            else { out.push_str("named"); }
+        } else if n.kind == PTR_TYPE || n.kind == ARG {
+            out.push_str(" mode=");
+            Self.append_u(inout out, n.value);
+        } else if n.kind == PARAM {
+            out.push_str(" mode=");
+            Self.append_u(inout out, n.aux);
+        } else if n.kind == FUNCTION || n.kind == STRUCT_DEF || n.kind == ENUM_DEF || n.kind == CONST_DECL {
+            out.push_str(" flags=");
+            Self.append_u(inout out, n.aux);
+        } else if n.kind == LET {
+            out.push_str(" flags=");
+            Self.append_u(inout out, n.aux);
+        } else if n.kind == FOR {
+            out.push_str(" binder=");
+            Self.append_u(inout out, n.aux);
+        } else if n.kind == FIELD_INIT {
+            out.push_str(" shorthand=");
+            Self.append_u(inout out, n.aux);
+        } else if n.kind == PATTERN {
+            out.push_str(" form=");
+            if n.a != NONE { out.push_str("path"); }
+            else if n.value == 95 { out.push_str("wildcard"); }
+            else if n.value == 27 { out.push_str("true"); }
+            else if n.value == 28 { out.push_str("false"); }
+            else if n.aux != 0 { out.push_str("neg-int"); }
+            else { out.push_str("int"); }
+        } else if n.kind == BOOL {
+            out.push_str(" value=");
+            Self.append_u(inout out, n.value);
+        }
+    }
+
+    fn dump_shape_node(borrow self, id: u64, inout out: StrBuf) {
+        if id == NONE {
+            out.push_str("_");
+            return;
+        }
+        let n = self.at(id);
+        out.push_str("(");
+        out.push_str(Self.kind_name(n.kind));
+        self.shape_meta(borrow n, inout out);
+        // The production parser promotes a final semicolon-terminated
+        // diverging statement into the block tail. Preserve the expression
+        // while erasing that storage-only difference.
+        if n.kind == BLOCK && n.b == NONE && n.a != NONE {
+            let link = self.at(n.a);
+            let statement = self.at(link.b);
+            let expr = self.at(statement.a);
+            if link.kind == LIST && statement.kind == EXPR_STMT &&
+                (expr.kind == BREAK || expr.kind == CONTINUE || expr.kind == RETURN || expr.kind == LOOP) {
+                out.push_str(" ");
+                self.dump_shape_node(link.a, inout out);
+                out.push_str(" ");
+                self.dump_shape_node(statement.a, inout out);
+                out.push_str(" _ _)");
+                return;
+            }
+        }
+        out.push_str(" ");
+        self.dump_shape_node(n.a, inout out);
+        out.push_str(" ");
+        self.dump_shape_node(n.b, inout out);
+        out.push_str(" ");
+        self.dump_shape_node(n.c, inout out);
+        out.push_str(" ");
+        self.dump_shape_node(n.d, inout out);
+        out.push_str(")");
+    }
+
+    fn dump_shape(borrow self, root: u64) -> StrBuf {
+        let mut out = StrBuf.new();
+        self.dump_shape_node(root, inout out);
         out.push_str("\n");
         out
     }

--- a/examples/ruelex/lex.rue
+++ b/examples/ruelex/lex.rue
@@ -86,6 +86,7 @@ pub struct Lexer {
     pretty: bool,
     last_kind: u64,
     last_value: u64,
+    last_aux: u64,
 
     fn new(src: Bytes, pretty: bool) -> Self {
         let mut lx = Self {
@@ -98,6 +99,7 @@ pub struct Lexer {
             pretty: pretty,
             last_kind: token.UNKNOWN,
             last_value: 0,
+            last_aux: 0,
         };
         lx.n = lx.src.len();
         lx
@@ -223,6 +225,12 @@ pub struct Lexer {
         if word_eq(borrow key, "bool") { return "TYPE(bool)"; }
         if word_eq(borrow key, "type") { return "TYPE(type)"; }
 
+        if word_eq(borrow key, "size_of") || word_eq(borrow key, "align_of") ||
+            word_eq(borrow key, "require_droppable") || word_eq(borrow key, "require_trivially_droppable") {
+            self.last_aux = 1;
+        } else if word_eq(borrow key, "offset_of") {
+            self.last_aux = 2;
+        }
         let sym = self.interner.intern(borrow key);
         self.last_kind = token.IDENT;
         self.last_value = sym;
@@ -428,6 +436,7 @@ pub struct Lexer {
             let c = self.peek(0);
             self.last_kind = token.UNKNOWN;
             self.last_value = 0;
+            self.last_aux = 0;
             let kind = if is_ident_start(c) {
                 self.lex_ident(start)
             } else if is_digit(c) {
@@ -448,6 +457,7 @@ pub struct Lexer {
                 start: start,
                 end: end,
                 value: self.last_value,
+                aux: self.last_aux,
             });
             self.emit(inout out, start, end, sl, sc, kind);
         }
@@ -456,6 +466,7 @@ pub struct Lexer {
             start: self.n,
             end: self.n,
             value: 0,
+            aux: 0,
         });
         self.emit(inout out, self.n, self.n, self.line, self.col, "EOF");
     }

--- a/examples/ruelex/main.rue
+++ b/examples/ruelex/main.rue
@@ -22,13 +22,18 @@
 // (symbol numbering), ast.rue (POD arena), parse.rue (grammar + recovery),
 // fmtutil.rue (formatting helpers), this root (I/O, argv, driver).
 //
-// Usage:  ruelex [--pretty|--ast] <file.rue> [<file.rue> ...]
+// Usage:  ruelex [--pretty|--ast|--ast-shape] <file.rue> [<file.rue> ...]
 //
 // For each file argument, tokenizes the entire file and prints one line per
 // token. The default output reproduces the Rue compiler's own `--emit tokens`
 // dump — `{start:>4}..{end:<3}  KIND` with 0-based byte offsets — so the two
 // can be diffed. `--pretty` prints `LINE:COL KIND` with 1-based spans instead;
 // `--ast` parses and prints the arena tree, returning nonzero on syntax errors.
+// `--ast-shape` prints the same tree as a canonical preorder S-expression with
+// lexemes, spans, and interner identities erased but grammar-bearing modes,
+// flags, operators, list order, and optional children retained. The differential
+// harness always co-runs the byte-exact default token oracle before accepting a
+// structural match, so erased lexical identity cannot conceal a disagreement.
 //
 // Reading uses std.fs (open + chunked read loop); argv comes from std.env;
 // output goes to stdout via the `print` builtin (which writes a borrowed StrBuf
@@ -88,7 +93,7 @@ fn str_eq(borrow a: StrBuf, flag: StrBuf) -> bool {
 
 // Tokenize one file and print its dump. When `with_header`, precede it with a
 // `=== <path> ===` banner so multi-file output stays navigable.
-fn process_file(borrow path: StrBuf, pretty: bool, ast_mode: bool, with_header: bool) -> bool {
+fn process_file(borrow path: StrBuf, pretty: bool, ast_mode: bool, shape_mode: bool, with_header: bool) -> bool {
     if with_header {
         let mut h = StrBuf.new();
         h.push_str("=== ");
@@ -106,14 +111,14 @@ fn process_file(borrow path: StrBuf, pretty: bool, ast_mode: bool, with_header: 
         return false;
     }
     let data = input.data;
-    if ast_mode {
+    if ast_mode || shape_mode {
         let result = parse.parse(lex.scan(data));
         if result.errors.len() != 0 {
             print(result.errors);
-            print(result.dump);
+            if shape_mode { print(result.shape); } else { print(result.dump); }
             false
         } else {
-            print(result.dump);
+            if shape_mode { print(result.shape); } else { print(result.dump); }
             true
         }
     } else {
@@ -129,6 +134,7 @@ fn main() -> i32 {
     // First pass: pick up flags and count file arguments.
     let mut pretty = false;
     let mut ast_mode = false;
+    let mut shape_mode = false;
     let mut nfiles: u64 = 0;
     let mut i: u64 = 1;
     while i < argc {
@@ -138,6 +144,8 @@ fn main() -> i32 {
                     pretty = true;
                 } else if str_eq(borrow a, "--ast") {
                     ast_mode = true;
+                } else if str_eq(borrow a, "--ast-shape") {
+                    shape_mode = true;
                 } else {
                     nfiles = nfiles + 1;
                 }
@@ -167,8 +175,10 @@ fn main() -> i32 {
                     // flag, skip
                 } else if str_eq(borrow a, "--ast") {
                     // flag, skip
+                } else if str_eq(borrow a, "--ast-shape") {
+                    // flag, skip
                 } else {
-                    if !process_file(borrow a, pretty, ast_mode, with_header) {
+                    if !process_file(borrow a, pretty, ast_mode, shape_mode, with_header) {
                         ok = false;
                     }
                 }
@@ -183,6 +193,6 @@ fn main() -> i32 {
 
 fn usage_text() -> StrBuf {
     let mut u = StrBuf.new();
-    u.push_str("usage: ruelex [--pretty|--ast] <file.rue> [<file.rue> ...]\n");
+    u.push_str("usage: ruelex [--pretty|--ast|--ast-shape] <file.rue> [<file.rue> ...]\n");
     u
 }

--- a/examples/ruelex/parse.rue
+++ b/examples/ruelex/parse.rue
@@ -11,6 +11,7 @@ const StrBuf = std.strbuf.StrBuf;
 
 pub struct ParseOutput {
     dump: StrBuf,
+    shape: StrBuf,
     errors: StrBuf,
     node_count: u64,
 }
@@ -33,7 +34,7 @@ pub struct Parser {
     }
 
     fn fallback() -> token.Token {
-        token.Token { kind: token.EOF, start: 0, end: 0, value: 0 }
+        token.Token { kind: token.EOF, start: 0, end: 0, value: 0, aux: 0 }
     }
 
     fn current(borrow self) -> token.Token {
@@ -319,7 +320,25 @@ pub struct Parser {
     fn parse_intrinsic(inout self) -> u64 {
         let at = self.bump();
         let name = if self.at(token.IDENT) || self.at(token.DROP) { self.bump() } else { self.expect(token.IDENT) };
-        let args = self.parse_call_args();
+        let _ = self.expect(token.LPAREN);
+        let mut args: u64 = 0;
+        let mut position: u64 = 0;
+        while !self.at(token.RPAREN) && !self.eof() {
+            let type_position = name.aux == 1 || (name.aux == 2 && position == 0);
+            let placeholder_type = name.aux == 0 &&
+                ((self.at(token.LPAREN) && self.kind_at(self.pos + 1) == token.RPAREN) ||
+                 (self.at(token.BANG) && (self.kind_at(self.pos + 1) == token.COMMA || self.kind_at(self.pos + 1) == token.RPAREN)) ||
+                 (self.at(token.LBRACKET) && self.bracket_has_semi()));
+            let value = if type_position || placeholder_type {
+                self.parse_type()
+            } else {
+                self.parse_expr(0, true)
+            };
+            args = self.append(args, self.add(ast.ARG, 0, self.arena.at(value).start, self.arena.at(value).end, value, 0, 0));
+            position = position + 1;
+            if !self.eat(token.COMMA) { break; }
+        }
+        let _ = self.expect(token.RPAREN);
         self.add_meta(ast.INTRINSIC, name.value, name.kind, at.start, self.previous().end, args, 0, 0, 0)
     }
 
@@ -528,6 +547,23 @@ pub struct Parser {
 
     fn is_primitive(kind: u64) -> bool { kind >= token.TYPE_I8 && kind <= token.TYPE_TYPE }
 
+    fn bracket_has_semi(borrow self) -> bool {
+        let mut p = self.pos;
+        let mut depth: u64 = 0;
+        loop {
+            let k = self.kind_at(p);
+            if k == token.EOF { return false; }
+            if k == token.LBRACKET || k == token.LPAREN || k == token.LBRACE { depth = depth + 1; }
+            else if k == token.RBRACKET {
+                if depth == 1 { return false; }
+                depth = depth - 1;
+            } else if k == token.RPAREN || k == token.RBRACE {
+                if depth != 0 { depth = depth - 1; }
+            } else if k == token.SEMI && depth == 1 { return true; }
+            p = p + 1;
+        }
+    }
+
     fn parse_type(inout self) -> u64 {
         let t = self.current();
         if Self.is_primitive(t.kind) || t.kind == token.SELFTYPE {
@@ -546,7 +582,10 @@ pub struct Parser {
         if t.kind == token.LBRACKET {
             let start = self.bump().start;
             let elem = self.parse_type();
-            let _ = self.expect(token.SEMI);
+            if !self.eat(token.SEMI) {
+                let close = self.expect(token.RBRACKET);
+                return self.add(ast.SLICE_TYPE, 0, start, close.end, elem, 0, 0);
+            }
             let len = self.parse_expr(0, true);
             let close = self.expect(token.RBRACKET);
             return self.add(ast.ARRAY_TYPE, 0, start, close.end, elem, len, 0);
@@ -784,7 +823,8 @@ pub struct Parser {
         let root = self.parse_program();
         let count = self.arena.len();
         let dump = self.arena.dump(root);
-        ParseOutput { dump: dump, errors: self.errors, node_count: count }
+        let shape = self.arena.dump_shape(root);
+        ParseOutput { dump: dump, shape: shape, errors: self.errors, node_count: count }
     }
 }
 

--- a/examples/ruelex/token.rue
+++ b/examples/ruelex/token.rue
@@ -98,6 +98,9 @@ pub struct Token {
     start: u64,
     end: u64,
     value: u64,
+    // Parser-only lexical policy (0 ordinary, 1 all intrinsic args are types,
+    // 2 only the first intrinsic arg is a type). Never affects token dumps.
+    aux: u64,
 }
 
 pub const Tokens = std.arraybuf.ArrayBuf(Token);

--- a/rust-project.json
+++ b/rust-project.json
@@ -11,19 +11,27 @@
           "name": "rue_air"
         },
         {
-          "crate": 7,
+          "crate": 4,
+          "name": "rue_cfg"
+        },
+        {
+          "crate": 9,
           "name": "rue_compiler"
         },
         {
           "crate": 19,
+          "name": "rue_rir"
+        },
+        {
+          "crate": 23,
           "name": "rue_span"
         },
         {
-          "crate": 61,
+          "crate": 65,
           "name": "lasso"
         },
         {
-          "crate": 99,
+          "crate": 103,
           "name": "serde_json"
         }
       ],
@@ -47,32 +55,92 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 2,
+          "crate": 3,
           "name": "rue_builtins"
         },
         {
-          "crate": 8,
+          "crate": 10,
           "name": "rue_error"
         },
         {
-          "crate": 16,
+          "crate": 19,
           "name": "rue_rir"
         },
         {
-          "crate": 17,
+          "crate": 21,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 19,
+          "crate": 23,
           "name": "rue_span"
         },
         {
-          "crate": 21,
+          "crate": 25,
           "name": "rue_target"
         },
         {
-          "crate": 61,
+          "crate": 65,
           "name": "lasso"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-air/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-air-fuzz-support",
+      "root_module": "crates/rue-air/src/lib.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 3,
+          "name": "rue_builtins"
+        },
+        {
+          "crate": 10,
+          "name": "rue_error"
+        },
+        {
+          "crate": 13,
+          "name": "rue_lexer"
+        },
+        {
+          "crate": 18,
+          "name": "rue_parser"
+        },
+        {
+          "crate": 19,
+          "name": "rue_rir"
+        },
+        {
+          "crate": 21,
+          "name": "rue_runtime_abi"
+        },
+        {
+          "crate": 23,
+          "name": "rue_span"
+        },
+        {
+          "crate": 25,
+          "name": "rue_target"
+        },
+        {
+          "crate": 65,
+          "name": "lasso"
+        },
+        {
+          "crate": 95,
+          "name": "rayon"
         }
       ],
       "is_workspace_member": true,
@@ -95,7 +163,7 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 17,
+          "crate": 21,
           "name": "rue_runtime_abi"
         }
       ],
@@ -123,15 +191,51 @@
           "name": "rue_air"
         },
         {
-          "crate": 8,
+          "crate": 10,
           "name": "rue_error"
         },
         {
-          "crate": 19,
+          "crate": 23,
           "name": "rue_span"
         },
         {
-          "crate": 61,
+          "crate": 65,
+          "name": "lasso"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-cfg/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-cfg-fuzz-support",
+      "root_module": "crates/rue-cfg/src/lib.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 1,
+          "name": "rue_air"
+        },
+        {
+          "crate": 10,
+          "name": "rue_error"
+        },
+        {
+          "crate": 23,
+          "name": "rue_span"
+        },
+        {
+          "crate": 65,
           "name": "lasso"
         }
       ],
@@ -155,27 +259,27 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 21,
+          "crate": 25,
           "name": "rue_target"
         },
         {
-          "crate": 22,
+          "crate": 26,
           "name": "rue_test_runner"
         },
         {
-          "crate": 70,
+          "crate": 74,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 97,
+          "crate": 101,
           "name": "serde"
         },
         {
-          "crate": 105,
+          "crate": 109,
           "name": "tempfile"
         },
         {
-          "crate": 108,
+          "crate": 112,
           "name": "toml"
         }
       ],
@@ -203,35 +307,35 @@
           "name": "rue_air"
         },
         {
-          "crate": 2,
+          "crate": 3,
           "name": "rue_builtins"
         },
         {
-          "crate": 3,
+          "crate": 4,
           "name": "rue_cfg"
         },
         {
-          "crate": 8,
+          "crate": 10,
           "name": "rue_error"
         },
         {
-          "crate": 17,
+          "crate": 21,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 19,
+          "crate": 23,
           "name": "rue_span"
         },
         {
-          "crate": 21,
+          "crate": 25,
           "name": "rue_target"
         },
         {
-          "crate": 52,
+          "crate": 56,
           "name": "fixedbitset"
         },
         {
-          "crate": 61,
+          "crate": 65,
           "name": "lasso"
         }
       ],
@@ -259,19 +363,19 @@
           "name": "rue_air"
         },
         {
-          "crate": 7,
+          "crate": 9,
           "name": "rue_compiler"
         },
         {
-          "crate": 19,
+          "crate": 23,
           "name": "rue_span"
         },
         {
-          "crate": 99,
+          "crate": 103,
           "name": "serde_json"
         },
         {
-          "crate": 101,
+          "crate": 105,
           "name": "sha2"
         }
       ],
@@ -299,83 +403,83 @@
           "name": "rue_air"
         },
         {
-          "crate": 2,
+          "crate": 3,
           "name": "rue_builtins"
         },
         {
-          "crate": 3,
+          "crate": 4,
           "name": "rue_cfg"
         },
         {
-          "crate": 5,
+          "crate": 7,
           "name": "rue_codegen"
         },
         {
-          "crate": 8,
+          "crate": 10,
           "name": "rue_error"
         },
         {
-          "crate": 10,
+          "crate": 13,
           "name": "rue_lexer"
         },
         {
-          "crate": 11,
+          "crate": 14,
           "name": "rue_linker"
         },
         {
-          "crate": 15,
+          "crate": 18,
           "name": "rue_parser"
         },
         {
-          "crate": 16,
+          "crate": 19,
           "name": "rue_rir"
         },
         {
-          "crate": 17,
+          "crate": 21,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 19,
+          "crate": 23,
           "name": "rue_span"
         },
         {
-          "crate": 21,
+          "crate": 25,
           "name": "rue_target"
         },
         {
-          "crate": 33,
+          "crate": 37,
           "name": "annotate_snippets"
         },
         {
-          "crate": 61,
+          "crate": 65,
           "name": "lasso"
         },
         {
-          "crate": 66,
+          "crate": 70,
           "name": "libc"
         },
         {
-          "crate": 91,
+          "crate": 95,
           "name": "rayon"
         },
         {
-          "crate": 97,
+          "crate": 101,
           "name": "serde"
         },
         {
-          "crate": 99,
+          "crate": 103,
           "name": "serde_json"
         },
         {
-          "crate": 101,
+          "crate": 105,
           "name": "sha2"
         },
         {
-          "crate": 105,
+          "crate": 109,
           "name": "tempfile"
         },
         {
-          "crate": 112,
+          "crate": 116,
           "name": "tracing"
         }
       ],
@@ -399,11 +503,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 19,
+          "crate": 23,
           "name": "rue_span"
         },
         {
-          "crate": 106,
+          "crate": 110,
           "name": "thiserror"
         }
       ],
@@ -422,36 +526,100 @@
       "is_proc_macro": false
     },
     {
+      "display_name": "rue-frontend-diff",
+      "root_module": "crates/rue-frontend-diff/src/main.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 13,
+          "name": "rue_lexer"
+        },
+        {
+          "crate": 18,
+          "name": "rue_parser"
+        },
+        {
+          "crate": 26,
+          "name": "rue_test_runner"
+        },
+        {
+          "crate": 65,
+          "name": "lasso"
+        },
+        {
+          "crate": 109,
+          "name": "tempfile"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-frontend-diff/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
       "display_name": "rue-fuzz",
       "root_module": "crates/rue-fuzz/src/main.rs",
       "edition": "2024",
       "deps": [
         {
+          "crate": 1,
+          "name": "rue_air"
+        },
+        {
+          "crate": 2,
+          "name": "rue_air_fuzz_support"
+        },
+        {
+          "crate": 4,
+          "name": "rue_cfg"
+        },
+        {
           "crate": 5,
-          "name": "rue_codegen"
+          "name": "rue_cfg_fuzz_support"
         },
         {
           "crate": 7,
+          "name": "rue_codegen"
+        },
+        {
+          "crate": 9,
           "name": "rue_compiler"
         },
         {
-          "crate": 10,
+          "crate": 13,
           "name": "rue_lexer"
         },
         {
-          "crate": 15,
+          "crate": 18,
           "name": "rue_parser"
         },
         {
-          "crate": 36,
+          "crate": 19,
+          "name": "rue_rir"
+        },
+        {
+          "crate": 20,
+          "name": "rue_rir_fuzz_support"
+        },
+        {
+          "crate": 40,
           "name": "anyhow"
         },
         {
-          "crate": 66,
+          "crate": 70,
           "name": "libc"
         },
         {
-          "crate": 84,
+          "crate": 88,
           "name": "proptest"
         }
       ],
@@ -475,19 +643,19 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 8,
+          "crate": 10,
           "name": "rue_error"
         },
         {
-          "crate": 19,
+          "crate": 23,
           "name": "rue_span"
         },
         {
-          "crate": 61,
+          "crate": 65,
           "name": "lasso"
         },
         {
-          "crate": 73,
+          "crate": 77,
           "name": "logos"
         }
       ],
@@ -511,11 +679,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 21,
+          "crate": 25,
           "name": "rue_target"
         },
         {
-          "crate": 112,
+          "crate": 116,
           "name": "tracing"
         }
       ],
@@ -539,31 +707,31 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 7,
+          "crate": 9,
           "name": "rue_compiler"
         },
         {
-          "crate": 8,
+          "crate": 10,
           "name": "rue_error"
         },
         {
-          "crate": 13,
+          "crate": 16,
           "name": "rue_oracle"
         },
         {
-          "crate": 22,
+          "crate": 26,
           "name": "rue_test_runner"
         },
         {
-          "crate": 97,
+          "crate": 101,
           "name": "serde"
         },
         {
-          "crate": 105,
+          "crate": 109,
           "name": "tempfile"
         },
         {
-          "crate": 108,
+          "crate": 112,
           "name": "toml"
         }
       ],
@@ -591,15 +759,15 @@
           "name": "rue_air"
         },
         {
-          "crate": 3,
+          "crate": 4,
           "name": "rue_cfg"
         },
         {
-          "crate": 7,
+          "crate": 9,
           "name": "rue_compiler"
         },
         {
-          "crate": 61,
+          "crate": 65,
           "name": "lasso"
         }
       ],
@@ -623,23 +791,23 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 10,
+          "crate": 13,
           "name": "rue_lexer"
         },
         {
-          "crate": 15,
+          "crate": 18,
           "name": "rue_parser"
         },
         {
-          "crate": 19,
+          "crate": 23,
           "name": "rue_span"
         },
         {
-          "crate": 61,
+          "crate": 65,
           "name": "lasso"
         },
         {
-          "crate": 99,
+          "crate": 103,
           "name": "serde_json"
         }
       ],
@@ -663,27 +831,27 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 8,
+          "crate": 10,
           "name": "rue_error"
         },
         {
-          "crate": 10,
+          "crate": 13,
           "name": "rue_lexer"
         },
         {
-          "crate": 19,
+          "crate": 23,
           "name": "rue_span"
         },
         {
-          "crate": 61,
+          "crate": 65,
           "name": "lasso"
         },
         {
-          "crate": 103,
+          "crate": 107,
           "name": "smallvec"
         },
         {
-          "crate": 112,
+          "crate": 116,
           "name": "tracing"
         }
       ],
@@ -707,19 +875,55 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 10,
+          "crate": 13,
           "name": "rue_lexer"
         },
         {
-          "crate": 15,
+          "crate": 18,
           "name": "rue_parser"
         },
         {
-          "crate": 19,
+          "crate": 23,
           "name": "rue_span"
         },
         {
-          "crate": 61,
+          "crate": 65,
+          "name": "lasso"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-rir/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-rir-fuzz-support",
+      "root_module": "crates/rue-rir/src/lib.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 13,
+          "name": "rue_lexer"
+        },
+        {
+          "crate": 18,
+          "name": "rue_parser"
+        },
+        {
+          "crate": 23,
+          "name": "rue_span"
+        },
+        {
+          "crate": 65,
           "name": "lasso"
         }
       ],
@@ -762,7 +966,7 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 17,
+          "crate": 21,
           "name": "rue_runtime_abi"
         }
       ],
@@ -805,15 +1009,15 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 22,
+          "crate": 26,
           "name": "rue_test_runner"
         },
         {
-          "crate": 70,
+          "crate": 74,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 105,
+          "crate": 109,
           "name": "tempfile"
         }
       ],
@@ -856,27 +1060,27 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 8,
+          "crate": 10,
           "name": "rue_error"
         },
         {
-          "crate": 21,
+          "crate": 25,
           "name": "rue_target"
         },
         {
-          "crate": 66,
+          "crate": 70,
           "name": "libc"
         },
         {
-          "crate": 97,
+          "crate": 101,
           "name": "serde"
         },
         {
-          "crate": 105,
+          "crate": 109,
           "name": "tempfile"
         },
         {
-          "crate": 108,
+          "crate": 112,
           "name": "toml"
         }
       ],
@@ -900,11 +1104,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 22,
+          "crate": 26,
           "name": "rue_test_runner"
         },
         {
-          "crate": 70,
+          "crate": 74,
           "name": "libtest2_mimic"
         }
       ],
@@ -928,39 +1132,39 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 7,
+          "crate": 9,
           "name": "rue_compiler"
         },
         {
-          "crate": 16,
+          "crate": 19,
           "name": "rue_rir"
         },
         {
-          "crate": 21,
+          "crate": 25,
           "name": "rue_target"
         },
         {
-          "crate": 66,
+          "crate": 70,
           "name": "libc"
         },
         {
-          "crate": 97,
+          "crate": 101,
           "name": "serde"
         },
         {
-          "crate": 99,
+          "crate": 103,
           "name": "serde_json"
         },
         {
-          "crate": 101,
+          "crate": 105,
           "name": "sha2"
         },
         {
-          "crate": 112,
+          "crate": 116,
           "name": "tracing"
         },
         {
-          "crate": 116,
+          "crate": 120,
           "name": "tracing_subscriber"
         }
       ],
@@ -984,39 +1188,39 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 7,
+          "crate": 9,
           "name": "rue_compiler"
         },
         {
-          "crate": 16,
+          "crate": 19,
           "name": "rue_rir"
         },
         {
-          "crate": 21,
+          "crate": 25,
           "name": "rue_target"
         },
         {
-          "crate": 66,
+          "crate": 70,
           "name": "libc"
         },
         {
-          "crate": 97,
+          "crate": 101,
           "name": "serde"
         },
         {
-          "crate": 99,
+          "crate": 103,
           "name": "serde_json"
         },
         {
-          "crate": 101,
+          "crate": 105,
           "name": "sha2"
         },
         {
-          "crate": 112,
+          "crate": 116,
           "name": "tracing"
         },
         {
-          "crate": 116,
+          "crate": 120,
           "name": "tracing_subscriber"
         }
       ],
@@ -1040,7 +1244,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 74,
+          "crate": 78,
           "name": "logos_codegen"
         }
       ],
@@ -1064,15 +1268,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 83,
+          "crate": 87,
           "name": "proc_macro2"
         },
         {
-          "crate": 86,
+          "crate": 90,
           "name": "quote"
         },
         {
-          "crate": 104,
+          "crate": 108,
           "name": "syn"
         }
       ],
@@ -1097,15 +1301,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 83,
+          "crate": 87,
           "name": "proc_macro2"
         },
         {
-          "crate": 86,
+          "crate": 90,
           "name": "quote"
         },
         {
-          "crate": 104,
+          "crate": 108,
           "name": "syn"
         }
       ],
@@ -1129,15 +1333,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 83,
+          "crate": 87,
           "name": "proc_macro2"
         },
         {
-          "crate": 86,
+          "crate": 90,
           "name": "quote"
         },
         {
-          "crate": 104,
+          "crate": 108,
           "name": "syn"
         }
       ],
@@ -1161,15 +1365,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 42,
+          "crate": 46,
           "name": "cfg_if"
         },
         {
-          "crate": 79,
+          "crate": 83,
           "name": "once_cell"
         },
         {
-          "crate": 123,
+          "crate": 127,
           "name": "zerocopy"
         }
       ],
@@ -1193,7 +1397,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 76,
+          "crate": 80,
           "name": "memchr"
         }
       ],
@@ -1239,11 +1443,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 35,
+          "crate": 39,
           "name": "anstyle"
         },
         {
-          "crate": 120,
+          "crate": 124,
           "name": "unicode_width"
         }
       ],
@@ -1352,7 +1556,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 39,
+          "crate": 43,
           "name": "bit_vec"
         }
       ],
@@ -1420,7 +1624,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 54,
+          "crate": 58,
           "name": "generic_array"
         }
       ],
@@ -1482,11 +1686,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 45,
+          "crate": 49,
           "name": "crossbeam_epoch"
         },
         {
-          "crate": 46,
+          "crate": 50,
           "name": "crossbeam_utils"
         }
       ],
@@ -1512,7 +1716,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 46,
+          "crate": 50,
           "name": "crossbeam_utils"
         }
       ],
@@ -1559,11 +1763,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 54,
+          "crate": 58,
           "name": "generic_array"
         },
         {
-          "crate": 117,
+          "crate": 121,
           "name": "typenum"
         }
       ],
@@ -1587,27 +1791,27 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 42,
+          "crate": 46,
           "name": "cfg_if"
         },
         {
-          "crate": 46,
+          "crate": 50,
           "name": "crossbeam_utils"
         },
         {
-          "crate": 56,
+          "crate": 60,
           "name": "hashbrown"
         },
         {
-          "crate": 71,
+          "crate": 75,
           "name": "lock_api"
         },
         {
-          "crate": 79,
+          "crate": 83,
           "name": "once_cell"
         },
         {
-          "crate": 80,
+          "crate": 84,
           "name": "parking_lot_core"
         }
       ],
@@ -1632,11 +1836,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 41,
+          "crate": 45,
           "name": "block_buffer"
         },
         {
-          "crate": 47,
+          "crate": 51,
           "name": "crypto_common"
         }
       ],
@@ -1743,7 +1947,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 117,
+          "crate": 121,
           "name": "typenum"
         }
       ],
@@ -1788,11 +1992,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 30,
+          "crate": 34,
           "name": "ahash"
         },
         {
-          "crate": 32,
+          "crate": 36,
           "name": "allocator_api2"
         }
       ],
@@ -1840,11 +2044,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 51,
+          "crate": 55,
           "name": "equivalent"
         },
         {
-          "crate": 57,
+          "crate": 61,
           "name": "hashbrown"
         }
       ],
@@ -1911,11 +2115,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 48,
+          "crate": 52,
           "name": "dashmap"
         },
         {
-          "crate": 56,
+          "crate": 60,
           "name": "hashbrown"
         }
       ],
@@ -1961,11 +2165,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 64,
+          "crate": 68,
           "name": "lexarg_error"
         },
         {
-          "crate": 65,
+          "crate": 69,
           "name": "lexarg_parser"
         }
       ],
@@ -1990,7 +2194,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 65,
+          "crate": 69,
           "name": "lexarg_parser"
         }
       ],
@@ -2056,7 +2260,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 60,
+          "crate": 64,
           "name": "json_write"
         }
       ],
@@ -2082,11 +2286,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 63,
+          "crate": 67,
           "name": "lexarg"
         },
         {
-          "crate": 64,
+          "crate": 68,
           "name": "lexarg_error"
         }
       ],
@@ -2111,27 +2315,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 34,
+          "crate": 38,
           "name": "anstream"
         },
         {
-          "crate": 35,
+          "crate": 39,
           "name": "anstyle"
         },
         {
-          "crate": 64,
+          "crate": 68,
           "name": "lexarg_error"
         },
         {
-          "crate": 65,
+          "crate": 69,
           "name": "lexarg_parser"
         },
         {
-          "crate": 67,
+          "crate": 71,
           "name": "libtest_json"
         },
         {
-          "crate": 68,
+          "crate": 72,
           "name": "libtest_lexarg"
         }
       ],
@@ -2158,11 +2362,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 67,
+          "crate": 71,
           "name": "libtest_json"
         },
         {
-          "crate": 69,
+          "crate": 73,
           "name": "libtest2_harness"
         }
       ],
@@ -2189,7 +2393,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 96,
+          "crate": 100,
           "name": "scopeguard"
         }
       ],
@@ -2235,7 +2439,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 26,
+          "crate": 30,
           "name": "logos_derive"
         }
       ],
@@ -2263,31 +2467,31 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 37,
+          "crate": 41,
           "name": "beef"
         },
         {
-          "crate": 53,
+          "crate": 57,
           "name": "fnv"
         },
         {
-          "crate": 62,
+          "crate": 66,
           "name": "lazy_static"
         },
         {
-          "crate": 83,
+          "crate": 87,
           "name": "proc_macro2"
         },
         {
-          "crate": 86,
+          "crate": 90,
           "name": "quote"
         },
         {
-          "crate": 94,
+          "crate": 98,
           "name": "regex_syntax"
         },
         {
-          "crate": 104,
+          "crate": 108,
           "name": "syn"
         }
       ],
@@ -2311,7 +2515,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 93,
+          "crate": 97,
           "name": "regex_automata"
         }
       ],
@@ -2458,7 +2662,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 123,
+          "crate": 127,
           "name": "zerocopy"
         }
       ],
@@ -2484,7 +2688,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 119,
+          "crate": 123,
           "name": "unicode_ident"
         }
       ],
@@ -2510,47 +2714,47 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 38,
+          "crate": 42,
           "name": "bit_set"
         },
         {
-          "crate": 39,
+          "crate": 43,
           "name": "bit_vec"
         },
         {
-          "crate": 40,
+          "crate": 44,
           "name": "bitflags"
         },
         {
-          "crate": 78,
+          "crate": 82,
           "name": "num_traits"
         },
         {
-          "crate": 87,
+          "crate": 91,
           "name": "rand"
         },
         {
-          "crate": 88,
+          "crate": 92,
           "name": "rand_chacha"
         },
         {
-          "crate": 90,
+          "crate": 94,
           "name": "rand_xorshift"
         },
         {
-          "crate": 94,
+          "crate": 98,
           "name": "regex_syntax"
         },
         {
-          "crate": 95,
+          "crate": 99,
           "name": "rusty_fork"
         },
         {
-          "crate": 105,
+          "crate": 109,
           "name": "tempfile"
         },
         {
-          "crate": 118,
+          "crate": 122,
           "name": "unarray"
         }
       ],
@@ -2601,7 +2805,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 83,
+          "crate": 87,
           "name": "proc_macro2"
         }
       ],
@@ -2627,7 +2831,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 89,
+          "crate": 93,
           "name": "rand_core"
         }
       ],
@@ -2654,11 +2858,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 82,
+          "crate": 86,
           "name": "ppv_lite86"
         },
         {
-          "crate": 89,
+          "crate": 93,
           "name": "rand_core"
         }
       ],
@@ -2683,7 +2887,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 55,
+          "crate": 59,
           "name": "getrandom"
         }
       ],
@@ -2709,7 +2913,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 89,
+          "crate": 93,
           "name": "rand_core"
         }
       ],
@@ -2733,11 +2937,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 50,
+          "crate": 54,
           "name": "either"
         },
         {
-          "crate": 92,
+          "crate": 96,
           "name": "rayon_core"
         }
       ],
@@ -2761,11 +2965,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 44,
+          "crate": 48,
           "name": "crossbeam_deque"
         },
         {
-          "crate": 46,
+          "crate": 50,
           "name": "crossbeam_utils"
         }
       ],
@@ -2789,15 +2993,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 31,
+          "crate": 35,
           "name": "aho_corasick"
         },
         {
-          "crate": 76,
+          "crate": 80,
           "name": "memchr"
         },
         {
-          "crate": 94,
+          "crate": 98,
           "name": "regex_syntax"
         }
       ],
@@ -2874,19 +3078,19 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 53,
+          "crate": 57,
           "name": "fnv"
         },
         {
-          "crate": 85,
+          "crate": 89,
           "name": "quick_error"
         },
         {
-          "crate": 105,
+          "crate": 109,
           "name": "tempfile"
         },
         {
-          "crate": 121,
+          "crate": 125,
           "name": "wait_timeout"
         }
       ],
@@ -2931,11 +3135,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 27,
+          "crate": 31,
           "name": "serde_derive"
         },
         {
-          "crate": 98,
+          "crate": 102,
           "name": "serde_core"
         }
       ],
@@ -2984,19 +3188,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 59,
+          "crate": 63,
           "name": "itoa"
         },
         {
-          "crate": 76,
+          "crate": 80,
           "name": "memchr"
         },
         {
-          "crate": 98,
+          "crate": 102,
           "name": "serde_core"
         },
         {
-          "crate": 124,
+          "crate": 128,
           "name": "zmij"
         }
       ],
@@ -3022,7 +3226,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 97,
+          "crate": 101,
           "name": "serde"
         }
       ],
@@ -3047,15 +3251,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 42,
+          "crate": 46,
           "name": "cfg_if"
         },
         {
-          "crate": 43,
+          "crate": 47,
           "name": "cpufeatures"
         },
         {
-          "crate": 49,
+          "crate": 53,
           "name": "digest"
         }
       ],
@@ -3079,7 +3283,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 62,
+          "crate": 66,
           "name": "lazy_static"
         }
       ],
@@ -3122,15 +3326,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 83,
+          "crate": 87,
           "name": "proc_macro2"
         },
         {
-          "crate": 86,
+          "crate": 90,
           "name": "quote"
         },
         {
-          "crate": 119,
+          "crate": 123,
           "name": "unicode_ident"
         }
       ],
@@ -3184,7 +3388,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 28,
+          "crate": 32,
           "name": "thiserror_impl"
         }
       ],
@@ -3210,7 +3414,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 42,
+          "crate": 46,
           "name": "cfg_if"
         }
       ],
@@ -3234,19 +3438,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 97,
+          "crate": 101,
           "name": "serde"
         },
         {
-          "crate": 100,
+          "crate": 104,
           "name": "serde_spanned"
         },
         {
-          "crate": 109,
+          "crate": 113,
           "name": "toml_datetime"
         },
         {
-          "crate": 110,
+          "crate": 114,
           "name": "toml_edit"
         }
       ],
@@ -3273,7 +3477,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 97,
+          "crate": 101,
           "name": "serde"
         }
       ],
@@ -3298,27 +3502,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 58,
+          "crate": 62,
           "name": "indexmap"
         },
         {
-          "crate": 97,
+          "crate": 101,
           "name": "serde"
         },
         {
-          "crate": 100,
+          "crate": 104,
           "name": "serde_spanned"
         },
         {
-          "crate": 109,
+          "crate": 113,
           "name": "toml_datetime"
         },
         {
-          "crate": 111,
+          "crate": 115,
           "name": "toml_write"
         },
         {
-          "crate": 122,
+          "crate": 126,
           "name": "winnow"
         }
       ],
@@ -3367,15 +3571,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 29,
+          "crate": 33,
           "name": "tracing_attributes"
         },
         {
-          "crate": 81,
+          "crate": 85,
           "name": "pin_project_lite"
         },
         {
-          "crate": 113,
+          "crate": 117,
           "name": "tracing_core"
         }
       ],
@@ -3403,7 +3607,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 79,
+          "crate": 83,
           "name": "once_cell"
         }
       ],
@@ -3430,15 +3634,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 72,
+          "crate": 76,
           "name": "log"
         },
         {
-          "crate": 79,
+          "crate": 83,
           "name": "once_cell"
         },
         {
-          "crate": 113,
+          "crate": 117,
           "name": "tracing_core"
         }
       ],
@@ -3464,11 +3668,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 97,
+          "crate": 101,
           "name": "serde"
         },
         {
-          "crate": 113,
+          "crate": 117,
           "name": "tracing_core"
         }
       ],
@@ -3492,55 +3696,55 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 75,
+          "crate": 79,
           "name": "matchers"
         },
         {
-          "crate": 77,
+          "crate": 81,
           "name": "nu_ansi_term"
         },
         {
-          "crate": 79,
+          "crate": 83,
           "name": "once_cell"
         },
         {
-          "crate": 93,
+          "crate": 97,
           "name": "regex_automata"
         },
         {
-          "crate": 97,
+          "crate": 101,
           "name": "serde"
         },
         {
-          "crate": 99,
+          "crate": 103,
           "name": "serde_json"
         },
         {
-          "crate": 102,
+          "crate": 106,
           "name": "sharded_slab"
         },
         {
-          "crate": 103,
+          "crate": 107,
           "name": "smallvec"
         },
         {
-          "crate": 107,
+          "crate": 111,
           "name": "thread_local"
         },
         {
-          "crate": 112,
+          "crate": 116,
           "name": "tracing"
         },
         {
-          "crate": 113,
+          "crate": 117,
           "name": "tracing_core"
         },
         {
-          "crate": 114,
+          "crate": 118,
           "name": "tracing_log"
         },
         {
-          "crate": 115,
+          "crate": 119,
           "name": "tracing_serde"
         }
       ],


### PR DESCRIPTION
## What changed

- add a paired production-vs-ruelex differential that checks byte-exact token/lexeme output and canonical AST structure across 117 checked-in Rue programs plus targeted grammar probes
- extend ruelex with canonical AST-shape output, slice types, type-position intrinsic arguments, and ordinary intrinsic placeholder classification
- add bounded subprocess execution and mismatch-sensitivity tests
- add a shared output-limited timeout runner, fixing RUE-990 while preserving the existing API

## Why

RUE-942 introduced an independent Rue-written stage-1 frontend, but its acceptance criterion requires structural agreement with the production parser. The paired token gate prevents erased names and literal payloads from hiding disagreements, while targeted probes cover syntax not present in standalone corpus files.

## Validation

- `scripts/rue quick` — 33/33 targets
- frontend differential — 117/117 files plus 2 syntax probes
- frontend unit tests — 5/5, including injected token-only and AST-only mismatches
- rue-test-runner unit tests — 91/91
- ruelex CLI — 1/1; rueparse CLI — 3/3
- x86-64 Linux and AArch64 Linux cross-target compilation
- `scripts/rue fmt`; `git diff --check`

Performance on the 32-file Rue frontend (6,200 lines, 38,786 tokens), five fresh `-j1 -O0` runs: 467.7 ms median total, 44.7 MB median peak RSS. This is +0.6% versus the 464.8 ms pre-oracle baseline.

Linear: RUE-942, RUE-990