### PR TITLE
RUE-867: Hide durable cache schemas

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -137,23 +137,217 @@ const RUE_866_INTERNAL_VOCABULARY: &[&str] = &[
     "SourceStats",
 ];
 
-fn public_signatures(source: &str) -> String {
-    let mut result = String::new();
-    let mut collecting = false;
-    for line in source.lines() {
+const RUE_867_DURABLE_VOCABULARY: &[&str] = &[
+    "DURABLE_ORDINARY_BODY_SCHEMA_VERSION",
+    "DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION",
+    "DurableAirInst",
+    "DurableAirInstData",
+    "DurableAirRef",
+    "DurableBodyAnchor",
+    "DurableBodyConversionFailure",
+    "DurableBodyProjectionFailure",
+    "DurableBodyWork",
+    "DurableCallArg",
+    "DurableMatchArm",
+    "DurableOrdinaryBody",
+    "DurableOrdinaryBodyPayload",
+    "DurablePattern",
+    "DurablePlace",
+    "DurablePlaceRef",
+    "DurableProjection",
+    "DurableSpecializedBody",
+    "DurableSpecializedBodyPayload",
+    "convert_semantic_specialized_body_exports",
+    "DURABLE_SEMANTIC_SCHEMA_VERSION",
+    "DurableConstValue",
+    "DurableDeclarationPayload",
+    "DurableDeclarationSemantic",
+    "DurableParameterMode",
+    "DurableSemanticExportFailure",
+    "DurableSemanticImportEpoch",
+    "DurableSemanticParameter",
+    "DurableSemanticProjectionFailure",
+    "DurableSemanticProjectionWork",
+    "DurableSemanticSchemaVersion",
+    "DurableType",
+];
+
+fn public_declarations(source: &str) -> Vec<String> {
+    let mut declarations = Vec::new();
+    let mut lines = source.lines();
+    while let Some(line) = lines.next() {
         let trimmed = line.trim_start();
-        if trimmed.starts_with("pub ") && !trimmed.starts_with("pub(crate)") {
-            collecting = true;
+        if !trimmed.starts_with("pub ") || trimmed.starts_with("pub(crate)") {
+            continue;
         }
-        if collecting {
-            result.push_str(line);
-            result.push('\n');
-            if line.contains('{') || line.contains(';') {
-                collecting = false;
+
+        let identifiers = code_identifiers(trimmed);
+        let owns_body = identifiers
+            .iter()
+            .any(|identifier| matches!(*identifier, "struct" | "enum" | "union" | "trait"));
+        let field_owned_body = identifiers
+            .iter()
+            .any(|identifier| matches!(*identifier, "struct" | "union"));
+        let field = !identifiers.iter().any(|identifier| {
+            matches!(
+                *identifier,
+                "fn" | "struct"
+                    | "enum"
+                    | "union"
+                    | "trait"
+                    | "type"
+                    | "use"
+                    | "const"
+                    | "static"
+                    | "mod"
+            )
+        });
+        let mut declaration = String::new();
+        let mut brace_depth = 0isize;
+        let mut opened_body = false;
+        let mut current = Some(line);
+        loop {
+            let declaration_line = current.take().expect("public declaration has a line");
+            declaration.push_str(declaration_line);
+            declaration.push('\n');
+            for byte in declaration_line.bytes() {
+                match byte {
+                    b'{' => {
+                        opened_body = true;
+                        brace_depth += 1;
+                    }
+                    b'}' if opened_body => brace_depth -= 1,
+                    _ => {}
+                }
+            }
+
+            let complete = if owns_body {
+                (opened_body && brace_depth == 0)
+                    || (!opened_body && declaration_line.contains(';'))
+            } else if field {
+                declaration_line.contains(',')
+            } else {
+                declaration_line.contains(';') || declaration_line.contains('{')
+            };
+            if complete {
+                break;
+            }
+            current = lines.next();
+            if current.is_none() {
+                break;
+            }
+        }
+        if field_owned_body && opened_body {
+            let open = declaration.find('{').expect("opened aggregate has a body");
+            let close = declaration
+                .rfind('}')
+                .expect("balanced aggregate has a body");
+            let mut public_shape = declaration[..=open].to_owned();
+            public_shape.push_str(&public_declarations(&declaration[open + 1..close]).concat());
+            public_shape.push('}');
+            declarations.push(public_shape);
+        } else {
+            declarations.push(declaration);
+        }
+    }
+    declarations
+}
+
+fn public_signatures(source: &str) -> String {
+    public_declarations(source).concat()
+}
+
+fn public_declaration_name(declaration: &str) -> Option<&str> {
+    let identifiers = code_identifiers(declaration);
+    let keyword = identifiers.iter().position(|identifier| {
+        matches!(
+            *identifier,
+            "fn" | "struct" | "enum" | "union" | "trait" | "type" | "const" | "static" | "mod"
+        )
+    })?;
+    identifiers.get(keyword + 1).copied()
+}
+
+fn impl_blocks(source: &str) -> Vec<&str> {
+    let mut blocks = Vec::new();
+    let mut offset = 0;
+    for line in source.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("impl ") || trimmed.starts_with("impl<") {
+            let leading = line.len() - trimmed.len();
+            let start = offset + leading;
+            let rest = &source[start..];
+            let Some(open) = rest.find('{') else {
+                offset += line.len();
+                continue;
+            };
+            let mut depth = 0usize;
+            for (index, byte) in rest[open..].bytes().enumerate() {
+                match byte {
+                    b'{' => depth += 1,
+                    b'}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            blocks.push(&rest[..open + index + 1]);
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        offset += line.len();
+    }
+    blocks
+}
+
+fn supported_public_surface(facade: &str, modules: &[(&str, &str)]) -> String {
+    let root_declarations = public_declarations(facade);
+    let public_module_names = root_declarations
+        .iter()
+        .filter_map(|declaration| {
+            declaration
+                .trim_start()
+                .strip_prefix("pub mod ")
+                .and_then(|module| module.split(';').next())
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+    let public_uses = public_use_declarations(facade);
+    let exported_identifiers = public_uses
+        .iter()
+        .flat_map(|declaration| code_identifiers(declaration))
+        .filter(|identifier| {
+            !matches!(
+                *identifier,
+                "pub" | "use" | "self" | "crate" | "super" | "as"
+            )
+        })
+        .map(str::to_owned)
+        .collect::<std::collections::BTreeSet<_>>();
+    let mut surface = root_declarations.concat();
+
+    for (module, source) in modules {
+        if public_module_names.contains(module) {
+            surface.push_str(&public_signatures(source));
+        }
+        for declaration in public_declarations(source) {
+            if public_declaration_name(&declaration)
+                .is_some_and(|name| exported_identifiers.contains(name))
+            {
+                surface.push_str(&declaration);
+            }
+        }
+        for implementation in impl_blocks(source) {
+            if code_identifiers(implementation)
+                .into_iter()
+                .take_while(|identifier| *identifier != "pub")
+                .any(|identifier| exported_identifiers.contains(identifier))
+            {
+                surface.push_str(&public_signatures(implementation));
             }
         }
     }
-    result
+    surface
 }
 
 fn public_use_declarations(source: &str) -> Vec<String> {
@@ -331,7 +525,10 @@ fn query_engine_records_cannot_return_to_the_supported_root() {
             }
         }
     }
-    for forbidden in RUE_866_INTERNAL_VOCABULARY {
+    for forbidden in RUE_866_INTERNAL_VOCABULARY
+        .iter()
+        .chain(RUE_867_DURABLE_VOCABULARY)
+    {
         assert!(
             !supported_exports.contains(forbidden),
             "query-engine implementation record returned to the supported root: {forbidden}"
@@ -377,17 +574,12 @@ fn unstable_views_do_not_alias_query_engine_records() {
             "internal vocabulary leaked through a supported public signature or field: {forbidden}"
         );
     }
-    for line in unstable
-        .lines()
-        .map(str::trim_start)
-        .filter(|line| line.starts_with("pub "))
-    {
-        for forbidden in RUE_866_INTERNAL_VOCABULARY {
-            assert!(
-                !line.contains(forbidden),
-                "unstable public item directly exposes internal vocabulary: {line}"
-            );
-        }
+    let supported_public = supported_public_surface(facade, PRODUCTION_MODULES);
+    for forbidden in RUE_867_DURABLE_VOCABULARY {
+        assert!(
+            !supported_public.contains(forbidden),
+            "durable cache schema leaked through the complete supported public surface: {forbidden}"
+        );
     }
     assert!(reviewed_public.contains("pub fn stage(&self) -> DiagnosticStage"));
 
@@ -417,6 +609,76 @@ fn qualified_public_globs_are_rejected() {
                 .iter()
                 .any(|declaration| public_use_is_glob(declaration)),
             "qualified glob fixture escaped the public-use guard: {fixture}"
+        );
+    }
+}
+
+#[test]
+fn supported_surface_scanner_closes_multiline_and_alias_escapes() {
+    let facade = r#"
+pub mod unstable;
+pub use session::{Exported, ExportedRecord};
+pub type Alias = durable_body::DurableType;
+"#;
+    let session = r#"
+pub struct ExportedRecord {
+    pub safe: usize,
+    pub leaked:
+        DurableOrdinaryBody,
+}
+pub struct Exported;
+impl Exported {
+    pub fn leaked(
+        &self,
+    ) -> DurableSpecializedBodyPayload {
+        unreachable!()
+    }
+}
+"#;
+    let unstable = r#"
+pub fn leaked(
+    value: usize,
+) -> DurableType {
+    unreachable!()
+}
+"#;
+    let surface = supported_public_surface(facade, &[("session", session), ("unstable", unstable)]);
+    for escaped in [
+        "durable_body::DurableType",
+        "DurableOrdinaryBody",
+        "DurableSpecializedBodyPayload",
+        "DurableType",
+    ] {
+        assert!(
+            surface.contains(escaped),
+            "balanced public-surface scanner missed adversarial escape: {escaped}"
+        );
+    }
+}
+
+#[test]
+fn durable_cache_schema_cannot_return_to_the_public_facade() {
+    let facade = include_str!("lib.rs");
+    assert!(facade.contains("mod durable_body;"));
+    assert!(facade.contains("mod durable_semantics;"));
+    assert!(!facade.contains("pub mod durable_body;"));
+    assert!(!facade.contains("pub mod durable_semantics;"));
+
+    let session = include_str!("session.rs");
+    let manifest_public =
+        public_signatures(inherent_impl(session, "SemanticDependencyInputManifest"));
+    let semantic_public = public_signatures(inherent_impl(
+        include_str!("canonical_semantic.rs"),
+        "CanonicalSemanticOutput",
+    ));
+    for raw_accessor in [
+        "durable_specialized_body_payloads",
+        "durable_ordinary_bodies",
+    ] {
+        assert!(
+            !manifest_public.contains(&format!("pub fn {raw_accessor}"))
+                && !semantic_public.contains(&format!("pub fn {raw_accessor}")),
+            "raw durable schema accessor returned to a public signature: {raw_accessor}"
         );
     }
 }

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -561,7 +561,9 @@ impl CanonicalSemanticOutput {
         &self.durable_ordinary_body_payloads
     }
 
-    pub fn durable_specialized_body_payloads(&self) -> &[crate::DurableSpecializedBodyPayload] {
+    pub(crate) fn durable_specialized_body_payloads(
+        &self,
+    ) -> &[crate::DurableSpecializedBodyPayload] {
         &self.durable_specialized_body_payloads
     }
     /// Explicitly unstable equality status for durable-cache instrumentation.

--- a/crates/rue-compiler/src/durable_body.rs
+++ b/crates/rue-compiler/src/durable_body.rs
@@ -21,14 +21,9 @@ pub const DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION: u32 = 5;
 
 /// Durable specialization of AIR's canonical body algebra. These aliases keep
 /// compiler consumers explicit about the stable identity domain.
-pub type DurableAirRef = rue_air::SemanticBodyRef;
-pub type DurablePlaceRef = rue_air::SemanticBodyPlaceRef;
 pub type DurableBodyAnchor = rue_air::SemanticBodyAnchor;
-pub type DurablePattern = rue_air::SemanticBodyPattern<StableDefinitionKey>;
-pub type DurableMatchArm = rue_air::SemanticBodyMatchArm<StableDefinitionKey>;
-pub type DurableCallArg = rue_air::SemanticBodyCallArg;
 pub type DurableProjection = rue_air::SemanticBodyProjection<StableDefinitionKey, crate::ModuleId>;
-pub type DurablePlace = rue_air::SemanticBodyPlace<StableDefinitionKey, crate::ModuleId>;
+#[cfg(test)]
 pub type DurableAirInst = rue_air::SemanticBodyInst<StableDefinitionKey, crate::ModuleId>;
 pub type DurableAirInstData = rue_air::SemanticBodyInstData<StableDefinitionKey, crate::ModuleId>;
 

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -15,9 +15,6 @@ use rue_air::{
 };
 use rue_span::FileId;
 
-/// A fresh AIR epoch populated only from request-independent semantic values.
-pub type DurableSemanticImportEpoch = SemanticImportEpoch<StableDefinitionKey, Arc<str>>;
-
 /// Reconstruct the representable declaration universe in a new AIR epoch.
 ///
 /// Nominal shells are issued in stable-key order before any field or variant
@@ -25,7 +22,7 @@ pub type DurableSemanticImportEpoch = SemanticImportEpoch<StableDefinitionKey, A
 /// returned epoch contains no handles from the exporting semantic request.
 pub fn import_durable_declaration_semantics(
     declarations: &[DurableDeclarationSemantic],
-) -> Result<DurableSemanticImportEpoch, SemanticImportFailure> {
+) -> Result<SemanticImportEpoch<StableDefinitionKey, Arc<str>>, SemanticImportFailure> {
     fn payload_matches_key(declaration: &DurableDeclarationSemantic) -> bool {
         matches!(
             (declaration.key.kind(), &declaration.payload),
@@ -382,12 +379,9 @@ pub enum DurableSemanticProjectionFailure {
     MissingDefinition,
     DuplicateDefinition,
     ExtraDefinition,
-    MissingShell,
     DuplicateShell,
     AmbiguousDefinition,
-    NamespaceMismatch,
     KindMismatch,
-    OwnerMismatch,
     ModuleMismatch,
     VisibilityMismatch,
     UnsupportedDeclaration,
@@ -690,14 +684,11 @@ fn validate_payload_shape(
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DurableSemanticExportFailure {
     ErrorType,
-    MissingTypePoolEntry,
     MissingStableNominalDefinition,
     MissingStableFunctionDefinition,
     UnresolvedModule,
     AnonymousNominalType,
-    UnsupportedLocalType,
     UnsupportedTypeForm,
-    UnsupportedConstValue,
     RecursiveStructuralType,
 }
 

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -170,19 +170,22 @@ pub use definition_snapshot::{
     DefinitionId, DefinitionKind, DefinitionNameKey, DefinitionNamespace, DefinitionOccurrenceId,
     DefinitionRecord, DefinitionShard, DefinitionSnapshot, ModuleDefinition,
 };
-pub use durable_body::{
-    DURABLE_ORDINARY_BODY_SCHEMA_VERSION, DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION, DurableAirInst,
-    DurableAirInstData, DurableAirRef, DurableBodyAnchor, DurableBodyConversionFailure,
-    DurableBodyProjectionFailure, DurableCallArg, DurableMatchArm, DurableOrdinaryBody,
-    DurableOrdinaryBodyPayload, DurablePattern, DurablePlace, DurablePlaceRef, DurableProjection,
-    DurableSpecializedBody, DurableSpecializedBodyPayload,
+#[cfg(test)]
+pub(crate) use durable_body::DurableBodyProjectionFailure;
+pub(crate) use durable_body::{
+    DURABLE_ORDINARY_BODY_SCHEMA_VERSION, DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION,
+    DurableAirInstData, DurableBodyAnchor, DurableOrdinaryBody, DurableOrdinaryBodyPayload,
+    DurableProjection, DurableSpecializedBody, DurableSpecializedBodyPayload,
     convert_semantic_specialized_body_exports,
 };
-pub use durable_semantics::{
-    DURABLE_SEMANTIC_SCHEMA_VERSION, DurableConstValue, DurableDeclarationPayload,
-    DurableDeclarationSemantic, DurableParameterMode, DurableSemanticExportFailure,
-    DurableSemanticImportEpoch, DurableSemanticParameter, DurableSemanticProjectionFailure,
-    DurableSemanticProjectionWork, DurableSemanticSchemaVersion, DurableType,
+pub(crate) use durable_semantics::{
+    DURABLE_SEMANTIC_SCHEMA_VERSION, DurableDeclarationSemantic, DurableSemanticExportFailure,
+    DurableSemanticProjectionFailure, DurableSemanticSchemaVersion,
+};
+#[cfg(test)]
+pub(crate) use durable_semantics::{
+    DurableConstValue, DurableDeclarationPayload, DurableParameterMode, DurableSemanticParameter,
+    DurableSemanticProjectionWork, DurableType,
 };
 
 // Backend presentation queries used by the command-line emit modes.

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -619,10 +619,8 @@ impl StableBodyDependencyInputRecord {
     pub fn direct_dependency_inputs(&self) -> &[StableDefinitionInputFingerprint] {
         &self.direct_dependency_inputs
     }
-    pub fn builtin_type_call_heads(&self) -> &[StableBuiltinTypeCallHeadInput] {
-        &self.builtin_type_call_heads
-    }
-    pub fn blockers(&self) -> &[SemanticDependencyBlocker] {
+    #[cfg(test)]
+    pub(crate) fn blockers(&self) -> &[SemanticDependencyBlocker] {
         &self.blockers
     }
     pub fn reusable_boundary_supported(&self) -> bool {
@@ -1023,9 +1021,6 @@ mod durable_body_integration_tests {
 pub struct StableDefinitionFingerprint([u8; 32]);
 
 impl StableDefinitionFingerprint {
-    pub fn bytes(self) -> [u8; 32] {
-        self.0
-    }
     #[cfg(test)]
     pub(crate) fn for_test(byte: u8) -> Self {
         Self([byte; 32])
@@ -1041,9 +1036,6 @@ pub enum StableDefinitionFingerprintPrecision {
     /// All declaration bytes are semantic signature input and there is no
     /// independently executable payload.
     ExactSignature,
-    /// The parser has no authoritative executable-payload boundary for this
-    /// declaration kind, so its complete declaration is hashed as a signature.
-    ConservativeFullDeclaration,
 }
 
 /// Immutable, relocation-independent inputs for one stable definition.
@@ -1410,9 +1402,8 @@ impl SemanticDependencyInputManifest {
     pub fn body_dependencies(&self) -> &[StableBodyDependencyInputRecord] {
         &self.body_dependencies
     }
-    /// Durable candidates published by this successful dependency manifest.
-    /// Production reuse consumes the session's last-successful canonical body
-    /// baseline; this accessor exposes the same stable artifacts to planners.
+    /// Test-only inspection of candidates owned by this successful manifest.
+    /// Production cache operations consume the owned field directly.
     #[cfg(test)]
     pub(crate) fn durable_ordinary_bodies(&self) -> &[crate::DurableOrdinaryBody] {
         &self.durable_ordinary_bodies
@@ -6854,7 +6845,6 @@ fn declaration_surfaces_match(
         ) && !matches!(
             left.precision,
             StableDefinitionFingerprintPrecision::SignatureAndInitializer
-                | StableDefinitionFingerprintPrecision::ConservativeFullDeclaration
         );
         let matches = supported
             && left.schema_version == right.schema_version

--- a/crates/rue-compiler/src/source_identity.rs
+++ b/crates/rue-compiler/src/source_identity.rs
@@ -452,7 +452,8 @@ impl StablePreviewFeatures {
         names.dedup();
         Self(names.into())
     }
-    pub fn names(&self) -> &[Arc<str>] {
+    #[cfg(test)]
+    pub(crate) fn names(&self) -> &[Arc<str>] {
         &self.0
     }
 }


### PR DESCRIPTION
## Summary

- remove durable body and semantic cache record exports from the compiler facade
- keep raw durable payload access session-owned and expose only owned unstable metrics and opaque compatibility status
- enforce the boundary with a balanced semantic scanner covering aliases, globs, fields, multiline signatures, public modules, and exported-owner impls

## Validation

- scripts/rue quick
- ./buck2 test //crates/rue-compiler:rue-compiler-public-api-test
- focused durable compatibility and facade guard tests
- benchmark build and smoke
- scripts/rue fmt
- git diff --check

Fixes RUE-867