### PR TITLE
RUE-685: adopt safe and Unicode string access

### DIFF
--- a/crates/rue-cli-tests/cases/std_m3.toml
+++ b/crates/rue-cli-tests/cases/std_m3.toml
@@ -50,7 +50,7 @@ fn main() -> i32 {
 
 [[case]]
 name = "std_strings_m3"
-description = "strings parse/find/trim/repeat helpers (14 checks -> exit 62)."
+description = "bounds-checked bytes plus byte- and character-oriented string helpers (22 checks -> exit 62)."
 env = { RUE_STD_PATH = "${REAL_STD}" }
 args = ["main.rue", "-o", "prog"]
 exit_code = 62
@@ -61,6 +61,7 @@ fn main() -> i32 {
     let mut score: i32 = 0;
     let Oi = std.option.Option(i64);
     let Ou = std.option.Option(u64);
+    let Ob = std.option.Option(u8);
 
     match std.strings.parse_int("-42") { Oi.Some(v) => { if v == -42 { score = score + 1; } }, Oi.None => {} }
     match std.strings.parse_int("1000") { Oi.Some(v) => { if v == 1000 { score = score + 1; } }, Oi.None => {} }
@@ -79,7 +80,42 @@ fn main() -> i32 {
     if std.strings.trim_end("hi  ").len() == 2 { score = score + 1; }
     if std.strings.repeat("ab", 3).len() == 6 { score = score + 1; }
 
-    if score == 14 { 62 } else { @intCast(score) }
+    match "abc".byte_at(0) { Ob.Some(v) => { if v == 97 { score = score + 1; } }, Ob.None => {} }
+    match "".byte_at(0) { Ob.Some(_) => {}, Ob.None => { score = score + 1; } }
+    match "abc".byte_at(3) { Ob.Some(_) => {}, Ob.None => { score = score + 1; } }
+
+    if std.strings.count_chars("") == 0 { score = score + 1; }
+    if std.strings.count_chars("ASCII") == 5 { score = score + 1; }
+    if std.strings.count_chars("café") == 4 { score = score + 1; }
+    if std.strings.count_chars_lossy("café") == 4 { score = score + 1; }
+
+    let mut invalid = std.strbuf.StrBuf.new();
+    invalid.push(97);
+    invalid.push(255);
+    invalid.push(98);
+    if std.strings.count_chars_lossy(invalid) == 3 { score = score + 1; }
+
+    if score == 22 { 62 } else { @intCast(score) }
+}
+""" }]
+
+[[case]]
+name = "std_strings_count_chars_strict_invalid_utf8_traps"
+description = "std.strings.count_chars uses strict UTF-8 decoding and traps on malformed input."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 101
+runtime_error_contains = ["invalid UTF-8"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let mut invalid = std.strbuf.StrBuf.new();
+    invalid.push(97);
+    invalid.push(255);
+    invalid.push(98);
+    let _count = std.strings.count_chars(invalid);
+    0
 }
 """ }]
 

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -978,6 +978,12 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "cli.std_m3",
+        "std_strings_count_chars_strict_invalid_utf8_traps",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_m3",
         "std_strings_m3",
         semantic(SemanticGapKind::TextProjectionRead),
         &[],

--- a/std/strings.rue
+++ b/std/strings.rue
@@ -1,34 +1,32 @@
-// std.strings — byte-oriented text helpers over `StrBuf` (RUE-677).
+// std.strings — byte- and character-oriented text helpers over `StrBuf`.
 //
-// Built on the working `StrBuf` surface: byte indexing (`s[i] -> u8`), `.len()`,
-// and the mutating builders `StrBuf.new()` + `.push(byte)`. Everything here is
-// byte-level (ASCII-oriented) and never inspects UTF-8 boundaries, matching
-// std.ascii. Fallible parses/searches return `option.Option(T)`.
+// Byte-oriented helpers use the bounds-checked `s.byte_at(i) -> Option(u8)`
+// surface. Character counts use strict or lossy UTF-8 scalar iteration.
+// Fallible parses/searches return `option.Option(T)`.
 //
 //     const std = @import("std");
 //     std.strings.parse_int("-42");        // Some(-42)
 //     std.strings.find("hello", 108);      // Some(2)  (first 'l')
 //     std.strings.trim("  hi  ");          // "hi"
 //     std.strings.repeat("ab", 3);         // "ababab"
-//
-// COMPILER-BUG WORKAROUND (see below): a `StrBuf` byte index `s[i]` used
-// DIRECTLY inside an `if`/`while` condition expression is currently rejected
-// with E0900 "cannot index into non-array type 'StrBuf'" — even though the very
-// same `s[i]` works when bound to a `let` first or used in tail position.
-// Minimal repro:
-//
-//     fn f(s: StrBuf) -> u8 { if s[0] == 45 { 1 } else { 9 } }   // E0900
-//     fn f(s: StrBuf) -> u8 { let c = s[0]; if c == 45 { 1 } else { 9 } }  // OK
-//
-// So every index below reads the byte into a local in statement position first,
-// then tests the local. This is filed for the compiler team; when it is fixed
-// the local bindings can be inlined back into the conditions.
+//     std.strings.count_chars("café");   // 4
 
 const ascii = @import("ascii.rue");
 const option = @import("option.rue");
 const math = @import("math.rue");
 const strbuf = @import("strbuf.rue");
 const StrBuf = strbuf.StrBuf;
+
+// Internal callers establish `index < s.len()` before reading. Keep the
+// impossible branch in one place while Rue's Option surface has no `expect`
+// helper that can express that invariant.
+fn bounded_byte_at(borrow s: StrBuf, index: u64) -> u8 {
+    let O = option.Option(u8);
+    match s.byte_at(index) {
+        O.Some(byte) => byte,
+        O.None => @panic("index out of bounds"),
+    }
+}
 
 // Parse a decimal integer with an optional leading '-'. Returns `None` on an
 // empty string, a lone '-', any non-digit byte, or arithmetic overflow of
@@ -44,7 +42,7 @@ pub fn parse_int(s: StrBuf) -> option.Option(i64) {
     }
     let mut i: u64 = 0;
     let mut neg = false;
-    let first = s[0];
+    let first = bounded_byte_at(borrow s, 0);
     if first == 45 {
         neg = true;
         i = 1;
@@ -55,7 +53,7 @@ pub fn parse_int(s: StrBuf) -> option.Option(i64) {
     let mut acc: i64 = 0;
     let ten: i64 = 10;
     while i < n {
-        let byte = s[i];
+        let byte = bounded_byte_at(borrow s, i);
         if !ascii.is_digit(byte) {
             return O.None;
         }
@@ -90,7 +88,7 @@ pub fn find(s: StrBuf, byte: u8) -> option.Option(u64) {
     let n = s.len();
     let mut i: u64 = 0;
     while i < n {
-        let c = s[i];
+        let c = bounded_byte_at(borrow s, i);
         if c == byte {
             return O.Some(i);
         }
@@ -105,7 +103,7 @@ pub fn rfind(s: StrBuf, byte: u8) -> option.Option(u64) {
     let mut i = s.len();
     while i > 0 {
         i = i - 1;
-        let c = s[i];
+        let c = bounded_byte_at(borrow s, i);
         if c == byte {
             return O.Some(i);
         }
@@ -119,7 +117,7 @@ pub fn count(s: StrBuf, byte: u8) -> u64 {
     let n = s.len();
     let mut i: u64 = 0;
     while i < n {
-        let cur = s[i];
+        let cur = bounded_byte_at(borrow s, i);
         if cur == byte {
             c = c + 1;
         }
@@ -133,7 +131,7 @@ pub fn starts_with_byte(s: StrBuf, byte: u8) -> bool {
     if s.len() == 0 {
         false
     } else {
-        let c = s[0];
+        let c = bounded_byte_at(borrow s, 0);
         c == byte
     }
 }
@@ -144,7 +142,7 @@ pub fn trim_start(s: StrBuf) -> StrBuf {
     let mut start: u64 = 0;
     let mut scanning = true;
     while scanning && start < n {
-        let c = s[start];
+        let c = bounded_byte_at(borrow s, start);
         if ascii.is_whitespace(c) {
             start = start + 1;
         } else {
@@ -154,7 +152,7 @@ pub fn trim_start(s: StrBuf) -> StrBuf {
     let mut out = StrBuf.new();
     let mut i = start;
     while i < n {
-        let c = s[i];
+        let c = bounded_byte_at(borrow s, i);
         out.push(c);
         i = i + 1;
     }
@@ -167,7 +165,7 @@ pub fn trim_end(s: StrBuf) -> StrBuf {
     let mut end = n;
     let mut scanning = true;
     while scanning && end > 0 {
-        let c = s[end - 1];
+        let c = bounded_byte_at(borrow s, end - 1);
         if ascii.is_whitespace(c) {
             end = end - 1;
         } else {
@@ -177,7 +175,7 @@ pub fn trim_end(s: StrBuf) -> StrBuf {
     let mut out = StrBuf.new();
     let mut i: u64 = 0;
     while i < end {
-        let c = s[i];
+        let c = bounded_byte_at(borrow s, i);
         out.push(c);
         i = i + 1;
     }
@@ -190,7 +188,7 @@ pub fn trim(s: StrBuf) -> StrBuf {
     let mut start: u64 = 0;
     let mut sc = true;
     while sc && start < n {
-        let c = s[start];
+        let c = bounded_byte_at(borrow s, start);
         if ascii.is_whitespace(c) {
             start = start + 1;
         } else {
@@ -200,7 +198,7 @@ pub fn trim(s: StrBuf) -> StrBuf {
     let mut end = n;
     let mut ec = true;
     while ec && end > start {
-        let c = s[end - 1];
+        let c = bounded_byte_at(borrow s, end - 1);
         if ascii.is_whitespace(c) {
             end = end - 1;
         } else {
@@ -210,7 +208,7 @@ pub fn trim(s: StrBuf) -> StrBuf {
     let mut out = StrBuf.new();
     let mut i = start;
     while i < end {
-        let c = s[i];
+        let c = bounded_byte_at(borrow s, i);
         out.push(c);
         i = i + 1;
     }
@@ -225,11 +223,30 @@ pub fn repeat(s: StrBuf, n: u64) -> StrBuf {
     while k < n {
         let mut i: u64 = 0;
         while i < len {
-            let c = s[i];
+            let c = bounded_byte_at(borrow s, i);
             out.push(c);
             i = i + 1;
         }
         k = k + 1;
     }
     out
+}
+
+// Number of Unicode scalar values in valid UTF-8. Traps on malformed UTF-8.
+pub fn count_chars(s: StrBuf) -> u64 {
+    let mut count: u64 = 0;
+    for _scalar in s.chars() {
+        count = count + 1;
+    }
+    count
+}
+
+// Number of Unicode scalar values after malformed UTF-8 is replaced with
+// U+FFFD using the canonical lossy decoder.
+pub fn count_chars_lossy(s: StrBuf) -> u64 {
+    let mut count: u64 = 0;
+    for _scalar in s.chars_lossy() {
+        count = count + 1;
+    }
+    count
 }


### PR DESCRIPTION
## What changed

- move all 14 `std.strings` positional reads from trapping raw indexing to the bounds-checked `StrBuf.byte_at(index) -> Option(u8)` API
- centralize the proven-in-bounds unwrap in one internal helper
- add strict `count_chars` and lossy `count_chars_lossy` Unicode-scalar helpers
- cover empty, in-bounds, out-of-bounds, ASCII, multibyte UTF-8, malformed lossy replacement, and strict malformed trapping
- register the new negative case's existing oracle model gap

## Why

RUE-685 was the remaining stdlib consumer of the safe byte-access and UTF-8 character-iteration work landed by RUE-602. This removes stale raw-indexing workarounds and gives `std.strings` a small public character-oriented surface.

## Validation

- `scripts/rue cli std_m3` — 11/11 passed
- `scripts/rue quick` — 33/33 targets passed
- `git diff --check`
- 2,148-line ruelex compile benchmark, seven alternating `-j1 -O0` samples: 0.48s median before and after

Linear: RUE-685

Papercut ledger: RUE-980 incremented from 1 to 2 for the single centralized dead `None` arm; RUE-991 filed for the macOS `/var` → `/private/var` std-root containment failure discovered during benchmarking.
