### PR TITLE
RUE-1001: schedule the payload_schemas nightly fuzz target

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -94,6 +94,12 @@ jobs:
         timeout-minutes: 10
         run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 compiler crates/rue-fuzz/corpus
 
+      - name: Fuzz payload schemas (5 minutes)
+        id: fuzz-payload-schemas
+        continue-on-error: true
+        timeout-minutes: 10
+        run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 payload_schemas crates/rue-fuzz/corpus
+
       - name: Fuzz x86-64 emitter (5 minutes)
         id: fuzz-emitter
         continue-on-error: true
@@ -142,6 +148,7 @@ jobs:
           steps.fuzz-parser.outcome == 'failure' ||
           steps.fuzz-sema.outcome == 'failure' ||
           steps.fuzz-compiler.outcome == 'failure' ||
+          steps.fuzz-payload-schemas.outcome == 'failure' ||
           steps.fuzz-emitter.outcome == 'failure' ||
           steps.fuzz-emitter-aarch64.outcome == 'failure' ||
           steps.fuzz-emitter-sequence.outcome == 'failure' ||
@@ -160,6 +167,7 @@ jobs:
               ['parser', '${{ steps.fuzz-parser.outcome }}'],
               ['sema', '${{ steps.fuzz-sema.outcome }}'],
               ['compiler', '${{ steps.fuzz-compiler.outcome }}'],
+              ['payload_schemas', '${{ steps.fuzz-payload-schemas.outcome }}'],
               ['emitter', '${{ steps.fuzz-emitter.outcome }}'],
               ['emitter_aarch64', '${{ steps.fuzz-emitter-aarch64.outcome }}'],
               ['emitter_sequence', '${{ steps.fuzz-emitter-sequence.outcome }}'],


### PR DESCRIPTION
The 2026-07-18 nightly fuzz failure was not an actual crash: RUE-924 registered the `payload_schemas` fuzz target in `crates/rue-fuzz/src/targets.rs` but never scheduled it in `fuzz.yml`, so the "Verify every registered fuzz target is scheduled" preflight guard (added for RUE-515) failed the job and auto-filed the tracking issue.

This adds the missing nightly coverage, keeping the target ordering of `all_targets()` in all three places:

- a "Fuzz payload schemas (5 minutes)" step (`--mutate --max-time=300`, `continue-on-error`, 10-minute step timeout) between `compiler` and `emitter`;
- the matching `fuzz-payload-schemas` outcome in the failure-aggregation condition;
- the matching entry in the notify script's failed-target list.

Verified locally: the extracted preflight-guard script now reports "All 8 registered fuzz targets are scheduled" including `payload_schemas`, and a 20-second live run of the target against a freshly initialized corpus completed with 5027 runs and 0 crashes. The job's 90-minute cap retains ample headroom with the extra 5-minute step.

Fixes RUE-1001

Fixes #1760

---
_Generated by [Claude Code](https://claude.ai/code/session_0171FcxJkBYFHhnFPtf31AQW)_