### PR TITLE
RUE-999: give the Mosaic 400-page scaling case a 60s budget

### DIFF
--- a/crates/rue-cli-tests/cases/examples_mosaic.toml
+++ b/crates/rue-cli-tests/cases/examples_mosaic.toml
@@ -84,6 +84,12 @@ name = "mosaic_scales_generated_workload_fourfold"
 description = "the 4x tier parses and renders 400 linked pages with proportional model counts"
 source_path = "examples/mosaic/main.rue"
 env = { RUE_STD_PATH = "${REAL_STD}" }
+# The 400-page tier renders quadratic output volume (~2.2 s median on an idle
+# host) and blows the default 10 s budget on loaded macOS CI runners, ejecting
+# unrelated PRs from the merge queue (RUE-999). The 200-page tier above stays
+# on the default budget as the timing canary; this tier only needs to catch
+# hangs and wrong counts.
+timeout_ms = 60000
 program_args = ["stress4"]
 exit_code = 0
 stdout = "stress pages=400 blocks=4400 links=400 anchors=800\nexpected_links=400\ndeterministic=true\nvalid=true\nselftests=30 failures=0\n"


### PR DESCRIPTION
`cli.examples_mosaic::mosaic_scales_generated_workload_fourfold` runs on the default 10s test budget, but the stress4 tier renders quadratic output volume (~2.2s median on an idle host per #1789's own measurements). On loaded macOS CI runners it intermittently exceeds the budget — it ejected three unrelated PRs (#1776, #1778, #1770) from the merge queue within half an hour today, each merge-group run failing on exactly this one case with `TIMEOUT: test execution timed out after 10000 ms`.

This gives the case an explicit 60s budget (`timeout_ms` is an existing per-case knob; `deep_nesting.toml` sets it already). The 200-page tier stays on the default budget as the timing canary; the fourfold tier exists to catch hangs and wrong scaling counts, so the generous budget preserves its purpose without the flake. The structural fix — making the stress-mode workload linear so the tiers measure runtime rather than site shape — is discussed on RUE-999 and left as follow-up.

Verified locally: full `cli.examples_mosaic` suite, 17/17 including the fourfold tier.

Fixes RUE-999

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTr1GrmuozXwd93nRkmPyC)_