### PR TITLE
RUE-856: extract CLI output orchestration

### DIFF
--- a/crates/rue-cli-tests/cases/output_guard.toml
+++ b/crates/rue-cli-tests/cases/output_guard.toml
@@ -37,6 +37,16 @@ args = ["a.rue", "prog"]
 exit_code = 5
 
 [[case]]
+# Destination/source identity is a closed-discovery preflight. It must win over
+# semantic diagnostics so an unsafe request does no semantic/codegen/link work.
+name = "output_alias_preflight_precedes_invalid_semantics"
+files = [{ path = "invalid.rue", source = "fn main() -> i32 { missing_name }\n" }]
+args = ["invalid.rue", "-o", "invalid.rue"]
+compile_fail = true
+error_contains = ["also an input source file"]
+compile_stderr_not_contains = ["missing_name"]
+
+[[case]]
 # RUE-351: an EXTENSIONLESS source used as `-o` must be refused. The old guard
 # only recognized inputs by a `.rue` suffix, so `rue prog -o prog` (prog is a
 # source) slipped through and the compiled ELF silently overwrote the source.

--- a/crates/rue-cli-tests/cases/output_publication.toml
+++ b/crates/rue-cli-tests/cases/output_publication.toml
@@ -19,7 +19,12 @@ name = "output_path_is_directory_fails"
 description = "-o pointing at a directory is a fatal E1403, not a warning + success."
 args = ["main.rue", "-o", "outdir"]
 compile_fail = true
-error_contains = ["output publication failed"]
+error_contains = [
+    "output publication failed",
+    "could not atomically install finished executable",
+    "rue-tmp",
+    "outdir",
+]
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 { 42 }
@@ -39,7 +44,7 @@ args = ["main.rue", "-o", "prog"]
 only_on = ["aarch64-macos"]
 env = { PATH = "" }
 compile_fail = true
-error_contains = ["output publication failed", "codesign"]
+error_contains = ["output publication failed", "could not sign temporary executable", "rue-tmp", "codesign"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 { 42 }
 """ }]

--- a/crates/rue/src/compile.rs
+++ b/crates/rue/src/compile.rs
@@ -1,0 +1,68 @@
+use rue_compiler::unstable::OneShotMetrics;
+use rue_compiler::{CompileErrors, CompileOptions, CompileWarning, CompilerSession};
+
+use crate::output::{PublicationDestination, PublishRequest, publish_executable};
+
+/// Typed ownership boundary for the compile/link/publish operation.
+pub(crate) struct CompileRequest<'a> {
+    pub(crate) session: &'a mut CompilerSession,
+    pub(crate) options: CompileOptions,
+    pub(crate) destination: PublicationDestination,
+}
+
+pub(crate) struct LinkedExecutable {
+    target: rue_target::Target,
+    warnings: Vec<CompileWarning>,
+    metrics: OneShotMetrics,
+    linked_bytes: Vec<u8>,
+    destination: PublicationDestination,
+}
+
+pub(crate) struct PublishedExecutable {
+    metrics: OneShotMetrics,
+    pub(crate) linked_bytes: Vec<u8>,
+}
+
+pub(crate) struct PublicationAttempt {
+    pub(crate) warnings: Vec<CompileWarning>,
+    pub(crate) result: Result<PublishedExecutable, crate::output::PublishError>,
+}
+
+/// Execute the canonical compiler session through linking.
+pub(crate) fn execute(request: CompileRequest<'_>) -> Result<LinkedExecutable, CompileErrors> {
+    let output = request
+        .session
+        .executable_in_compile_scope(&request.options)?;
+    let metrics = output.unstable_metrics();
+    Ok(LinkedExecutable {
+        target: request.options.target,
+        warnings: output.warnings,
+        metrics,
+        linked_bytes: output.elf,
+        destination: request.destination,
+    })
+}
+
+impl LinkedExecutable {
+    /// Finalize and publish the linked bytes after compiler timing/accounting closes.
+    pub(crate) fn publish(self) -> PublicationAttempt {
+        let publication = publish_executable(PublishRequest {
+            destination: self.destination,
+            bytes: &self.linked_bytes,
+            target: self.target,
+        });
+        PublicationAttempt {
+            warnings: self.warnings,
+            result: publication.map(|()| PublishedExecutable {
+                metrics: self.metrics,
+                linked_bytes: self.linked_bytes,
+            }),
+        }
+    }
+}
+
+impl PublishedExecutable {
+    pub(crate) fn unstable_metrics(&self) -> OneShotMetrics {
+        self.metrics
+    }
+}

--- a/crates/rue/src/emit.rs
+++ b/crates/rue/src/emit.rs
@@ -1,0 +1,569 @@
+use std::fmt::Write as _;
+use std::sync::Arc;
+
+#[cfg(test)]
+use rue_compiler::unstable::MetricsSnapshot;
+use rue_compiler::unstable::{
+    ImportDiscoveryRevision, ImportDiscoveryStatus, LowerMetrics, ParseMetrics, SemanticMetrics,
+};
+use rue_compiler::{
+    Ast, CanonicalRirOutput, CanonicalSemanticOutput, CompileError, CompileErrors, CompileOptions,
+    CompileWarning, CompilerSession, DependencyEnvelope, DependencyEnvelopeStatus, ErrorKind,
+    FrozenTypeInternPool, Lexer, SourceSnapshot, Token, generate_emitted_asm,
+    generate_liveness_info, generate_lowering_info, generate_mir, generate_regalloc_info,
+    generate_stack_frame_info, parse_source_snapshot_for_ast_presentation,
+};
+use rue_rir::RirPrinter;
+use tracing::info_span;
+
+use crate::DiagnosticOutput;
+
+/// Compilation stages that can be emitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EmitStage {
+    /// Emit tokens from the lexer.
+    Tokens,
+    /// Emit the abstract syntax tree.
+    Ast,
+    /// Emit RIR (untyped intermediate representation).
+    Rir,
+    /// Emit AIR (typed intermediate representation).
+    Air,
+    /// Emit CFG (control flow graph).
+    Cfg,
+    /// Emit lowering (CFG to MIR instruction selection).
+    Lowering,
+    /// Emit MIR (machine intermediate representation).
+    Mir,
+    /// Emit liveness analysis information.
+    Liveness,
+    /// Emit register allocation debug info.
+    RegAlloc,
+    /// Emit assembly text.
+    Asm,
+    /// Emit stack frame layout per function.
+    StackFrame,
+    /// Emit the source dependency graph discovered while loading imports.
+    Deps,
+}
+
+pub(crate) struct EmitFrontend {
+    parsed: Arc<rue_compiler::ParsedProgram>,
+    rir: Arc<CanonicalRirOutput>,
+    semantic: Arc<CanonicalSemanticOutput>,
+    pub(crate) work: EmitWork,
+    #[cfg(test)]
+    pub(crate) session_work: MetricsSnapshot,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct EmitWork {
+    pub(crate) parsed: ParseMetrics,
+    pub(crate) lowered: LowerMetrics,
+    pub(crate) semantic: SemanticMetrics,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EmitFrontendRoute {
+    None,
+    AstOnlySyntax,
+    SessionQuery,
+}
+
+pub(crate) fn emit_frontend_route(stages: &[EmitStage]) -> EmitFrontendRoute {
+    if stages.iter().any(|stage| {
+        matches!(
+            stage,
+            EmitStage::Rir
+                | EmitStage::Air
+                | EmitStage::Cfg
+                | EmitStage::Lowering
+                | EmitStage::Mir
+                | EmitStage::Liveness
+                | EmitStage::RegAlloc
+                | EmitStage::Asm
+                | EmitStage::StackFrame
+        )
+    }) {
+        EmitFrontendRoute::SessionQuery
+    } else if stages.contains(&EmitStage::Ast) {
+        EmitFrontendRoute::AstOnlySyntax
+    } else {
+        EmitFrontendRoute::None
+    }
+}
+
+pub(crate) fn build_emit_frontend_in_session(
+    session: &mut CompilerSession,
+    options: CompileOptions,
+) -> Result<EmitFrontend, CompileErrors> {
+    let parsed = session.published().cloned().ok_or_else(|| {
+        CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+            "emit requires a published closed discovery revision".into(),
+        )))
+    })?;
+    let rir = {
+        let _span = info_span!("semantic_astgen").entered();
+        session.rir()?
+    };
+    let semantic = session.semantic(&options)?;
+    let session_work = session.unstable_metrics();
+    Ok(EmitFrontend {
+        parsed,
+        rir,
+        semantic: semantic.clone(),
+        work: EmitWork {
+            parsed: session_work.parse_metrics(),
+            lowered: session_work.lower_metrics(),
+            semantic: semantic.unstable_metrics(),
+        },
+        #[cfg(test)]
+        session_work,
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn build_emit_frontend(
+    source_snapshot: &SourceSnapshot,
+    options: CompileOptions,
+) -> Result<EmitFrontend, CompileErrors> {
+    let mut session = CompilerSession::new();
+    session
+        .update_for_presentation(source_snapshot)
+        .into_result()?;
+    build_emit_frontend_in_session(&mut session, options)
+}
+
+impl EmitFrontend {
+    fn rir(&self) -> &rue_compiler::Rir {
+        self.rir.rir()
+    }
+
+    fn interner(&self) -> &rue_compiler::ThreadedRodeo {
+        self.rir.semantic_symbols().interner()
+    }
+
+    fn functions(&self) -> &[rue_compiler::FunctionWithCfg] {
+        self.semantic.functions()
+    }
+
+    fn type_pool(&self) -> &FrozenTypeInternPool {
+        self.semantic.type_pool()
+    }
+
+    fn strings(&self) -> &[String] {
+        self.semantic.strings()
+    }
+
+    fn warnings(&self) -> &[CompileWarning] {
+        self.semantic.warnings()
+    }
+
+    fn query_work(&self) -> EmitWork {
+        self.work
+    }
+}
+
+/// Error returned when parsing an emit stage name fails.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParseEmitStageError(String);
+
+impl std::fmt::Display for ParseEmitStageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unknown emit stage '{}'", self.0)
+    }
+}
+
+impl std::error::Error for ParseEmitStageError {}
+
+impl std::str::FromStr for EmitStage {
+    type Err = ParseEmitStageError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "tokens" => Ok(EmitStage::Tokens),
+            "ast" => Ok(EmitStage::Ast),
+            "rir" => Ok(EmitStage::Rir),
+            "air" => Ok(EmitStage::Air),
+            "cfg" => Ok(EmitStage::Cfg),
+            "lowering" => Ok(EmitStage::Lowering),
+            "mir" => Ok(EmitStage::Mir),
+            "liveness" => Ok(EmitStage::Liveness),
+            "regalloc" => Ok(EmitStage::RegAlloc),
+            "asm" => Ok(EmitStage::Asm),
+            "stackframe" => Ok(EmitStage::StackFrame),
+            "deps" => Ok(EmitStage::Deps),
+            _ => Err(ParseEmitStageError(s.to_string())),
+        }
+    }
+}
+
+impl EmitStage {
+    pub(crate) fn all_names() -> &'static str {
+        "tokens, ast, rir, air, cfg, lowering, mir, liveness, regalloc, asm, stackframe, deps"
+    }
+}
+
+/// Handle emit stages for multi-file compilation.
+///
+/// For early stages (tokens, ast), each file is processed and labeled individually.
+/// For later stages (rir, air, cfg, etc.), the merged program is used.
+pub(crate) struct EmitRequest<'a, 'diagnostics> {
+    pub(crate) source_snapshot: &'a SourceSnapshot,
+    pub(crate) session: &'a mut CompilerSession,
+    pub(crate) stages: &'a [EmitStage],
+    pub(crate) discovery_revision: &'a ImportDiscoveryRevision,
+    pub(crate) compile_options: CompileOptions,
+    pub(crate) diagnostics: &'a DiagnosticOutput<'diagnostics>,
+}
+
+pub(crate) fn execute(request: EmitRequest<'_, '_>) -> Result<(), ()> {
+    let EmitRequest {
+        source_snapshot,
+        session,
+        stages,
+        discovery_revision,
+        compile_options,
+        diagnostics,
+    } = request;
+
+    if stages.contains(&EmitStage::Deps) {
+        if stages.len() != 1 {
+            eprintln!("Error: --emit deps cannot be combined with other --emit stages");
+            return Err(());
+        }
+        let dependency_envelope = DependencyEnvelope::from_closed_revision(discovery_revision)
+            .expect("closed valid or resolution-incomplete discovery has dependency topology");
+        let incomplete = dependency_envelope.status == DependencyEnvelopeStatus::Incomplete;
+        match serde_json::to_string_pretty(&dependency_envelope) {
+            Ok(json) => println!("{json}"),
+            Err(error) => {
+                eprintln!("Error emitting dependency envelope: {error}");
+                return Err(());
+            }
+        }
+        if incomplete {
+            diagnostics.print_errors(discovery_revision.diagnostics());
+            return Err(());
+        }
+        return Ok(());
+    }
+
+    if discovery_revision.status() != ImportDiscoveryStatus::ClosedValid {
+        diagnostics.print_errors(discovery_revision.diagnostics());
+        return Err(());
+    }
+    // Determine which stages we need
+    let needs_tokens = stages.contains(&EmitStage::Tokens);
+    let needs_ast = stages.contains(&EmitStage::Ast);
+
+    // For tokens, we need to lex each file separately (before parsing merges interners)
+    // We'll collect per-file tokens if needed
+    let per_file_tokens: Option<Vec<(String, Vec<Token>)>> = if needs_tokens {
+        let mut file_tokens = Vec::with_capacity(source_snapshot.len());
+        for source in source_snapshot.files() {
+            // Lex with the file's real FileId so a lex error in the Nth file
+            // is attributed to that file, not to the first one (RUE-38).
+            let lexer = Lexer::with_file_id(source.source, source.file_id);
+            match lexer.tokenize_preserving_interner() {
+                Ok((tokens, _interner)) => {
+                    file_tokens.push((source.path.to_string(), tokens));
+                }
+                Err((errors, _interner)) => {
+                    diagnostics.print_errors(&errors);
+                    return Err(());
+                }
+            }
+        }
+        Some(file_tokens)
+    } else {
+        None
+    };
+
+    let frontend_route = emit_frontend_route(stages);
+    // AST-only preserves its syntax-only behavior (duplicates are printable).
+    // Combined AST+later canonical modes reuse the unit's once-only projection.
+    let mut per_file_asts: Option<Vec<(String, std::sync::Arc<Ast>)>> =
+        if frontend_route == EmitFrontendRoute::AstOnlySyntax {
+            match parse_source_snapshot_for_ast_presentation(source_snapshot) {
+                Ok(presentation) => {
+                    debug_assert_eq!(
+                        presentation.work().parsed.syntax.parser_invocations,
+                        source_snapshot.len()
+                    );
+                    Some(presentation.files().to_vec())
+                }
+                Err(errors) => {
+                    diagnostics.print_errors(&errors);
+                    return Err(());
+                }
+            }
+        } else {
+            None
+        };
+
+    let frontend_state = if frontend_route == EmitFrontendRoute::SessionQuery {
+        let frontend = match build_emit_frontend_in_session(session, compile_options.clone()) {
+            Ok(frontend) => frontend,
+            Err(errors) => {
+                diagnostics.print_errors(&errors);
+                return Err(());
+            }
+        };
+        if needs_ast {
+            per_file_asts = Some(
+                source_snapshot
+                    .files()
+                    .map(|source| {
+                        let module = frontend
+                            .parsed
+                            .modules()
+                            .iter()
+                            .find(|module| module.file_id() == source.file_id)
+                            .expect("frontend parsed every snapshot source");
+                        (source.path.to_string(), module.shared_ast())
+                    })
+                    .collect(),
+            );
+        }
+        Some(frontend)
+    } else {
+        None
+    };
+    if let Some(state) = &frontend_state {
+        // Every --emit mode must surface frontend warnings (RUE-130).
+        diagnostics.print_warnings(state.warnings());
+        let work = state.query_work();
+        debug_assert_eq!(state.parsed.modules().len(), source_snapshot.len());
+        debug_assert!(work.parsed.parser_invocations <= source_snapshot.len());
+        debug_assert_eq!(work.lowered.parser_invocations, 0);
+        debug_assert_eq!(work.semantic.binding.bind_invocations, 1);
+        debug_assert_eq!(work.semantic.manifest.build_invocations, 1);
+    }
+
+    // Now emit in order
+    for stage in stages {
+        match stage {
+            EmitStage::Tokens => {
+                if let Some(ref file_tokens) = per_file_tokens {
+                    for (path, tokens) in file_tokens {
+                        println!("=== Tokens ({}) ===", path);
+                        for token in tokens {
+                            println!("{}", token);
+                        }
+                        println!();
+                    }
+                }
+            }
+            EmitStage::Ast => {
+                if let Some(ref asts) = per_file_asts {
+                    for (path, ast) in asts {
+                        println!("=== AST ({}) ===", path);
+                        print!("{}", ast);
+                        println!();
+                    }
+                }
+            }
+            EmitStage::Rir => {
+                println!("=== RIR ===");
+                if let Some(ref state) = frontend_state {
+                    let order = state
+                        .rir
+                        .presentation_order(source_snapshot.files().map(|source| source.file_id));
+                    let printer = RirPrinter::with_presentation_order(
+                        state.rir(),
+                        state.interner(),
+                        order.instructions,
+                        order.extra,
+                    );
+                    println!("{}", printer);
+                }
+                println!();
+            }
+            EmitStage::Air => {
+                println!("=== AIR ===");
+                if let Some(ref state) = frontend_state {
+                    for func in state.functions() {
+                        println!("function {}:", func.analyzed.name);
+                        println!(
+                            "{}",
+                            func.analyzed.air.display_with_interner(state.interner())
+                        );
+                    }
+                }
+                println!();
+            }
+            EmitStage::Cfg => {
+                println!("=== CFG ===");
+                if let Some(ref state) = frontend_state {
+                    for func in state.functions() {
+                        println!("{}", func.cfg.display_with_interner(state.interner()));
+                    }
+                }
+                println!();
+            }
+            EmitStage::Lowering => {
+                let mut output = String::new();
+                if let Some(ref state) = frontend_state {
+                    for func in state.functions() {
+                        let lowering_info = match generate_lowering_info(
+                            &func.cfg,
+                            state.type_pool(),
+                            state.interner(),
+                            compile_options.target,
+                        ) {
+                            Ok(info) => info,
+                            Err(e) => {
+                                diagnostics.print_error(&e);
+                                return Err(());
+                            }
+                        };
+                        write!(&mut output, "{}", lowering_info).expect("write to String");
+                    }
+                }
+                output.push('\n');
+                print!("{}", output);
+            }
+            EmitStage::Mir => {
+                let mut output = String::new();
+                writeln!(&mut output, "=== MIR ({}) ===", compile_options.target)
+                    .expect("write to String");
+                if let Some(ref state) = frontend_state {
+                    for func in state.functions() {
+                        let mir = match generate_mir(
+                            &func.cfg,
+                            state.type_pool(),
+                            state.interner(),
+                            compile_options.target,
+                        ) {
+                            Ok(mir) => mir,
+                            Err(e) => {
+                                diagnostics.print_error(&e);
+                                return Err(());
+                            }
+                        };
+                        writeln!(&mut output, "function {}:", func.analyzed.name)
+                            .expect("write to String");
+                        writeln!(&mut output, "{}", mir).expect("write to String");
+                    }
+                }
+                output.push('\n');
+                print!("{}", output);
+            }
+            EmitStage::Liveness => {
+                let mut output = String::new();
+                writeln!(
+                    &mut output,
+                    "=== Liveness Analysis ({}) ===",
+                    compile_options.target
+                )
+                .expect("write to String");
+                if let Some(ref state) = frontend_state {
+                    for func in state.functions() {
+                        let liveness_info = match generate_liveness_info(
+                            &func.cfg,
+                            state.type_pool(),
+                            state.interner(),
+                            compile_options.target,
+                        ) {
+                            Ok(info) => info,
+                            Err(e) => {
+                                diagnostics.print_error(&e);
+                                return Err(());
+                            }
+                        };
+                        writeln!(&mut output, "function {}:", func.analyzed.name)
+                            .expect("write to String");
+                        writeln!(&mut output, "{}", liveness_info).expect("write to String");
+                    }
+                }
+                output.push('\n');
+                print!("{}", output);
+            }
+            EmitStage::RegAlloc => {
+                let mut output = String::new();
+                writeln!(
+                    &mut output,
+                    "=== Register Allocation ({}) ===",
+                    compile_options.target
+                )
+                .expect("write to String");
+                if let Some(ref state) = frontend_state {
+                    for func in state.functions() {
+                        let regalloc_info = match generate_regalloc_info(
+                            &func.cfg,
+                            state.type_pool(),
+                            state.interner(),
+                            compile_options.target,
+                        ) {
+                            Ok(info) => info,
+                            Err(e) => {
+                                diagnostics.print_error(&e);
+                                return Err(());
+                            }
+                        };
+                        writeln!(&mut output, "function {}:", func.analyzed.name)
+                            .expect("write to String");
+                        write!(&mut output, "{}", regalloc_info).expect("write to String");
+                    }
+                }
+                output.push('\n');
+                print!("{}", output);
+            }
+            EmitStage::Asm => {
+                let mut output = String::new();
+                writeln!(&mut output, "=== Assembly ({}) ===", compile_options.target)
+                    .expect("write to String");
+                if let Some(ref state) = frontend_state {
+                    for func in state.functions() {
+                        let asm = match generate_emitted_asm(
+                            &func.cfg,
+                            state.type_pool(),
+                            state.strings(),
+                            state.interner(),
+                            compile_options.target,
+                        ) {
+                            Ok(asm) => asm,
+                            Err(e) => {
+                                diagnostics.print_error(&e);
+                                return Err(());
+                            }
+                        };
+                        writeln!(&mut output, ".globl {}", func.analyzed.name)
+                            .expect("write to String");
+                        writeln!(&mut output, "{}:", func.analyzed.name).expect("write to String");
+                        write!(&mut output, "{}", asm).expect("write to String");
+                    }
+                }
+                output.push('\n');
+                print!("{}", output);
+            }
+            EmitStage::StackFrame => {
+                let mut output = String::new();
+                if let Some(ref state) = frontend_state {
+                    for func in state.functions() {
+                        let frame_info = match generate_stack_frame_info(
+                            &func.cfg,
+                            &func.analyzed.name,
+                            state.type_pool(),
+                            state.interner(),
+                            compile_options.target,
+                        ) {
+                            Ok(info) => info,
+                            Err(e) => {
+                                diagnostics.print_error(&e);
+                                return Err(());
+                            }
+                        };
+                        writeln!(&mut output, "{}", frame_info).expect("write to String");
+                    }
+                }
+                print!("{}", output);
+            }
+            // Dependency presentation returns before frontend planning above.
+            EmitStage::Deps => {}
+        }
+    }
+
+    Ok(())
+}

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -2,227 +2,37 @@ use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::io::Read;
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
-#[cfg(target_os = "macos")]
-use std::process::Command;
 use std::sync::Arc;
 
-use tracing::{Level, info_span};
+use tracing::Level;
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::{EnvFilter, Layer as _, fmt};
 
 #[cfg(rue_benchmark_allocations)]
 mod allocation;
+mod compile;
+mod emit;
+mod output;
+mod platform_signing;
 mod timing;
 
+use emit::EmitStage;
 #[cfg(test)]
-use rue_compiler::unstable::MetricsSnapshot;
-use rue_compiler::unstable::{
-    ImportDiscoveryRevision, ImportDiscoveryStatus, LowerMetrics, ParseMetrics, SemanticMetrics,
-};
+use emit::{EmitFrontendRoute, build_emit_frontend, emit_frontend_route};
+#[cfg(test)]
+use rue_compiler::parse_source_snapshot_for_ast_presentation;
+use rue_compiler::unstable::{ImportDiscoveryRevision, ImportDiscoveryStatus};
+
 use rue_compiler::{
-    AcceptedImportSource, Ast, CanonicalRirOutput, CanonicalSemanticOutput, CompileError,
-    CompileErrors, CompileOptions, CompileWarning, CompilerSession, DependencyEnvelope,
-    DependencyEnvelopeStatus, DiscoverySourceAssembler, ErrorKind, FileId, FileMetadataFingerprint,
-    FrozenTypeInternPool, ImportDiscoveryContext, ImportObservation, ImportObservationLedger,
-    ImportObservationStatus, Lexer, LinkerMode, MultiFileFormatter, MultiFileJsonFormatter,
-    OptLevel, PhysicalFileIdentity, PreviewFeature, PreviewFeatures, SourceInfo, SourceMetadata,
-    SourceSnapshot, Token, configure_thread_pool, generate_emitted_asm, generate_liveness_info,
-    generate_lowering_info, generate_mir, generate_regalloc_info, generate_stack_frame_info,
-    parse_source_snapshot_for_ast_presentation,
+    AcceptedImportSource, CompileError, CompileErrors, CompileOptions, CompileWarning,
+    CompilerSession, DependencyEnvelope, DiscoverySourceAssembler, FileId, FileMetadataFingerprint,
+    ImportDiscoveryContext, ImportObservation, ImportObservationLedger, ImportObservationStatus,
+    LinkerMode, MultiFileFormatter, MultiFileJsonFormatter, OptLevel, PhysicalFileIdentity,
+    PreviewFeature, PreviewFeatures, SourceInfo, SourceMetadata, SourceSnapshot,
+    configure_thread_pool,
 };
-use rue_rir::RirPrinter;
 use rue_target::Target;
-
-/// Compilation stages that can be emitted.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum EmitStage {
-    /// Emit tokens from the lexer.
-    Tokens,
-    /// Emit the abstract syntax tree.
-    Ast,
-    /// Emit RIR (untyped intermediate representation).
-    Rir,
-    /// Emit AIR (typed intermediate representation).
-    Air,
-    /// Emit CFG (control flow graph).
-    Cfg,
-    /// Emit lowering (CFG to MIR instruction selection).
-    Lowering,
-    /// Emit MIR (machine intermediate representation).
-    Mir,
-    /// Emit liveness analysis information.
-    Liveness,
-    /// Emit register allocation debug info.
-    RegAlloc,
-    /// Emit assembly text.
-    Asm,
-    /// Emit stack frame layout per function.
-    StackFrame,
-    /// Emit the source dependency graph discovered while loading imports.
-    Deps,
-}
-
-struct EmitFrontend {
-    parsed: Arc<rue_compiler::ParsedProgram>,
-    rir: Arc<CanonicalRirOutput>,
-    semantic: Arc<CanonicalSemanticOutput>,
-    work: EmitWork,
-    #[cfg(test)]
-    session_work: MetricsSnapshot,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct EmitWork {
-    parsed: ParseMetrics,
-    lowered: LowerMetrics,
-    semantic: SemanticMetrics,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum EmitFrontendRoute {
-    None,
-    AstOnlySyntax,
-    SessionQuery,
-}
-
-fn emit_frontend_route(stages: &[EmitStage]) -> EmitFrontendRoute {
-    if stages.iter().any(|stage| {
-        matches!(
-            stage,
-            EmitStage::Rir
-                | EmitStage::Air
-                | EmitStage::Cfg
-                | EmitStage::Lowering
-                | EmitStage::Mir
-                | EmitStage::Liveness
-                | EmitStage::RegAlloc
-                | EmitStage::Asm
-                | EmitStage::StackFrame
-        )
-    }) {
-        EmitFrontendRoute::SessionQuery
-    } else if stages.contains(&EmitStage::Ast) {
-        EmitFrontendRoute::AstOnlySyntax
-    } else {
-        EmitFrontendRoute::None
-    }
-}
-
-fn build_emit_frontend_in_session(
-    session: &mut CompilerSession,
-    options: CompileOptions,
-) -> Result<EmitFrontend, CompileErrors> {
-    let parsed = session.published().cloned().ok_or_else(|| {
-        CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
-            "emit requires a published closed discovery revision".into(),
-        )))
-    })?;
-    let rir = {
-        let _span = info_span!("semantic_astgen").entered();
-        session.rir()?
-    };
-    let semantic = session.semantic(&options)?;
-    let session_work = session.unstable_metrics();
-    Ok(EmitFrontend {
-        parsed,
-        rir,
-        semantic: semantic.clone(),
-        work: EmitWork {
-            parsed: session_work.parse_metrics(),
-            lowered: session_work.lower_metrics(),
-            semantic: semantic.unstable_metrics(),
-        },
-        #[cfg(test)]
-        session_work,
-    })
-}
-
-#[cfg(test)]
-fn build_emit_frontend(
-    source_snapshot: &SourceSnapshot,
-    options: CompileOptions,
-) -> Result<EmitFrontend, CompileErrors> {
-    let mut session = CompilerSession::new();
-    session
-        .update_for_presentation(source_snapshot)
-        .into_result()?;
-    build_emit_frontend_in_session(&mut session, options)
-}
-
-impl EmitFrontend {
-    fn rir(&self) -> &rue_compiler::Rir {
-        self.rir.rir()
-    }
-
-    fn interner(&self) -> &rue_compiler::ThreadedRodeo {
-        self.rir.semantic_symbols().interner()
-    }
-
-    fn functions(&self) -> &[rue_compiler::FunctionWithCfg] {
-        self.semantic.functions()
-    }
-
-    fn type_pool(&self) -> &FrozenTypeInternPool {
-        self.semantic.type_pool()
-    }
-
-    fn strings(&self) -> &[String] {
-        self.semantic.strings()
-    }
-
-    fn warnings(&self) -> &[CompileWarning] {
-        self.semantic.warnings()
-    }
-
-    fn query_work(&self) -> EmitWork {
-        self.work
-    }
-}
-
-/// Error returned when parsing an emit stage name fails.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ParseEmitStageError(String);
-
-impl std::fmt::Display for ParseEmitStageError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "unknown emit stage '{}'", self.0)
-    }
-}
-
-impl std::error::Error for ParseEmitStageError {}
-
-impl std::str::FromStr for EmitStage {
-    type Err = ParseEmitStageError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "tokens" => Ok(EmitStage::Tokens),
-            "ast" => Ok(EmitStage::Ast),
-            "rir" => Ok(EmitStage::Rir),
-            "air" => Ok(EmitStage::Air),
-            "cfg" => Ok(EmitStage::Cfg),
-            "lowering" => Ok(EmitStage::Lowering),
-            "mir" => Ok(EmitStage::Mir),
-            "liveness" => Ok(EmitStage::Liveness),
-            "regalloc" => Ok(EmitStage::RegAlloc),
-            "asm" => Ok(EmitStage::Asm),
-            "stackframe" => Ok(EmitStage::StackFrame),
-            "deps" => Ok(EmitStage::Deps),
-            _ => Err(ParseEmitStageError(s.to_string())),
-        }
-    }
-}
-
-impl EmitStage {
-    fn all_names() -> &'static str {
-        "tokens, ast, rir, air, cfg, lowering, mir, liveness, regalloc, asm, stackframe, deps"
-    }
-}
-
-/// Log level for tracing output.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum LogLevel {
     /// No logging output (default).
@@ -477,180 +287,6 @@ enum ParseResult {
     Error,
     /// User requested help or version (already printed, should exit 0).
     Exit,
-}
-
-/// Resolve a path to a canonical key for the output-clobber comparison.
-///
-/// Sources always exist, so they canonicalize directly. The output file
-/// usually does NOT exist yet, so `canonicalize` fails on it; in that case we
-/// canonicalize the parent directory and re-attach the file name, which still
-/// collapses `./prog` and `prog` (or `dir/../prog`) to the same key. When even
-/// the parent can't be resolved — as in unit tests with fake paths that touch
-/// no real files — we fall back to the raw path, preserving the old
-/// exact-string behavior. Extension is irrelevant; only the resolved location
-/// matters (RUE-351).
-fn clobber_key(path: &str) -> PathBuf {
-    let p = Path::new(path);
-    if let Ok(canon) = fs::canonicalize(p) {
-        return canon;
-    }
-    match (p.parent(), p.file_name()) {
-        (Some(parent), Some(name)) => {
-            // An empty parent means the path is a bare file name in the cwd.
-            let parent = if parent.as_os_str().is_empty() {
-                Path::new(".")
-            } else {
-                parent
-            };
-            match fs::canonicalize(parent) {
-                Ok(canon_parent) => canon_parent.join(name),
-                Err(_) => p.to_path_buf(),
-            }
-        }
-        _ => p.to_path_buf(),
-    }
-}
-
-/// Would writing the output destroy the source file at `source`?
-///
-/// Two complementary checks (RUE-527):
-/// - resolved-path equality via [`clobber_key`], which collapses spellings
-///   and symlinks — and works when the output does not exist yet;
-/// - device+inode equality, which catches HARD links: `ln main.rue program`
-///   gives two distinct canonical names for one shared inode, so writing
-///   `program` destroys `main.rue`. Only checkable when the output exists;
-///   `output_meta` is its metadata (`None` when it doesn't exist).
-fn output_would_clobber(
-    output_key: &Path,
-    output_meta: Option<&fs::Metadata>,
-    source: &str,
-) -> bool {
-    if clobber_key(source) == *output_key {
-        return true;
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-        if let (Some(out_meta), Ok(src_meta)) = (output_meta, fs::metadata(source)) {
-            return out_meta.dev() == src_meta.dev() && out_meta.ino() == src_meta.ino();
-        }
-    }
-    false
-}
-
-/// Refuse an output path that names (or hard-links) any source of the
-/// compilation. `sources` is whatever set is known at the call site: the
-/// positional paths at argument-parse time, and the full import-discovered
-/// set later — imports are appended after parsing, so the guard must run
-/// again once they are known (RUE-527).
-fn check_output_clobbers_source<'a>(
-    output_path: &str,
-    sources: impl IntoIterator<Item = &'a str>,
-) -> Result<(), ()> {
-    let output_key = clobber_key(output_path);
-    let output_meta = fs::metadata(output_path).ok();
-    for source in sources {
-        if output_would_clobber(&output_key, output_meta.as_ref(), source) {
-            eprintln!(
-                "Error: output path '{output_path}' is also an input source file; \
-                 refusing to overwrite it"
-            );
-            return Err(());
-        }
-    }
-    Ok(())
-}
-
-/// Publish the linked executable image to `output_path` atomically.
-///
-/// The image is written to a same-directory temporary file, finalized there
-/// (executable permissions; ad-hoc codesign for Mach-O targets on a macOS
-/// host, which Mach-O executables require to run), and renamed into place
-/// only once complete. On any failure the temporary file is removed and an
-/// `OutputPublication` error is returned, so the output path never holds a
-/// partial, mis-permissioned, or unsigned artifact: it either keeps its
-/// previous contents or receives the fully finalized executable (RUE-781).
-///
-/// Signing before the rename is sound because the signing identifier is
-/// pinned (`dev.rue-lang.program`, RUE-619): the temporary path does not
-/// influence the signed bytes.
-fn publish_executable(output_path: &str, image: &[u8], target: Target) -> Result<(), CompileError> {
-    #[cfg(not(target_os = "macos"))]
-    let _ = target;
-    let fail = |message: String| {
-        Err(CompileError::without_span(ErrorKind::OutputPublication(
-            message,
-        )))
-    };
-    let temp_path = format!("{}.tmp.{}", output_path, std::process::id());
-    let cleanup = |result| {
-        let _ = fs::remove_file(&temp_path);
-        result
-    };
-
-    if let Err(e) = fs::write(&temp_path, image) {
-        return cleanup(fail(format!("could not write {temp_path}: {e}")));
-    }
-
-    #[cfg(unix)]
-    {
-        let path = Path::new(&temp_path);
-        let metadata = match fs::metadata(path) {
-            Ok(metadata) => metadata,
-            Err(e) => {
-                return cleanup(fail(format!(
-                    "could not read file metadata for {temp_path}: {e}"
-                )));
-            }
-        };
-        let mut perms = metadata.permissions();
-        perms.set_mode(0o755);
-        if let Err(e) = fs::set_permissions(path, perms) {
-            return cleanup(fail(format!(
-                "could not set executable permissions on {temp_path}: {e}"
-            )));
-        }
-    }
-
-    // Ad-hoc codesign for macOS-target executables (required to run on
-    // ARM64). A command-line Mach-O has no Info.plist, so codesign's default
-    // identifier would come from the file name; pin both identity and
-    // timestamp policy so the destination path never changes the program
-    // bytes (RUE-619).
-    #[cfg(target_os = "macos")]
-    if target.is_macho() {
-        let result = Command::new("codesign")
-            .args([
-                "-f",
-                "-s",
-                "-",
-                "--identifier",
-                "dev.rue-lang.program",
-                "--timestamp=none",
-                &temp_path,
-            ])
-            .output();
-        match result {
-            Ok(output) => {
-                if !output.status.success() {
-                    return cleanup(fail(format!(
-                        "codesign failed: {}",
-                        String::from_utf8_lossy(&output.stderr)
-                    )));
-                }
-            }
-            Err(e) => {
-                return cleanup(fail(format!("could not run codesign: {e}")));
-            }
-        }
-    }
-
-    if let Err(e) = fs::rename(&temp_path, output_path) {
-        return cleanup(fail(format!(
-            "could not move finished executable to {output_path}: {e}"
-        )));
-    }
-    Ok(())
 }
 
 fn parse_jobs_value(jobs_str: &str) -> Option<usize> {
@@ -2003,31 +1639,32 @@ fn main() {
         .collect();
     let diagnostics = DiagnosticOutput::new(options.error_format, source_infos);
 
-    if options.emit_stages.contains(&EmitStage::Deps) {
-        if options.emit_stages.len() != 1 {
-            eprintln!("Error: --emit deps cannot be combined with other --emit stages");
-            std::process::exit(1);
-        }
-        if options.benchmark_json {
-            eprintln!(
-                "Error: --emit cannot be combined with --benchmark-json (both write to stdout)"
-            );
-            std::process::exit(1);
-        }
-        let dependency_envelope =
-            DependencyEnvelope::from_closed_revision(&import_discovery.revision)
-                .expect("closed valid or resolution-incomplete discovery has dependency topology");
-        let incomplete = dependency_envelope.status == DependencyEnvelopeStatus::Incomplete;
-        match serde_json::to_string_pretty(&dependency_envelope) {
-            Ok(json) => println!("{json}"),
-            Err(e) => {
-                eprintln!("Error emitting dependency envelope: {e}");
+    // --emit and --benchmark-json both own stdout, so combining them would
+    // interleave IR text with the benchmark JSON and corrupt it — reject early.
+    if options.benchmark_json && !options.emit_stages.is_empty() {
+        eprintln!("Error: --emit cannot be combined with --benchmark-json (both write to stdout)");
+        std::process::exit(1);
+    }
+
+    // Handle emit modes with multi-file support
+    if !options.emit_stages.is_empty() {
+        {
+            let _compile = compile_span.enter();
+            if let Err(()) = emit::execute(emit::EmitRequest {
+                source_snapshot: &source_snapshot,
+                session: &mut import_discovery.session,
+                stages: &options.emit_stages,
+                discovery_revision: &import_discovery.revision,
+                compile_options: CompileOptions {
+                    target: options.target,
+                    linker: options.linker.clone(),
+                    opt_level: options.opt_level,
+                    preview_features: options.preview_features.clone(),
+                },
+                diagnostics: &diagnostics,
+            }) {
                 std::process::exit(1);
             }
-        }
-        if incomplete {
-            diagnostics.print_errors(import_discovery.revision.diagnostics());
-            std::process::exit(1);
         }
         drop(compile_span);
         print_timing_output(
@@ -2046,52 +1683,26 @@ fn main() {
         std::process::exit(1);
     }
 
-    // Only a closed-valid revision may reach output validation. Canonical
-    // attempted-revision diagnostics take precedence over an output-path
-    // conflict, matching discovery failure ordering. Run the guard only now,
-    // once @import discovery has appended the full source set. --emit never
-    // writes the output path.
-    if options.emit_stages.is_empty()
-        && check_output_clobbers_source(
-            &options.output_path,
-            source_snapshot.files().map(|source| source.path),
-        )
-        .is_err()
-    {
-        std::process::exit(1);
-    }
-
-    // --emit and --benchmark-json both own stdout, so combining them would
-    // interleave IR text with the benchmark JSON and corrupt it — reject early.
-    if options.benchmark_json && !options.emit_stages.is_empty() {
-        eprintln!("Error: --emit cannot be combined with --benchmark-json (both write to stdout)");
-        std::process::exit(1);
-    }
-
-    // Handle emit modes with multi-file support
-    if !options.emit_stages.is_empty() {
-        {
-            let _compile = compile_span.enter();
-            if let Err(()) = handle_emit_multi_file(
-                &source_snapshot,
-                &mut import_discovery.session,
-                &options,
-                &diagnostics,
-            ) {
-                std::process::exit(1);
-            }
+    // Closed discovery fixes the complete source identity set. Validate the
+    // destination before semantic/codegen/link work, then retain that set for
+    // mandatory revalidation immediately before atomic publication.
+    let publication_destination = match output::preflight_destination(
+        Path::new(&options.output_path),
+        source_snapshot.files().map(|source| source.path),
+    ) {
+        Ok(destination) => destination,
+        Err(output::PublishError::WouldClobberSource) => {
+            eprintln!(
+                "Error: output path '{}' is also an input source file; refusing to overwrite it",
+                options.output_path
+            );
+            std::process::exit(1);
         }
-        drop(compile_span);
-        print_timing_output(
-            &timing_data,
-            options.time_passes,
-            options.benchmark_json,
-            &options.target,
-            None,
-            None,
-        );
-        return;
-    }
+        Err(error) => {
+            diagnostics.print_error(&error.into_compile_error());
+            std::process::exit(1);
+        }
+    };
 
     // Normal compilation - uses multi-file compilation for all source files
     let compile_options = CompileOptions {
@@ -2106,9 +1717,11 @@ fn main() {
     }
     let compile_result = {
         let _compile = compile_span.enter();
-        import_discovery
-            .session
-            .executable_in_compile_scope(&compile_options)
+        compile::execute(compile::CompileRequest {
+            session: &mut import_discovery.session,
+            options: compile_options,
+            destination: publication_destination,
+        })
     };
     drop(compile_span);
     #[cfg(rue_benchmark_allocations)]
@@ -2117,18 +1730,25 @@ fn main() {
     }
     match compile_result {
         Ok(output) => {
-            // Print warnings using the diagnostic formatter
-            diagnostics.print_warnings(&output.warnings);
-
-            // Publish the executable atomically. Any failure is fatal: a
-            // partially written, mis-permissioned, or unsigned artifact must
-            // not be left at the output path behind a success exit (RUE-781).
-            if let Err(error) =
-                publish_executable(&options.output_path, &output.elf, compile_options.target)
-            {
-                diagnostics.print_error(&error);
-                std::process::exit(1);
-            }
+            let publication = output.publish();
+            // Warnings live outside the publication result so failures cannot
+            // discard them; present them before inspecting and reporting the
+            // publication outcome.
+            diagnostics.print_warnings(&publication.warnings);
+            let output = match publication.result {
+                Ok(output) => output,
+                Err(output::PublishError::WouldClobberSource) => {
+                    eprintln!(
+                        "Error: output path '{}' is also an input source file; refusing to overwrite it",
+                        options.output_path
+                    );
+                    std::process::exit(1);
+                }
+                Err(error) => {
+                    diagnostics.print_error(&error.into_compile_error());
+                    std::process::exit(1);
+                }
+            };
 
             // Don't print normal compilation message when using --benchmark-json
             // as it would interfere with JSON parsing
@@ -2157,7 +1777,9 @@ fn main() {
                         tokens: source_stats.tokens,
                     }
                 }),
-                options.benchmark_json.then_some(output.elf.as_slice()),
+                options
+                    .benchmark_json
+                    .then_some(output.linked_bytes.as_slice()),
             );
         }
         Err(errors) => {
@@ -2165,337 +1787,6 @@ fn main() {
             std::process::exit(1);
         }
     }
-}
-
-/// Handle emit stages for multi-file compilation.
-///
-/// For early stages (tokens, ast), each file is processed and labeled individually.
-/// For later stages (rir, air, cfg, etc.), the merged program is used.
-fn handle_emit_multi_file(
-    source_snapshot: &SourceSnapshot,
-    session: &mut CompilerSession,
-    options: &Options,
-    diagnostics: &DiagnosticOutput<'_>,
-) -> Result<(), ()> {
-    // Determine which stages we need
-    let needs_tokens = options.emit_stages.contains(&EmitStage::Tokens);
-    let needs_ast = options.emit_stages.contains(&EmitStage::Ast);
-
-    // For tokens, we need to lex each file separately (before parsing merges interners)
-    // We'll collect per-file tokens if needed
-    let per_file_tokens: Option<Vec<(String, Vec<Token>)>> = if needs_tokens {
-        let mut file_tokens = Vec::with_capacity(source_snapshot.len());
-        for source in source_snapshot.files() {
-            // Lex with the file's real FileId so a lex error in the Nth file
-            // is attributed to that file, not to the first one (RUE-38).
-            let lexer = Lexer::with_file_id(source.source, source.file_id);
-            match lexer.tokenize_preserving_interner() {
-                Ok((tokens, _interner)) => {
-                    file_tokens.push((source.path.to_string(), tokens));
-                }
-                Err((errors, _interner)) => {
-                    diagnostics.print_errors(&errors);
-                    return Err(());
-                }
-            }
-        }
-        Some(file_tokens)
-    } else {
-        None
-    };
-
-    let frontend_route = emit_frontend_route(&options.emit_stages);
-    // AST-only preserves its syntax-only behavior (duplicates are printable).
-    // Combined AST+later canonical modes reuse the unit's once-only projection.
-    let mut per_file_asts: Option<Vec<(String, std::sync::Arc<Ast>)>> =
-        if frontend_route == EmitFrontendRoute::AstOnlySyntax {
-            match parse_source_snapshot_for_ast_presentation(source_snapshot) {
-                Ok(presentation) => {
-                    debug_assert_eq!(
-                        presentation.work().parsed.syntax.parser_invocations,
-                        source_snapshot.len()
-                    );
-                    Some(presentation.files().to_vec())
-                }
-                Err(errors) => {
-                    diagnostics.print_errors(&errors);
-                    return Err(());
-                }
-            }
-        } else {
-            None
-        };
-
-    let frontend_state = if frontend_route == EmitFrontendRoute::SessionQuery {
-        let compile_options = CompileOptions {
-            target: options.target,
-            linker: options.linker.clone(),
-            opt_level: options.opt_level,
-            preview_features: options.preview_features.clone(),
-        };
-        let frontend = match build_emit_frontend_in_session(session, compile_options) {
-            Ok(frontend) => frontend,
-            Err(errors) => {
-                diagnostics.print_errors(&errors);
-                return Err(());
-            }
-        };
-        if needs_ast {
-            per_file_asts = Some(
-                source_snapshot
-                    .files()
-                    .map(|source| {
-                        let module = frontend
-                            .parsed
-                            .modules()
-                            .iter()
-                            .find(|module| module.file_id() == source.file_id)
-                            .expect("frontend parsed every snapshot source");
-                        (source.path.to_string(), module.shared_ast())
-                    })
-                    .collect(),
-            );
-        }
-        Some(frontend)
-    } else {
-        None
-    };
-    if let Some(state) = &frontend_state {
-        // Every --emit mode must surface frontend warnings (RUE-130).
-        diagnostics.print_warnings(state.warnings());
-        let work = state.query_work();
-        debug_assert_eq!(state.parsed.modules().len(), source_snapshot.len());
-        debug_assert!(work.parsed.parser_invocations <= source_snapshot.len());
-        debug_assert_eq!(work.lowered.parser_invocations, 0);
-        debug_assert_eq!(work.semantic.binding.bind_invocations, 1);
-        debug_assert_eq!(work.semantic.manifest.build_invocations, 1);
-    }
-
-    use std::fmt::Write as _;
-
-    // Now emit in order
-    for stage in &options.emit_stages {
-        match stage {
-            EmitStage::Tokens => {
-                if let Some(ref file_tokens) = per_file_tokens {
-                    for (path, tokens) in file_tokens {
-                        println!("=== Tokens ({}) ===", path);
-                        for token in tokens {
-                            println!("{}", token);
-                        }
-                        println!();
-                    }
-                }
-            }
-            EmitStage::Ast => {
-                if let Some(ref asts) = per_file_asts {
-                    for (path, ast) in asts {
-                        println!("=== AST ({}) ===", path);
-                        print!("{}", ast);
-                        println!();
-                    }
-                }
-            }
-            EmitStage::Rir => {
-                println!("=== RIR ===");
-                if let Some(ref state) = frontend_state {
-                    let order = state
-                        .rir
-                        .presentation_order(source_snapshot.files().map(|source| source.file_id));
-                    let printer = RirPrinter::with_presentation_order(
-                        state.rir(),
-                        state.interner(),
-                        order.instructions,
-                        order.extra,
-                    );
-                    println!("{}", printer);
-                }
-                println!();
-            }
-            EmitStage::Air => {
-                println!("=== AIR ===");
-                if let Some(ref state) = frontend_state {
-                    for func in state.functions() {
-                        println!("function {}:", func.analyzed.name);
-                        println!(
-                            "{}",
-                            func.analyzed.air.display_with_interner(state.interner())
-                        );
-                    }
-                }
-                println!();
-            }
-            EmitStage::Cfg => {
-                println!("=== CFG ===");
-                if let Some(ref state) = frontend_state {
-                    for func in state.functions() {
-                        println!("{}", func.cfg.display_with_interner(state.interner()));
-                    }
-                }
-                println!();
-            }
-            EmitStage::Lowering => {
-                let mut output = String::new();
-                if let Some(ref state) = frontend_state {
-                    for func in state.functions() {
-                        let lowering_info = match generate_lowering_info(
-                            &func.cfg,
-                            state.type_pool(),
-                            state.interner(),
-                            options.target,
-                        ) {
-                            Ok(info) => info,
-                            Err(e) => {
-                                diagnostics.print_error(&e);
-                                return Err(());
-                            }
-                        };
-                        write!(&mut output, "{}", lowering_info).expect("write to String");
-                    }
-                }
-                output.push('\n');
-                print!("{}", output);
-            }
-            EmitStage::Mir => {
-                let mut output = String::new();
-                writeln!(&mut output, "=== MIR ({}) ===", options.target).expect("write to String");
-                if let Some(ref state) = frontend_state {
-                    for func in state.functions() {
-                        let mir = match generate_mir(
-                            &func.cfg,
-                            state.type_pool(),
-                            state.interner(),
-                            options.target,
-                        ) {
-                            Ok(mir) => mir,
-                            Err(e) => {
-                                diagnostics.print_error(&e);
-                                return Err(());
-                            }
-                        };
-                        writeln!(&mut output, "function {}:", func.analyzed.name)
-                            .expect("write to String");
-                        writeln!(&mut output, "{}", mir).expect("write to String");
-                    }
-                }
-                output.push('\n');
-                print!("{}", output);
-            }
-            EmitStage::Liveness => {
-                let mut output = String::new();
-                writeln!(
-                    &mut output,
-                    "=== Liveness Analysis ({}) ===",
-                    options.target
-                )
-                .expect("write to String");
-                if let Some(ref state) = frontend_state {
-                    for func in state.functions() {
-                        let liveness_info = match generate_liveness_info(
-                            &func.cfg,
-                            state.type_pool(),
-                            state.interner(),
-                            options.target,
-                        ) {
-                            Ok(info) => info,
-                            Err(e) => {
-                                diagnostics.print_error(&e);
-                                return Err(());
-                            }
-                        };
-                        writeln!(&mut output, "function {}:", func.analyzed.name)
-                            .expect("write to String");
-                        writeln!(&mut output, "{}", liveness_info).expect("write to String");
-                    }
-                }
-                output.push('\n');
-                print!("{}", output);
-            }
-            EmitStage::RegAlloc => {
-                let mut output = String::new();
-                writeln!(
-                    &mut output,
-                    "=== Register Allocation ({}) ===",
-                    options.target
-                )
-                .expect("write to String");
-                if let Some(ref state) = frontend_state {
-                    for func in state.functions() {
-                        let regalloc_info = match generate_regalloc_info(
-                            &func.cfg,
-                            state.type_pool(),
-                            state.interner(),
-                            options.target,
-                        ) {
-                            Ok(info) => info,
-                            Err(e) => {
-                                diagnostics.print_error(&e);
-                                return Err(());
-                            }
-                        };
-                        writeln!(&mut output, "function {}:", func.analyzed.name)
-                            .expect("write to String");
-                        write!(&mut output, "{}", regalloc_info).expect("write to String");
-                    }
-                }
-                output.push('\n');
-                print!("{}", output);
-            }
-            EmitStage::Asm => {
-                let mut output = String::new();
-                writeln!(&mut output, "=== Assembly ({}) ===", options.target)
-                    .expect("write to String");
-                if let Some(ref state) = frontend_state {
-                    for func in state.functions() {
-                        let asm = match generate_emitted_asm(
-                            &func.cfg,
-                            state.type_pool(),
-                            state.strings(),
-                            state.interner(),
-                            options.target,
-                        ) {
-                            Ok(asm) => asm,
-                            Err(e) => {
-                                diagnostics.print_error(&e);
-                                return Err(());
-                            }
-                        };
-                        writeln!(&mut output, ".globl {}", func.analyzed.name)
-                            .expect("write to String");
-                        writeln!(&mut output, "{}:", func.analyzed.name).expect("write to String");
-                        write!(&mut output, "{}", asm).expect("write to String");
-                    }
-                }
-                output.push('\n');
-                print!("{}", output);
-            }
-            EmitStage::StackFrame => {
-                let mut output = String::new();
-                if let Some(ref state) = frontend_state {
-                    for func in state.functions() {
-                        let frame_info = match generate_stack_frame_info(
-                            &func.cfg,
-                            &func.analyzed.name,
-                            state.type_pool(),
-                            state.interner(),
-                            options.target,
-                        ) {
-                            Ok(info) => info,
-                            Err(e) => {
-                                diagnostics.print_error(&e);
-                                return Err(());
-                            }
-                        };
-                        writeln!(&mut output, "{}", frame_info).expect("write to String");
-                    }
-                }
-                print!("{}", output);
-            }
-            EmitStage::Deps => unreachable!("--emit deps is handled before frontend emission"),
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -3103,45 +2394,6 @@ mod tests {
 
         let _ = fs::remove_dir_all(&dir);
     }
-
-    #[cfg(unix)]
-    #[test]
-    fn clobber_guard_catches_hard_link_alias() {
-        // RUE-527: a hard link gives the output a DIFFERENT canonical path
-        // from the source while sharing its inode — `ln main.rue program;
-        // rue main.rue -o program` destroyed main.rue. The guard must compare
-        // device+inode, not just resolved paths.
-        let dir =
-            std::env::temp_dir().join(format!("rue-clobber-hardlink-test-{}", std::process::id()));
-        fs::create_dir_all(&dir).unwrap();
-        let source = dir.join("main.rue");
-        let link = dir.join("program");
-        let _ = fs::remove_file(&link);
-        fs::write(&source, "fn main() -> i32 { 0 }\n").unwrap();
-        fs::hard_link(&source, &link).unwrap();
-
-        let source_str = source.to_str().unwrap();
-        let link_str = link.to_str().unwrap();
-        let output_key = clobber_key(link_str);
-        let output_meta = fs::metadata(link_str).ok();
-        assert!(output_would_clobber(
-            &output_key,
-            output_meta.as_ref(),
-            source_str
-        ));
-
-        // A distinct file in the same directory is NOT a clobber.
-        let other = dir.join("other.rue");
-        fs::write(&other, "fn main() -> i32 { 1 }\n").unwrap();
-        assert!(!output_would_clobber(
-            &output_key,
-            output_meta.as_ref(),
-            other.to_str().unwrap()
-        ));
-
-        let _ = fs::remove_dir_all(&dir);
-    }
-
     #[test]
     fn parse_emit_ast() {
         let opts = unwrap_options(parse_args_from(&["--emit", "ast", "source.rue"]));
@@ -3872,61 +3124,5 @@ mod tests {
     #[test]
     fn log_format_all_names() {
         assert_eq!(LogFormat::all_names(), "text, json");
-    }
-
-    // ========== Atomic executable publication (RUE-781) ==========
-
-    fn publish_test_dir(label: &str) -> std::path::PathBuf {
-        let dir = env::temp_dir().join(format!("rue-publish-{label}-{}", std::process::id()));
-        let _ = fs::remove_dir_all(&dir);
-        fs::create_dir_all(&dir).expect("create publish test dir");
-        dir
-    }
-
-    #[test]
-    fn publish_executable_success_installs_output_and_no_temp() {
-        let dir = publish_test_dir("ok");
-        let output = dir.join("prog");
-        let output_str = output.to_str().unwrap();
-        publish_executable(output_str, b"image-bytes", Target::X86_64Linux)
-            .expect("publication succeeds");
-        assert_eq!(fs::read(&output).unwrap(), b"image-bytes");
-        #[cfg(unix)]
-        assert_eq!(
-            fs::metadata(&output).unwrap().permissions().mode() & 0o777,
-            0o755
-        );
-        let leftovers: Vec<_> = fs::read_dir(&dir)
-            .unwrap()
-            .map(|e| e.unwrap().file_name())
-            .filter(|name| name != "prog")
-            .collect();
-        assert!(leftovers.is_empty(), "temp files left: {leftovers:?}");
-        let _ = fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn publish_executable_failure_is_atomic() {
-        let dir = publish_test_dir("fail");
-        // The output path is an existing directory, so the final rename must
-        // fail after the temp file was fully written — the failure mode where
-        // a non-atomic implementation leaves debris.
-        let output = dir.join("occupied");
-        fs::create_dir_all(&output).unwrap();
-        let output_str = output.to_str().unwrap();
-        let error = publish_executable(output_str, b"image-bytes", Target::X86_64Linux)
-            .expect_err("publication must fail");
-        assert!(matches!(error.kind, ErrorKind::OutputPublication(_)));
-        assert!(output.is_dir(), "output path must be untouched");
-        let leftovers: Vec<_> = fs::read_dir(&dir)
-            .unwrap()
-            .map(|e| e.unwrap().file_name())
-            .filter(|name| name != "occupied")
-            .collect();
-        assert!(
-            leftovers.is_empty(),
-            "failed publication left artifacts: {leftovers:?}"
-        );
-        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/crates/rue/src/output.rs
+++ b/crates/rue/src/output.rs
@@ -1,0 +1,427 @@
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use rue_compiler::{CompileError, ErrorKind};
+use rue_target::Target;
+
+use crate::platform_signing::{SigningError, SigningRequest, sign_executable};
+
+/// Complete request for publishing a linked executable.
+pub(crate) struct PublishRequest<'a> {
+    pub(crate) destination: PublicationDestination,
+    pub(crate) bytes: &'a [u8],
+    pub(crate) target: Target,
+}
+
+pub(crate) struct PublicationDestination {
+    path: PathBuf,
+    source_paths: Vec<String>,
+}
+
+#[derive(Debug)]
+pub(crate) enum PublishError {
+    WouldClobberSource,
+    Io {
+        operation: &'static str,
+        paths: Vec<PathBuf>,
+        error: io::Error,
+    },
+    Signing {
+        path: PathBuf,
+        error: SigningError,
+    },
+}
+
+impl PublishError {
+    fn io(operation: &'static str, paths: Vec<PathBuf>, error: io::Error) -> Self {
+        Self::Io {
+            operation,
+            paths,
+            error,
+        }
+    }
+
+    pub(crate) fn into_compile_error(self) -> CompileError {
+        let message = match self {
+            Self::WouldClobberSource => {
+                "output path is also an input source file; refusing to overwrite it".to_owned()
+            }
+            Self::Io {
+                operation,
+                paths,
+                error,
+            } => format!(
+                "{operation} ({}): {error}",
+                paths
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(" -> ")
+            ),
+            Self::Signing { path, error } => {
+                format!(
+                    "could not sign temporary executable {}: {error}",
+                    path.display()
+                )
+            }
+        };
+        CompileError::without_span(ErrorKind::OutputPublication(message))
+    }
+}
+
+fn clobber_key(path: &Path) -> PathBuf {
+    if let Ok(canonical) = fs::canonicalize(path) {
+        return canonical;
+    }
+    match (path.parent(), path.file_name()) {
+        (Some(parent), Some(name)) => {
+            let parent = if parent.as_os_str().is_empty() {
+                Path::new(".")
+            } else {
+                parent
+            };
+            fs::canonicalize(parent)
+                .map(|canonical| canonical.join(name))
+                .unwrap_or_else(|_| path.to_path_buf())
+        }
+        _ => path.to_path_buf(),
+    }
+}
+
+fn output_would_clobber(
+    output_key: &Path,
+    output_metadata: Option<&fs::Metadata>,
+    source: &Path,
+) -> bool {
+    if clobber_key(source) == output_key {
+        return true;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if let (Some(output), Ok(source)) = (output_metadata, fs::metadata(source)) {
+            return output.dev() == source.dev() && output.ino() == source.ino();
+        }
+    }
+    false
+}
+
+fn validate_destination(destination: &PublicationDestination) -> Result<(), PublishError> {
+    let output_key = clobber_key(&destination.path);
+    let output_metadata = fs::metadata(&destination.path).ok();
+    if destination.source_paths.iter().any(|source| {
+        output_would_clobber(&output_key, output_metadata.as_ref(), Path::new(source))
+    }) {
+        return Err(PublishError::WouldClobberSource);
+    }
+    Ok(())
+}
+
+/// Validate source/output identity before compilation and retain the complete
+/// source set for mandatory revalidation immediately before publication.
+pub(crate) fn preflight_destination<'a>(
+    path: &Path,
+    source_paths: impl IntoIterator<Item = &'a str>,
+) -> Result<PublicationDestination, PublishError> {
+    let destination = PublicationDestination {
+        path: path.to_owned(),
+        source_paths: source_paths.into_iter().map(str::to_owned).collect(),
+    };
+    validate_destination(&destination)?;
+    Ok(destination)
+}
+
+struct PendingOutput(PathBuf);
+
+impl PendingOutput {
+    fn publish(mut self) {
+        self.0 = PathBuf::new();
+    }
+}
+
+impl Drop for PendingOutput {
+    fn drop(&mut self) {
+        if !self.0.as_os_str().is_empty() {
+            let _ = fs::remove_file(&self.0);
+        }
+    }
+}
+
+fn create_pending_output(destination: &Path) -> Result<(PendingOutput, fs::File), PublishError> {
+    let directory = destination.parent().unwrap_or_else(|| Path::new("."));
+    let name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("rue-output");
+    for attempt in 0..1000_u32 {
+        let path = directory.join(format!(".{name}.rue-tmp-{}-{attempt}", std::process::id()));
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(file) => return Ok((PendingOutput(path), file)),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(PublishError::io(
+                    "could not create temporary executable",
+                    vec![path],
+                    error,
+                ));
+            }
+        }
+    }
+    Err(PublishError::io(
+        "could not allocate a temporary executable path",
+        vec![destination.to_owned()],
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "all temporary output names already exist",
+        ),
+    ))
+}
+
+fn finalize_executable(path: &Path, target: Target) -> Result<(), PublishError> {
+    #[cfg(unix)]
+    {
+        let metadata = fs::metadata(path).map_err(|error| {
+            PublishError::io(
+                "could not read temporary executable metadata",
+                vec![path.to_owned()],
+                error,
+            )
+        })?;
+        let mut permissions = metadata.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).map_err(|error| {
+            PublishError::io(
+                "could not set temporary executable permissions",
+                vec![path.to_owned()],
+                error,
+            )
+        })?;
+    }
+
+    sign_executable(SigningRequest { path, target }).map_err(|error| PublishError::Signing {
+        path: path.to_owned(),
+        error,
+    })?;
+    Ok(())
+}
+
+/// Write, finalize, and atomically publish an executable in its destination directory.
+/// Every failure retains its operation and affected path context.
+///
+/// Until the final rename succeeds, an existing destination is untouched. The
+/// cleanup guard removes partial output on every failure path.
+pub(crate) fn publish_executable(request: PublishRequest<'_>) -> Result<(), PublishError> {
+    publish_executable_with_finalizer(request, finalize_executable)
+}
+
+fn publish_executable_with_finalizer(
+    request: PublishRequest<'_>,
+    finalizer: impl FnOnce(&Path, Target) -> Result<(), PublishError>,
+) -> Result<(), PublishError> {
+    validate_destination(&request.destination)?;
+    let destination = &request.destination.path;
+    let (pending, mut file) = create_pending_output(destination)?;
+    file.write_all(request.bytes).map_err(|error| {
+        PublishError::io(
+            "could not write temporary executable",
+            vec![pending.0.clone()],
+            error,
+        )
+    })?;
+    file.flush().map_err(|error| {
+        PublishError::io(
+            "could not flush temporary executable",
+            vec![pending.0.clone()],
+            error,
+        )
+    })?;
+    drop(file);
+
+    finalizer(&pending.0, request.target)?;
+
+    replace_destination(&pending.0, destination).map_err(|error| {
+        PublishError::io(
+            "could not atomically install finished executable",
+            vec![pending.0.clone(), destination.to_owned()],
+            error,
+        )
+    })?;
+    pending.publish();
+    Ok(())
+}
+
+/// Supported Rue hosts are Unix systems, where rename replaces an existing
+/// non-directory destination atomically. Other hosts refuse replacement rather
+/// than opening a remove-then-rename window that could lose an old executable.
+#[cfg(unix)]
+fn replace_destination(source: &Path, destination: &Path) -> io::Result<()> {
+    fs::rename(source, destination)
+}
+
+#[cfg(not(unix))]
+fn replace_destination(source: &Path, destination: &Path) -> io::Result<()> {
+    if destination.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "atomic replacement of an existing output is unsupported on this host",
+        ));
+    }
+    fs::rename(source, destination)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temporary_directory(name: &str) -> PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("rue-{name}-{unique}"));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn publication_replaces_the_destination_and_leaves_no_temporary_file() {
+        let directory = temporary_directory("publish");
+        let destination = directory.join("program");
+        fs::write(&destination, b"old").unwrap();
+        let destination = preflight_destination(&destination, std::iter::empty::<&str>()).unwrap();
+
+        publish_executable(PublishRequest {
+            destination,
+            bytes: b"new executable",
+            target: Target::X86_64Linux,
+        })
+        .unwrap();
+
+        assert_eq!(
+            fs::read(directory.join("program")).unwrap(),
+            b"new executable"
+        );
+        assert_eq!(fs::read_dir(&directory).unwrap().count(), 1);
+        #[cfg(unix)]
+        assert_eq!(
+            fs::metadata(directory.join("program"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o755
+        );
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn failed_publication_preserves_an_existing_destination() {
+        let directory = temporary_directory("publish-failure");
+        let destination = directory.join("program");
+        fs::create_dir(&destination).unwrap();
+        let publication_destination =
+            preflight_destination(&destination, std::iter::empty::<&str>()).unwrap();
+
+        assert!(
+            publish_executable(PublishRequest {
+                destination: publication_destination,
+                bytes: b"new",
+                target: Target::X86_64Linux,
+            })
+            .is_err()
+        );
+        assert!(destination.is_dir());
+        assert_eq!(fs::read_dir(&directory).unwrap().count(), 1);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn finalization_failure_preserves_destination_and_removes_temporary_file() {
+        let directory = temporary_directory("publish-finalization-failure");
+        let destination = directory.join("program");
+        fs::write(&destination, b"old executable").unwrap();
+        let publication_destination =
+            preflight_destination(&destination, std::iter::empty::<&str>()).unwrap();
+
+        let result = publish_executable_with_finalizer(
+            PublishRequest {
+                destination: publication_destination,
+                bytes: b"new executable",
+                target: Target::X86_64Linux,
+            },
+            |temporary, _target| {
+                Err(PublishError::io(
+                    "injected finalization failure",
+                    vec![temporary.to_owned()],
+                    io::Error::other("finalizer rejected executable"),
+                ))
+            },
+        );
+
+        assert!(matches!(
+            result,
+            Err(PublishError::Io {
+                operation: "injected finalization failure",
+                ..
+            })
+        ));
+        assert_eq!(fs::read(&destination).unwrap(), b"old executable");
+        assert_eq!(fs::read_dir(&directory).unwrap().count(), 1);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn publication_refuses_a_hard_link_to_any_source() {
+        let directory = temporary_directory("publish-clobber");
+        let source = directory.join("main.rue");
+        let destination = directory.join("program");
+        fs::write(&source, "fn main() -> i32 { 0 }\n").unwrap();
+        let source_paths = vec![source.display().to_string()];
+        let publication_destination =
+            preflight_destination(&destination, source_paths.iter().map(String::as_str)).unwrap();
+        // The filesystem can change between preflight and publication. Create
+        // the alias afterwards to prove mandatory revalidation closes the gap.
+        fs::hard_link(&source, &destination).unwrap();
+
+        assert!(matches!(
+            publish_executable(PublishRequest {
+                destination: publication_destination,
+                bytes: b"executable",
+                target: Target::X86_64Linux,
+            }),
+            Err(PublishError::WouldClobberSource)
+        ));
+        assert_eq!(
+            fs::read_to_string(&source).unwrap(),
+            "fn main() -> i32 { 0 }\n"
+        );
+        assert_eq!(fs::read_dir(&directory).unwrap().count(), 2);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn replacing_an_existing_destination_is_explicitly_refused() {
+        let directory = temporary_directory("publish-replace-policy");
+        let destination = directory.join("program");
+        fs::write(&destination, b"old").unwrap();
+        let destination = preflight_destination(&destination, std::iter::empty::<&str>()).unwrap();
+
+        assert!(matches!(
+            publish_executable(PublishRequest {
+                destination,
+                bytes: b"new",
+                target: Target::X86_64Linux,
+            }),
+            Err(PublishError::Io { error, .. })
+                if error.kind() == io::ErrorKind::Unsupported
+        ));
+        assert_eq!(fs::read(directory.join("program")).unwrap(), b"old");
+        fs::remove_dir_all(directory).unwrap();
+    }
+}

--- a/crates/rue/src/platform_signing.rs
+++ b/crates/rue/src/platform_signing.rs
@@ -1,0 +1,179 @@
+use std::ffi::{OsStr, OsString};
+use std::io;
+use std::path::Path;
+
+use rue_target::Target;
+
+pub(crate) struct SigningRequest<'a> {
+    pub(crate) path: &'a Path,
+    pub(crate) target: Target,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum SigningResult {
+    NotRequired,
+    Signed,
+}
+
+#[derive(Debug)]
+pub(crate) enum SigningError {
+    Launch(io::Error),
+    Rejected(String),
+}
+
+impl std::fmt::Display for SigningError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Launch(error) => write!(formatter, "could not run codesign: {error}"),
+            Self::Rejected(stderr) => write!(formatter, "codesign failed: {stderr}"),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SigningCommand {
+    program: &'static OsStr,
+    arguments: Vec<OsString>,
+}
+
+#[derive(Debug)]
+struct CommandResult {
+    success: bool,
+    stderr: Vec<u8>,
+}
+
+fn signing_command(request: &SigningRequest<'_>, host_is_macos: bool) -> Option<SigningCommand> {
+    if !host_is_macos || !request.target.is_macho() {
+        return None;
+    }
+    Some(SigningCommand {
+        program: OsStr::new("codesign"),
+        arguments: [
+            OsString::from("-f"),
+            OsString::from("-s"),
+            OsString::from("-"),
+            OsString::from("--identifier"),
+            OsString::from("dev.rue-lang.program"),
+            OsString::from("--timestamp=none"),
+            request.path.as_os_str().to_owned(),
+        ]
+        .into(),
+    })
+}
+
+fn sign_with_runner(
+    request: SigningRequest<'_>,
+    host_is_macos: bool,
+    runner: impl FnOnce(&SigningCommand) -> io::Result<CommandResult>,
+) -> Result<SigningResult, SigningError> {
+    let Some(command) = signing_command(&request, host_is_macos) else {
+        return Ok(SigningResult::NotRequired);
+    };
+    match runner(&command) {
+        Ok(output) if output.success => Ok(SigningResult::Signed),
+        Ok(output) => Err(SigningError::Rejected(
+            String::from_utf8_lossy(&output.stderr).into_owned(),
+        )),
+        Err(error) => Err(SigningError::Launch(error)),
+    }
+}
+
+/// Apply required platform signing before an executable is made visible.
+pub(crate) fn sign_executable(request: SigningRequest<'_>) -> Result<SigningResult, SigningError> {
+    sign_with_runner(request, cfg!(target_os = "macos"), |command| {
+        let output = std::process::Command::new(command.program)
+            .args(&command.arguments)
+            .output()?;
+        Ok(CommandResult {
+            success: output.status.success(),
+            stderr: output.stderr,
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn macos_signing_command_pins_identity_timestamp_and_path() {
+        let path = PathBuf::from("/tmp/program-under-publication");
+        let request = SigningRequest {
+            path: &path,
+            target: Target::Aarch64Macos,
+        };
+        let command = signing_command(&request, true).unwrap();
+        assert_eq!(command.program, OsStr::new("codesign"));
+        assert_eq!(
+            command.arguments,
+            [
+                "-f",
+                "-s",
+                "-",
+                "--identifier",
+                "dev.rue-lang.program",
+                "--timestamp=none",
+                "/tmp/program-under-publication",
+            ]
+            .map(OsString::from)
+        );
+    }
+
+    #[test]
+    fn signing_policy_skips_non_macos_targets_and_hosts() {
+        let path = PathBuf::from("program");
+        assert!(
+            signing_command(
+                &SigningRequest {
+                    path: &path,
+                    target: Target::X86_64Linux,
+                },
+                true
+            )
+            .is_none()
+        );
+        assert!(
+            signing_command(
+                &SigningRequest {
+                    path: &path,
+                    target: Target::Aarch64Macos,
+                },
+                false
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn signing_failures_are_fatal_typed_errors() {
+        let path = PathBuf::from("program");
+        let request = SigningRequest {
+            path: &path,
+            target: Target::Aarch64Macos,
+        };
+        let failure = sign_with_runner(request, true, |_| {
+            Err(io::Error::new(io::ErrorKind::NotFound, "missing codesign"))
+        });
+        assert!(
+            matches!(failure, Err(SigningError::Launch(error)) if error.kind() == io::ErrorKind::NotFound)
+        );
+
+        let rejected = sign_with_runner(
+            SigningRequest {
+                path: &path,
+                target: Target::Aarch64Macos,
+            },
+            true,
+            |_| {
+                Ok(CommandResult {
+                    success: false,
+                    stderr: b"bad signature".to_vec(),
+                })
+            },
+        );
+        assert!(
+            matches!(rejected, Err(SigningError::Rejected(message)) if message == "bad signature")
+        );
+    }
+}

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -713,13 +713,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn emit_driver_does_not_restore_the_retired_peer_orchestrator() {
+    fn cli_orchestration_modules_do_not_restore_the_retired_peer_orchestrator() {
         let retired_type = ["Compilation", "Unit"].concat();
-        let source = include_str!("main.rs");
-        assert!(
-            !source.contains(&retired_type),
-            "emit paths must query CompilerSession directly"
-        );
+        for (name, source) in [
+            ("main.rs", include_str!("main.rs")),
+            ("compile.rs", include_str!("compile.rs")),
+            ("emit.rs", include_str!("emit.rs")),
+        ] {
+            assert!(
+                !source.contains(&retired_type),
+                "{name} must query CompilerSession directly"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- extract typed emit planning/presentation, compile/link execution, output publication, and platform-signing modules from the CLI entrypoint
- retain the canonical `CompilerSession` pipeline for every emit and executable path
- make source-clobber preflight and publication revalidation mandatory through an opaque typed destination
- preserve compiler-warning ordering, atomic Unix replacement, explicit non-Unix refusal, permissions, cleanup, and best-effort macOS signing
- add focused output, signing, emit, dependency, diagnostic-precedence, and architecture inventory coverage

## Validation

- `scripts/rue fmt`
- Rue unit tests (153/153)
- output-guard CLI (7/7)
- emit pipeline CLI (15/15)
- module/dependency CLI (123/123)
- linker CLI (6/6)
- ABI CLI (55/55)
- `scripts/rue quick` (33 targets)
- frontend structural differential (189/189)

Fixes RUE-856