### PR TITLE
RUE-1002: recover noisy scaling evidence and report benchmark failures

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,8 +20,13 @@ on:
         default: '5'
         type: string
 
+# issues:write is required by the notify job below; without it the
+# github-script call fails with "Resource not accessible by integration"
+# and trunk benchmark failures are found but never reported (the same
+# silent-failure mode the fuzz workflow hit on 2026-07-03/04).
 permissions:
   contents: write  # collect job pushes history to the perf branch
+  issues: write    # notify job files/updates the benchmark-failure issue
 
 concurrency:
   group: benchmarks
@@ -204,3 +209,77 @@ jobs:
             git commit -m "Benchmark results for $short_sha ($platform_count platforms)"
             git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" HEAD:perf
           fi
+
+  # Trunk benchmark failures previously only turned the Actions run red;
+  # nobody is watching that page, so they sat unnoticed until someone
+  # looked at the performance dashboard. Mirror the fuzz workflow: keep one
+  # open tracking issue and append later failures to it as comments.
+  # Runs cancelled by the concurrency group (rapid trunk merges) are not
+  # failures and do not report.
+  notify-failure:
+    name: Notify on failure
+    needs: [benchmark, collect-results]
+    runs-on: ubuntu-latest
+    if: ${{ failure() }}
+
+    steps:
+      - name: Create or comment on the benchmark-failure issue
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const results = [
+              ['benchmark', '${{ needs.benchmark.result }}'],
+              ['collect-results', '${{ needs.collect-results.result }}'],
+            ];
+            const failed = results.filter(([, r]) => r === 'failure').map(([n]) => n);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const summary = `**Run:** ${runUrl}\n**Commit:** ${context.sha}\n**Failed jobs:** ${failed.join(', ') || '(job-level failure)'}\n`;
+            const body = `## Benchmark Workflow Failure
+
+            The trunk benchmark workflow failed.
+
+            ${summary}
+            ### Next Steps
+            1. Open the run above and check which platform job failed and why.
+               Common failure classes:
+               - \`Budget violation ...\` (exit 2): a scaling family's growth
+                 lower bound exceeded its manifest budget — a real complexity
+                 regression until proven otherwise.
+               - \`Insufficient scaling evidence ...\` (exit 3): evidence stayed
+                 indeterminate even after the runner's noise-driven sample
+                 top-up — usually a very noisy runner, worth a rerun before
+                 deeper digging.
+               - Validation errors from \`validate-benchmark.py\`: the results
+                 schema or corpus drifted from the manifest.
+            2. Reproduce locally with \`./bench.sh --iterations 5 --output
+               results.json --no-history\`.
+            3. Fix the regression (or harness bug) on a feature branch and let
+               the next trunk run confirm.
+            `;
+
+            // One open tracking issue at a time; failures while it is open
+            // are appended as comments instead of being silently dropped.
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'benchmark-failure'
+            });
+
+            if (issues.data.length === 0) {
+              const title = `Benchmark workflow failed on trunk (${new Date().toISOString().split('T')[0]})`;
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: body,
+                labels: ['benchmark-failure', 'bug']
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issues.data[0].number,
+                body: `Another trunk benchmark failure while this issue is open.\n\n${summary}`
+              });
+            }

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -80,9 +80,15 @@ Scaling tiers have bounded per-compile timeouts plus adjacent-tier latency/unit
 and memory/unit budgets. A violation requires the conservative lower growth
 bound to exceed its budget; bounds crossing the budget and runs with fewer than
 three samples remain visibly indeterminate. A range guard also keeps extreme
-minority samples from becoming a false `±0` conclusion when MAD is zero.
-Both proven violations and indeterminate evidence fail enforcement and are not
-publishable. Passing a loose bound is not a claim of linear complexity.
+minority samples from becoming a false `±0` conclusion when MAD is zero: it
+trims the most isolated edge observation once per five samples before
+comparing the remaining range to the guard threshold. When noise alone makes
+evidence indeterminate (an extreme sample range or growth uncertainty crossing
+the budget), the runner collects additional rounds of samples for the
+implicated tiers, bounded at three times the base iterations per tier, before
+concluding. Both proven violations and evidence still indeterminate at that
+bound fail enforcement and are not publishable. Passing a loose bound is not a
+claim of linear complexity.
 Absolute time is shown but is not the complexity budget. The scaling section
 is separate from the static phase-probe aggregate.
 

--- a/scripts/benchmark_metrics.py
+++ b/scripts/benchmark_metrics.py
@@ -122,13 +122,14 @@ def robust_summary(values: object) -> dict | None:
     sample_range = maximum - minimum
     # MAD intentionally ignores a minority of outliers. That is useful for a
     # center estimate, but a zero/tiny MAD must not certify benchmark evidence
-    # when the observed range is repeatedly extreme. With at least five
-    # samples, trim the single most isolated edge observation for this guard
-    # only so an isolated scheduler delay cannot fail an otherwise stable run.
-    # The public minimum, maximum, and range below continue to preserve every
-    # observation.
+    # when the observed range is repeatedly extreme. For this guard only, trim
+    # the most isolated edge observation once per five samples so a minority of
+    # isolated scheduler delays cannot fail an otherwise stable run, while a
+    # sample set that stays dispersed after additional evidence collection
+    # still classifies as extreme. The public minimum, maximum, and range below
+    # continue to preserve every observation.
     guarded = sorted(numeric)
-    if len(guarded) >= 5:
+    for _ in range(len(numeric) // 5):
         low_gap = guarded[1] - guarded[0]
         high_gap = guarded[-1] - guarded[-2]
         guarded = guarded[1:] if low_gap >= high_gap else guarded[:-1]

--- a/scripts/benchmark_scaling.py
+++ b/scripts/benchmark_scaling.py
@@ -62,6 +62,20 @@ def compile_once(
 
 MIN_GROWTH_SAMPLES = 3
 
+# Shared CI runners can make one collection round indeterminate through
+# scheduler noise alone (an extreme sample range or growth uncertainty that
+# crosses the budget). Those reasons are evidence problems, not proven
+# regressions, so the runner collects additional rounds of samples for the
+# implicated tiers instead of failing enforcement on the first noisy round.
+# Each tier is bounded at MAX_SAMPLE_MULTIPLIER times the base iterations;
+# evidence that is still indeterminate at the bound fails enforcement as
+# before. `at_least_three_samples_required` is deliberately excluded: it
+# reflects the caller's --iterations choice, not runner noise.
+MAX_SAMPLE_MULTIPLIER = 3
+RESAMPLE_REASONS = frozenset(
+    {"extreme_sample_range", "uncertainty_crosses_budget", "variation_reaches_zero"}
+)
+
 
 def _metric_summary(samples: list[float | int]) -> dict:
     summary = robust_summary(samples)
@@ -216,41 +230,84 @@ def derive_family(family: dict, tiers: list[dict]) -> dict:
     }
 
 
+def collect_round(state: dict, family: dict, rue_bin: Path, iterations: int, platform: str) -> None:
+    """Append one round of compile samples to a tier's raw evidence."""
+    for offset in range(iterations):
+        iteration = len(state["payloads"]) + offset
+        try:
+            payload, peak = compile_once(
+                rue_bin,
+                state["source"],
+                state["root"] / f"out-{iteration}",
+                platform,
+                family["timeout_seconds"],
+            )
+        except subprocess.TimeoutExpired as error:
+            raise RuntimeError(
+                f"scaling compile timed out after {family['timeout_seconds']}s: "
+                f"{family['name']} size {state['input_size']}"
+            ) from error
+        state["payloads"].append(payload)
+        if peak is not None and peak > 0:
+            state["peak_memory_samples_bytes"].append(peak)
+
+
+def tier_evidence(state: dict) -> dict:
+    aggregate = aggregate_iterations(state["payloads"])
+    return {
+        "input_size": state["input_size"],
+        "samples_ms": [
+            float(parse_iteration_json(payload)["total_ms"])
+            for payload in state["payloads"]
+        ],
+        "peak_memory_samples_bytes": state["peak_memory_samples_bytes"],
+        "passes": aggregate["passes"],
+        "source_metrics": aggregate["source_metrics"],
+    }
+
+
+def noisy_tier_sizes(derived: dict) -> set[int]:
+    """Return tier sizes implicated in noise-driven indeterminate evidence."""
+    sizes = set()
+    for row in derived["adjacent_growth"]:
+        for evidence in (row["latency_per_unit_growth"], row["memory_per_unit_growth"]):
+            if (
+                evidence["classification"] == "indeterminate"
+                and evidence["reason"] in RESAMPLE_REASONS
+            ):
+                sizes.update((row["from_size"], row["to_size"]))
+    return sizes
+
+
 def run_family(family: dict, rue_bin: Path, iterations: int, platform: str, work: Path) -> dict:
-    tiers = []
+    states = []
     for size in family["sizes"]:
         tier_root = work / family["name"] / str(size)
-        source = generate(family["generator"], tier_root, size)
-        payloads = []
-        memory = []
-        for iteration in range(iterations):
-            try:
-                payload, peak = compile_once(
-                    rue_bin,
-                    source,
-                    tier_root / f"out-{iteration}",
-                    platform,
-                    family["timeout_seconds"],
-                )
-            except subprocess.TimeoutExpired as error:
-                raise RuntimeError(
-                    f"scaling compile timed out after {family['timeout_seconds']}s: "
-                    f"{family['name']} size {size}"
-                ) from error
-            payloads.append(payload)
-            if peak is not None and peak > 0:
-                memory.append(peak)
-        aggregate = aggregate_iterations(payloads)
-        samples = [float(parse_iteration_json(payload)["total_ms"]) for payload in payloads]
-        tier = {
-            "input_size": size,
-            "samples_ms": samples,
-            "peak_memory_samples_bytes": memory,
-            "passes": aggregate["passes"],
-            "source_metrics": aggregate["source_metrics"],
-        }
-        tiers.append(tier)
-    return derive_family(family, tiers)
+        states.append(
+            {
+                "input_size": size,
+                "root": tier_root,
+                "source": generate(family["generator"], tier_root, size),
+                "payloads": [],
+                "peak_memory_samples_bytes": [],
+            }
+        )
+    for state in states:
+        collect_round(state, family, rue_bin, iterations, platform)
+    derived = derive_family(family, [tier_evidence(state) for state in states])
+    max_samples = iterations * MAX_SAMPLE_MULTIPLIER
+    while True:
+        eligible = [
+            state
+            for state in states
+            if state["input_size"] in noisy_tier_sizes(derived)
+            and len(state["payloads"]) + iterations <= max_samples
+        ]
+        if not eligible:
+            return derived
+        for state in eligible:
+            collect_round(state, family, rue_bin, iterations, platform)
+        derived = derive_family(family, [tier_evidence(state) for state in states])
 
 
 def budget_status(families: list[dict]) -> str:

--- a/scripts/benchmark_validation.py
+++ b/scripts/benchmark_validation.py
@@ -11,7 +11,7 @@ from benchmark_manifest import (
     validate_readme_inventory,
     validate_static_dimensions,
 )
-from benchmark_scaling import budget_status, derive_family
+from benchmark_scaling import MAX_SAMPLE_MULTIPLIER, budget_status, derive_family
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -78,10 +78,14 @@ def validate_scaling_results(data: object, manifest_path: Path) -> list[str]:
                 continue
             latency = tier.get("samples_ms")
             memory = tier.get("peak_memory_samples_bytes")
+            # Noise-driven top-up appends whole extra rounds per tier, so a
+            # valid tier holds between one and MAX_SAMPLE_MULTIPLIER rounds.
+            valid_iterations = isinstance(iterations, int) and not isinstance(iterations, bool)
             for label, samples in (("latency", latency), ("peak memory", memory)):
                 if (
                     not isinstance(samples, list)
-                    or len(samples) != iterations
+                    or not valid_iterations
+                    or not iterations <= len(samples) <= iterations * MAX_SAMPLE_MULTIPLIER
                     or any(
                         not _is_finite_non_negative_number(value) or value <= 0
                         for value in samples

--- a/scripts/test-benchmark-tools.py
+++ b/scripts/test-benchmark-tools.py
@@ -988,6 +988,139 @@ class BenchmarkValidationTests(unittest.TestCase):
         )
         self.assertIn("per_tier_compile_timeout_seconds", quiet["budgets"])
 
+    def test_range_guard_trims_one_edge_outlier_per_five_samples(self):
+        # Five samples tolerate one isolated scheduler delay but not two.
+        one_outlier = [10.0] * 4 + [1000.0]
+        self.assertEqual(
+            metrics.robust_summary(one_outlier)["dispersion_classification"],
+            "robust",
+        )
+        two_outliers = [0.1] + [10.0] * 3 + [1000.0]
+        self.assertEqual(
+            metrics.robust_summary(two_outliers)["dispersion_classification"],
+            "extreme_range",
+        )
+        # A noise-driven top-up to ten samples earns a second trimmed edge, so
+        # the same two isolated outliers no longer poison the evidence.
+        topped_up = [0.1] + [10.0] * 8 + [1000.0]
+        self.assertEqual(
+            metrics.robust_summary(topped_up)["dispersion_classification"],
+            "robust",
+        )
+        # More isolated outliers than the trim allowance stay extreme: ten
+        # samples earn two trims, so a third outlier still poisons the run.
+        three_outliers = [10.0] * 7 + [1000.0, 2000.0, 3000.0]
+        self.assertEqual(
+            metrics.robust_summary(three_outliers)["dispersion_classification"],
+            "extreme_range",
+        )
+
+    def test_scaling_runner_resamples_noisy_tiers_until_evidence_is_determinate(self):
+        family = manifest_tools.scaling_families(INPUT_ROOT / "benchmarks/manifest.toml")[0]
+        centers = dict(zip(family["sizes"], (10.0, 30.0, 90.0)))
+
+        def payload(total_ms):
+            return json.dumps(
+                {
+                    "total_ms": total_ms,
+                    "passes": [{"name": family["focus_pass"], "duration_ms": total_ms}],
+                    "source_metrics": {"bytes": 8, "files": 1, "lines": 1, "tokens": 4},
+                }
+            )
+
+        def run_with_samples(sample_for_call):
+            calls = {}
+
+            def fake_compile(rue_bin, source, output, platform, timeout):
+                size = int(source.parent.name)
+                index = calls.get(size, 0)
+                calls[size] = index + 1
+                return payload(sample_for_call(size, index)), size * 1024
+
+            with tempfile.TemporaryDirectory() as temp:
+                with mock.patch.object(
+                    scaling, "generate", side_effect=lambda name, root, size: root / "main.rue"
+                ), mock.patch.object(scaling, "compile_once", side_effect=fake_compile):
+                    return scaling.run_family(family, Path("rue"), 5, "darwin", Path(temp))
+
+        # Two opposing scheduler outliers in the middle tier's first round
+        # made round one indeterminate; one top-up round of clean samples
+        # must recover determinate, in-budget evidence.
+        def transient_noise(size, index):
+            if size == family["sizes"][1] and index in (3, 4):
+                return centers[size] / 100 if index == 3 else centers[size] * 100
+            return centers[size]
+
+        recovered = run_with_samples(transient_noise)
+        self.assertEqual(recovered["classification"], "within_normalized_growth_budget")
+        self.assertEqual(scaling.budget_status([recovered]), "passed")
+        self.assertEqual(
+            [len(tier["samples_ms"]) for tier in recovered["tiers"]], [10, 10, 10]
+        )
+
+        # Persistent noise never converges; sampling must stop at
+        # MAX_SAMPLE_MULTIPLIER rounds and report indeterminate as before.
+        def persistent_noise(size, index):
+            if size == family["sizes"][1]:
+                return centers[size] * 100 if index % 2 else centers[size]
+            return centers[size]
+
+        capped = run_with_samples(persistent_noise)
+        self.assertEqual(capped["classification"], "indeterminate")
+        self.assertEqual(scaling.budget_status([capped]), "indeterminate")
+        self.assertEqual(
+            [len(tier["samples_ms"]) for tier in capped["tiers"]],
+            [5 * scaling.MAX_SAMPLE_MULTIPLIER] * 3,
+        )
+
+    def test_scaling_validation_accepts_topped_up_tiers_and_bounds_sample_counts(self):
+        manifest_path = INPUT_ROOT / "benchmarks/manifest.toml"
+        declared = manifest_tools.scaling_families(manifest_path)[0]
+
+        def build_result(middle_tier_samples):
+            result = self.valid_result()
+            counts = [5, middle_tier_samples, 5]
+            tiers = [
+                {
+                    "input_size": size,
+                    "samples_ms": [float(size)] * count,
+                    "peak_memory_samples_bytes": [size * 1024] * count,
+                    "source_metrics": {
+                        "bytes": size * 8,
+                        "files": 1,
+                        "lines": size,
+                        "tokens": size * 4,
+                    },
+                    "passes": {
+                        declared["focus_pass"]: {
+                            "mean_ms": float(size),
+                            "invocations": size,
+                            "root_invocations": 0,
+                            "leaf_invocations": size,
+                        }
+                    },
+                }
+                for size, count in zip(declared["sizes"], counts)
+            ]
+            result["scaling"]["families"][0] = scaling.derive_family(declared, tiers)
+            return result
+
+        # A tier topped up within the multiplier publishes cleanly.
+        topped_up = build_result(5 * scaling.MAX_SAMPLE_MULTIPLIER)
+        self.assertEqual(
+            validator.validate_manifest_results(topped_up, manifest_path), []
+        )
+        # Counts beyond the multiplier or below the base iterations are
+        # invalid evidence, not a bigger top-up.
+        for count in (5 * scaling.MAX_SAMPLE_MULTIPLIER + 1, 4):
+            errors = validator.validate_manifest_results(
+                build_result(count), manifest_path
+            )
+            self.assertTrue(
+                any("invalid latency samples" in error for error in errors),
+                errors,
+            )
+
     def test_scaling_cli_enforcement_rejects_failed_and_indeterminate(self):
         manifest_path = INPUT_ROOT / "benchmarks/manifest.toml"
         argv = [


### PR DESCRIPTION
The trunk Benchmarks workflow failed on macOS ARM64 in run 29640628633 with `Insufficient scaling evidence module_fanout: extreme_sample_range` (exit 3): shared-runner scheduler noise made one collection round's dispersion extreme, and the harness had no recovery path, so a single noisy round failed the whole job.

## Noise-driven evidence top-up

When scaling evidence is indeterminate for a noise reason (`extreme_sample_range`, `uncertainty_crosses_budget`, `variation_reaches_zero`), `benchmark_scaling.py` now collects additional rounds of samples for the implicated tiers and re-derives, bounded at `MAX_SAMPLE_MULTIPLIER` (3) times the base iterations per tier. Evidence still indeterminate at the bound fails enforcement exactly as before, and `at_least_three_samples_required` deliberately does not top up because it reflects the caller's `--iterations` choice rather than runner noise.

To make the top-up able to rescue a tier that caught two isolated scheduler delays, the `robust_summary` range guard trims the most isolated edge observation once per five samples instead of exactly once. Five-to-nine-sample behavior is unchanged; samples that stay dispersed after additional evidence still classify as `extreme_range` (a third isolated outlier at ten samples still poisons the run). Publication validation accepts per-tier sample counts between the base iterations and the bound, keeping collection, derivation, and validation coherent.

## Failure reporting

Benchmark failures on trunk previously only turned the Actions run red. `benchmarks.yml` now mirrors the fuzz workflow: a `notify-failure` job keeps one open `benchmark-failure` tracking issue and appends later failures to it as comments, with the run URL, commit, failed jobs, and triage guidance for the three failure classes (budget violation, insufficient evidence, validation error). Runs cancelled by the concurrency group do not report.

## Validation

- `python3 scripts/test-benchmark-tools.py`: 113 tests pass, including new coverage for the per-five-samples trim allowance, top-up convergence and the sampling cap, and validator acceptance/bounds for topped-up tiers.
- End-to-end on Linux: built the compiler, ran `benchmark_scaling.py --enforce-budgets` directly (exit 0, all families determinate) and the full `./bench.sh --iterations 5` → `validate-benchmark.py` pipeline (validation passed).

Fixes RUE-1002