### PR TITLE
RUE-1000: compact enum memory under aggregate_layout (ADR-0052 phase 5.6)

### DIFF
--- a/crates/rue-cli-tests/cases/aggregate_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout.toml
@@ -306,3 +306,191 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["aggregate_layout", "not yet implemented"]
+
+# ADR-0052 phase 5.6 (RUE-1000): compact enum memory. A compact enum has a
+# smallest-sufficient unsigned tag at offset 0 and its payload placed at the
+# maximum variant alignment. A discriminant-only enum narrows to just its tag,
+# so @size_of reflects the u8 tag (1) rather than the eight-byte slot.
+[[case]]
+name = "compact_enum_tag_narrows_size"
+description = "A discriminant-only enum is one byte (u8 tag) under --preview aggregate_layout; a payload enum sizes tag + max-aligned payload."
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Flag { Off, On }
+enum Opt { Some(i32), None }
+enum Num { B(u8), W(i32), Big(i64) }
+fn main() -> i32 {
+    @dbg(@size_of(Flag) == 1);
+    @dbg(@size_of(Opt) == 8);
+    @dbg(@size_of(Num) == 16);
+    @dbg(@align_of(Num) == 8);
+    0
+}
+""" }]
+stdout = "true\ntrue\ntrue\ntrue\n"
+exit_code = 0
+
+# RUE-1000: a frame-resident enum keeps its slot-based value decomposition
+# (discriminant slot + payload slots) untouched by the compact layout, so
+# constructing and matching an enum that never reaches physical memory now
+# compiles and runs under the preview (RUE-989 refused every enum value).
+[[case]]
+name = "compact_enum_frame_match_allowed"
+description = "A frame-only enum construct-and-match compiles and runs under --preview aggregate_layout (RUE-1000)."
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Color { Red, Green, Blue }
+enum Shape { Circle(i32), Rect(i32, i32), Empty }
+fn main() -> i32 {
+    let c = Color.Green;
+    let base = match c { Color.Red => 1, Color.Green => 2, Color.Blue => 3, };
+    let s = Shape.Rect(3, 4);
+    let area = match s { Shape.Circle(r) => r, Shape.Rect(w, h) => w + h, Shape.Empty => 0, };
+    base + area
+}
+""" }]
+exit_code = 9
+
+# RUE-1000: an Option-like enum round-trips through heap memory. The tag is
+# written narrow at offset 0 and read back zero-extended; the i32 payload lives
+# at the compact payload offset. Some(42) reads back 42; None matches None.
+[[case]]
+name = "compact_enum_option_heap_roundtrip"
+description = "An Option-like enum write/read/match round-trips through heap memory under --preview aggregate_layout (RUE-1000)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Opt { Some(i32), None }
+fn main() -> i32 {
+    checked {
+        let p: ptr mut Opt = @alloc(1);
+        @ptr_write(p, Opt.Some(42));
+        let some = @ptr_read(p);
+        match some { Opt.Some(x) => @dbg(x), Opt.None => @dbg(-1), };
+        @ptr_write(p, Opt.None);
+        let none = @ptr_read(p);
+        match none { Opt.Some(x) => @dbg(x), Opt.None => @dbg(-1), };
+        @free(p, 1);
+    };
+    0
+}
+""" }]
+stdout = "42\n-1\n"
+exit_code = 0
+
+# RUE-1000: an enum whose variants carry payloads of mixed widths (u8/i32/i64)
+# round-trips through heap memory. Every variant's single field shares the same
+# payload position; the union slot writes/reads the widest width (8 bytes) and
+# the narrower values are clean in their slot, so each variant round-trips.
+[[case]]
+name = "compact_enum_mixed_payload_widths"
+description = "An enum with u8/i32/i64 payload variants round-trips each through heap memory under --preview aggregate_layout (RUE-1000)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Num { B(u8), W(i32), Big(i64) }
+fn main() -> i32 {
+    checked {
+        let p: ptr mut Num = @alloc(1);
+        @ptr_write(p, Num.B(200));
+        let a = @ptr_read(p);
+        match a { Num.B(x) => @dbg(x), Num.W(y) => @dbg(y), Num.Big(z) => { let zi: i64 = z; @dbg(zi); }, };
+        @ptr_write(p, Num.W(-12345));
+        let b = @ptr_read(p);
+        match b { Num.B(x) => @dbg(x), Num.W(y) => @dbg(y), Num.Big(z) => { let zi: i64 = z; @dbg(zi); }, };
+        @ptr_write(p, Num.Big(9000000000));
+        let c = @ptr_read(p);
+        match c { Num.B(x) => @dbg(x), Num.W(y) => @dbg(y), Num.Big(z) => { let zi: i64 = z; @dbg(zi); }, };
+        @free(p, 1);
+    };
+    0
+}
+""" }]
+stdout = "200\n-12345\n9000000000\n"
+exit_code = 0
+
+# RUE-1000: an enum whose variants carry uniform multi-field payloads
+# (Rect(i32,i32)) round-trips through heap memory: both payload slots occupy
+# distinct, non-overlapping compact positions (payload_offset and +4).
+[[case]]
+name = "compact_enum_uniform_multifield_heap"
+description = "A multi-field payload enum (Rect(i32,i32)) round-trips through heap memory under --preview aggregate_layout (RUE-1000)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Shape { Circle(i32), Rect(i32, i32), Empty }
+fn main() -> i32 {
+    checked {
+        let p: ptr mut Shape = @alloc(1);
+        @ptr_write(p, Shape.Rect(3, 4));
+        let r = @ptr_read(p);
+        match r { Shape.Circle(a) => @dbg(a), Shape.Rect(w, h) => @dbg(w + h), Shape.Empty => @dbg(0), };
+        @ptr_write(p, Shape.Circle(9));
+        let c = @ptr_read(p);
+        match c { Shape.Circle(a) => @dbg(a), Shape.Rect(w, h) => @dbg(w + h), Shape.Empty => @dbg(0), };
+        @free(p, 1);
+    };
+    0
+}
+""" }]
+stdout = "7\n9\n"
+exit_code = 0
+
+# RUE-1000 keeps refusing enums whose compact memory image is variant-dependent:
+# A(i64) and B(i32,i32) would need overlapping union slots (the i64 field spans
+# both i32 positions), so there is no single slot->byte map. Refused loudly.
+[[case]]
+name = "compact_enum_overlapping_union_still_fails"
+description = "An enum whose union payload slots overlap (i64 vs two i32) has no variant-independent memory image and is refused."
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Bad { A(i64), B(i32, i32) }
+fn main() -> i32 {
+    checked {
+        let p: ptr mut Bad = @alloc(1);
+        @ptr_write(p, Bad.A(5));
+    };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["aggregate_layout", "not yet implemented"]
+
+# RUE-1000 keeps refusing a nested-aggregate enum payload through a pointer:
+# a struct payload has no single-slot scalar memory image in this phase.
+[[case]]
+name = "compact_enum_struct_payload_still_fails"
+description = "An enum with a struct payload marshalled through a pointer is still refused under --preview aggregate_layout."
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Res { id: i32 }
+enum Holder { Full(Res), Nothing }
+fn main() -> i32 {
+    checked {
+        let p: ptr mut Holder = @alloc(1);
+        @ptr_write(p, Holder.Full(Res { id: 7 }));
+    };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["aggregate_layout", "not yet implemented"]
+
+# RUE-1000 keeps refusing a compact enum crossing a CALL boundary by value:
+# the preserved slot call convention cannot express it and the indirect
+# marshalling is the next phase (RUE-976's transitional indirect rule).
+[[case]]
+name = "compact_enum_crossing_call_still_fails"
+description = "A compact enum passed by value across a call is still refused under --preview aggregate_layout (call marshalling is the next phase)."
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Opt { Some(i32), None }
+fn unwrap(o: Opt) -> i32 {
+    match o { Opt.Some(x) => x, Opt.None => 0, }
+}
+fn main() -> i32 {
+    unwrap(Opt.Some(5))
+}
+""" }]
+compile_fail = true
+error_contains = ["aggregate_layout", "not yet implemented"]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1478,7 +1478,13 @@ impl<'a> CfgLower<'a> {
             crate::value_plan::IntrinsicOperation::PtrRead => {
                 let ptr = plan.args[0].primary;
                 let count = plan.result_slots;
-                if count > 1 {
+                if let Some(map) = &plan.physical_slots {
+                    // A compact enum pointee: load each internal slot from its
+                    // physical byte position, extended into the slot-shaped vreg
+                    // (RUE-1000).
+                    slots = crate::agg_slots::load_enum_slots_through_ptr(self, ptr, map);
+                    slots[0]
+                } else if count > 1 {
                     slots = crate::agg_slots::load_slots_through_ptr(self, ptr, count);
                     slots[0]
                 } else {
@@ -1510,7 +1516,16 @@ impl<'a> CfgLower<'a> {
             crate::value_plan::IntrinsicOperation::PtrWrite => {
                 let ptr = plan.args[0].primary;
                 let value = &plan.args[1];
-                if value.slot_count == 0 {
+                if let Some(map) = &plan.physical_slots {
+                    // A compact enum value: truncate each internal slot to its
+                    // physical width at its compact byte offset (RUE-1000).
+                    let vals = if value.slots.is_empty() {
+                        vec![value.primary]
+                    } else {
+                        value.slots.clone()
+                    };
+                    crate::agg_slots::store_enum_slots_through_ptr(self, &vals, ptr, map);
+                } else if value.slot_count == 0 {
                     // Zero-sized values have no bytes to write.
                 } else if !value.slots.is_empty() {
                     crate::agg_slots::store_slots_through_ptr(self, &value.slots, ptr, 0);
@@ -2733,6 +2748,23 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     }
 }
 
+impl CfgLower<'_> {
+    /// Materialize `ptr + byte_offset` for a narrow access that encodes no
+    /// offset, returning `ptr` unchanged when the offset is zero (RUE-1000).
+    fn narrow_ptr_base(&mut self, ptr: VReg, byte_offset: i32) -> VReg {
+        if byte_offset == 0 {
+            return ptr;
+        }
+        let base = self.mir.alloc_vreg();
+        self.mir.push(Aarch64Inst::AddImm {
+            dst: Operand::Virtual(base),
+            src: Operand::Virtual(ptr),
+            imm: byte_offset,
+        });
+        base
+    }
+}
+
 impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     fn ctx(&self) -> &crate::cfg_lower::CfgLowerContext<'_> {
         &self.ctx
@@ -2780,6 +2812,37 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
             dst: Operand::Virtual(dst),
             base: ptr,
             offset: byte_offset,
+        });
+    }
+    fn emit_narrow_store_through_ptr(
+        &mut self,
+        src: VReg,
+        ptr: VReg,
+        byte_offset: i32,
+        access: crate::types::NarrowScalar,
+    ) {
+        // The narrow store addresses `[base]` with no offset, so materialize the
+        // base pointer plus the byte offset first (RUE-1000).
+        let base = self.narrow_ptr_base(ptr, byte_offset);
+        self.mir.push(Aarch64Inst::NarrowStoreIndexed {
+            src: Operand::Virtual(src),
+            base,
+            width: access.width,
+        });
+    }
+    fn emit_narrow_load_through_ptr(
+        &mut self,
+        dst: VReg,
+        ptr: VReg,
+        byte_offset: i32,
+        access: crate::types::NarrowScalar,
+    ) {
+        let base = self.narrow_ptr_base(ptr, byte_offset);
+        self.mir.push(Aarch64Inst::NarrowLoadIndexed {
+            dst: Operand::Virtual(dst),
+            base,
+            width: access.width,
+            signed: access.signed,
         });
     }
 }
@@ -3166,6 +3229,70 @@ mod tests {
                 Aarch64Inst::NarrowStoreIndexed { .. } | Aarch64Inst::NarrowLoadIndexed { .. }
             )),
             "gate-off must not emit any narrow access"
+        );
+    }
+
+    /// RUE-1000: a compact enum with a variant-independent memory image
+    /// round-trips through a typed pointer on AArch64, marshalling the narrow
+    /// tag at offset 0 and the payload at its compact offset. Gate-off keeps the
+    /// eight-byte slot access.
+    #[test]
+    fn aggregate_layout_allows_compact_enum_memory() {
+        let source = "enum Opt { Some(i32), None } \
+                      fn main() -> i32 { checked { let p: ptr mut Opt = @alloc(1); \
+                      @ptr_write(p, Opt.Some(42)); let e = @ptr_read(p); \
+                      match e { Opt.Some(x) => @dbg(x), Opt.None => @dbg(0), }; \
+                      @free(p, 1); }; 0 }";
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let mir = try_lower_first_fn(source, preview)
+            .expect("a compact enum with a variant-independent image must lower");
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::NarrowStoreIndexed { width: 1, .. })),
+            "the enum write must store the u8 tag narrow at offset 0"
+        );
+        assert!(
+            mir.instructions().iter().any(|inst| matches!(
+                inst,
+                Aarch64Inst::NarrowLoadIndexed {
+                    width: 1,
+                    signed: false,
+                    ..
+                }
+            )),
+            "the enum read must load the u8 tag zero-extended"
+        );
+
+        let off = try_lower_first_fn(source, PreviewFeatures::new())
+            .expect("the same program lowers under the default slot model");
+        assert!(
+            off.instructions().iter().all(|inst| !matches!(
+                inst,
+                Aarch64Inst::NarrowStoreIndexed { .. } | Aarch64Inst::NarrowLoadIndexed { .. }
+            )),
+            "gate-off must not emit any narrow access"
+        );
+    }
+
+    /// RUE-1000 keeps refusing a compact enum whose union payload slots would
+    /// overlap (`A(i64)` versus `B(i32, i32)`) on AArch64: no
+    /// variant-independent slot→byte image, so it fails loudly.
+    #[test]
+    fn aggregate_layout_refuses_variant_dependent_enum_memory() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let err = try_lower_first_fn(
+            "enum Bad { A(i64), B(i32, i32) } \
+             fn main() -> i32 { checked { let p: ptr mut Bad = @alloc(1); \
+             @ptr_write(p, Bad.A(5)); }; 0 }",
+            preview,
+        )
+        .expect_err("a variant-dependent enum memory image must be refused");
+        assert!(
+            format!("{err:?}").contains("aggregate_layout"),
+            "refusal must name the feature, got: {err:?}"
         );
     }
 

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -61,6 +61,68 @@ pub(crate) trait SlotBackend: BoundsCheckBackend {
 
     /// Emit a load of the value at `byte_offset` from pointer `ptr` into `dst`.
     fn emit_load_through_ptr(&mut self, dst: VReg, ptr: VReg, byte_offset: i32);
+
+    /// Emit a narrow (1/2/4-byte) store of the low `access.width` bytes of `src`
+    /// through pointer `ptr` at `byte_offset` from it (RUE-1000).
+    fn emit_narrow_store_through_ptr(
+        &mut self,
+        src: VReg,
+        ptr: VReg,
+        byte_offset: i32,
+        access: crate::types::NarrowScalar,
+    );
+
+    /// Emit a narrow (1/2/4-byte) load at `byte_offset` from pointer `ptr` into
+    /// `dst`, extended per `access.signed` into the slot-shaped vreg (RUE-1000).
+    fn emit_narrow_load_through_ptr(
+        &mut self,
+        dst: VReg,
+        ptr: VReg,
+        byte_offset: i32,
+        access: crate::types::NarrowScalar,
+    );
+}
+
+/// Store a whole compact enum value's `vals` (one vreg per internal slot, slot 0
+/// first) through `ptr` using the enum's physical slot map (ADR-0052 phase 5.6,
+/// RUE-1000). Each slot truncates to its physical width at its compact byte
+/// offset: the discriminant to the narrow tag at offset 0, each payload slot to
+/// its union field position. `ptr` is the enum's low-end address (`@alloc` /
+/// `@raw` / `@ptr_offset`).
+pub(crate) fn store_enum_slots_through_ptr<B: SlotBackend>(
+    b: &mut B,
+    vals: &[VReg],
+    ptr: VReg,
+    map: &[crate::types::PhysicalEnumSlot],
+) {
+    for (val, slot) in vals.iter().zip(map.iter()) {
+        match slot.access {
+            None => b.emit_store_through_ptr(*val, ptr, slot.byte_offset),
+            Some(access) => b.emit_narrow_store_through_ptr(*val, ptr, slot.byte_offset, access),
+        }
+    }
+}
+
+/// Load a whole compact enum value's internal slots from `ptr` using the enum's
+/// physical slot map (ADR-0052 phase 5.6, RUE-1000), returning the vregs in
+/// internal slot order. Each slot extends its narrow physical bytes back into the
+/// slot-shaped vreg (the discriminant zero-extends; payload slots extend per the
+/// widest field's signedness). The counterpart of [`store_enum_slots_through_ptr`].
+pub(crate) fn load_enum_slots_through_ptr<B: SlotBackend>(
+    b: &mut B,
+    ptr: VReg,
+    map: &[crate::types::PhysicalEnumSlot],
+) -> Vec<VReg> {
+    let mut vregs = Vec::with_capacity(map.len());
+    for slot in map {
+        let dst = b.alloc_vreg();
+        match slot.access {
+            None => b.emit_load_through_ptr(dst, ptr, slot.byte_offset),
+            Some(access) => b.emit_narrow_load_through_ptr(dst, ptr, slot.byte_offset, access),
+        }
+        vregs.push(dst);
+    }
+    vregs
 }
 
 /// Get or compute the slot vregs for a multi-slot aggregate value

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -312,6 +312,164 @@ pub(crate) fn narrow_scalar_access(
     Some(NarrowScalar { width, signed })
 }
 
+/// Physical width (1/2/4/8) and load extension of a scalar leaf, independent of
+/// the compact gate. Full eight-byte leaves (`i64`/`u64`/pointers) report width
+/// 8; a load of them needs no narrowing. Returns `None` for aggregate,
+/// zero-sized, or compile-time-only types, which have no scalar leaf.
+fn scalar_physical_access(ty: Type) -> Option<(u8, bool)> {
+    match ty.kind() {
+        TypeKind::I8 => Some((1, true)),
+        TypeKind::U8 | TypeKind::Bool => Some((1, false)),
+        TypeKind::I16 => Some((2, true)),
+        TypeKind::U16 => Some((2, false)),
+        TypeKind::I32 => Some((4, true)),
+        TypeKind::U32 => Some((4, false)),
+        TypeKind::I64 | TypeKind::U64 | TypeKind::PtrConst(_) | TypeKind::PtrMut(_) => {
+            Some((8, false))
+        }
+        _ => None,
+    }
+}
+
+/// One internal value-decomposition slot of a compact enum mapped onto its
+/// physical byte position (ADR-0052 phase 5.6, RUE-1000).
+///
+/// The discriminant slot maps to the narrow tag at offset 0; every payload slot
+/// maps to a payload-union field position at its compact byte offset, accessed
+/// narrow ([`Some`]) or full-slot ([`None`], an eight-byte leaf). Both backends
+/// consume this to marshal a whole compact enum value across a typed pointer:
+/// stores truncate each slot to its physical width, loads extend back into the
+/// slot-shaped vreg.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PhysicalEnumSlot {
+    /// Byte offset of this slot within the compact enum.
+    pub byte_offset: i32,
+    /// Narrow (1/2/4-byte) access, or `None` for a full eight-byte slot.
+    pub access: Option<NarrowScalar>,
+}
+
+/// The internal-slot → physical-byte map for whole-enum memory marshalling under
+/// the compact layout (ADR-0052 phase 5.6), or `None` when the enum's compact
+/// memory access is *not* variant-independent and must stay refused.
+///
+/// A whole-enum `@ptr_write`/`@ptr_read` sees an opaque enum value (the runtime
+/// variant is unknown at the access), so a single slot→byte map must be correct
+/// for *every* variant. That holds only when the payload is a union of scalar
+/// fields whose positions agree across variants: at each payload position every
+/// variant that carries a field there places it at the same byte offset with the
+/// same physical width (and the widest field's signedness), the positions do not
+/// overlap, and they fit within the enum. Enums that fail any of these
+/// conditions (non-scalar payloads, variant-dependent field offsets/widths, or
+/// overlapping union slots) have no variant-independent memory image and are
+/// kept loudly refused by [`compact_physical_access_unsupported`] rather than
+/// miscompiled.
+///
+/// The byte offsets come straight from the canonical layout authority
+/// (`layout()`'s [`rue_air::layout::LayoutKind::Enum`] tag/payload placement), so
+/// the marshalling and `@size_of`/`@offset_of` agree by construction.
+pub(crate) fn enum_physical_slot_map(
+    type_pool: &FrozenTypeInternPool,
+    ty: Type,
+) -> Option<Vec<PhysicalEnumSlot>> {
+    use rue_air::layout::LayoutKind;
+
+    if !type_pool.compact_layout() {
+        return None;
+    }
+    let enum_id = ty.as_enum()?;
+    let layout = type_pool.layout(ty);
+    let (tag_size, payload_offset, variant_offsets) = match &layout.kind {
+        LayoutKind::Enum {
+            tag,
+            payload_offset,
+            variants,
+        } => (tag.size, *payload_offset, variants),
+        _ => return None,
+    };
+
+    // Slot 0: the smallest-sufficient unsigned tag at offset 0 (u8/u16/u32),
+    // zero-extended on load.
+    let tag_width = u8::try_from(tag_size).ok()?;
+    if !matches!(tag_width, 1 | 2 | 4) {
+        return None;
+    }
+    let mut slots = vec![PhysicalEnumSlot {
+        byte_offset: 0,
+        access: Some(NarrowScalar {
+            width: tag_width,
+            signed: false,
+        }),
+    }];
+
+    // Payload union positions, one per scalar field position across all variants.
+    #[derive(Clone, Copy)]
+    struct Position {
+        offset: i32,
+        width: u8,
+        signed: bool,
+    }
+    let def = type_pool.enum_def(enum_id);
+    let mut positions: Vec<Position> = Vec::new();
+    for variant in 0..def.variant_count() {
+        let payload = def.variant_payload(variant);
+        for (field_index, &field_ty) in payload.iter().enumerate() {
+            // Only scalar payload fields have a single-slot memory image; a
+            // nested aggregate payload has no variant-independent slot map.
+            let (width, signed) = scalar_physical_access(field_ty)?;
+            let offset = i32::try_from(variant_offsets[variant][field_index]).ok()?;
+            if let Some(pos) = positions.get_mut(field_index) {
+                if pos.offset != offset {
+                    // Variant-dependent field offset: not a single memory image.
+                    return None;
+                }
+                match width.cmp(&pos.width) {
+                    std::cmp::Ordering::Greater => {
+                        pos.width = width;
+                        pos.signed = signed;
+                    }
+                    // Equal widest widths must agree on signedness, or the load
+                    // extension of the union slot would be ambiguous.
+                    std::cmp::Ordering::Equal if pos.signed != signed => return None,
+                    _ => {}
+                }
+            } else {
+                positions.push(Position {
+                    offset,
+                    width,
+                    signed,
+                });
+            }
+        }
+    }
+
+    // Reject overlapping union slots and anything spilling past the enum.
+    let size = i32::try_from(layout.size).ok()?;
+    let mut prev_end = i32::try_from(payload_offset).ok()?;
+    for pos in &positions {
+        if pos.offset < prev_end || pos.offset + i32::from(pos.width) > size {
+            return None;
+        }
+        prev_end = pos.offset + i32::from(pos.width);
+        slots.push(PhysicalEnumSlot {
+            byte_offset: pos.offset,
+            access: if pos.width == 8 {
+                None
+            } else {
+                Some(NarrowScalar {
+                    width: pos.width,
+                    signed: pos.signed,
+                })
+            },
+        });
+    }
+
+    // The map must cover exactly the enum's internal value-decomposition slots.
+    if slots.len() != type_pool.abi_slot_count(ty) as usize {
+        return None;
+    }
+    Some(slots)
+}
+
 /// The pointee of a pointer type, or the type itself when it is not a pointer.
 fn pointee_or_self(type_pool: &FrozenTypeInternPool, ty: Type) -> Type {
     match ty.kind() {
@@ -339,16 +497,21 @@ fn pointee_or_self(type_pool: &FrozenTypeInternPool, ty: Type) -> Type {
 /// canonical [`is_slot_identical_layout`] authority rather than a parallel local
 /// judgment:
 ///
-/// - a non-slot-identical **array** or **enum** value (dynamic array indexing
-///   strides by the compact element size while the slot-based frame stores
-///   elements at the slot stride, and compact enum memory is unimplemented);
-/// - a **pointer to a non-slot-identical aggregate** (whole-aggregate
-///   marshalling through a pointer is unimplemented, and frame-versus-heap
-///   pointer provenance is ambiguous, so `@raw`/`@field_ptr` of an aggregate and
-///   an aggregate-pointee `@alloc` are refused);
+/// - a non-slot-identical **array** value (dynamic array indexing strides by the
+///   compact element size while the slot-based frame stores elements at the slot
+///   stride). A non-slot-identical **struct** or **enum** value may exist in the
+///   frame — a struct uses static slot-offset field access and a payload enum
+///   keeps its slot-based value decomposition (RUE-975) — so only the boundary
+///   checks below constrain them;
+/// - a **pointer to a struct/array** that is non-slot-identical, or to an **enum
+///   without a variant-independent memory image** (whole-aggregate marshalling
+///   through a pointer is unimplemented for those, and frame-versus-heap
+///   provenance is ambiguous). A compact enum *with* such an image (RUE-1000) is
+///   allowed through pointers, including `@alloc`;
 /// - a **by-reference non-slot-identical aggregate** parameter;
 /// - a non-slot-identical aggregate that **crosses a call boundary** as an
-///   argument or as the **return value** (RUE-976's transitional indirect rule).
+///   argument or as the **return value** (RUE-976's transitional indirect rule;
+///   enums included — call marshalling is the next phase).
 ///
 /// Purely compile-time layout queries (`@size_of`/`@align_of`/`@offset_of`) fold
 /// to constants before code generation. Slot-identical aggregates (all
@@ -356,8 +519,9 @@ fn pointee_or_self(type_pool: &FrozenTypeInternPool, ty: Type) -> Type {
 /// byte-addressed raw-byte family (`@byte_read`/`@byte_write`/`@alloc_bytes`).
 ///
 /// Returning `None` never weakens correctness: every remaining physical access
-/// is either byte-for-byte identical to the slot model or a narrow scalar access
-/// RUE-989 lowers correctly.
+/// is either byte-for-byte identical to the slot model, a narrow scalar access
+/// (RUE-989), or a compact enum marshalled through its variant-independent memory
+/// image (RUE-1000).
 pub(crate) fn compact_physical_access_unsupported(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,
@@ -368,14 +532,28 @@ pub(crate) fn compact_physical_access_unsupported(
     }
 
     // A non-slot-identical aggregate (struct/array/enum) whose whole-value
-    // marshalling across a memory or call boundary RUE-989 does not implement.
-    // Narrow SCALAR access through typed pointers IS implemented, so scalars
-    // never trigger a refusal here.
+    // marshalling across a CALL boundary is still unimplemented (RUE-976's
+    // transitional indirect rule; call marshalling is the next phase). Narrow
+    // SCALAR access through typed pointers IS implemented, so scalars never
+    // trigger a refusal here.
     let unimplemented_aggregate = |ty: Type| -> bool {
         matches!(
             ty.kind(),
             TypeKind::Struct(_) | TypeKind::Array(_) | TypeKind::Enum(_)
         ) && !is_slot_identical_layout(type_pool, ty)
+    };
+
+    // A non-slot-identical aggregate whose whole-value marshalling THROUGH A
+    // TYPED POINTER (memory) is unimplemented. RUE-1000 implements compact enum
+    // memory for enums with a variant-independent slot→byte image (see
+    // [`enum_physical_slot_map`]), so those enums are no longer refused here;
+    // structs and arrays, and enums without such an image, still are.
+    let unimplemented_through_pointer = |ty: Type| -> bool {
+        match ty.kind() {
+            TypeKind::Enum(_) => enum_physical_slot_map(type_pool, ty).is_none(),
+            TypeKind::Struct(_) | TypeKind::Array(_) => !is_slot_identical_layout(type_pool, ty),
+            _ => false,
+        }
     };
 
     // Returned aggregates are written to the caller's sret buffer in physical
@@ -388,25 +566,28 @@ pub(crate) fn compact_physical_access_unsupported(
         let value = CfgValue::from_raw(raw as u32);
         let inst = cfg.get_inst(value);
 
-        // A non-slot-identical ARRAY or ENUM value is refused outright: dynamic
-        // array indexing strides by the compact element size while the frame is
-        // slot-based, and compact enum memory is unimplemented. A non-slot-
-        // identical STRUCT value, by contrast, is allowed to exist in the frame
-        // (static slot-offset field access, narrow scalar field pointers); the
-        // boundary checks below still refuse a struct that crosses a pointer,
-        // call, return, or by-ref boundary.
-        if matches!(inst.ty.kind(), TypeKind::Array(_) | TypeKind::Enum(_))
+        // A non-slot-identical ARRAY value is refused outright: dynamic array
+        // indexing strides by the compact element size while the frame is
+        // slot-based. A non-slot-identical STRUCT or ENUM value, by contrast, is
+        // allowed to exist in the frame — a struct uses static slot-offset field
+        // access and narrow scalar field pointers, and an enum keeps its
+        // slot-based value decomposition (discriminant slot + payload slots)
+        // untouched by the compact layout (RUE-975). The boundary checks below
+        // still refuse either aggregate crossing a pointer (unless the enum has
+        // a variant-independent memory image), call, return, or by-ref boundary.
+        if matches!(inst.ty.kind(), TypeKind::Array(_))
             && !is_slot_identical_layout(type_pool, inst.ty)
         {
             return Some(inst.ty);
         }
 
         // A pointer to a non-slot-identical aggregate: whole-aggregate
-        // marshalling through a pointer is unimplemented and the pointer's
-        // frame-versus-heap provenance is ambiguous.
+        // marshalling through a pointer is unimplemented (except a compact enum
+        // with a variant-independent memory image, RUE-1000) and the pointer's
+        // frame-versus-heap provenance is otherwise ambiguous.
         if matches!(inst.ty.kind(), TypeKind::PtrConst(_) | TypeKind::PtrMut(_)) {
             let pointee = pointee_or_self(type_pool, inst.ty);
-            if unimplemented_aggregate(pointee) {
+            if unimplemented_through_pointer(pointee) {
                 return Some(pointee);
             }
         }
@@ -432,8 +613,10 @@ pub(crate) fn compact_physical_access_unsupported(
                 }
             }
             // Typed pointer reads/writes and typed allocation address memory by
-            // the pointee's physical layout. A narrow scalar pointee is now
-            // lowered correctly; a non-slot-identical aggregate pointee is
+            // the pointee's physical layout. A narrow scalar pointee is lowered
+            // correctly (RUE-989); a compact enum pointee with a
+            // variant-independent memory image is marshalled slot by slot
+            // (RUE-1000); a struct/array (or intractable enum) pointee is
             // refused. The byte-addressed raw-byte family is not matched here —
             // it is correct under any layout.
             CfgInstData::Intrinsic { name, .. } => {
@@ -445,7 +628,7 @@ pub(crate) fn compact_physical_access_unsupported(
                     }
                     for ty in relevant {
                         let pointee = pointee_or_self(type_pool, ty);
-                        if unimplemented_aggregate(pointee) {
+                        if unimplemented_through_pointer(pointee) {
                             return Some(pointee);
                         }
                     }
@@ -473,10 +656,11 @@ pub(crate) fn ensure_compact_layout_codegen_supported(
         return Err(rue_error::CompileError::without_span(
             rue_error::ErrorKind::InternalCodegenError(format!(
                 "aggregate_layout: physical-layout code generation for type `{name}` (in function \
-                 `{}`) is not yet implemented. RUE-989 lowers narrow (one/two/four-byte) scalar \
-                 access through typed pointers, but whole-aggregate marshalling through pointers \
-                 and across call boundaries, and compact enum memory, are still staged for a \
-                 follow-up.",
+                 `{}`) is not yet implemented. Narrow scalar access through typed pointers \
+                 (RUE-989) and compact enum memory for enums with a variant-independent memory \
+                 image (RUE-1000) are lowered, but whole struct/array marshalling through \
+                 pointers, aggregates crossing call boundaries, and enums without a \
+                 variant-independent memory image are still staged for a follow-up.",
                 cfg.fn_name()
             )),
         ));

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -324,6 +324,12 @@ pub struct IntrinsicPlan {
     /// inactive, so both backends fall back to their existing slot-shaped
     /// load/store and gate-off behavior is unchanged.
     pub narrow_access: Option<crate::types::NarrowScalar>,
+    /// For a typed `@ptr_read`/`@ptr_write` of a compact enum pointee under the
+    /// compact layout, the internal-slot → physical-byte map used to marshal the
+    /// whole enum value across the pointer (ADR-0052 phase 5.6, RUE-1000).
+    /// `None` for every other operation and gate-off, so the existing
+    /// slot-shaped path is unchanged.
+    pub physical_slots: Option<Vec<crate::types::PhysicalEnumSlot>>,
 }
 
 /// Place with every dynamic index already materialized. The plan contains no
@@ -1609,6 +1615,20 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     ),
                     _ => None,
                 };
+                // A compact enum pointee marshals its whole value through the
+                // pointer via the enum's internal-slot → physical-byte map
+                // (RUE-1000). The read's pointee is its result type; the write's
+                // pointee is the value operand's type.
+                let physical_slots = match operation {
+                    IntrinsicOperation::PtrRead => {
+                        crate::types::enum_physical_slot_map(ctx.type_pool, inst.ty)
+                    }
+                    IntrinsicOperation::PtrWrite => crate::types::enum_physical_slot_map(
+                        ctx.type_pool,
+                        ctx.cfg.get_inst(args[1]).ty,
+                    ),
+                    _ => None,
+                };
                 let result = adapter.emit_intrinsic(IntrinsicPlan {
                     operation,
                     runtime_call,
@@ -1617,6 +1637,7 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     result_slots,
                     scale,
                     narrow_access,
+                    physical_slots,
                 });
                 cache_result(adapter, value, result);
                 Some(ValueKind::Intrinsic)

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1732,7 +1732,13 @@ impl<'a> CfgLower<'a> {
             crate::value_plan::IntrinsicOperation::PtrRead => {
                 let ptr = plan.args[0].primary;
                 let count = plan.result_slots;
-                if count > 1 {
+                if let Some(map) = &plan.physical_slots {
+                    // A compact enum pointee: load each internal slot from its
+                    // physical byte position, extended into the slot-shaped vreg
+                    // (RUE-1000).
+                    slots = crate::agg_slots::load_enum_slots_through_ptr(self, ptr, map);
+                    slots[0]
+                } else if count > 1 {
                     slots = crate::agg_slots::load_slots_through_ptr(self, ptr, count);
                     slots[0]
                 } else {
@@ -1765,7 +1771,16 @@ impl<'a> CfgLower<'a> {
             crate::value_plan::IntrinsicOperation::PtrWrite => {
                 let ptr = plan.args[0].primary;
                 let value = &plan.args[1];
-                if value.slot_count == 0 {
+                if let Some(map) = &plan.physical_slots {
+                    // A compact enum value: truncate each internal slot to its
+                    // physical width at its compact byte offset (RUE-1000).
+                    let vals = if value.slots.is_empty() {
+                        vec![value.primary]
+                    } else {
+                        value.slots.clone()
+                    };
+                    crate::agg_slots::store_enum_slots_through_ptr(self, &vals, ptr, map);
+                } else if value.slot_count == 0 {
                     // Zero-sized values have no bytes to write.
                 } else if !value.slots.is_empty() {
                     crate::agg_slots::store_slots_through_ptr(self, &value.slots, ptr, 0);
@@ -2568,6 +2583,27 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     }
 }
 
+impl CfgLower<'_> {
+    /// Materialize `ptr + byte_offset` for a narrow access that encodes no
+    /// displacement, returning `ptr` unchanged when the offset is zero
+    /// (RUE-1000).
+    fn narrow_ptr_base(&mut self, ptr: VReg, byte_offset: i32) -> VReg {
+        if byte_offset == 0 {
+            return ptr;
+        }
+        let base = self.mir.alloc_vreg();
+        self.mir.push(X86Inst::MovRR {
+            dst: Operand::Virtual(base),
+            src: Operand::Virtual(ptr),
+        });
+        self.mir.push(X86Inst::AddRI {
+            dst: Operand::Virtual(base),
+            imm: byte_offset,
+        });
+        base
+    }
+}
+
 impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     fn ctx(&self) -> &crate::cfg_lower::CfgLowerContext<'_> {
         &self.ctx
@@ -2615,6 +2651,37 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
             dst: Operand::Virtual(dst),
             base: ptr,
             offset: byte_offset,
+        });
+    }
+    fn emit_narrow_store_through_ptr(
+        &mut self,
+        src: VReg,
+        ptr: VReg,
+        byte_offset: i32,
+        access: crate::types::NarrowScalar,
+    ) {
+        // The narrow store addresses `[base]` with no displacement, so fold the
+        // byte offset into a materialized base pointer first (RUE-1000).
+        let base = self.narrow_ptr_base(ptr, byte_offset);
+        self.mir.push(X86Inst::NarrowStoreIndexed {
+            base,
+            src: Operand::Virtual(src),
+            width: access.width,
+        });
+    }
+    fn emit_narrow_load_through_ptr(
+        &mut self,
+        dst: VReg,
+        ptr: VReg,
+        byte_offset: i32,
+        access: crate::types::NarrowScalar,
+    ) {
+        let base = self.narrow_ptr_base(ptr, byte_offset);
+        self.mir.push(X86Inst::NarrowLoadIndexed {
+            dst: Operand::Virtual(dst),
+            base,
+            width: access.width,
+            signed: access.signed,
         });
     }
 }
@@ -3025,6 +3092,71 @@ mod tests {
                 X86Inst::NarrowStoreIndexed { .. } | X86Inst::NarrowLoadIndexed { .. }
             )),
             "gate-off must not emit any narrow access"
+        );
+    }
+
+    /// RUE-1000: under `aggregate_layout`, a compact enum with a
+    /// variant-independent memory image round-trips through a typed pointer,
+    /// marshalling the narrow tag at offset 0 and the payload at its compact
+    /// offset. Gate-off, the same program uses eight-byte slot access.
+    #[test]
+    fn aggregate_layout_allows_compact_enum_memory() {
+        let source = "enum Opt { Some(i32), None } \
+                      fn main() -> i32 { checked { let p: ptr mut Opt = @alloc(1); \
+                      @ptr_write(p, Opt.Some(42)); let e = @ptr_read(p); \
+                      match e { Opt.Some(x) => @dbg(x), Opt.None => @dbg(0), }; \
+                      @free(p, 1); }; 0 }";
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let mir = try_lower_first_fn(source, preview)
+            .expect("a compact enum with a variant-independent image must lower");
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::NarrowStoreIndexed { width: 1, .. })),
+            "the enum write must store the u8 tag narrow at offset 0"
+        );
+        assert!(
+            mir.instructions().iter().any(|inst| matches!(
+                inst,
+                X86Inst::NarrowLoadIndexed {
+                    width: 1,
+                    signed: false,
+                    ..
+                }
+            )),
+            "the enum read must load the u8 tag zero-extended"
+        );
+
+        // Gate-off, the identical program keeps eight-byte slot marshalling.
+        let off = try_lower_first_fn(source, PreviewFeatures::new())
+            .expect("the same program lowers under the default slot model");
+        assert!(
+            off.instructions().iter().all(|inst| !matches!(
+                inst,
+                X86Inst::NarrowStoreIndexed { .. } | X86Inst::NarrowLoadIndexed { .. }
+            )),
+            "gate-off must not emit any narrow access"
+        );
+    }
+
+    /// RUE-1000 keeps refusing a compact enum whose union payload slots would
+    /// overlap (`A(i64)` versus `B(i32, i32)`): there is no variant-independent
+    /// slot→byte memory image, so it must fail loudly rather than miscompile.
+    #[test]
+    fn aggregate_layout_refuses_variant_dependent_enum_memory() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let err = try_lower_first_fn(
+            "enum Bad { A(i64), B(i32, i32) } \
+             fn main() -> i32 { checked { let p: ptr mut Bad = @alloc(1); \
+             @ptr_write(p, Bad.A(5)); }; 0 }",
+            preview,
+        )
+        .expect_err("a variant-dependent enum memory image must be refused");
+        assert!(
+            format!("{err:?}").contains("aggregate_layout"),
+            "refusal must name the feature, got: {err:?}"
         );
     }
 

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -574,6 +574,27 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
     ),
+    // ADR-0052 phase 5.6 (RUE-1000): the compact-enum heap round-trips reach
+    // memory through `@alloc`, outside the oracle model (same gap as the narrow
+    // heap cases above).
+    Entry::new(
+        "cli.aggregate_layout",
+        "compact_enum_option_heap_roundtrip",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_layout",
+        "compact_enum_mixed_payload_widths",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_layout",
+        "compact_enum_uniform_multifield_heap",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
     Entry::new(
         "cli.partial_move_depth",
         "disjoint_sibling_after_subfield_move_ok",


### PR DESCRIPTION
## Summary

Next rung of the RUE-987 stabilization ladder: compact enum values are now correct in physical memory under the `aggregate_layout` preview on both backends, and the RUE-974 refusal is lifted for them. Gate-off code generation is byte-identical.

**Mechanism**: `enum_physical_slot_map` builds an internal-slot→physical-byte map from the layout authority — the narrow tag (u8/u16/u32 per ruling 4) at offset 0 plus each payload slot at its compact offset. The map exists only when the payload is a scalar union whose positions agree across variants (same offset/width/signedness, non-overlapping, in-bounds); both backends then marshal slot-by-slot through the pointer, **reusing RUE-989's narrow load/store MIR** with the byte offset folded into a materialized base pointer — no new MIR variants. Discriminant-only enums narrow to their tag; frame-resident enums compile under the gate (frames stay slot-based per RUE-975).

**Still refused, loudly**: enums without a variant-independent memory image (aggregate payloads, variant-dependent positions, overlapping unions like `{A(i64), B(i32,i32)}`), whole struct/array marshalling through pointers, and non-slot-identical aggregates crossing call boundaries — call marshalling is Layout 5.7, next.

## Verification

Verified by execution at integration: Option-like, mixed-payload-width, and multi-field (`Rect(i32,i32)`) enums round-trip through `@alloc`/`@ptr_write`/`@ptr_read`/`match` under the gate; same programs byte-identical without the flag. Four new codegen units (both backends); eight new gated CLI cases (five executing, three refusal) with oracle model-gap ledger entries; `enum_payloads` 23 unchanged gate-off; oracle-diff corpus audit green locally (the arm64 lesson from #1783 applied); full `test.sh` green except the four known uid-0 environmental failures, checked against both harness failure formats.

Fixes RUE-1000

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_