### PR TITLE
RUE-955: add ownership-safe byte string bridges

### DIFF
--- a/crates/rue-cli-tests/cases/std_byte_bridges.toml
+++ b/crates/rue-cli-tests/cases/std_byte_bridges.toml
@@ -1,0 +1,105 @@
+# Ownership-safe bulk bridges between core `str`, std `StrBuf`, and
+# `ArrayBuf(u8)` (RUE-955). These are exercised through the real std bundle so
+# the test covers source-defined implementations rather than compiler magic.
+
+[section]
+id = "cli.std_byte_bridges"
+name = "Standard byte-string bridges"
+description = "Borrowed copying conversions and bulk append operations connect str, StrBuf, and ArrayBuf(u8)."
+
+[[case]]
+name = "all_three_representations_round_trip_without_consuming_sources"
+description = "Typed str values, owned strings, and byte buffers copy and append in both directions while their sources remain usable."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+const Bytes = std.arraybuf.ArrayBuf(u8);
+const LABEL: str = "café";
+
+fn main() -> i32 {
+    let label: str = LABEL;
+    let text = S.from_str(borrow label);
+    if text != "café" || LABEL.len() != 5 { return 1; }
+
+    let bytes = text.to_bytes();
+    if bytes.len() != 5 || bytes.get_or(3, 0) != 195 || bytes.get_or(4, 0) != 169 { return 2; }
+    if text != "café" { return 3; }
+
+    let copied_back = S.from_bytes(borrow bytes);
+    if copied_back != text || bytes.len() != 5 { return 4; }
+
+    let mut combined: S = "[";
+    combined.append_borrowed(borrow text);
+    combined.append_str(borrow label);
+    combined.append_bytes(borrow bytes);
+    combined.push_str("]");
+    if combined != "[cafécafécafé]" { return 5; }
+    if text != "café" || bytes.len() != 5 { return 6; }
+
+    let direct = Bytes.from_str(borrow label);
+    let x: str = "x";
+    let mut extended = Bytes.from_str(borrow x);
+    extended.extend_from(borrow direct);
+    extended.extend_str(borrow label);
+    if extended.len() != 11 { return 7; }
+    if extended.get_or(0, 0) != 120 || extended.get_or(1, 0) != 99 { return 8; }
+    if direct.len() != 5 || direct.get_or(4, 0) != 169 { return 9; }
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 0
+
+[[case]]
+name = "byte_range_bridges_reject_out_of_bounds_ranges"
+description = "The checked ArrayBuf(u8)-to-StrBuf range bridge traps before reading beyond the borrowed source."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+const Bytes = std.arraybuf.ArrayBuf(u8);
+
+fn main() -> i32 {
+    let view: str = "abc";
+    let bytes = Bytes.from_str(borrow view);
+    let impossible = S.from_byte_range(borrow bytes, 2, 2);
+    @intCast(impossible.len())
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 101
+runtime_error_contains = ["index out of bounds"]
+
+[[case]]
+name = "empty_bridges_and_spare_capacity_are_preserved"
+description = "Empty copies are valid and appending into pre-reserved destinations does not shrink or replace their capacity contract."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+const Bytes = std.arraybuf.ArrayBuf(u8);
+
+fn main() -> i32 {
+    let empty_view: str = "";
+    let empty_text = S.from_str(borrow empty_view);
+    let empty_bytes = Bytes.from_str(borrow empty_view);
+    if !empty_text.is_empty() || !empty_bytes.is_empty() { return 1; }
+
+    let mut text = S.with_capacity(64);
+    let cap = text.capacity();
+    text.append_bytes(borrow empty_bytes);
+    text.append_str(borrow empty_view);
+    text.append_borrowed(borrow empty_text);
+    if !text.is_empty() || text.capacity() != cap { return 2; }
+
+    let mut bytes = Bytes.with_capacity(64);
+    let bytes_cap = bytes.capacity();
+    bytes.extend_from(borrow empty_bytes);
+    bytes.extend_str(borrow empty_view);
+    if !bytes.is_empty() || bytes.capacity() != bytes_cap { return 3; }
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 0

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -941,6 +941,24 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
+        "cli.std_byte_bridges",
+        "all_three_representations_round_trip_without_consuming_sources",
+        intrinsic(UnsupportedIntrinsicKind::AllocateBytes),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_byte_bridges",
+        "byte_range_bridges_reject_out_of_bounds_ranges",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_byte_bridges",
+        "empty_bridges_and_spare_capacity_are_preserved",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
+    Entry::new(
         "cli.std_m3",
         "std_rand_m3",
         semantic(SemanticGapKind::InoutParameterForwarding),

--- a/examples/jsonfmt/main.rue
+++ b/examples/jsonfmt/main.rue
@@ -36,28 +36,8 @@ fn read_file(borrow path: StrBuf) -> OptBytes {
     O.Some(data)
 }
 
-fn bytes_to_string(borrow data: Bytes) -> StrBuf {
-    let mut out = StrBuf.with_capacity(data.len());
-    let mut i: u64 = 0;
-    while i < data.len() {
-        out.push(data.get_or(i, 0));
-        i = i + 1;
-    }
-    out
-}
-
-fn string_to_bytes(borrow text: StrBuf) -> Bytes {
-    let mut out = Bytes.with_capacity(text.len());
-    let mut i: u64 = 0;
-    while i < text.len() {
-        out.push(StrBuf.byte_at_borrowed(borrow text, i));
-        i = i + 1;
-    }
-    out
-}
-
 fn write_file(borrow path: StrBuf, borrow text: StrBuf) -> bool {
-    let bytes = string_to_bytes(borrow text);
+    let bytes = text.to_bytes();
     let mut file = match std.fs.File.create(borrow path) {
         FileRes.Ok(f) => f,
         FileRes.Err(e) => return false,
@@ -94,7 +74,7 @@ fn main() -> i32 {
             return 2;
         },
     };
-    let source = bytes_to_string(borrow bytes);
+    let source = StrBuf.from_bytes(borrow bytes);
     let value = match std.json.parse(source) {
         JsonRes.Ok(v) => v,
         JsonRes.Err(e) => {

--- a/examples/mosaic/io.rue
+++ b/examples/mosaic/io.rue
@@ -31,10 +31,7 @@ pub fn read_text(borrow path: StrBuf) -> std.option.Option(StrBuf) {
     let O = std.option.Option(StrBuf);
     match read_bytes(borrow path) {
         OptBytes.Some(bytes) => {
-            let mut out = StrBuf.new();
-            let mut i: u64 = 0;
-            while i < bytes.len() { out.push(bytes.get_or(i, 0)); i = i + 1; }
-            O.Some(out)
+            O.Some(StrBuf.from_bytes(borrow bytes))
         },
         OptBytes.None => O.None,
     }
@@ -45,7 +42,7 @@ pub fn write_text(borrow path: StrBuf, borrow value: StrBuf) -> bool {
         FileRes.Ok(f) => f,
         FileRes.Err(e) => { return false; },
     };
-    let bytes = text.bytes_of(borrow value);
+    let bytes = value.to_bytes();
     let ok = match file.write_all(borrow bytes) {
         WriteRes.Ok(unit) => true,
         WriteRes.Err(e) => false,

--- a/examples/mosaic/navigation.rue
+++ b/examples/mosaic/navigation.rue
@@ -2,13 +2,7 @@
 const std = @import("std");
 const escape = @import("escape.rue");
 const model = @import("model.rue");
-const text = @import("text.rue");
 const StrBuf = std.strbuf.StrBuf;
-
-fn append_borrowed(borrow value: StrBuf, inout out: StrBuf) {
-    let mut i: u64 = 0;
-    while i < value.len() { out.push(text.byte_of(borrow value, i)); i = i + 1; }
-}
 
 fn append_page_link(borrow site: model.Site, page_index: u64, current: u64, inout out: StrBuf) {
     let page = site.pages.get_or(page_index, model.empty_page());
@@ -47,7 +41,7 @@ fn position(borrow site: model.Site, page_index: u64) -> u64 {
 fn adjacent_link(borrow site: model.Site, nav_index: u64, borrow relation: StrBuf, inout out: StrBuf) {
     let page_index = site.navigation.get_or(nav_index, 0);
     let page = site.pages.get_or(page_index, model.empty_page());
-    out.push_str("<a rel=\""); append_borrowed(borrow relation, inout out); out.push_str("\" href=\"");
+    out.push_str("<a rel=\""); out.append_borrowed(borrow relation); out.push_str("\" href=\"");
     let path = site.strings.copy(page.output_id);
     escape.url_attribute(borrow path, inout out);
     out.push_str("\">");

--- a/examples/mosaic/render.rue
+++ b/examples/mosaic/render.rue
@@ -5,11 +5,6 @@ const model = @import("model.rue");
 const text = @import("text.rue");
 const StrBuf = std.strbuf.StrBuf;
 
-fn append_borrowed(borrow value: StrBuf, inout out: StrBuf) {
-    let mut i: u64 = 0;
-    while i < value.len() { out.push(text.byte_of(borrow value, i)); i = i + 1; }
-}
-
 fn render_inline(borrow site: model.Site, inline_index: u64, inout out: StrBuf) {
     let node = site.inlines.get_or(inline_index, model.Inline { tag: 0, text_id: 0, target_id: 0, line: 0 });
     let value = site.strings.copy(node.text_id);
@@ -53,9 +48,9 @@ fn render_text_block(
     inout out: StrBuf,
 ) {
     let block = site.blocks.get_or(block_index, model.Block { tag: 0, text_id: 0, level: 0, first: 0, count: 0, line: 0, aux: 0 });
-    append_borrowed(borrow open, inout out);
+    out.append_borrowed(borrow open);
     render_inline_range(borrow site, block.first, block.count, inout out);
-    append_borrowed(borrow close, inout out);
+    out.append_borrowed(borrow close);
 }
 
 fn render_heading(borrow site: model.Site, page_index: u64, block_index: u64, inout out: StrBuf) {

--- a/examples/mosaic/text.rue
+++ b/examples/mosaic/text.rue
@@ -2,7 +2,6 @@
 // bytes with ASCII markup punctuation; non-ASCII bytes pass through untouched.
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
-const Bytes = std.arraybuf.ArrayBuf(u8);
 const OptU8 = std.option.Option(u8);
 
 pub fn byte_of(borrow value: StrBuf, i: u64) -> u8 {
@@ -167,17 +166,8 @@ pub fn join_path(borrow base: StrBuf, borrow leaf: StrBuf) -> StrBuf {
     if leaf.len() > 0 && byte_of(borrow leaf, 0) == 47 { return slice(borrow leaf, 0, leaf.len()); }
     let mut out = slice(borrow base, 0, base.len());
     if out.len() > 0 && byte_of(borrow out, out.len() - 1) != 47 { out.push(47); }
-    let mut i: u64 = 0;
-    while i < leaf.len() { out.push(byte_of(borrow leaf, i)); i = i + 1; }
+    out.append_borrowed(borrow leaf);
     normalize_path(borrow out)
-}
-
-pub fn bytes_of(borrow value: StrBuf) -> Bytes {
-    let mut out = Bytes.new();
-    out.reserve(value.len());
-    let mut i: u64 = 0;
-    while i < value.len() { out.push(byte_of(borrow value, i)); i = i + 1; }
-    out
 }
 
 pub fn decimal(value: u64) -> StrBuf { @to_string(value) }

--- a/examples/rill/main.rue
+++ b/examples/rill/main.rue
@@ -42,32 +42,17 @@ const vm = @import("vm.rue");
 const StrBuf = std.strbuf.StrBuf;
 const Bytes = std.arraybuf.ArrayBuf(u8);
 const OptStr = std.option.Option(StrBuf);
-const OptU8 = std.option.Option(u8);
 const OptBytes = std.option.Option(Bytes);
 const FileRes = std.result.Result(std.fs.File, std.fs.FileError);
 const ReadRes = std.result.Result(u64, std.fs.FileError);
 
 fn bytes_of(borrow text: StrBuf) -> Bytes {
-    let mut bytes = Bytes.new();
-    let mut i: u64 = 0;
-    while i < text.len() {
-        match text.byte_at(i) {
-            OptU8.Some(b) => { bytes.push(b); },
-            OptU8.None => {},
-        }
-        i = i + 1;
-    }
-    bytes
+    text.to_bytes()
 }
 
 fn copy_bytes(borrow source: Bytes) -> Bytes {
-    let mut copy = Bytes.new();
-    copy.reserve(source.len());
-    let mut i: u64 = 0;
-    while i < source.len() {
-        copy.push(source.get_or(i, 0));
-        i = i + 1;
-    }
+    let mut copy = Bytes.with_capacity(source.len());
+    copy.extend_from(borrow source);
     copy
 }
 

--- a/examples/ruelex/lex.rue
+++ b/examples/ruelex/lex.rue
@@ -152,13 +152,7 @@ pub struct Lexer {
 
     // A fresh StrBuf of source bytes [a, b).
     fn slice_key(borrow self, a: u64, b: u64) -> StrBuf {
-        let mut k = StrBuf.new();
-        let mut i = a;
-        while i < b {
-            k.push(self.at(i));
-            i = i + 1;
-        }
-        k
+        StrBuf.from_byte_range(borrow self.src, a, b - a)
     }
 
     // --- token recognizers (cursor is at the token start; each consumes the

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -12,8 +12,10 @@
 // - std.option.Option: Optional values
 // - std.result.Result: Fallible values (Ok/Err), propagated with `?`
 // - std.intmap.IntMap / std.strmap.StrMap: open-addressing hash maps
-// - std.strbuf.StrBuf: Source-defined growable string buffer header
-// - std.arraybuf.ArrayBuf: Growable heap-backed collections
+// - std.strbuf.StrBuf: Growable strings, with copying bridges to str and
+//   ArrayBuf(u8) (`from_str`, `from_bytes`, `to_bytes`, and append variants)
+// - std.arraybuf.ArrayBuf: Growable heap-backed collections; ArrayBuf(u8) can
+//   copy from str with `from_str` / `extend_str`
 // - std.fs.File: File IO v0 (open/create/append/read/write/close over @syscall)
 
 // Re-export library modules.

--- a/std/arraybuf.rue
+++ b/std/arraybuf.rue
@@ -29,6 +29,13 @@
 //     // the heap buffer is freed AUTOMATICALLY when `v` goes out of scope
 //     // (the `drop fn` below); call `v.free()` only for explicit early release.
 //
+// Byte buffers also have explicit copying bridges from core string views:
+//
+//     let Bytes = std.arraybuf.ArrayBuf(u8);
+//     let label: str = "Rue";
+//     let mut bytes = Bytes.from_str(borrow label);
+//     bytes.extend_str(borrow label); // label remains usable
+//
 // RAII: `ArrayBuf` owns its buffer and frees it in its destructor at scope exit
 // (RUE-312), so callers no longer have to remember `free()`. `free()` remains
 // available to release the buffer early; it resets the buffer to empty, so the
@@ -133,6 +140,17 @@ pub fn ArrayBuf(comptime T: type) -> type {
             v
         }
 
+        // Copy the bytes of a `str` view into a new `ArrayBuf(u8)`. This
+        // method is intentionally available through the generic type function
+        // but only type-checks for `T == u8`: `value[i]` is a `u8`, so using it
+        // with any other element type produces the ordinary element mismatch.
+        // The source is borrowed and remains usable after the copy (RUE-955).
+        fn from_str(borrow value: str) -> Self {
+            let mut out = Self.with_capacity(value.len());
+            out.extend_str(borrow value);
+            out
+        }
+
         // --- reads ---
 
         fn len(borrow self) -> u64 { self.len }
@@ -229,6 +247,37 @@ pub fn ArrayBuf(comptime T: type) -> type {
                 @ptr_write(slot, x);
             };
             self.len = self.len + 1;
+        }
+
+        // Append a by-copy collection in one capacity operation. Reading a
+        // drop-glue element would create an aliasing owner, so this operation
+        // has the same trivially-droppable gate as `get` (RUE-651). The source
+        // remains unchanged and self-aliasing is rejected by Rue's ordinary
+        // borrow/exclusivity rules.
+        fn extend_from(inout self, borrow other: Self) {
+            @require_trivially_droppable(T);
+            self.reserve(other.len);
+            let mut i: u64 = 0;
+            while i < other.len {
+                let value = checked { @ptr_read(@ptr_offset(other.buf, i)) };
+                checked {
+                    @ptr_write(@ptr_offset(self.buf, self.len), value);
+                };
+                self.len = self.len + 1;
+                i = i + 1;
+            }
+        }
+
+        // Append the bytes of a borrowed `str` view to an `ArrayBuf(u8)` with
+        // one reserve. As with `from_str`, the body deliberately type-checks
+        // only for the byte specialization (`T == u8`).
+        fn extend_str(inout self, borrow value: str) {
+            self.reserve(value.len());
+            let mut i: u64 = 0;
+            while i < value.len() {
+                self.push(value[i]);
+                i = i + 1;
+            }
         }
 
         // Remove and return the last element as `Some(x)`, or `None` when the

--- a/std/strbuf.rue
+++ b/std/strbuf.rue
@@ -4,8 +4,14 @@
 // A value with `cap > 0` owns exactly `cap` packed bytes at alignment one.
 // Allocation failure is fail-fast, and an owner header is changed only after
 // its replacement allocation has succeeded.
+//
+// Interoperability with core `str` and `ArrayBuf(u8)` is explicit and copying:
+// `from_str`, `from_bytes`, and `to_bytes` create independent owners, while
+// `append_str`, `append_bytes`, and `append_borrowed` keep their source usable.
+// No bridge aliases or transfers either container's private allocation.
 
 const option = @import("option.rue");
+const arraybuf = @import("arraybuf.rue");
 
 // Raw-pointer operations are private module implementation details. Keeping
 // them outside the public struct prevents callers from laundering unchecked
@@ -51,6 +57,44 @@ pub struct StrBuf {
 
     fn with_capacity(requested: u64) -> Self {
         Self.allocate(requested)
+    }
+
+    // Copy a borrowed core string view into a new owned buffer. The view may
+    // come from a literal, fixed string, or another StrBuf; it never escapes
+    // and the source remains usable after this call (RUE-955).
+    fn from_str(borrow source: str) -> Self {
+        let mut out = Self.allocate(source.len());
+        let mut i: u64 = 0;
+        while i < source.len() {
+            write_packed_byte(out.buf, i, source[i]);
+            i = i + 1;
+        }
+        out.len = source.len();
+        out
+    }
+
+    // Copy an ArrayBuf(u8) into a new owned string buffer. This is an explicit
+    // copy rather than an ownership cast: the two types use distinct allocator
+    // and capacity invariants, and both owners remain independently valid.
+    fn from_bytes(borrow source: arraybuf.ArrayBuf(u8)) -> Self {
+        Self.from_byte_range(borrow source, 0, source.len())
+    }
+
+    // Copy a checked byte-buffer range `[start, start + count)` into a new
+    // string. This gives lexers/parsers a bulk spelling for the common token
+    // lexeme bridge without exposing either container's backing pointer.
+    fn from_byte_range(borrow source: arraybuf.ArrayBuf(u8), start: u64, count: u64) -> Self {
+        if start > source.len() || count > source.len() - start {
+            @panic("index out of bounds");
+        }
+        let mut out = Self.allocate(count);
+        let mut i: u64 = 0;
+        while i < count {
+            write_packed_byte(out.buf, i, source.get_or(start + i, 0));
+            i = i + 1;
+        }
+        out.len = count;
+        out
     }
 
     // Shared allocator used by constructors and owned algorithms.
@@ -141,6 +185,60 @@ pub struct StrBuf {
         Self.append_owned(other, inout self);
     }
 
+    // Append without consuming the source owner. This is the efficient bridge
+    // for callers that only hold a borrow: grow once, then bulk-copy the packed
+    // bytes directly between distinct allocations.
+    fn append_borrowed(inout self, borrow other: Self) {
+        let source_len = other.len;
+        let destination_start = self.len;
+        self.grow(source_len);
+        if source_len == 0 {
+            return;
+        }
+        copy_packed_bytes(other.buf, 0, self.buf, destination_start, source_len);
+        self.len = destination_start + source_len;
+    }
+
+    // Append a borrowed core string view without forcing the caller to create
+    // a temporary StrBuf. The target reserves once; byte indexing is packed
+    // and preserves arbitrary UTF-8 or non-UTF-8 byte sequences.
+    fn append_str(inout self, borrow source: str) {
+        self.grow(source.len());
+        let destination_start = self.len;
+        let mut i: u64 = 0;
+        while i < source.len() {
+            write_packed_byte(self.buf, destination_start + i, source[i]);
+            i = i + 1;
+        }
+        self.len = destination_start + source.len();
+    }
+
+    // Append a borrowed byte buffer without consuming it. Reserving before the
+    // loop avoids the hand-written caller pattern's repeated growth checks.
+    fn append_bytes(inout self, borrow source: arraybuf.ArrayBuf(u8)) {
+        self.append_byte_range(borrow source, 0, source.len());
+    }
+
+    // Append a checked range from a borrowed byte buffer, reserving once.
+    fn append_byte_range(
+        inout self,
+        borrow source: arraybuf.ArrayBuf(u8),
+        start: u64,
+        count: u64,
+    ) {
+        if start > source.len() || count > source.len() - start {
+            @panic("index out of bounds");
+        }
+        self.grow(count);
+        let destination_start = self.len;
+        let mut i: u64 = 0;
+        while i < count {
+            write_packed_byte(self.buf, destination_start + i, source.get_or(start + i, 0));
+            i = i + 1;
+        }
+        self.len = destination_start + count;
+    }
+
     // The normal source append path consumes a separate owner. Literal inputs
     // may share static storage safely because the destination is promoted to a
     // fresh allocation before any writes.
@@ -179,6 +277,19 @@ pub struct StrBuf {
         copy_packed_bytes(self.buf, 0, result.buf, 0, self.len);
         result.len = self.len;
         result
+    }
+
+    // Copy the packed bytes into an independently owned ArrayBuf(u8). The
+    // source remains valid and keeps its existing allocation/capacity.
+    fn to_bytes(borrow self) -> arraybuf.ArrayBuf(u8) {
+        let Bytes = arraybuf.ArrayBuf(u8);
+        let mut out = Bytes.with_capacity(self.len);
+        let mut i: u64 = 0;
+        while i < self.len {
+            out.push(read_packed_byte(self.buf, i));
+            i = i + 1;
+        }
+        out
     }
 
     fn substring(borrow self, start: u64, count: u64) -> Self {


### PR DESCRIPTION
## Summary

- add explicit copying bridges among core `str`, `StrBuf`, and `ArrayBuf(u8)`
- add borrowed append and checked byte-range APIs while preserving source ownership
- replace hand-written conversion loops in jsonfmt, Mosaic, Rill, and ruelex
- add focused UTF-8, source-reuse, capacity, empty-input, and bounds regressions

## Why

Rue dogfood programs repeatedly hand-copied bytes between the three string/byte representations. Besides boilerplate and repeated growth checks, each local loop had to get ownership and range behavior right. These standard-library bridges centralize that behavior as explicit copies: sources stay usable and each resulting owner retains its own allocation invariants.

Closes RUE-955.

## Validation

- `scripts/rue cli std_byte_bridges` (3 passed)
- jsonfmt (5), ruelex (1), Rill (12), and Mosaic (17) focused cases passed
- `scripts/rue quick` (33 targets passed, rerun after rebase)
- `scripts/rue test` (full suite passed)
  - CLI: 1,581 passed, 2 ignored
  - spec: 2,135 passed, 18 ignored
  - UI: 191 passed
  - generated oracle smoke: 64/64 agreements
- spec traceability: 100% normative coverage (767/767)
- ADR registry validation: 62 records valid
- formatting and `git diff --check` passed