### PR TITLE
RUE-1004: call-boundary marshalling for compact aggregates (ADR-0052 phase 5.7)

### DIFF
--- a/crates/rue-cli-tests/cases/aggregate_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout.toml
@@ -494,3 +494,240 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["aggregate_layout", "not yet implemented"]
+
+# RUE-1004 (ADR-0052 phase 5.7): call-boundary marshalling for compact
+# aggregates. A non-slot-identical aggregate the preserved slot convention
+# cannot pass by registers now crosses a call indirectly through its compact
+# memory image on both backends: a return goes through the caller's sret buffer
+# as the compact image, and an `inout` / `borrow` parameter is accessed through
+# its by-reference pointer. A by-value indirect argument stays refused (its
+# callee parameter ABI is not yet remapped from the CFG's N decomposition slots
+# to one incoming pointer).
+
+# A padded struct { u8, i32, u8 } is three slots (<= the six return registers),
+# so before the compact layout it returned in registers; under the gate it is
+# non-slot-identical, so the classifier forces it indirect (sret) and the callee
+# writes its compact image (a@0, b@4, c@8) through the sret buffer. The caller
+# reads that image back, extending each field into its slot-shaped vreg.
+[[case]]
+name = "compact_struct_return_sret_roundtrip"
+description = "A padded struct returned by value round-trips its fields through the compact sret image under --preview aggregate_layout (RUE-1004)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Padded { a: u8, b: i32, c: u8 }
+fn make(x: i32) -> Padded { Padded { a: 7, b: x, c: 9 } }
+fn main() -> i32 {
+    let p = make(1000);
+    @dbg(p.a);
+    @dbg(p.b);
+    @dbg(p.c);
+    0
+}
+""" }]
+stdout = "7\n1000\n9\n"
+exit_code = 0
+
+# A compact Option-like enum returned by value crosses via the sret buffer as
+# its variant-independent image (u8 tag @0, i32 payload @4). Both Some and None
+# round-trip and match correctly in the caller.
+[[case]]
+name = "compact_enum_return_sret_roundtrip"
+description = "An Option-like enum returned by value round-trips through the compact sret image under --preview aggregate_layout (RUE-1004)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Opt { Some(i32), None }
+fn wrap(x: i32) -> Opt { Opt.Some(x) }
+fn none() -> Opt { Opt.None }
+fn main() -> i32 {
+    let a = wrap(42);
+    match a { Opt.Some(x) => @dbg(x), Opt.None => @dbg(-1), };
+    let b = none();
+    match b { Opt.Some(x) => @dbg(x), Opt.None => @dbg(-1), };
+    0
+}
+""" }]
+stdout = "42\n-1\n"
+exit_code = 0
+
+# An `inout` compact struct is passed by reference to the caller's slot-based
+# frame storage (RUE-975 keeps a struct frame value slot-shaped, and a pointer
+# to a compact heap aggregate cannot exist under the gate), so the callee reads
+# and writes it through the by-reference pointer with the existing slot-shaped
+# transport. The callee's mutation is observed by the caller.
+[[case]]
+name = "compact_struct_inout_mutation"
+description = "An inout compact struct mutated by the callee is observed by the caller under --preview aggregate_layout (RUE-1004)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Padded { a: u8, b: i32, c: u8 }
+fn bump(inout p: Padded) {
+    p.b = p.b + 100;
+    p.a = 5;
+}
+fn main() -> i32 {
+    let mut s = Padded { a: 1, b: 200, c: 3 };
+    bump(inout s);
+    @dbg(s.a);
+    @dbg(s.b);
+    @dbg(s.c);
+    0
+}
+""" }]
+stdout = "5\n300\n3\n"
+exit_code = 0
+
+# A `borrow` compact struct is likewise passed by reference; the callee reads
+# its fields through the pointer without mutating the caller's value.
+[[case]]
+name = "compact_struct_borrow_read"
+description = "A borrow compact struct read field-by-field in the callee under --preview aggregate_layout (RUE-1004)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Padded { a: u8, b: i32, c: u8 }
+fn total(borrow p: Padded) -> i32 { p.b }
+fn main() -> i32 {
+    let s = Padded { a: 1, b: 777, c: 3 };
+    @dbg(total(borrow s));
+    0
+}
+""" }]
+stdout = "777\n"
+exit_code = 0
+
+# A by-value non-slot-identical struct argument still crosses indirectly by the
+# classifier, but its caller-owned compact-buffer marshalling is not yet
+# implemented: the callee parameter ABI would have to consume one incoming
+# pointer for a value the CFG models as N decomposition slots. Refused loudly.
+[[case]]
+name = "compact_struct_by_value_arg_still_fails"
+description = "A compact struct passed by value across a call is still refused under --preview aggregate_layout (indirect by-value argument marshalling is the next phase)."
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Padded { a: u8, b: i32, c: u8 }
+fn sum(p: Padded) -> i32 { p.b }
+fn main() -> i32 {
+    let s = Padded { a: 1, b: 5, c: 3 };
+    sum(s)
+}
+""" }]
+compile_fail = true
+error_contains = ["aggregate_layout", "not yet implemented"]
+
+# RUE-1004 prize: a std-like generic `ArrayBuf(i32)` compiles and runs under
+# --preview aggregate_layout. `ArrayBuf(T)` is `{ buf: ptr mut T, len: u64,
+# cap: u64 }` — all eight-byte leaves, so it is slot-identical and crosses its
+# `borrow self` / `inout self` method calls unchanged; the i32 heap elements use
+# RUE-989 narrow access; and `get`/`pop` return `Option(i32)` BY VALUE, which is
+# non-slot-identical and now crosses the return boundary as its compact sret
+# image (RUE-1004). This is the first `@import`-style generic-container dogfood
+# to compile and execute under the compact-layout gate.
+[[case]]
+name = "compact_arraybuf_option_return_dogfood"
+description = "A generic ArrayBuf(i32) push/get/pop dogfood compiles and runs under --preview aggregate_layout; Option(i32) returns cross via the compact sret image (RUE-1004)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """const arraybuf = @import("arraybuf.rue");
+
+fn main() -> i32 {
+    let V = arraybuf.ArrayBuf(i32);
+    let O = arraybuf.Option(i32);
+    let mut v = V.new();
+    v.push(10);
+    v.push(20);
+    v.push(30);
+    @dbg(v.len());
+    @dbg(match v.get(1) { O.Some(x) => x, O.None => -1 });
+    @dbg(match v.pop() { O.Some(x) => x, O.None => -1 });
+    @dbg(v.len());
+    v.free();
+    0
+}""" },
+  { path = "arraybuf.rue", source = """
+
+pub fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+
+pub fn ArrayBuf(comptime T: type) -> type {
+    struct {
+        buf: ptr mut T,
+        len: u64,
+        cap: u64,
+
+        fn new() -> Self {
+            let zero: u64 = 0;
+            Self { buf: checked { @int_to_ptr(zero) }, len: 0, cap: 0 }
+        }
+        fn len(borrow self) -> u64 { self.len }
+        fn is_empty(borrow self) -> bool { self.len == 0 }
+        fn capacity(borrow self) -> u64 { self.cap }
+
+        fn reserve(inout self) {
+            if self.len == self.cap {
+                let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
+                checked {
+                    let grown = @realloc(self.buf, self.cap, new_cap);
+                    self.buf = grown;
+                };
+                self.cap = new_cap;
+            }
+        }
+        fn push(inout self, x: T) {
+            self.reserve();
+            checked {
+                let slot = @ptr_offset(self.buf, self.len);
+                @ptr_write(slot, x);
+            };
+            self.len = self.len + 1;
+        }
+        fn get(borrow self, i: u64) -> Option(T) {
+            let O = Option(T);
+            if i < self.len {
+                O.Some(checked { @ptr_read(@ptr_offset(self.buf, i)) })
+            } else {
+                O.None
+            }
+        }
+        fn get_or(borrow self, i: u64, default: T) -> T {
+            if i < self.len {
+                checked { @ptr_read(@ptr_offset(self.buf, i)) }
+            } else {
+                default
+            }
+        }
+        fn set(inout self, i: u64, x: T) {
+            if i < self.len {
+                checked {
+                    let slot = @ptr_offset(self.buf, i);
+                    @ptr_write(slot, x);
+                };
+            }
+        }
+        fn pop(inout self) -> Option(T) {
+            let O = Option(T);
+            if self.len == 0 {
+                O.None
+            } else {
+                self.len = self.len - 1;
+                O.Some(checked { @ptr_read(@ptr_offset(self.buf, self.len)) })
+            }
+        }
+        fn clear(inout self) { self.len = 0; }
+        fn free(inout self) {
+            checked { @free(self.buf, self.cap); };
+            let zero: u64 = 0;
+            self.buf = checked { @int_to_ptr(zero) };
+            self.len = 0;
+            self.cap = 0;
+        }
+    }
+}
+""" },
+]
+stdout = "3\n20\n30\n2\n"
+exit_code = 0

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -750,17 +750,29 @@ impl<'a> CfgLower<'a> {
                 slot_count,
                 storage_bytes,
             } => {
-                let slots: Vec<_> = (0..slot_count)
-                    .map(|index| {
-                        let slot = self.mir.alloc_vreg();
-                        self.mir.push(Aarch64Inst::Ldr {
-                            dst: Operand::Virtual(slot),
-                            base: Reg::Sp,
-                            offset: (index * 8) as i32,
-                        });
-                        slot
-                    })
-                    .collect();
+                let slots = if let Some(map) = &plan.compact_return_image {
+                    // Compact aggregate return (RUE-1004): read the callee-written
+                    // compact image back from the sret buffer, extending each slot
+                    // from its physical width at its compact byte offset.
+                    let base = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Virtual(base),
+                        src: Operand::Physical(Reg::Sp),
+                    });
+                    crate::agg_slots::load_enum_slots_through_ptr(self, base, map)
+                } else {
+                    (0..slot_count)
+                        .map(|index| {
+                            let slot = self.mir.alloc_vreg();
+                            self.mir.push(Aarch64Inst::Ldr {
+                                dst: Operand::Virtual(slot),
+                                base: Reg::Sp,
+                                offset: (index * 8) as i32,
+                            });
+                            slot
+                        })
+                        .collect()
+                };
                 self.mir.push(Aarch64Inst::AddImm {
                     dst: Operand::Physical(Reg::Sp),
                     src: Operand::Physical(Reg::Sp),
@@ -2542,7 +2554,15 @@ impl<'a> CfgLower<'a> {
                     }
                     ReturnValuePlan::Aggregate { slots, return_plan } => {
                         if return_plan.uses_sret() {
-                            crate::agg_slots::store_slots_to_sret(self, &slots);
+                            match crate::types::aggregate_physical_slot_map(
+                                self.ctx.type_pool,
+                                self.ctx.cfg.return_type(),
+                            ) {
+                                Some(map) => crate::agg_slots::store_slots_to_sret_compact(
+                                    self, &slots, &map,
+                                ),
+                                None => crate::agg_slots::store_slots_to_sret(self, &slots),
+                            }
                         } else {
                             for (index, slot) in slots.iter().enumerate() {
                                 if index < RET_REGS.len() {
@@ -3273,6 +3293,71 @@ mod tests {
                 Aarch64Inst::NarrowStoreIndexed { .. } | Aarch64Inst::NarrowLoadIndexed { .. }
             )),
             "gate-off must not emit any narrow access"
+        );
+    }
+
+    /// RUE-1004: on AArch64, a non-slot-identical struct returned by value is
+    /// forced indirect (sret); the caller reads the callee-written compact image
+    /// back from the sret buffer with narrow loads at the compact offsets (`main`
+    /// is the caller here). Gate-off reads eight-byte slots, no narrow access.
+    #[test]
+    fn aggregate_layout_allows_compact_struct_sret_return() {
+        let source = "struct Padded { a: u8, b: i32, c: u8 } \
+                      fn make() -> Padded { Padded { a: 7, b: 1000, c: 9 } } \
+                      fn main() -> i32 { let p = make(); @dbg(p.b); 0 }";
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let mir =
+            try_lower_first_fn(source, preview).expect("a compact struct sret return must lower");
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::NarrowLoadIndexed { width: 1, .. })),
+            "the caller must read the u8 fields narrow from the compact sret image"
+        );
+
+        let off = try_lower_first_fn(source, PreviewFeatures::new())
+            .expect("the same program lowers under the default slot model");
+        assert!(
+            off.instructions()
+                .iter()
+                .all(|inst| !matches!(inst, Aarch64Inst::NarrowLoadIndexed { .. })),
+            "gate-off must not emit any narrow sret read-back"
+        );
+    }
+
+    /// RUE-1004: on AArch64, an `inout` non-slot-identical struct argument is
+    /// accepted (slot-shaped by-ref transport to the caller's frame storage).
+    #[test]
+    fn aggregate_layout_allows_inout_compact_struct_param() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        try_lower_first_fn(
+            "struct Padded { a: u8, b: i32, c: u8 } \
+             fn bump(inout p: Padded) { p.b = p.b + 1; } \
+             fn main() -> i32 { let mut s = Padded { a: 1, b: 2, c: 3 }; bump(inout s); s.b }",
+            preview,
+        )
+        .expect("an inout compact struct argument must lower");
+    }
+
+    /// RUE-1004 keeps refusing a non-slot-identical struct passed BY VALUE across
+    /// a call on AArch64: the callee parameter ABI is not yet remapped from the
+    /// CFG's N decomposition slots to one incoming compact-buffer pointer.
+    #[test]
+    fn aggregate_layout_refuses_by_value_compact_struct_arg() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let err = try_lower_first_fn(
+            "struct Padded { a: u8, b: i32, c: u8 } \
+             fn main() -> i32 { sum(Padded { a: 1, b: 5, c: 3 }) } \
+             fn sum(p: Padded) -> i32 { p.b }",
+            preview,
+        )
+        .expect_err("a by-value compact struct argument must be refused");
+        assert!(
+            format!("{err:?}").contains("aggregate_layout"),
+            "refusal must name the feature, got: {err:?}"
         );
     }
 

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -278,6 +278,22 @@ pub(crate) fn store_slots_to_sret<B: SlotBackend>(b: &mut B, vals: &[VReg]) {
     }
 }
 
+/// Compact counterpart of [`store_slots_to_sret`] (ADR-0052 phase 5.7,
+/// RUE-1004): load the sret buffer pointer and store the return value's slots as
+/// the aggregate's compact memory image — each slot truncated to its physical
+/// width at its compact byte offset (`map`) — rather than one eight-byte slot
+/// per field. The caller reads the same image back with the matching map.
+pub(crate) fn store_slots_to_sret_compact<B: SlotBackend>(
+    b: &mut B,
+    vals: &[VReg],
+    map: &[crate::types::PhysicalEnumSlot],
+) {
+    let ptr = b.alloc_vreg();
+    let sret_slot = b.ctx().sret_ptr_slot();
+    b.emit_load_slot(ptr, sret_slot);
+    store_enum_slots_through_ptr(b, vals, ptr, map);
+}
+
 /// Load `count` slots through `ptr` at ASCENDING byte offsets (slot k at
 /// `ptr + k*8`), returning the freshly-allocated vregs in logical slot order.
 /// The public counterpart of [`store_slots_through_ptr`]: used by `@ptr_read`

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -175,6 +175,12 @@ pub struct CallPlan {
     /// present.  This is the only slot vector the adapters may marshal.
     pub abi_slots: Vec<VReg>,
     pub return_plan: ReturnPlan,
+    /// For a compact aggregate returned via sret under `aggregate_layout`
+    /// (ADR-0052 phase 5.7, RUE-1004), the internal-slot → physical-byte image
+    /// the callee writes and the caller reads back through the sret buffer.
+    /// `None` for a slot-identical sret return (read back one slot per eight
+    /// bytes, unchanged) and for every non-sret return.
+    pub compact_return_image: Option<Vec<crate::types::PhysicalEnumSlot>>,
     /// Result vreg reserved by the shared dispatcher before argument leaves
     /// materialize, preserving the canonical event allocation order.
     pub result: Option<VReg>,
@@ -204,6 +210,10 @@ pub enum CallArgInput {
 pub struct CallInputs {
     pub args: Vec<CallArgInput>,
     pub return_plan: ReturnPlan,
+    /// The compact sret image for the return type, when it is a non-slot-identical
+    /// aggregate returned via sret under `aggregate_layout` (RUE-1004). See
+    /// [`CallPlan::compact_return_image`].
+    pub compact_return_image: Option<Vec<crate::types::PhysicalEnumSlot>>,
 }
 
 impl CallInputs {
@@ -235,9 +245,18 @@ impl CallInputs {
                 .unwrap_or_else(|message| panic!("{message}"))
             })
             .collect();
+        let return_plan = return_plan(type_pool, return_ty, ret_reg_budget);
+        // A compact aggregate returned via sret carries its physical image so both
+        // the callee write and the caller read-back marshal the same bytes.
+        let compact_return_image = if return_plan.uses_sret() {
+            types::aggregate_physical_slot_map(type_pool, return_ty)
+        } else {
+            None
+        };
         Self {
             args,
-            return_plan: return_plan(type_pool, return_ty, ret_reg_budget),
+            return_plan,
+            compact_return_image,
         }
     }
 }
@@ -299,6 +318,7 @@ impl CallPlan {
         Self::from_inputs_with_result(
             target,
             return_plan,
+            None,
             args,
             arg_reg_budget,
             materializer,
@@ -309,6 +329,7 @@ impl CallPlan {
     pub fn from_inputs_with_result<M: CallMaterializer>(
         target: CallTarget,
         return_plan: ReturnPlan,
+        compact_return_image: Option<Vec<crate::types::PhysicalEnumSlot>>,
         args: &[CallArgInput],
         arg_reg_budget: usize,
         materializer: &mut M,
@@ -382,6 +403,7 @@ impl CallPlan {
             user_args,
             abi_slots,
             return_plan,
+            compact_return_image,
             result,
             stack_slot_count,
             stack_bytes,
@@ -402,6 +424,7 @@ impl CallPlan {
             }],
             abi_slots: slots.to_vec(),
             return_plan: ReturnPlan::ZeroSized,
+            compact_return_image: None,
             result: None,
             stack_slot_count,
             stack_bytes: align_up((stack_slot_count * 8) as u32, 16),
@@ -539,6 +562,7 @@ mod tests {
             ],
             abi_slots: slots.clone(),
             return_plan: ReturnPlan::ZeroSized,
+            compact_return_image: None,
             result: None,
             stack_slot_count: 0,
             stack_bytes: 0,

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -331,18 +331,20 @@ fn scalar_physical_access(ty: Type) -> Option<(u8, bool)> {
     }
 }
 
-/// One internal value-decomposition slot of a compact enum mapped onto its
-/// physical byte position (ADR-0052 phase 5.6, RUE-1000).
+/// One internal value-decomposition slot of a compact aggregate mapped onto its
+/// physical byte position (ADR-0052 phase 5.6/5.7, RUE-1000/RUE-1004).
 ///
-/// The discriminant slot maps to the narrow tag at offset 0; every payload slot
-/// maps to a payload-union field position at its compact byte offset, accessed
-/// narrow ([`Some`]) or full-slot ([`None`], an eight-byte leaf). Both backends
-/// consume this to marshal a whole compact enum value across a typed pointer:
-/// stores truncate each slot to its physical width, loads extend back into the
-/// slot-shaped vreg.
+/// For an enum the discriminant slot maps to the narrow tag at offset 0 and every
+/// payload slot to a payload-union field position; for a struct each slot maps to
+/// a flattened scalar field at its compact byte offset. Each is accessed narrow
+/// ([`Some`]) or full-slot ([`None`], an eight-byte leaf). Both backends consume
+/// this to marshal a whole compact aggregate value across a typed pointer: stores
+/// truncate each slot to its physical width, loads extend back into the
+/// slot-shaped vreg. (The `Enum` in the name is historical; the map now serves
+/// every aggregate with a variant-independent compact image.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PhysicalEnumSlot {
-    /// Byte offset of this slot within the compact enum.
+    /// Byte offset of this slot within the compact aggregate.
     pub byte_offset: i32,
     /// Narrow (1/2/4-byte) access, or `None` for a full eight-byte slot.
     pub access: Option<NarrowScalar>,
@@ -470,6 +472,94 @@ pub(crate) fn enum_physical_slot_map(
     Some(slots)
 }
 
+/// The internal-slot → physical-byte map for whole-aggregate memory marshalling
+/// at a call boundary under the compact layout (ADR-0052 phase 5.7, RUE-1004),
+/// or `None` when the aggregate has no variant-independent compact memory image
+/// and must stay refused.
+///
+/// This is the single authority the call-boundary marshalling consults so the
+/// caller-side compact image write, the callee-side unmarshalling, and the
+/// sret/return image agree by construction. It flattens the aggregate to its
+/// internal value-decomposition slots in the same order
+/// [`aggregate_leaf_types`]/[`require_aggregate_slots`] use, giving each slot its
+/// compact byte offset from the canonical layout authority:
+///
+/// - **struct**: each field is placed at its layout byte offset and recursively
+///   flattened; a scalar field is one slot, a nested struct/enum contributes its
+///   own sub-map shifted by the field offset;
+/// - **enum**: delegated to [`enum_physical_slot_map`] (the variant-independent
+///   tag+payload image);
+/// - **array**: `None` — a fixed array's compact stride differs from the slot
+///   stride and array call marshalling is not implemented (kept refused);
+/// - **scalar / unit**: a single slot (or none), for the recursive cases.
+///
+/// Returns `None` (stay refused) for any aggregate containing a construct without
+/// a variant-independent image (an array, or an enum [`enum_physical_slot_map`]
+/// rejects), and asserts the flattened slot count equals the type's
+/// [`type_slot_count`]. Always `None` with the gate off.
+pub(crate) fn aggregate_physical_slot_map(
+    type_pool: &FrozenTypeInternPool,
+    ty: Type,
+) -> Option<Vec<PhysicalEnumSlot>> {
+    if !type_pool.compact_layout() {
+        return None;
+    }
+    let mut slots = Vec::new();
+    push_physical_slots(type_pool, ty, 0, &mut slots)?;
+    if slots.len() != type_pool.abi_slot_count(ty) as usize {
+        return None;
+    }
+    Some(slots)
+}
+
+/// Append the compact physical slots of `ty` (each offset by `base_offset`) to
+/// `out`, in internal value-decomposition slot order. Returns `None` when any
+/// leaf lacks a variant-independent compact image (see
+/// [`aggregate_physical_slot_map`]).
+fn push_physical_slots(
+    type_pool: &FrozenTypeInternPool,
+    ty: Type,
+    base_offset: i32,
+    out: &mut Vec<PhysicalEnumSlot>,
+) -> Option<()> {
+    use rue_air::layout::LayoutKind;
+    match ty.kind() {
+        TypeKind::Unit | TypeKind::Never => Some(()),
+        TypeKind::Struct(struct_id) => {
+            let layout = type_pool.layout(ty);
+            let LayoutKind::Struct { field_offsets, .. } = &layout.kind else {
+                return None;
+            };
+            let def = type_pool.struct_def(struct_id);
+            for (index, field) in def.fields.iter().enumerate() {
+                let field_offset = i32::try_from(*field_offsets.get(index)?).ok()?;
+                push_physical_slots(type_pool, field.ty, base_offset + field_offset, out)?;
+            }
+            Some(())
+        }
+        TypeKind::Enum(_) => {
+            for slot in enum_physical_slot_map(type_pool, ty)? {
+                out.push(PhysicalEnumSlot {
+                    byte_offset: base_offset + slot.byte_offset,
+                    access: slot.access,
+                });
+            }
+            Some(())
+        }
+        // A fixed array's compact stride differs from the slot stride; array call
+        // marshalling is not implemented, so the whole aggregate stays refused.
+        TypeKind::Array(_) => None,
+        _ => {
+            let (width, signed) = scalar_physical_access(ty)?;
+            out.push(PhysicalEnumSlot {
+                byte_offset: base_offset,
+                access: (width != 8).then_some(NarrowScalar { width, signed }),
+            });
+            Some(())
+        }
+    }
+}
+
 /// The pointee of a pointer type, or the type itself when it is not a pointer.
 fn pointee_or_self(type_pool: &FrozenTypeInternPool, ty: Type) -> Type {
     match ty.kind() {
@@ -543,6 +633,16 @@ pub(crate) fn compact_physical_access_unsupported(
         ) && !is_slot_identical_layout(type_pool, ty)
     };
 
+    // A non-slot-identical aggregate crossing a CALL boundary (return via sret,
+    // by-value argument, or by-reference parameter) that has NO variant-
+    // independent compact memory image, so the call marshalling cannot build or
+    // consume one (RUE-1004). Aggregates WITH an image are marshalled through a
+    // caller-owned compact buffer and are allowed; arrays and enums without an
+    // image stay refused.
+    let call_boundary_unsupported = |ty: Type| -> bool {
+        unimplemented_aggregate(ty) && aggregate_physical_slot_map(type_pool, ty).is_none()
+    };
+
     // A non-slot-identical aggregate whose whole-value marshalling THROUGH A
     // TYPED POINTER (memory) is unimplemented. RUE-1000 implements compact enum
     // memory for enums with a variant-independent slot→byte image (see
@@ -556,9 +656,10 @@ pub(crate) fn compact_physical_access_unsupported(
         }
     };
 
-    // Returned aggregates are written to the caller's sret buffer in physical
-    // memory (RUE-976's transitional indirect rule; unimplemented).
-    if unimplemented_aggregate(cfg.return_type()) {
+    // A returned aggregate is written to the caller's sret buffer as its compact
+    // memory image (RUE-1004); refused only when it has no variant-independent
+    // image (an array, or an enum without one).
+    if call_boundary_unsupported(cfg.return_type()) {
         return Some(cfg.return_type());
     }
 
@@ -597,17 +698,38 @@ pub(crate) fn compact_physical_access_unsupported(
             // slot-based frame; whole-aggregate compact access is unimplemented.
             // A by-reference narrow scalar reads/writes its eight-byte slot
             // through the pointer and is correct, so scalars are allowed.
+            // A by-reference (`inout`/`borrow`) aggregate parameter is a pointer
+            // into the caller's slot-based frame storage (RUE-975 keeps a struct
+            // frame value slot-shaped, and a pointer to a compact heap aggregate
+            // cannot exist under the gate — see the pointer check above), so its
+            // whole-value access through the pointer is the existing slot-shaped
+            // by-ref path and is physically correct. Allowed for aggregates with a
+            // variant-independent compact image (RUE-1004); arrays and imageless
+            // enums stay refused.
             CfgInstData::Param { index } => {
-                if cfg.is_param_by_ref(*index) && unimplemented_aggregate(inst.ty) {
+                if cfg.is_param_by_ref(*index) && call_boundary_unsupported(inst.ty) {
                     return Some(inst.ty);
                 }
             }
-            // A non-slot-identical aggregate passed by value crosses the call
-            // boundary indirectly (RUE-976); that marshalling is unimplemented.
+            // An aggregate crossing a call boundary. A by-reference (`inout` /
+            // `borrow`) argument uses the same slot-shaped by-ref transport as a
+            // by-ref parameter and is allowed with a compact image (RUE-1004). A
+            // by-value non-slot-identical aggregate still crosses indirectly by the
+            // classifier (RUE-976); its caller-owned compact-buffer marshalling is
+            // not implemented, because the callee-side parameter ABI would have to
+            // consume one incoming pointer for a value the CFG still models as N
+            // decomposition slots, and per-source-parameter types are not plumbed
+            // to code generation to recompute that mapping. Refused loudly.
             CfgInstData::Call { .. } => {
                 for arg in cfg.get_call_args(&inst.data) {
                     let arg_ty = cfg.get_inst(arg.value).ty;
-                    if unimplemented_aggregate(arg_ty) {
+                    let unsupported = match arg.mode {
+                        rue_cfg::CfgArgMode::Inout | rue_cfg::CfgArgMode::Borrow => {
+                            call_boundary_unsupported(arg_ty)
+                        }
+                        rue_cfg::CfgArgMode::Normal => unimplemented_aggregate(arg_ty),
+                    };
+                    if unsupported {
                         return Some(arg_ty);
                     }
                 }
@@ -657,10 +779,12 @@ pub(crate) fn ensure_compact_layout_codegen_supported(
             rue_error::ErrorKind::InternalCodegenError(format!(
                 "aggregate_layout: physical-layout code generation for type `{name}` (in function \
                  `{}`) is not yet implemented. Narrow scalar access through typed pointers \
-                 (RUE-989) and compact enum memory for enums with a variant-independent memory \
-                 image (RUE-1000) are lowered, but whole struct/array marshalling through \
-                 pointers, aggregates crossing call boundaries, and enums without a \
-                 variant-independent memory image are still staged for a follow-up.",
+                 (RUE-989), compact enum memory for enums with a variant-independent memory image \
+                 (RUE-1000), and call-boundary marshalling of a compact aggregate through its \
+                 memory image — sret returns and `inout`/`borrow` parameters (RUE-1004) — are \
+                 lowered, but whole struct/array marshalling through arbitrary pointers, a compact \
+                 aggregate passed BY VALUE across a call, arrays crossing a call, and enums \
+                 without a variant-independent memory image are still staged for a follow-up.",
                 cfg.fn_name()
             )),
         ));

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -1405,6 +1405,7 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                 let plan = crate::call_plan::CallPlan::from_inputs_with_result(
                     crate::call_plan::CallTarget::rue(symbol),
                     inputs.return_plan,
+                    inputs.compact_return_image.clone(),
                     &inputs.args,
                     adapter.call_arg_register_budget(),
                     adapter,

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -949,17 +949,29 @@ impl<'a> CfgLower<'a> {
                 slot_count,
                 storage_bytes,
             } => {
-                let slots: Vec<_> = (0..slot_count)
-                    .map(|index| {
-                        let slot = self.mir.alloc_vreg();
-                        self.mir.push(X86Inst::MovRM {
-                            dst: Operand::Virtual(slot),
-                            base: Reg::Rsp,
-                            offset: (index * 8) as i32,
-                        });
-                        slot
-                    })
-                    .collect();
+                let slots = if let Some(map) = &plan.compact_return_image {
+                    // Compact aggregate return (RUE-1004): read the callee-written
+                    // compact image back from the sret buffer, extending each slot
+                    // from its physical width at its compact byte offset.
+                    let base = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(base),
+                        src: Operand::Physical(Reg::Rsp),
+                    });
+                    crate::agg_slots::load_enum_slots_through_ptr(self, base, map)
+                } else {
+                    (0..slot_count)
+                        .map(|index| {
+                            let slot = self.mir.alloc_vreg();
+                            self.mir.push(X86Inst::MovRM {
+                                dst: Operand::Virtual(slot),
+                                base: Reg::Rsp,
+                                offset: (index * 8) as i32,
+                            });
+                            slot
+                        })
+                        .collect()
+                };
                 self.mir.push(X86Inst::AddRI {
                     dst: Operand::Physical(Reg::Rsp),
                     imm: storage_bytes as i32,
@@ -2375,7 +2387,15 @@ impl<'a> CfgLower<'a> {
                     }
                     ReturnValuePlan::Aggregate { slots, return_plan } => {
                         if return_plan.uses_sret() {
-                            crate::agg_slots::store_slots_to_sret(self, &slots);
+                            match crate::types::aggregate_physical_slot_map(
+                                self.ctx.type_pool,
+                                self.ctx.cfg.return_type(),
+                            ) {
+                                Some(map) => crate::agg_slots::store_slots_to_sret_compact(
+                                    self, &slots, &map,
+                                ),
+                                None => crate::agg_slots::store_slots_to_sret(self, &slots),
+                            }
                         } else {
                             for (index, slot) in slots.iter().enumerate().rev() {
                                 if index < RET_REGS.len() {
@@ -3137,6 +3157,74 @@ mod tests {
                 X86Inst::NarrowStoreIndexed { .. } | X86Inst::NarrowLoadIndexed { .. }
             )),
             "gate-off must not emit any narrow access"
+        );
+    }
+
+    /// RUE-1004: under `aggregate_layout`, a non-slot-identical struct returned
+    /// by value is forced indirect (sret); the caller reads the callee-written
+    /// compact image back from the sret buffer, extending each narrow field from
+    /// its compact byte offset (`main` here is the caller). Gate-off, the same
+    /// return reads eight-byte slots and emits no narrow access.
+    #[test]
+    fn aggregate_layout_allows_compact_struct_sret_return() {
+        let source = "struct Padded { a: u8, b: i32, c: u8 } \
+                      fn make() -> Padded { Padded { a: 7, b: 1000, c: 9 } } \
+                      fn main() -> i32 { let p = make(); @dbg(p.b); 0 }";
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let mir =
+            try_lower_first_fn(source, preview).expect("a compact struct sret return must lower");
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::NarrowLoadIndexed { width: 1, .. })),
+            "the caller must read the u8 fields narrow from the compact sret image"
+        );
+
+        let off = try_lower_first_fn(source, PreviewFeatures::new())
+            .expect("the same program lowers under the default slot model");
+        assert!(
+            off.instructions()
+                .iter()
+                .all(|inst| !matches!(inst, X86Inst::NarrowLoadIndexed { .. })),
+            "gate-off must not emit any narrow sret read-back"
+        );
+    }
+
+    /// RUE-1004: under `aggregate_layout`, an `inout` non-slot-identical struct
+    /// argument is accepted — the callee reads/writes the caller's slot-based
+    /// frame storage through the by-reference pointer (slot-shaped transport), so
+    /// the call site lowers rather than being refused.
+    #[test]
+    fn aggregate_layout_allows_inout_compact_struct_param() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        try_lower_first_fn(
+            "struct Padded { a: u8, b: i32, c: u8 } \
+             fn bump(inout p: Padded) { p.b = p.b + 1; } \
+             fn main() -> i32 { let mut s = Padded { a: 1, b: 2, c: 3 }; bump(inout s); s.b }",
+            preview,
+        )
+        .expect("an inout compact struct argument must lower");
+    }
+
+    /// RUE-1004 keeps refusing a non-slot-identical struct passed BY VALUE across
+    /// a call: the callee parameter ABI is not yet remapped from the CFG's N
+    /// decomposition slots to one incoming compact-buffer pointer.
+    #[test]
+    fn aggregate_layout_refuses_by_value_compact_struct_arg() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let err = try_lower_first_fn(
+            "struct Padded { a: u8, b: i32, c: u8 } \
+             fn main() -> i32 { sum(Padded { a: 1, b: 5, c: 3 }) } \
+             fn sum(p: Padded) -> i32 { p.b }",
+            preview,
+        )
+        .expect_err("a by-value compact struct argument must be refused");
+        assert!(
+            format!("{err:?}").contains("aggregate_layout"),
+            "refusal must name the feature, got: {err:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

The milestone rung of the RUE-987 ladder: **std now works under the gate**. A generic `@import`'d `ArrayBuf(i32)` (push/get/pop/len/free) compiles and executes identically with and without `--preview aggregate_layout` — the first `@import` generic-container dogfood green under compact layout, re-verified by execution at integration.

What makes it work — the indirect call crossing the RUE-976 classifier already decides is now implemented on both backends, lifting the RUE-974 refusal for it:

- **Returns**: a non-slot-identical struct/enum returned by value goes indirect and is marshalled through the caller's sret buffer as its **compact memory image** — callee truncates each slot at its compact offset, caller reads it back extending each field, reusing the RUE-989/RUE-1000 marshalling with no new MIR. `Option(i32)` returns are exactly this path.
- **inout/borrow params**: keep the slot-shaped by-ref transport (the pointee is the caller's slot-based frame per RUE-975; whole-aggregate pointer marshalling remains refused, so no compact pointee can reach them).

**Still refused, loudly**: non-slot-identical aggregates passed **by value** across a call — the precise blocker is that per-source-parameter types aren't plumbed to codegen (only `num_params` + per-slot by-ref flags reach the backend), so the callee prologue can't recompute per-parameter incoming widths. Plumbing per-parameter ABI descriptors from the CFG is the next rung. Also refused: arrays crossing calls, whole struct/array through arbitrary pointers, imageless enums.

Gate-off code generation is byte-identical.

## Verification

Six new codegen units (both backends); six new gated CLI cases (sret struct/enum round-trips → 7/1000/9 and Some(42)/None, inout mutation, borrow read, by-value still-refused, the ArrayBuf dogfood → 3/20/30/2); oracle-diff corpus audit green; full `test.sh` green except the four known uid-0 environmental failures, checked against both harness failure formats. The ArrayBuf dogfood and sret round-trips re-executed by hand on the integrated tree.

Fixes RUE-1004

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_