### PR TITLE
RUE-1006: promote the remote cache into CI and drop trunk-push runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,18 @@
 name: CI
 
+# No `push: [trunk]` trigger (RUE-1006): trunk only advances through the merge
+# queue, and the merge_group run's checks are attached to the exact commit that
+# lands, so a trunk push run would re-validate an identical tree — ~8 duplicate
+# (including a macOS slot) per merge, usually cancelled mid-flight by the
+# concurrency group after burning runner time. Benchmarks keep their push
+# trigger (per-commit history is their purpose); use workflow_dispatch for a
+# manual re-validation of trunk.
 on:
-  push:
-    branches: [trunk]
   pull_request:
     branches: [trunk]
   merge_group:
     branches: [trunk]
+  workflow_dispatch:
 
 # Cancel in-progress runs for the same branch
 concurrency:
@@ -46,6 +52,23 @@ jobs:
           key: dotslash-linux-x64-${{ hashFiles('buck2') }}
           restore-keys: |
             dotslash-linux-x64-
+
+      # BuildBuddy remote action cache (RUE-316/RUE-1006). GitHub withholds
+      # repo secrets from pull_request runs whose head branch lives in a fork —
+      # the normal contribution flow here — so the key is only present on
+      # merge_group and workflow_dispatch runs. That is where it matters: the
+      # merge queue serializes on this workflow. The cold fallback is
+      # mandatory; this step must never fail because the secret is absent.
+      - name: Provision remote build cache
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          if [ -z "${BUILDBUDDY_API_KEY:-}" ]; then
+            echo "BUILDBUDDY_API_KEY unavailable (fork PR or unset); building without the remote cache."
+            exit 0
+          fi
+          scripts/provision-build-cache install
+          scripts/provision-build-cache apply
 
       - name: Run clippy
         # Builds the [clippy.txt] subtarget for every first-party crate and
@@ -118,6 +141,26 @@ jobs:
           restore-keys: |
             dotslash-${{ matrix.name }}-
 
+      # BuildBuddy remote action cache (RUE-316/RUE-1006); see the clippy job
+      # for the secret-availability contract. NOT on linux-x64: that lane runs
+      # the compiler reproducibility check, whose guard requires a cache-free,
+      # .buckconfig-only configuration so the reference and relocated candidate
+      # builds are identically configured — a `.buckconfig.local` is a hard
+      # error in scripts/check-reproducible-compiler.sh. Warming that lane by
+      # dropping the config before the repro step is a possible follow-up once
+      # cache behavior is proven in the queue (RUE-1006).
+      - name: Provision remote build cache
+        if: matrix.name != 'linux-x64'
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          if [ -z "${BUILDBUDDY_API_KEY:-}" ]; then
+            echo "BUILDBUDDY_API_KEY unavailable (fork PR or unset); building without the remote cache."
+            exit 0
+          fi
+          scripts/provision-build-cache install
+          scripts/provision-build-cache apply
+
       # Uses hermetic Rust toolchain downloaded by Buck2
       # First verify everything builds (catches issues tests might miss)
       - name: Build all targets
@@ -173,6 +216,23 @@ jobs:
           key: dotslash-linux-x64-${{ hashFiles('buck2') }}
           restore-keys: |
             dotslash-linux-x64-
+
+      # BuildBuddy remote action cache (RUE-316/RUE-1006); see the clippy job
+      # for the secret-availability contract. This job is the workflow's
+      # critical path (~16 min cold, dominated by the full release build), so
+      # it benefits the most. The RUE-277 debug-vs-release assertion below is
+      # a byte comparison of two separately keyed configurations and is
+      # unaffected by where the artifacts were produced.
+      - name: Provision remote build cache
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          if [ -z "${BUILDBUDDY_API_KEY:-}" ]; then
+            echo "BUILDBUDDY_API_KEY unavailable (fork PR or unset); building without the remote cache."
+            exit 0
+          fi
+          scripts/provision-build-cache install
+          scripts/provision-build-cache apply
 
       # Regression guard for RUE-277: `//platforms:release` must produce a
       # genuinely-optimized binary that differs from the debug build. If the

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -22,9 +22,10 @@ name: Sanitizer
 # Separate workflow so both jobs run in parallel with the fast `test` job in
 # ci.yml rather than serializing behind it.
 
+# No `push: [trunk]` trigger (RUE-1006): trunk only advances through the merge
+# queue, whose merge_group run already validated the exact commit that lands —
+# a trunk push run would re-test an identical tree. See ci.yml.
 on:
-  push:
-    branches: [trunk]
   pull_request:
     branches: [trunk]
   merge_group:
@@ -55,6 +56,19 @@ jobs:
           key: dotslash-linux-x64-${{ hashFiles('buck2') }}
           restore-keys: |
             dotslash-linux-x64-
+
+      # BuildBuddy remote action cache (RUE-316/RUE-1006); see ci.yml's clippy
+      # job for the secret-availability contract (absent on fork PRs → cold).
+      - name: Provision remote build cache
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          if [ -z "${BUILDBUDDY_API_KEY:-}" ]; then
+            echo "BUILDBUDDY_API_KEY unavailable (fork PR or unset); building without the remote cache."
+            exit 0
+          fi
+          scripts/provision-build-cache install
+          scripts/provision-build-cache apply
 
       - name: Install valgrind
         run: |

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -107,11 +107,33 @@ build + suite green). 1, 2, 4 live in the opt-in `.buckconfig.local` / the
 ## CI
 
 CI reads the key from the `BUILDBUDDY_API_KEY` repo secret (never from a file).
-The `cache-probe` workflow (`.github/workflows/cache-probe.yml`) writes a transient
-`.buckconfig.local` from the secret, does a cold build then a clean-and-rebuild, and
-reports buck2's `Commands: (cached / remote / local)` line. Run it with
-`gh workflow run cache-probe.yml`. Once proven green with real hit-rates, the cache
-config can be promoted into the main build and test jobs.
+The cache is provisioned (RUE-1006) in the `CI` workflow's `clippy`, `release`,
+and non-x64 `test` jobs, and in the sanitizer `valgrind` job, via
+`scripts/provision-build-cache install && apply` gated on secret presence.
+
+Availability rules, which the workflow steps must respect:
+
+- **Fork `pull_request` runs have no secret.** GitHub withholds repository
+  secrets from any workflow run whose head branch lives in a fork, regardless
+  of the author's permissions — and the normal contribution flow here is
+  fork-based. Those lanes build cold, exactly as before the cache existed. The
+  provisioning step therefore treats an empty key as "skip", never "fail".
+- **`merge_group` runs have the secret.** The merge queue is the serial
+  bottleneck, so this is where the warm cache pays off. These runs execute
+  already-approved, queued code, which is also why letting them write to the
+  shared cache (`allow_cache_uploads`) is acceptable.
+- **The linux-x64 `test` lane is intentionally cache-free.** It runs
+  `scripts/check-reproducible-compiler.sh` (RUE-617), which hard-errors on a
+  `.buckconfig.local`: the reference and relocated candidate builds must be
+  identically configured for the byte comparison to indict path/scheduling/
+  environment leaks rather than configuration drift. Warming that lane by
+  removing the config before the repro step is a possible follow-up once the
+  queue has demonstrated real hit-rates.
+
+The `cache-probe` workflow (`.github/workflows/cache-probe.yml`) remains the
+measurement tool: it writes a transient config from the secret, does a cold
+build then a clean-and-rebuild, and reports buck2's `Commands: (cached /
+remote / local)` line. Run it with `gh workflow run cache-probe.yml`.
 
 ## Toward a fully hermetic linker
 

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -1,7 +1,22 @@
 # Required CI
 
 The `CI` workflow (`.github/workflows/ci.yml`) supplies the required pull-request
-and merge-group checks. Containers executed by that workflow must use a reviewed,
+and merge-group checks.
+
+## Triggers
+
+`CI` and `Sanitizer` run on `pull_request` and `merge_group` only (plus
+`workflow_dispatch` for manual re-validation). There is deliberately no
+`push: [trunk]` trigger (RUE-1006): trunk only advances through the merge
+queue, and the merge_group run's checks are attached to the exact commit that
+lands, so a post-merge trunk run would re-test an identical tree. Do not
+re-add a push trigger to these workflows; `Benchmarks` keeps its push trigger
+because per-commit measurement on trunk is its purpose.
+
+The build jobs use the shared BuildBuddy remote action cache when the
+`BUILDBUDDY_API_KEY` secret is available (merge_group runs; fork PRs build
+cold) — see `docs/process/build-cache.md` for the availability rules,
+including why the linux-x64 test lane stays cache-free. Containers executed by that workflow must use a reviewed,
 human-readable release tag and the immutable OCI index digest for that tag. The
 repository gate `//:required-ci-container-pin-validation` rejects a moving
 `latest` image reference, and the normal `./test.sh` run includes that gate.


### PR DESCRIPTION
The merge queue serializes on the `CI` workflow, and measured job timings show its ~16-minute wall clock is entirely the `release` job's cold full-workspace build (11.5 min release build + 3.5 min debug/release assert; every other job finishes in ≤7.5 min). Last night's flaky-test backup multiplied that gate across every queued entry.

## Changes

**Promote the BuildBuddy remote action cache into required CI** (the promotion `docs/process/build-cache.md` already planned once the groundwork landed):

- `clippy`, `release`, the non-x64 `test` lanes, and the sanitizer `valgrind` job provision the cache via `scripts/provision-build-cache install && apply`, gated on `BUILDBUDDY_API_KEY` presence.
- Fork `pull_request` runs never receive repo secrets, so those lanes detect the empty key and build cold — exactly today's behavior, never a failure. `merge_group` runs (the serial bottleneck, and already-approved queued code) get the warm cache and may upload to it.
- The linux-x64 `test` lane is intentionally left cache-free: `scripts/check-reproducible-compiler.sh` (RUE-617) hard-errors on `.buckconfig.local`, because the reference and relocated candidate builds must be identically configured for the byte comparison to be meaningful. Warming that lane is a documented follow-up once the queue shows real hit-rates.

**Drop the `push: [trunk]` triggers from `CI` and `Sanitizer`.** Trunk only advances through the merge queue, and the merge_group run's checks are attached to the exact commit that lands, so the post-merge trunk run re-tested an identical tree (~10 duplicate jobs per merge, including a macOS slot, frequently cancelled mid-flight by the concurrency group after burning runner time). `Benchmarks` keeps its push trigger — per-commit trunk history is its purpose — and `CI` gains `workflow_dispatch` for manual re-validation.

Docs updated: `docs/process/ci.md` (trigger policy) and `docs/process/build-cache.md` (CI availability rules).

## Validation

- Both workflow YAMLs parse; every `run:` block is shellcheck-clean at warning level (the pinned actionlint container could not be executed in the authoring sandbox — the `actionlint` job on this PR is the authoritative check).
- The `remote_cache` execution platform wraps the host platforms from `prelude//platforms:default` and only toggles cache/executor behavior, so it composes with `--target-platforms //platforms:release` (target configuration is orthogonal to execution platform).
- This PR's head branch lives in the base repository, so its `pull_request` run receives the secret and is the first live exercise of the warm-cache path — its job timings against the baseline above are the empirical hit-rate signal. Fork-headed PRs will take the cold path.

Fixes RUE-1006