### PR TITLE
RUE-1003: keep Mosaic generated output linear in page count

### DIFF
--- a/crates/rue-cli-tests/cases/examples_mosaic.toml
+++ b/crates/rue-cli-tests/cases/examples_mosaic.toml
@@ -84,12 +84,9 @@ name = "mosaic_scales_generated_workload_fourfold"
 description = "the 4x tier parses and renders 400 linked pages with proportional model counts"
 source_path = "examples/mosaic/main.rue"
 env = { RUE_STD_PATH = "${REAL_STD}" }
-# The 400-page tier renders quadratic output volume (~2.2 s median on an idle
-# host) and blows the default 10 s budget on loaded macOS CI runners, ejecting
-# unrelated PRs from the merge queue (RUE-999). The 200-page tier above stays
-# on the default budget as the timing canary; this tier only needs to catch
-# hangs and wrong counts.
-timeout_ms = 60000
+# Rendered navigation is a bounded window (RUE-1003), so generated output
+# volume is linear in page count and this tier fits the default budget that
+# its quadratic predecessor blew on loaded macOS CI runners (RUE-999).
 program_args = ["stress4"]
 exit_code = 0
 stdout = "stress pages=400 blocks=4400 links=400 anchors=800\nexpected_links=400\ndeterministic=true\nvalid=true\nselftests=30 failures=0\n"

--- a/examples/mosaic/architecture.rue
+++ b/examples/mosaic/architecture.rue
@@ -114,7 +114,9 @@ fn limits(inout out: StrBuf) {
     out.push_str("  Template expressions expose a fixed environment and explicit filters.\n");
     out.push_str("  Local links may contain fragments but not query strings.\n");
     out.push_str("  External HTTP, HTTPS, mailto, and unknown safe schemes are not crawled.\n");
-    out.push_str("  Draft documents are parsed but omitted from navigation and outputs.\n\n");
+    out.push_str("  Draft documents are parsed but omitted from navigation and outputs.\n");
+    out.push_str("  Rendered primary navigation is a 16-entry window around the current page,\n");
+    out.push_str("  keeping generated output volume linear in page count.\n\n");
 }
 
 fn maintenance(inout out: StrBuf) {

--- a/examples/mosaic/complexity.rue
+++ b/examples/mosaic/complexity.rue
@@ -3,6 +3,7 @@
 // different hosts and spotting accidental quadratic growth.
 const std = @import("std");
 const model = @import("model.rue");
+const navigation = @import("navigation.rue");
 
 pub struct Complexity {
     pool_probe_units: u64,
@@ -41,12 +42,14 @@ pub fn estimate(borrow site: model.Site) -> Complexity {
     let inlines = site.inlines.len();
     let links = site.links.len();
     let anchors = site.anchors.len();
-    let pool_probe_units = saturated_mul(strings, strings + 1) / 2;
+    // Interning is hash-indexed, so probing is amortized-constant per string.
+    let pool_probe_units = strings;
     let parse_units = saturated_add(blocks, inlines);
     let inline_units = saturated_add(inlines, links);
     let graph_units = saturated_mul(links, saturated_add(pages, anchors));
     let reachability_units = saturated_add(pages, links);
-    let render_units = saturated_add(saturated_add(blocks, inlines), saturated_mul(pages, site.navigation.len()));
+    // Each page renders a bounded navigation window, not the full list.
+    let render_units = saturated_add(saturated_add(blocks, inlines), saturated_mul(pages, navigation.window_len(borrow site)));
     let mut words: u64 = 0;
     let mut i: u64 = 0;
     while i < site.pages.len() {

--- a/examples/mosaic/navigation.rue
+++ b/examples/mosaic/navigation.rue
@@ -1,8 +1,32 @@
-// Deterministic site navigation and previous/next page links.
+// Deterministic site navigation and previous/next page links. The rendered
+// primary navigation is a bounded window of WINDOW entries containing the
+// current page, so sitewide generated output volume stays linear in page
+// count instead of quadratic (RUE-1003). The navigation model still contains
+// every published page; only rendering is windowed. outputaudit and
+// complexity derive their expected counts from window_len/window_start, so
+// the rendered-link audit and the work-unit estimate share this computation.
 const std = @import("std");
 const escape = @import("escape.rue");
 const model = @import("model.rue");
 const StrBuf = std.strbuf.StrBuf;
+
+pub fn WINDOW() -> u64 { 16 }
+
+pub fn window_len(borrow site: model.Site) -> u64 {
+    if site.navigation.len() < WINDOW() { site.navigation.len() } else { WINDOW() }
+}
+
+pub fn window_start(borrow site: model.Site, current: u64) -> u64 {
+    let len = site.navigation.len();
+    if len <= WINDOW() { return 0; }
+    let pos = position(borrow site, current);
+    if pos == model.NONE() { return 0; }
+    let half = WINDOW() / 2;
+    if pos <= half { return 0; }
+    let max_start = len - WINDOW();
+    let start = pos - half;
+    if start > max_start { max_start } else { start }
+}
 
 fn append_page_link(borrow site: model.Site, page_index: u64, current: u64, inout out: StrBuf) {
     let page = site.pages.get_or(page_index, model.empty_page());
@@ -20,9 +44,11 @@ fn append_page_link(borrow site: model.Site, page_index: u64, current: u64, inou
 pub fn primary(borrow site: model.Site, current: u64) -> StrBuf {
     let mut out = StrBuf.new();
     out.push_str("<nav class=\"site-nav\" aria-label=\"Primary\"><ul>");
+    let start = window_start(borrow site, current);
+    let count = window_len(borrow site);
     let mut i: u64 = 0;
-    while i < site.navigation.len() {
-        append_page_link(borrow site, site.navigation.get_or(i, 0), current, inout out);
+    while i < count {
+        append_page_link(borrow site, site.navigation.get_or(start + i, 0), current, inout out);
         i = i + 1;
     }
     out.push_str("</ul></nav>");

--- a/examples/mosaic/outputaudit.rue
+++ b/examples/mosaic/outputaudit.rue
@@ -3,6 +3,7 @@
 const std = @import("std");
 const htmlcheck = @import("htmlcheck.rue");
 const model = @import("model.rue");
+const navigation = @import("navigation.rue");
 const text = @import("text.rue");
 const StrBuf = std.strbuf.StrBuf;
 
@@ -91,8 +92,9 @@ fn expected_toc_count(borrow site: model.Site, page_index: u64) -> u64 {
 fn expected_rendered_links(borrow site: model.Site, page_index: u64) -> u64 {
     let page = site.pages.get_or(page_index, model.empty_page());
     let content = page.link_count;
-    // Primary navigation plus the brand link and keyboard skip link.
-    let primary = site.navigation.len() + 2;
+    // The rendered primary-navigation window plus the brand link and
+    // keyboard skip link.
+    let primary = navigation.window_len(borrow site) + 2;
     let mut pager: u64 = 0;
     let mut pos: u64 = 0;
     while pos < site.navigation.len() {

--- a/examples/mosaic/pool.rue
+++ b/examples/mosaic/pool.rue
@@ -1,5 +1,11 @@
 // Shared byte pool for Mosaic. Every parsed string is represented by a stable
 // integer id, keeping the site model trivially copyable and arena-friendly.
+// An open-addressed hash index makes interning amortized O(length), so total
+// intern work stays linear in input volume instead of quadratic in pool size
+// (RUE-1003). The index is hand-rolled from the pool's own primitive arrays
+// because a StrMap(u64) field on this cross-module public struct fails
+// comptime type reduction while RUE-993 is open. Ids are never removed, so
+// the table needs no tombstones: a slot holds id + 1, and 0 means empty.
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
 const U64s = std.arraybuf.ArrayBuf(u64);
@@ -9,17 +15,64 @@ pub struct Pool {
     bytes: StrBuf,
     offsets: U64s,
     lengths: U64s,
+    slots: U64s,
+    slot_cap: u64,
 
     fn new() -> Self {
-        Self { bytes: StrBuf.new(), offsets: U64s.new(), lengths: U64s.new() }
+        let mut pool = Self {
+            bytes: StrBuf.new(),
+            offsets: U64s.new(),
+            lengths: U64s.new(),
+            slots: U64s.new(),
+            slot_cap: 0,
+        };
+        pool.grow_slots(16);
+        pool
     }
 
     fn len(borrow self) -> u64 { self.offsets.len() }
 
+    // FNV-1a over the candidate's bytes; must match `hash` over pooled ids so
+    // rebuilt tables and fresh probes agree on slot positions.
+    fn value_hash(borrow value: StrBuf) -> u64 {
+        let mut h: u64 = 14695981039346656037;
+        let mut i: u64 = 0;
+        while i < value.len() {
+            let b = match value.byte_at(i) { OptU8.Some(x) => x, OptU8.None => 0 };
+            h = h ^ @intCast(b);
+            h = @wrapping_mul(h, 1099511628211);
+            i = i + 1;
+        }
+        h
+    }
+
+    // Re-hash every interned id into a table of `new_cap` slots.
+    fn grow_slots(inout self, new_cap: u64) {
+        let mut fresh = U64s.new();
+        let mut i: u64 = 0;
+        while i < new_cap { fresh.push(0); i = i + 1; }
+        let mut id: u64 = 0;
+        while id < self.len() {
+            let mut slot = self.hash(id) % new_cap;
+            while fresh.get_or(slot, 0) != 0 { slot = (slot + 1) % new_cap; }
+            fresh.set(slot, id + 1);
+            id = id + 1;
+        }
+        self.slots = fresh;
+        self.slot_cap = new_cap;
+    }
+
     fn intern(inout self, borrow value: StrBuf) -> u64 {
-        let existing = self.find(borrow value);
-        if existing < self.len() { return existing; }
+        // Grow above 50% load so probe chains stay short.
+        if (self.len() + 1) * 2 > self.slot_cap { self.grow_slots(self.slot_cap * 2); }
+        let mut slot = Self.value_hash(borrow value) % self.slot_cap;
+        while self.slots.get_or(slot, 0) != 0 {
+            let id = self.slots.get_or(slot, 0) - 1;
+            if self.equals(id, borrow value) { return id; }
+            slot = (slot + 1) % self.slot_cap;
+        }
         let id = self.len();
+        self.slots.set(slot, id + 1);
         self.offsets.push(self.bytes.len());
         self.lengths.push(value.len());
         let mut i: u64 = 0;
@@ -36,10 +89,12 @@ pub struct Pool {
     fn intern_literal(inout self, value: StrBuf) -> u64 { self.intern(borrow value) }
 
     fn find(borrow self, borrow value: StrBuf) -> u64 {
-        let mut id: u64 = 0;
-        while id < self.len() {
+        if self.slot_cap == 0 { return self.len(); }
+        let mut slot = Self.value_hash(borrow value) % self.slot_cap;
+        while self.slots.get_or(slot, 0) != 0 {
+            let id = self.slots.get_or(slot, 0) - 1;
             if self.equals(id, borrow value) { return id; }
-            id = id + 1;
+            slot = (slot + 1) % self.slot_cap;
         }
         self.len()
     }


### PR DESCRIPTION
The Mosaic stress workload grew quadratically, exactly as the RUE-994 PR description observed: every page rendered the full primary navigation, so sitewide HTML volume was pages × navigation length; string interning added a second quadratic term through the pool's linear-scan lookup. The 400-page tier took ~2.4 s and 85 MB — the runtime cost behind the bumped CLI timeout and merge-queue noise (RUE-999).

## Bounded navigation window

Rendered primary navigation is now a deterministic 16-entry window containing the current page (`navigation.WINDOW/window_start/window_len`). The navigation *model* still lists every published page — health, ratios, capacity, and arena checks are untouched — only rendering is windowed. `outputaudit` and the `complexity` estimate derive their expected counts from the same window functions the renderer uses, so the rendered-link audit stays a real cross-check. Sites with ≤16 navigation entries render byte-identically to before, which keeps every existing CLI fixture's expected output valid. The window semantics are documented in the help text's v1 limits.

## Hash-indexed string interning

`pool.intern` probed every existing string linearly, making total intern work quadratic in pool size (the old `pool_probe_units = strings²/2 ` estimate modeled precisely this). The pool now keeps an open-addressed hash index built from its own primitive arrays — slot holds id + 1, ids are never removed so no tombstones; `find` and `intern` share the probe path. A `StrMap(u64)` field would be the natural spelling, but that still fails comptime type reduction on a cross-module public struct (RUE-993), the same limitation Rill's pool documents.

## Measurements (x86-64 Linux, idle host)

| Tier | Before | After |
| --- | --- | --- |
| 100 pages | 0.14 s / 8 MB | 0.04 s / 4 MB |
| 200 pages | 0.53 s / 27 MB | 0.09 s / 8 MB |
| 400 pages | 2.44 s / 85 MB | 0.20 s / 15 MB |

Growth per doubling drops from ~3.8–4.6x to ~2.2x. The 4x CLI tier no longer needs its bumped 60 s timeout and returns to the default budget. Remaining linear scans (anchor resolution, reachability) are second-order at these tiers and stay honestly modeled in `graph_units`.

## Validation

- `scripts/rue cli examples_mosaic`: 17/17 pass, both stress tiers on default budgets.
- Manual 20-page `build`: every page's rendered nav is exactly the expected 16-entry window (verified at both edges and mid-list), `aria-current` appears once per page, and the output audit passes on all pages.
- 400-page stress reports `deterministic=true valid=true selftests=30 failures=0`.
- `scripts/rue quick`: the only failures are the pre-existing unreadable-file tests, which cannot fail as root in this container; verified identical on clean trunk.

Fixes RUE-1003