### PR TITLE
RUE-1005: per-parameter ABI descriptors and by-value compact args (ADR-0052 phase 5.8)

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -78,8 +78,8 @@ pub use sema::{
     SemanticBindingManifestWork, SemanticDeclarationExport, SemanticDeclarationExportWork,
     SemanticDeclarationPayload, SemanticDeclarationShell, SemanticDeclarationShellIdentity,
     SemanticExportConstValue, SemanticExportFailure, SemanticExportParameter, SemanticExportType,
-    SemanticNominalIdentity, SemanticParameterMode, SpecializedFreeFunctionDependencyEvent,
-    SpecializedFreeFunctionOrigin,
+    SemanticNominalIdentity, SemanticParameterMode, SourceParamAbi,
+    SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
 };
 pub use semantic_body::{
     SEMANTIC_BODY_INST_KINDS, SemanticBody, SemanticBodyAnchor, SemanticBodyCallArg,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -73,7 +73,8 @@ pub use output::{
     ImplicitNamedDestructorDependencyEvent, NamedConstDependencyEvent,
     NamedConstDependencyTargetEvent, NamedDestructorDependencyEvent, NamedMethodDependencyEvent,
     NamedMethodDependencyTargetEvent, OrdinaryFreeFunctionDependencyEvent, ParamSlotModes,
-    SemaOutput, SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
+    SemaOutput, SourceParamAbi, SpecializedFreeFunctionDependencyEvent,
+    SpecializedFreeFunctionOrigin,
 };
 
 use std::collections::{HashMap, HashSet};

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -284,6 +284,57 @@ pub struct ImplicitNamedDestructorDependencyEvent {
     pub target_owner_name: String,
 }
 
+/// Per-source-parameter native ABI descriptor carried from semantic analysis
+/// into code generation (ADR-0052 phase 5.8, RUE-1005).
+///
+/// The per-ABI-slot [`ParamSlotModes::by_ref`] vector tells code generation
+/// which *slots* transport a pointer, but not how a *source parameter* groups
+/// its slots — which the callee prologue needs to map incoming argument
+/// registers onto frame parameter slots. A by-value non-slot-identical compact
+/// aggregate crosses as one [`ArgClass::Indirect`] pointer (one incoming
+/// register) while occupying `slot_count` frame slots, so the prologue cannot
+/// assume one incoming register per parameter slot. This descriptor carries the
+/// classifier's decision plus the parameter's slot span so the prologue can
+/// compute per-parameter incoming-register widths from the classifier authority
+/// rather than re-deriving them. With the gate off every parameter is
+/// [`ArgClass::Direct`] (or a single by-reference pointer slot) and
+/// `arg_class.crossing_slots() == slot_count`, so the plumbing is behaviourally
+/// inert and the emitted prologue is byte-identical.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceParamAbi {
+    /// First parameter ABI slot this source parameter occupies.
+    pub start_slot: u32,
+    /// Physical value-decomposition width (frame slots reserved), equal to
+    /// [`crate::NativeCallAbi::arg_slot_width`].
+    pub slot_count: u32,
+    /// Number of incoming argument registers this parameter consumes, equal to
+    /// the classifier's [`crate::ArgClass::crossing_slots`]. For a direct
+    /// parameter this equals `slot_count`; for a by-reference pointer or a
+    /// by-value indirect compact aggregate it is one (the pointer), which is why
+    /// `crossing_regs < slot_count` distinguishes exactly the by-value indirect
+    /// aggregate the callee must unmarshal.
+    pub crossing_regs: u32,
+    /// The aggregate type — carried *only* for a by-value indirect parameter, so
+    /// code generation can build its compact memory image; `None` for every
+    /// direct parameter and every by-reference pointer. Withholding the type
+    /// from a pointer-only or direct parameter keeps that CFG layout-independent
+    /// and reusable when an unrelated pointee struct's layout changes; a by-value
+    /// indirect aggregate already depends on its own layout (it reads its
+    /// fields), so carrying the type adds no new dependency.
+    pub ty: Option<crate::Type>,
+}
+
+impl SourceParamAbi {
+    /// Whether this parameter is a by-value aggregate the classifier forced
+    /// indirect: it reserves `slot_count` frame slots but arrives as one pointer
+    /// register, so the callee unmarshals its compact image at entry (RUE-1005).
+    /// A by-reference pointer (`crossing_regs == slot_count == 1`) and a direct
+    /// parameter (`crossing_regs == slot_count`) are both excluded.
+    pub const fn is_by_value_indirect(&self) -> bool {
+        self.crossing_regs < self.slot_count
+    }
+}
+
 /// Per-ABI-slot parameter access metadata preserved into CFG.
 ///
 /// `by_ref` describes the physical calling convention: both `borrow` and
@@ -291,6 +342,12 @@ pub struct ImplicitNamedDestructorDependencyEvent {
 /// distinct source-level permission needed by consumers such as the oracle;
 /// only logical `inout` slots are writable. Keeping the two facts separate
 /// prevents a shared borrow from being mistaken for mutable caller storage.
+///
+/// `SourceParamAbi` grouping is *not* stored here: it is derived at CFG-build
+/// time from the AIR parameter types and this per-slot `by_ref` vector (see
+/// `rue_cfg`), so a durable/imported body — which serializes only the per-slot
+/// vectors and rebuilds its CFG from the same AIR — reconstructs an identical
+/// grouping without extending this identity-bearing slot-mode structure.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ParamSlotModes {
     by_ref: Vec<bool>,
@@ -322,7 +379,7 @@ impl ParamSlotModes {
 impl From<Vec<bool>> for ParamSlotModes {
     fn from(by_ref: Vec<bool>) -> Self {
         let writable = vec![false; by_ref.len()];
-        Self { by_ref, writable }
+        Self::new(by_ref, writable)
     }
 }
 

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -6,7 +6,8 @@
 use lasso::ThreadedRodeo;
 use rue_air::{
     AirArgMode, AirInstData, AirPattern, AirPlaceBase, AirPlaceRef, AirProjection, AirRef,
-    FrozenTypeInternPool, ParamSlotModes, StructId, Type, TypeKind, ValidatedAir,
+    ArgConvention, FrozenTypeInternPool, NativeCallAbi, ParamSlotModes, SourceParamAbi, StructId,
+    Type, TypeKind, ValidatedAir,
 };
 use rue_error::{CompileError, CompileWarning, ErrorKind, WarningKind};
 
@@ -248,6 +249,76 @@ pub struct CfgBuilder<'a> {
     anonymous_destructor_dependency_incomplete: bool,
 }
 
+/// Derive the grouped per-source-parameter ABI descriptors (ADR-0052 phase 5.8,
+/// RUE-1005) from the AIR and the per-slot by-reference vector.
+///
+/// The parameter type at each slot span comes from the AIR: every by-value
+/// (`Normal`) parameter — used or not — is recorded in `param_drops` with its
+/// start slot and type, and any additional used parameter (a destructor `self`,
+/// whose drops are cleared) is recovered from its `Param` instruction. Each
+/// parameter's incoming-register crossing width is decided by the native
+/// call-ABI classifier and stored as a plain integer; the descriptor carries no
+/// `Type`, so a pointer-only consumer's CFG stays layout-independent and
+/// reusable when a pointee struct's layout changes. Walking the slots and
+/// advancing by each parameter's decomposition width reconstructs the exact
+/// grouping identically for a fresh analysis and a durable/imported body, since
+/// both rebuild from the same AIR.
+fn derive_source_param_abi(builder: &CfgBuilder<'_>) -> Vec<SourceParamAbi> {
+    let air = builder.air;
+    let type_pool = builder.type_pool;
+    let num_params = builder.cfg.num_params();
+    let by_ref: Vec<bool> = builder.cfg.param_modes().to_vec();
+    let abi = NativeCallAbi::for_arguments(type_pool);
+
+    // Slot -> source type. `param_drops` covers every Normal by-value parameter
+    // (including unused ones); `Param` instructions supplement any used
+    // parameter whose drop entry was cleared (destructor receivers).
+    let mut ty_at: std::collections::HashMap<u32, Type> = std::collections::HashMap::new();
+    for &(slot, ty) in air.param_drops() {
+        ty_at.entry(slot).or_insert(ty);
+    }
+    for i in 0..air.len() {
+        let inst = air.get(AirRef::from_raw(i as u32));
+        if let AirInstData::Param { index } = inst.data {
+            ty_at.entry(index).or_insert(inst.ty);
+        }
+    }
+
+    let mut descriptors = Vec::new();
+    let mut slot = 0u32;
+    while slot < num_params {
+        let is_by_ref = by_ref.get(slot as usize).copied().unwrap_or(false);
+        let (slot_count, crossing_regs, ty) = if is_by_ref {
+            // A by-reference parameter is always one pointer slot; its type is
+            // never consulted by code generation.
+            (1, 1, None)
+        } else if let Some(&ty) = ty_at.get(&slot) {
+            let width = type_pool.abi_slot_count(ty).max(1);
+            let crossing = abi
+                .classify_arg(ty, ArgConvention::ByValue)
+                .crossing_slots()
+                .max(1);
+            // Carry the type only when the parameter crosses indirectly (one
+            // pointer over a multi-slot span), so a direct parameter's CFG stays
+            // layout-independent.
+            let carried_ty = (crossing < width).then_some(ty);
+            (width, crossing, carried_ty)
+        } else {
+            // No recorded type for a by-value slot: a single direct slot, which
+            // homes exactly as the historical prologue.
+            (1, 1, None)
+        };
+        descriptors.push(SourceParamAbi {
+            start_slot: slot,
+            slot_count,
+            crossing_regs,
+            ty,
+        });
+        slot += slot_count;
+    }
+    descriptors
+}
+
 impl<'a> CfgBuilder<'a> {
     fn payload_or<T>(
         &mut self,
@@ -477,6 +548,13 @@ impl<'a> CfgBuilder<'a> {
             .all_struct_ids()
             .filter(|id| builder.implicit_named_destructors.contains(id))
             .collect();
+
+        // Derive the grouped per-source-parameter ABI descriptors (RUE-1005)
+        // from the AIR, which both a fresh analysis and a durable/imported body
+        // rebuild identically, so the CFG's grouping matches across reuse.
+        let source_param_abi = derive_source_param_abi(&builder);
+        builder.cfg.set_source_param_abi(source_param_abi);
+
         let cfg = match builder.cfg.finish(builder.type_pool) {
             Ok(cfg) => Some(cfg),
             Err(error) => {

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -739,6 +739,14 @@ pub struct Cfg {
     /// on either side of such a write are NOT interchangeable. Passes that
     /// treat parameter reads as pure must consult this set.
     address_taken_params: std::collections::HashSet<u32>,
+    /// Grouped per-source-parameter ABI descriptors (ADR-0052 phase 5.8,
+    /// RUE-1005), derived at construction from the AIR parameter types and the
+    /// per-slot by-reference vector. Empty for a directly constructed CFG
+    /// (synthetic tests), in which case code generation homes one incoming
+    /// register per parameter slot (the historical prologue). Deriving it from
+    /// the AIR keeps a durable/imported body — which rebuilds its CFG from the
+    /// same AIR — identical to its freshly analyzed counterpart.
+    source_param_abi: Vec<rue_air::SourceParamAbi>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -895,6 +903,7 @@ impl Clone for Cfg {
             param_modes: self.param_modes.clone(),
             address_taken_slots: self.address_taken_slots.clone(),
             address_taken_params: self.address_taken_params.clone(),
+            source_param_abi: self.source_param_abi.clone(),
         }
     }
 }
@@ -924,6 +933,23 @@ impl Cfg {
         cfg.entry = self.entry;
         cfg.address_taken_slots = self.address_taken_slots.clone();
         cfg.address_taken_params = self.address_taken_params.clone();
+        // Descriptors carry a type only for a by-value indirect aggregate
+        // parameter, remapped across pools like any other CFG type (RUE-1005).
+        cfg.source_param_abi = self
+            .source_param_abi
+            .iter()
+            .map(|param| {
+                Ok(rue_air::SourceParamAbi {
+                    start_slot: param.start_slot,
+                    slot_count: param.slot_count,
+                    crossing_regs: param.crossing_regs,
+                    ty: match param.ty {
+                        Some(t) => Some(ty(t).map_err(CfgRemapError::Domain)?),
+                        None => None,
+                    },
+                })
+            })
+            .collect::<Result<Vec<_>, CfgRemapError<E>>>()?;
 
         macro_rules! binary {
             ($variant:ident, $a:expr, $b:expr) => {
@@ -1183,7 +1209,15 @@ impl Cfg {
             param_modes: param_modes.into(),
             address_taken_slots: std::collections::HashSet::new(),
             address_taken_params: std::collections::HashSet::new(),
+            source_param_abi: Vec::new(),
         }
+    }
+
+    /// Install the grouped per-source-parameter ABI descriptors derived by the
+    /// CFG builder from the AIR (RUE-1005). See the `source_param_abi` field.
+    #[inline]
+    pub fn set_source_param_abi(&mut self, descriptors: Vec<rue_air::SourceParamAbi>) {
+        self.source_param_abi = descriptors;
     }
 
     /// Record that `slot`'s address escapes through an address-taking
@@ -1304,6 +1338,14 @@ impl Cfg {
     #[inline]
     pub fn param_modes(&self) -> &[bool] {
         self.param_modes.by_ref()
+    }
+
+    /// Get the grouped per-source-parameter ABI descriptors (RUE-1005), or an
+    /// empty slice for a directly constructed CFG (synthetic tests), in which
+    /// case code generation homes one incoming register per parameter slot.
+    #[inline]
+    pub fn source_param_abi(&self) -> &[rue_air::SourceParamAbi] {
+        &self.source_param_abi
     }
 
     /// Create a new basic block and return its ID.

--- a/crates/rue-cli-tests/cases/aggregate_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout.toml
@@ -476,20 +476,22 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = ["aggregate_layout", "not yet implemented"]
 
-# RUE-1000 keeps refusing a compact enum crossing a CALL boundary by value:
-# the preserved slot call convention cannot express it and the indirect
-# marshalling is the next phase (RUE-976's transitional indirect rule).
+# An IMAGELESS compact enum crossing a CALL boundary by value stays refused
+# (RUE-1005): overlapping union payload slots (`A(i64)` versus `B(i32, i32)`)
+# give no variant-independent memory image, so the caller cannot build a compact
+# buffer and the callee cannot unmarshal one. A compact enum WITH an image now
+# crosses by value (see `compact_enum_by_value_match`).
 [[case]]
-name = "compact_enum_crossing_call_still_fails"
-description = "A compact enum passed by value across a call is still refused under --preview aggregate_layout (call marshalling is the next phase)."
+name = "imageless_enum_crossing_call_still_fails"
+description = "A variant-dependent (imageless) compact enum passed by value across a call is still refused under --preview aggregate_layout (RUE-1005)."
 args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
 files = [{ path = "main.rue", source = """
-enum Opt { Some(i32), None }
-fn unwrap(o: Opt) -> i32 {
-    match o { Opt.Some(x) => x, Opt.None => 0, }
+enum Bad { A(i64), B(i32, i32) }
+fn first(v: Bad) -> i64 {
+    match v { Bad.A(x) => x, Bad.B(y, z) => @intCast(y + z), }
 }
 fn main() -> i32 {
-    unwrap(Opt.Some(5))
+    @intCast(first(Bad.A(5)))
 }
 """ }]
 compile_fail = true
@@ -598,20 +600,138 @@ fn main() -> i32 {
 stdout = "777\n"
 exit_code = 0
 
-# A by-value non-slot-identical struct argument still crosses indirectly by the
-# classifier, but its caller-owned compact-buffer marshalling is not yet
-# implemented: the callee parameter ABI would have to consume one incoming
-# pointer for a value the CFG models as N decomposition slots. Refused loudly.
+# RUE-1005: a by-value non-slot-identical struct argument now crosses indirectly.
+# The caller writes the aggregate's compact image (a@0, b@4, c@8) into a
+# caller-owned buffer and passes one pointer; the callee prologue homes that
+# pointer and unmarshals the image into its frame slots at entry, so every field
+# reads back correctly. Gate-off passes slot-shaped registers identically.
 [[case]]
-name = "compact_struct_by_value_arg_still_fails"
-description = "A compact struct passed by value across a call is still refused under --preview aggregate_layout (indirect by-value argument marshalling is the next phase)."
+name = "compact_struct_by_value_read_fields"
+description = "A compact struct passed by value has all fields read in the callee via the caller-written compact image and homed pointer under --preview aggregate_layout (RUE-1005)."
+differential_opt = true
 args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Padded { a: u8, b: i32, c: u8 }
-fn sum(p: Padded) -> i32 { p.b }
+fn sum(p: Padded) -> i32 {
+    @dbg(p.a);
+    @dbg(p.b);
+    @dbg(p.c);
+    p.b
+}
 fn main() -> i32 {
     let s = Padded { a: 1, b: 5, c: 3 };
-    sum(s)
+    @dbg(sum(s));
+    0
+}
+""" }]
+stdout = "1\n5\n3\n5\n"
+exit_code = 0
+
+# A compact Option-like enum passed BY VALUE crosses through its caller-owned
+# compact image (u8 tag @0, i32 payload @4); the callee unmarshals it and matches
+# both variants correctly.
+[[case]]
+name = "compact_enum_by_value_match"
+description = "An Option-like enum passed by value is matched in the callee through the compact image and homed pointer under --preview aggregate_layout (RUE-1005)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Opt { Some(i32), None }
+fn unwrap_or(o: Opt, d: i32) -> i32 {
+    match o { Opt.Some(x) => x, Opt.None => d, }
+}
+fn main() -> i32 {
+    @dbg(unwrap_or(Opt.Some(42), 0));
+    @dbg(unwrap_or(Opt.None, -7));
+    0
+}
+""" }]
+stdout = "42\n-7\n"
+exit_code = 0
+
+# A two-level call chain (main -> f -> g) re-passes the compact struct by value
+# at each rung: each callee re-materializes the compact image into its own buffer
+# for the next call, and the deepest callee reads every field.
+[[case]]
+name = "compact_struct_by_value_two_level_chain"
+description = "A compact struct passed by value through a two-level call chain (caller -> f -> g) reads correctly at the bottom under --preview aggregate_layout (RUE-1005)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Padded { a: u8, b: i32, c: u8 }
+fn g(p: Padded) -> i32 { @intCast(p.a) + p.b + @intCast(p.c) }
+fn f(p: Padded) -> i32 { g(p) }
+fn main() -> i32 {
+    let s = Padded { a: 1, b: 100, c: 2 };
+    @dbg(f(s));
+    0
+}
+""" }]
+stdout = "103\n"
+exit_code = 0
+
+# A mixed-signature call: a scalar (i64), a by-value compact struct forced
+# indirect, and a bool. The compact struct crosses as one pointer while the
+# scalars stay direct, and the argument-register shift is handled per the
+# preserved convention.
+[[case]]
+name = "compact_mixed_signature_by_value"
+description = "A call mixing i64, a by-value compact struct, and bool passes the struct indirectly while scalars stay direct under --preview aggregate_layout (RUE-1005)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Padded { a: u8, b: i32, c: u8 }
+fn mix(x: i64, p: Padded, flag: bool) -> i64 {
+    let bb: i64 = @intCast(p.b);
+    if flag { x + bb } else { x }
+}
+fn main() -> i32 {
+    let s = Padded { a: 1, b: 40, c: 2 };
+    let t = Padded { a: 1, b: 40, c: 2 };
+    @dbg(mix(1000, s, true));
+    @dbg(mix(1000, t, false));
+    0
+}
+""" }]
+stdout = "1040\n1000\n"
+exit_code = 0
+
+# A function that BOTH takes a compact aggregate by value AND returns one by
+# value exercises the caller-owned argument buffer and the sret compact image in
+# the same call: the argument buffer is freed after the call, before the sret
+# read-back reads its buffer.
+[[case]]
+name = "compact_struct_takes_and_returns_by_value"
+description = "A call that both takes and returns a compact aggregate by value round-trips under --preview aggregate_layout (RUE-1005)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Padded { a: u8, b: i32, c: u8 }
+fn bump(p: Padded) -> Padded { Padded { a: p.a, b: p.b + 1, c: p.c } }
+fn main() -> i32 {
+    let s = Padded { a: 3, b: 10, c: 7 };
+    let r = bump(s);
+    @dbg(r.a);
+    @dbg(r.b);
+    @dbg(r.c);
+    0
+}
+""" }]
+stdout = "3\n11\n7\n"
+exit_code = 0
+
+# A by-value ARRAY argument stays refused: a fixed array's compact stride differs
+# from the slot stride, so it has no variant-independent compact image and call
+# marshalling for it is not implemented.
+[[case]]
+name = "compact_array_by_value_arg_still_fails"
+description = "A by-value fixed array crossing a call is still refused under --preview aggregate_layout (no variant-independent compact image)."
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn sum(a: [i32; 3]) -> i32 { a[0] + a[1] + a[2] }
+fn main() -> i32 {
+    let xs = [1, 2, 3];
+    sum(xs)
 }
 """ }]
 compile_fail = true

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -96,6 +96,31 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
         });
         pointer
     }
+
+    fn materialize_indirect_value_arg(
+        &mut self,
+        value: CfgValue,
+        image: &[crate::types::PhysicalEnumSlot],
+        storage_bytes: u32,
+    ) -> VReg {
+        // Reserve a caller-owned buffer just below the sret storage (RUE-1005),
+        // capture its address, and write the aggregate's compact image into it —
+        // each slot truncated to its physical width at its compact byte offset,
+        // exactly the image the callee prologue unmarshals.
+        self.mir.push(Aarch64Inst::SubImm {
+            dst: Operand::Physical(Reg::Sp),
+            src: Operand::Physical(Reg::Sp),
+            imm: storage_bytes as i32,
+        });
+        let pointer = self.mir.alloc_vreg();
+        self.mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Virtual(pointer),
+            src: Operand::Physical(Reg::Sp),
+        });
+        let slots = self.require_aggregate_slots(value);
+        crate::agg_slots::store_enum_slots_through_ptr(self, &slots, pointer, image);
+        pointer
+    }
 }
 
 impl<'a> CfgLower<'a> {
@@ -743,6 +768,16 @@ impl<'a> CfgLower<'a> {
                 dst: Operand::Physical(Reg::Sp),
                 src: Operand::Physical(Reg::Sp),
                 imm: plan.stack_bytes as i32,
+            });
+        }
+        // Free the by-value indirect argument buffers (RUE-1005), restoring sp
+        // to the sret storage (or the pre-call baseline) before the sret
+        // read-back reads its buffer at a fixed offset.
+        if plan.caller_indirect_bytes > 0 {
+            self.mir.push(Aarch64Inst::AddImm {
+                dst: Operand::Physical(Reg::Sp),
+                src: Operand::Physical(Reg::Sp),
+                imm: plan.caller_indirect_bytes as i32,
             });
         }
         let slots = match plan.return_plan {
@@ -2658,6 +2693,12 @@ impl crate::terminator_plan::TerminatorAdapter for CfgLower<'_> {
 impl crate::terminator_plan::CfgLowerAdapter for CfgLower<'_> {
     fn preload_by_ref_params(&mut self) {
         self.preload_by_ref_param_ptrs();
+        // Unmarshal each by-value indirect compact aggregate parameter from the
+        // homed pointer into its frame slots at entry (RUE-1005), so field
+        // projection and whole-value reads see the correct decomposition.
+        for (base_slot, map) in crate::value_plan::indirect_value_params(&self.ctx) {
+            crate::agg_slots::unmarshal_indirect_value_param(self, base_slot, &map);
+        }
     }
 
     fn prepare_block_param(&mut self, block: BlockId, index: u32, value: CfgValue, ty: Type) {
@@ -3162,6 +3203,16 @@ mod tests {
         source: &str,
         preview: PreviewFeatures,
     ) -> rue_error::CompileResult<Aarch64Mir> {
+        try_lower_named_fn(source, preview, None)
+    }
+
+    /// Lower a specific function by name (or the first function when `None`),
+    /// so tests can exercise a callee whose caller sorts ahead of it.
+    fn try_lower_named_fn(
+        source: &str,
+        preview: PreviewFeatures,
+        name: Option<&str>,
+    ) -> rue_error::CompileResult<Aarch64Mir> {
         let lexer = Lexer::new(source);
         let (tokens, interner) = lexer.tokenize().unwrap();
         let parser = Parser::new(tokens, interner);
@@ -3172,7 +3223,14 @@ mod tests {
         let output = Sema::new_synthetic(&rir, &mut interner, preview)
             .analyze_all()
             .unwrap();
-        let func = &output.functions[0];
+        let func = match name {
+            Some(name) => output
+                .functions
+                .iter()
+                .find(|f| f.name == name)
+                .unwrap_or_else(|| panic!("no function named `{name}`")),
+            None => &output.functions[0],
+        };
         let type_pool = &output.type_pool;
         let cfg_output = CfgBuilder::build(
             &func.air,
@@ -3341,23 +3399,62 @@ mod tests {
         .expect("an inout compact struct argument must lower");
     }
 
-    /// RUE-1004 keeps refusing a non-slot-identical struct passed BY VALUE across
-    /// a call on AArch64: the callee parameter ABI is not yet remapped from the
-    /// CFG's N decomposition slots to one incoming compact-buffer pointer.
+    /// RUE-1005: on AArch64, a non-slot-identical struct passed BY VALUE across a
+    /// call now lowers. The caller (`main`, first here) writes the compact image
+    /// into a caller-owned buffer with narrow stores and passes one pointer;
+    /// gate-off it passes slot-shaped registers with no narrow store.
     #[test]
-    fn aggregate_layout_refuses_by_value_compact_struct_arg() {
+    fn aggregate_layout_allows_by_value_compact_struct_arg_caller() {
+        let source = "struct Padded { a: u8, b: i32, c: u8 } \
+                      fn main() -> i32 { sum(Padded { a: 1, b: 5, c: 3 }) } \
+                      fn sum(p: Padded) -> i32 { p.b }";
         let mut preview = PreviewFeatures::new();
         preview.insert(PreviewFeature::AggregateLayout);
-        let err = try_lower_first_fn(
-            "struct Padded { a: u8, b: i32, c: u8 } \
-             fn main() -> i32 { sum(Padded { a: 1, b: 5, c: 3 }) } \
-             fn sum(p: Padded) -> i32 { p.b }",
-            preview,
-        )
-        .expect_err("a by-value compact struct argument must be refused");
+        let mir = try_lower_first_fn(source, preview)
+            .expect("a by-value compact struct argument must lower");
         assert!(
-            format!("{err:?}").contains("aggregate_layout"),
-            "refusal must name the feature, got: {err:?}"
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::NarrowStoreIndexed { width: 1, .. })),
+            "the caller must write the u8 fields narrow into the compact argument buffer"
+        );
+
+        let off = try_lower_first_fn(source, PreviewFeatures::new())
+            .expect("the same program lowers under the default slot model");
+        assert!(
+            off.instructions()
+                .iter()
+                .all(|inst| !matches!(inst, Aarch64Inst::NarrowStoreIndexed { .. })),
+            "gate-off must not emit any narrow argument-buffer store"
+        );
+    }
+
+    /// RUE-1005 callee side on AArch64: the receiving function unmarshals the
+    /// compact image (narrow loads) from the homed pointer into its frame slots
+    /// at entry; gate-off it reads slot-shaped registers with no narrow load.
+    #[test]
+    fn aggregate_layout_allows_by_value_compact_struct_arg_callee() {
+        let source = "struct Padded { a: u8, b: i32, c: u8 } \
+                      fn sum(p: Padded) -> i32 { p.b } \
+                      fn main() -> i32 { sum(Padded { a: 1, b: 5, c: 3 }) }";
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let mir = try_lower_named_fn(source, preview, Some("sum"))
+            .expect("the callee of a by-value compact struct argument must lower");
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::NarrowLoadIndexed { width: 1, .. })),
+            "the callee must unmarshal the u8 fields narrow from the homed pointer"
+        );
+
+        let off = try_lower_named_fn(source, PreviewFeatures::new(), Some("sum"))
+            .expect("the same program lowers under the default slot model");
+        assert!(
+            off.instructions()
+                .iter()
+                .all(|inst| !matches!(inst, Aarch64Inst::NarrowLoadIndexed { .. })),
+            "gate-off must not emit any narrow parameter unmarshalling"
         );
     }
 

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -351,6 +351,9 @@ pub struct Emitter<'a> {
     inst_start: usize,
     /// Whether to generate assembly text (only needed for --emit asm).
     emit_asm: bool,
+    /// Per-source-parameter prologue homing plan (RUE-1005). Empty means one
+    /// incoming register per parameter slot (the historical prologue).
+    param_homing: Vec<crate::codegen_pipeline::ParamHoming>,
 }
 
 impl<'a> Emitter<'a> {
@@ -390,7 +393,18 @@ impl<'a> Emitter<'a> {
             strings,
             inst_start: 0,
             emit_asm: false,
+            param_homing: Vec::new(),
         }
+    }
+
+    /// Supply the per-source-parameter prologue homing plan (RUE-1005). Without
+    /// it the prologue homes one incoming register per parameter slot.
+    pub(crate) fn with_param_homing(
+        mut self,
+        param_homing: Vec<crate::codegen_pipeline::ParamHoming>,
+    ) -> Self {
+        self.param_homing = param_homing;
+        self
     }
 
     /// Mark the function as returning via sret (hidden buffer pointer as the
@@ -399,6 +413,21 @@ impl<'a> Emitter<'a> {
     pub fn with_sret(mut self, has_sret: bool) -> Self {
         self.has_sret = has_sret;
         self
+    }
+
+    /// The prologue homing plan, falling back to one incoming register per
+    /// parameter slot when no grouped plan was supplied (RUE-1005).
+    fn param_homing_or_per_slot(&self) -> Vec<crate::codegen_pipeline::ParamHoming> {
+        if self.param_homing.is_empty() {
+            (0..self.num_params)
+                .map(|slot| crate::codegen_pipeline::ParamHoming {
+                    start_slot: slot,
+                    reg_count: 1,
+                })
+                .collect()
+        } else {
+            self.param_homing.clone()
+        }
     }
 
     // ==================== Instruction recording helpers ====================
@@ -600,28 +629,38 @@ impl<'a> Emitter<'a> {
         ];
         let callee_saved_size = self.callee_saved_stack_size();
         let abi_shift = self.has_sret as u32;
-        for i in 0..self.num_params {
-            // Use num_locals_original (not num_locals, which includes spill
-            // slots): CfgLower generated the body's param reads against the
-            // pre-spill count. (RUE-129)
-            let slot = self.num_locals_original + i;
-            // Skip past callee-saved registers in the offset calculation
-            let offset = -callee_saved_size + crate::frame_layout::slot_offset_pre_saved(slot);
-            let abi_index = (i + abi_shift) as usize;
+        // Home incoming argument registers into the frame parameter area. Each
+        // source parameter consumes `reg_count` consecutive incoming registers
+        // (RUE-1005): a by-value indirect compact aggregate arrives as one
+        // pointer register while reserving `slot_count` frame slots, shifting
+        // later parameters. Gate-off every parameter is direct with
+        // `reg_count == slot_count`, so this is byte-identical to the historical
+        // one-register-per-slot loop.
+        let mut abi_index = abi_shift as usize;
+        for homing in self.param_homing_or_per_slot() {
+            for k in 0..homing.reg_count {
+                // Use num_locals_original (not num_locals, which includes spill
+                // slots): CfgLower generated the body's param reads against the
+                // pre-spill count. (RUE-129)
+                let slot = self.num_locals_original + homing.start_slot + k;
+                // Skip past callee-saved registers in the offset calculation
+                let offset = -callee_saved_size + crate::frame_layout::slot_offset_pre_saved(slot);
 
-            if abi_index < param_regs.len() {
-                self.begin_inst();
-                self.emit_str(param_regs[abi_index], Reg::Fp, offset);
-                end_inst!(self, "str {}, [x29, #{}]", param_regs[abi_index], offset);
-            } else {
-                // Stack-passed arg: copy from above the frame into the param area
-                let src_offset = 16 + (abi_index as i32 - param_regs.len() as i32) * 8;
-                self.begin_inst();
-                self.emit_ldr(Reg::X9, Reg::Fp, src_offset);
-                end_inst!(self, "ldr x9, [x29, #{}]", src_offset);
-                self.begin_inst();
-                self.emit_str(Reg::X9, Reg::Fp, offset);
-                end_inst!(self, "str x9, [x29, #{}]", offset);
+                if abi_index < param_regs.len() {
+                    self.begin_inst();
+                    self.emit_str(param_regs[abi_index], Reg::Fp, offset);
+                    end_inst!(self, "str {}, [x29, #{}]", param_regs[abi_index], offset);
+                } else {
+                    // Stack-passed arg: copy from above the frame into the param area
+                    let src_offset = 16 + (abi_index as i32 - param_regs.len() as i32) * 8;
+                    self.begin_inst();
+                    self.emit_ldr(Reg::X9, Reg::Fp, src_offset);
+                    end_inst!(self, "ldr x9, [x29, #{}]", src_offset);
+                    self.begin_inst();
+                    self.emit_str(Reg::X9, Reg::Fp, offset);
+                    end_inst!(self, "str x9, [x29, #{}]", offset);
+                }
+                abi_index += 1;
             }
         }
 

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -98,7 +98,8 @@ where
         &prepared.used_callee_saved,
         &local_strings,
     )
-    .with_sret(prepared.has_sret);
+    .with_sret(prepared.has_sret)
+    .with_param_homing(prepared.param_homing.clone());
     let emitted = emit(emitter)?;
     Ok((emitted, local_strings))
 }

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -125,6 +125,29 @@ pub(crate) fn load_enum_slots_through_ptr<B: SlotBackend>(
     vregs
 }
 
+/// Unmarshal a by-value indirect compact aggregate parameter into its frame
+/// slots at function entry (ADR-0052 phase 5.8, RUE-1005).
+///
+/// The callee prologue homed a single incoming pointer to the parameter's base
+/// frame slot `base_slot`. This reads that pointer, loads the aggregate's
+/// compact memory image through it (each slot extended from its physical width
+/// at its compact byte offset), and stores the resulting slot-shaped values back
+/// into the parameter's frame region in the ascending layout every consumer
+/// reads — so ordinary field projection and whole-value materialization both see
+/// the correct decomposition without a special parameter path. The pointer is
+/// fully consumed (its loads emitted) before the frame stores overwrite
+/// `base_slot`.
+pub(crate) fn unmarshal_indirect_value_param<B: SlotBackend>(
+    b: &mut B,
+    base_slot: u32,
+    map: &[crate::types::PhysicalEnumSlot],
+) {
+    let ptr = b.alloc_vreg();
+    b.emit_load_slot(ptr, base_slot);
+    let vals = load_enum_slots_through_ptr(b, ptr, map);
+    store_slots(b, &vals, base_slot);
+}
+
 /// Get or compute the slot vregs for a multi-slot aggregate value
 /// (struct, builtin String, or fixed-size array).
 ///

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -5,7 +5,7 @@
 //! lowerers consume the normalized slot vector and only choose how to marshal
 //! those slots for their ABI.
 
-use rue_air::{FrozenTypeInternPool, NativeCallAbi, ReturnClass};
+use rue_air::{ArgClass, ArgConvention, FrozenTypeInternPool, NativeCallAbi, ReturnClass};
 use rue_cfg::{Cfg, CfgArgMode, CfgCallArg, Type};
 use rue_runtime_abi::{ReservedExportClass, ReservedExportId};
 
@@ -186,6 +186,12 @@ pub struct CallPlan {
     pub result: Option<VReg>,
     pub stack_slot_count: usize,
     pub stack_bytes: u32,
+    /// Total bytes of caller-owned compact-image buffers reserved for by-value
+    /// indirect aggregate arguments (RUE-1005). Allocated below the sret buffer
+    /// and above the outgoing stack arguments; freed together right after the
+    /// call, before the sret read-back. Zero when no argument crosses
+    /// indirectly.
+    pub caller_indirect_bytes: u32,
 }
 
 /// Input metadata for one CFG call argument. This is copied out of the CFG
@@ -198,6 +204,17 @@ pub enum CallArgInput {
         value: rue_cfg::CfgValue,
         slot_count: u32,
         is_multislot_aggregate: bool,
+    },
+    /// A by-value non-slot-identical compact aggregate the classifier forces
+    /// indirect under `aggregate_layout` (RUE-976/RUE-1005): the caller writes
+    /// its compact memory `image` into a caller-owned buffer of `storage_bytes`
+    /// and passes one pointer to the callee, which unmarshals it in its
+    /// prologue. Kept separate from `Value` so the single pointer ABI slot and
+    /// the buffer accounting cannot be confused with an N-slot direct value.
+    IndirectValue {
+        value: rue_cfg::CfgValue,
+        image: Vec<crate::types::PhysicalEnumSlot>,
+        storage_bytes: u32,
     },
     ByRef {
         mode: ByRefMode,
@@ -235,6 +252,30 @@ impl CallInputs {
             .zip(by_ref_plans)
             .map(|(arg, by_ref_plan)| {
                 let arg_ty = cfg.get_inst(arg.value).ty;
+                // A by-value aggregate the classifier forces indirect under the
+                // compact layout crosses through a caller-owned compact image
+                // buffer (RUE-1005), not as N direct decomposition slots. The
+                // refusal scan has already guaranteed such an aggregate has a
+                // variant-independent image before lowering reaches here.
+                if matches!(arg.mode, CfgArgMode::Normal)
+                    && matches!(
+                        NativeCallAbi::for_arguments(type_pool)
+                            .classify_arg(arg_ty, ArgConvention::ByValue),
+                        ArgClass::Indirect
+                    )
+                {
+                    let image = types::aggregate_physical_slot_map(type_pool, arg_ty).expect(
+                        "a by-value indirect compact aggregate argument must have a \
+                         variant-independent memory image (guaranteed by the refusal scan)",
+                    );
+                    let storage_bytes =
+                        align_up(types::type_size_bytes(type_pool, arg_ty) as u32, 16);
+                    return CallArgInput::IndirectValue {
+                        value: arg.value,
+                        image,
+                        storage_bytes,
+                    };
+                }
                 normalize_call_arg(
                     arg.mode,
                     arg.value,
@@ -299,6 +340,16 @@ pub trait CallMaterializer {
     fn materialize_aggregate(&mut self, value: rue_cfg::CfgValue) -> Vec<VReg>;
     fn materialize_by_ref(&mut self, plan: &crate::value_plan::ByRefAddressPlan) -> VReg;
     fn materialize_sret_pointer(&mut self, storage_bytes: u32) -> VReg;
+    /// Reserve a `storage_bytes` caller-owned buffer, write the aggregate
+    /// `value`'s compact `image` into it, and return a pointer to it (RUE-1005).
+    /// The single pointer becomes the argument's ABI slot; the callee prologue
+    /// homes it and unmarshals the image into its frame parameter slots.
+    fn materialize_indirect_value_arg(
+        &mut self,
+        value: rue_cfg::CfgValue,
+        image: &[crate::types::PhysicalEnumSlot],
+        storage_bytes: u32,
+    ) -> VReg;
 }
 
 impl CallPlan {
@@ -355,6 +406,7 @@ impl CallPlan {
         }
 
         let mut user_args = Vec::with_capacity(args.len());
+        let mut caller_indirect_bytes = 0u32;
         for arg in args {
             let (mode, slots) = match arg {
                 CallArgInput::ByRef { mode, address } => (
@@ -363,6 +415,20 @@ impl CallPlan {
                     // no storage slots. This branch precedes ZST omission.
                     vec![materializer.materialize_by_ref(address)],
                 ),
+                CallArgInput::IndirectValue {
+                    value,
+                    image,
+                    storage_bytes,
+                } => {
+                    // The caller writes the aggregate's compact image into its
+                    // own buffer and passes one pointer (RUE-1005). The buffers
+                    // are reserved below the sret storage and freed together
+                    // after the call.
+                    caller_indirect_bytes += *storage_bytes;
+                    let pointer =
+                        materializer.materialize_indirect_value_arg(*value, image, *storage_bytes);
+                    (UserArgMode::Value, vec![pointer])
+                }
                 CallArgInput::Value {
                     value,
                     slot_count,
@@ -407,6 +473,7 @@ impl CallPlan {
             result,
             stack_slot_count,
             stack_bytes,
+            caller_indirect_bytes,
         }
     }
 
@@ -428,6 +495,7 @@ impl CallPlan {
             result: None,
             stack_slot_count,
             stack_bytes: align_up((stack_slot_count * 8) as u32, 16),
+            caller_indirect_bytes: 0,
         }
     }
 }
@@ -475,6 +543,15 @@ mod tests {
 
         fn materialize_sret_pointer(&mut self, _storage_bytes: u32) -> VReg {
             VReg::new(40)
+        }
+
+        fn materialize_indirect_value_arg(
+            &mut self,
+            _value: rue_cfg::CfgValue,
+            _image: &[crate::types::PhysicalEnumSlot],
+            _storage_bytes: u32,
+        ) -> VReg {
+            VReg::new(50)
         }
     }
 
@@ -566,6 +643,7 @@ mod tests {
             result: None,
             stack_slot_count: 0,
             stack_bytes: 0,
+            caller_indirect_bytes: 0,
         };
 
         assert!(plan.user_args[0].slots.is_empty());

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -9,6 +9,48 @@ use rue_air::FrozenTypeInternPool;
 use rue_cfg::Cfg;
 use rue_error::CompileResult;
 
+/// How the callee prologue homes one source parameter's incoming argument
+/// registers into its frame parameter slots (ADR-0052 phase 5.8, RUE-1005).
+///
+/// The historical prologue assumed one incoming register per parameter slot. A
+/// by-value indirect compact aggregate breaks that: it arrives as one pointer
+/// register (`reg_count == 1`) yet reserves `slot_count` frame slots, so
+/// subsequent parameters' incoming registers shift. Each entry homes `reg_count`
+/// consecutive incoming registers starting at the running argument index into
+/// frame parameter slots `[start_slot, start_slot + reg_count)`; the parameter's
+/// remaining reserved slots (for an indirect aggregate) are filled lazily by the
+/// body from the homed pointer. With the gate off every parameter is direct and
+/// `reg_count == slot_count`, so the emitted prologue is byte-identical.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ParamHoming {
+    pub(crate) start_slot: u32,
+    pub(crate) reg_count: u32,
+}
+
+/// Build the callee prologue's per-source-parameter homing plan from the CFG's
+/// grouped descriptors, each carrying its precomputed incoming-register crossing
+/// width (RUE-1005). Falls back to one register per parameter slot when the CFG
+/// carries no grouped source-parameter layout (a directly constructed CFG in
+/// synthetic tests), reproducing the historical prologue exactly.
+pub(crate) fn param_homing_plan(cfg: &Cfg) -> Vec<ParamHoming> {
+    let source_params = cfg.source_param_abi();
+    if source_params.is_empty() {
+        return (0..cfg.num_params())
+            .map(|slot| ParamHoming {
+                start_slot: slot,
+                reg_count: 1,
+            })
+            .collect();
+    }
+    source_params
+        .iter()
+        .map(|param| ParamHoming {
+            start_slot: param.start_slot,
+            reg_count: param.crossing_regs,
+        })
+        .collect()
+}
+
 /// A target's MIR after allocation, peephole optimization, scheduling, and
 /// stack verification, together with the frame metadata its emitter needs.
 pub(crate) struct PreparedMir<M, R> {
@@ -18,6 +60,8 @@ pub(crate) struct PreparedMir<M, R> {
     pub(crate) num_params: u32,
     pub(crate) has_sret: bool,
     pub(crate) used_callee_saved: Vec<R>,
+    /// Per-source-parameter prologue homing plan (RUE-1005).
+    pub(crate) param_homing: Vec<ParamHoming>,
 }
 
 /// Run the target-independent backend pipeline around concrete pass hooks.
@@ -49,6 +93,7 @@ where
     let num_locals_original = cfg.num_locals();
     let num_params = cfg.num_params();
     let has_sret = crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, return_reg_count);
+    let param_homing = param_homing_plan(cfg);
 
     let mir = lower()?;
     let existing_slots = num_locals_original + num_params + u32::from(has_sret);
@@ -65,6 +110,7 @@ where
         num_params,
         has_sret,
         used_callee_saved,
+        param_homing,
     })
 }
 

--- a/crates/rue-codegen/src/runtime_call_plan.rs
+++ b/crates/rue-codegen/src/runtime_call_plan.rs
@@ -225,6 +225,16 @@ impl RuntimeCallPlan {
                 CallArgInput::ByRef { address, .. } => {
                     slots.push(materializer.materialize_by_ref(address));
                 }
+                // A by-value indirect compact aggregate (RUE-1005) only arises
+                // for a Rue-target call under `aggregate_layout`; the register-
+                // only TargetC memory builtins take scalars and pointers, never a
+                // by-value compact aggregate, so it cannot reach a runtime call.
+                CallArgInput::IndirectValue { .. } => {
+                    unreachable!(
+                        "a compiler-built memory routine cannot take a by-value indirect \
+                         compact aggregate argument"
+                    )
+                }
                 CallArgInput::Value {
                     value,
                     slot_count,

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -713,23 +713,17 @@ pub(crate) fn compact_physical_access_unsupported(
             }
             // An aggregate crossing a call boundary. A by-reference (`inout` /
             // `borrow`) argument uses the same slot-shaped by-ref transport as a
-            // by-ref parameter and is allowed with a compact image (RUE-1004). A
-            // by-value non-slot-identical aggregate still crosses indirectly by the
-            // classifier (RUE-976); its caller-owned compact-buffer marshalling is
-            // not implemented, because the callee-side parameter ABI would have to
-            // consume one incoming pointer for a value the CFG still models as N
-            // decomposition slots, and per-source-parameter types are not plumbed
-            // to code generation to recompute that mapping. Refused loudly.
+            // by-ref parameter (RUE-1004). A by-value non-slot-identical aggregate
+            // crosses indirectly by the classifier (RUE-976): the caller writes
+            // its compact image to a caller-owned buffer and passes one pointer,
+            // and the callee prologue homes that pointer and unmarshals the image
+            // (RUE-1005, per-source-parameter ABI descriptors now plumbed). Both
+            // are allowed exactly when the aggregate has a variant-independent
+            // compact image; arrays and imageless enums stay refused.
             CfgInstData::Call { .. } => {
                 for arg in cfg.get_call_args(&inst.data) {
                     let arg_ty = cfg.get_inst(arg.value).ty;
-                    let unsupported = match arg.mode {
-                        rue_cfg::CfgArgMode::Inout | rue_cfg::CfgArgMode::Borrow => {
-                            call_boundary_unsupported(arg_ty)
-                        }
-                        rue_cfg::CfgArgMode::Normal => unimplemented_aggregate(arg_ty),
-                    };
-                    if unsupported {
+                    if call_boundary_unsupported(arg_ty) {
                         return Some(arg_ty);
                     }
                 }
@@ -781,10 +775,10 @@ pub(crate) fn ensure_compact_layout_codegen_supported(
                  `{}`) is not yet implemented. Narrow scalar access through typed pointers \
                  (RUE-989), compact enum memory for enums with a variant-independent memory image \
                  (RUE-1000), and call-boundary marshalling of a compact aggregate through its \
-                 memory image — sret returns and `inout`/`borrow` parameters (RUE-1004) — are \
-                 lowered, but whole struct/array marshalling through arbitrary pointers, a compact \
-                 aggregate passed BY VALUE across a call, arrays crossing a call, and enums \
-                 without a variant-independent memory image are still staged for a follow-up.",
+                 memory image — sret returns and `inout`/`borrow` parameters (RUE-1004), and \
+                 by-value arguments (RUE-1005) — are lowered, but whole struct/array marshalling \
+                 through arbitrary pointers, arrays crossing a call, and enums without a \
+                 variant-independent memory image are still staged for a follow-up.",
                 cfg.fn_name()
             )),
         ));

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -2133,6 +2133,32 @@ pub(crate) fn by_ref_param_slots(ctx: &CfgLowerContext<'_>) -> Vec<u32> {
         .collect()
 }
 
+/// Return each by-value indirect compact aggregate parameter's base frame slot
+/// and compact memory image (ADR-0052 phase 5.8, RUE-1005), for the entry-time
+/// unmarshalling both backends perform before the block walk.
+///
+/// The CFG's grouped descriptors flag which parameters cross as one pointer over
+/// a multi-slot span ([`rue_air::SourceParamAbi::is_by_value_indirect`]). The
+/// parameter's type — needed only to build its compact image — is recovered from
+/// its `Param` instruction; a parameter never read has no such instruction and
+/// needs no unmarshalling (nothing observes its frame slots), so it is skipped.
+/// Empty with the gate off, for functions with no such parameter, and for a
+/// directly constructed CFG with no grouped layout.
+pub(crate) fn indirect_value_params(
+    ctx: &CfgLowerContext<'_>,
+) -> Vec<(u32, Vec<crate::types::PhysicalEnumSlot>)> {
+    ctx.cfg
+        .source_param_abi()
+        .iter()
+        .filter(|param| param.is_by_value_indirect())
+        .filter_map(|param| {
+            let ty = param.ty?;
+            let map = crate::types::aggregate_physical_slot_map(ctx.type_pool, ty)?;
+            Some((ctx.num_locals + param.start_slot, map))
+        })
+        .collect()
+}
+
 /// Validate the shared slot policy for a value and its materialized cache.
 pub fn assert_slot_policy(plan: ValuePlan, actual: usize) {
     if plan.shape.requires_complete_slots() {

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -102,6 +102,30 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
         });
         pointer
     }
+
+    fn materialize_indirect_value_arg(
+        &mut self,
+        value: CfgValue,
+        image: &[crate::types::PhysicalEnumSlot],
+        storage_bytes: u32,
+    ) -> VReg {
+        // Reserve a caller-owned buffer just below the sret storage (RUE-1005),
+        // capture its address, and write the aggregate's compact image into it —
+        // each slot truncated to its physical width at its compact byte offset,
+        // exactly the image the callee prologue unmarshals.
+        self.mir.push(X86Inst::AddRI {
+            dst: Operand::Physical(Reg::Rsp),
+            imm: -(storage_bytes as i32),
+        });
+        let pointer = self.mir.alloc_vreg();
+        self.mir.push(X86Inst::MovRR {
+            dst: Operand::Virtual(pointer),
+            src: Operand::Physical(Reg::Rsp),
+        });
+        let slots = self.require_aggregate_slots(value);
+        crate::agg_slots::store_enum_slots_through_ptr(self, &slots, pointer, image);
+        pointer
+    }
 }
 
 impl<'a> CfgLower<'a> {
@@ -942,6 +966,15 @@ impl<'a> CfgLower<'a> {
             self.mir.push(X86Inst::AddRI {
                 dst: Operand::Physical(Reg::Rsp),
                 imm: plan.stack_bytes as i32,
+            });
+        }
+        // Free the by-value indirect argument buffers (RUE-1005), restoring rsp
+        // to the sret storage (or the pre-call baseline) before the sret
+        // read-back reads its buffer at a fixed offset.
+        if plan.caller_indirect_bytes > 0 {
+            self.mir.push(X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rsp),
+                imm: plan.caller_indirect_bytes as i32,
             });
         }
         let slots = match plan.return_plan {
@@ -2491,6 +2524,12 @@ impl crate::terminator_plan::TerminatorAdapter for CfgLower<'_> {
 impl crate::terminator_plan::CfgLowerAdapter for CfgLower<'_> {
     fn preload_by_ref_params(&mut self) {
         self.preload_by_ref_param_ptrs();
+        // Unmarshal each by-value indirect compact aggregate parameter from the
+        // homed pointer into its frame slots at entry (RUE-1005), so field
+        // projection and whole-value reads see the correct decomposition.
+        for (base_slot, map) in crate::value_plan::indirect_value_params(&self.ctx) {
+            crate::agg_slots::unmarshal_indirect_value_param(self, base_slot, &map);
+        }
     }
 
     fn prepare_block_param(&mut self, block: BlockId, index: u32, value: CfgValue, ty: Type) {
@@ -3028,6 +3067,16 @@ mod tests {
         source: &str,
         preview: PreviewFeatures,
     ) -> rue_error::CompileResult<X86Mir> {
+        try_lower_named_fn(source, preview, None)
+    }
+
+    /// Lower a specific function by name (or the first function when `None`),
+    /// so tests can exercise a callee whose caller sorts ahead of it.
+    fn try_lower_named_fn(
+        source: &str,
+        preview: PreviewFeatures,
+        name: Option<&str>,
+    ) -> rue_error::CompileResult<X86Mir> {
         let lexer = Lexer::new(source);
         let (tokens, interner) = lexer.tokenize().unwrap();
         let parser = Parser::new(tokens, interner);
@@ -3038,7 +3087,14 @@ mod tests {
         let output = Sema::new_synthetic(&rir, &mut interner, preview)
             .analyze_all()
             .unwrap();
-        let func = &output.functions[0];
+        let func = match name {
+            Some(name) => output
+                .functions
+                .iter()
+                .find(|f| f.name == name)
+                .unwrap_or_else(|| panic!("no function named `{name}`")),
+            None => &output.functions[0],
+        };
         let type_pool = &output.type_pool;
         let cfg_output = CfgBuilder::build(
             &func.air,
@@ -3208,23 +3264,151 @@ mod tests {
         .expect("an inout compact struct argument must lower");
     }
 
-    /// RUE-1004 keeps refusing a non-slot-identical struct passed BY VALUE across
-    /// a call: the callee parameter ABI is not yet remapped from the CFG's N
-    /// decomposition slots to one incoming compact-buffer pointer.
+    /// RUE-1005: under `aggregate_layout`, a non-slot-identical struct passed BY
+    /// VALUE across a call now lowers. The caller (`main`, first here) writes the
+    /// aggregate's compact image into a caller-owned buffer with narrow stores
+    /// and passes one pointer. Gate-off, the same call passes slot-shaped
+    /// registers and emits no narrow store.
     #[test]
-    fn aggregate_layout_refuses_by_value_compact_struct_arg() {
+    fn aggregate_layout_allows_by_value_compact_struct_arg_caller() {
+        let source = "struct Padded { a: u8, b: i32, c: u8 } \
+                      fn main() -> i32 { sum(Padded { a: 1, b: 5, c: 3 }) } \
+                      fn sum(p: Padded) -> i32 { p.b }";
         let mut preview = PreviewFeatures::new();
         preview.insert(PreviewFeature::AggregateLayout);
-        let err = try_lower_first_fn(
-            "struct Padded { a: u8, b: i32, c: u8 } \
-             fn main() -> i32 { sum(Padded { a: 1, b: 5, c: 3 }) } \
-             fn sum(p: Padded) -> i32 { p.b }",
-            preview,
-        )
-        .expect_err("a by-value compact struct argument must be refused");
+        let mir = try_lower_first_fn(source, preview)
+            .expect("a by-value compact struct argument must lower");
         assert!(
-            format!("{err:?}").contains("aggregate_layout"),
-            "refusal must name the feature, got: {err:?}"
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::NarrowStoreIndexed { width: 1, .. })),
+            "the caller must write the u8 fields narrow into the compact argument buffer"
+        );
+
+        let off = try_lower_first_fn(source, PreviewFeatures::new())
+            .expect("the same program lowers under the default slot model");
+        assert!(
+            off.instructions()
+                .iter()
+                .all(|inst| !matches!(inst, X86Inst::NarrowStoreIndexed { .. })),
+            "gate-off must not emit any narrow argument-buffer store"
+        );
+    }
+
+    /// RUE-1005 callee side: the function receiving a by-value compact aggregate
+    /// unmarshals its compact image (narrow loads) from the homed pointer into
+    /// its frame slots at entry. Gate-off, it reads slot-shaped registers with no
+    /// narrow load.
+    #[test]
+    fn aggregate_layout_allows_by_value_compact_struct_arg_callee() {
+        let source = "struct Padded { a: u8, b: i32, c: u8 } \
+                      fn sum(p: Padded) -> i32 { p.b } \
+                      fn main() -> i32 { sum(Padded { a: 1, b: 5, c: 3 }) }";
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let mir = try_lower_named_fn(source, preview, Some("sum"))
+            .expect("the callee of a by-value compact struct argument must lower");
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::NarrowLoadIndexed { width: 1, .. })),
+            "the callee must unmarshal the u8 fields narrow from the homed pointer"
+        );
+
+        let off = try_lower_named_fn(source, PreviewFeatures::new(), Some("sum"))
+            .expect("the same program lowers under the default slot model");
+        assert!(
+            off.instructions()
+                .iter()
+                .all(|inst| !matches!(inst, X86Inst::NarrowLoadIndexed { .. })),
+            "gate-off must not emit any narrow parameter unmarshalling"
+        );
+    }
+
+    /// RUE-1005 descriptor plumbing: with the gate off, the per-source-parameter
+    /// prologue homing plan is byte-identical to the historical one-register-per-
+    /// slot loop — a multi-slot direct struct parameter homes exactly one
+    /// incoming register per frame slot, so the flattened register→slot mapping is
+    /// the identity. With the gate on, the same struct parameter crosses as one
+    /// indirect pointer, so its plan entry consumes a single register while still
+    /// reserving all three frame slots.
+    #[test]
+    fn param_homing_plan_is_inert_gate_off_and_collapses_indirect_gate_on() {
+        use rue_cfg::CfgBuilder;
+        let source = "struct Padded { a: u8, b: i32, c: u8 } \
+                      fn take(p: Padded, q: i32) -> i32 { p.b + q } \
+                      fn main() -> i32 { take(Padded { a: 1, b: 5, c: 3 }, 9) }";
+
+        let plan_for = |preview: PreviewFeatures| {
+            let lexer = Lexer::new(source);
+            let (tokens, interner) = lexer.tokenize().unwrap();
+            let (ast, mut interner) = Parser::new(tokens, interner).parse().unwrap();
+            let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
+            astgen.append_items(&ast.items);
+            let rir = astgen.finish();
+            let output = Sema::new_synthetic(&rir, &mut interner, preview)
+                .analyze_all()
+                .unwrap();
+            let func = output.functions.iter().find(|f| f.name == "take").unwrap();
+            let type_pool = &output.type_pool;
+            let cfg = CfgBuilder::build(
+                &func.air,
+                func.num_locals,
+                func.num_param_slots,
+                &func.name,
+                type_pool,
+                func.param_modes.clone(),
+                &interner,
+                func.allow_unreachable_code,
+            )
+            .cfg
+            .unwrap();
+            let _ = type_pool;
+            let plan = crate::codegen_pipeline::param_homing_plan(&cfg);
+            (plan, cfg.num_params())
+        };
+
+        // Gate-off: total incoming registers equals the parameter slot count and
+        // register i homes into frame slot i (identity) — the historical prologue.
+        let (off, num_params) = plan_for(PreviewFeatures::new());
+        assert_eq!(off.iter().map(|h| h.reg_count).sum::<u32>(), num_params);
+        let mut reg = 0u32;
+        for homing in &off {
+            for k in 0..homing.reg_count {
+                assert_eq!(
+                    homing.start_slot + k,
+                    reg,
+                    "gate-off homing must be identity"
+                );
+                reg += 1;
+            }
+        }
+
+        // Gate-on: the compact struct parameter collapses to one incoming pointer
+        // register while its three frame slots stay reserved, so the total
+        // incoming register count drops below the parameter slot count.
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let (on, num_params_on) = plan_for(preview);
+        assert_eq!(num_params_on, 4, "Padded (3 slots) + i32 (1 slot)");
+        assert_eq!(
+            on.iter().map(|h| h.reg_count).sum::<u32>(),
+            2,
+            "one pointer for the compact struct plus one register for the i32"
+        );
+        assert_eq!(
+            on[0],
+            crate::codegen_pipeline::ParamHoming {
+                start_slot: 0,
+                reg_count: 1
+            }
+        );
+        assert_eq!(
+            on[1],
+            crate::codegen_pipeline::ParamHoming {
+                start_slot: 3,
+                reg_count: 1
+            }
         );
     }
 

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -244,6 +244,9 @@ pub struct Emitter<'a> {
     inst_start: usize,
     /// Whether to generate assembly text (only needed for --emit asm).
     emit_asm: bool,
+    /// Per-source-parameter prologue homing plan (RUE-1005). Empty means one
+    /// incoming register per parameter slot (the historical prologue).
+    param_homing: Vec<crate::codegen_pipeline::ParamHoming>,
 }
 
 impl<'a> Emitter<'a> {
@@ -288,7 +291,18 @@ impl<'a> Emitter<'a> {
             has_frame: false,
             inst_start: 0,
             emit_asm: false,
+            param_homing: Vec::new(),
         }
+    }
+
+    /// Supply the per-source-parameter prologue homing plan (RUE-1005). Without
+    /// it the prologue homes one incoming register per parameter slot.
+    pub(crate) fn with_param_homing(
+        mut self,
+        param_homing: Vec<crate::codegen_pipeline::ParamHoming>,
+    ) -> Self {
+        self.param_homing = param_homing;
+        self
     }
 
     /// Mark the function as returning via sret (hidden buffer pointer as the
@@ -448,6 +462,21 @@ impl<'a> Emitter<'a> {
     /// pop rbp              ; restore rbp
     /// ret
     /// ```
+    /// The prologue homing plan, falling back to one incoming register per
+    /// parameter slot when no grouped plan was supplied (RUE-1005).
+    fn param_homing_or_per_slot(&self) -> Vec<crate::codegen_pipeline::ParamHoming> {
+        if self.param_homing.is_empty() {
+            (0..self.num_params)
+                .map(|slot| crate::codegen_pipeline::ParamHoming {
+                    start_slot: slot,
+                    reg_count: 1,
+                })
+                .collect()
+        } else {
+            self.param_homing.clone()
+        }
+    }
+
     fn emit_prologue(&mut self) {
         self.record_comment("prologue");
 
@@ -518,29 +547,41 @@ impl<'a> Emitter<'a> {
         let callee_saved_size = self.callee_saved_size();
         let abi_shift = self.has_sret as u32;
 
-        for i in 0..self.num_params {
-            // Use num_locals_original (not num_locals which includes spills)
-            // because CfgLower generates param offsets based on the original count
-            let slot = self.num_locals_original + i;
-            // Skip past callee-saved registers in the offset calculation
-            let offset = -callee_saved_size + crate::frame_layout::slot_offset_pre_saved(slot);
-            let abi_index = i + abi_shift;
+        // Home incoming argument registers into the frame parameter area. Each
+        // source parameter consumes `reg_count` consecutive incoming registers
+        // (RUE-1005): normally one per frame slot, but a by-value indirect
+        // compact aggregate arrives as one pointer register while reserving
+        // `slot_count` frame slots, shifting later parameters' registers. The
+        // running `abi_index` counts consumed argument registers; frame slots
+        // come from each parameter's `start_slot`. Gate-off every parameter is
+        // direct with `reg_count == slot_count`, so this is byte-identical to
+        // the historical one-register-per-slot loop.
+        let mut abi_index = abi_shift;
+        for homing in self.param_homing_or_per_slot() {
+            for k in 0..homing.reg_count {
+                // Use num_locals_original (not num_locals which includes spills)
+                // because CfgLower generates param offsets based on the original count
+                let slot = self.num_locals_original + homing.start_slot + k;
+                // Skip past callee-saved registers in the offset calculation
+                let offset = -callee_saved_size + crate::frame_layout::slot_offset_pre_saved(slot);
 
-            if (abi_index as usize) < ARG_REGS.len() {
-                let reg = ARG_REGS[abi_index as usize];
-                // Emit: mov [rbp + offset], reg
-                self.begin_inst();
-                self.emit_mov_mr(Reg::Rbp, offset, reg);
-                end_inst!(self, "mov [rbp{}], {}", offset, reg);
-            } else {
-                // Stack-passed arg: copy from above the frame into the param area
-                let src_offset = 16 + (abi_index as i32 - ARG_REGS.len() as i32) * 8;
-                self.begin_inst();
-                self.emit_mov_rm(Reg::Rax, Reg::Rbp, src_offset);
-                end_inst!(self, "mov rax, [rbp+{}]", src_offset);
-                self.begin_inst();
-                self.emit_mov_mr(Reg::Rbp, offset, Reg::Rax);
-                end_inst!(self, "mov [rbp{}], rax", offset);
+                if (abi_index as usize) < ARG_REGS.len() {
+                    let reg = ARG_REGS[abi_index as usize];
+                    // Emit: mov [rbp + offset], reg
+                    self.begin_inst();
+                    self.emit_mov_mr(Reg::Rbp, offset, reg);
+                    end_inst!(self, "mov [rbp{}], {}", offset, reg);
+                } else {
+                    // Stack-passed arg: copy from above the frame into the param area
+                    let src_offset = 16 + (abi_index as i32 - ARG_REGS.len() as i32) * 8;
+                    self.begin_inst();
+                    self.emit_mov_rm(Reg::Rax, Reg::Rbp, src_offset);
+                    end_inst!(self, "mov rax, [rbp+{}]", src_offset);
+                    self.begin_inst();
+                    self.emit_mov_mr(Reg::Rbp, offset, Reg::Rax);
+                    end_inst!(self, "mov [rbp{}], rax", offset);
+                }
+                abi_index += 1;
             }
         }
 

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -94,7 +94,8 @@ where
         &prepared.used_callee_saved,
         &local_strings,
     )
-    .with_sret(prepared.has_sret);
+    .with_sret(prepared.has_sret)
+    .with_param_homing(prepared.param_homing.clone());
     let emitted = emit(emitter)?;
     Ok((emitted, local_strings))
 }


### PR DESCRIPTION
## Summary

The last named call-boundary refusal falls: non-slot-identical compact aggregates can now be passed **by value** across calls under `--preview aggregate_layout`, on both backends. Gate-off code generation is byte-identical.

- **Descriptor plumbing** (the RUE-1004 blocker): each function's CFG now carries a `SourceParamAbi` per source parameter — `start_slot`, `slot_count`, `crossing_regs` (from the call-ABI classifier, never re-decided in the backends), and the source type carried *only* for by-value indirect aggregates so pointer-only consumers stay layout-independent and CFG reuse across preview modes is preserved. Derived at CFG-build time from the AIR; durable/imported bodies rebuild them identically.
- **Callee prologue** homes `crossing_regs` registers per parameter instead of one per slot; gate off `crossing_regs == slot_count`, proven byte-identical by a dedicated inertness unit test plus the unmodified encoding-exact suites.
- **Caller side**: materializes the compact image into caller-owned buffer space and passes one pointer per `ArgClass::Indirect`, argument shifting mirroring the existing sret convention; callee unmarshals to slot-shaped frame storage at entry.
- **Still refused, loudly**: arrays crossing calls, imageless (variant-dependent) enums crossing calls, whole-aggregate marshalling through arbitrary pointers.

## Verification

Verified by execution at integration: `{u8,i32,u8}` by-value through a two-level call chain (42), Option enum matched by value, nested compact struct, mixed `i64`+struct+`bool` signature, take-and-return compact aggregates, and the ArrayBuf std dogfood re-run gated/ungated (3/20/30/2 both). Three new codegen units including the gate-off inertness test; seven new gated CLI cases (`aggregate_layout` 31); `abi` 59, `aggregate_abi_matrix` 37, `arraybuf` 19; oracle-diff corpus audit green; full `test.sh` green except the four known uid-0 environmental failures, both harness failure formats checked.

Fixes RUE-1005

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_