### PR TITLE
RUE-993: resolve bare module receivers on demand during ctor reduction

### DIFF
--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1350,7 +1350,16 @@ impl<D: DeclarationPhase> Sema<'_, D> {
             return Ok(None);
         };
         let module_file_id = if chain_rev.is_empty() {
-            let Some(binding) = self.module_bindings.get(&(file_id, recv_name)).cloned() else {
+            // Resolve through the declaration namespace, not the raw binding
+            // table: while declarations are being bound, the defining file's
+            // import constant may not be collected yet. A struct field like
+            // `index: std.strmap.StrMap(u64)` reduces `StrMap`'s body during
+            // field resolution, and the nested `let U64s = arraybuf.ArrayBuf(..)`
+            // inside that body names an import of *strmap's* file that nothing
+            // has demanded before — a raw lookup miss here silently made the
+            // whole reduction non-evaluable and surfaced as E1200 (RUE-993).
+            // The re-export chain branch below already resolves on demand.
+            let Some(binding) = self.resolve_module_binding_in_file(file_id, recv_name)? else {
                 return Ok(None);
             };
             let Some(module_id) = binding.ty.as_module() else {

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -1328,7 +1328,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     /// constant dependency. Once declaration binding completes, the table is
     /// authoritative: body analysis never rediscovers imports or mutates the
     /// source-declaration namespace after the [`super::BoundSema`] boundary.
-    fn resolve_module_binding_in_file(
+    pub(crate) fn resolve_module_binding_in_file(
         &mut self,
         file_id: FileId,
         name: Spur,

--- a/crates/rue-cli-tests/cases/comptime_cross_module.toml
+++ b/crates/rue-cli-tests/cases/comptime_cross_module.toml
@@ -297,3 +297,104 @@ fn main() -> i32 {
 """ },
 ]
 exit_code = 42
+
+# --- RUE-993: named struct fields retaining specializations whose ctor
+# bodies contain module-qualified nested constructor calls. Field-type
+# resolution reduces the ctor body during declaration binding, before the
+# defining file's import constants are collected; the nested `mk.Mk(T)` /
+# `arraybuf.ArrayBuf(u64)` receiver must resolve through the declaration
+# namespace (on-demand), not the raw binding table, or the whole reduction
+# silently degrades to E1200. ---
+[[case]]
+name = "struct_field_retains_ctor_with_nested_module_call"
+description = "A named struct retains `wrap.Wrap(i32)` whose body opens with `let Inner = mk.Mk(T)` from a third module (RUE-993)."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "mk.rue", source = """
+pub fn Mk(comptime T: type) -> type {
+    struct { value: T }
+}
+""" },
+  { path = "wrap.rue", source = """
+const mk = @import("mk.rue");
+
+pub fn Wrap(comptime T: type) -> type {
+    let Inner = mk.Mk(T);
+    struct {
+        inner: Inner,
+        fn make(v: T) -> Self {
+            let I = mk.Mk(T);
+            Self { inner: I { value: v } }
+        }
+        fn get(borrow self) -> T { self.inner.value }
+    }
+}
+""" },
+  { path = "main.rue", source = """
+const wrap = @import("wrap.rue");
+
+pub struct Holder {
+    w: wrap.Wrap(i32),
+
+    fn new() -> Self {
+        let W = wrap.Wrap(i32);
+        Self { w: W.make(7) }
+    }
+}
+
+fn main() -> i32 {
+    let h = Holder.new();
+    h.w.get()
+}
+""" },
+]
+exit_code = 7
+
+[[case]]
+name = "struct_field_retains_std_strmap_specialization"
+description = "A public cross-module struct retains `std.strmap.StrMap(u64)` as a field and uses it at runtime (RUE-993)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "pool.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const OptU64 = std.option.Option(u64);
+
+pub struct Pool {
+    index: std.strmap.StrMap(u64),
+
+    fn new() -> Self {
+        let M = std.strmap.StrMap(u64);
+        Self { index: M.new(0) }
+    }
+
+    fn put(inout self, borrow key: StrBuf, value: u64) {
+        self.index.insert(borrow key, value);
+    }
+
+    fn get_or(borrow self, borrow key: StrBuf, fallback: u64) -> u64 {
+        match self.index.get(borrow key) { OptU64.Some(v) => v, OptU64.None => fallback }
+    }
+}
+""" },
+  { path = "main.rue", source = """
+const std = @import("std");
+const pool = @import("pool.rue");
+
+fn main() -> i32 {
+    let mut p = pool.Pool.new();
+    let k1: std.strbuf.StrBuf = "alpha";
+    let k2: std.strbuf.StrBuf = "beta";
+    let absent: std.strbuf.StrBuf = "absent";
+    p.put(borrow k1, 11);
+    p.put(borrow k2, 22);
+    println(@to_string(p.get_or(borrow k1, 0)));
+    println(@to_string(p.get_or(borrow k2, 0)));
+    println(@to_string(p.get_or(borrow absent, 99)));
+    0
+}
+""" },
+]
+exit_code = 0
+stdout = "11\n22\n99\n"


### PR DESCRIPTION
A named struct could not retain a specialization like `std.strmap.StrMap(u64)` as a field — the whole struct failed with `E1200: the type constructor 'std.strmap.StrMap' did not reduce to a concrete type at compile time`. The issue framed this as a cross-module public-struct limitation, but a same-file struct fails identically; and `ArrayBuf`/`Option` fields always worked while `StrMap`/`IntMap` failed.

## Root cause

The discriminating factor is the constructor *body*: `StrMap`'s body opens with `let U64s = arraybuf.ArrayBuf(u64)` — a **module-qualified nested constructor call**. Field-type resolution reduces the constructor body during declaration binding, and at that point nothing has yet demanded the constructor's own file's import constants. `eval_module_qualified_comptime_call` looked the bare receiver (`arraybuf`) up in the **raw** `module_bindings` table, missed, and returned "non-evaluable" — silently degrading the entire reduction to E1200 on the retaining struct. By body-analysis time all bindings exist, which is why the function-local `let M = std.strmap.StrMap(u64)` spelling worked and masked this for so long.

Minimal trigger (no std): a field of type `wrap.Wrap(u64)` where `wrap.rue`'s constructor opens with `let Inner = mk.Mk(T)` from a third module. Same-module nesting works (no binding lookup); local-let position works (body phase).

## Fix

Route the bare-receiver lookup through `resolve_module_binding_in_file` — the existing on-demand declaration-namespace path (RUE-603/RUE-724 machinery) that qualified type annotations and the re-export chain branch of this same function already use. Bumped that helper to `pub(crate)`. Collection failures still propagate as their real diagnostics rather than degrading to a lookup miss.

## Validation

- The issue's exact repro compiles and runs; a fuller runtime program (cross-module `Pool` with a `StrMap(u64)` field: insert two keys, hit both, miss a third) prints the expected values.
- Two regression cases added to `cli.comptime_cross_module`: the minimal three-module shape (compile + runtime exit code) and the std `StrMap`-field shape (runtime stdout), both pinned to RUE-993.
- Suites on this base: full CLI 1606 passed earlier and the filtered comptime_cross_module 11/11 after rebase; spec 2138; UI 193; rue-air 494. Formatting clean.

Follow-up: RUE-1008 tracks adopting retained `StrMap` indexes in the Rill/Mosaic example pools that worked around this bug.

Fixes RUE-993