### PR TITLE
RUE-795: canonicalize by-value type metadata

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -133,7 +133,6 @@ fn canonical_type_surface_has_one_checked_handle_and_private_storage_ids() {
     assert!(types.contains("pub fn try_kind(&self) -> Option<TypeKind>"));
     assert!(public_surface.contains("pub struct TypeInternPool"));
     assert!(pool.contains("pub fn all_types(&self) -> impl ExactSizeIterator<Item = Type> + '_"));
-    assert!(pool.contains("pub(crate) fn mark_struct_linear("));
     assert!(pool.contains("pub(crate) fn set_struct_destructor("));
     assert!(pool.contains("pub(crate) fn requalify_struct_destructor("));
 }

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -100,6 +100,30 @@ pub enum TypeValidationError {
     RecoveryType,
 }
 
+/// Canonical ownership properties derived from the by-value containment graph.
+///
+/// The mutable pool may temporarily leave an entry unanalyzed while named
+/// declarations are incomplete. Semantic finalization computes the whole graph
+/// in one bounded pass; types created later by specialization derive their facts
+/// from already-finalized children as they are interned.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct TypeContainmentFacts {
+    carries_linear: bool,
+    needs_drop: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TypeContainmentCycle {
+    pub(crate) root: Type,
+    pub(crate) path: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct TypeContainmentWork {
+    pub(crate) nodes: usize,
+    pub(crate) edges: usize,
+}
+
 impl TypeData {
     fn is_incomplete(&self) -> bool {
         matches!(
@@ -302,6 +326,11 @@ struct TypeInternPoolInner {
     /// Structural type deduplication: pointee -> canonical ptr mut `Type`.
     ptr_mut_map: HashMap<Type, Type>,
 
+    /// Ownership facts indexed in lockstep with `types`. `None` is permitted
+    /// only while declaration shells or a metadata mutation await the next
+    /// canonical containment pass.
+    containment_facts: Vec<Option<TypeContainmentFacts>>,
+
     /// Nominal struct lookup: (defining file, source name) -> canonical `Type`.
     struct_by_file_name: HashMap<(FileId, Spur), Type>,
 
@@ -390,6 +419,238 @@ impl TypeInternPoolInner {
     fn next_pool_index(&self) -> u32 {
         checked_pool_index(self.types.len())
             .expect("type intern pool exceeds the 24-bit Type payload capacity")
+    }
+
+    fn by_value_child_index(&self, ty: Type) -> Option<usize> {
+        match ty.kind() {
+            TypeKind::Struct(id) => Some(id.pool_index() as usize),
+            TypeKind::Enum(id) => Some(id.pool_index() as usize),
+            TypeKind::Array(id) => Some(id.pool_index() as usize),
+            _ => None,
+        }
+    }
+
+    fn containment_edges(&self) -> Vec<Vec<usize>> {
+        self.types
+            .iter()
+            .map(|entry| match entry {
+                TypeData::Struct(data) => data
+                    .def
+                    .fields
+                    .iter()
+                    .filter_map(|field| self.by_value_child_index(field.ty))
+                    .collect(),
+                TypeData::Enum(data) => data
+                    .def
+                    .variant_payloads
+                    .iter()
+                    .flatten()
+                    .filter_map(|&ty| self.by_value_child_index(ty))
+                    .collect(),
+                // Preserve the language's recursive-type diagnostic even for
+                // zero-length arrays: arrays are inline structural edges. The
+                // fact fold below gives a zero-length node zero ownership
+                // multiplicity, so it carries neither linearity nor drop glue.
+                TypeData::Array { element, .. } => {
+                    self.by_value_child_index(*element).into_iter().collect()
+                }
+                TypeData::ReservedStruct
+                | TypeData::DeclaredStruct(_)
+                | TypeData::DeclaredEnum(_)
+                | TypeData::PtrConst { .. }
+                | TypeData::PtrMut { .. } => Vec::new(),
+            })
+            .collect()
+    }
+
+    fn containment_cycle_path(&self, path: &[usize], repeated: usize) -> Vec<String> {
+        path.iter()
+            .copied()
+            .chain(std::iter::once(repeated))
+            .filter_map(|index| match &self.types[index] {
+                TypeData::Struct(data) => Some(data.def.name.clone()),
+                TypeData::Enum(data) => Some(data.def.name.clone()),
+                TypeData::Array { .. }
+                | TypeData::PtrConst { .. }
+                | TypeData::PtrMut { .. }
+                | TypeData::ReservedStruct
+                | TypeData::DeclaredStruct(_)
+                | TypeData::DeclaredEnum(_) => None,
+            })
+            .collect()
+    }
+
+    fn type_for_index(&self, index: usize) -> Type {
+        match &self.types[index] {
+            TypeData::Struct(_) | TypeData::DeclaredStruct(_) => {
+                Type::new_struct(StructId::from_pool_index(index as u32))
+            }
+            TypeData::Enum(_) | TypeData::DeclaredEnum(_) => {
+                Type::new_enum(EnumId::from_pool_index(index as u32))
+            }
+            TypeData::Array { .. } => Type::new_array(ArrayTypeId::from_pool_index(index as u32)),
+            TypeData::PtrConst { .. } => {
+                Type::new_ptr_const(PtrConstTypeId::from_pool_index(index as u32))
+            }
+            TypeData::PtrMut { .. } => {
+                Type::new_ptr_mut(PtrMutTypeId::from_pool_index(index as u32))
+            }
+            TypeData::ReservedStruct => Type::new_struct(StructId::from_pool_index(index as u32)),
+        }
+    }
+
+    /// Compute cycle, linearity, and drop facts from the one canonical
+    /// by-value graph. The explicit DFS stack makes both cycle detection and
+    /// postorder construction independent of the host call stack.
+    fn finalize_containment_metadata(
+        &mut self,
+    ) -> Result<TypeContainmentWork, TypeContainmentCycle> {
+        debug_assert_eq!(self.types.len(), self.containment_facts.len());
+        let edges = self.containment_edges();
+        let work = TypeContainmentWork {
+            nodes: edges.len(),
+            edges: edges.iter().map(Vec::len).sum(),
+        };
+        let mut color = vec![0u8; edges.len()];
+        let mut postorder = Vec::with_capacity(edges.len());
+        let mut path = Vec::new();
+
+        for root in 0..edges.len() {
+            if color[root] != 0 {
+                continue;
+            }
+            color[root] = 1;
+            path.push(root);
+            let mut stack = vec![(root, 0usize)];
+            while let Some((node, next_child)) = stack.last_mut() {
+                if let Some(&child) = edges[*node].get(*next_child) {
+                    *next_child += 1;
+                    match color[child] {
+                        0 => {
+                            color[child] = 1;
+                            path.push(child);
+                            stack.push((child, 0));
+                        }
+                        1 => {
+                            return Err(TypeContainmentCycle {
+                                root: self.type_for_index(root),
+                                path: self.containment_cycle_path(&path, child),
+                            });
+                        }
+                        2 => {}
+                        _ => unreachable!("containment DFS color"),
+                    }
+                } else {
+                    let (finished, _) = stack.pop().expect("non-empty DFS stack");
+                    let popped = path.pop().expect("DFS path matches stack");
+                    debug_assert_eq!(finished, popped);
+                    color[finished] = 2;
+                    postorder.push(finished);
+                }
+            }
+        }
+
+        let mut facts = vec![TypeContainmentFacts::default(); self.types.len()];
+        for &index in &postorder {
+            let mut value = match &self.types[index] {
+                TypeData::Struct(data) => TypeContainmentFacts {
+                    carries_linear: data.def.is_linear,
+                    needs_drop: data.def.destructor.is_some(),
+                },
+                TypeData::Enum(_)
+                | TypeData::Array { .. }
+                | TypeData::PtrConst { .. }
+                | TypeData::PtrMut { .. } => TypeContainmentFacts::default(),
+                TypeData::ReservedStruct
+                | TypeData::DeclaredStruct(_)
+                | TypeData::DeclaredEnum(_) => continue,
+            };
+            let has_values = !matches!(self.types[index], TypeData::Array { len: 0, .. });
+            if has_values {
+                for &child in &edges[index] {
+                    value.carries_linear |= facts[child].carries_linear;
+                    value.needs_drop |= facts[child].needs_drop;
+                }
+            }
+            facts[index] = value;
+        }
+
+        for (index, value) in facts.iter().copied().enumerate() {
+            if value.carries_linear {
+                if let TypeData::Struct(data) = &mut self.types[index] {
+                    data.def.is_linear = true;
+                }
+            }
+        }
+        self.containment_facts = facts.into_iter().map(Some).collect();
+        Ok(work)
+    }
+
+    fn facts_for_type(&self, ty: Type) -> Option<TypeContainmentFacts> {
+        match ty.kind() {
+            TypeKind::Struct(id) => self
+                .containment_facts
+                .get(id.pool_index() as usize)
+                .copied()?,
+            TypeKind::Enum(id) => self
+                .containment_facts
+                .get(id.pool_index() as usize)
+                .copied()?,
+            TypeKind::Array(id) => self
+                .containment_facts
+                .get(id.pool_index() as usize)
+                .copied()?,
+            TypeKind::PtrConst(_) | TypeKind::PtrMut(_) => Some(TypeContainmentFacts::default()),
+            _ => Some(TypeContainmentFacts::default()),
+        }
+    }
+
+    fn incremental_facts(&self, entry: &TypeData) -> Option<TypeContainmentFacts> {
+        let mut facts = match entry {
+            TypeData::Struct(data) => TypeContainmentFacts {
+                carries_linear: data.def.is_linear,
+                needs_drop: data.def.destructor.is_some(),
+            },
+            TypeData::Enum(_)
+            | TypeData::Array { .. }
+            | TypeData::PtrConst { .. }
+            | TypeData::PtrMut { .. } => TypeContainmentFacts::default(),
+            TypeData::ReservedStruct | TypeData::DeclaredStruct(_) | TypeData::DeclaredEnum(_) => {
+                return None;
+            }
+        };
+        let mut merge = |child: Type| -> Option<()> {
+            if self.by_value_child_index(child).is_none() {
+                return Some(());
+            }
+            let child = self.facts_for_type(child)?;
+            facts.carries_linear |= child.carries_linear;
+            facts.needs_drop |= child.needs_drop;
+            Some(())
+        };
+        match entry {
+            TypeData::Struct(data) => {
+                for field in &data.def.fields {
+                    merge(field.ty)?;
+                }
+            }
+            TypeData::Enum(data) => {
+                for &child in data.def.variant_payloads.iter().flatten() {
+                    merge(child)?;
+                }
+            }
+            TypeData::Array { element, len } if *len != 0 => merge(*element)?,
+            TypeData::Array { .. } => {}
+            TypeData::PtrConst { .. } | TypeData::PtrMut { .. } => {}
+            TypeData::ReservedStruct | TypeData::DeclaredStruct(_) | TypeData::DeclaredEnum(_) => {
+                unreachable!()
+            }
+        }
+        Some(facts)
+    }
+
+    fn invalidate_containment_metadata(&mut self) {
+        self.containment_facts.fill(None);
     }
 
     #[inline]
@@ -537,6 +798,53 @@ impl TypeInternPoolInner {
 
     fn validate_complete_type(&self, ty: Type) -> Result<(), TypeValidationError> {
         self.validate_type_inner(ty, ValidationMode::Complete, &mut TypeVisitSet::new())
+    }
+
+    /// Validate a query's root handle without rewalking a frozen pool's
+    /// already-validated graph. This catches invalid encodings, out-of-range
+    /// indices, and wrong-kind compact handles while keeping canonical fact
+    /// queries O(1) and independent of the host call stack.
+    fn validate_complete_root(&self, ty: Type) -> Result<(), TypeValidationError> {
+        let kind = ty.try_kind().ok_or(TypeValidationError::InvalidEncoding)?;
+        let (index, expected) = match kind {
+            TypeKind::I8
+            | TypeKind::I16
+            | TypeKind::I32
+            | TypeKind::I64
+            | TypeKind::U8
+            | TypeKind::U16
+            | TypeKind::U32
+            | TypeKind::U64
+            | TypeKind::Bool
+            | TypeKind::Unit
+            | TypeKind::Never
+            | TypeKind::ComptimeType
+            | TypeKind::Module(_) => return Ok(()),
+            TypeKind::Error => return Err(TypeValidationError::RecoveryType),
+            TypeKind::Struct(id) => (id.pool_index(), PoolEntryKind::Struct),
+            TypeKind::Enum(id) => (id.pool_index(), PoolEntryKind::Enum),
+            TypeKind::Array(id) => (id.pool_index(), PoolEntryKind::Array),
+            TypeKind::PtrConst(id) => (id.pool_index(), PoolEntryKind::PtrConst),
+            TypeKind::PtrMut(id) => (id.pool_index(), PoolEntryKind::PtrMut),
+        };
+        let entry = self
+            .types
+            .get(index as usize)
+            .ok_or(TypeValidationError::PoolIndexOutOfRange)?;
+        if entry.kind() != expected {
+            return if matches!(entry, TypeData::ReservedStruct) {
+                Err(TypeValidationError::ReservedEntry)
+            } else {
+                Err(TypeValidationError::KindMismatch)
+            };
+        }
+        if matches!(
+            entry,
+            TypeData::DeclaredStruct(_) | TypeData::DeclaredEnum(_)
+        ) {
+            return Err(TypeValidationError::IncompleteDefinition);
+        }
+        Ok(())
     }
 
     fn validate_type_inner(
@@ -1158,6 +1466,7 @@ impl TypeInternPool {
                 array_map: HashMap::new(),
                 ptr_const_map: HashMap::new(),
                 ptr_mut_map: HashMap::new(),
+                containment_facts: Vec::new(),
                 struct_by_file_name: HashMap::new(),
                 enum_by_file_name: HashMap::new(),
                 symbol_paths: HashMap::new(),
@@ -1174,7 +1483,7 @@ impl TypeInternPool {
     /// remain separate: type definitions retain stable string names rather than
     /// storing a [`Spur`] from a CFG or codegen request.
     pub fn freeze(self) -> FrozenTypeInternPool {
-        let inner = self
+        let mut inner = self
             .inner
             .into_inner()
             .unwrap_or_else(PoisonError::into_inner);
@@ -1186,6 +1495,14 @@ impl TypeInternPool {
         {
             panic!("cannot freeze incomplete type-pool entry {index}: {entry:?}");
         }
+        inner
+            .finalize_containment_metadata()
+            .unwrap_or_else(|cycle| {
+                panic!(
+                    "cannot freeze cyclic by-value type graph: {}",
+                    cycle.path.join(" -> ")
+                )
+            });
         FrozenTypeInternPool {
             inner: Arc::new(inner),
         }
@@ -1362,7 +1679,16 @@ impl TypeInternPool {
         let struct_id = StructId::from_pool_index(pool_index);
         let ty = Type::new_struct(struct_id);
 
-        inner.types.push(TypeData::Struct(StructData { name, def }));
+        let mut entry = TypeData::Struct(StructData { name, def });
+        let facts = inner.incremental_facts(&entry);
+        if facts.is_some_and(|facts| facts.carries_linear) {
+            let TypeData::Struct(data) = &mut entry else {
+                unreachable!()
+            };
+            data.def.is_linear = true;
+        }
+        inner.types.push(entry);
+        inner.containment_facts.push(facts);
         inner.struct_by_file_name.insert(key, ty);
 
         (struct_id, true)
@@ -1395,6 +1721,7 @@ impl TypeInternPool {
         inner
             .types
             .push(TypeData::DeclaredStruct(StructData { name, def: shell }));
+        inner.containment_facts.push(None);
         inner.struct_by_file_name.insert(key, ty);
         (StructId::from_pool_index(pool_index), true)
     }
@@ -1424,6 +1751,7 @@ impl TypeInternPool {
 
         let pool_index = inner.next_pool_index();
         inner.types.push(TypeData::ReservedStruct);
+        inner.containment_facts.push(None);
 
         StructId::from_pool_index(pool_index)
     }
@@ -1469,7 +1797,16 @@ impl TypeInternPool {
 
         // Update the placeholder with actual data
         let key = (def.file_id, name);
-        inner.types[pool_index] = TypeData::Struct(StructData { name, def });
+        let mut entry = TypeData::Struct(StructData { name, def });
+        let facts = inner.incremental_facts(&entry);
+        if facts.is_some_and(|facts| facts.carries_linear) {
+            let TypeData::Struct(data) = &mut entry else {
+                unreachable!()
+            };
+            data.def.is_linear = true;
+        }
+        inner.types[pool_index] = entry;
+        inner.containment_facts[pool_index] = facts;
 
         // Register in the defining-file lookup.
         inner
@@ -1506,6 +1843,9 @@ impl TypeInternPool {
                 pool_index, other
             ),
         }
+        // Named declarations are still collecting explicit linear/destructor
+        // metadata. Keep their facts unknown until semantic finalization.
+        inner.containment_facts[pool_index] = None;
     }
 
     /// Register a new enum (nominal - no deduplication).
@@ -1542,7 +1882,10 @@ impl TypeInternPool {
         let enum_id = EnumId::from_pool_index(pool_index);
         let ty = Type::new_enum(enum_id);
 
-        inner.types.push(TypeData::Enum(EnumData { name, def }));
+        let entry = TypeData::Enum(EnumData { name, def });
+        let facts = inner.incremental_facts(&entry);
+        inner.types.push(entry);
+        inner.containment_facts.push(facts);
         inner.enum_by_file_name.insert(key, ty);
 
         (enum_id, true)
@@ -1575,6 +1918,7 @@ impl TypeInternPool {
         inner
             .types
             .push(TypeData::DeclaredEnum(EnumData { name, def: shell }));
+        inner.containment_facts.push(None);
         inner.enum_by_file_name.insert(key, ty);
         (EnumId::from_pool_index(pool_index), true)
     }
@@ -1608,6 +1952,7 @@ impl TypeInternPool {
                 pool_index, other
             ),
         }
+        inner.containment_facts[pool_index] = None;
     }
 
     /// Intern an array after validating its canonical child in this pool.
@@ -1636,7 +1981,10 @@ impl TypeInternPool {
         let pool_index = inner.next_pool_index();
         let ty = Type::new_array(ArrayTypeId::from_pool_index(pool_index));
 
-        inner.types.push(TypeData::Array { element, len });
+        let entry = TypeData::Array { element, len };
+        let facts = inner.incremental_facts(&entry);
+        inner.types.push(entry);
+        inner.containment_facts.push(facts);
         inner.array_map.insert(key, ty);
 
         Ok(ty)
@@ -1666,7 +2014,10 @@ impl TypeInternPool {
         let pool_index = inner.next_pool_index();
         let ty = Type::new_ptr_const(PtrConstTypeId::from_pool_index(pool_index));
 
-        inner.types.push(TypeData::PtrConst { pointee });
+        let entry = TypeData::PtrConst { pointee };
+        let facts = inner.incremental_facts(&entry);
+        inner.types.push(entry);
+        inner.containment_facts.push(facts);
         inner.ptr_const_map.insert(pointee, ty);
 
         Ok(ty)
@@ -1696,7 +2047,10 @@ impl TypeInternPool {
         let pool_index = inner.next_pool_index();
         let ty = Type::new_ptr_mut(PtrMutTypeId::from_pool_index(pool_index));
 
-        inner.types.push(TypeData::PtrMut { pointee });
+        let entry = TypeData::PtrMut { pointee };
+        let facts = inner.incremental_facts(&entry);
+        inner.types.push(entry);
+        inner.containment_facts.push(facts);
         inner.ptr_mut_map.insert(pointee, ty);
 
         Ok(ty)
@@ -1997,16 +2351,6 @@ impl TypeInternPool {
         inner.enum_symbol_name(enum_id)
     }
 
-    /// Monotonically mark a complete struct as linear during semantic
-    /// metadata finalization.
-    ///
-    /// This operation is idempotent and cannot change nominal identity,
-    /// fields, or any other completed definition data.
-    pub(crate) fn mark_struct_linear(&self, struct_id: StructId) {
-        let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
-        inner.struct_def_mut(struct_id).is_linear = true;
-    }
-
     /// Assign a complete struct's destructor symbol exactly once.
     ///
     /// Destructor discovery is a semantic metadata-finalization step. It
@@ -2024,6 +2368,7 @@ impl TypeInternPool {
             "struct destructor metadata can only be assigned once"
         );
         def.destructor = Some(symbol);
+        inner.invalidate_containment_metadata();
     }
 
     /// Requalify an already-assigned destructor symbol after nominal-name
@@ -2047,6 +2392,43 @@ impl TypeInternPool {
             "destructor requalification requires a different symbol"
         );
         *destructor = symbol;
+    }
+
+    /// Finalize the canonical by-value graph after declaration fields,
+    /// payloads, destructors, and explicit linear markers are known.
+    pub(crate) fn finalize_containment_metadata(
+        &self,
+    ) -> Result<TypeContainmentWork, TypeContainmentCycle> {
+        self.inner
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .finalize_containment_metadata()
+    }
+
+    pub(crate) fn try_type_carries_linear(&self, ty: Type) -> Option<bool> {
+        self.inner
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .facts_for_type(ty)
+            .map(|facts| facts.carries_linear)
+    }
+
+    pub(crate) fn try_type_needs_drop(&self, ty: Type) -> Option<bool> {
+        self.inner
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .facts_for_type(ty)
+            .map(|facts| facts.needs_drop)
+    }
+
+    pub(crate) fn type_carries_linear(&self, ty: Type) -> bool {
+        self.try_type_carries_linear(ty)
+            .expect("linearity query requires finalized containment metadata")
+    }
+
+    pub(crate) fn type_needs_drop(&self, ty: Type) -> bool {
+        self.try_type_needs_drop(ty)
+            .expect("drop query requires finalized containment metadata")
     }
 
     /// Get an array type definition by ArrayTypeId.
@@ -2252,6 +2634,28 @@ impl TypeInternPool {
 impl FrozenTypeInternPool {
     pub fn new() -> Self {
         TypeInternPool::new().freeze()
+    }
+
+    /// Whether `ty` transitively contains a linear value by value.
+    pub fn type_carries_linear(&self, ty: Type) -> bool {
+        self.inner
+            .validate_complete_root(ty)
+            .expect("containment query requires a complete canonical type handle");
+        self.inner
+            .facts_for_type(ty)
+            .expect("frozen type pool has complete containment metadata")
+            .carries_linear
+    }
+
+    /// Whether dropping `ty` requires a destructor or nested drop glue.
+    pub fn type_needs_drop(&self, ty: Type) -> bool {
+        self.inner
+            .validate_complete_root(ty)
+            .expect("containment query requires a complete canonical type handle");
+        self.inner
+            .facts_for_type(ty)
+            .expect("frozen type pool has complete containment metadata")
+            .needs_drop
     }
 
     /// Return the flattened runtime ABI width of `ty` in eight-byte slots.
@@ -2552,6 +2956,7 @@ impl Clone for TypeInternPool {
                 array_map: inner.array_map.clone(),
                 ptr_const_map: inner.ptr_const_map.clone(),
                 ptr_mut_map: inner.ptr_mut_map.clone(),
+                containment_facts: inner.containment_facts.clone(),
                 struct_by_file_name: inner.struct_by_file_name.clone(),
                 enum_by_file_name: inner.enum_by_file_name.clone(),
                 symbol_paths: inner.symbol_paths.clone(),
@@ -2856,19 +3261,16 @@ mod tests {
     fn struct_metadata_finalization_is_narrow_and_monotonic() {
         let declarations = ThreadedRodeo::default();
         let pool = TypeInternPool::new();
-        let (owner, _) = pool.register_struct(
-            declarations.get_or_intern("Owner"),
-            struct_def(
-                "Owner",
-                vec![StructField {
-                    name: "value".into(),
-                    ty: Type::I64,
-                }],
-            ),
+        let mut owner_def = struct_def(
+            "Owner",
+            vec![StructField {
+                name: "value".into(),
+                ty: Type::I64,
+            }],
         );
+        owner_def.is_linear = true;
+        let (owner, _) = pool.register_struct(declarations.get_or_intern("Owner"), owner_def);
 
-        pool.mark_struct_linear(owner);
-        pool.mark_struct_linear(owner);
         pool.set_struct_destructor(owner, "Owner.__drop".into());
         pool.requalify_struct_destructor(owner, "Owner$left.__drop".into());
 
@@ -2878,6 +3280,106 @@ mod tests {
         assert_eq!(def.name, "Owner");
         assert_eq!(def.fields.len(), 1);
         assert_eq!(def.fields[0].ty, Type::I64);
+    }
+
+    #[test]
+    fn containment_metadata_work_is_linear_for_eight_thousand_types() {
+        const COUNT: usize = 8_000;
+        let declarations = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let ids = (0..COUNT)
+            .map(|_| pool.reserve_struct_id())
+            .collect::<Vec<_>>();
+
+        for (index, &id) in ids.iter().enumerate() {
+            let name = format!("Chain{index}");
+            let fields = ids
+                .get(index + 1)
+                .map(|&next| {
+                    vec![StructField {
+                        name: "next".into(),
+                        ty: Type::new_struct(next),
+                    }]
+                })
+                .unwrap_or_default();
+            let mut def = struct_def(&name, fields);
+            if index + 1 == COUNT {
+                def.is_linear = true;
+                def.destructor = Some(format!("{name}.__drop"));
+            }
+            pool.complete_struct_registration(id, declarations.get_or_intern(&name), def);
+        }
+
+        let work = pool.finalize_containment_metadata().unwrap();
+        assert_eq!(work.nodes, COUNT);
+        assert_eq!(work.edges, COUNT - 1);
+        assert!(pool.type_carries_linear(Type::new_struct(ids[0])));
+        assert!(pool.type_needs_drop(Type::new_struct(ids[0])));
+    }
+
+    #[test]
+    fn late_types_derive_facts_and_zero_arrays_and_pointers_terminate_containment() {
+        let declarations = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let mut resource = struct_def("Resource", vec![]);
+        resource.is_linear = true;
+        resource.destructor = Some("Resource.__drop".into());
+        let (resource, _) = pool.register_struct(declarations.get_or_intern("Resource"), resource);
+        pool.finalize_containment_metadata().unwrap();
+
+        let empty_array = pool
+            .try_intern_array(Type::new_struct(resource), 0)
+            .unwrap();
+        let one_array = pool
+            .try_intern_array(Type::new_struct(resource), 1)
+            .unwrap();
+        let pointer = pool.try_intern_ptr_mut(Type::new_struct(resource)).unwrap();
+        let choice = EnumDef {
+            name: "Choice".into(),
+            variants: vec!["Some".into(), "None".into()],
+            variant_payloads: vec![vec![one_array], vec![pointer]],
+            is_pub: false,
+            file_id: FileId::DEFAULT,
+        };
+        let (choice, _) = pool.register_enum(declarations.get_or_intern("Choice"), choice);
+        let (wrapper, _) = pool.register_struct(
+            declarations.get_or_intern("Wrapper"),
+            struct_def(
+                "Wrapper",
+                vec![StructField {
+                    name: "choice".into(),
+                    ty: Type::new_enum(choice),
+                }],
+            ),
+        );
+
+        assert!(!pool.type_carries_linear(empty_array));
+        assert!(!pool.type_needs_drop(empty_array));
+        assert!(pool.type_carries_linear(one_array));
+        assert!(pool.type_needs_drop(one_array));
+        assert!(!pool.type_carries_linear(pointer));
+        assert!(!pool.type_needs_drop(pointer));
+        assert!(pool.type_carries_linear(Type::new_enum(choice)));
+        assert!(pool.type_needs_drop(Type::new_enum(choice)));
+        assert!(pool.struct_def(wrapper).is_linear);
+
+        let frozen = pool.freeze();
+        assert!(frozen.type_carries_linear(Type::new_struct(wrapper)));
+        assert!(frozen.type_needs_drop(Type::new_struct(wrapper)));
+    }
+
+    #[test]
+    #[should_panic(expected = "complete canonical type handle")]
+    fn frozen_containment_queries_reject_wrong_kind_handles() {
+        let declarations = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let (owner, _) = pool.register_struct(
+            declarations.get_or_intern("Owner"),
+            struct_def("Owner", vec![]),
+        );
+        let frozen = pool.freeze();
+        let wrong_kind = Type::new_array(ArrayTypeId::from_pool_index(owner.pool_index()));
+        let _ = frozen.type_needs_drop(wrong_kind);
     }
 
     #[test]

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -721,7 +721,6 @@ impl<'a> DeclarationShells<'a> {
         self.sema
             .check_recursive_value_types()
             .map_err(|_| DeclarationInstallFailure::NominalShapeMismatch)?;
-        self.sema.propagate_field_linearity();
         self.sema
             .validate_deferred_ownership_gates()
             .map_err(|_| DeclarationInstallFailure::NominalShapeMismatch)?;

--- a/crates/rue-air/src/sema/builtins.rs
+++ b/crates/rue-air/src/sema/builtins.rs
@@ -7,6 +7,12 @@ use rue_builtins::BUILTIN_ENUMS;
 use super::{DeclarationPhase, Sema};
 use crate::types::{EnumDef, Type, TypeKind};
 
+#[derive(Clone, Copy)]
+enum OwnershipProperty {
+    Linearity,
+    Drop,
+}
+
 impl<'a> Sema<'a> {
     /// Phase 0: Inject compiler-provided enums.
     pub(crate) fn inject_builtin_types(&mut self) {
@@ -68,22 +74,6 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         self.type_pool.lang_item_type(crate::LangItem::StrBuf)
     }
 
-    /// Check if a type is a linear type.
-    /// Only struct types can be linear - primitives and other types are not linear.
-    pub(crate) fn is_type_linear(&self, ty: Type) -> bool {
-        match ty.kind() {
-            TypeKind::Struct(struct_id) => {
-                let struct_def = self
-                    .type_pool
-                    .try_struct_def(struct_id)
-                    .expect("linearity queries require a complete struct definition");
-                struct_def.is_linear
-            }
-            // Only struct types can be linear
-            _ => false,
-        }
-    }
-
     /// Check if a type carries a linear value when stored by value: a linear
     /// struct itself, or an array whose element type carries one.
     ///
@@ -95,30 +85,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     /// declaration fixpoint the struct flags are the values being converged;
     /// outside that fixpoint callers require finalized declaration ownership.
     pub(crate) fn type_carries_linear(&self, ty: Type) -> bool {
-        match ty.kind() {
-            TypeKind::Struct(_) => self.is_type_linear(ty),
-            TypeKind::Array(array_id) => {
-                let (element_type, _length) = self.type_pool.array_def(array_id);
-                self.type_carries_linear(element_type)
-            }
-            // An enum carries a linear value when any variant payload does
-            // (RUE-221, multiplicity join: a linear-payload variant makes the
-            // whole enum linear/must-consume). The discriminant selects the
-            // active variant at runtime, so a conservative static check
-            // requires consumption if *any* variant could carry one.
-            TypeKind::Enum(enum_id) => {
-                let enum_def = self
-                    .type_pool
-                    .try_enum_def(enum_id)
-                    .expect("linearity queries require a complete enum definition");
-                enum_def
-                    .variant_payloads
-                    .iter()
-                    .flatten()
-                    .any(|&payload_ty| self.type_carries_linear(payload_ty))
-            }
-            _ => false,
-        }
+        self.type_pool.type_carries_linear(ty)
     }
 
     /// Whether a type has drop glue — a destructor that runs at scope exit,
@@ -134,35 +101,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     /// Every reachable nominal definition and destructor assignment must be
     /// finalized before this query is authoritative.
     pub(crate) fn type_has_drop_glue(&self, ty: Type) -> bool {
-        match ty.kind() {
-            TypeKind::Struct(struct_id) => {
-                let struct_def = self
-                    .type_pool
-                    .try_struct_def(struct_id)
-                    .expect("drop-glue queries require a complete struct definition");
-                struct_def.destructor.is_some()
-                    || struct_def
-                        .fields
-                        .iter()
-                        .any(|f| self.type_has_drop_glue(f.ty))
-            }
-            TypeKind::Enum(enum_id) => {
-                let enum_def = self
-                    .type_pool
-                    .try_enum_def(enum_id)
-                    .expect("drop-glue queries require a complete enum definition");
-                enum_def
-                    .variant_payloads
-                    .iter()
-                    .flatten()
-                    .any(|&payload_ty| self.type_has_drop_glue(payload_ty))
-            }
-            TypeKind::Array(array_id) => {
-                let (element_type, _length) = self.type_pool.array_def(array_id);
-                self.type_has_drop_glue(element_type)
-            }
-            _ => false,
-        }
+        self.type_pool.type_needs_drop(ty)
     }
 
     /// Whether declaration finalization can still change an ownership query
@@ -182,52 +121,88 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     /// Return only declaration-time ownership facts that cannot be invalidated
     /// by later payload completion or infectious-linearity propagation.
     pub(crate) fn known_linear_during_binding(&self, ty: Type) -> Option<bool> {
-        match ty.kind() {
-            TypeKind::Struct(id) => self
-                .type_pool
-                .struct_metadata(id)
-                .and_then(|metadata| metadata.is_linear.then_some(true)),
-            TypeKind::Enum(id) => {
-                let def = self.type_pool.try_enum_def(id)?;
-                let mut deferred = false;
-                for payload in def.variant_payloads.iter().flatten() {
-                    match self.known_linear_during_binding(*payload) {
-                        Some(true) => return Some(true),
-                        Some(false) => {}
-                        None => deferred = true,
-                    }
-                }
-                (!deferred).then_some(false)
-            }
-            TypeKind::Array(id) => self.known_linear_during_binding(self.type_pool.array_def(id).0),
-            _ => Some(false),
-        }
+        self.known_ownership_during_binding(ty, OwnershipProperty::Linearity)
     }
 
     /// Return only declaration-time drop-glue facts that cannot be invalidated
     /// by later payload completion or destructor collection.
     pub(crate) fn known_drop_glue_during_binding(&self, ty: Type) -> Option<bool> {
-        match ty.kind() {
-            TypeKind::Struct(id) => self
-                .type_pool
-                .struct_metadata(id)
-                .and_then(|metadata| metadata.destructor.is_some().then_some(true)),
-            TypeKind::Enum(id) => {
-                let def = self.type_pool.try_enum_def(id)?;
-                let mut deferred = false;
-                for payload in def.variant_payloads.iter().flatten() {
-                    match self.known_drop_glue_during_binding(*payload) {
-                        Some(true) => return Some(true),
-                        Some(false) => {}
-                        None => deferred = true,
+        self.known_ownership_during_binding(ty, OwnershipProperty::Drop)
+    }
+
+    fn known_ownership_during_binding(
+        &self,
+        root: Type,
+        property: OwnershipProperty,
+    ) -> Option<bool> {
+        let mut results = std::collections::HashMap::<Type, Option<bool>>::new();
+        let mut visiting = std::collections::HashSet::new();
+        let mut stack = vec![(root, false)];
+        while let Some((ty, expanded)) = stack.pop() {
+            if results.contains_key(&ty) {
+                continue;
+            }
+            if expanded {
+                visiting.remove(&ty);
+                let value = match ty.kind() {
+                    TypeKind::Struct(id) => {
+                        self.type_pool
+                            .struct_metadata(id)
+                            .and_then(|metadata| match property {
+                                OwnershipProperty::Linearity => metadata.is_linear.then_some(true),
+                                OwnershipProperty::Drop => {
+                                    metadata.destructor.is_some().then_some(true)
+                                }
+                            })
+                    }
+                    TypeKind::Enum(id) => self.type_pool.try_enum_def(id).and_then(|def| {
+                        let mut unknown = false;
+                        for &child in def.variant_payloads.iter().flatten() {
+                            match results.get(&child).copied().flatten() {
+                                Some(true) => return Some(true),
+                                Some(false) => {}
+                                None => unknown = true,
+                            }
+                        }
+                        (!unknown).then_some(false)
+                    }),
+                    TypeKind::Array(id) => {
+                        let (element, len) = self.type_pool.array_def(id);
+                        if len == 0 {
+                            Some(false)
+                        } else {
+                            results.get(&element).copied().flatten()
+                        }
+                    }
+                    _ => Some(false),
+                };
+                results.insert(ty, value);
+                continue;
+            }
+
+            if !visiting.insert(ty) {
+                continue;
+            }
+            stack.push((ty, true));
+            match ty.kind() {
+                TypeKind::Enum(id) => {
+                    if let Some(def) = self.type_pool.try_enum_def(id) {
+                        for &child in def.variant_payloads.iter().flatten().rev() {
+                            if !visiting.contains(&child) {
+                                stack.push((child, false));
+                            }
+                        }
                     }
                 }
-                (!deferred).then_some(false)
+                TypeKind::Array(id) => {
+                    let (child, len) = self.type_pool.array_def(id);
+                    if len != 0 && !visiting.contains(&child) {
+                        stack.push((child, false));
+                    }
+                }
+                _ => {}
             }
-            TypeKind::Array(id) => {
-                self.known_drop_glue_during_binding(self.type_pool.array_def(id).0)
-            }
-            _ => Some(false),
         }
+        results.get(&root).copied().flatten()
     }
 }

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -23,16 +23,6 @@ use crate::inference::{FunctionSig, MethodSig};
 use crate::path_norm::{mangle_symbol_component, normalize_module_path};
 use crate::types::{EnumDef, EnumId, StructDef, StructField, StructId, Type, TypeKind};
 
-/// A node in the "contains by value" type graph, used by
-/// [`Sema::check_recursive_value_types`] to detect infinite-size cycles
-/// (RUE-264). Only aggregate types (struct, enum) can participate in such a
-/// cycle; the array element is followed transitively but is not itself a node.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum TypeNode {
-    Struct(StructId),
-    Enum(EnumId),
-}
-
 impl<'a, D: DeclarationPhase> Sema<'a, D> {
     pub(crate) fn source_function_name(&self, internal_name: Spur) -> Spur {
         self.function_source_names
@@ -522,8 +512,13 @@ impl<'a> Sema<'a> {
             // recurses through the field graph and overflows the host stack
             // (RUE-264).
             self.check_recursive_value_types()?;
-            self.propagate_field_linearity();
             self.resolve_remaining_declarations()?;
+            // Destructor discovery can change drop facts without changing the
+            // already-proven-acyclic graph. Refresh the same canonical metadata
+            // before deferred ownership gates and body analysis query it.
+            self.type_pool
+                .finalize_containment_metadata()
+                .expect("destructor collection cannot introduce containment cycles");
             self.validate_deferred_ownership_gates()?;
             // Now that value constants are separated from module bindings, reject
             // any value-constant name that collides with a function/struct/enum
@@ -853,42 +848,6 @@ impl<'a> Sema<'a> {
         Ok(())
     }
 
-    /// Propagate linearity from fields to containing structs (infectious
-    /// linearity, spec 3.8:57 / RUE-40).
-    ///
-    /// A struct with a field whose type carries a linear value (directly,
-    /// through an array, or through a nested struct) must itself be linear:
-    /// if the container could be implicitly dropped, the linear field would
-    /// be silently dropped with it. Runs to a fixpoint so linearity flows
-    /// through arbitrarily deep nestings. The causing field is recorded in
-    /// [`Sema::infectious_linear`] for diagnostics.
-    pub(crate) fn propagate_field_linearity(&mut self) {
-        let struct_ids: Vec<StructId> = self.type_pool.all_struct_ids();
-        loop {
-            let mut changed = false;
-            for &struct_id in &struct_ids {
-                let def = self.type_pool.struct_def(struct_id);
-                if def.is_linear {
-                    continue;
-                }
-                let Some(cause) = def
-                    .fields
-                    .iter()
-                    .find(|field| self.type_carries_linear(field.ty))
-                else {
-                    continue;
-                };
-                let cause = (cause.name.clone(), self.format_type_name(cause.ty));
-                self.type_pool.mark_struct_linear(struct_id);
-                self.infectious_linear.insert(struct_id, cause);
-                changed = true;
-            }
-            if !changed {
-                break;
-            }
-        }
-    }
-
     /// Resolve struct field types. Must run before @copy validation.
     pub(crate) fn resolve_struct_fields(&mut self) -> CompileResult<()> {
         for (_, inst) in self.rir.iter() {
@@ -1009,101 +968,68 @@ impl<'a> Sema<'a> {
     /// A pointer field (`ptr const T` / `ptr mut T`) is indirection, not
     /// by-value containment, so it breaks the cycle and is allowed — that is
     /// how a recursive data structure is written.
-    pub(crate) fn check_recursive_value_types(&self) -> CompileResult<()> {
-        // Drive from each user-declared struct/enum so the diagnostic points at
-        // the offending declaration (the RIR carries the span; the type pool
-        // does not).
-        for (_, inst) in self.rir.iter() {
-            let (name_sym, span) = match &inst.data {
-                InstData::StructDecl { name, .. } | InstData::EnumDecl { name, .. } => {
-                    (*name, inst.span)
+    pub(crate) fn check_recursive_value_types(&mut self) -> CompileResult<()> {
+        let explicitly_linear: HashSet<_> = self
+            .type_pool
+            .all_struct_ids()
+            .into_iter()
+            .filter(|&id| self.type_pool.struct_def(id).is_linear)
+            .collect();
+        if let Err(cycle) = self.type_pool.finalize_containment_metadata() {
+            // Drive diagnostics from the source declaration so the canonical
+            // graph remains span-free while E0483 retains its exact span.
+            for (_, inst) in self.rir.iter() {
+                let (name_sym, span) = match &inst.data {
+                    InstData::StructDecl { name, .. } | InstData::EnumDecl { name, .. } => {
+                        (*name, inst.span)
+                    }
+                    _ => continue,
+                };
+                let key = (span.file_id, name_sym);
+                let start_ty = if let Some(&struct_id) = self.structs_by_file_name.get(&key) {
+                    Type::new_struct(struct_id)
+                } else if let Some(&enum_id) = self.enums_by_file_name.get(&key) {
+                    Type::new_enum(enum_id)
+                } else {
+                    continue;
+                };
+                if start_ty != cycle.root {
+                    continue;
                 }
-                _ => continue,
-            };
-            let key = (span.file_id, name_sym);
-            let start_ty = if let Some(&struct_id) = self.structs_by_file_name.get(&key) {
-                Type::new_struct(struct_id)
-            } else if let Some(&enum_id) = self.enums_by_file_name.get(&key) {
-                Type::new_enum(enum_id)
-            } else {
-                continue;
-            };
-
-            let mut on_path: HashSet<TypeNode> = HashSet::new();
-            let mut path: Vec<String> = Vec::new();
-            if let Some(cycle) = self.find_value_cycle(start_ty, &mut on_path, &mut path) {
                 let name = self.interner.resolve(&name_sym).to_string();
                 return Err(CompileError::new(
                     ErrorKind::RecursiveTypeInfiniteSize {
                         name,
-                        cycle: cycle.join(" -> "),
+                        cycle: cycle.path.join(" -> "),
                     },
                     span,
                 ));
             }
+            unreachable!("containment cycle root must be a source nominal declaration");
+        }
+
+        // The canonical pass has propagated infectious linearity. Preserve the
+        // first declaration-order causing field for the existing diagnostic
+        // note without maintaining a second propagation authority.
+        for struct_id in self.type_pool.all_struct_ids() {
+            if explicitly_linear.contains(&struct_id) {
+                continue;
+            }
+            let def = self.type_pool.struct_def(struct_id);
+            if !def.is_linear {
+                continue;
+            }
+            let Some(cause) = def
+                .fields
+                .iter()
+                .find(|field| self.type_pool.type_carries_linear(field.ty))
+            else {
+                continue;
+            };
+            let cause = (cause.name.clone(), self.format_type_name(cause.ty));
+            self.infectious_linear.insert(struct_id, cause);
         }
         Ok(())
-    }
-
-    /// Depth-first search for a by-value containment cycle in the type graph,
-    /// mirroring the traversal `drop_glue::type_needs_drop` performs (structs
-    /// recurse through fields, enums through variant payloads, arrays through
-    /// the element type; pointers and scalars terminate). Returns the cyclic
-    /// containment path (as type names) if `ty` transitively contains a struct
-    /// or enum already on the current path.
-    fn find_value_cycle(
-        &self,
-        ty: Type,
-        on_path: &mut HashSet<TypeNode>,
-        path: &mut Vec<String>,
-    ) -> Option<Vec<String>> {
-        match ty.kind() {
-            TypeKind::Struct(id) => {
-                let def = self.type_pool.struct_def(id);
-                if !on_path.insert(TypeNode::Struct(id)) {
-                    // Back-edge: this struct is already on the current path.
-                    let mut cycle = path.clone();
-                    cycle.push(def.name.clone());
-                    return Some(cycle);
-                }
-                path.push(def.name.clone());
-                for field in &def.fields {
-                    if let Some(cycle) = self.find_value_cycle(field.ty, on_path, path) {
-                        return Some(cycle);
-                    }
-                }
-                path.pop();
-                on_path.remove(&TypeNode::Struct(id));
-                None
-            }
-            TypeKind::Enum(id) => {
-                let def = self.type_pool.enum_def(id);
-                if !on_path.insert(TypeNode::Enum(id)) {
-                    let mut cycle = path.clone();
-                    cycle.push(def.name.clone());
-                    return Some(cycle);
-                }
-                path.push(def.name.clone());
-                for payload_ty in def.variant_payloads.iter().flatten() {
-                    if let Some(cycle) = self.find_value_cycle(*payload_ty, on_path, path) {
-                        return Some(cycle);
-                    }
-                }
-                path.pop();
-                on_path.remove(&TypeNode::Enum(id));
-                None
-            }
-            // An array stores its elements inline, so a by-value cycle can run
-            // through the element type (`struct A { a: [A; 1] }`).
-            TypeKind::Array(array_id) => {
-                let (element_ty, _length) = self.type_pool.array_def(array_id);
-                self.find_value_cycle(element_ty, on_path, path)
-            }
-            // Pointers are indirection (they break the cycle); scalars, unit,
-            // never, error, module and comptime-type carry no by-value struct
-            // containment.
-            _ => None,
-        }
     }
 
     /// Resolve @copy validation, destructors, functions, and methods.

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -245,6 +245,10 @@ pub struct CfgBuilder<'a> {
     /// and never a leak.
     moved: MoveState,
     implicit_named_destructors: std::collections::HashSet<StructId>,
+    /// Aggregate types whose destructor dependencies have already been
+    /// discovered for this CFG body. Keeps repeated drops linear in the size
+    /// of the reachable type graph rather than rewalking the same subgraphs.
+    implicit_destructor_types: std::collections::HashSet<Type>,
     anonymous_destructor_dependency_incomplete: bool,
 }
 
@@ -415,6 +419,7 @@ impl<'a> CfgBuilder<'a> {
             ever_field_moved: std::collections::HashSet::new(),
             moved: MoveState::default(),
             implicit_named_destructors: std::collections::HashSet::new(),
+            implicit_destructor_types: std::collections::HashSet::new(),
             anonymous_destructor_dependency_incomplete: false,
         };
 
@@ -2228,33 +2233,35 @@ impl<'a> CfgBuilder<'a> {
     }
 
     fn record_implicit_destructors(&mut self, ty: Type) {
-        match ty.kind() {
-            TypeKind::Struct(struct_id) => {
-                let def = self.type_pool.struct_def(struct_id);
-                if def.destructor.is_some() && !def.is_builtin {
-                    if def.name.starts_with("__anon_struct_") {
-                        self.anonymous_destructor_dependency_incomplete = true;
-                    } else {
-                        self.implicit_named_destructors.insert(struct_id);
+        let mut pending = vec![ty];
+        while let Some(ty) = pending.pop() {
+            if !self.implicit_destructor_types.insert(ty) {
+                continue;
+            }
+            match ty.kind() {
+                TypeKind::Struct(struct_id) => {
+                    let def = self.type_pool.struct_def(struct_id);
+                    if def.destructor.is_some() && !def.is_builtin {
+                        if def.name.starts_with("__anon_struct_") {
+                            self.anonymous_destructor_dependency_incomplete = true;
+                        } else {
+                            self.implicit_named_destructors.insert(struct_id);
+                        }
+                    }
+                    pending.extend(def.fields.iter().map(|field| field.ty));
+                }
+                TypeKind::Enum(enum_id) => {
+                    let def = self.type_pool.enum_def(enum_id);
+                    pending.extend(def.variant_payloads.iter().flatten().copied());
+                }
+                TypeKind::Array(array_id) => {
+                    let (element, len) = self.type_pool.array_def(array_id);
+                    if len != 0 {
+                        pending.push(element);
                     }
                 }
-                for field in &def.fields {
-                    self.record_implicit_destructors(field.ty);
-                }
+                _ => {}
             }
-            TypeKind::Enum(enum_id) => {
-                let def = self.type_pool.enum_def(enum_id);
-                for payload in &def.variant_payloads {
-                    for field in payload {
-                        self.record_implicit_destructors(*field);
-                    }
-                }
-            }
-            TypeKind::Array(array_id) => {
-                let (element, _) = self.type_pool.array_def(array_id);
-                self.record_implicit_destructors(element);
-            }
-            _ => {}
         }
     }
 
@@ -2420,59 +2427,7 @@ impl<'a> CfgBuilder<'a> {
     /// - Struct: needs drop when it declares a destructor or any field needs drop
     /// - Array: needs drop if element type needs drop
     fn type_needs_drop(&self, ty: Type) -> bool {
-        match ty.kind() {
-            // Primitive types are trivially droppable
-            // ComptimeType is a comptime-only type and has no runtime representation
-            TypeKind::I8
-            | TypeKind::I16
-            | TypeKind::I32
-            | TypeKind::I64
-            | TypeKind::U8
-            | TypeKind::U16
-            | TypeKind::U32
-            | TypeKind::U64
-            | TypeKind::Bool
-            | TypeKind::Unit
-            | TypeKind::Never
-            | TypeKind::Error
-            | TypeKind::ComptimeType => false,
-
-            // An enum needs drop if any variant payload needs drop (RUE-221):
-            // at scope exit the discriminant selects the active variant and
-            // its payload's drop glue runs. A discriminant-only (C-like) enum
-            // has no payloads and is trivially droppable.
-            TypeKind::Enum(enum_id) => {
-                let enum_def = self.type_pool.enum_def(enum_id);
-                enum_def
-                    .variant_payloads
-                    .iter()
-                    .flatten()
-                    .any(|&ty| self.type_needs_drop(ty))
-            }
-
-            // Struct types need drop if they declare a destructor or contain a
-            // field that needs drop.
-            TypeKind::Struct(struct_id) => {
-                let struct_def = self.type_pool.struct_def(struct_id);
-                if struct_def.destructor.is_some() {
-                    return true;
-                }
-                // Otherwise, check if any field needs drop
-                struct_def.fields.iter().any(|f| self.type_needs_drop(f.ty))
-            }
-
-            // Array types need drop if element type needs drop
-            TypeKind::Array(array_id) => {
-                let (element_type, _length) = self.type_pool.array_def(array_id);
-                self.type_needs_drop(element_type)
-            }
-
-            // Pointer types don't need drop (they're just addresses)
-            TypeKind::PtrConst(_) | TypeKind::PtrMut(_) => false,
-
-            // Module types don't need drop (compile-time only)
-            TypeKind::Module(_) => false,
-        }
+        self.type_pool.type_needs_drop(ty)
     }
 
     /// Convert AIR argument mode to CFG argument mode.

--- a/crates/rue-cli-tests/cases/recursive_value_type.toml
+++ b/crates/rue-cli-tests/cases/recursive_value_type.toml
@@ -55,6 +55,16 @@ fn main() -> i32 { 0 }
 """ }]
 
 [[case]]
+name = "zero_array_recursion_preserves_e0483"
+description = "A zero-length array carries no ownership facts, but preserves the existing structural recursive-type diagnostic."
+compile_fail = true
+error_contains = ["E0483", "infinite size", "A -> A"]
+files = [{ path = "main.rue", source = """
+struct A { a: [A; 0] }
+fn main() -> i32 { 0 }
+""" }]
+
+[[case]]
 name = "pointer_indirection_breaks_cycle_control"
 description = "Control: recursion through a pointer is a valid recursive type and compiles."
 compile_only = true

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -29,64 +29,7 @@ use rue_span::Span;
 
 /// Check if a type needs drop.
 fn type_needs_drop(ty: Type, type_pool: &FrozenTypeInternPool) -> bool {
-    match ty.kind() {
-        // Primitive types are trivially droppable
-        // ComptimeType is comptime-only, no runtime representation
-        TypeKind::I8
-        | TypeKind::I16
-        | TypeKind::I32
-        | TypeKind::I64
-        | TypeKind::U8
-        | TypeKind::U16
-        | TypeKind::U32
-        | TypeKind::U64
-        | TypeKind::Bool
-        | TypeKind::Unit
-        | TypeKind::Never
-        | TypeKind::Error
-        | TypeKind::ComptimeType => false,
-
-        // An enum needs drop if any variant payload needs drop (RUE-221): at
-        // scope exit its active-variant drop glue switches on the discriminant
-        // and drops the selected payload. Discriminant-only enums are trivial.
-        TypeKind::Enum(enum_id) => {
-            let enum_def = type_pool.enum_def(enum_id);
-            enum_def
-                .variant_payloads
-                .iter()
-                .flatten()
-                .any(|&ty| type_needs_drop(ty, type_pool))
-        }
-
-        // Struct types need drop if they have a destructor (e.g., builtin String)
-        // or if any field needs drop
-        TypeKind::Struct(struct_id) => {
-            let struct_def = type_pool.struct_def(struct_id);
-            // Builtins with destructors (like String) need drop
-            if struct_def.destructor.is_some() {
-                return true;
-            }
-            // Otherwise, check if any field needs drop
-            struct_def
-                .fields
-                .iter()
-                .any(|f| type_needs_drop(f.ty, type_pool))
-        }
-
-        // Note: String is now Type::Struct with is_builtin=true, handled above
-
-        // Array types need drop if element type needs drop
-        TypeKind::Array(array_id) => {
-            let (element_type, _length) = type_pool.array_def(array_id);
-            type_needs_drop(element_type, type_pool)
-        }
-
-        // Pointer types don't need drop (they're just addresses)
-        TypeKind::PtrConst(_) | TypeKind::PtrMut(_) => false,
-
-        // Module types don't need drop (compile-time only)
-        TypeKind::Module(_) => false,
-    }
+    type_pool.type_needs_drop(ty)
 }
 
 /// Synthesize drop glue functions for all structs and arrays that need them.

--- a/crates/rue-ui-tests/cases/diagnostics/droppable_gate.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/droppable_gate.toml
@@ -83,6 +83,21 @@ compile_fail = false
 exit_code = 0
 
 [[case]]
+name = "zero_linear_array_is_droppable"
+description = "A zero-length array holds no linear values, so the droppable gate accepts it under spec 3.8:74."
+source = """
+linear struct Token { v: i32 }
+fn Gated(comptime T: type) -> type {
+    @require_droppable(T);
+    struct { y: T }
+}
+const G = Gated([Token; 0]);
+fn main() -> i32 { 0 }
+"""
+compile_fail = false
+exit_code = 0
+
+[[case]]
 name = "e0499_linear_names_and_labels"
 description = "The linear-element rejection (E0499) gets the same application-site label (RUE-610)"
 source = """

--- a/crates/rue-ui-tests/cases/diagnostics/trivially_droppable_gate.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/trivially_droppable_gate.toml
@@ -120,3 +120,19 @@ fn main() -> i32 { 0 }
 """
 compile_fail = false
 exit_code = 0
+
+[[case]]
+name = "zero_drop_array_is_trivially_droppable"
+description = "A zero-length array has no elements to drop, so the trivially-droppable gate accepts it."
+source = """
+struct D { v: i32 }
+drop fn D(self) {}
+fn Gated(comptime T: type) -> type {
+    @require_trivially_droppable(T);
+    struct { y: T }
+}
+const G = Gated([D; 0]);
+fn main() -> i32 { 0 }
+"""
+compile_fail = false
+exit_code = 0


### PR DESCRIPTION
## Summary

- compute recursive-value cycles, infectious linearity, and drop requirements from one canonical by-value containment graph
- use an explicit iterative DFS and bounded postorder fold, with incremental facts for late specialized types
- migrate AIR, CFG, and compiler drop-glue consumers to canonical queries and bound CFG destructor dependency discovery per body
- preserve deterministic E0483 diagnostics and zero-length-array ownership semantics

## Validation

- `scripts/rue fmt`
- `scripts/rue quick`
- `scripts/rue test`
- focused AIR, recursive-value, zero-length-array, and ownership-gate suites
- 8,000-node structural scaling test
- adversarial architectural review

Fixes RUE-795
