### PR TITLE
RUE-727: reuse durable module bindings

### DIFF
--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -109,6 +109,12 @@ pub enum SemanticDeclarationPayload {
         ty: SemanticExportType,
         value: SemanticExportConstValue,
     },
+    /// A top-level constant whose initializer resolved to a module. The
+    /// target is the canonical semantic epoch's durable module identity, not
+    /// its compact request-local module handle.
+    ModuleBinding {
+        target: SemanticExportType,
+    },
     Destructor,
 }
 
@@ -409,6 +415,13 @@ impl<'a> DeclarationShells<'a> {
         self.binding_work.durable_install_invocations += 1;
         let mut records = BTreeMap::new();
         for export in exports {
+            if matches!(
+                export.payload,
+                SemanticDeclarationPayload::ModuleBinding { .. }
+            ) != (export.identity.kind == StableDefinitionKind::ModuleBinding)
+            {
+                return Err(DeclarationInstallFailure::KindMismatch);
+            }
             let module_path = self
                 .sema
                 .get_symbol_path(export.identity.file_id)
@@ -421,7 +434,15 @@ impl<'a> DeclarationShells<'a> {
                     .trusted_standard_library_files
                     .contains(&export.identity.file_id),
                 namespace: export.identity.namespace,
-                kind: export.identity.kind,
+                // Const shells are captured before initializer evaluation can
+                // classify module bindings. The distinct payload and exported
+                // kind are validated above, then joined to that exact const
+                // shell for installation.
+                kind: if export.identity.kind == StableDefinitionKind::ModuleBinding {
+                    StableDefinitionKind::ValueConst
+                } else {
+                    export.identity.kind
+                },
                 name: export.identity.name.clone(),
                 owner: export.identity.owner.clone(),
             };
@@ -439,6 +460,36 @@ impl<'a> DeclarationShells<'a> {
                 .ok_or(DeclarationInstallFailure::MissingPayload)?;
             if record.identity.is_public != shell.is_public {
                 return Err(DeclarationInstallFailure::VisibilityMismatch);
+            }
+        }
+
+        // Resolve every module target before mutating any nominal or callable
+        // state. An absent or ambiguous durable ID therefore fails the whole
+        // installation atomically.
+        let mut module_by_durable_id = BTreeMap::new();
+        for index in 0..self.sema.module_registry.len() {
+            let id = crate::ModuleId::new(index as u32);
+            let durable_id = self.sema.module_registry.get_def(id).durable_id;
+            if module_by_durable_id.insert(durable_id, id).is_some() {
+                return Err(DeclarationInstallFailure::UnsupportedType);
+            }
+        }
+        let mut module_targets = BTreeMap::new();
+        for pending in &self.pending_payloads {
+            let record = records[&pending.shell.identity];
+            if let SemanticDeclarationPayload::ModuleBinding { target } = &record.payload {
+                let SemanticExportType::Module(target) = target else {
+                    return Err(DeclarationInstallFailure::UnsupportedType);
+                };
+                let target = *module_by_durable_id
+                    .get(target.as_ref())
+                    .ok_or(DeclarationInstallFailure::UnsupportedType)?;
+                let InstData::ConstDecl { ty: None, .. } =
+                    &self.sema.rir.get(pending.declaration).data
+                else {
+                    return Err(DeclarationInstallFailure::KindMismatch);
+                };
+                module_targets.insert(pending.shell.identity.clone(), Type::new_module(target));
             }
         }
 
@@ -711,6 +762,27 @@ impl<'a> DeclarationShells<'a> {
                     self.sema
                         .collect_destructor(owner, pending.shell.declaration_span)
                         .map_err(|_| DeclarationInstallFailure::NominalShapeMismatch)?;
+                }
+                (
+                    SemanticDeclarationPayload::ModuleBinding { .. },
+                    DeclarationPayloadSource::Const { .. },
+                ) => {
+                    let target = *module_targets
+                        .get(&pending.shell.identity)
+                        .ok_or(DeclarationInstallFailure::UnsupportedType)?;
+                    let name = self
+                        .sema
+                        .interner
+                        .get_or_intern(pending.shell.identity.name.as_ref());
+                    self.sema.module_bindings.insert(
+                        (pending.shell.declaration_span.file_id, name),
+                        super::ConstInfo {
+                            is_pub: pending.shell.is_public,
+                            ty: target,
+                            value: ConstValue::Type(target),
+                            span: pending.shell.declaration_span,
+                        },
+                    );
                 }
                 (_, DeclarationPayloadSource::Const { .. }) => {
                     return Err(DeclarationInstallFailure::UnsupportedDeclaration);
@@ -1514,12 +1586,18 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
         SemanticExportFailure,
     > {
         let mut records = Vec::with_capacity(manifest.bindings.len());
-        for identity in manifest
-            .bindings
-            .iter()
-            .filter(|b| b.kind != StableDefinitionKind::ModuleBinding)
-        {
+        for identity in manifest.bindings.iter() {
             let name = self.interner.get_or_intern(identity.name.as_ref());
+            // Pre-resolution const shells cannot distinguish value constants
+            // from module bindings. Classify them from the successfully bound
+            // namespace while exporting, then carry that exact kind across
+            // the owned declaration boundary.
+            let mut identity = identity.clone();
+            if identity.kind == StableDefinitionKind::ValueConst
+                && self.module_bindings.contains_key(&(identity.file_id, name))
+            {
+                identity.kind = StableDefinitionKind::ModuleBinding;
+            }
             let payload = match identity.kind {
                 StableDefinitionKind::Function => {
                     let internal = *self
@@ -1651,13 +1729,18 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                         value,
                     }
                 }
+                StableDefinitionKind::ModuleBinding => {
+                    let info = self
+                        .module_bindings
+                        .get(&(identity.file_id, name))
+                        .ok_or(SemanticExportFailure::UnmappedFunction)?;
+                    SemanticDeclarationPayload::ModuleBinding {
+                        target: self.export_type(info.ty, &mut Vec::new())?,
+                    }
+                }
                 StableDefinitionKind::Destructor => SemanticDeclarationPayload::Destructor,
-                StableDefinitionKind::ModuleBinding => unreachable!(),
             };
-            records.push(SemanticDeclarationExport {
-                identity: identity.clone(),
-                payload,
-            });
+            records.push(SemanticDeclarationExport { identity, payload });
         }
         let len = records.len();
         Ok((

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -656,7 +656,7 @@ pub(crate) fn analyze_prepared_canonical_program_with_durable_export(
         definitions,
         declaration_index,
     } = prepared;
-    let mut declaration_reuse = CanonicalDeclarationReuseWork {
+    let declaration_reuse = CanonicalDeclarationReuseWork {
         semantic_epochs_started: 1,
         declaration_indexes_built: declaration_index.build_invocations,
         shell_predeclaration_epochs: 1,
@@ -666,29 +666,11 @@ pub(crate) fn analyze_prepared_canonical_program_with_durable_export(
         declaration_resolution_failure(failure, declaration_index, false, declaration_reuse)
     })?;
 
-    let durable_declarations =
-        match bound.with_declaration_semantics_from_shells(&shell_records, |records, _work| {
-            crate::durable_semantics::convert_declaration_semantics(merged, &definitions, records)
-        }) {
-            Ok(Ok(values)) => Some(values),
-            Ok(Err(reason)) => {
-                declaration_reuse.unsupported_export_fallbacks += 1;
-                declaration_reuse.last_fallback_reason = Some(
-                    CanonicalDeclarationFallbackReason::UnsupportedExport(reason),
-                );
-                None
-            }
-            Err(reason) => {
-                let reason = crate::DurableSemanticExportFailure::from(reason);
-                declaration_reuse.unsupported_export_fallbacks += 1;
-                declaration_reuse.last_fallback_reason = Some(
-                    CanonicalDeclarationFallbackReason::UnsupportedExport(reason),
-                );
-                None
-            }
-        };
+    let declaration_exports = bound
+        .with_declaration_semantics_from_shells(&shell_records, |records, _work| records.to_vec())
+        .map_err(crate::DurableSemanticExportFailure::from);
 
-    let output = finish_canonical_analysis(
+    let mut output = finish_canonical_analysis(
         input,
         merged,
         rir,
@@ -697,19 +679,41 @@ pub(crate) fn analyze_prepared_canonical_program_with_durable_export(
         declaration_index,
         bound,
         definitions.clone(),
-        CanonicalDeclarationReuseWork {
-            durable_cache_population_exports: usize::from(durable_declarations.is_some()),
-            ..declaration_reuse
-        },
+        declaration_reuse,
         body_candidates,
         specialized_body_candidates,
         durable_cfg_candidates,
         body_work,
         sema_span,
     )?;
+    // Final analysis has now issued the authoritative post-classification
+    // definition universe. Join the already-owned AIR exports to that exact
+    // universe without a second definition-issuance pass or RIR traversal.
+    let durable_declarations = declaration_exports.and_then(|records| {
+        crate::durable_semantics::convert_declaration_semantics(
+            merged,
+            &output.body_owner_issuer,
+            &records,
+        )
+    });
+    let durable_declarations = match durable_declarations {
+        Ok(values) => Some(values),
+        Err(reason) => {
+            output.work.declaration_reuse.unsupported_export_fallbacks += 1;
+            output.work.declaration_reuse.last_fallback_reason = Some(
+                CanonicalDeclarationFallbackReason::UnsupportedExport(reason),
+            );
+            None
+        }
+    };
+    output
+        .work
+        .declaration_reuse
+        .durable_cache_population_exports = usize::from(durable_declarations.is_some());
+    let durable_definitions = output.body_owner_issuer.clone();
     Ok(CanonicalOrdinaryAnalysis {
         output,
-        definitions,
+        definitions: durable_definitions,
         durable_declarations,
     })
 }
@@ -763,8 +767,7 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
         Err(reason) => {
             reuse.fallbacks = 1;
             match reason {
-                crate::DurableSemanticProjectionFailure::UnsupportedDeclaration
-                | crate::DurableSemanticProjectionFailure::UnsupportedType => {
+                crate::DurableSemanticProjectionFailure::UnsupportedDeclaration => {
                     reuse.structural_validation_fallbacks = 1;
                 }
                 _ => reuse.stable_join_fallbacks = 1,

--- a/crates/rue-compiler/src/durable_compatibility_tests.rs
+++ b/crates/rue-compiler/src/durable_compatibility_tests.rs
@@ -20,9 +20,9 @@ use crate::*;
 const REVIEWED_SEMANTIC_SCHEMA: DurableSemanticSchemaVersion = DurableSemanticSchemaVersion {
     major: 1,
     minor: 0,
-    // Epoch 2: const string values joined the durable const payloads
-    // (SemanticImportConstValue::String, RUE-957).
-    implementation_epoch: 2,
+    // Epoch 3: const string values and canonical module bindings joined the
+    // durable declaration payloads (RUE-957, RUE-727).
+    implementation_epoch: 3,
 };
 const REVIEWED_ORDINARY_BODY_SCHEMA: u32 = 6;
 const REVIEWED_SPECIALIZED_BODY_SCHEMA: u32 = 5;
@@ -30,7 +30,7 @@ const REVIEWED_CFG_SCHEMA: u32 = 1;
 const REVIEWED_BODY_KINDS: usize = 58;
 const REVIEWED_TYPE_KINDS: usize = 19;
 const REVIEWED_CONST_KINDS: usize = 6;
-const REVIEWED_DECLARATION_PAYLOAD_KINDS: usize = 5;
+const REVIEWED_DECLARATION_PAYLOAD_KINDS: usize = 6;
 const REVIEWED_DEFINITION_KINDS: usize = 8;
 const REVIEWED_DEFINITION_NAMESPACES: usize = 4;
 
@@ -275,6 +275,11 @@ fn every_declaration_payload_and_parameter_mode_imports_in_one_bounded_epoch() {
         StableDefinitionNamespace::Value,
         "ANSWER",
     );
+    let module_binding = key(
+        StableDefinitionKind::ModuleBinding,
+        StableDefinitionNamespace::Value,
+        "support",
+    );
     let destructor = key(
         StableDefinitionKind::Destructor,
         StableDefinitionNamespace::Destructor,
@@ -342,6 +347,13 @@ fn every_declaration_payload_and_parameter_mode_imports_in_one_bounded_epoch() {
             },
         },
         DurableDeclarationSemantic {
+            key: module_binding,
+            is_public: false,
+            payload: DurableDeclarationPayload::ModuleBinding {
+                target: module("pkg/support.rue"),
+            },
+        },
+        DurableDeclarationSemantic {
             key: destructor,
             is_public: false,
             payload: DurableDeclarationPayload::Destructor,
@@ -374,6 +386,7 @@ fn every_declaration_payload_and_parameter_mode_imports_in_one_bounded_epoch() {
             DurableDeclarationPayload::Struct { .. } => "struct",
             DurableDeclarationPayload::Enum { .. } => "enum",
             DurableDeclarationPayload::Const { .. } => "const",
+            DurableDeclarationPayload::ModuleBinding { .. } => "module_binding",
             DurableDeclarationPayload::Destructor => "destructor",
         })
         .collect::<BTreeSet<_>>();

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -43,6 +43,9 @@ pub fn import_durable_declaration_semantics(
             ) | (
                 StableDefinitionKind::Destructor,
                 DurableDeclarationPayload::Destructor
+            ) | (
+                StableDefinitionKind::ModuleBinding,
+                DurableDeclarationPayload::ModuleBinding { .. }
             )
         )
     }
@@ -96,6 +99,9 @@ pub fn import_durable_declaration_semantics(
                 if let DurableConstValue::Type(ty) = value {
                     collect_modules(ty, &mut modules);
                 }
+            }
+            DurableDeclarationPayload::ModuleBinding { target } => {
+                modules.insert(Arc::from(target.as_str()));
             }
             DurableDeclarationPayload::Destructor => {}
         }
@@ -194,6 +200,9 @@ pub fn import_durable_declaration_semantics(
                 epoch.validate_callable_signature(&parameters, &result.import_dto())?;
             }
             DurableDeclarationPayload::Destructor => {}
+            DurableDeclarationPayload::ModuleBinding { target } => {
+                epoch.import_type(&DurableType::Module(target.clone()).import_dto())?;
+            }
         }
     }
     Ok(epoch)
@@ -216,9 +225,9 @@ pub const DURABLE_SEMANTIC_SCHEMA_VERSION: DurableSemanticSchemaVersion =
     DurableSemanticSchemaVersion {
         major: 1,
         minor: 0,
-        // Epoch 2: const string values joined the durable const payloads
-        // (SemanticImportConstValue::String, RUE-957).
-        implementation_epoch: 2,
+        // Epoch 3: const string values and canonical module bindings are part
+        // of the durable declaration algebra (RUE-957, RUE-727).
+        implementation_epoch: 3,
     };
 
 const DURABLE_SEMANTIC_COMPATIBLE_MINORS: &[u16] = &[0];
@@ -312,6 +321,10 @@ pub enum DurableDeclarationPayload {
         ty: DurableType,
         value: DurableConstValue,
     },
+    /// The resolved canonical target of a top-level module-valued constant.
+    ModuleBinding {
+        target: ModuleId,
+    },
     Destructor,
 }
 
@@ -385,7 +398,6 @@ pub enum DurableSemanticProjectionFailure {
     ModuleMismatch,
     VisibilityMismatch,
     UnsupportedDeclaration,
-    UnsupportedType,
 }
 
 /// Project stable-keyed semantics into exact-current-revision AIR DTOs.
@@ -431,22 +443,55 @@ pub fn project_durable_declaration_semantics(
         }
     }
 
-    let mut shell_by_key = BTreeMap::new();
-    for shell in shells {
-        let join_key = ProjectionJoinKey::from_shell(shell)
-            .ok_or(DurableSemanticProjectionFailure::UnsupportedDeclaration)?;
-        let key = definition_by_join_key
-            .get(&join_key)
-            .cloned()
-            .ok_or(DurableSemanticProjectionFailure::MissingDefinition)?;
-        if shell_by_key.insert(key, shell).is_some() {
-            return Err(DurableSemanticProjectionFailure::DuplicateShell);
-        }
-    }
     let mut durable_by_key = BTreeMap::new();
     for record in durable {
         if durable_by_key.insert(record.key.clone(), record).is_some() {
             return Err(DurableSemanticProjectionFailure::DuplicateDefinition);
+        }
+    }
+    let durable_by_join_key = durable_by_key
+        .keys()
+        .map(|key| (ProjectionJoinKey::from_definition(key), key.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let mut shell_by_key = BTreeMap::new();
+    for shell in shells {
+        let join_key = ProjectionJoinKey::from_shell(shell)
+            .ok_or(DurableSemanticProjectionFailure::UnsupportedDeclaration)?;
+        let exact_definition = definition_by_join_key.get(&join_key).cloned();
+        let exact_durable = exact_definition
+            .as_ref()
+            .filter(|key| durable_by_key.contains_key(*key))
+            .cloned();
+        let key = if let Some(key) = exact_durable {
+            key
+        } else if shell.identity.kind == StableDefinitionKind::ValueConst {
+            // Const shells are deliberately captured before initializer
+            // evaluation. A previous durable module payload may reclassify
+            // only this exact current const declaration; either the current
+            // provisional ValueConst definition or an authoritative
+            // ModuleBinding definition must prove its provenance.
+            let mut module_join = join_key.clone();
+            module_join.kind = StableDefinitionKind::ModuleBinding;
+            let authoritative = definition_by_join_key.get(&module_join);
+            if exact_definition.is_none() && authoritative.is_none() {
+                return Err(DurableSemanticProjectionFailure::MissingDefinition);
+            }
+            let key = durable_by_join_key
+                .get(&module_join)
+                .cloned()
+                .ok_or(DurableSemanticProjectionFailure::MissingDefinition)?;
+            if !matches!(
+                durable_by_key[&key].payload,
+                DurableDeclarationPayload::ModuleBinding { .. }
+            ) {
+                return Err(DurableSemanticProjectionFailure::KindMismatch);
+            }
+            key
+        } else {
+            return Err(DurableSemanticProjectionFailure::MissingDefinition);
+        };
+        if shell_by_key.insert(key, shell).is_some() {
+            return Err(DurableSemanticProjectionFailure::DuplicateShell);
         }
     }
     let expected = shell_by_key.keys().cloned().collect::<BTreeSet<_>>();
@@ -481,7 +526,11 @@ pub fn project_durable_declaration_semantics(
                 file_id,
                 declaration_span: shell.declaration_span,
                 namespace: shell.identity.namespace,
-                kind: shell.identity.kind,
+                kind: if key.kind() == StableDefinitionKind::ModuleBinding {
+                    StableDefinitionKind::ModuleBinding
+                } else {
+                    shell.identity.kind
+                },
                 name: shell.identity.name.clone(),
                 owner: shell.identity.owner.clone(),
                 is_public: shell.is_public,
@@ -578,9 +627,10 @@ fn project_type(
             },
             F::PtrConst(value) => SemanticExportType::PtrConst(Box::new(value)),
             F::PtrMut(value) => SemanticExportType::PtrMut(Box::new(value)),
-            F::Module(_) => {
-                return Err(DurableSemanticProjectionFailure::UnsupportedType);
-            }
+            F::Module(module) => module_files
+                .contains_key(module)
+                .then(|| SemanticExportType::Module(Arc::from(module.as_str())))
+                .ok_or(DurableSemanticProjectionFailure::ModuleMismatch)?,
         })
     })
 }
@@ -646,6 +696,15 @@ fn project_payload(
                 .into(),
         },
         DurableDeclarationPayload::Destructor => SemanticDeclarationPayload::Destructor,
+        DurableDeclarationPayload::ModuleBinding { target } => {
+            SemanticDeclarationPayload::ModuleBinding {
+                target: project_type(
+                    &DurableType::Module(target.clone()),
+                    definitions,
+                    module_files,
+                )?,
+            }
+        }
         DurableDeclarationPayload::Const { .. } => {
             return Err(DurableSemanticProjectionFailure::UnsupportedDeclaration);
         }
@@ -675,6 +734,10 @@ fn validate_payload_shape(
         }
         (StableDefinitionKind::Struct, SemanticDeclarationPayload::Struct { .. })
         | (StableDefinitionKind::Enum, SemanticDeclarationPayload::Enum { .. })
+        | (
+            StableDefinitionKind::ValueConst | StableDefinitionKind::ModuleBinding,
+            SemanticDeclarationPayload::ModuleBinding { .. },
+        )
         | (StableDefinitionKind::Destructor, SemanticDeclarationPayload::Destructor) => Ok(()),
         _ => Err(DurableSemanticProjectionFailure::KindMismatch),
     }
@@ -720,7 +783,7 @@ pub(crate) fn convert_declaration_semantics(
             StableDefinitionKind::Destructor => StableDefinitionKind::Destructor,
             StableDefinitionKind::Method => StableDefinitionKind::Method,
             StableDefinitionKind::AssociatedFunction => StableDefinitionKind::AssociatedFunction,
-            StableDefinitionKind::ModuleBinding => return None,
+            StableDefinitionKind::ModuleBinding => StableDefinitionKind::ModuleBinding,
         })
     }
     let module_for_file = |file_id| {
@@ -919,6 +982,12 @@ pub(crate) fn convert_declaration_semantics(
                 }
             }
             SemanticDeclarationPayload::Destructor => DurableDeclarationPayload::Destructor,
+            SemanticDeclarationPayload::ModuleBinding { target } => {
+                let DurableType::Module(target) = ty(target, merged, definitions)? else {
+                    return Err(DurableSemanticExportFailure::UnresolvedModule);
+                };
+                DurableDeclarationPayload::ModuleBinding { target }
+            }
         };
         result.push(DurableDeclarationSemantic {
             key,

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1769,6 +1769,7 @@ impl FrontendQueryDatabase {
 struct DurableDeclarationCache {
     schema_version: crate::DurableSemanticSchemaVersion,
     root: crate::ModuleId,
+    imports: CanonicalImportGraph,
     target: crate::Target,
     preview_features: crate::PreviewFeatures,
     fingerprints: Arc<[StableDefinitionInputFingerprint]>,
@@ -4939,6 +4940,7 @@ impl CompilerSession {
                 return None;
             }
             if cache.root != *merged.ast().root()
+                || cache.imports != imports
                 || cache.target != options.target
                 || cache.preview_features != options.preview_features
             {
@@ -5047,6 +5049,7 @@ impl CompilerSession {
                         published_declaration_cache = Some(DurableDeclarationCache {
                             schema_version: crate::DURABLE_SEMANTIC_SCHEMA_VERSION,
                             root: merged.ast().root().clone(),
+                            imports: imports.clone(),
                             target: options.target,
                             preview_features: options.preview_features.clone(),
                             fingerprints: fingerprints.into(),
@@ -6831,10 +6834,50 @@ fn declaration_surfaces_match(
     if previous.len() != current.len() {
         return (false, 0);
     }
+    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    struct JoinKey {
+        module: crate::ModuleId,
+        namespace: StableDefinitionNamespace,
+        kind: StableDefinitionKind,
+        name: Arc<str>,
+        owner: Option<(crate::ModuleId, StableDefinitionKind, Arc<str>)>,
+    }
+    let join_key = |fingerprint: &StableDefinitionInputFingerprint| {
+        let key = &fingerprint.key;
+        JoinKey {
+            module: key.module().clone(),
+            namespace: key.namespace(),
+            // The current pre-resolution shell cannot distinguish these two
+            // kinds. The cached payload must still be a distinct
+            // ModuleBinding and is checked below.
+            kind: match key.kind() {
+                StableDefinitionKind::ModuleBinding => StableDefinitionKind::ValueConst,
+                kind => kind,
+            },
+            name: Arc::from(key.name()),
+            owner: key.owner().map(|owner| {
+                (
+                    owner.module().clone(),
+                    owner.kind(),
+                    Arc::from(owner.name()),
+                )
+            }),
+        }
+    };
+    let current = current
+        .iter()
+        .map(|fingerprint| (join_key(fingerprint), fingerprint))
+        .collect::<BTreeMap<_, _>>();
+    if current.len() != previous.len() {
+        return (false, 0);
+    }
     let mut compared = 0;
-    for (left, right) in previous.iter().zip(current) {
+    for left in previous {
         compared += 1;
-        let supported = matches!(
+        let Some(right) = current.get(&join_key(left)) else {
+            return (false, compared);
+        };
+        let ordinary_supported = matches!(
             left.key.kind(),
             StableDefinitionKind::Function
                 | StableDefinitionKind::Struct
@@ -6846,12 +6889,20 @@ fn declaration_surfaces_match(
             left.precision,
             StableDefinitionFingerprintPrecision::SignatureAndInitializer
         );
-        let matches = supported
+        let module_binding_supported = left.key.kind() == StableDefinitionKind::ModuleBinding
+            && matches!(
+                right.key.kind(),
+                StableDefinitionKind::ValueConst | StableDefinitionKind::ModuleBinding
+            )
+            && left.precision == StableDefinitionFingerprintPrecision::SignatureAndInitializer
+            && right.precision == StableDefinitionFingerprintPrecision::SignatureAndInitializer
+            && left.body_or_initializer == right.body_or_initializer;
+        let matches = (ordinary_supported || module_binding_supported)
             && left.schema_version == right.schema_version
-            && left.key == right.key
-            && left.declaration == right.declaration
             && left.signature == right.signature
-            && left.precision == right.precision;
+            && left.precision == right.precision
+            && (module_binding_supported
+                || (left.key == right.key && left.declaration == right.declaration));
         if !matches {
             return (false, compared);
         }
@@ -8577,6 +8628,136 @@ mod tests {
             format!("{:?}", reused.warnings()),
             format!("{:?}", ordinary.warnings())
         );
+    }
+
+    #[test]
+    fn module_bindings_populate_the_durable_baseline_and_reuse_across_relocation() {
+        let original = snapshot(
+            &[
+                (
+                    71,
+                    "/old/main.rue",
+                    "main.rue",
+                    "const lib = @import(\"lib.rue\"); fn main() -> i32 { lib.value() + 1 }",
+                ),
+                (
+                    72,
+                    "/old/lib.rue",
+                    "lib.rue",
+                    "pub fn value() -> i32 { 40 }",
+                ),
+            ],
+            71,
+        );
+        let relocated_edit = snapshot(
+            &[
+                (4, "/new/lib.rue", "lib.rue", "pub fn value() -> i32 { 40 }"),
+                (
+                    9,
+                    "/new/main.rue",
+                    "main.rue",
+                    "const lib = @import(\"lib.rue\"); fn main() -> i32 { lib.value() + 2 }",
+                ),
+            ],
+            9,
+        );
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        publish_with_test_imports(&mut session, &original);
+        let cold = session.semantic(&options).unwrap();
+        assert_eq!(cold.work().binding.declaration_resolution_invocations, 1);
+        assert_eq!(
+            cold.work()
+                .declaration_reuse
+                .durable_cache_population_exports,
+            1
+        );
+        let module = session
+            .durable_declaration_cache
+            .as_ref()
+            .unwrap()
+            .semantics
+            .iter()
+            .find(|record| record.key.kind() == StableDefinitionKind::ModuleBinding)
+            .unwrap();
+        assert!(matches!(
+            &module.payload,
+            crate::DurableDeclarationPayload::ModuleBinding { target }
+                if target.as_str() == "lib.rue"
+        ));
+
+        publish_with_test_imports(&mut session, &relocated_edit);
+        let reused = session.semantic(&options).unwrap();
+        assert_eq!(reused.work().binding.declaration_resolution_invocations, 0);
+        assert_eq!(reused.work().binding.durable_payloads_installed, 3);
+        assert_eq!(reused.work().declaration_reuse.durable_records_reused, 3);
+        assert_eq!(
+            reused
+                .work()
+                .declaration_reuse
+                .ordinary_declaration_resolutions_skipped,
+            1
+        );
+        assert_eq!(reused.work().declaration_reuse.fallbacks, 0);
+
+        let mut fresh = CompilerSession::new();
+        publish_with_test_imports(&mut fresh, &relocated_edit);
+        let ordinary = fresh.semantic(&options).unwrap();
+        assert_semantic_artifact_parity(&session, &reused, &ordinary);
+        assert_diagnostic_parity(&session, &fresh);
+    }
+
+    #[test]
+    fn unresolved_durable_module_target_falls_back_without_installing() {
+        let source = |body: i32| {
+            snapshot(
+                &[
+                    (
+                        1,
+                        "/p/main.rue",
+                        "main.rue",
+                        &format!(
+                            "const lib = @import(\"lib.rue\"); fn main() -> i32 {{ lib.value() + {body} }}"
+                        ),
+                    ),
+                    (2, "/p/lib.rue", "lib.rue", "pub fn value() -> i32 { 40 }"),
+                ],
+                1,
+            )
+        };
+        let first = source(1);
+        let edited = source(2);
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        publish_with_test_imports(&mut session, &first);
+        session.semantic(&options).unwrap();
+        let cache = session.durable_declaration_cache.as_mut().unwrap();
+        let mut records = cache.semantics.to_vec();
+        let module = records
+            .iter_mut()
+            .find(|record| record.key.kind() == StableDefinitionKind::ModuleBinding)
+            .unwrap();
+        module.payload = crate::DurableDeclarationPayload::ModuleBinding {
+            target: crate::ModuleId::from_logical_path("missing.rue").unwrap(),
+        };
+        cache.semantics = records.into();
+
+        publish_with_test_imports(&mut session, &edited);
+        let fallback = session.semantic(&options).unwrap();
+        assert_eq!(
+            fallback.work().binding.declaration_resolution_invocations,
+            1
+        );
+        assert_eq!(fallback.work().binding.durable_install_invocations, 0);
+        assert_eq!(fallback.work().binding.durable_payloads_installed, 0);
+        assert_eq!(fallback.work().declaration_reuse.fallbacks, 1);
+        assert_eq!(fallback.work().declaration_reuse.fallback_epochs_started, 0);
+
+        let mut fresh = CompilerSession::new();
+        publish_with_test_imports(&mut fresh, &edited);
+        let ordinary = fresh.semantic(&options).unwrap();
+        assert_semantic_artifact_parity(&session, &fallback, &ordinary);
+        assert_diagnostic_parity(&session, &fresh);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- represent resolved module constants as distinct durable declaration payloads keyed by canonical module identity
- reuse those bindings across source relocation, FileId changes, and input reordering while gating the cache on the accepted import graph
- validate every module target before installation so missing targets fall back atomically to ordinary declaration resolution
- update the durable compatibility review gate and add focused cache-reuse and fail-closed regression tests

## Root cause and impact

Module-valued constants were excluded from durable declaration export because pre-resolution const shells could not distinguish them from ordinary value constants. Any program with an import therefore suppressed durable cache population and repeated declaration resolution. The new post-classification export records the canonical module target and projects it back onto the exact provisional const shell without persisting request-local IDs.

## Validation

- `scripts/rue unit compiler module_bindings_populate_the_durable_baseline_and_reuse_across_relocation`
- `scripts/rue unit compiler unresolved_durable_module_target_falls_back_without_installing`
- durable compatibility tests
- `scripts/rue fmt`
- `git diff --check`
- `scripts/rue quick` (33 targets, zero failures)
- adversarial cross-phase review: no actionable findings

Fixes RUE-727