### PR TITLE
RUE-792: bound malformed parser recovery diagnostics

### DIFF
--- a/crates/rue-compiler/src/syntax.rs
+++ b/crates/rue-compiler/src/syntax.rs
@@ -136,7 +136,9 @@ mod tests {
     use rue_span::FileId;
 
     use super::*;
-    use crate::{Item, SourceMetadata};
+    use crate::{
+        ColorChoice, DiagnosticFormatter, Item, JsonDiagnosticFormatter, SourceInfo, SourceMetadata,
+    };
 
     fn snapshot(entries: &[(u32, &str, &str)]) -> SourceSnapshot {
         let physical_paths: HashMap<_, _> = entries
@@ -214,6 +216,55 @@ mod tests {
                 .sum::<usize>()
         );
         assert_eq!(work.tokens, 13);
+    }
+
+    #[test]
+    fn parser_budget_is_per_file_and_later_files_are_still_parsed() {
+        fn malformed_items(prefix: &str) -> String {
+            let mut source = String::new();
+            for index in 0..rue_parser::PARSER_DIAGNOSTIC_BUDGET + 25 {
+                source.push_str(&format!("fn {prefix}_{index}(,) -> i32 {{ 0 }}\n"));
+            }
+            source
+        }
+
+        let first = malformed_items("first");
+        let second = malformed_items("second");
+        let snapshot = snapshot(&[
+            (10, "first.rue", &first),
+            (20, "good.rue", "fn good() {}"),
+            (30, "second.rue", &second),
+        ]);
+
+        let SyntaxPresentationOutcome { result, work } = parse_snapshot_for_presentation(&snapshot);
+        let errors = result.unwrap_err();
+        let summaries = errors
+            .iter()
+            .filter(|error| matches!(error.kind, ErrorKind::ParserDiagnosticsOmitted { .. }))
+            .collect::<Vec<_>>();
+
+        assert_eq!(errors.len(), 2 * (rue_parser::PARSER_DIAGNOSTIC_BUDGET + 1));
+        assert_eq!(summaries.len(), 2);
+        assert_eq!(summaries[0].span().unwrap().file_id, FileId::new(10));
+        assert_eq!(summaries[1].span().unwrap().file_id, FileId::new(30));
+        assert_eq!(work.parser_invocations, 3);
+
+        let source_info = SourceInfo::new(&first, "first.rue");
+        let text = DiagnosticFormatter::with_color_choice(&source_info, ColorChoice::Never)
+            .format_error(summaries[0]);
+        assert!(
+            text.contains(
+                "[E0103]: additional parser diagnostics omitted after the first 100 errors"
+            )
+        );
+
+        let json_formatter = JsonDiagnosticFormatter::new(&source_info);
+        let json = json_formatter.format_error(summaries[0]).to_json();
+        assert_eq!(json, json_formatter.format_error(summaries[0]).to_json());
+        assert!(json.contains("\"code\":\"E0103\""));
+        assert!(json.contains(
+            "\"message\":\"additional parser diagnostics omitted after the first 100 errors\""
+        ));
     }
 
     #[test]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -99,6 +99,9 @@ impl ErrorCode {
     // end-of-file as UnexpectedToken { found: "end of file" }. Keep the
     // number retired rather than reusing it.
     pub const PARSE_ERROR: Self = Self(102);
+    /// The per-file parser recovery diagnostic budget was exceeded. The
+    /// detailed diagnostics before this summary remain available.
+    pub const PARSER_DIAGNOSTICS_OMITTED: Self = Self(103);
 
     // ========================================================================
     // Semantic errors (E0200-E0399)
@@ -1085,6 +1088,10 @@ pub enum ErrorKind {
     /// Used for parser-generated errors that don't fit the "expected X, found Y" pattern.
     #[error("{0}")]
     ParseError(String),
+    /// Summary emitted after parser recovery reaches its per-file diagnostic
+    /// budget. `limit` is the number of detailed diagnostics retained.
+    #[error("additional parser diagnostics omitted after the first {limit} errors")]
+    ParserDiagnosticsOmitted { limit: usize },
     /// Source is nested more deeply than the compiler supports. Reported by
     /// the parser's nesting pre-scan and by the AstGen depth guard so that
     /// pathologically nested input yields a clean diagnostic instead of a
@@ -1644,6 +1651,7 @@ impl ErrorKind {
             // Parser errors (E0100-E0199)
             ErrorKind::UnexpectedToken { .. } => ErrorCode::UNEXPECTED_TOKEN,
             ErrorKind::ParseError(_) => ErrorCode::PARSE_ERROR,
+            ErrorKind::ParserDiagnosticsOmitted { .. } => ErrorCode::PARSER_DIAGNOSTICS_OMITTED,
             ErrorKind::NestingLimitExceeded { .. } => ErrorCode::NESTING_LIMIT_EXCEEDED,
 
             // Semantic errors (E0200-E0399)
@@ -2937,6 +2945,10 @@ mod tests {
         assert_eq!(
             ErrorKind::ParseError("custom error".into()).code(),
             ErrorCode::PARSE_ERROR
+        );
+        assert_eq!(
+            ErrorKind::ParserDiagnosticsOmitted { limit: 100 }.code(),
+            ErrorCode::PARSER_DIAGNOSTICS_OMITTED
         );
     }
 

--- a/crates/rue-parser/src/lib.rs
+++ b/crates/rue-parser/src/lib.rs
@@ -8,6 +8,15 @@ mod validate;
 
 pub use validate::KNOWN_DIRECTIVES;
 
+/// Maximum number of detailed parser diagnostics retained for one source file.
+/// If more unique grammar-recovery or post-parse validation diagnostics are
+/// produced, the parser appends one
+/// [`rue_error::ErrorKind::ParserDiagnosticsOmitted`] summary.
+///
+/// The budget is local to each [`Parser`] invocation. Lexer diagnostics come
+/// from the preceding lexer phase and are intentionally outside this budget.
+pub const PARSER_DIAGNOSTIC_BUDGET: usize = 100;
+
 pub use ast::{
     ArgMode,
     ArrayLength,

--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -19,7 +19,7 @@ pub struct Parser {
     interner: ThreadedRodeo,
     syms: PrimitiveTypeSpurs,
     file_id: FileId,
-    errors: Vec<CompileError>,
+    errors: diagnostics::ParserDiagnostics,
 }
 struct PrimitiveTypeSpurs {
     i8: Spur,
@@ -81,7 +81,7 @@ impl Parser {
             interner,
             syms,
             file_id,
-            errors: Vec::new(),
+            errors: diagnostics::ParserDiagnostics::default(),
         }
     }
 
@@ -135,11 +135,10 @@ impl Parser {
             }
             items
         };
-        let raw_parse_error_count = self.errors.len();
-        self.remove_subsumed_identifier_errors();
-        diagnostics::dedupe_parse_errors(&mut self.errors);
-        let parse_error_count = self.errors.len();
-        if !self.errors.is_empty() {
+        let raw_parse_error_count = self.errors.raw_count();
+        let (errors, diagnostic_equality_checks) = std::mem::take(&mut self.errors).finish();
+        let parse_error_count = errors.len();
+        if !errors.is_empty() {
             info!(
                 outcome = "parse_error",
                 input_token_count,
@@ -147,10 +146,11 @@ impl Parser {
                 ast_item_count = 0,
                 raw_parse_error_count,
                 parse_error_count,
+                diagnostic_equality_checks,
                 validation_error_count = 0,
                 "parser complete"
             );
-            return Err((CompileErrors::from(self.errors), self.interner));
+            return Err((CompileErrors::from(errors), self.interner));
         }
 
         let ast = Ast { items };
@@ -305,6 +305,67 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![8, 29, 50]
         );
+    }
+
+    #[test]
+    fn thousands_of_recovery_points_have_a_bounded_diagnostic_result() {
+        let mut source = String::new();
+        for index in 0..2_000 {
+            source.push_str(&format!("fn broken{index}(,) -> i32 {{ 0 }}\n"));
+        }
+
+        let errors = parse_source(&source).unwrap_err();
+
+        assert_eq!(
+            errors.len(),
+            crate::PARSER_DIAGNOSTIC_BUDGET + 1,
+            "{errors:?}"
+        );
+        assert!(
+            errors
+                .iter()
+                .take(crate::PARSER_DIAGNOSTIC_BUDGET)
+                .all(|error| matches!(error.kind, ErrorKind::UnexpectedToken { .. }))
+        );
+        assert!(matches!(
+            errors.as_slice().last().map(|error| &error.kind),
+            Some(ErrorKind::ParserDiagnosticsOmitted { limit })
+                if *limit == crate::PARSER_DIAGNOSTIC_BUDGET
+        ));
+    }
+
+    #[test]
+    fn thousands_of_validation_errors_use_the_same_bounded_parser_budget() {
+        let mut source = String::new();
+        for index in 0..2_000 {
+            source.push_str(&format!("@unknown{index} fn valid{index}() {{}}\n"));
+        }
+
+        let errors = parse_source(&source).unwrap_err();
+
+        assert_eq!(errors.len(), crate::PARSER_DIAGNOSTIC_BUDGET + 1);
+        assert!(
+            errors
+                .iter()
+                .take(crate::PARSER_DIAGNOSTIC_BUDGET)
+                .all(|error| matches!(&error.kind, ErrorKind::ParseError(message)
+                if message.starts_with("unknown directive")))
+        );
+        assert!(matches!(
+            errors.as_slice().last().map(|error| &error.kind),
+            Some(ErrorKind::ParserDiagnosticsOmitted { limit })
+                if *limit == crate::PARSER_DIAGNOSTIC_BUDGET
+        ));
+    }
+
+    #[test]
+    fn one_long_discarded_region_makes_progress_without_payload_growth() {
+        let source = format!("fn broken( {}", "discarded ".repeat(50_000));
+
+        let errors = parse_source(&source).unwrap_err();
+
+        assert_eq!(errors.len(), 1);
+        assert!(errors.first().unwrap().to_string().len() < 100);
     }
 
     #[test]

--- a/crates/rue-parser/src/parser/expressions.rs
+++ b/crates/rue-parser/src/parser/expressions.rs
@@ -484,7 +484,7 @@ impl Parser {
                         Ok(name) => name,
                         Err(()) => {
                             let previous_end = at.span.start.saturating_sub(5);
-                            self.errors.push(CompileError::new(
+                            self.record_error(CompileError::new(
                                 ErrorKind::UnexpectedToken {
                                     expected: "identifier".into(),
                                     found: "'@'".into(),

--- a/crates/rue-parser/src/parser/shared.rs
+++ b/crates/rue-parser/src/parser/shared.rs
@@ -53,16 +53,19 @@ impl Parser {
             .get(self.cursor)
             .map(|t| t.span)
             .unwrap_or_else(|| Span::point_in_file(self.file_id, self.end_offset()));
-        self.errors.push(CompileError::new(
+        self.record_error(CompileError::new(
             ErrorKind::ParseError(message.into()),
             span,
         ));
     }
     pub(super) fn error_at(&mut self, message: impl Into<String>, span: Span) {
-        self.errors.push(CompileError::new(
+        self.record_error(CompileError::new(
             ErrorKind::ParseError(message.into()),
             span,
         ));
+    }
+    pub(super) fn record_error(&mut self, error: CompileError) {
+        self.errors.push(error);
     }
     pub(super) fn unexpected(&mut self, expected: impl Into<String>) {
         let expected = expected.into();
@@ -72,18 +75,6 @@ impl Parser {
             .get(self.cursor)
             .map(|token| token.span)
             .unwrap_or_else(|| Span::point_in_file(self.file_id, self.end_offset()));
-        if expected == "identifier"
-            && self.errors.iter().any(|error| {
-                error.span() == Some(span)
-                    && matches!(
-                        &error.kind,
-                        ErrorKind::UnexpectedToken { expected, found }
-                            if expected == "identifier or 'drop'" && found == found_kind.name()
-                    )
-            })
-        {
-            return;
-        }
         let mut error = CompileError::new(
             ErrorKind::UnexpectedToken {
                 expected: expected.into(),
@@ -104,27 +95,7 @@ impl Parser {
                  `Enum.Variant` or `Type.function()`",
             );
         }
-        self.errors.push(error);
-    }
-    pub(super) fn remove_subsumed_identifier_errors(&mut self) {
-        let mut retained = Vec::with_capacity(self.errors.len());
-        for error in std::mem::take(&mut self.errors) {
-            let subsumed = matches!(
-                &error.kind,
-                ErrorKind::UnexpectedToken { expected, .. } if expected == "identifier"
-            ) && retained.iter().any(|prior: &CompileError| {
-                prior.span() == error.span()
-                    && matches!(
-                        &prior.kind,
-                        ErrorKind::UnexpectedToken { expected, .. }
-                            if expected == "identifier or 'drop'"
-                    )
-            });
-            if !subsumed {
-                retained.push(error);
-            }
-        }
-        self.errors = retained;
+        self.record_error(error);
     }
     pub(super) fn eat(&mut self, kind: TokenKind) -> bool {
         if self.at(kind) {
@@ -220,6 +191,9 @@ impl Parser {
         // and re-parsing it as a fresh top-level item emits phantom errors at
         // valid lines (RUE-726). A stray close brace clamps to zero so text
         // after an over-closed item still synchronizes.
+        // Recovery advances the cursor in place and never copies the skipped
+        // token region into a diagnostic payload, so a long malformed region
+        // costs constant auxiliary recovery storage (RUE-792).
         let mut brace_depth: usize = 0;
         if !self.at(TokenKind::Eof) {
             debug_assert_eq!(
@@ -278,7 +252,7 @@ impl Parser {
                     _ => None,
                 };
                 if let Some(expected) = expected {
-                    self.errors.push(CompileError::new(
+                    self.record_error(CompileError::new(
                         ErrorKind::UnexpectedToken {
                             expected: expected.into(),
                             found: token.kind.name().to_owned().into(),
@@ -331,7 +305,7 @@ impl Parser {
                     .and_then(|index| self.tokens.get(index))
                     .map(|token| token.span.end)
                     .unwrap_or(token.span.start);
-                self.errors.push(CompileError::new(
+                self.record_error(CompileError::new(
                     ErrorKind::UnexpectedToken {
                         expected: "identifier".into(),
                         found: "'fn'".into(),
@@ -350,7 +324,7 @@ impl Parser {
                 if let Some(token) = self.tokens.get(pattern_index)
                     && !matches!(token.kind, TokenKind::Ident(_) | TokenKind::Underscore)
                 {
-                    self.errors.push(CompileError::new(
+                    self.record_error(CompileError::new(
                         ErrorKind::UnexpectedToken {
                             expected: "identifier or '_'".into(),
                             found: token.kind.name().to_owned().into(),

--- a/crates/rue-parser/src/parser/statements.rs
+++ b/crates/rue-parser/src/parser/statements.rs
@@ -363,7 +363,7 @@ impl Parser {
                             .unwrap_or_else(|| {
                                 Span::point_in_file(self.file_id, self.end_offset())
                             });
-                        self.errors.push(
+                        self.record_error(
                             CompileError::new(
                                 ErrorKind::ParseError(
                                     "a block-like expression in statement position is a \

--- a/crates/rue-parser/src/parser_policy/diagnostics.rs
+++ b/crates/rue-parser/src/parser_policy/diagnostics.rs
@@ -1,33 +1,152 @@
-//! Parser-independent diagnostic postprocessing.
+//! Parser-independent diagnostic collection policy.
 //!
-//! Parser adapters construct [`CompileError`] values, then apply this policy
-//! before exposing them. The first diagnostic determines ordering; only equal
-//! error kinds at the same complete primary span are duplicates.
+//! Parser adapters emit [`CompileError`] values through [`ParserDiagnostics`].
+//! The collector preserves first occurrence order and treats only equal error
+//! kinds at the same complete primary span as duplicates. Rich labels, notes,
+//! helps, and suggestions are intentionally not part of this parser policy's
+//! exact key.
+
+use std::collections::{HashMap, hash_map::RandomState};
+use std::fmt::{self, Write as _};
+use std::hash::{BuildHasher, Hash, Hasher};
 
 use rue_error::{CompileError, ErrorKind};
-use rue_span::Span;
 
-/// Drop diagnostics with the same kind and primary span, preserving first-seen
-/// order. Distinct diagnostics at one location and identical diagnostics in
-/// different files remain visible.
-pub(crate) fn dedupe_parse_errors(errors: &mut Vec<CompileError>) {
-    // Parse error lists are tiny, so a linear seen set avoids hashing overhead.
-    let mut seen: Vec<(Option<Span>, ErrorKind)> = Vec::new();
-    errors.retain(|error| {
-        let key = (error.span(), error.kind.clone());
-        if seen.contains(&key) {
-            false
-        } else {
-            seen.push(key);
-            true
+use crate::PARSER_DIAGNOSTIC_BUDGET;
+
+/// A formatting sink that feeds an error kind's display representation into a
+/// hasher without allocating a temporary `String`.
+struct HashWriter<'a, H>(&'a mut H);
+
+impl<H: Hasher> fmt::Write for HashWriter<'_, H> {
+    fn write_str(&mut self, value: &str) -> fmt::Result {
+        self.0.write(value.as_bytes());
+        Ok(())
+    }
+}
+
+fn fingerprint(state: &RandomState, error: &CompileError) -> u64 {
+    let mut hasher = state.build_hasher();
+    error.span().hash(&mut hasher);
+    std::mem::discriminant(&error.kind).hash(&mut hasher);
+    write!(HashWriter(&mut hasher), "{}", error.kind).expect("hash formatting cannot fail");
+    hasher.finish()
+}
+
+/// Bounded diagnostic state for one parser invocation and therefore one file.
+///
+/// Fingerprints make exact deduplication expected-linear. Equality against
+/// every matching fingerprint keeps hash collisions exact without cloning
+/// [`ErrorKind`]. Only retained details participate in the seen index: after
+/// the budget is full, every new unique diagnostic is omitted anyway. One
+/// unretained latest diagnostic is held separately because recovery decisions
+/// must inspect the error that just occurred, not a stale retained error.
+#[derive(Default)]
+pub(crate) struct ParserDiagnostics {
+    retained: Vec<CompileError>,
+    fingerprint_state: RandomState,
+    seen: HashMap<u64, Vec<usize>>,
+    last_retained: Option<usize>,
+    last_unretained: Option<CompileError>,
+    summary_span: Option<rue_span::Span>,
+    summary_without_span: bool,
+    raw_count: usize,
+    exact_comparisons: usize,
+}
+
+impl ParserDiagnostics {
+    /// Record one raw grammar diagnostic through the canonical bounded path.
+    pub(crate) fn push(&mut self, error: CompileError) {
+        self.raw_count += 1;
+        // Preserve the historical temporal subsumption rule: a *current*
+        // narrow identifier error is omitted only when its targeted superset
+        // already precedes it. The raw current error still becomes `last()` so
+        // recovery sees exactly the error just emitted. A later superset never
+        // removes or reorders an earlier narrow diagnostic.
+        let current_narrow_is_subsumed = matches!(
+            &error.kind,
+            ErrorKind::UnexpectedToken { expected, .. } if expected == "identifier"
+        ) && self.retained.iter().any(|prior| {
+            prior.span() == error.span()
+                && matches!(
+                    &prior.kind,
+                    ErrorKind::UnexpectedToken { expected, .. }
+                        if expected == "identifier or 'drop'"
+                )
+        });
+        if current_narrow_is_subsumed {
+            self.set_unretained_last(error);
+            return;
         }
-    });
+
+        let fingerprint = fingerprint(&self.fingerprint_state, &error);
+        let duplicate = self.seen.get(&fingerprint).is_some_and(|indices| {
+            indices.iter().any(|&index| {
+                self.exact_comparisons += 1;
+                let prior = &self.retained[index];
+                prior.span() == error.span() && prior.kind == error.kind
+            })
+        });
+
+        if duplicate {
+            self.set_unretained_last(error);
+            return;
+        }
+
+        if self.retained.len() < PARSER_DIAGNOSTIC_BUDGET {
+            self.seen
+                .entry(fingerprint)
+                .or_default()
+                .push(self.retained.len());
+            self.retained.push(error);
+            self.last_retained = Some(self.retained.len() - 1);
+            self.last_unretained = None;
+        } else {
+            if self.summary_span.is_none() && !self.summary_without_span {
+                match error.span() {
+                    Some(span) => self.summary_span = Some(span),
+                    None => self.summary_without_span = true,
+                }
+            }
+            self.set_unretained_last(error);
+        }
+    }
+
+    fn set_unretained_last(&mut self, error: CompileError) {
+        self.last_retained = None;
+        self.last_unretained = Some(error);
+    }
+
+    pub(crate) fn last(&self) -> Option<&CompileError> {
+        self.last_unretained.as_ref().or_else(|| {
+            self.last_retained
+                .and_then(|index| self.retained.get(index))
+        })
+    }
+
+    pub(crate) fn raw_count(&self) -> usize {
+        self.raw_count
+    }
+
+    /// Finish collection, appending the deterministic summary only after
+    /// recovery no longer needs `last()`.
+    pub(crate) fn finish(mut self) -> (Vec<CompileError>, usize) {
+        let summary = ErrorKind::ParserDiagnosticsOmitted {
+            limit: PARSER_DIAGNOSTIC_BUDGET,
+        };
+        if let Some(span) = self.summary_span {
+            self.retained.push(CompileError::new(summary, span));
+        } else if self.summary_without_span {
+            self.retained.push(CompileError::without_span(summary));
+        }
+        (self.retained, self.exact_comparisons)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rue_span::FileId;
+    use rue_span::{FileId, Span};
 
     fn error(message: &str, file: u32, start: u32) -> CompileError {
         CompileError::new(
@@ -36,22 +155,147 @@ mod tests {
         )
     }
 
+    fn unexpected(expected: &'static str, start: u32) -> CompileError {
+        CompileError::new(
+            ErrorKind::UnexpectedToken {
+                expected: expected.into(),
+                found: "'@'".into(),
+            },
+            Span::new(start, start + 1),
+        )
+    }
+
     #[test]
-    fn dedupe_preserves_order_and_distinctions() {
-        let mut errors = vec![
+    fn dedupe_preserves_order_and_exact_key_distinctions() {
+        let mut diagnostics = ParserDiagnostics::default();
+        for error in [
             error("first", 1, 4),
-            error("first", 1, 4),
+            error("first", 1, 4).with_help("rich payload is ignored by parser dedupe"),
             error("second", 1, 4),
             error("first", 2, 4),
             error("first", 1, 5),
-        ];
+        ] {
+            diagnostics.push(error);
+        }
 
-        dedupe_parse_errors(&mut errors);
+        let (errors, _) = diagnostics.finish();
 
         assert_eq!(errors.len(), 4);
         assert_eq!(errors[0].to_string(), "first");
+        assert!(errors[0].diagnostic().helps.is_empty());
         assert_eq!(errors[1].to_string(), "second");
         assert_eq!(errors[2].span().unwrap().file_id, FileId::new(2));
         assert_eq!(errors[3].span().unwrap().start, 5);
+    }
+
+    #[test]
+    fn duplicate_heavy_work_is_linear_in_input_count() {
+        const UNIQUE: usize = 50;
+        const REPETITIONS: usize = 200;
+        let mut diagnostics = ParserDiagnostics::default();
+        for _ in 0..REPETITIONS {
+            for start in 0..UNIQUE {
+                diagnostics.push(error("same kind", 1, start as u32));
+            }
+        }
+
+        let (errors, comparisons) = diagnostics.finish();
+
+        assert_eq!(errors.len(), UNIQUE);
+        assert_eq!(comparisons, UNIQUE * (REPETITIONS - 1));
+    }
+
+    #[test]
+    fn earlier_broad_identifier_error_suppresses_only_the_later_narrow_error() {
+        let mut diagnostics = ParserDiagnostics::default();
+        diagnostics.push(unexpected("identifier or 'drop'", 4));
+        diagnostics.push(unexpected("identifier", 4));
+
+        assert!(matches!(
+            &diagnostics.last().unwrap().kind,
+            ErrorKind::UnexpectedToken { expected, .. } if expected == "identifier"
+        ));
+        let (errors, _) = diagnostics.finish();
+        assert_eq!(errors.len(), 1);
+        assert!(matches!(
+            &errors[0].kind,
+            ErrorKind::UnexpectedToken { expected, .. }
+                if expected == "identifier or 'drop'"
+        ));
+    }
+
+    #[test]
+    fn earlier_narrow_identifier_error_is_not_removed_by_a_later_broad_error() {
+        let mut diagnostics = ParserDiagnostics::default();
+        diagnostics.push(unexpected("identifier", 4));
+        diagnostics.push(unexpected("identifier or 'drop'", 4));
+
+        let (errors, _) = diagnostics.finish();
+        assert_eq!(errors.len(), 2);
+        assert!(matches!(
+            &errors[0].kind,
+            ErrorKind::UnexpectedToken { expected, .. } if expected == "identifier"
+        ));
+        assert!(matches!(
+            &errors[1].kind,
+            ErrorKind::UnexpectedToken { expected, .. }
+                if expected == "identifier or 'drop'"
+        ));
+    }
+
+    #[test]
+    fn later_broad_error_does_not_reopen_a_slot_or_move_the_summary_boundary() {
+        let mut diagnostics = ParserDiagnostics::default();
+        diagnostics.push(unexpected("identifier", 4));
+        for start in 1..PARSER_DIAGNOSTIC_BUDGET {
+            diagnostics.push(error("detail", 1, 100 + start as u32));
+        }
+        diagnostics.push(error("first omitted", 1, 10_000));
+        diagnostics.push(unexpected("identifier or 'drop'", 4));
+
+        let (errors, _) = diagnostics.finish();
+        assert_eq!(errors.len(), PARSER_DIAGNOSTIC_BUDGET + 1);
+        assert!(matches!(
+            &errors[0].kind,
+            ErrorKind::UnexpectedToken { expected, .. } if expected == "identifier"
+        ));
+        assert_eq!(
+            errors.last().unwrap().span().unwrap(),
+            Span::with_file(FileId::new(1), 10_000, 10_001)
+        );
+    }
+
+    #[test]
+    fn collector_remains_bounded_and_summary_is_deterministic() {
+        let mut diagnostics = ParserDiagnostics::default();
+        for start in 0..10_000 {
+            diagnostics.push(error("malformed item", 7, start as u32));
+            assert!(diagnostics.retained.len() <= PARSER_DIAGNOSTIC_BUDGET);
+            assert!(diagnostics.seen.len() <= PARSER_DIAGNOSTIC_BUDGET);
+            assert_eq!(
+                diagnostics.last().unwrap().span().unwrap().start,
+                start as u32
+            );
+        }
+
+        let (errors, _) = diagnostics.finish();
+
+        assert_eq!(errors.len(), PARSER_DIAGNOSTIC_BUDGET + 1);
+        assert_eq!(
+            errors[PARSER_DIAGNOSTIC_BUDGET - 1].span().unwrap().start,
+            99
+        );
+        let summary = &errors[PARSER_DIAGNOSTIC_BUDGET];
+        assert_eq!(summary.span().unwrap().start, 100);
+        assert_eq!(
+            summary.kind,
+            ErrorKind::ParserDiagnosticsOmitted {
+                limit: PARSER_DIAGNOSTIC_BUDGET
+            }
+        );
+        assert_eq!(
+            summary.to_string(),
+            "additional parser diagnostics omitted after the first 100 errors"
+        );
     }
 }

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -14,6 +14,7 @@
 //! unknown intrinsics.
 
 use crate::ast::{Ast, Directive, Expr, IntrinsicArg, Item, Method, Statement, TypeExpr};
+use crate::parser_policy::diagnostics::ParserDiagnostics;
 use lasso::ThreadedRodeo;
 use rue_error::{CompileError, ErrorKind};
 
@@ -34,22 +35,22 @@ pub const KNOWN_DIRECTIVES: &[&str] = &["allow", "copy"];
 pub const KNOWN_WARNING_NAMES: &[&str] =
     &["unused_variable", "unused_function", "unreachable_code"];
 
-/// Walk the AST and report every directive whose name is not in
-/// [`KNOWN_DIRECTIVES`].
+/// Walk the AST and report directive-validation diagnostics through the same
+/// bounded per-file policy as grammar recovery.
 pub fn check_directives(ast: &Ast, interner: &ThreadedRodeo) -> Vec<CompileError> {
     let mut v = Validator {
         interner,
-        errors: Vec::new(),
+        errors: ParserDiagnostics::default(),
     };
     for item in &ast.items {
         v.check_item(item);
     }
-    v.errors
+    v.errors.finish().0
 }
 
 struct Validator<'a> {
     interner: &'a ThreadedRodeo,
-    errors: Vec<CompileError>,
+    errors: ParserDiagnostics,
 }
 
 #[derive(Clone, Copy)]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,6 +146,16 @@ retain presentation order without constructing a second parsed or merged
 program. Duplicate, cross-kind, and program-wide `main` legality is implemented
 once by canonical merge candidate validation.
 
+The parser retains at most 100 detailed diagnostics per source file across
+grammar recovery and post-parse directive validation. Exact duplicates (the
+same error kind and complete primary span) are removed in first-occurrence
+order before that budget is applied; rich labels, notes, helps, and suggestions
+do not distinguish parser duplicates. If unique parser diagnostics exceed the
+budget, one E0103 summary is appended at the first omitted diagnostic's span.
+Each file gets a fresh budget, and snapshot parsing continues with later files.
+Lexer errors come from the preceding lexer phase and retain their separate
+phase-specific behavior.
+
 The `rue-compiler` facade mirrors implementation ownership rather than a
 monolithic driver:
 


### PR DESCRIPTION
Parser recovery previously accumulated every raw diagnostic, cloned error kinds, and deduplicated with a quadratic insertion-order scan. Pathological malformed input could therefore amplify time, memory, and output without a per-file bound.

This change introduces one online parser diagnostic collector that preserves first-occurrence order and exact kind-plus-span equality while using randomized fingerprints with exact collision checks. It retains at most 100 detailed diagnostics per file, then emits one deterministic E0103 summary at the first omitted diagnostic. Grammar recovery and post-parse validation share the bound; lexer diagnostics remain a separate preceding phase. Cursor recovery continues to skip discarded regions in place and preserves the RUE-726 synchronization behavior.

Coverage stresses 10,000 collector emissions, 2,000 recovery points, 2,000 validation errors, a 50,000-token discarded region, temporal targeted-diagnostic ordering, per-file reset/later-file continuation, and deterministic human/JSON rendering.

Validation:
- scripts/rue fmt
- scripts/rue quick
- scripts/rue test
- focused parser, compiler, UI, and CLI diagnostic suites

Fixes RUE-792