### PR TITLE
RUE-1008: adopt a retained StrMap index in the Rill string pool

### DIFF
--- a/examples/mosaic/pool.rue
+++ b/examples/mosaic/pool.rue
@@ -2,10 +2,11 @@
 // integer id, keeping the site model trivially copyable and arena-friendly.
 // An open-addressed hash index makes interning amortized O(length), so total
 // intern work stays linear in input volume instead of quadratic in pool size
-// (RUE-1003). The index is hand-rolled from the pool's own primitive arrays
-// because a StrMap(u64) field on this cross-module public struct fails
-// comptime type reduction while RUE-993 is open. Ids are never removed, so
-// the table needs no tombstones: a slot holds id + 1, and 0 means empty.
+// (RUE-1003). A retained StrMap(u64) field works since RUE-993, but it would
+// copy every key's bytes into a second table; this index is built from the
+// pool's own primitive arrays so the pooled bytes stay the only copy
+// (RUE-1008). Ids are never removed, so the table needs no tombstones: a
+// slot holds id + 1, and 0 means empty.
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
 const U64s = std.arraybuf.ArrayBuf(u64);

--- a/examples/rill/pool.rue
+++ b/examples/rill/pool.rue
@@ -1,18 +1,22 @@
 // A pooled string table used for source identifiers, literals, and runtime
 // concatenation. Entries are described by offsets and lengths; no owned
-// StrBuf ever needs to be read by copy from an ArrayBuf.
+// StrBuf ever needs to be read by copy from an ArrayBuf. A retained StrMap
+// index makes intern and find amortized O(length) in pool size (RUE-1008).
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
 const U64s = std.arraybuf.ArrayBuf(u64);
+const U64Map = std.strmap.StrMap(u64);
 const OptU8 = std.option.Option(u8);
+const OptU64 = std.option.Option(u64);
 
 pub struct Pool {
     bytes: StrBuf,
     offs: U64s,
     lens: U64s,
+    index: U64Map,
 
     fn new() -> Self {
-        Self { bytes: StrBuf.new(), offs: U64s.new(), lens: U64s.new() }
+        Self { bytes: StrBuf.new(), offs: U64s.new(), lens: U64s.new(), index: U64Map.new(0) }
     }
 
     fn byte_of(borrow value: StrBuf, i: u64) -> u8 {
@@ -55,16 +59,10 @@ pub struct Pool {
     }
 
     fn intern(inout self, borrow text: StrBuf) -> u64 {
-        // A StrMap index would make this lookup amortized O(1), but retaining
-        // StrMap(u64) as a field of this cross-module public struct currently
-        // fails comptime type reduction (RUE-993). Keep the canonical pool and
-        // a correct linear lookup until that generic-field restriction lifts.
+        let existing = self.find(borrow text);
+        if existing != 18446744073709551615 { return existing; }
         let n = self.len();
-        let mut i: u64 = 0;
-        while i < n {
-            if self.equals_buf(i, borrow text) { return i; }
-            i = i + 1;
-        }
+        self.index.insert(borrow text, n);
         let off = self.bytes.len();
         let len = text.len();
         let mut j: u64 = 0;
@@ -78,12 +76,10 @@ pub struct Pool {
     }
 
     fn find(borrow self, borrow text: StrBuf) -> u64 {
-        let mut i: u64 = 0;
-        while i < self.len() {
-            if self.equals_buf(i, borrow text) { return i; }
-            i = i + 1;
+        match self.index.get(borrow text) {
+            OptU64.Some(id) => id,
+            OptU64.None => 18446744073709551615,
         }
-        18446744073709551615
     }
 
     fn intern_range(inout self, borrow source: StrBuf, start: u64, len: u64) -> u64 {


### PR DESCRIPTION
Follow-up to RUE-993 (#1804), cleaning up the two example string pools that worked around the now-fixed papercut.

## Rill

`pool.intern` scanned every interned string per lookup — O(symbols²) total — with a comment promising the natural spelling "until that generic-field restriction lifts". The pool now retains `index: U64Map` (a `StrMap(u64)` field declared through a module-level `const U64Map = std.strmap.StrMap(u64)` alias — deliberately the *other* spelling RUE-993 broke, so this example dogfoods both fixed forms). `intern` and `find` are now amortized O(length); `intern_range` and `concat` inherit the indexed path. All public behavior, ids, and the `find` miss sentinel are unchanged.

## Mosaic

Keeps its hand-rolled open-addressed table **deliberately**: it's already amortized O(1) and indexes the pooled bytes in place, whereas a retained `StrMap` would copy every key's bytes into a second table. The header comment now states that trade-off instead of citing RUE-993 as a live blocker.

## Validation

- `scripts/rue cli examples_rill`: 12/12 pass (including `--stress`, which exercises symbol interning across 300 generated functions and still prints the exact expected output).
- `scripts/rue cli examples_mosaic`: 17/17 pass.
- Direct runs of `rill --stress` and `mosaic stress` produce identical results to before the change.

Fixes RUE-1008