### PR TITLE
RUE-1007: deterministic zero-padding on compact construction (ADR-0052 phase 5.9)

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -1039,6 +1039,93 @@ impl TypeInternPoolInner {
         }
     }
 
+    /// The byte ranges of `ty`'s compact memory image that no leaf field
+    /// occupies: interior and tail struct padding, an enum's tag-to-payload gap
+    /// and tail padding, and any gaps between an enum's union payload positions.
+    ///
+    /// These are exactly the bytes ADR-0052 ruling 5 (deterministic zero on
+    /// construction) requires cleared wherever a compact image is materialized,
+    /// and the complement of the value-decomposition slots the codegen image map
+    /// writes — so zeroing these ranges and then storing the fields
+    /// deterministically initializes every byte of the image. Empty under the
+    /// slot model (no padding exists), so a gate-off build derives no ranges and
+    /// emits no zeroing.
+    fn compact_image_padding_ranges(&self, ty: Type) -> Vec<PaddingRange> {
+        if !self.compact_layout {
+            return Vec::new();
+        }
+        let (size, _) = self.compact_size_align(ty);
+        if size == 0 {
+            return Vec::new();
+        }
+        let mut covered: Vec<(u64, u64)> = Vec::new();
+        self.collect_compact_leaf_ranges(ty, 0, &mut covered);
+        // Complement the covered leaf ranges against `[0, size)`.
+        covered.sort_by_key(|&(start, _)| start);
+        let mut ranges = Vec::new();
+        let mut cursor = 0u64;
+        for (start, end) in covered {
+            if start > cursor {
+                ranges.push(PaddingRange {
+                    start: cursor,
+                    end: start,
+                });
+            }
+            cursor = cursor.max(end);
+        }
+        if cursor < size {
+            ranges.push(PaddingRange {
+                start: cursor,
+                end: size,
+            });
+        }
+        ranges
+    }
+
+    /// Append the absolute byte ranges every leaf scalar of `ty`'s compact image
+    /// occupies (offset by `base`) to `out`. A struct recurses through its
+    /// fields; an array through its elements; an enum contributes its tag range
+    /// plus every variant's every payload-field range (their union is the
+    /// variant-independent payload image); a scalar contributes its own byte
+    /// span. The counterpart of the codegen image map, kept here so the layout
+    /// authority is the single source of which bytes are padding.
+    fn collect_compact_leaf_ranges(&self, ty: Type, base: u64, out: &mut Vec<(u64, u64)>) {
+        match ty.kind() {
+            TypeKind::Struct(id) => {
+                let layout = self.compact_struct_layout(id);
+                let fields = self.struct_def(id).fields.clone();
+                for (field, &offset) in fields.iter().zip(layout.field_offsets.iter()) {
+                    self.collect_compact_leaf_ranges(field.ty, base + offset, out);
+                }
+            }
+            TypeKind::Array(id) => {
+                let (element, count) = self.array_def(id);
+                let (stride, _) = self.compact_size_align(element);
+                for k in 0..count {
+                    self.collect_compact_leaf_ranges(element, base + k * stride, out);
+                }
+            }
+            TypeKind::Enum(id) => {
+                let layout = self.compact_enum_layout(id);
+                out.push((base, base + layout.tag_size));
+                let def = self.enum_def(id);
+                for variant in 0..def.variant_count() {
+                    let payload = def.variant_payload(variant);
+                    for (field_index, &field_ty) in payload.iter().enumerate() {
+                        let offset = layout.variants[variant][field_index];
+                        self.collect_compact_leaf_ranges(field_ty, base + offset, out);
+                    }
+                }
+            }
+            _ => {
+                let (size, _) = self.compact_size_align(ty);
+                if size > 0 {
+                    out.push((base, base + size));
+                }
+            }
+        }
+    }
+
     fn file_symbol_component(&self, file_id: FileId) -> String {
         self.symbol_paths
             .get(&file_id)
@@ -2279,6 +2366,18 @@ impl FrozenTypeInternPool {
         self.validate_complete_type(ty)
             .expect("backend layout requires a complete, non-recovery type graph");
         self.inner.layout(ty)
+    }
+
+    /// The byte ranges of `ty`'s compact memory image that hold padding rather
+    /// than a leaf field (ADR-0052 ruling 5). Code generation zeros exactly these
+    /// ranges wherever it materializes a compact image — heap enum stores, sret
+    /// buffers, and by-value argument buffers — so the padding is deterministically
+    /// zero on construction. Always empty with the compact layout off, keeping
+    /// gate-off code byte-identical.
+    pub fn compact_image_padding_ranges(&self, ty: Type) -> Vec<PaddingRange> {
+        self.validate_complete_type(ty)
+            .expect("backend layout requires a complete, non-recovery type graph");
+        self.inner.compact_image_padding_ranges(ty)
     }
 
     /// Byte offset of a struct field within its aggregate, the shared source for
@@ -4001,6 +4100,128 @@ mod tests {
         assert_eq!(frozen.struct_field_slot_offset(id, 0), 0);
         assert_eq!(frozen.struct_field_slot_offset(id, 1), 1);
         assert_eq!(frozen.struct_field_slot_offset(id, 2), 2);
+    }
+
+    #[test]
+    fn compact_image_padding_ranges_cover_struct_interior_and_tail_gaps() {
+        // Padded { a: u8, b: i32, c: u8 }: a@0, pad[1,4), b@4, c@8, tail[9,12).
+        let pool = TypeInternPool::new();
+        pool.set_compact_layout(true);
+        let interner = ThreadedRodeo::default();
+        let (id, _) = pool.register_struct(
+            interner.get_or_intern("Padded"),
+            struct_def(
+                "Padded",
+                vec![
+                    StructField {
+                        name: "a".into(),
+                        ty: Type::U8,
+                    },
+                    StructField {
+                        name: "b".into(),
+                        ty: Type::I32,
+                    },
+                    StructField {
+                        name: "c".into(),
+                        ty: Type::U8,
+                    },
+                ],
+            ),
+        );
+        let frozen = pool.freeze();
+        assert_eq!(
+            frozen.compact_image_padding_ranges(Type::new_struct(id)),
+            vec![
+                PaddingRange { start: 1, end: 4 },
+                PaddingRange { start: 9, end: 12 },
+            ]
+        );
+    }
+
+    #[test]
+    fn compact_image_padding_ranges_cover_enum_tag_gap_and_tail() {
+        // Wide { A(u8, i32), B }: u8 tag@0, payload@4 (i32 alignment). Payload
+        // packs u8@0,i32@4 => u8 abs@4, i32 abs@8; size = align_up(4+8,4) = 12.
+        // Padding: tag-to-payload [1,4) and the gap [5,8) after the u8 field.
+        let pool = TypeInternPool::new();
+        pool.set_compact_layout(true);
+        let interner = ThreadedRodeo::default();
+        let def = EnumDef {
+            name: "Wide".to_string(),
+            variants: vec!["A".to_string(), "B".to_string()],
+            variant_payloads: vec![vec![Type::U8, Type::I32], vec![]],
+            is_pub: false,
+            file_id: FileId::DEFAULT,
+        };
+        let (id, _) = pool.register_enum(interner.get_or_intern("Wide"), def);
+        let frozen = pool.freeze();
+        assert_eq!(
+            frozen.compact_image_padding_ranges(Type::new_enum(id)),
+            vec![
+                PaddingRange { start: 1, end: 4 },
+                PaddingRange { start: 5, end: 8 },
+            ]
+        );
+    }
+
+    #[test]
+    fn compact_image_padding_ranges_are_empty_without_the_gate() {
+        // The slot model has no padding, so a gate-off pool derives no ranges —
+        // the property that keeps gate-off code byte-identical.
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let (id, _) = pool.register_struct(
+            interner.get_or_intern("Padded"),
+            struct_def(
+                "Padded",
+                vec![
+                    StructField {
+                        name: "a".into(),
+                        ty: Type::U8,
+                    },
+                    StructField {
+                        name: "b".into(),
+                        ty: Type::I32,
+                    },
+                ],
+            ),
+        );
+        let frozen = pool.freeze();
+        assert!(
+            frozen
+                .compact_image_padding_ranges(Type::new_struct(id))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn compact_image_padding_ranges_empty_for_packed_all_i64_struct() {
+        // An all-eight-byte-leaf struct is slot-identical: no padding to zero.
+        let pool = TypeInternPool::new();
+        pool.set_compact_layout(true);
+        let interner = ThreadedRodeo::default();
+        let (id, _) = pool.register_struct(
+            interner.get_or_intern("Packed"),
+            struct_def(
+                "Packed",
+                vec![
+                    StructField {
+                        name: "a".into(),
+                        ty: Type::I64,
+                    },
+                    StructField {
+                        name: "b".into(),
+                        ty: Type::I64,
+                    },
+                ],
+            ),
+        );
+        let frozen = pool.freeze();
+        assert!(
+            frozen
+                .compact_image_padding_ranges(Type::new_struct(id))
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/rue-cli-tests/cases/aggregate_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout.toml
@@ -436,6 +436,68 @@ fn main() -> i32 {
 stdout = "7\n9\n"
 exit_code = 0
 
+# RUE-1007 (ADR-0052 phase 5.9, ruling 5): deterministic zero on construction.
+# Wherever a compact image is materialized, its padding bytes are zeroed before
+# the field stores. `Wide { A(u8, i32), B }` has a u8 tag @0, payload @4 (i32
+# alignment), a u8 field @4 and an i32 field @8, size 12 => padding [1,4) (the
+# tag-to-payload gap) and [5,8) (after the u8 field). Poisoning every byte to
+# 0xFF first, an `@ptr_write` must leave those padding bytes deterministically
+# zero, and re-poisoning then writing a different variant must leave no residue.
+[[case]]
+name = "compact_enum_padding_is_deterministically_zeroed"
+description = "An enum heap image zeros its tag-to-payload and inter-field padding on @ptr_write, with no residue across an overwrite (RUE-1007)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "--preview", "raw_bytes", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Wide { A(u8, i32), B }
+fn main() -> i32 {
+    checked {
+        let ep: ptr mut Wide = @alloc(1);
+        let addr: u64 = @ptr_to_int(ep);
+        let bp: ptr mut u8 = @int_to_ptr(addr);
+        // Poison every byte so any un-zeroed padding would be observable.
+        @byte_write(bp, 0, 255);
+        @byte_write(bp, 1, 255);
+        @byte_write(bp, 2, 255);
+        @byte_write(bp, 3, 255);
+        @byte_write(bp, 4, 255);
+        @byte_write(bp, 5, 255);
+        @byte_write(bp, 6, 255);
+        @byte_write(bp, 7, 255);
+        @ptr_write(ep, Wide.A(7, 16909060));
+        // Padding bytes must be deterministically zero.
+        if @byte_read(bp, 1) != 0 { return 1; }
+        if @byte_read(bp, 2) != 0 { return 2; }
+        if @byte_read(bp, 3) != 0 { return 3; }
+        if @byte_read(bp, 5) != 0 { return 4; }
+        if @byte_read(bp, 6) != 0 { return 5; }
+        if @byte_read(bp, 7) != 0 { return 6; }
+        // Fields survive the zeroing.
+        let a = @ptr_read(ep);
+        match a { Wide.A(b, w) => { if b != 7 { return 7; } if w != 16909060 { return 8; } }, Wide.B => { return 9; }, };
+        // Overwrite: re-poison the padding, then write a different variant. No
+        // residue of the poison (or of A) may remain in B's unused bytes.
+        @byte_write(bp, 1, 255);
+        @byte_write(bp, 2, 255);
+        @byte_write(bp, 3, 255);
+        @byte_write(bp, 5, 255);
+        @byte_write(bp, 6, 255);
+        @byte_write(bp, 7, 255);
+        @ptr_write(ep, Wide.B);
+        if @byte_read(bp, 1) != 0 { return 10; }
+        if @byte_read(bp, 2) != 0 { return 11; }
+        if @byte_read(bp, 3) != 0 { return 12; }
+        if @byte_read(bp, 5) != 0 { return 13; }
+        if @byte_read(bp, 6) != 0 { return 14; }
+        if @byte_read(bp, 7) != 0 { return 15; }
+        @free(ep, 1);
+    };
+    0
+}
+""" }]
+stdout = ""
+exit_code = 0
+
 # RUE-1000 keeps refusing enums whose compact memory image is variant-dependent:
 # A(i64) and B(i32,i32) would need overlapping union slots (the i64 field spans
 # both i32 positions), so there is no single slot->byte map. Refused loudly.

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -101,12 +101,14 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
         &mut self,
         value: CfgValue,
         image: &[crate::types::PhysicalEnumSlot],
+        padding: &[rue_air::layout::PaddingRange],
         storage_bytes: u32,
     ) -> VReg {
         // Reserve a caller-owned buffer just below the sret storage (RUE-1005),
         // capture its address, and write the aggregate's compact image into it —
         // each slot truncated to its physical width at its compact byte offset,
-        // exactly the image the callee prologue unmarshals.
+        // exactly the image the callee prologue unmarshals. The image's padding is
+        // zeroed first (ADR-0052 ruling 5) so the buffer is fully initialized.
         self.mir.push(Aarch64Inst::SubImm {
             dst: Operand::Physical(Reg::Sp),
             src: Operand::Physical(Reg::Sp),
@@ -118,7 +120,7 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
             src: Operand::Physical(Reg::Sp),
         });
         let slots = self.require_aggregate_slots(value);
-        crate::agg_slots::store_enum_slots_through_ptr(self, &slots, pointer, image);
+        crate::agg_slots::store_enum_slots_through_ptr(self, &slots, pointer, image, padding);
         pointer
     }
 }
@@ -1565,13 +1567,20 @@ impl<'a> CfgLower<'a> {
                 let value = &plan.args[1];
                 if let Some(map) = &plan.physical_slots {
                     // A compact enum value: truncate each internal slot to its
-                    // physical width at its compact byte offset (RUE-1000).
+                    // physical width at its compact byte offset (RUE-1000). The
+                    // pointee's padding is zeroed first (ADR-0052 ruling 5).
                     let vals = if value.slots.is_empty() {
                         vec![value.primary]
                     } else {
                         value.slots.clone()
                     };
-                    crate::agg_slots::store_enum_slots_through_ptr(self, &vals, ptr, map);
+                    crate::agg_slots::store_enum_slots_through_ptr(
+                        self,
+                        &vals,
+                        ptr,
+                        map,
+                        &plan.image_padding,
+                    );
                 } else if value.slot_count == 0 {
                     // Zero-sized values have no bytes to write.
                 } else if !value.slots.is_empty() {
@@ -2589,13 +2598,20 @@ impl<'a> CfgLower<'a> {
                     }
                     ReturnValuePlan::Aggregate { slots, return_plan } => {
                         if return_plan.uses_sret() {
+                            let return_ty = self.ctx.cfg.return_type();
                             match crate::types::aggregate_physical_slot_map(
                                 self.ctx.type_pool,
-                                self.ctx.cfg.return_type(),
+                                return_ty,
                             ) {
-                                Some(map) => crate::agg_slots::store_slots_to_sret_compact(
-                                    self, &slots, &map,
-                                ),
+                                Some(map) => {
+                                    // The sret image is written compact; its padding
+                                    // is zeroed first (ADR-0052 ruling 5).
+                                    let padding =
+                                        self.ctx.type_pool.compact_image_padding_ranges(return_ty);
+                                    crate::agg_slots::store_slots_to_sret_compact(
+                                        self, &slots, &map, &padding,
+                                    )
+                                }
                                 None => crate::agg_slots::store_slots_to_sret(self, &slots),
                             }
                         } else {
@@ -2905,6 +2921,14 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
             width: access.width,
             signed: access.signed,
         });
+    }
+    fn emit_zero_vreg(&mut self) -> VReg {
+        let dst = self.mir.alloc_vreg();
+        self.mir.push(Aarch64Inst::MovImm {
+            dst: Operand::Virtual(dst),
+            imm: 0,
+        });
+        dst
     }
 }
 

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -22,7 +22,7 @@
 use std::collections::HashMap;
 
 use rue_air::Type;
-use rue_air::layout::SLOT_BYTES;
+use rue_air::layout::{PaddingRange, SLOT_BYTES};
 use rue_cfg::CfgValue;
 
 use crate::allocation::BoundsCheckBackend;
@@ -81,6 +81,57 @@ pub(crate) trait SlotBackend: BoundsCheckBackend {
         byte_offset: i32,
         access: crate::types::NarrowScalar,
     );
+
+    /// Allocate a fresh vreg holding the constant zero, used to clear a compact
+    /// image's padding bytes (ADR-0052 ruling 5).
+    fn emit_zero_vreg(&mut self) -> VReg;
+}
+
+/// Zero the padding byte `ranges` of a compact memory image reached through
+/// `ptr` (ADR-0052 ruling 5, deterministic zero on construction). Each range is
+/// covered by the widest aligned zero stores (8/4/2/1 bytes) from one reused
+/// zero vreg; a compact aggregate's padding gaps are each at most `alignment - 1`
+/// (< 8) bytes, so this is a handful of stores per image. Empty `ranges` — every
+/// gate-off build, and any padding-free type — emit nothing, keeping gate-off
+/// code byte-identical.
+pub(crate) fn zero_padding_through_ptr<B: SlotBackend>(
+    b: &mut B,
+    ptr: VReg,
+    ranges: &[PaddingRange],
+) {
+    if ranges.is_empty() {
+        return;
+    }
+    let zero = b.emit_zero_vreg();
+    for range in ranges {
+        let mut offset = range.start as i32;
+        let end = range.end as i32;
+        while offset < end {
+            let remaining = (end - offset) as u32;
+            if remaining >= 8 {
+                b.emit_store_through_ptr(zero, ptr, offset);
+                offset += SLOT_BYTES as i32;
+            } else {
+                let width: u8 = if remaining >= 4 {
+                    4
+                } else if remaining >= 2 {
+                    2
+                } else {
+                    1
+                };
+                b.emit_narrow_store_through_ptr(
+                    zero,
+                    ptr,
+                    offset,
+                    crate::types::NarrowScalar {
+                        width,
+                        signed: false,
+                    },
+                );
+                offset += i32::from(width);
+            }
+        }
+    }
 }
 
 /// Store a whole compact enum value's `vals` (one vreg per internal slot, slot 0
@@ -94,7 +145,12 @@ pub(crate) fn store_enum_slots_through_ptr<B: SlotBackend>(
     vals: &[VReg],
     ptr: VReg,
     map: &[crate::types::PhysicalEnumSlot],
+    padding: &[PaddingRange],
 ) {
+    // Deterministic zero on construction (ADR-0052 ruling 5): clear the image's
+    // padding gaps first, then the field stores below overwrite every non-padding
+    // byte, so the whole image is initialized regardless of prior memory contents.
+    zero_padding_through_ptr(b, ptr, padding);
     for (val, slot) in vals.iter().zip(map.iter()) {
         match slot.access {
             None => b.emit_store_through_ptr(*val, ptr, slot.byte_offset),
@@ -310,11 +366,12 @@ pub(crate) fn store_slots_to_sret_compact<B: SlotBackend>(
     b: &mut B,
     vals: &[VReg],
     map: &[crate::types::PhysicalEnumSlot],
+    padding: &[PaddingRange],
 ) {
     let ptr = b.alloc_vreg();
     let sret_slot = b.ctx().sret_ptr_slot();
     b.emit_load_slot(ptr, sret_slot);
-    store_enum_slots_through_ptr(b, vals, ptr, map);
+    store_enum_slots_through_ptr(b, vals, ptr, map, padding);
 }
 
 /// Load `count` slots through `ptr` at ASCENDING byte offsets (slot k at

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -214,6 +214,10 @@ pub enum CallArgInput {
     IndirectValue {
         value: rue_cfg::CfgValue,
         image: Vec<crate::types::PhysicalEnumSlot>,
+        /// Byte ranges of the compact image that hold padding, zeroed before the
+        /// field stores so the caller-owned buffer is deterministically
+        /// initialized (ADR-0052 ruling 5).
+        padding: Vec<rue_air::layout::PaddingRange>,
         storage_bytes: u32,
     },
     ByRef {
@@ -268,11 +272,13 @@ impl CallInputs {
                         "a by-value indirect compact aggregate argument must have a \
                          variant-independent memory image (guaranteed by the refusal scan)",
                     );
+                    let padding = type_pool.compact_image_padding_ranges(arg_ty);
                     let storage_bytes =
                         align_up(types::type_size_bytes(type_pool, arg_ty) as u32, 16);
                     return CallArgInput::IndirectValue {
                         value: arg.value,
                         image,
+                        padding,
                         storage_bytes,
                     };
                 }
@@ -348,6 +354,7 @@ pub trait CallMaterializer {
         &mut self,
         value: rue_cfg::CfgValue,
         image: &[crate::types::PhysicalEnumSlot],
+        padding: &[rue_air::layout::PaddingRange],
         storage_bytes: u32,
     ) -> VReg;
 }
@@ -418,6 +425,7 @@ impl CallPlan {
                 CallArgInput::IndirectValue {
                     value,
                     image,
+                    padding,
                     storage_bytes,
                 } => {
                     // The caller writes the aggregate's compact image into its
@@ -425,8 +433,12 @@ impl CallPlan {
                     // are reserved below the sret storage and freed together
                     // after the call.
                     caller_indirect_bytes += *storage_bytes;
-                    let pointer =
-                        materializer.materialize_indirect_value_arg(*value, image, *storage_bytes);
+                    let pointer = materializer.materialize_indirect_value_arg(
+                        *value,
+                        image,
+                        padding,
+                        *storage_bytes,
+                    );
                     (UserArgMode::Value, vec![pointer])
                 }
                 CallArgInput::Value {
@@ -549,6 +561,7 @@ mod tests {
             &mut self,
             _value: rue_cfg::CfgValue,
             _image: &[crate::types::PhysicalEnumSlot],
+            _padding: &[rue_air::layout::PaddingRange],
             _storage_bytes: u32,
         ) -> VReg {
             VReg::new(50)

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -330,6 +330,12 @@ pub struct IntrinsicPlan {
     /// `None` for every other operation and gate-off, so the existing
     /// slot-shaped path is unchanged.
     pub physical_slots: Option<Vec<crate::types::PhysicalEnumSlot>>,
+    /// For a typed `@ptr_write` of a compact aggregate pointee, the byte ranges
+    /// of its memory image that hold padding (ADR-0052 ruling 5). The backend
+    /// zeros these before the field stores so the image is deterministically
+    /// initialized. Empty for every other operation, a padding-free pointee, and
+    /// gate-off, so no zeroing is emitted there.
+    pub image_padding: Vec<rue_air::layout::PaddingRange>,
 }
 
 /// Place with every dynamic index already materialized. The plan contains no
@@ -1630,6 +1636,15 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     ),
                     _ => None,
                 };
+                // A compact enum `@ptr_write` initializes the whole image, so the
+                // pointee's padding is zeroed before the field stores (ADR-0052
+                // ruling 5). Only the write needs it; the read never stores.
+                let image_padding = match operation {
+                    IntrinsicOperation::PtrWrite if physical_slots.is_some() => ctx
+                        .type_pool
+                        .compact_image_padding_ranges(ctx.cfg.get_inst(args[1]).ty),
+                    _ => Vec::new(),
+                };
                 let result = adapter.emit_intrinsic(IntrinsicPlan {
                     operation,
                     runtime_call,
@@ -1639,6 +1654,7 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     scale,
                     narrow_access,
                     physical_slots,
+                    image_padding,
                 });
                 cache_result(adapter, value, result);
                 Some(ValueKind::Intrinsic)

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -107,12 +107,14 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
         &mut self,
         value: CfgValue,
         image: &[crate::types::PhysicalEnumSlot],
+        padding: &[rue_air::layout::PaddingRange],
         storage_bytes: u32,
     ) -> VReg {
         // Reserve a caller-owned buffer just below the sret storage (RUE-1005),
         // capture its address, and write the aggregate's compact image into it —
         // each slot truncated to its physical width at its compact byte offset,
-        // exactly the image the callee prologue unmarshals.
+        // exactly the image the callee prologue unmarshals. The image's padding is
+        // zeroed first (ADR-0052 ruling 5) so the buffer is fully initialized.
         self.mir.push(X86Inst::AddRI {
             dst: Operand::Physical(Reg::Rsp),
             imm: -(storage_bytes as i32),
@@ -123,7 +125,7 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
             src: Operand::Physical(Reg::Rsp),
         });
         let slots = self.require_aggregate_slots(value);
-        crate::agg_slots::store_enum_slots_through_ptr(self, &slots, pointer, image);
+        crate::agg_slots::store_enum_slots_through_ptr(self, &slots, pointer, image, padding);
         pointer
     }
 }
@@ -1818,13 +1820,20 @@ impl<'a> CfgLower<'a> {
                 let value = &plan.args[1];
                 if let Some(map) = &plan.physical_slots {
                     // A compact enum value: truncate each internal slot to its
-                    // physical width at its compact byte offset (RUE-1000).
+                    // physical width at its compact byte offset (RUE-1000). The
+                    // pointee's padding is zeroed first (ADR-0052 ruling 5).
                     let vals = if value.slots.is_empty() {
                         vec![value.primary]
                     } else {
                         value.slots.clone()
                     };
-                    crate::agg_slots::store_enum_slots_through_ptr(self, &vals, ptr, map);
+                    crate::agg_slots::store_enum_slots_through_ptr(
+                        self,
+                        &vals,
+                        ptr,
+                        map,
+                        &plan.image_padding,
+                    );
                 } else if value.slot_count == 0 {
                     // Zero-sized values have no bytes to write.
                 } else if !value.slots.is_empty() {
@@ -2420,13 +2429,20 @@ impl<'a> CfgLower<'a> {
                     }
                     ReturnValuePlan::Aggregate { slots, return_plan } => {
                         if return_plan.uses_sret() {
+                            let return_ty = self.ctx.cfg.return_type();
                             match crate::types::aggregate_physical_slot_map(
                                 self.ctx.type_pool,
-                                self.ctx.cfg.return_type(),
+                                return_ty,
                             ) {
-                                Some(map) => crate::agg_slots::store_slots_to_sret_compact(
-                                    self, &slots, &map,
-                                ),
+                                Some(map) => {
+                                    // The sret image is written compact; its padding
+                                    // is zeroed first (ADR-0052 ruling 5).
+                                    let padding =
+                                        self.ctx.type_pool.compact_image_padding_ranges(return_ty);
+                                    crate::agg_slots::store_slots_to_sret_compact(
+                                        self, &slots, &map, &padding,
+                                    )
+                                }
                                 None => crate::agg_slots::store_slots_to_sret(self, &slots),
                             }
                         } else {
@@ -2742,6 +2758,14 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
             width: access.width,
             signed: access.signed,
         });
+    }
+    fn emit_zero_vreg(&mut self) -> VReg {
+        let dst = self.mir.alloc_vreg();
+        self.mir.push(X86Inst::MovRI64 {
+            dst: Operand::Virtual(dst),
+            imm: 0,
+        });
+        dst
     }
 }
 

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -596,6 +596,12 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
+        "cli.aggregate_layout",
+        "compact_enum_padding_is_deterministically_zeroed",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
         "cli.partial_move_depth",
         "disjoint_sibling_after_subfield_move_ok",
         semantic(SemanticGapKind::TextProjectionRead),


### PR DESCRIPTION
## Summary

The last unimplemented ADR-0052 acceptance ruling (5): under `aggregate_layout`, every materialized compact memory image deterministically zeroes its padding, on both backends. Gate-off is byte-identical.

- **Authority-owned ranges**: new `compact_image_padding_ranges(ty)` on the layout authority — struct interior/tail padding plus enum tag-to-payload/tail/union-position gaps, computed as the exact complement of the image map so the authority and the zeroing cannot disagree. Backends never re-derive ranges (the query returns nothing under the slot model, making zeroing a natural gate-off no-op).
- **Shared emitter**: `zero_padding_through_ptr` emits widest-aligned 8/4/2/1-byte zero stores from one reused zero vreg (gaps ≤7 bytes), applied at every live image-store site: heap `@ptr_write`, callee sret buffers, by-value arg buffers.
- **Ruling 5 cost numbers** (best of 5, recorded for the revisit gate): a pathological 200M-iteration loop of nothing but padded-enum `@ptr_write` regresses **+32.5%** (0.713s→0.945s) — the constructed worst case; the `aggregate_layout` corpus and the ArrayBuf std dogfood are **within noise**. Realistic cost is under threshold; no revisit warranted.
- **Determinism proven, not assumed**: a gated CLI case poisons the image to 0xFF via `@byte_write` (`raw_bytes` preview), writes the enum, reads padding back through a u8 pointer → zeroes, no residue across variant overwrite — and the case *fails* with zeroing disabled. Ruling 6 cross-checked (no safe byte-export intrinsic exists yet to widen).

A nice full-circle note: the `@byte_*` intrinsics from ADR-0059 — where this whole workstream started — are the instrument that verifies the layout ruling.

## Verification

Re-executed the determinism program by hand at integration with both previews composed. air 498 (padding-range units); codegen 579; cli `aggregate_layout` 32, `arraybuf` 19; spec `raw_bytes` 27; oracle-diff corpus audit green (new case ledgered); full `test.sh` green except the four known uid-0 environmental failures, both harness failure formats checked.

Fixes RUE-1007

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_