### PR TITLE
RUE-1006: enable Rust action cache uploads

### DIFF
--- a/.buckconfig.local.example
+++ b/.buckconfig.local.example
@@ -21,11 +21,13 @@
 # $ORIGIN under RE) and links via `cc`+lld; the remote_cache platform pins the
 # rbe-ubuntu22-04 container image (Python 3.10 for the prelude's rustc wrapper).
 #
-# The exact knobs below matter (all three were required to connect):
+# The exact knobs below matter (all four are required for useful Rust hits):
 #   - grpc:// scheme on the addresses (buck2 rejects grpcs://; tls=true upgrades)
 #   - digest_algorithms = SHA256 (BuildBuddy's CAS digest)
 #   - remote_enabled=True in the platform (OSS buck2 only opens the RE connection
 #     when remote is enabled — even for cache-only use)
+#   - default_allow_cache_upload=true (the upload-enabled executor is one gate;
+#     ordinary Rust actions defer to this separate OSS-default-off gate)
 
 [buck2_re_client]
 engine_address = grpc://remote.buildbuddy.io
@@ -36,6 +38,7 @@ http_headers = x-buildbuddy-api-key:<YOUR_BUILDBUDDY_API_KEY>
 
 [buck2]
 digest_algorithms = SHA256
+default_allow_cache_upload = true
 
 [build]
 # Route commands through the remote-cache platform. The repository ./buck2

--- a/.github/workflows/cache-probe.yml
+++ b/.github/workflows/cache-probe.yml
@@ -2,9 +2,9 @@ name: Cache probe
 
 # Validates + measures the BuildBuddy remote cache (RUE-316). Non-blocking:
 # never gates a merge. Run manually with `gh workflow run cache-probe.yml`
-# (on a repo that has the BUILDBUDDY_API_KEY secret). It does a cold build,
-# then clears the local buck-out and rebuilds — the second build should show
-# remote cache hits in buck2's "Commands:" line.
+# (on a repo that has the BUILDBUDDY_API_KEY secret). It builds the same release
+# target graph as CI, clears the local buck-out, and rebuilds. The workflow fails
+# unless the second build converts locally executed cold actions into cache hits.
 on:
   workflow_dispatch:
 
@@ -36,10 +36,10 @@ jobs:
           scripts/provision-build-cache install
           scripts/provision-build-cache apply
 
-      - name: Cold build (populates the remote cache)
+      - name: Cold release build (populates the remote cache)
         run: |
           set +e
-          /usr/bin/time -v ./buck2 build --prefer-local //crates/rue:rue >cold.log 2>&1
+          /usr/bin/time -v ./buck2 build --prefer-local //crates/... --target-platforms //platforms:release >cold.log 2>&1
           status=$?
           set -e
           if [ "$status" -ne 0 ]; then
@@ -49,13 +49,13 @@ jobs:
             echo "::error::Cold cache-probe build failed with exit $status"
             exit "$status"
           fi
-          grep -E '^(Cache hits:|Commands:|Network:)' cold.log | tail -3 || tail -10 cold.log
+          grep -E '(Cache hits:|Commands:|Network:)' cold.log | tail -3 || tail -10 cold.log
 
-      - name: Clear local buck-out, rebuild (should hit the remote cache)
+      - name: Clear local buck-out, rebuild release (should hit the remote cache)
         run: |
           ./buck2 clean
           set +e
-          /usr/bin/time -v ./buck2 build --prefer-local //crates/rue:rue >warm.log 2>&1
+          /usr/bin/time -v ./buck2 build --prefer-local //crates/... --target-platforms //platforms:release >warm.log 2>&1
           status=$?
           set -e
           if [ "$status" -ne 0 ]; then
@@ -65,7 +65,29 @@ jobs:
             echo "::error::Warm cache-probe build failed with exit $status"
             exit "$status"
           fi
-          grep -E '^(Cache hits:|Commands:|Network:)' warm.log | tail -3 || tail -10 warm.log
+          grep -E '(Cache hits:|Commands:|Network:)' warm.log | tail -3 || tail -10 warm.log
+
+          command_field() {
+            grep -oE 'Commands: [0-9]+ \(cached: [0-9]+, remote: [0-9]+, local: [0-9]+\)' "$1" |
+              tail -1 |
+              sed -E "s/.*$2: ([0-9]+).*/\\1/"
+          }
+          cold_local="$(command_field cold.log local)"
+          warm_cached="$(command_field warm.log cached)"
+          warm_local="$(command_field warm.log local)"
+          if [ -z "$cold_local" ] || [ -z "$warm_cached" ] || [ -z "$warm_local" ]; then
+            echo "::error::Could not parse Buck command counters from the cache-probe logs."
+            exit 1
+          fi
+          if [ "$warm_cached" -eq 0 ]; then
+            echo "::error::Warm build reported zero remote-cache hits."
+            exit 1
+          fi
+          if [ "$cold_local" -gt 0 ] && [ "$warm_local" -ge "$cold_local" ]; then
+            echo "::error::Warm build did not convert any cold local actions into cache hits (cold local: $cold_local; warm local: $warm_local)."
+            exit 1
+          fi
+          echo "Warm cache reused cold results (cold local: $cold_local; warm cached: $warm_cached; warm local: $warm_local)."
 
       - name: Upload probe logs
         if: always()
@@ -93,5 +115,5 @@ jobs:
             echo "COLD: $(command_summary cold.log)"
             echo "WARM: $(command_summary warm.log)"
             echo '```'
-            echo "A non-zero 'cached'/'remote' count on WARM means the remote cache is working."
+            echo "The probe step verifies that WARM converts cold local actions into cache hits."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/buck2-bin
+++ b/buck2-bin
@@ -4,86 +4,86 @@
   "name": "buck2",
   "platforms": {
     "macos-aarch64": {
-      "size": 33728207,
+      "size": 33767304,
       "hash": "blake3",
-      "digest": "3bbd7cfe1b51d17124f5634812ae904254e01da429a61f62fe9c3d7c45e12dd9",
+      "digest": "273310835d3d76bb89c2a1a2caf3197ec61f409ee87f85929387672a94e0db64",
       "format": "zst",
       "path": "buck2-aarch64-apple-darwin",
       "providers": [
         {
-          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-aarch64-apple-darwin.zst"
+          "url": "https://github.com/facebook/buck2/releases/download/2026-07-15/buck2-aarch64-apple-darwin.zst"
         }
       ]
     },
     "windows-aarch64": {
-      "size": 29333382,
+      "size": 29431570,
       "hash": "blake3",
-      "digest": "34417c30bd88b2110e00044f619aae791ec4e2d7f982aeb0fa43f01c0c2b06ac",
+      "digest": "3ab7ee99dfc16c2b47722ea9b31dde8d385bdbe140b8c48acecc760a5e58c5f3",
       "format": "zst",
       "path": "buck2-aarch64-pc-windows-msvc.exe",
       "providers": [
         {
-          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-aarch64-pc-windows-msvc.exe.zst"
+          "url": "https://github.com/facebook/buck2/releases/download/2026-07-15/buck2-aarch64-pc-windows-msvc.exe.zst"
         }
       ]
     },
     "linux-aarch64": {
-      "size": 36896909,
+      "size": 36976879,
       "hash": "blake3",
-      "digest": "889091fae4410776de12ddc1ec676f019a0b9bd9bacf69298e5d0b16482f9ae6",
+      "digest": "5b160a0c1ecad8489201a370bbf9fab684720d8d73110e75e06e72ed339dff73",
       "format": "zst",
       "path": "buck2-aarch64-unknown-linux-musl",
       "providers": [
         {
-          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-aarch64-unknown-linux-musl.zst"
+          "url": "https://github.com/facebook/buck2/releases/download/2026-07-15/buck2-aarch64-unknown-linux-musl.zst"
         }
       ]
     },
     "linux-riscv64": {
-      "size": 39062685,
+      "size": 39118879,
       "hash": "blake3",
-      "digest": "4c6275d204a22fe5920bbf6fadf41a04580ec79b713c2447fcc264534f78e221",
+      "digest": "b2728337070e6da11d7bf1af29bccb51fc885d05bc2b1bb1d883a4bcf1980ea1",
       "format": "zst",
       "path": "buck2-riscv64gc-unknown-linux-gnu",
       "providers": [
         {
-          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-riscv64gc-unknown-linux-gnu.zst"
+          "url": "https://github.com/facebook/buck2/releases/download/2026-07-15/buck2-riscv64gc-unknown-linux-gnu.zst"
         }
       ]
     },
     "macos-x86_64": {
-      "size": 35999107,
+      "size": 36044403,
       "hash": "blake3",
-      "digest": "688c7d5da371fcb0dc8d337c37a55963e3001688e0942473c0f9897cb11170d9",
+      "digest": "0b8eb714f509a2886ce407477b2744f3e5cff0b448487959fe71a722af56faeb",
       "format": "zst",
       "path": "buck2-x86_64-apple-darwin",
       "providers": [
         {
-          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-x86_64-apple-darwin.zst"
+          "url": "https://github.com/facebook/buck2/releases/download/2026-07-15/buck2-x86_64-apple-darwin.zst"
         }
       ]
     },
     "windows-x86_64": {
-      "size": 31097651,
+      "size": 31139540,
       "hash": "blake3",
-      "digest": "fae94eafc83a7e780c66775760e3ca2e92f499047299968ae7847ee3300f2970",
+      "digest": "4943266f41e3de7848801befbd89c1ddbae61252a3042fc646e072cbe6abcea6",
       "format": "zst",
       "path": "buck2-x86_64-pc-windows-msvc.exe",
       "providers": [
         {
-          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-x86_64-pc-windows-msvc.exe.zst"
+          "url": "https://github.com/facebook/buck2/releases/download/2026-07-15/buck2-x86_64-pc-windows-msvc.exe.zst"
         }
       ]
     },
     "linux-x86_64": {
-      "size": 38600655,
+      "size": 38640905,
       "hash": "blake3",
-      "digest": "807fe2ba2c7aaf3a3a312de4220cee2abba9f37940c45b5a5f42ff1fd33dc089",
+      "digest": "0f55638c3245d041cfced0e0eda5396f057007521e58cf7ab6ec3efdd0df6f49",
       "format": "zst",
       "path": "buck2-x86_64-unknown-linux-musl",
       "providers": [
         {
-          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-x86_64-unknown-linux-musl.zst"
+          "url": "https://github.com/facebook/buck2/releases/download/2026-07-15/buck2-x86_64-unknown-linux-musl.zst"
         }
       ]
     }

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -84,15 +84,23 @@ they're recorded here so a future config change doesn't silently regress:
    wrapper adds `--prefer-local` to ordinary build/test/run/install commands.
    Remote cache lookup still happens before a local miss executes. An explicit
    execution-mode flag overrides the wrapper.
-3. **rustc under RE** (`toolchains/rust/defs.bzl`): rustc finds `librustc_driver.so`
+3. **Two cache-upload gates**: the execution platform's
+   `allow_cache_uploads = True` permits local-result uploads, but ordinary Rust
+   actions also defer to the OSS-default-off
+   `[buck2] default_allow_cache_upload = true` setting. Buck 2026-07-01 still
+   hard-disabled uploads for most Rust actions; Buck 2026-07-15 contains the
+   upstream fix that makes them honor this setting. Both the pin and the config
+   knob are required — without them the client connects and downloads CAS
+   inputs, but locally compiled Rust results never populate the action cache.
+4. **rustc under RE** (`toolchains/rust/defs.bzl`): rustc finds `librustc_driver.so`
    via its native `$ORIGIN/../lib` RPATH, which only resolves if the whole toolchain
    tree is materialized on the remote worker. The `compiler`/`rustdoc` RunInfo carry
    the full distribution as a hidden input so RE uploads it co-located. This is the
    relocatable, canonical fix — *not* an absolute-path `LD_LIBRARY_PATH` hack.
-4. **Container** (`platforms/remote_cache.bzl`): pinned to `rbe-ubuntu22-04`
+5. **Container** (`platforms/remote_cache.bzl`): pinned to `rbe-ubuntu22-04`
    (Python 3.10 — the prelude's rustc wrapper needs ≥3.9; the default image ships
    3.6).
-5. **Linker** (RUE-320, NOT landed): the remote worker needs the linker driver to
+6. **Linker** (RUE-320, NOT landed): the remote worker needs the linker driver to
    be **`cc`** instead of `clang++` (lld — `-fuse-ld=lld`, shipped with rust — does
    the real linking; the driver just needs to exist, and `cc` is everywhere while
    `clang++` is not). This was proven with `linker = "cc"` in `toolchains/BUCK`, but
@@ -100,9 +108,10 @@ they're recorded here so a future config change doesn't silently regress:
    find 'ld'` when the hermetic lld flags aren't on the command). It has to be
    **scoped to the remote platform** instead — tracked as RUE-320.
 
-Change 3 (`$ORIGIN` toolchain-tree) is global and local-safe (verified: local
-build + suite green). 1, 2, 4 live in the opt-in `.buckconfig.local` / the
-`remote_cache` platform. 5 is the remaining blocker for a default-on RE.
+Change 4 (`$ORIGIN` toolchain-tree) is global and local-safe (verified: local
+build + suite green). 1, 2, 3, and 5 live in the opt-in
+`.buckconfig.local` / the `remote_cache` platform. 6 is the remaining blocker
+for default-on RE.
 
 ## CI
 
@@ -132,8 +141,10 @@ Availability rules, which the workflow steps must respect:
 
 The `cache-probe` workflow (`.github/workflows/cache-probe.yml`) remains the
 measurement tool: it writes a transient config from the secret, does a cold
-build then a clean-and-rebuild, and reports buck2's `Commands: (cached /
-remote / local)` line. Run it with `gh workflow run cache-probe.yml`.
+release build of `//crates/...` then a clean-and-rebuild, and reports buck2's
+`Commands: (cached / remote / local)` line. It fails when the warm build does
+not convert any cold local actions into cache hits. Run it with
+`gh workflow run cache-probe.yml`.
 
 ## Toward a fully hermetic linker
 

--- a/scripts/provision-build-cache
+++ b/scripts/provision-build-cache
@@ -40,6 +40,10 @@ validate_config() {
         echo "error: BuildBuddy config does not contain a configured API key" >&2
         return 1
     fi
+    if ! grep -Eq '^[[:space:]]*default_allow_cache_upload[[:space:]]*=[[:space:]]*true([[:space:]]|$)' "$central_config"; then
+        echo "error: BuildBuddy config does not enable Rust action uploads; rerun scripts/provision-build-cache install" >&2
+        return 1
+    fi
 }
 
 install_config() {
@@ -70,6 +74,9 @@ EOF
 
 [buck2]
 digest_algorithms = SHA256
+# Buck 2026-07-15 lets ordinary Rust actions defer to this OSS-default-off
+# switch. The executor's allow_cache_uploads flag is a separate required gate.
+default_allow_cache_upload = true
 
 [build]
 execution_platforms = root//platforms:remote_cache

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -34,6 +34,18 @@ test_cache_provisioning() {
     make_rue_root "$sb/primary"
     make_rue_root "$sb/worktree"
 
+    mkdir -p "$(dirname "$config")"
+    cat >"$config" <<EOF
+[buck2_re_client]
+http_headers = x-buildbuddy-api-key:$key
+EOF
+    chmod 600 "$config"
+    rc=0
+    HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
+        "$SRC_ROOT/scripts/provision-build-cache" status "$sb/primary" >/dev/null 2>&1 || rc=$?
+    check "cache: pre-upload-gate configs require migration" \
+        "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+
     rc=0
     out="$(HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" BUILDBUDDY_API_KEY="$key" \
         "$SRC_ROOT/scripts/provision-build-cache" install 2>&1)" || rc=$?
@@ -41,6 +53,8 @@ test_cache_provisioning() {
     check "cache: install never prints the key" "$([[ "$out" != *"$key"* ]] && echo 0 || echo 1)"
     mode="$(stat -c '%a' "$config" 2>/dev/null || stat -f '%Lp' "$config")"
     check "cache: central config is private" "$([ $((8#$mode & 077)) -eq 0 ] && echo 0 || echo 1)"
+    check "cache: Rust action uploads are enabled" \
+        "$(grep -Eq '^default_allow_cache_upload = true$' "$config" && echo 0 || echo 1)"
 
     rc=0
     out="$(HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
@@ -122,6 +136,8 @@ test_buck_wrapper_auto_provisions() {
     cat >"$config" <<'EOF'
 [buck2_re_client]
 http_headers = x-buildbuddy-api-key:test-secret
+[buck2]
+default_allow_cache_upload = true
 [build]
 execution_platforms = root//platforms:remote_cache
 EOF


### PR DESCRIPTION
## Summary

- upgrade Buck2 to the 2026-07-15 release that lets ordinary Rust actions honor the global cache-upload default
- enable and validate `default_allow_cache_upload` in the private BuildBuddy config
- make the manual cache probe exercise the exact release target graph and fail when a warm rebuild does not improve

## Root cause

The BuildBuddy key and remote-cache connection were valid, but Buck 2026-07-01 passed `allow_cache_upload = false` for most Rust actions. The execution platform's `allow_cache_uploads = True` was therefore necessary but insufficient: release builds connected to BuildBuddy while continuing to execute every Rust action locally and never populated the action cache.

Buck 2026-07-15 contains the upstream prelude fix. This change also enables the separate OSS-default-off `[buck2] default_allow_cache_upload = true` gate required by that fix.

## Validation

- `scripts/test-build-sharing.sh` — 29 checks passed
- `scripts/test-wrapper-scripts.sh` — 53 checks passed
- `scripts/rue quick` — passed after rebasing onto current trunk
- Actionlint — passed
- full local suite completed all heavy suites; the generated oracle hit its documented load-sensitive child timeout during the combined run, then passed 64/64 in the prescribed isolated rerun

The updated `cache-probe` workflow is the post-merge end-to-end check: it performs the same release `//crates/...` build as CI, cleans local outputs, rebuilds, and requires the warm run to convert cold local actions into cache hits.

Fixes RUE-1006
