### PR TITLE
RUE-868: narrow the compiler facade

### DIFF
--- a/crates/rue-air-profile/src/main.rs
+++ b/crates/rue-air-profile/src/main.rs
@@ -142,11 +142,10 @@ fn main() {
     let elapsed_ns = started.elapsed().as_nanos();
     ENABLED.store(false, Ordering::SeqCst);
 
-    let rir_stats = session
-        .rir()
-        .expect("successful semantic query retains validated RIR")
-        .rir()
-        .payload_storage_stats();
+    drop(session);
+    let semantic = rue_compiler::unstable::into_oracle_semantic_state(semantic)
+        .expect("one-shot profiler session uniquely owns its frontend artifacts");
+    let rir_stats = semantic.rir_payload_storage_stats;
     let rir_family_logical_bytes: Map<String, Value> = RIR_PAYLOAD_FAMILY_NAMES
         .into_iter()
         .zip(rir_stats.family_logical_bytes)
@@ -155,7 +154,7 @@ fn main() {
 
     let mut total = AirPayloadStorageStats::default();
     let mut cfg_total = CfgPayloadStorageStats::default();
-    for function in semantic.functions() {
+    for function in &semantic.functions {
         let stats = air_payload_storage_stats(&function.analyzed.air);
         for (to, from) in total
             .family_logical_bytes
@@ -208,7 +207,7 @@ fn main() {
             "air_phase_ns": elapsed_ns,
             "allocations": ALLOCATIONS.load(Ordering::SeqCst),
             "allocated_bytes": ALLOCATED_BYTES.load(Ordering::SeqCst),
-            "functions": semantic.functions().len(),
+            "functions": semantic.functions.len(),
             "family_logical_bytes": family_logical_bytes,
             "word_store_logical_bytes": total.word_store_logical_bytes,
             "word_store_capacity_bytes": total.word_store_capacity_bytes,

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -4,16 +4,18 @@
 
 use std::{collections::HashMap, env, process, sync::Arc, time::Instant};
 
+#[cfg(test)]
 use rue_air::{FrozenTypeInternPool, TypeKind};
 use rue_compiler::unstable::{
     DependencyBaseline, DependencyIncompleteReason, DependencySurface, FullInvalidationReason,
-    InvalidationMetrics, InvalidationScope, MetricsSnapshot, ParseMetrics,
+    InvalidationMetrics, InvalidationScope, MetricsSnapshot, ParseMetrics, query_merge,
+    semantic_parity_snapshot,
 };
 use rue_compiler::{
-    AcceptedReadManifestEntry, CanonicalSemanticOutput, CompileOptions, CompilerSession,
-    DiscoverySourceAssembler, FileMetadataFingerprint, FrontendDiagnosticSnapshot,
-    ImportDiscoveryContext, ImportObservationLedger, OptLevel, PhysicalFileIdentity,
-    SourceMetadata, SourceSnapshot,
+    AcceptedReadManifestEntry, CompileOptions, CompilerSession, DiscoverySourceAssembler,
+    FileMetadataFingerprint, FrontendDiagnosticSnapshot, ImportDiscoveryContext,
+    ImportObservationLedger, OptLevel, PhysicalFileIdentity, SemanticView, SourceMetadata,
+    SourceSnapshot,
 };
 use rue_span::FileId;
 use serde_json::{Value, json};
@@ -603,7 +605,7 @@ fn measured_semantic(
     session: &mut CompilerSession,
     source: &SourceSnapshot,
     options: &CompileOptions,
-) -> (Value, Arc<CanonicalSemanticOutput>) {
+) -> (Value, Arc<SemanticView>) {
     let mut output = None;
     let value = measure(session, |session| {
         let update = session.update(source);
@@ -615,6 +617,7 @@ fn measured_semantic(
     (value, output.unwrap())
 }
 
+#[cfg(test)]
 fn type_pool_snapshot(pool: &FrozenTypeInternPool) -> Vec<String> {
     pool.all_types()
         .map(|ty| match ty.kind() {
@@ -657,7 +660,7 @@ fn assert_diagnostic_parity(
 
 fn assert_cold_reused_parity(
     reused_session: &mut CompilerSession,
-    reused: &CanonicalSemanticOutput,
+    reused: &SemanticView,
     source: &SourceSnapshot,
     options: &CompileOptions,
 ) -> Value {
@@ -674,7 +677,7 @@ fn assert_cold_reused_parity(
 
 fn assert_cold_reused_parity_with_discovery<F, G>(
     reused_session: &mut CompilerSession,
-    reused: &CanonicalSemanticOutput,
+    reused: &SemanticView,
     source: &SourceSnapshot,
     options: &CompileOptions,
     std_dir: Option<&str>,
@@ -706,104 +709,8 @@ where
         cold_count(&["cfg", "builds_succeeded"])
     );
     assert_eq!(
-        format!("{:?}", reused.functions()),
-        format!("{:?}", cold.functions())
-    );
-    assert_eq!(reused.unstable_input_debug(), cold.unstable_input_debug());
-    assert_eq!(reused.type_pool().stats(), cold.type_pool().stats());
-    assert_eq!(
-        type_pool_snapshot(reused.type_pool()),
-        type_pool_snapshot(cold.type_pool())
-    );
-    let bound_definition_snapshot = |output: &CanonicalSemanticOutput| {
-        output.bound_definitions().map(|definitions| {
-            definitions
-                .definitions()
-                .iter()
-                .map(|definition| {
-                    format!(
-                        "{:?}|{:?}|{:?}|{:?}",
-                        definition.stable_key(),
-                        definition.occurrence(),
-                        definition.declaration_span(),
-                        definition.visibility()
-                    )
-                })
-                .collect::<Vec<_>>()
-        })
-    };
-    assert_eq!(
-        bound_definition_snapshot(reused),
-        bound_definition_snapshot(&cold)
-    );
-    assert_eq!(reused.strings(), cold.strings());
-    assert_eq!(
-        format!("{:?}", reused.warnings()),
-        format!("{:?}", cold.warnings())
-    );
-    assert_eq!(
-        format!("{:?}", reused.analyzed_body_owners()),
-        format!("{:?}", cold.analyzed_body_owners())
-    );
-    assert_eq!(
-        format!("{:?}", reused.body_named_dependencies()),
-        format!("{:?}", cold.body_named_dependencies())
-    );
-    assert_eq!(
-        format!("{:?}", reused.ordinary_free_function_dependencies()),
-        format!("{:?}", cold.ordinary_free_function_dependencies())
-    );
-    assert_eq!(
-        format!("{:?}", reused.specialized_free_function_origins()),
-        format!("{:?}", cold.specialized_free_function_origins())
-    );
-    assert_eq!(
-        format!("{:?}", reused.specialized_free_function_dependencies()),
-        format!("{:?}", cold.specialized_free_function_dependencies())
-    );
-    assert_eq!(
-        reused.unstable_durable_artifact_status(),
-        cold.unstable_durable_artifact_status()
-    );
-    assert_eq!(
-        reused.ordinary_free_function_dependencies_complete(),
-        cold.ordinary_free_function_dependencies_complete()
-    );
-    assert_eq!(
-        reused.specialized_free_function_dependencies_complete(),
-        cold.specialized_free_function_dependencies_complete()
-    );
-    assert_eq!(
-        reused.non_generic_named_method_dependencies_complete(),
-        cold.non_generic_named_method_dependencies_complete()
-    );
-    assert_eq!(
-        reused.generic_named_method_dependencies_complete(),
-        cold.generic_named_method_dependencies_complete()
-    );
-    assert_eq!(
-        reused.named_destructor_dependencies_complete(),
-        cold.named_destructor_dependencies_complete()
-    );
-    assert_eq!(
-        reused.declaration_type_dependencies_complete(),
-        cold.declaration_type_dependencies_complete()
-    );
-    assert_eq!(
-        reused.declaration_type_call_head_dependencies_complete(),
-        cold.declaration_type_call_head_dependencies_complete()
-    );
-    assert_eq!(
-        reused.supported_type_call_heads_complete(),
-        cold.supported_type_call_heads_complete()
-    );
-    assert_eq!(
-        reused.named_value_const_dependencies_complete(),
-        cold.named_value_const_dependencies_complete()
-    );
-    assert_eq!(
-        reused.implicit_named_destructor_dependencies_complete(),
-        cold.implicit_named_destructor_dependencies_complete()
+        semantic_parity_snapshot(reused),
+        semantic_parity_snapshot(&cold)
     );
 
     let reused_manifest = reused_session
@@ -905,41 +812,6 @@ where
     assert_eq!(
         reused_manifest.definition_universe_complete(),
         cold_manifest.definition_universe_complete()
-    );
-
-    assert_eq!(
-        format!("{:?}", reused.named_method_dependencies()),
-        format!("{:?}", cold.named_method_dependencies())
-    );
-    assert_eq!(
-        format!("{:?}", reused.named_destructor_dependencies()),
-        format!("{:?}", cold.named_destructor_dependencies())
-    );
-    assert_eq!(
-        format!("{:?}", reused.declaration_type_dependencies()),
-        format!("{:?}", cold.declaration_type_dependencies())
-    );
-    assert_eq!(
-        format!("{:?}", reused.declaration_type_call_head_dependencies()),
-        format!("{:?}", cold.declaration_type_call_head_dependencies())
-    );
-    assert_eq!(
-        format!(
-            "{:?}",
-            reused.declaration_builtin_type_call_head_dependencies()
-        ),
-        format!(
-            "{:?}",
-            cold.declaration_builtin_type_call_head_dependencies()
-        )
-    );
-    assert_eq!(
-        format!("{:?}", reused.named_const_dependencies()),
-        format!("{:?}", cold.named_const_dependencies())
-    );
-    assert_eq!(
-        format!("{:?}", reused.implicit_named_destructor_dependencies()),
-        format!("{:?}", cold.implicit_named_destructor_dependencies())
     );
 
     prepare_executable(reused_session, source);
@@ -1111,7 +983,7 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
         "cold",
         measure(&mut session, |session| {
             let parse = session.update(&fixture.base).unstable_metrics();
-            session.merge().unwrap();
+            query_merge(session).unwrap();
             session.rir().unwrap();
             session.semantic(&options).unwrap();
             parse
@@ -1121,7 +993,7 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
         "exact_noop",
         measure(&mut session, |session| {
             let parse = session.update(&fixture.base).unstable_metrics();
-            session.merge().unwrap();
+            query_merge(session).unwrap();
             session.rir().unwrap();
             session.semantic(&options).unwrap();
             parse
@@ -1134,7 +1006,7 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
             assert!(update.downstream_invalidated());
             let parse = update.unstable_metrics();
             update.into_result().unwrap();
-            session.merge().unwrap();
+            query_merge(session).unwrap();
             session.rir().unwrap();
             session.semantic(&options).unwrap();
             parse
@@ -1147,7 +1019,7 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
             assert!(update.downstream_invalidated());
             let parse = update.unstable_metrics();
             update.into_result().unwrap();
-            session.merge().unwrap();
+            query_merge(session).unwrap();
             session.rir().unwrap();
             session.semantic(&options).unwrap();
             parse
@@ -1159,7 +1031,7 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
             let update = session.update(&fixture.syntax_error);
             assert!(update.result().is_err());
             let parse = update.unstable_metrics();
-            session.merge().unwrap();
+            query_merge(session).unwrap();
             session.rir().unwrap();
             session.semantic(&options).unwrap();
             parse
@@ -1169,7 +1041,7 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
         "syntax_recovery",
         measure(&mut session, |session| {
             let parse = session.update(&fixture.identity_edit).unstable_metrics();
-            session.merge().unwrap();
+            query_merge(session).unwrap();
             session.rir().unwrap();
             session.semantic(&options).unwrap();
             parse

--- a/crates/rue-compiler-session-bench/src/representative.rs
+++ b/crates/rue-compiler-session-bench/src/representative.rs
@@ -7,9 +7,9 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use rue_compiler::{
-    AcceptedImportSource, AcceptedReadManifestEntry, CanonicalSemanticOutput, CompileOptions,
-    CompilerSession, DiscoverySourceAssembler, FileMetadataFingerprint, ImportDiscoveryContext,
-    ImportObservation, ImportObservationLedger, PhysicalFileIdentity, SourceSnapshot,
+    AcceptedImportSource, AcceptedReadManifestEntry, CompileOptions, CompilerSession,
+    DiscoverySourceAssembler, FileMetadataFingerprint, ImportDiscoveryContext, ImportObservation,
+    ImportObservationLedger, PhysicalFileIdentity, SemanticView, SourceSnapshot,
 };
 use serde_json::{Value, json};
 
@@ -183,7 +183,7 @@ fn measured_project_semantic(
     session: &mut CompilerSession,
     source: &SourceSnapshot,
     options: &CompileOptions,
-) -> (Value, Arc<CanonicalSemanticOutput>) {
+) -> (Value, Arc<SemanticView>) {
     let mut output = None;
     let value = measure(session, |session| {
         let update = session.update(source);

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1,6 +1,7 @@
 //! RUE-736 review gate for the curated compiler facade.
 
 const PRODUCTION_MODULES: &[(&str, &str)] = &[
+    ("artifact_views", include_str!("artifact_views.rs")),
     ("backend", include_str!("backend.rs")),
     ("bound_definitions", include_str!("bound_definitions.rs")),
     ("canonical_lower", include_str!("canonical_lower.rs")),
@@ -37,6 +38,34 @@ const PRODUCTION_MODULES: &[(&str, &str)] = &[
     ("syntax", include_str!("syntax.rs")),
     ("typed_query_store", include_str!("typed_query_store.rs")),
     ("unstable", include_str!("unstable.rs")),
+];
+
+const RUE_868_RAW_FACADE_VOCABULARY: &[&str] = &[
+    "Lexer",
+    "Token",
+    "TokenKind",
+    "Ast",
+    "Rir",
+    "ThreadedRodeo",
+    "FrozenTypeInternPool",
+    "TypeInternPool",
+    "SemanticSymbol",
+    "SemanticSymbolUniverse",
+    "CanonicalRirOutput",
+    "CanonicalSemanticOutput",
+    "CanonicalMergedProgram",
+    "ParsedProgram",
+    "FunctionWithCfg",
+    "Mir",
+    "generate_emitted_asm",
+    "generate_liveness_info",
+    "generate_lowering_info",
+    "generate_mir",
+    "generate_regalloc_info",
+    "generate_stack_frame_info",
+    "LoweringDebugInfo",
+    "RegAllocDebugInfo",
+    "StackFrameInfo",
 ];
 
 fn code_identifiers(source: &str) -> Vec<&str> {
@@ -126,7 +155,6 @@ const RUE_866_INTERNAL_VOCABULARY: &[&str] = &[
     "StableOptLevel",
     "StablePreviewFeatures",
     "ParseInvalidationSummary",
-    "ParsedAstPresentationWork",
     "ParsedModulesWork",
     "CanonicalMergeWork",
     "CanonicalRirWork",
@@ -461,6 +489,91 @@ fn facade_stays_small_and_session_centered() {
         [("queries", "compile_snapshot".to_owned())],
         "production modules may define exactly one public compile function"
     );
+}
+
+#[test]
+fn raw_phase_owners_and_backend_drivers_cannot_return_to_the_stable_facade() {
+    let facade = include_str!("lib.rs");
+    let root_exports = public_use_declarations(facade).concat();
+    let session = public_signatures(inherent_impl(include_str!("session.rs"), "CompilerSession"));
+    let update = public_signatures(inherent_impl(
+        include_str!("session.rs"),
+        "CompilerSessionUpdate",
+    ));
+    let views = public_declarations(include_str!("artifact_views.rs")).concat();
+    let stable_surface = [root_exports, session.clone(), update, views].concat();
+    let identifiers = code_identifiers(&stable_surface);
+
+    for forbidden in RUE_868_RAW_FACADE_VOCABULARY {
+        assert!(
+            !identifiers.contains(forbidden),
+            "raw phase owner or backend presentation symbol returned to the stable facade: {forbidden}"
+        );
+    }
+
+    let session_methods = code_identifiers(&session);
+    for internal in [
+        "merge",
+        "update_for_presentation",
+        "inject_stale_query_for_oracle",
+    ] {
+        assert!(
+            !session_methods.contains(&internal),
+            "internal orchestration method returned to CompilerSession's supported surface: {internal}"
+        );
+    }
+
+    let root_identifiers = code_identifiers(facade);
+    for required in [
+        "TokenView",
+        "SyntaxNodeView",
+        "SyntaxView",
+        "RirInstructionView",
+        "RirOperandView",
+        "RirView",
+        "SemanticView",
+        "FunctionView",
+        "CfgBlockView",
+        "CfgInstructionView",
+        "CfgSuccessorView",
+        "CfgView",
+        "SourceIdentityView",
+        "SourceLocationView",
+        "TypeView",
+    ] {
+        assert!(
+            root_identifiers.contains(&required),
+            "stable owner-bound artifact view is missing from the root: {required}"
+        );
+    }
+
+    let artifact_views = include_str!("artifact_views.rs");
+    for raw_presentation in [
+        "impl std::fmt::Display for TokenView",
+        "impl fmt::Display for TokenView",
+        "pub fn text(",
+        "pub fn air_text(",
+    ] {
+        assert!(
+            !artifact_views.contains(raw_presentation),
+            "raw phase presentation returned through stable views: {raw_presentation}"
+        );
+    }
+
+    for view in [
+        "SourceLocationView",
+        "SyntaxNodeView",
+        "RirInstructionView",
+        "RirOperandView",
+        "CfgInstructionView",
+        "CfgSuccessorView",
+    ] {
+        let signatures = public_signatures(inherent_impl(artifact_views, view));
+        assert!(
+            !code_identifiers(&signatures).contains(&"Span"),
+            "stable owner-bound view exposes a raw Span: {view}"
+        );
+    }
 }
 
 #[test]

--- a/crates/rue-compiler/src/artifact_views.rs
+++ b/crates/rue-compiler/src/artifact_views.rs
@@ -1,0 +1,2153 @@
+//! Immutable, owner-retaining projections of canonical compiler artifacts.
+//!
+//! These views resolve strings and expose checked structural traversal. They
+//! do not reveal phase storage, interners, type pools, owner-relative handles,
+//! or the phases' textual debug formats.
+
+use std::{borrow::Cow, fmt, sync::Arc};
+
+use crate::{CanonicalRirOutput, CanonicalSemanticOutput, ParsedProgram};
+
+#[derive(Clone)]
+#[allow(dead_code)] // Variant payloads deliberately pin the authorizing owner.
+enum SourceLocationOwner {
+    Syntax(Arc<crate::parsed_modules::ParsedModule>),
+    Rir(Arc<CanonicalRirOutput>),
+}
+
+/// Opaque exact identity for a source retained by a compiler artifact.
+#[derive(Clone)]
+pub struct SourceIdentityView {
+    owner: SourceLocationOwner,
+    source: crate::ModuleRevision,
+}
+
+impl SourceIdentityView {
+    pub fn same_source(&self, other: &Self) -> bool {
+        self.source == other.source
+    }
+}
+
+impl fmt::Debug for SourceIdentityView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let _retain_owner = &self.owner;
+        formatter.write_str("SourceIdentityView(<opaque>)")
+    }
+}
+
+/// Validated byte bounds and opaque source identity retained by an artifact.
+#[derive(Clone)]
+pub struct SourceLocationView {
+    owner: SourceLocationOwner,
+    source: crate::ModuleRevision,
+    start: u32,
+    end: u32,
+    source_length: u32,
+}
+
+impl SourceLocationView {
+    fn syntax(owner: Arc<crate::parsed_modules::ParsedModule>, span: crate::Span) -> Self {
+        let source_length = u32::try_from(owner.source_text().len())
+            .expect("parsed source length is bounded by SourceSnapshot");
+        debug_assert_eq!(span.file_id, owner.file_id());
+        debug_assert!(span.start <= span.end && span.end <= source_length);
+        Self {
+            source: owner.revision().clone(),
+            owner: SourceLocationOwner::Syntax(owner),
+            start: span.start,
+            end: span.end,
+            source_length,
+        }
+    }
+
+    fn rir(owner: Arc<CanonicalRirOutput>, span: crate::Span) -> Self {
+        let (source, source_length) = owner.source_identity_and_length(span.file_id);
+        let source = source.clone();
+        debug_assert!(span.start <= span.end && span.end <= source_length);
+        Self {
+            source,
+            owner: SourceLocationOwner::Rir(owner),
+            start: span.start,
+            end: span.end,
+            source_length,
+        }
+    }
+
+    pub fn source_identity(&self) -> SourceIdentityView {
+        SourceIdentityView {
+            owner: self.owner.clone(),
+            source: self.source.clone(),
+        }
+    }
+
+    pub fn start(&self) -> u32 {
+        self.start
+    }
+
+    pub fn end(&self) -> u32 {
+        self.end
+    }
+
+    pub fn source_length(&self) -> u32 {
+        self.source_length
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.start <= self.end && self.end <= self.source_length
+    }
+}
+
+impl fmt::Debug for SourceLocationView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SourceLocationView")
+            .field("source", &self.source_identity())
+            .field("start", &self.start)
+            .field("end", &self.end)
+            .field("source_length", &self.source_length)
+            .finish()
+    }
+}
+
+/// One resolved token tied to an immutable syntax owner.
+#[derive(Clone)]
+pub struct TokenView {
+    owner: Arc<crate::parsed_modules::ParsedModule>,
+    index: usize,
+}
+
+impl TokenView {
+    fn token(&self) -> &rue_lexer::Token {
+        &self.owner.tokens()[self.index]
+    }
+
+    pub fn kind(&self) -> &str {
+        use rue_lexer::TokenKind::*;
+        match self.token().kind {
+            Fn => "FN",
+            Let => "LET",
+            Mut => "MUT",
+            Inout => "INOUT",
+            Borrow => "BORROW",
+            If => "IF",
+            Else => "ELSE",
+            Match => "MATCH",
+            While => "WHILE",
+            Loop => "LOOP",
+            For => "FOR",
+            In => "IN",
+            Break => "BREAK",
+            Continue => "CONTINUE",
+            Return => "RETURN",
+            True => "TRUE",
+            False => "FALSE",
+            Struct => "STRUCT",
+            Enum => "ENUM",
+            Impl => "IMPL",
+            Drop => "DROP",
+            Linear => "LINEAR",
+            SelfValue => "SELF",
+            SelfType => "SELFTYPE",
+            Comptime => "COMPTIME",
+            Pub => "PUB",
+            Const => "CONST",
+            Checked => "CHECKED",
+            Unchecked => "UNCHECKED",
+            Ptr => "PTR",
+            I8 => "TYPE(i8)",
+            I16 => "TYPE(i16)",
+            I32 => "TYPE(i32)",
+            I64 => "TYPE(i64)",
+            U8 => "TYPE(u8)",
+            U16 => "TYPE(u16)",
+            U32 => "TYPE(u32)",
+            U64 => "TYPE(u64)",
+            Bool => "TYPE(bool)",
+            Type => "TYPE(type)",
+            Underscore => "UNDERSCORE",
+            Int(_) => "INT",
+            String(_) => "STRING",
+            Ident(_) => "IDENT",
+            Plus => "PLUS",
+            Minus => "MINUS",
+            Star => "STAR",
+            Slash => "SLASH",
+            Percent => "PERCENT",
+            Eq => "EQ",
+            EqEq => "EQEQ",
+            Bang => "BANG",
+            BangEq => "BANGEQ",
+            Lt => "LT",
+            Gt => "GT",
+            LtEq => "LTEQ",
+            GtEq => "GTEQ",
+            AmpAmp => "AMPAMP",
+            PipePipe => "PIPEPIPE",
+            Amp => "AMP",
+            Pipe => "PIPE",
+            Caret => "CARET",
+            Tilde => "TILDE",
+            LtLt => "LTLT",
+            GtGt => "GTGT",
+            LParen => "LPAREN",
+            RParen => "RPAREN",
+            LBrace => "LBRACE",
+            RBrace => "RBRACE",
+            LBracket => "LBRACKET",
+            RBracket => "RBRACKET",
+            Arrow => "ARROW",
+            FatArrow => "FATARROW",
+            ColonColon => "COLONCOLON",
+            Colon => "COLON",
+            Semi => "SEMI",
+            Comma => "COMMA",
+            Dot => "DOT",
+            At => "AT",
+            Question => "QUESTION",
+            Eof => "EOF",
+        }
+    }
+
+    pub fn value(&self) -> Option<Cow<'_, str>> {
+        match self.token().kind {
+            rue_lexer::TokenKind::Ident(symbol) | rue_lexer::TokenKind::String(symbol) => {
+                Some(Cow::Borrowed(self.owner.resolve_raw_symbol(symbol)))
+            }
+            rue_lexer::TokenKind::Int(value) => Some(Cow::Owned(value.to_string())),
+            _ => None,
+        }
+    }
+
+    pub fn start(&self) -> u32 {
+        self.token().span.start
+    }
+
+    pub fn end(&self) -> u32 {
+        self.token().span.end
+    }
+
+    pub fn location(&self) -> SourceLocationView {
+        SourceLocationView::syntax(self.owner.clone(), self.token().span)
+    }
+}
+
+impl fmt::Debug for TokenView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TokenView")
+            .field("kind", &self.kind())
+            .field("value", &self.value())
+            .field("start", &self.start())
+            .field("end", &self.end())
+            .finish()
+    }
+}
+
+struct SyntaxNodeRecord {
+    kind: &'static str,
+    span: crate::Span,
+    name: Option<Arc<str>>,
+    value: Option<Arc<str>>,
+    children: Arc<[Arc<SyntaxNodeRecord>]>,
+}
+
+/// One owner-bound syntax node with resolved strings and checked children.
+#[derive(Clone)]
+pub struct SyntaxNodeView {
+    owner: Arc<crate::parsed_modules::ParsedModule>,
+    node: Arc<SyntaxNodeRecord>,
+}
+
+impl SyntaxNodeView {
+    pub fn kind(&self) -> &str {
+        self.node.kind
+    }
+
+    pub fn location(&self) -> SourceLocationView {
+        SourceLocationView::syntax(self.owner.clone(), self.node.span)
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        self.node.name.as_deref()
+    }
+
+    pub fn value(&self) -> Option<&str> {
+        self.node.value.as_deref()
+    }
+
+    pub fn child_count(&self) -> usize {
+        self.node.children.len()
+    }
+
+    pub fn children(&self) -> impl ExactSizeIterator<Item = SyntaxNodeView> + '_ {
+        self.node
+            .children
+            .iter()
+            .cloned()
+            .map(|node| SyntaxNodeView {
+                owner: self.owner.clone(),
+                node,
+            })
+    }
+}
+
+impl fmt::Debug for SyntaxNodeView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SyntaxNodeView")
+            .field("kind", &self.kind())
+            .field("location", &self.location())
+            .field("name", &self.name())
+            .field("value", &self.value())
+            .field("child_count", &self.child_count())
+            .finish()
+    }
+}
+
+/// One source module in a [`SyntaxView`].
+#[derive(Clone)]
+pub struct SyntaxModuleView {
+    owner: Arc<crate::parsed_modules::ParsedModule>,
+}
+
+impl SyntaxModuleView {
+    pub fn file_id(&self) -> crate::FileId {
+        self.owner.file_id()
+    }
+
+    pub fn path(&self) -> &str {
+        self.owner.physical_path()
+    }
+
+    pub fn source(&self) -> &str {
+        self.owner.source_text()
+    }
+
+    pub fn tokens(&self) -> impl ExactSizeIterator<Item = TokenView> + '_ {
+        (0..self.owner.tokens().len()).map(|index| TokenView {
+            owner: self.owner.clone(),
+            index,
+        })
+    }
+
+    pub fn item_count(&self) -> usize {
+        self.owner.ast().items.len()
+    }
+
+    pub fn nodes(&self) -> impl ExactSizeIterator<Item = SyntaxNodeView> + '_ {
+        self.owner
+            .ast()
+            .items
+            .iter()
+            .map(|item| syntax_item_record(&self.owner, item))
+            .map(|node| SyntaxNodeView {
+                owner: self.owner.clone(),
+                node,
+            })
+    }
+}
+
+impl fmt::Debug for SyntaxModuleView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SyntaxModuleView")
+            .field("file_id", &self.file_id())
+            .field("path", &self.path())
+            .field("token_count", &self.owner.tokens().len())
+            .field("item_count", &self.item_count())
+            .finish()
+    }
+}
+
+/// Retainable syntax projection of the session's canonical parsed program.
+#[derive(Clone)]
+pub struct SyntaxView {
+    owner: Arc<ParsedProgram>,
+}
+
+impl SyntaxView {
+    pub(crate) fn new(owner: Arc<ParsedProgram>) -> Self {
+        Self { owner }
+    }
+
+    pub fn modules(&self) -> impl ExactSizeIterator<Item = SyntaxModuleView> + '_ {
+        self.owner
+            .modules()
+            .iter()
+            .cloned()
+            .map(|owner| SyntaxModuleView { owner })
+    }
+
+    pub fn source_revision(&self) -> &crate::SourceRevision {
+        self.owner.source_revision()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn owner(&self) -> &Arc<ParsedProgram> {
+        &self.owner
+    }
+}
+
+impl fmt::Debug for SyntaxView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SyntaxView")
+            .field("source_revision", self.source_revision())
+            .field("module_count", &self.owner.modules().len())
+            .finish()
+    }
+}
+
+/// One checked RIR instruction record.
+#[derive(Clone)]
+pub struct RirInstructionView {
+    owner: Arc<CanonicalRirOutput>,
+    ordinal: usize,
+}
+
+impl RirInstructionView {
+    fn instruction(&self) -> &rue_rir::Inst {
+        self.owner
+            .rir()
+            .get(rue_rir::InstRef::from_raw(self.ordinal as u32))
+    }
+
+    pub fn ordinal(&self) -> usize {
+        self.ordinal
+    }
+
+    pub fn kind(&self) -> &str {
+        rir_kind(&self.instruction().data)
+    }
+
+    pub fn location(&self) -> SourceLocationView {
+        SourceLocationView::rir(self.owner.clone(), self.instruction().span)
+    }
+
+    pub fn operand_count(&self) -> usize {
+        self.operands().len()
+    }
+
+    pub fn operands(&self) -> impl ExactSizeIterator<Item = RirOperandView> + '_ {
+        rir_operands(self.owner.rir(), &self.instruction().data)
+            .into_iter()
+            .map(|operand| RirOperandView {
+                owner: self.owner.clone(),
+                role: operand.role,
+                target: operand.target,
+            })
+    }
+}
+
+impl fmt::Debug for RirInstructionView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RirInstructionView")
+            .field("ordinal", &self.ordinal())
+            .field("kind", &self.kind())
+            .field("location", &self.location())
+            .field("operand_count", &self.operand_count())
+            .finish()
+    }
+}
+
+struct RirOperandRecord {
+    role: &'static str,
+    target: usize,
+}
+
+/// A checked reference from one RIR instruction to another in the same owner.
+#[derive(Clone)]
+pub struct RirOperandView {
+    owner: Arc<CanonicalRirOutput>,
+    role: &'static str,
+    target: usize,
+}
+
+impl RirOperandView {
+    pub fn role(&self) -> &str {
+        self.role
+    }
+
+    pub fn target_ordinal(&self) -> usize {
+        self.target
+    }
+
+    pub fn target(&self) -> RirInstructionView {
+        debug_assert!(self.target < self.owner.rir().len());
+        RirInstructionView {
+            owner: self.owner.clone(),
+            ordinal: self.target,
+        }
+    }
+}
+
+impl fmt::Debug for RirOperandView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RirOperandView")
+            .field("role", &self.role())
+            .field("target_ordinal", &self.target_ordinal())
+            .finish()
+    }
+}
+
+/// Retainable immutable RIR projection.
+#[derive(Clone)]
+pub struct RirView {
+    owner: Arc<CanonicalRirOutput>,
+}
+
+impl RirView {
+    pub(crate) fn new(owner: Arc<CanonicalRirOutput>) -> Self {
+        Self { owner }
+    }
+
+    pub fn len(&self) -> usize {
+        self.owner.rir().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn shares_owner(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.owner, &other.owner)
+    }
+
+    pub fn instructions(&self) -> impl ExactSizeIterator<Item = RirInstructionView> + '_ {
+        (0..self.len()).map(|ordinal| RirInstructionView {
+            owner: self.owner.clone(),
+            ordinal,
+        })
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn owner(&self) -> &Arc<CanonicalRirOutput> {
+        &self.owner
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn rir(&self) -> &rue_rir::Rir {
+        self.owner.rir()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn presentation_order(
+        &self,
+        files: impl IntoIterator<Item = crate::FileId>,
+    ) -> crate::canonical_lower::CanonicalRirPresentationOrder {
+        self.owner.presentation_order(files)
+    }
+}
+
+impl fmt::Debug for RirView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RirView")
+            .field("instruction_count", &self.len())
+            .finish()
+    }
+}
+
+/// Structural type summary bound to one semantic owner.
+#[derive(Clone)]
+pub struct TypeView {
+    owner: Arc<CanonicalSemanticOutput>,
+}
+
+impl TypeView {
+    pub(crate) fn new(owner: Arc<CanonicalSemanticOutput>) -> Self {
+        Self { owner }
+    }
+
+    pub fn struct_count(&self) -> usize {
+        self.owner.type_pool().stats().struct_count
+    }
+
+    pub fn enum_count(&self) -> usize {
+        self.owner.type_pool().stats().enum_count
+    }
+}
+
+impl fmt::Debug for TypeView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TypeView")
+            .field("struct_count", &self.struct_count())
+            .field("enum_count", &self.enum_count())
+            .finish()
+    }
+}
+
+/// One checked CFG block record.
+#[derive(Clone)]
+pub struct CfgBlockView {
+    owner: Arc<CanonicalSemanticOutput>,
+    function: usize,
+    block: usize,
+}
+
+impl CfgBlockView {
+    fn block(&self) -> &rue_cfg::BasicBlock {
+        &self.owner.functions()[self.function].cfg.blocks()[self.block]
+    }
+
+    pub fn ordinal(&self) -> usize {
+        self.block
+    }
+
+    pub fn parameter_count(&self) -> usize {
+        self.block().params.len()
+    }
+
+    pub fn instruction_count(&self) -> usize {
+        self.instructions().len()
+    }
+
+    pub fn instructions(&self) -> impl ExactSizeIterator<Item = CfgInstructionView> + '_ {
+        self.block().insts.iter().map(|value| CfgInstructionView {
+            owner: self.owner.clone(),
+            function: self.function,
+            value: value.as_u32() as usize,
+        })
+    }
+
+    pub fn terminator_kind(&self) -> &str {
+        match self.block().terminator {
+            rue_cfg::Terminator::Goto { .. } => "goto",
+            rue_cfg::Terminator::Branch { .. } => "branch",
+            rue_cfg::Terminator::Switch { .. } => "switch",
+            rue_cfg::Terminator::Return { .. } => "return",
+            rue_cfg::Terminator::Unreachable => "unreachable",
+            rue_cfg::Terminator::None => "none",
+        }
+    }
+
+    pub fn successor_count(&self) -> usize {
+        self.successors().len()
+    }
+
+    pub fn successors(&self) -> impl ExactSizeIterator<Item = CfgSuccessorView> + '_ {
+        cfg_successors(
+            &self.owner.functions()[self.function].cfg,
+            &self.block().terminator,
+        )
+        .into_iter()
+        .map(|successor| CfgSuccessorView {
+            owner: self.owner.clone(),
+            function: self.function,
+            role: successor.role,
+            target: successor.target,
+            case_value: successor.case_value,
+        })
+    }
+}
+
+impl fmt::Debug for CfgBlockView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CfgBlockView")
+            .field("ordinal", &self.ordinal())
+            .field("parameter_count", &self.parameter_count())
+            .field("instruction_count", &self.instruction_count())
+            .field("terminator_kind", &self.terminator_kind())
+            .field("successor_count", &self.successor_count())
+            .finish()
+    }
+}
+
+/// One checked CFG instruction retained by its semantic function owner.
+#[derive(Clone)]
+pub struct CfgInstructionView {
+    owner: Arc<CanonicalSemanticOutput>,
+    function: usize,
+    value: usize,
+}
+
+impl CfgInstructionView {
+    fn instruction(&self) -> &rue_cfg::CfgInst {
+        self.owner.functions()[self.function]
+            .cfg
+            .get_inst(rue_cfg::CfgValue::from_raw(self.value as u32))
+    }
+
+    pub fn ordinal(&self) -> usize {
+        self.value
+    }
+
+    pub fn kind(&self) -> &str {
+        cfg_instruction_kind(&self.instruction().data)
+    }
+}
+
+impl fmt::Debug for CfgInstructionView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CfgInstructionView")
+            .field("ordinal", &self.ordinal())
+            .field("kind", &self.kind())
+            .finish()
+    }
+}
+
+struct CfgSuccessorRecord {
+    role: &'static str,
+    target: usize,
+    case_value: Option<i64>,
+}
+
+/// One checked outgoing block edge retained by its semantic function owner.
+#[derive(Clone)]
+pub struct CfgSuccessorView {
+    owner: Arc<CanonicalSemanticOutput>,
+    function: usize,
+    role: &'static str,
+    target: usize,
+    case_value: Option<i64>,
+}
+
+impl CfgSuccessorView {
+    pub fn role(&self) -> &str {
+        self.role
+    }
+
+    pub fn target_ordinal(&self) -> usize {
+        self.target
+    }
+
+    pub fn case_value(&self) -> Option<i64> {
+        self.case_value
+    }
+
+    pub fn target(&self) -> CfgBlockView {
+        debug_assert!(self.target < self.owner.functions()[self.function].cfg.blocks().len());
+        CfgBlockView {
+            owner: self.owner.clone(),
+            function: self.function,
+            block: self.target,
+        }
+    }
+}
+
+impl fmt::Debug for CfgSuccessorView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CfgSuccessorView")
+            .field("role", &self.role())
+            .field("target_ordinal", &self.target_ordinal())
+            .field("case_value", &self.case_value())
+            .finish()
+    }
+}
+
+/// Checked CFG projection for one function.
+#[derive(Clone)]
+pub struct CfgView {
+    owner: Arc<CanonicalSemanticOutput>,
+    function: usize,
+}
+
+impl CfgView {
+    fn function(&self) -> &crate::FunctionWithCfg {
+        &self.owner.functions()[self.function]
+    }
+
+    pub fn block_count(&self) -> usize {
+        self.function().cfg.blocks().len()
+    }
+
+    pub fn blocks(&self) -> impl ExactSizeIterator<Item = CfgBlockView> + '_ {
+        (0..self.block_count()).map(|block| CfgBlockView {
+            owner: self.owner.clone(),
+            function: self.function,
+            block,
+        })
+    }
+}
+
+impl fmt::Debug for CfgView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CfgView")
+            .field("block_count", &self.block_count())
+            .finish()
+    }
+}
+
+/// One function in a [`SemanticView`].
+#[derive(Clone)]
+pub struct FunctionView {
+    owner: Arc<CanonicalSemanticOutput>,
+    function: usize,
+}
+
+impl FunctionView {
+    fn function(&self) -> &crate::FunctionWithCfg {
+        &self.owner.functions()[self.function]
+    }
+
+    pub fn name(&self) -> &str {
+        &self.function().analyzed.name
+    }
+
+    pub fn instruction_count(&self) -> usize {
+        self.function().analyzed.air.len()
+    }
+
+    pub fn local_count(&self) -> u32 {
+        self.function().analyzed.num_locals
+    }
+
+    pub fn parameter_slot_count(&self) -> u32 {
+        self.function().analyzed.num_param_slots
+    }
+
+    pub fn cfg(&self) -> CfgView {
+        CfgView {
+            owner: self.owner.clone(),
+            function: self.function,
+        }
+    }
+}
+
+impl fmt::Debug for FunctionView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FunctionView")
+            .field("name", &self.name())
+            .field("instruction_count", &self.instruction_count())
+            .field("local_count", &self.local_count())
+            .field("parameter_slot_count", &self.parameter_slot_count())
+            .field("block_count", &self.cfg().block_count())
+            .finish()
+    }
+}
+
+/// Retainable immutable semantic projection.
+#[derive(Clone)]
+pub struct SemanticView {
+    owner: Arc<CanonicalSemanticOutput>,
+    rir: Arc<CanonicalRirOutput>,
+}
+
+impl SemanticView {
+    pub(crate) fn new(owner: Arc<CanonicalSemanticOutput>, rir: Arc<CanonicalRirOutput>) -> Self {
+        Self { owner, rir }
+    }
+
+    pub fn function_views(&self) -> impl ExactSizeIterator<Item = FunctionView> + '_ {
+        (0..self.owner.functions().len()).map(|function| FunctionView {
+            owner: self.owner.clone(),
+            function,
+        })
+    }
+
+    pub fn types(&self) -> TypeView {
+        TypeView::new(self.owner.clone())
+    }
+
+    pub fn shares_owner(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.owner, &other.owner)
+    }
+
+    /// User-facing diagnostics retained by the semantic result. These are
+    /// facade diagnostics, not access to AIR or CFG storage.
+    pub fn warnings(&self) -> &[crate::CompileWarning] {
+        self.owner.warnings()
+    }
+
+    pub fn string_literals(&self) -> impl ExactSizeIterator<Item = &str> {
+        self.owner.strings().iter().map(String::as_str)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn owner(&self) -> &Arc<CanonicalSemanticOutput> {
+        &self.owner
+    }
+
+    pub(crate) fn into_owners(self) -> (Arc<CanonicalSemanticOutput>, Arc<CanonicalRirOutput>) {
+        (self.owner, self.rir)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn unstable_metrics(&self) -> crate::unstable::SemanticMetrics {
+        self.owner.unstable_metrics()
+    }
+}
+
+impl fmt::Debug for SemanticView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SemanticView")
+            .field("function_count", &self.owner.functions().len())
+            .field("warning_count", &self.owner.warnings().len())
+            .field("string_literal_count", &self.owner.strings().len())
+            .field("types", &self.types())
+            .finish()
+    }
+}
+
+fn syntax_record(
+    kind: &'static str,
+    span: crate::Span,
+    name: Option<Arc<str>>,
+    value: Option<Arc<str>>,
+    children: Vec<Arc<SyntaxNodeRecord>>,
+) -> Arc<SyntaxNodeRecord> {
+    Arc::new(SyntaxNodeRecord {
+        kind,
+        span,
+        name,
+        value,
+        children: children.into(),
+    })
+}
+
+fn resolved_ident(
+    owner: &crate::parsed_modules::ParsedModule,
+    ident: rue_parser::Ident,
+) -> Arc<str> {
+    Arc::from(owner.resolve_raw_symbol(ident.name))
+}
+
+fn resolved_idents(
+    owner: &crate::parsed_modules::ParsedModule,
+    idents: &[rue_parser::Ident],
+    separator: &str,
+) -> Arc<str> {
+    idents
+        .iter()
+        .map(|ident| owner.resolve_raw_symbol(ident.name))
+        .collect::<Vec<_>>()
+        .join(separator)
+        .into()
+}
+
+fn directive_records<'a>(
+    owner: &'a crate::parsed_modules::ParsedModule,
+    directives: &'a [rue_parser::Directive],
+) -> impl Iterator<Item = Arc<SyntaxNodeRecord>> + 'a {
+    directives.iter().map(|directive| {
+        let children = directive
+            .args
+            .iter()
+            .map(|arg| match arg {
+                rue_parser::DirectiveArg::Ident(ident) => syntax_record(
+                    "directive_argument",
+                    ident.span,
+                    Some(resolved_ident(owner, *ident)),
+                    None,
+                    Vec::new(),
+                ),
+            })
+            .collect();
+        syntax_record(
+            "directive",
+            directive.span,
+            Some(resolved_ident(owner, directive.name)),
+            None,
+            children,
+        )
+    })
+}
+
+fn syntax_item_record(
+    owner: &crate::parsed_modules::ParsedModule,
+    item: &rue_parser::Item,
+) -> Arc<SyntaxNodeRecord> {
+    match item {
+        rue_parser::Item::Function(function) => function_record(owner, function, "function"),
+        rue_parser::Item::Struct(structure) => {
+            let mut children = directive_records(owner, &structure.directives).collect::<Vec<_>>();
+            children.push(modifier_record(
+                structure.span,
+                "visibility",
+                visibility_name(structure.visibility),
+            ));
+            children.push(modifier_record(
+                structure.span,
+                "linear",
+                bool_name(structure.is_linear),
+            ));
+            children.extend(structure.fields.iter().map(|field| {
+                syntax_record(
+                    "field",
+                    field.span,
+                    Some(resolved_ident(owner, field.name)),
+                    None,
+                    vec![type_record(owner, &field.ty)],
+                )
+            }));
+            children.extend(
+                structure
+                    .methods
+                    .iter()
+                    .map(|method| method_record(owner, method)),
+            );
+            syntax_record(
+                "struct",
+                structure.span,
+                Some(resolved_ident(owner, structure.name)),
+                None,
+                children,
+            )
+        }
+        rue_parser::Item::Enum(enumeration) => {
+            let mut children = vec![modifier_record(
+                enumeration.span,
+                "visibility",
+                visibility_name(enumeration.visibility),
+            )];
+            children.extend(enumeration.variants.iter().map(|variant| {
+                syntax_record(
+                    "enum_variant",
+                    variant.span,
+                    Some(resolved_ident(owner, variant.name)),
+                    None,
+                    variant
+                        .payload
+                        .iter()
+                        .map(|ty| type_record(owner, ty))
+                        .collect(),
+                )
+            }));
+            syntax_record(
+                "enum",
+                enumeration.span,
+                Some(resolved_ident(owner, enumeration.name)),
+                None,
+                children,
+            )
+        }
+        rue_parser::Item::DropFn(drop_fn) => syntax_record(
+            "drop_function",
+            drop_fn.span,
+            Some(resolved_ident(owner, drop_fn.type_name)),
+            None,
+            vec![
+                receiver_record(drop_fn.self_param.clone()),
+                expr_record(owner, &drop_fn.body),
+            ],
+        ),
+        rue_parser::Item::Const(constant) => {
+            let mut children = directive_records(owner, &constant.directives).collect::<Vec<_>>();
+            children.push(modifier_record(
+                constant.span,
+                "visibility",
+                visibility_name(constant.visibility),
+            ));
+            children.extend(constant.ty.iter().map(|ty| type_record(owner, ty)));
+            children.push(expr_record(owner, &constant.init));
+            syntax_record(
+                "const",
+                constant.span,
+                Some(resolved_ident(owner, constant.name)),
+                None,
+                children,
+            )
+        }
+        rue_parser::Item::Error(span) => syntax_record("error", *span, None, None, Vec::new()),
+    }
+}
+
+fn function_record(
+    owner: &crate::parsed_modules::ParsedModule,
+    function: &rue_parser::Function,
+    kind: &'static str,
+) -> Arc<SyntaxNodeRecord> {
+    let mut children = directive_records(owner, &function.directives).collect::<Vec<_>>();
+    children.push(modifier_record(
+        function.span,
+        "visibility",
+        visibility_name(function.visibility),
+    ));
+    children.push(modifier_record(
+        function.span,
+        "unchecked",
+        bool_name(function.is_unchecked),
+    ));
+    children.extend(
+        function
+            .params
+            .iter()
+            .map(|param| param_record(owner, param)),
+    );
+    children.extend(function.return_type.iter().map(|ty| type_record(owner, ty)));
+    children.push(expr_record(owner, &function.body));
+    syntax_record(
+        kind,
+        function.span,
+        Some(resolved_ident(owner, function.name)),
+        None,
+        children,
+    )
+}
+
+fn method_record(
+    owner: &crate::parsed_modules::ParsedModule,
+    method: &rue_parser::Method,
+) -> Arc<SyntaxNodeRecord> {
+    let mut children = directive_records(owner, &method.directives).collect::<Vec<_>>();
+    children.extend(method.receiver.iter().cloned().map(receiver_record));
+    children.extend(method.params.iter().map(|param| param_record(owner, param)));
+    children.extend(method.return_type.iter().map(|ty| type_record(owner, ty)));
+    children.push(expr_record(owner, &method.body));
+    syntax_record(
+        "method",
+        method.span,
+        Some(resolved_ident(owner, method.name)),
+        None,
+        children,
+    )
+}
+
+fn visibility_name(visibility: rue_parser::ast::Visibility) -> &'static str {
+    match visibility {
+        rue_parser::ast::Visibility::Private => "private",
+        rue_parser::ast::Visibility::Public => "public",
+    }
+}
+
+fn bool_name(value: bool) -> &'static str {
+    if value { "true" } else { "false" }
+}
+
+fn modifier_record(
+    span: crate::Span,
+    name: &'static str,
+    value: &'static str,
+) -> Arc<SyntaxNodeRecord> {
+    syntax_record(
+        "modifier",
+        span,
+        Some(Arc::from(name)),
+        Some(Arc::from(value)),
+        Vec::new(),
+    )
+}
+
+fn receiver_record(receiver: rue_parser::SelfParam) -> Arc<SyntaxNodeRecord> {
+    syntax_record(
+        "receiver",
+        receiver.span,
+        Some(Arc::from("self")),
+        Some(
+            format!(
+                "mode={};mutable={}",
+                if receiver.mode == rue_parser::ParamMode::Normal {
+                    "normal"
+                } else {
+                    receiver.mode.keyword()
+                },
+                bool_name(receiver.is_mut)
+            )
+            .into(),
+        ),
+        Vec::new(),
+    )
+}
+
+fn argument_mode_name(mode: rue_parser::ArgMode) -> &'static str {
+    match mode {
+        rue_parser::ArgMode::Normal => "normal",
+        rue_parser::ArgMode::Inout => "inout",
+        rue_parser::ArgMode::Borrow => "borrow",
+    }
+}
+
+fn call_argument_record(
+    owner: &crate::parsed_modules::ParsedModule,
+    argument: &rue_parser::CallArg,
+) -> Arc<SyntaxNodeRecord> {
+    syntax_record(
+        "argument",
+        argument.span,
+        None,
+        Some(Arc::from(argument_mode_name(argument.mode))),
+        vec![expr_record(owner, &argument.expr)],
+    )
+}
+
+fn param_record(
+    owner: &crate::parsed_modules::ParsedModule,
+    param: &rue_parser::Param,
+) -> Arc<SyntaxNodeRecord> {
+    syntax_record(
+        "parameter",
+        param.span,
+        Some(resolved_ident(owner, param.name)),
+        Some(Arc::from(if param.mode == rue_parser::ParamMode::Normal {
+            "normal"
+        } else {
+            param.mode.keyword()
+        })),
+        vec![type_record(owner, &param.ty)],
+    )
+}
+
+fn type_record(
+    owner: &crate::parsed_modules::ParsedModule,
+    ty: &rue_parser::TypeExpr,
+) -> Arc<SyntaxNodeRecord> {
+    use rue_parser::TypeExpr;
+    let span = ty.span();
+    match ty {
+        TypeExpr::Named(ident) => syntax_record(
+            "named_type",
+            span,
+            Some(resolved_ident(owner, *ident)),
+            None,
+            Vec::new(),
+        ),
+        TypeExpr::Qualified { segments, .. } => syntax_record(
+            "qualified_type",
+            span,
+            Some(resolved_idents(owner, segments, ".")),
+            None,
+            Vec::new(),
+        ),
+        TypeExpr::Unit(_) => syntax_record("unit_type", span, None, None, Vec::new()),
+        TypeExpr::Never(_) => syntax_record("never_type", span, None, None, Vec::new()),
+        TypeExpr::Array {
+            element, length, ..
+        } => syntax_record(
+            "array_type",
+            span,
+            None,
+            None,
+            vec![
+                type_record(owner, element),
+                array_length_record(owner, length, span),
+            ],
+        ),
+        TypeExpr::Slice { element, .. } => syntax_record(
+            "slice_type",
+            span,
+            None,
+            None,
+            vec![type_record(owner, element)],
+        ),
+        TypeExpr::AnonymousStruct {
+            fields, methods, ..
+        } => {
+            let mut children = fields
+                .iter()
+                .map(|field| {
+                    syntax_record(
+                        "field",
+                        field.span,
+                        Some(resolved_ident(owner, field.name)),
+                        None,
+                        vec![type_record(owner, &field.ty)],
+                    )
+                })
+                .collect::<Vec<_>>();
+            children.extend(methods.iter().map(|method| method_record(owner, method)));
+            syntax_record("anonymous_struct_type", span, None, None, children)
+        }
+        TypeExpr::AnonymousEnum { variants, .. } => syntax_record(
+            "anonymous_enum_type",
+            span,
+            None,
+            None,
+            variants
+                .iter()
+                .map(|variant| {
+                    syntax_record(
+                        "enum_variant",
+                        variant.span,
+                        Some(resolved_ident(owner, variant.name)),
+                        None,
+                        variant
+                            .payload
+                            .iter()
+                            .map(|ty| type_record(owner, ty))
+                            .collect(),
+                    )
+                })
+                .collect(),
+        ),
+        TypeExpr::PointerConst { pointee, .. } => syntax_record(
+            "const_pointer_type",
+            span,
+            None,
+            None,
+            vec![type_record(owner, pointee)],
+        ),
+        TypeExpr::PointerMut { pointee, .. } => syntax_record(
+            "mutable_pointer_type",
+            span,
+            None,
+            None,
+            vec![type_record(owner, pointee)],
+        ),
+        TypeExpr::TypeCall { name, args, .. } => syntax_record(
+            "type_call",
+            span,
+            Some(resolved_ident(owner, *name)),
+            None,
+            args.iter().map(|arg| type_record(owner, arg)).collect(),
+        ),
+        TypeExpr::QualifiedTypeCall { segments, args, .. } => syntax_record(
+            "qualified_type_call",
+            span,
+            Some(resolved_idents(owner, segments, ".")),
+            None,
+            args.iter().map(|arg| type_record(owner, arg)).collect(),
+        ),
+        TypeExpr::StrFixed { name, length, .. } => syntax_record(
+            "fixed_string_type",
+            span,
+            Some(resolved_ident(owner, *name)),
+            Some(length.to_string().into()),
+            Vec::new(),
+        ),
+        TypeExpr::IntArg { value, .. } => syntax_record(
+            "integer_type_argument",
+            span,
+            None,
+            Some(value.to_string().into()),
+            Vec::new(),
+        ),
+    }
+}
+
+fn array_length_record(
+    owner: &crate::parsed_modules::ParsedModule,
+    length: &rue_parser::ArrayLength,
+    span: crate::Span,
+) -> Arc<SyntaxNodeRecord> {
+    match length {
+        rue_parser::ArrayLength::Literal(value) => syntax_record(
+            "array_length",
+            span,
+            None,
+            Some(value.to_string().into()),
+            Vec::new(),
+        ),
+        rue_parser::ArrayLength::Named(ident) => syntax_record(
+            "array_length",
+            ident.span,
+            Some(resolved_ident(owner, *ident)),
+            None,
+            Vec::new(),
+        ),
+        rue_parser::ArrayLength::Call { name, args } => syntax_record(
+            "array_length_call",
+            name.span,
+            Some(resolved_ident(owner, *name)),
+            None,
+            args.iter()
+                .map(|arg| array_length_record(owner, arg, name.span))
+                .collect(),
+        ),
+    }
+}
+
+fn block_record(
+    owner: &crate::parsed_modules::ParsedModule,
+    block: &rue_parser::BlockExpr,
+) -> Arc<SyntaxNodeRecord> {
+    let mut children = block
+        .statements
+        .iter()
+        .map(|statement| statement_record(owner, statement))
+        .collect::<Vec<_>>();
+    children.push(expr_record(owner, &block.expr));
+    syntax_record("block", block.span, None, None, children)
+}
+
+fn statement_record(
+    owner: &crate::parsed_modules::ParsedModule,
+    statement: &rue_parser::Statement,
+) -> Arc<SyntaxNodeRecord> {
+    match statement {
+        rue_parser::Statement::Let(statement) => {
+            let (name, pattern) = match statement.pattern {
+                rue_parser::LetPattern::Ident(ident) => (Some(resolved_ident(owner, ident)), "let"),
+                rue_parser::LetPattern::Wildcard(_) => (None, "let_wildcard"),
+            };
+            let mut children = directive_records(owner, &statement.directives).collect::<Vec<_>>();
+            children.push(modifier_record(
+                statement.span,
+                "mutable",
+                bool_name(statement.is_mut),
+            ));
+            children.extend(statement.ty.iter().map(|ty| type_record(owner, ty)));
+            children.push(expr_record(owner, &statement.init));
+            syntax_record(pattern, statement.span, name, None, children)
+        }
+        rue_parser::Statement::Assign(statement) => {
+            let target = match &statement.target {
+                rue_parser::AssignTarget::Var(ident) => syntax_record(
+                    "assignment_target",
+                    ident.span,
+                    Some(resolved_ident(owner, *ident)),
+                    None,
+                    Vec::new(),
+                ),
+                rue_parser::AssignTarget::Field(field) => field_record(owner, field),
+                rue_parser::AssignTarget::Index(index) => syntax_record(
+                    "index",
+                    index.span,
+                    None,
+                    None,
+                    vec![
+                        expr_record(owner, &index.base),
+                        expr_record(owner, &index.index),
+                    ],
+                ),
+            };
+            syntax_record(
+                "assignment",
+                statement.span,
+                None,
+                None,
+                vec![target, expr_record(owner, &statement.value)],
+            )
+        }
+        rue_parser::Statement::Expr(expression) => syntax_record(
+            "expression_statement",
+            expression.span(),
+            None,
+            None,
+            vec![expr_record(owner, expression)],
+        ),
+    }
+}
+
+fn field_record(
+    owner: &crate::parsed_modules::ParsedModule,
+    field: &rue_parser::FieldExpr,
+) -> Arc<SyntaxNodeRecord> {
+    syntax_record(
+        "field_access",
+        field.span,
+        Some(resolved_ident(owner, field.field)),
+        None,
+        vec![expr_record(owner, &field.base)],
+    )
+}
+
+fn expr_record(
+    owner: &crate::parsed_modules::ParsedModule,
+    expression: &rue_parser::Expr,
+) -> Arc<SyntaxNodeRecord> {
+    use rue_parser::Expr;
+    let span = expression.span();
+    match expression {
+        Expr::Int(literal) => syntax_record(
+            "integer_literal",
+            span,
+            None,
+            Some(literal.value.to_string().into()),
+            Vec::new(),
+        ),
+        Expr::String(literal) => syntax_record(
+            "string_literal",
+            span,
+            None,
+            Some(Arc::from(owner.resolve_raw_symbol(literal.value))),
+            Vec::new(),
+        ),
+        Expr::Bool(literal) => syntax_record(
+            "boolean_literal",
+            span,
+            None,
+            Some(literal.value.to_string().into()),
+            Vec::new(),
+        ),
+        Expr::Unit(_) => syntax_record("unit_literal", span, None, None, Vec::new()),
+        Expr::Ident(ident) => syntax_record(
+            "identifier",
+            span,
+            Some(resolved_ident(owner, *ident)),
+            None,
+            Vec::new(),
+        ),
+        Expr::Binary(binary) => syntax_record(
+            "binary",
+            span,
+            None,
+            Some(binary_operator(binary.op).into()),
+            vec![
+                expr_record(owner, &binary.left),
+                expr_record(owner, &binary.right),
+            ],
+        ),
+        Expr::Unary(unary) => syntax_record(
+            "unary",
+            span,
+            None,
+            Some(unary_operator(unary.op).into()),
+            vec![expr_record(owner, &unary.operand)],
+        ),
+        Expr::Paren(paren) => syntax_record(
+            "parenthesized",
+            span,
+            None,
+            None,
+            vec![expr_record(owner, &paren.inner)],
+        ),
+        Expr::Block(block) => block_record(owner, block),
+        Expr::If(branch) => {
+            let mut children = vec![
+                expr_record(owner, &branch.cond),
+                block_record(owner, &branch.then_block),
+            ];
+            children.extend(
+                branch
+                    .else_block
+                    .iter()
+                    .map(|block| block_record(owner, block)),
+            );
+            syntax_record("if", span, None, None, children)
+        }
+        Expr::Match(matched) => {
+            let mut children = vec![expr_record(owner, &matched.scrutinee)];
+            children.extend(matched.arms.iter().map(|arm| {
+                syntax_record(
+                    "match_arm",
+                    arm.span,
+                    None,
+                    None,
+                    vec![
+                        pattern_record(owner, &arm.pattern),
+                        expr_record(owner, &arm.body),
+                    ],
+                )
+            }));
+            syntax_record("match", span, None, None, children)
+        }
+        Expr::While(loop_expression) => syntax_record(
+            "while",
+            span,
+            None,
+            None,
+            vec![
+                expr_record(owner, &loop_expression.cond),
+                block_record(owner, &loop_expression.body),
+            ],
+        ),
+        Expr::Loop(loop_expression) => syntax_record(
+            "loop",
+            span,
+            None,
+            None,
+            vec![block_record(owner, &loop_expression.body)],
+        ),
+        Expr::For(loop_expression) => {
+            let binder = match loop_expression.binder {
+                rue_parser::LetPattern::Ident(ident) => syntax_record(
+                    "binding_pattern",
+                    ident.span,
+                    Some(resolved_ident(owner, ident)),
+                    None,
+                    Vec::new(),
+                ),
+                rue_parser::LetPattern::Wildcard(span) => {
+                    syntax_record("wildcard_pattern", span, None, None, Vec::new())
+                }
+            };
+            syntax_record(
+                "for",
+                span,
+                None,
+                None,
+                vec![
+                    binder,
+                    expr_record(owner, &loop_expression.iterable),
+                    block_record(owner, &loop_expression.body),
+                ],
+            )
+        }
+        Expr::Call(call) => syntax_record(
+            "call",
+            span,
+            Some(resolved_ident(owner, call.name)),
+            None,
+            call.args
+                .iter()
+                .map(|argument| call_argument_record(owner, argument))
+                .collect(),
+        ),
+        Expr::Break(break_expression) => syntax_record(
+            "break",
+            span,
+            None,
+            None,
+            break_expression
+                .value
+                .iter()
+                .map(|value| expr_record(owner, value))
+                .collect(),
+        ),
+        Expr::Continue(_) => syntax_record("continue", span, None, None, Vec::new()),
+        Expr::Return(return_expression) => syntax_record(
+            "return",
+            span,
+            None,
+            None,
+            return_expression
+                .value
+                .iter()
+                .map(|value| expr_record(owner, value))
+                .collect(),
+        ),
+        Expr::StructLit(literal) => {
+            let mut children = literal
+                .base
+                .iter()
+                .map(|base| expr_record(owner, base))
+                .collect::<Vec<_>>();
+            children.extend(
+                literal
+                    .ctor_args
+                    .iter()
+                    .flatten()
+                    .map(|argument| call_argument_record(owner, argument)),
+            );
+            children.extend(literal.fields.iter().map(|field| {
+                syntax_record(
+                    "field_initializer",
+                    field.span,
+                    Some(resolved_ident(owner, field.name)),
+                    Some(
+                        if field.shorthand {
+                            "shorthand"
+                        } else {
+                            "explicit"
+                        }
+                        .into(),
+                    ),
+                    vec![expr_record(owner, &field.value)],
+                )
+            }));
+            syntax_record(
+                "struct_literal",
+                span,
+                Some(resolved_ident(owner, literal.name)),
+                None,
+                children,
+            )
+        }
+        Expr::Field(field) => field_record(owner, field),
+        Expr::MethodCall(call) => {
+            let mut children = vec![expr_record(owner, &call.receiver)];
+            children.extend(
+                call.args
+                    .iter()
+                    .map(|argument| call_argument_record(owner, argument)),
+            );
+            syntax_record(
+                "method_call",
+                span,
+                Some(resolved_ident(owner, call.method)),
+                None,
+                children,
+            )
+        }
+        Expr::Try(try_expression) => syntax_record(
+            "try",
+            span,
+            None,
+            None,
+            vec![expr_record(owner, &try_expression.operand)],
+        ),
+        Expr::IntrinsicCall(call) => syntax_record(
+            "intrinsic_call",
+            span,
+            Some(resolved_ident(owner, call.name)),
+            None,
+            call.args
+                .iter()
+                .map(|argument| match argument {
+                    rue_parser::IntrinsicArg::Expr(expression) => expr_record(owner, expression),
+                    rue_parser::IntrinsicArg::Type(ty) => type_record(owner, ty),
+                })
+                .collect(),
+        ),
+        Expr::ArrayLit(array) => {
+            let mut children = array
+                .elements
+                .iter()
+                .map(|element| expr_record(owner, element))
+                .collect::<Vec<_>>();
+            children.extend(
+                array
+                    .repeat
+                    .iter()
+                    .map(|length| array_length_record(owner, length, span)),
+            );
+            syntax_record("array_literal", span, None, None, children)
+        }
+        Expr::Index(index) => syntax_record(
+            "index",
+            span,
+            None,
+            None,
+            vec![
+                expr_record(owner, &index.base),
+                expr_record(owner, &index.index),
+            ],
+        ),
+        Expr::Path(path) => syntax_record(
+            "path",
+            span,
+            Some(
+                format!(
+                    "{}::{}",
+                    owner.resolve_raw_symbol(path.type_name.name),
+                    owner.resolve_raw_symbol(path.variant.name)
+                )
+                .into(),
+            ),
+            None,
+            path.base
+                .iter()
+                .map(|base| expr_record(owner, base))
+                .collect(),
+        ),
+        Expr::SelfExpr(_) => syntax_record("self", span, None, None, Vec::new()),
+        Expr::Comptime(block) => syntax_record(
+            "comptime",
+            span,
+            None,
+            None,
+            vec![expr_record(owner, &block.expr)],
+        ),
+        Expr::Checked(block) => syntax_record(
+            "checked",
+            span,
+            None,
+            None,
+            vec![expr_record(owner, &block.expr)],
+        ),
+        Expr::TypeLit(literal) => syntax_record(
+            "type_literal",
+            span,
+            None,
+            None,
+            vec![type_record(owner, &literal.type_expr)],
+        ),
+        Expr::Error(_) => syntax_record("error", span, None, None, Vec::new()),
+    }
+}
+
+fn pattern_record(
+    owner: &crate::parsed_modules::ParsedModule,
+    pattern: &rue_parser::Pattern,
+) -> Arc<SyntaxNodeRecord> {
+    let span = pattern.span();
+    match pattern {
+        rue_parser::Pattern::Wildcard(_) => {
+            syntax_record("wildcard_pattern", span, None, None, Vec::new())
+        }
+        rue_parser::Pattern::Int(literal) => syntax_record(
+            "integer_pattern",
+            span,
+            None,
+            Some(literal.value.to_string().into()),
+            Vec::new(),
+        ),
+        rue_parser::Pattern::NegInt(literal) => syntax_record(
+            "integer_pattern",
+            span,
+            None,
+            Some(format!("-{}", literal.value).into()),
+            Vec::new(),
+        ),
+        rue_parser::Pattern::Bool(literal) => syntax_record(
+            "boolean_pattern",
+            span,
+            None,
+            Some(literal.value.to_string().into()),
+            Vec::new(),
+        ),
+        rue_parser::Pattern::Path(path) => {
+            let mut children = path
+                .base
+                .iter()
+                .map(|base| expr_record(owner, base))
+                .collect::<Vec<_>>();
+            children.extend(
+                path.ctor_args
+                    .iter()
+                    .flatten()
+                    .map(|argument| call_argument_record(owner, argument)),
+            );
+            children.extend(path.bindings.iter().map(|binding| {
+                syntax_record(
+                    "binding",
+                    binding.span,
+                    Some(resolved_ident(owner, *binding)),
+                    None,
+                    Vec::new(),
+                )
+            }));
+            syntax_record(
+                "path_pattern",
+                span,
+                Some(
+                    format!(
+                        "{}::{}",
+                        owner.resolve_raw_symbol(path.type_name.name),
+                        owner.resolve_raw_symbol(path.variant.name)
+                    )
+                    .into(),
+                ),
+                None,
+                children,
+            )
+        }
+    }
+}
+
+fn binary_operator(operator: rue_parser::BinaryOp) -> &'static str {
+    use rue_parser::BinaryOp::*;
+    match operator {
+        Add => "add",
+        Sub => "subtract",
+        Mul => "multiply",
+        Div => "divide",
+        Mod => "modulo",
+        Eq => "equal",
+        Ne => "not_equal",
+        Lt => "less_than",
+        Gt => "greater_than",
+        Le => "less_or_equal",
+        Ge => "greater_or_equal",
+        And => "logical_and",
+        Or => "logical_or",
+        BitAnd => "bit_and",
+        BitOr => "bit_or",
+        BitXor => "bit_xor",
+        Shl => "shift_left",
+        Shr => "shift_right",
+    }
+}
+
+fn unary_operator(operator: rue_parser::UnaryOp) -> &'static str {
+    match operator {
+        rue_parser::UnaryOp::Neg => "negate",
+        rue_parser::UnaryOp::Not => "logical_not",
+        rue_parser::UnaryOp::BitNot => "bit_not",
+    }
+}
+
+fn cfg_instruction_kind(data: &rue_cfg::CfgInstData) -> &'static str {
+    use rue_cfg::CfgInstData::*;
+    match data {
+        Const(_) => "integer_constant",
+        BoolConst(_) => "boolean_constant",
+        StringConst(_) => "string_constant",
+        Param { .. } => "parameter",
+        BlockParam { .. } => "block_parameter",
+        Add(..) => "add",
+        Sub(..) => "subtract",
+        Mul(..) => "multiply",
+        WrappingAdd(..) => "wrapping_add",
+        WrappingSub(..) => "wrapping_subtract",
+        WrappingMul(..) => "wrapping_multiply",
+        Div(..) => "divide",
+        Mod(..) => "modulo",
+        Eq(..) => "equal",
+        Ne(..) => "not_equal",
+        Lt(..) => "less_than",
+        Gt(..) => "greater_than",
+        Le(..) => "less_or_equal",
+        Ge(..) => "greater_or_equal",
+        BitAnd(..) => "bit_and",
+        BitOr(..) => "bit_or",
+        BitXor(..) => "bit_xor",
+        Shl(..) => "shift_left",
+        Shr(..) => "shift_right",
+        Neg(_) => "negate",
+        Not(_) => "logical_not",
+        BitNot(_) => "bit_not",
+        Alloc { .. } => "allocate",
+        Load { .. } => "load",
+        Store { .. } => "store",
+        ParamStore { .. } => "parameter_store",
+        PlaceRead { .. } => "place_read",
+        PlaceWrite { .. } => "place_write",
+        Call { .. } => "call",
+        Intrinsic { .. } => "intrinsic",
+        StructInit { .. } => "struct_initializer",
+        ArrayInit { .. } => "array_initializer",
+        EnumVariant { .. } => "enum_variant",
+        EnumPayloadGet { .. } => "enum_payload_read",
+        IntCast { .. } => "integer_cast",
+        Drop { .. } => "drop",
+        StorageLive { .. } => "storage_live",
+        StorageDead { .. } => "storage_dead",
+    }
+}
+
+fn cfg_successors(cfg: &rue_cfg::Cfg, terminator: &rue_cfg::Terminator) -> Vec<CfgSuccessorRecord> {
+    use rue_cfg::Terminator;
+    let mut successors = Vec::new();
+    let mut push = |role, target: rue_cfg::BlockId, case_value| {
+        let target = target.as_u32() as usize;
+        debug_assert!(target < cfg.blocks().len());
+        successors.push(CfgSuccessorRecord {
+            role,
+            target,
+            case_value,
+        });
+    };
+    match terminator {
+        Terminator::Goto { target, .. } => push("goto", *target, None),
+        Terminator::Branch {
+            then_block,
+            else_block,
+            ..
+        } => {
+            push("then", *then_block, None);
+            push("else", *else_block, None);
+        }
+        Terminator::Switch { default, .. } => {
+            for (value, target) in cfg.get_switch_cases(terminator) {
+                push("case", *target, Some(*value));
+            }
+            push("default", *default, None);
+        }
+        Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => {}
+    }
+    successors
+}
+
+fn rir_kind(data: &rue_rir::InstData) -> &'static str {
+    use rue_rir::InstData::*;
+    match data {
+        IntConst(_) => "integer_constant",
+        BoolConst(_) => "boolean_constant",
+        StringConst(_) => "string_constant",
+        UnitConst => "unit_constant",
+        Add { .. } => "add",
+        Sub { .. } => "subtract",
+        Mul { .. } => "multiply",
+        Div { .. } => "divide",
+        Mod { .. } => "modulo",
+        Eq { .. } => "equal",
+        Ne { .. } => "not_equal",
+        Lt { .. } => "less_than",
+        Gt { .. } => "greater_than",
+        Le { .. } => "less_or_equal",
+        Ge { .. } => "greater_or_equal",
+        And { .. } => "logical_and",
+        Or { .. } => "logical_or",
+        BitAnd { .. } => "bit_and",
+        BitOr { .. } => "bit_or",
+        BitXor { .. } => "bit_xor",
+        Shl { .. } => "shift_left",
+        Shr { .. } => "shift_right",
+        Neg { .. } => "negate",
+        Not { .. } => "logical_not",
+        BitNot { .. } => "bit_not",
+        Try { .. } => "try",
+        Branch { .. } => "branch",
+        Loop { .. } => "loop",
+        InfiniteLoop { .. } => "infinite_loop",
+        Match { .. } => "match",
+        Break { .. } => "break",
+        Continue => "continue",
+        FnDecl { .. } => "function_declaration",
+        ConstDecl { .. } => "constant_declaration",
+        Call { .. } => "call",
+        Intrinsic { .. } => "intrinsic",
+        InternalIntrinsic { .. } => "internal_intrinsic",
+        TypeIntrinsic { .. } => "type_intrinsic",
+        OffsetOf { .. } => "offset_of",
+        Ret(_) => "return",
+        Block { .. } => "block",
+        Alloc { .. } => "allocate",
+        VarRef { .. } => "variable_reference",
+        Assign { .. } => "assignment",
+        StructDecl { .. } => "struct_declaration",
+        StructInit { .. } => "struct_initializer",
+        FieldGet { .. } => "field_read",
+        FieldSet { .. } => "field_write",
+        EnumDecl { .. } => "enum_declaration",
+        EnumVariant { .. } => "enum_variant",
+        ArrayInit { .. } => "array_initializer",
+        ArrayRepeat { .. } => "array_repeat",
+        IndexGet { .. } => "index_read",
+        IndexSet { .. } => "index_write",
+        MethodCall { .. } => "method_call",
+        DropFnDecl { .. } => "drop_function_declaration",
+        Comptime { .. } => "comptime",
+        Checked { .. } => "checked",
+        TypeConst { .. } => "type_constant",
+        AnonStructType { .. } => "anonymous_struct_type",
+        AnonEnumType { .. } => "anonymous_enum_type",
+    }
+}
+
+fn rir_operands(rir: &rue_rir::Rir, data: &rue_rir::InstData) -> Vec<RirOperandRecord> {
+    use rue_rir::InstData::*;
+    let mut operands = Vec::new();
+    let mut push = |role, reference: rue_rir::InstRef| {
+        let target = reference.as_u32() as usize;
+        debug_assert!(target < rir.len());
+        operands.push(RirOperandRecord { role, target });
+    };
+    match data {
+        Add { lhs, rhs }
+        | Sub { lhs, rhs }
+        | Mul { lhs, rhs }
+        | Div { lhs, rhs }
+        | Mod { lhs, rhs }
+        | Eq { lhs, rhs }
+        | Ne { lhs, rhs }
+        | Lt { lhs, rhs }
+        | Gt { lhs, rhs }
+        | Le { lhs, rhs }
+        | Ge { lhs, rhs }
+        | And { lhs, rhs }
+        | Or { lhs, rhs }
+        | BitAnd { lhs, rhs }
+        | BitOr { lhs, rhs }
+        | BitXor { lhs, rhs }
+        | Shl { lhs, rhs }
+        | Shr { lhs, rhs } => {
+            push("left", *lhs);
+            push("right", *rhs);
+        }
+        Neg { operand } | Not { operand } | BitNot { operand } | Try { operand } => {
+            push("operand", *operand);
+        }
+        Branch {
+            cond,
+            then_block,
+            else_block,
+        } => {
+            push("condition", *cond);
+            push("then", *then_block);
+            if let Some(block) = else_block {
+                push("else", *block);
+            }
+        }
+        Loop { cond, body } => {
+            push("condition", *cond);
+            push("body", *body);
+        }
+        InfiniteLoop { body, .. } => push("body", *body),
+        Match { scrutinee, arms } => {
+            push("scrutinee", *scrutinee);
+            for (pattern, body) in rir.match_arms(arms).iter() {
+                if let rue_rir::RirPatternView::Path {
+                    module, ctor_head, ..
+                } = pattern
+                {
+                    if let Some(module) = module {
+                        push("pattern_module", module);
+                    }
+                    if let Some(ctor_head) = ctor_head {
+                        push("pattern_constructor", ctor_head);
+                    }
+                }
+                push("arm_body", body);
+            }
+        }
+        Break { value } | Ret(value) => {
+            if let Some(value) = value {
+                push("value", *value);
+            }
+        }
+        FnDecl { body, .. } | DropFnDecl { body, .. } => push("body", *body),
+        ConstDecl { init, .. } | Alloc { init, .. } => push("initializer", *init),
+        Assign { value, .. } => push("value", *value),
+        Call { args, .. } => {
+            for argument in rir.call_args(args) {
+                push("argument", argument.value);
+            }
+        }
+        Intrinsic { args, .. } => {
+            for argument in rir.intrinsic_args(args) {
+                push("argument", argument);
+            }
+        }
+        InternalIntrinsic { args, .. } => {
+            for argument in rir.internal_intrinsic_args(args) {
+                push("argument", argument);
+            }
+        }
+        Block { instructions } => {
+            for instruction in rir.block_insts(instructions) {
+                push("instruction", instruction);
+            }
+        }
+        StructDecl { methods, .. } => {
+            for method in rir.struct_methods(methods) {
+                push("method", method);
+            }
+        }
+        StructInit {
+            module,
+            ctor_head,
+            fields,
+            ..
+        } => {
+            if let Some(module) = module {
+                push("module", *module);
+            }
+            if let Some(ctor_head) = ctor_head {
+                push("constructor", *ctor_head);
+            }
+            for (_, value) in rir.field_inits(fields) {
+                push("field", value);
+            }
+        }
+        FieldGet { base, .. } => push("base", *base),
+        FieldSet { base, value, .. } => {
+            push("base", *base);
+            push("value", *value);
+        }
+        EnumVariant { module, .. } => {
+            if let Some(module) = module {
+                push("module", *module);
+            }
+        }
+        ArrayInit { elements } => {
+            for element in rir.array_elements(elements) {
+                push("element", element);
+            }
+        }
+        ArrayRepeat { value, .. } => push("value", *value),
+        IndexGet { base, index } => {
+            push("base", *base);
+            push("index", *index);
+        }
+        IndexSet { base, index, value } => {
+            push("base", *base);
+            push("index", *index);
+            push("value", *value);
+        }
+        MethodCall { receiver, args, .. } => {
+            push("receiver", *receiver);
+            for argument in rir.call_args(args) {
+                push("argument", argument.value);
+            }
+        }
+        Comptime { expr } | Checked { expr } => push("expression", *expr),
+        AnonStructType { methods, .. } => {
+            for method in rir.anon_struct_methods(methods) {
+                push("method", method);
+            }
+        }
+        IntConst(_)
+        | BoolConst(_)
+        | StringConst(_)
+        | UnitConst
+        | Continue
+        | TypeIntrinsic { .. }
+        | OffsetOf { .. }
+        | VarRef { .. }
+        | EnumDecl { .. }
+        | TypeConst { .. }
+        | AnonEnumType { .. } => {}
+    }
+    operands
+}

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -187,6 +187,8 @@ impl Mir {
     /// This prints the MIR instructions in assembly-like format.
     /// When called with allocated MIR (post-regalloc), physical registers
     /// are shown (rax, rbx, r12 for x86-64; x0, x1, x19 for aarch64).
+    #[cfg(test)]
+    #[allow(dead_code)]
     pub fn format_assembly(&self) -> String {
         let mut output = String::new();
         match self {

--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -35,6 +35,7 @@ pub struct CanonicalRirOutput {
     symbols: SemanticSymbolUniverse,
     work: CanonicalRirWork,
     module_ranges: Vec<CanonicalRirModuleRange>,
+    sources: Vec<CanonicalRirSource>,
 }
 
 #[derive(Debug)]
@@ -42,6 +43,13 @@ struct CanonicalRirModuleRange {
     file_id: FileId,
     instructions: Range<u32>,
     extra: Range<u32>,
+}
+
+#[derive(Debug)]
+struct CanonicalRirSource {
+    file_id: FileId,
+    revision: crate::ModuleRevision,
+    length: u32,
 }
 
 /// Ephemeral caller-order indices consumed by the read-only RIR printer.
@@ -67,7 +75,7 @@ impl CanonicalRirOutput {
                 })
     }
 
-    pub fn into_parts(self) -> (ValidatedRir, SemanticSymbolUniverse) {
+    pub(crate) fn into_parts(self) -> (ValidatedRir, SemanticSymbolUniverse) {
         (self.rir, self.symbols)
     }
 
@@ -85,6 +93,18 @@ impl CanonicalRirOutput {
 
     pub fn work(&self) -> CanonicalRirWork {
         self.work
+    }
+
+    pub(crate) fn source_identity_and_length(
+        &self,
+        file_id: FileId,
+    ) -> (&crate::ModuleRevision, u32) {
+        let source = self
+            .sources
+            .iter()
+            .find(|source| source.file_id == file_id)
+            .expect("validated RIR spans name a retained canonical source");
+        (&source.revision, source.length)
     }
 
     /// Return a read-only instruction presentation order for caller-ordered files.
@@ -210,12 +230,16 @@ pub(crate) fn lower_canonical_rir_with_work(
             }
         }
     };
-    let source_lengths: Vec<(FileId, u32)> = ast
+    let sources: Vec<CanonicalRirSource> = ast
         .modules()
         .iter()
         .map(|module| {
             u32::try_from(module.source_text().len())
-                .map(|length| (module.file_id(), length))
+                .map(|length| CanonicalRirSource {
+                    file_id: module.file_id(),
+                    revision: module.revision().clone(),
+                    length,
+                })
                 .map_err(|_| {
                     CompileError::new(
                         ErrorKind::InternalError(
@@ -227,6 +251,10 @@ pub(crate) fn lower_canonical_rir_with_work(
         })
         .collect::<Result<_, _>>()
         .map_err(|error| (error, work))?;
+    let source_lengths = sources
+        .iter()
+        .map(|source| (source.file_id, source.length))
+        .collect::<Vec<_>>();
     let validation = RirValidationContext {
         symbol_count: symbols.interner().len(),
         source_lengths: &source_lengths,
@@ -252,6 +280,7 @@ pub(crate) fn lower_canonical_rir_with_work(
         symbols,
         work,
         module_ranges,
+        sources,
     })
 }
 

--- a/crates/rue-compiler/src/canonical_merge.rs
+++ b/crates/rue-compiler/src/canonical_merge.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use rue_error::{CompileError, CompileErrors, ErrorKind};
 use rue_span::Span;
 
-use crate::parsed_modules::{ParsedAstView, ParsedItemView, ParsedModule, ParsedProgram};
+use crate::parsed_modules::{ParsedAstView, ParsedModule, ParsedProgram};
 use crate::{DefinitionKind, DefinitionSnapshot, ImportDirectives, ModuleId, SourceRevision};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -55,13 +55,6 @@ impl CanonicalMergedAst {
     }
     pub fn ast_views(&self) -> impl ExactSizeIterator<Item = ParsedAstView> + '_ {
         self.modules.iter().cloned().map(ParsedAstView::from_module)
-    }
-    pub fn item_views(&self) -> impl Iterator<Item = ParsedItemView> + '_ {
-        self.modules.iter().flat_map(|module| {
-            let module = module.clone();
-            (0..module.ast().items.len())
-                .map(move |index| ParsedItemView::from_module_index(module.clone(), index))
-        })
     }
     pub fn validate_view(&self, view: &ParsedAstView) -> Result<(), CompileError> {
         let index = self

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -406,6 +406,7 @@ pub struct CanonicalSemanticOutput {
     type_pool: FrozenTypeInternPool,
     strings: Vec<String>,
     warnings: Vec<CompileWarning>,
+    #[cfg_attr(not(test), allow(dead_code))]
     bound_definitions: Option<BoundDefinitionSet>,
     body_owner_issuer: BoundDefinitionSet,
     durable_ordinary_body_payloads: Arc<[crate::DurableOrdinaryBodyPayload]>,
@@ -438,7 +439,129 @@ pub struct CanonicalSemanticOutput {
 }
 
 impl CanonicalSemanticOutput {
-    pub fn into_parts(
+    pub(crate) fn unstable_parity_snapshot(&self) -> crate::unstable::SemanticParitySnapshot {
+        use std::fmt::Write as _;
+
+        let type_pool = self
+            .type_pool
+            .all_types()
+            .map(|ty| match ty.kind() {
+                rue_air::TypeKind::Struct(id) => {
+                    format!("struct:{:?}", self.type_pool.struct_def(id))
+                }
+                rue_air::TypeKind::Enum(id) => {
+                    format!("enum:{:?}", self.type_pool.enum_def(id))
+                }
+                rue_air::TypeKind::Array(id) => {
+                    let (element, len) = self.type_pool.array_def(id);
+                    format!("array:{element:?}:{len}")
+                }
+                rue_air::TypeKind::PtrConst(id) => {
+                    format!("ptr_const:{:?}", self.type_pool.ptr_const_def(id))
+                }
+                rue_air::TypeKind::PtrMut(id) => {
+                    format!("ptr_mut:{:?}", self.type_pool.ptr_mut_def(id))
+                }
+                _ => unreachable!("type pool stores only composite types"),
+            })
+            .collect::<Vec<_>>();
+        let mut details = String::new();
+        macro_rules! record {
+            ($name:literal, $value:expr) => {
+                writeln!(&mut details, concat!($name, "={:?}"), $value)
+                    .expect("write parity snapshot to String")
+            };
+        }
+        record!("input", &self.input);
+        record!("functions", &self.functions);
+        record!("type_pool", type_pool);
+        record!("bound_definitions", &self.bound_definitions);
+        record!("strings", &self.strings);
+        record!("warnings", &self.warnings);
+        record!("analyzed_body_owners", &self.analyzed_body_owners);
+        record!("body_named_dependencies", &self.body_named_dependencies);
+        record!(
+            "ordinary_free_function_dependencies",
+            &self.ordinary_free_function_dependencies
+        );
+        record!(
+            "specialized_free_function_origins",
+            &self.specialized_free_function_origins
+        );
+        record!(
+            "specialized_free_function_dependencies",
+            &self.specialized_free_function_dependencies
+        );
+        record!(
+            "ordinary_free_function_dependencies_complete",
+            self.ordinary_free_function_dependencies_complete
+        );
+        record!(
+            "specialized_free_function_dependencies_complete",
+            self.specialized_free_function_dependencies_complete
+        );
+        record!("named_method_dependencies", &self.named_method_dependencies);
+        record!(
+            "non_generic_named_method_dependencies_complete",
+            self.non_generic_named_method_dependencies_complete
+        );
+        record!(
+            "generic_named_method_dependencies_complete",
+            self.generic_named_method_dependencies_complete
+        );
+        record!(
+            "named_destructor_dependencies",
+            &self.named_destructor_dependencies
+        );
+        record!(
+            "named_destructor_dependencies_complete",
+            self.named_destructor_dependencies_complete
+        );
+        record!(
+            "declaration_type_dependencies",
+            &self.declaration_type_dependencies
+        );
+        record!(
+            "declaration_type_dependencies_complete",
+            self.declaration_type_dependencies_complete
+        );
+        record!(
+            "declaration_type_call_head_dependencies",
+            &self.declaration_type_call_head_dependencies
+        );
+        record!(
+            "declaration_type_call_head_dependencies_complete",
+            self.declaration_type_call_head_dependencies_complete
+        );
+        record!(
+            "declaration_builtin_type_call_head_dependencies",
+            &self.declaration_builtin_type_call_head_dependencies
+        );
+        record!(
+            "supported_type_call_heads_complete",
+            self.supported_type_call_heads_complete
+        );
+        record!("named_const_dependencies", &self.named_const_dependencies);
+        record!(
+            "named_value_const_dependencies_complete",
+            self.named_value_const_dependencies_complete
+        );
+        record!(
+            "implicit_named_destructor_dependencies",
+            &self.implicit_named_destructor_dependencies
+        );
+        record!(
+            "implicit_named_destructor_dependencies_complete",
+            self.implicit_named_destructor_dependencies_complete
+        );
+        record!(
+            "durable_artifact_status",
+            self.unstable_durable_artifact_status()
+        );
+        crate::unstable::SemanticParitySnapshot::new(details)
+    }
+
+    pub(crate) fn into_parts(
         self,
     ) -> (
         Vec<FunctionWithCfg>,
@@ -454,7 +577,7 @@ impl CanonicalSemanticOutput {
         &self.input
     }
     /// Debug-only identity projection for differential and benchmark tooling.
-    pub fn unstable_input_debug(&self) -> String {
+    pub(crate) fn unstable_input_debug(&self) -> String {
         format!("{:?}", self.input)
     }
     /// Analyzed functions paired with optimized CFGs in machine-symbol order.
@@ -551,7 +674,8 @@ impl CanonicalSemanticOutput {
         &self.durable_cfgs
     }
     /// Stable definition identities when requested for this run.
-    pub fn bound_definitions(&self) -> Option<&BoundDefinitionSet> {
+    #[cfg(test)]
+    pub(crate) fn bound_definitions(&self) -> Option<&BoundDefinitionSet> {
         self.bound_definitions.as_ref()
     }
     pub(crate) fn body_owner_issuer(&self) -> &BoundDefinitionSet {
@@ -567,7 +691,9 @@ impl CanonicalSemanticOutput {
         &self.durable_specialized_body_payloads
     }
     /// Explicitly unstable equality status for durable-cache instrumentation.
-    pub fn unstable_durable_artifact_status(&self) -> crate::unstable::DurableArtifactStatus {
+    pub(crate) fn unstable_durable_artifact_status(
+        &self,
+    ) -> crate::unstable::DurableArtifactStatus {
         crate::unstable::DurableArtifactStatus::from_debug(&self.durable_specialized_body_payloads)
     }
     /// Structural work performed by this request.

--- a/crates/rue-compiler/src/durable_compatibility_tests.rs
+++ b/crates/rue-compiler/src/durable_compatibility_tests.rs
@@ -779,16 +779,16 @@ fn relocation_file_ids_and_input_order_preserve_same_version_body_values() {
     let options = CompileOptions::default();
     let mut warm = CompilerSession::new();
     warm.update(&original).into_result().unwrap();
-    warm.semantic(&options).unwrap();
+    warm.canonical_semantic(&options).unwrap();
     warm.update(&relocated).into_result().unwrap();
-    let reused = warm.semantic(&options).unwrap();
+    let reused = warm.canonical_semantic(&options).unwrap();
     assert_eq!(reused.work().durable_bodies.reused_bodies, 3);
     assert_eq!(reused.work().durable_bodies.candidate_fallbacks, 0);
     assert_eq!(reused.work().body_analysis.bodies_attempted, 0);
 
     let mut cold = CompilerSession::new();
     cold.update(&relocated).into_result().unwrap();
-    let fresh = cold.semantic(&options).unwrap();
+    let fresh = cold.canonical_semantic(&options).unwrap();
     assert_eq!(
         format!("{:?}", reused.functions()),
         format!("{:?}", fresh.functions())
@@ -829,9 +829,9 @@ fn representative_body_families_project_and_import_through_production_reuse() {
         let relocated = snapshot(&[(3, "/new/main.rue", "main.rue", source)], 3);
         let mut warm = CompilerSession::new();
         warm.update(&original).into_result().unwrap();
-        warm.semantic(&options).unwrap();
+        warm.canonical_semantic(&options).unwrap();
         warm.update(&relocated).into_result().unwrap();
-        let reused = warm.semantic(&options).unwrap();
+        let reused = warm.canonical_semantic(&options).unwrap();
         assert!(
             reused.work().durable_bodies.projection_completions > 0,
             "{name} never traversed durable body projection"
@@ -845,7 +845,7 @@ fn representative_body_families_project_and_import_through_production_reuse() {
 
         let mut cold = CompilerSession::new();
         cold.update(&relocated).into_result().unwrap();
-        let fresh = cold.semantic(&options).unwrap();
+        let fresh = cold.canonical_semantic(&options).unwrap();
         assert_eq!(
             format!("{:?}", reused.functions()),
             format!("{:?}", fresh.functions()),
@@ -882,11 +882,11 @@ fn one_corrupt_body_falls_back_without_poisoning_other_semantic_or_cfg_reuse() {
     };
     let mut warm = CompilerSession::new();
     warm.update(&original).into_result().unwrap();
-    warm.semantic(&options).unwrap();
+    warm.canonical_semantic(&options).unwrap();
     warm.corrupt_durable_body_schema_for_test("first", u32::MAX);
     warm.corrupt_durable_cfg_schema_for_test("first", u32::MAX);
     warm.update(&edited).into_result().unwrap();
-    let reused = warm.semantic(&options).unwrap();
+    let reused = warm.canonical_semantic(&options).unwrap();
 
     assert_eq!(reused.work().durable_bodies.projection_failures, 1);
     assert_eq!(reused.work().durable_bodies.candidate_fallbacks, 1);
@@ -898,7 +898,7 @@ fn one_corrupt_body_falls_back_without_poisoning_other_semantic_or_cfg_reuse() {
 
     let mut cold = CompilerSession::new();
     cold.update(&edited).into_result().unwrap();
-    let fresh = cold.semantic(&options).unwrap();
+    let fresh = cold.canonical_semantic(&options).unwrap();
     assert_eq!(fresh.work().cfg.cfg_reuses, 0);
     assert_eq!(fresh.work().cfg.cfg_builds_attempted, 3);
     assert_eq!(
@@ -950,14 +950,14 @@ fn specialized_body_previous_current_and_future_schemas_isolate_one_candidate() 
     for version in versions {
         let mut warm = CompilerSession::new();
         warm.update(&original).into_result().unwrap();
-        let baseline = warm.semantic(&options).unwrap();
+        let baseline = warm.canonical_semantic(&options).unwrap();
         assert_eq!(
             baseline.work().body_analysis.specialized_bodies_attempted,
             2
         );
         warm.corrupt_durable_specialized_body_schema_for_test("choose", 0, version);
         warm.update(&relocated).into_result().unwrap();
-        let reused = warm.semantic(&options).unwrap();
+        let reused = warm.canonical_semantic(&options).unwrap();
         let compatible = version == DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION;
 
         assert_eq!(
@@ -987,7 +987,7 @@ fn specialized_body_previous_current_and_future_schemas_isolate_one_candidate() 
 
         let mut cold = CompilerSession::new();
         cold.update(&relocated).into_result().unwrap();
-        let fresh = cold.semantic(&options).unwrap();
+        let fresh = cold.canonical_semantic(&options).unwrap();
         assert_eq!(
             format!("{:?}", reused.functions()),
             format!("{:?}", fresh.functions())

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -1503,7 +1503,9 @@ mod tests {
             closed.graph().unwrap().graph().records()[0].resolution(),
             crate::CanonicalImportResolution::Resolved(module) if module.as_str() == "a.rue"
         ));
-        let semantic = session.semantic(&crate::CompileOptions::default()).unwrap();
+        let semantic = session
+            .canonical_semantic(&crate::CompileOptions::default())
+            .unwrap();
         assert_eq!(semantic.functions().len(), 2);
     }
 
@@ -1523,7 +1525,7 @@ mod tests {
         let snapshot =
             SourceSnapshot::single("/project/main.rue", "fn main() { @import(1); }").unwrap();
         let mut session = crate::CompilerSession::new();
-        let parsed = session.update(&snapshot).into_result().unwrap();
+        let parsed = session.update(&snapshot).into_owner_result().unwrap();
         assert_eq!(parsed.invalid_imports().len(), 1);
         assert!(matches!(
             parsed.invalid_imports()[0].shape(),
@@ -1829,7 +1831,7 @@ mod tests {
             .unwrap();
 
         assert!(Arc::ptr_eq(closed.program().unwrap(), &staged));
-        assert!(Arc::ptr_eq(session.published().unwrap(), &staged));
+        assert!(Arc::ptr_eq(session.published_owner().unwrap(), &staged));
         assert_eq!(closed.parse_work().syntax.lexer_invocations, 1);
         assert_eq!(closed.parse_work().syntax.parser_invocations, 1);
         assert_eq!(crate::parsed_modules::parse_operation_entries(), 0);
@@ -1842,7 +1844,7 @@ mod tests {
         assert_eq!(exact.work().syntax.lexer_invocations, 0);
         assert_eq!(exact.work().syntax.parser_invocations, 0);
         assert_eq!(crate::parsed_modules::parse_operation_entries(), 0);
-        assert!(Arc::ptr_eq(exact.result().unwrap(), &staged));
+        assert!(Arc::ptr_eq(exact.result_owner().unwrap(), &staged));
     }
 
     #[test]
@@ -1865,11 +1867,11 @@ mod tests {
                 ImportObservationLedger::default(),
             )
             .unwrap();
-        assert!(session.published().is_none());
+        assert!(session.published_owner().is_none());
         session
             .close_import_discovery(ImportObservationLedger::default())
             .unwrap_err();
-        assert!(session.published().is_none());
+        assert!(session.published_owner().is_none());
 
         let direct = session.update_for_presentation(&source);
         assert_eq!(direct.work(), crate::ParsedModulesWork::default());
@@ -1993,7 +1995,7 @@ mod tests {
         let work = closed.parse_work();
 
         assert!(Arc::ptr_eq(closed.program().unwrap(), &staged));
-        assert!(Arc::ptr_eq(session.published().unwrap(), &staged));
+        assert!(Arc::ptr_eq(session.published_owner().unwrap(), &staged));
         assert_eq!(work.syntax.lexer_invocations, 2);
         assert_eq!(work.syntax.parser_invocations, 2);
         assert_eq!(work.syntax.tokens, staged.token_count());
@@ -2003,7 +2005,7 @@ mod tests {
 
         let exact = session.update_for_presentation(&complete);
         assert_eq!(exact.work(), crate::ParsedModulesWork::default());
-        assert!(Arc::ptr_eq(exact.result().unwrap(), &staged));
+        assert!(Arc::ptr_eq(exact.result_owner().unwrap(), &staged));
 
         let broken_in_presentation_order = snapshot(
             &[
@@ -2577,7 +2579,7 @@ mod tests {
         }
         session.close_import_discovery(ledger).unwrap_err();
         let errors = session
-            .semantic(&crate::CompileOptions::default())
+            .canonical_semantic(&crate::CompileOptions::default())
             .unwrap_err();
         assert_eq!(errors.len(), 1);
         assert!(matches!(
@@ -2596,7 +2598,7 @@ mod tests {
         .unwrap();
         let mut session = crate::CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let errors = session.rir().unwrap_err();
+        let errors = session.canonical_rir().unwrap_err();
         assert_eq!(errors.len(), 1);
         assert!(matches!(
             errors.first().unwrap().kind,
@@ -2613,7 +2615,11 @@ mod tests {
         assert!(input.context().is_none());
         assert_eq!(session.work().rir.executions, 0);
         assert_eq!(session.work().last_rir, crate::CanonicalRirWork::default());
-        assert!(session.semantic(&crate::CompileOptions::default()).is_err());
+        assert!(
+            session
+                .canonical_semantic(&crate::CompileOptions::default())
+                .is_err()
+        );
         assert_eq!(session.work().semantic.executions, 0);
         let one_shot =
             crate::compile_snapshot(&source, &crate::CompileOptions::default()).unwrap_err();

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -23,13 +23,14 @@
 //! let mut session = CompilerSession::new();
 //! session.update(&snapshot).into_result()?;
 //! let semantic = session.semantic(&CompileOptions::default())?;
-//! assert_eq!(semantic.functions().len(), 1);
+//! assert_eq!(semantic.function_views().len(), 1);
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
 //! Callers that only need a final executable may use [`compile_snapshot`], the
 //! sole one-shot adapter. Filesystem discovery remains the caller's job.
 
+mod artifact_views;
 mod backend;
 mod bound_definitions;
 mod canonical_lower;
@@ -74,6 +75,11 @@ mod durable_compatibility_tests;
 mod integration_tests;
 
 // Supported source, identity, option, session, and diagnostic surface.
+pub use artifact_views::{
+    CfgBlockView, CfgInstructionView, CfgSuccessorView, CfgView, FunctionView, RirInstructionView,
+    RirOperandView, RirView, SemanticView, SourceIdentityView, SourceLocationView,
+    SyntaxModuleView, SyntaxNodeView, SyntaxView, TokenView, TypeView,
+};
 pub use dependency_envelope::{
     DependencyAcceptedRead, DependencyContext, DependencyEnvelope, DependencyEnvelopeStatus,
     DependencyObservation, DependencyObservationOutcome, DependencyRequest,
@@ -98,13 +104,9 @@ pub use import_graph::{
     ImportDirective, ImportDirectives,
 };
 pub(crate) use import_graph::{ResolvedCodegenRevision, ResolvedProgramRevision};
-pub use parsed_modules::{
-    InvalidImportShape, ParsedAstPresentation, ParsedInvalidImport, ParsedProgram,
-    parse_source_snapshot_for_ast_presentation,
-};
-pub use queries::{
-    CompileOptions, CompileOutput, FunctionWithCfg, LinkerMode, SourceView, compile_snapshot,
-};
+pub(crate) use parsed_modules::{InvalidImportShape, ParsedProgram};
+pub(crate) use queries::FunctionWithCfg;
+pub use queries::{CompileOptions, CompileOutput, LinkerMode, SourceView, compile_snapshot};
 pub use session::{CanonicalImportGraphOutput, CompilerSession, CompilerSessionUpdate};
 pub use source_identity::{ModuleId, ModuleRevision, SourceId, SourceIdVersion, SourceRevision};
 pub use source_metadata::SourceMetadata;
@@ -129,9 +131,7 @@ pub(crate) use definition_snapshot::DefinitionShardWork;
 #[allow(unused_imports)]
 pub(crate) use durable_body::DurableBodyWork;
 #[allow(unused_imports)]
-pub(crate) use parsed_modules::{
-    ParseInvalidationSummary, ParsedAstPresentationWork, ParsedModulesWork,
-};
+pub(crate) use parsed_modules::{ParseInvalidationSummary, ParsedModulesWork};
 pub(crate) use queries::{PipelineWork, SourceStats};
 #[allow(unused_imports)]
 pub(crate) use semantic_symbols::SemanticTranslationWork;
@@ -159,13 +159,15 @@ pub(crate) use source_identity::{
 };
 
 // Immutable query artifacts and stable identities returned by CompilerSession.
+#[cfg(test)]
+pub(crate) use backend::generate_mir;
 pub use bound_definitions::{
     BoundDefinitionId, BoundDefinitionRecord, BoundDefinitionSet, SnapshotBoundDefinitionId,
     StableDefinitionKey, StableDefinitionKind, StableDefinitionNamespace, StableNamedTypeKey,
 };
-pub use canonical_lower::CanonicalRirOutput;
-pub use canonical_merge::{CanonicalMergedAst, CanonicalMergedProgram};
-pub use canonical_semantic::CanonicalSemanticOutput;
+pub(crate) use canonical_lower::CanonicalRirOutput;
+pub(crate) use canonical_merge::CanonicalMergedProgram;
+pub(crate) use canonical_semantic::CanonicalSemanticOutput;
 pub use definition_snapshot::{
     DefinitionId, DefinitionKind, DefinitionNameKey, DefinitionNamespace, DefinitionOccurrenceId,
     DefinitionRecord, DefinitionShard, DefinitionSnapshot, ModuleDefinition,
@@ -188,25 +190,15 @@ pub(crate) use durable_semantics::{
     DurableSemanticProjectionWork, DurableType,
 };
 
-// Backend presentation queries used by the command-line emit modes.
-pub use backend::{
-    Mir, generate_emitted_asm, generate_liveness_info, generate_lowering_info, generate_mir,
-    generate_regalloc_info,
-};
-
 // Small foundational types callers need to configure or inspect the facade.
-pub use rue_air::{FrozenTypeInternPool, TypeInternPool};
+pub(crate) use rue_air::FrozenTypeInternPool;
 pub use rue_cfg::OptLevel;
-pub use rue_codegen::{
-    LoweringDebugInfo, RegAllocDebugInfo, StackFrameInfo, generate_stack_frame_info,
-};
 pub use rue_error::{
     Applicability, CompileError, CompileErrors, CompileResult, CompileWarning, Diagnostic,
     ErrorCode, ErrorKind, MultiErrorResult, PreviewFeature, PreviewFeatures, Suggestion, VERSION,
     WarningKind,
 };
-pub use rue_lexer::{Lexer, Token, TokenKind};
-pub use rue_parser::Ast;
+pub(crate) use rue_lexer::Lexer;
 pub use rue_span::{FileId, Span};
 pub use rue_target::{Arch, Target};
 
@@ -226,10 +218,10 @@ pub(crate) use parsed_modules::CanonicalParseUpdate;
 pub(crate) use queries::build_functions_and_cfgs;
 #[cfg(test)]
 pub(crate) use rue_parser::Item;
-pub use semantic_symbols::{SemanticSymbol, SemanticSymbolUniverse};
+pub(crate) use semantic_symbols::SemanticSymbolUniverse;
 pub(crate) use syntax::SyntaxWork;
 
-pub use lasso::ThreadedRodeo;
+pub(crate) use lasso::ThreadedRodeo;
 pub(crate) use rue_air::{AnalyzedFunction, SemaOutput, Type};
 pub(crate) use rue_cfg::{CfgBuilder, ValidatedCfg as Cfg};
 pub(crate) use rue_codegen::{RelocationKind, X86Mir, aarch64::Aarch64Mir};
@@ -237,7 +229,6 @@ pub(crate) use rue_linker::{
     Archive, CodeRelocation, Linker, ObjectBuilder, ObjectFile, RelocationType,
 };
 pub(crate) use rue_parser::Parser;
-pub use rue_rir::Rir;
 
 /// Configure Rayon's global worker pool once, before issuing compiler queries.
 pub fn configure_thread_pool(jobs: usize) {

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -18,12 +18,11 @@ use rue_parser::{
     AssignTarget, Ast, Expr, IntrinsicArg, Item, Pattern, Statement, TypeExpr, ast::Visibility,
 };
 use rue_span::{FileId, Span};
-use tracing::info_span;
 
 use crate::definition_snapshot::{definition_parts, validate_span};
 use crate::{
     DefinitionKind, DefinitionNamespace, ImportDirective, ImportDirectives, ModuleId,
-    ModuleRevision, MultiErrorResult, SourceId, SourceRevision, SourceSnapshot, SyntaxWork,
+    ModuleRevision, SourceId, SourceRevision, SourceSnapshot, SyntaxWork,
 };
 
 #[derive(Debug)]
@@ -200,6 +199,7 @@ struct ParsedSyntaxPayload {
     file_id: FileId,
     source_text: Arc<String>,
     token_count: usize,
+    tokens: Arc<[rue_lexer::Token]>,
     ast: ProvenancedAst,
     resolver: FrozenSymbolResolver,
     definitions: ParsedDefinitionIndex,
@@ -259,11 +259,6 @@ pub struct ParsedItemView {
 }
 
 impl ParsedItemView {
-    pub(crate) fn from_module_index(module: Arc<ParsedModule>, index: usize) -> Self {
-        debug_assert!(index < module.ast().items.len());
-        Self { module, index }
-    }
-
     pub fn module(&self) -> &Arc<ParsedModule> {
         &self.module
     }
@@ -313,6 +308,12 @@ impl ParsedModule {
     }
     pub(crate) fn token_count(&self) -> usize {
         self.payload.token_count
+    }
+    pub(crate) fn tokens(&self) -> &[rue_lexer::Token] {
+        &self.payload.tokens
+    }
+    pub(crate) fn resolve_raw_symbol(&self, symbol: Spur) -> &str {
+        self.payload.resolver.resolver.resolve(&symbol)
     }
     pub(crate) fn shared_source_text(&self) -> Arc<String> {
         self.payload.source_text.clone()
@@ -498,6 +499,7 @@ impl ParsedProgram {
             })
     }
 
+    #[cfg(test)]
     pub(crate) fn shared_symbol_strings(&self) -> Option<Vec<&str>> {
         let first = self.modules.first()?;
         if self.modules.iter().all(|module| {
@@ -736,64 +738,6 @@ pub(crate) fn parse_source_snapshot_modules_reusing(
     outcome.result.map(|program| (program, outcome.work))
 }
 
-/// Caller-ordered syntax presentation for AST output.
-#[derive(Debug)]
-pub struct ParsedAstPresentation {
-    files: Vec<(String, Arc<Ast>)>,
-    work: ParsedAstPresentationWork,
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct ParsedAstPresentationWork {
-    pub parsed: ParsedModulesWork,
-    pub merge_invocations: usize,
-    pub astgen_invocations: usize,
-    pub bind_invocations: usize,
-    pub manifest_invocations: usize,
-}
-
-impl ParsedAstPresentation {
-    pub fn files(&self) -> &[(String, Arc<Ast>)] {
-        &self.files
-    }
-
-    pub fn work(&self) -> ParsedAstPresentationWork {
-        self.work
-    }
-}
-
-/// Parse once for exact shared-Spur AST presentation without merge or lowering.
-pub fn parse_source_snapshot_for_ast_presentation(
-    snapshot: &SourceSnapshot,
-) -> MultiErrorResult<ParsedAstPresentation> {
-    let _span = info_span!(
-        "parse",
-        file_count = snapshot.len(),
-        purpose = "ast_presentation"
-    )
-    .entered();
-    let outcome = crate::syntax::parse_snapshot_for_presentation(snapshot);
-    let syntax = outcome.work;
-    let asts = outcome.result?;
-    let files = snapshot
-        .files()
-        .zip(asts)
-        .map(|(source, ast)| (source.path.to_string(), ast))
-        .collect();
-    Ok(ParsedAstPresentation {
-        files,
-        work: ParsedAstPresentationWork {
-            parsed: ParsedModulesWork {
-                syntax,
-                modules_considered: snapshot.len(),
-                modules_reparsed: snapshot.len(),
-                ..ParsedModulesWork::default()
-            },
-            ..ParsedAstPresentationWork::default()
-        },
-    })
-}
-
 /// Parse one stable module and return the exact syntax work performed.
 #[cfg(test)]
 pub(crate) fn parse_source_snapshot_module_with_stats(
@@ -820,9 +764,17 @@ fn parse_snapshot_file(
     let source = snapshot.source(file_id).expect("metadata membership");
     let outcome = crate::syntax::parse_file(source, ThreadedRodeo::new());
     let work = outcome.work;
+    let tokens = outcome.tokens;
     let result = outcome.result.and_then(|ast| {
-        build_module(snapshot, file_id, ast, outcome.interner, work.tokens)
-            .map_err(CompileErrors::from)
+        build_module(
+            snapshot,
+            file_id,
+            ast,
+            outcome.interner,
+            work.tokens,
+            tokens,
+        )
+        .map_err(CompileErrors::from)
     });
     (result, work)
 }
@@ -920,6 +872,7 @@ fn build_module(
     ast: Arc<Ast>,
     interner: ThreadedRodeo,
     token_count: usize,
+    tokens: Arc<[rue_lexer::Token]>,
 ) -> CompileResult<Arc<ParsedModule>> {
     let token = Arc::new(SymbolProvenance);
     let module = snapshot.module_id(file_id).expect("snapshot membership");
@@ -933,6 +886,7 @@ fn build_module(
         token,
         import_sites,
         token_count,
+        tokens,
     )
 }
 
@@ -944,6 +898,7 @@ fn build_module_with_resolver(
     token: Arc<SymbolProvenance>,
     import_sites: ImportSiteCollector,
     token_count: usize,
+    tokens: Arc<[rue_lexer::Token]>,
 ) -> CompileResult<Arc<ParsedModule>> {
     let module = snapshot
         .module_id(file_id)
@@ -977,6 +932,7 @@ fn build_module_with_resolver(
         file_id,
         source_text,
         token_count,
+        tokens,
         ast: provenanced_ast,
         resolver,
         definitions,

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -77,7 +77,7 @@ mod tests {
             .update_for_presentation(&snapshot)
             .into_result()
             .unwrap();
-        let cold = warm_session.semantic(&cold_options).unwrap();
+        let cold = warm_session.canonical_semantic(&cold_options).unwrap();
         assert_eq!(cold.work().body_analysis.specialized_bodies_attempted, 1);
         assert_eq!(
             cold.work().body_analysis.specialized_body_exports_succeeded,
@@ -94,7 +94,7 @@ mod tests {
             1
         );
         assert!(cold.durable_specialized_body_payloads()[0].dependency_boundary_complete);
-        let warm = warm_session.semantic(&optimized).unwrap();
+        let warm = warm_session.canonical_semantic(&optimized).unwrap();
         assert_eq!(warm.work().body_analysis.specialized_bodies_reused, 1);
         assert_eq!(warm.work().body_analysis.specialized_bodies_attempted, 0);
         assert_eq!(
@@ -110,7 +110,7 @@ mod tests {
             .update_for_presentation(&snapshot)
             .into_result()
             .unwrap();
-        let fresh = fresh_session.semantic(&optimized).unwrap();
+        let fresh = fresh_session.canonical_semantic(&optimized).unwrap();
         assert_eq!(
             format!("{:?}", warm.functions()),
             format!("{:?}", fresh.functions())
@@ -637,7 +637,7 @@ mod tests {
 
         let mut session = CompilerSession::new();
         session.update(&snapshot).into_result().unwrap();
-        let semantic = session.semantic(&options).unwrap();
+        let semantic = session.canonical_semantic(&options).unwrap();
 
         assert_eq!(semantic.functions().len(), 1);
         assert_eq!(semantic.input(), &expected_link.codegen);
@@ -669,7 +669,11 @@ mod tests {
             SourceMetadata::from_sources(&sources, root, std::collections::HashMap::new()).unwrap();
         let snapshot = SourceSnapshot::from_sources(&sources, metadata.clone()).unwrap();
 
-        let errors = parse_source_snapshot_for_ast_presentation(&snapshot).unwrap_err();
+        let mut session = CompilerSession::new();
+        let errors = session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap_err();
         assert_eq!(
             errors
                 .iter()

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -610,7 +610,7 @@ pub(crate) fn compile_with_session(
     options: &CompileOptions,
 ) -> MultiErrorResult<CompileOutput> {
     let source_tokens = session
-        .published()
+        .published_owner()
         .filter(|program| program.belongs_to_exact_snapshot(snapshot))
         .map(|program| program.token_count())
         .ok_or_else(|| {
@@ -623,9 +623,9 @@ pub(crate) fn compile_with_session(
 
     let rir = {
         let _span = info_span!("semantic_astgen").entered();
-        session.rir()?
+        session.canonical_rir()?
     };
-    let semantic = session.semantic(options)?;
+    let semantic = session.canonical_semantic(options)?;
     let session_work = session.work();
     let mut output = crate::backend::compile_backend(
         semantic.functions(),

--- a/crates/rue-compiler/src/semantic_symbols.rs
+++ b/crates/rue-compiler/src/semantic_symbols.rs
@@ -6,7 +6,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use lasso::{Spur, ThreadedRodeo};
 use rue_error::{CompileError, CompileResult, ErrorKind};
 
-use crate::parsed_modules::{ParsedAstView, ParsedProgram, ParsedSymbol};
+#[cfg(test)]
+use crate::parsed_modules::ParsedProgram;
+use crate::parsed_modules::{ParsedAstView, ParsedSymbol};
 
 #[derive(Debug)]
 struct SemanticSymbolProvenance;
@@ -15,6 +17,7 @@ struct SemanticSymbolProvenance;
 #[derive(Debug, Clone)]
 pub struct SemanticSymbol {
     spur: Spur,
+    #[cfg_attr(not(test), allow(dead_code))]
     provenance: Arc<SemanticSymbolProvenance>,
 }
 
@@ -46,12 +49,13 @@ pub struct SemanticSymbolUniverse {
 }
 
 impl SemanticSymbolUniverse {
-    pub fn into_interner(self) -> ThreadedRodeo {
+    pub(crate) fn into_interner(self) -> ThreadedRodeo {
         self.interner
     }
 
     /// Start a destination universe for one canonical program traversal.
-    pub fn new(program: &ParsedProgram) -> Self {
+    #[cfg(test)]
+    pub(crate) fn new(program: &ParsedProgram) -> Self {
         let universe = Self::from_modules(program.modules());
         if let Some(symbols) = program.shared_symbol_strings() {
             for symbol in symbols {
@@ -85,7 +89,8 @@ impl SemanticSymbolUniverse {
     /// Translate a provenanced local symbol through its owning module view.
     ///
     /// This API deliberately accepts no naked local `Spur`.
-    pub fn translate(
+    #[cfg(test)]
+    pub(crate) fn translate(
         &mut self,
         owner: &ParsedAstView,
         symbol: &ParsedSymbol,
@@ -124,7 +129,8 @@ impl SemanticSymbolUniverse {
     }
 
     /// Resolve only symbols issued by this exact semantic universe.
-    pub fn resolve<'a>(&'a self, symbol: &SemanticSymbol) -> CompileResult<&'a str> {
+    #[cfg(test)]
+    pub(crate) fn resolve<'a>(&'a self, symbol: &SemanticSymbol) -> CompileResult<&'a str> {
         if !Arc::ptr_eq(&self.provenance, &symbol.provenance) {
             return Err(invalid_input(
                 "semantic symbol belongs to a foreign semantic universe",

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -658,12 +658,14 @@ mod durable_body_integration_tests {
 
     fn durable_candidates(source: &SourceSnapshot) -> Arc<[crate::DurableOrdinaryBody]> {
         let mut session = CompilerSession::new();
-        let program = session.update(source).into_result().unwrap();
+        let program = session.update(source).into_owner_result().unwrap();
         if !program.import_directives().is_empty() {
             let graph = crate::test_support::test_fixture_import_graph(&program).unwrap();
             session.adopt_test_import_graph(graph);
         }
-        let semantic = session.semantic(&CompileOptions::default()).unwrap();
+        let semantic = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert!(
             semantic.work().durable_bodies.conversion_completions > 0,
             "semantic work={:#?}",
@@ -807,7 +809,9 @@ mod durable_body_integration_tests {
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let semantic = session.semantic(&CompileOptions::default()).unwrap();
+        let semantic = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert!(
             semantic.work().durable_bodies.conversion_completions > 0,
             "semantic work={:#?}",
@@ -1006,7 +1010,9 @@ mod durable_body_integration_tests {
                 .unwrap();
             assert!(manifest.durable_ordinary_bodies().is_empty());
             assert!(!manifest.body_dependencies().is_empty());
-            let semantic = session.semantic(&CompileOptions::default()).unwrap();
+            let semantic = session
+                .canonical_semantic(&CompileOptions::default())
+                .unwrap();
             assert!(!semantic.functions().is_empty());
             assert_eq!(
                 semantic.work().durable_bodies.last_export_failure,
@@ -1551,7 +1557,6 @@ pub struct DefinitionQueryRecord {
     pub failed: bool,
 }
 
-#[derive(Debug)]
 pub struct CompilerSessionUpdate {
     result: Result<Arc<ParsedProgram>, CompileErrors>,
     work: ParsedModulesWork,
@@ -1559,6 +1564,17 @@ pub struct CompilerSessionUpdate {
     invalidation: ParseInvalidationSummary,
     downstream_invalidated: bool,
     diagnostics: Arc<FrontendDiagnosticSnapshot>,
+}
+
+impl std::fmt::Debug for CompilerSessionUpdate {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("CompilerSessionUpdate")
+            .field("successful", &self.result.is_ok())
+            .field("downstream_invalidated", &self.downstream_invalidated)
+            .field("diagnostics", &self.diagnostics)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1630,10 +1646,20 @@ impl ImportDiscoveryRevisionArtifact {
 }
 
 impl CompilerSessionUpdate {
-    pub fn result(&self) -> Result<&Arc<ParsedProgram>, &CompileErrors> {
+    pub fn result(&self) -> Result<crate::SyntaxView, &CompileErrors> {
+        self.result
+            .as_ref()
+            .map(|owner| crate::SyntaxView::new(owner.clone()))
+    }
+    pub fn into_result(self) -> Result<crate::SyntaxView, CompileErrors> {
+        self.result.map(crate::SyntaxView::new)
+    }
+    #[cfg(test)]
+    pub(crate) fn result_owner(&self) -> Result<&Arc<ParsedProgram>, &CompileErrors> {
         self.result.as_ref()
     }
-    pub fn into_result(self) -> Result<Arc<ParsedProgram>, CompileErrors> {
+    #[cfg(test)]
+    pub(crate) fn into_owner_result(self) -> Result<Arc<ParsedProgram>, CompileErrors> {
         self.result
     }
     #[cfg(test)]
@@ -2247,6 +2273,7 @@ struct SemanticBindingLookupKey {
 struct SemanticCacheEntry {
     key: SemanticQueryKey,
     result: Result<Arc<CanonicalSemanticOutput>, CompileErrors>,
+    rir: Option<Arc<CanonicalRirOutput>>,
     diagnostics: Arc<FrontendDiagnosticSnapshot>,
     successful_body_cache: Option<DurableOrdinaryBodyCache>,
     durable_declaration_cache: Option<DurableDeclarationCache>,
@@ -2565,7 +2592,7 @@ impl CompilerSession {
     /// oracle. This is deliberately typed and narrow; production callers have
     /// no reason to use it.
     #[doc(hidden)]
-    pub fn inject_stale_query_for_oracle(
+    pub(crate) fn inject_stale_query_for_oracle(
         &mut self,
         fault: crate::unstable::DifferentialOracleFault,
     ) -> bool {
@@ -2585,6 +2612,7 @@ impl CompilerSession {
                 };
                 let mut injected = current;
                 injected.result = stale.result.clone();
+                injected.rir = stale.rir.clone();
                 injected.successful_body_cache = stale.successful_body_cache.clone();
                 injected.durable_declaration_cache = stale.durable_declaration_cache.clone();
                 injected.successful_cfg_cache = stale.successful_cfg_cache.clone();
@@ -2817,7 +2845,11 @@ impl CompilerSession {
         };
         Ok(graph)
     }
-    pub fn published(&self) -> Option<&Arc<ParsedProgram>> {
+    pub fn published(&self) -> Option<crate::SyntaxView> {
+        self.published.as_ref().cloned().map(crate::SyntaxView::new)
+    }
+
+    pub(crate) fn published_owner(&self) -> Option<&Arc<ParsedProgram>> {
         self.published.as_ref()
     }
 
@@ -3738,7 +3770,10 @@ impl CompilerSession {
     /// Query artifacts still use stable module identity. Only syntax and merge
     /// diagnostic ordering follows [`SourceSnapshot::files`], which is useful
     /// for command-line and other presentation-oriented consumers.
-    pub fn update_for_presentation(&mut self, snapshot: &SourceSnapshot) -> CompilerSessionUpdate {
+    pub(crate) fn update_for_presentation(
+        &mut self,
+        snapshot: &SourceSnapshot,
+    ) -> CompilerSessionUpdate {
         #[cfg(test)]
         {
             self.supplied_test_import_graph = None;
@@ -4273,7 +4308,7 @@ impl CompilerSession {
         }))
     }
 
-    pub fn merge(&mut self) -> Result<Arc<CanonicalMergedProgram>, CompileErrors> {
+    pub(crate) fn merge(&mut self) -> Result<Arc<CanonicalMergedProgram>, CompileErrors> {
         let mut guard = self.metrics.begin::<MergeQuery>();
         let attempt_id = guard.id;
         let mut execution = QueryAttemptExecution::Rejected;
@@ -4479,7 +4514,12 @@ impl CompilerSession {
         merged
     }
 
-    pub fn rir(&mut self) -> Result<Arc<CanonicalRirOutput>, CompileErrors> {
+    /// Query the canonical RIR through an immutable, owner-retaining view.
+    pub fn rir(&mut self) -> Result<Arc<crate::RirView>, CompileErrors> {
+        self.canonical_rir().map(crate::RirView::new).map(Arc::new)
+    }
+
+    pub(crate) fn canonical_rir(&mut self) -> Result<Arc<CanonicalRirOutput>, CompileErrors> {
         let mut guard = self.metrics.begin::<RirQuery>();
         let attempt_id = guard.id;
         let mut execution = QueryAttemptExecution::Rejected;
@@ -4504,6 +4544,13 @@ impl CompilerSession {
         guard.finish(execution, origin, &result, structural);
         self.metrics.synchronize();
         result
+    }
+
+    pub(crate) fn selected_semantic_rir_owner(&self) -> Option<Arc<CanonicalRirOutput>> {
+        self.queries
+            .semantic
+            .selected_record(&self.queries.graph)
+            .and_then(|record| record.rir.clone())
     }
 
     fn rir_attempt(
@@ -4612,7 +4659,19 @@ impl CompilerSession {
     }
 
     /// Analyze the current published revision without issuing stable definition IDs.
+    /// Query semantic analysis and optimized CFGs through immutable views.
     pub fn semantic(
+        &mut self,
+        options: &CompileOptions,
+    ) -> Result<Arc<crate::SemanticView>, CompileErrors> {
+        let owner = self.canonical_semantic(options)?;
+        let rir = self
+            .selected_semantic_rir_owner()
+            .expect("successful semantic query retains its exact RIR terminal");
+        Ok(Arc::new(crate::SemanticView::new(owner, rir)))
+    }
+
+    pub(crate) fn canonical_semantic(
         &mut self,
         options: &CompileOptions,
     ) -> Result<Arc<CanonicalSemanticOutput>, CompileErrors> {
@@ -4745,7 +4804,7 @@ impl CompilerSession {
             .clone()
             .unwrap_or(previous_cfg_cache);
 
-        let rir = match self.rir() {
+        let rir = match self.canonical_rir() {
             Ok(rir) => rir,
             Err(errors) => {
                 let record = SemanticQueryRecord {
@@ -4781,6 +4840,7 @@ impl CompilerSession {
                         SemanticCacheEntry {
                             key,
                             result: Err(errors.clone()),
+                            rir: None,
                             diagnostics,
                             successful_body_cache: None,
                             durable_declaration_cache: None,
@@ -5144,6 +5204,7 @@ impl CompilerSession {
                 SemanticCacheEntry {
                     key,
                     result: result.clone(),
+                    rir: result.is_ok().then(|| rir.clone()),
                     diagnostics,
                     successful_body_cache: result.is_ok().then_some(published_body_cache).flatten(),
                     durable_declaration_cache: result
@@ -5239,7 +5300,7 @@ impl CompilerSession {
             guard.bind(handle.as_view());
             return entry.output.result;
         }
-        let rir = match self.rir() {
+        let rir = match self.canonical_rir() {
             Ok(rir) => rir,
             Err(errors) => {
                 let record = DefinitionQueryRecord {
@@ -5331,7 +5392,7 @@ impl CompilerSession {
                 self.refresh_retention_metrics();
                 return Err(errors);
             }
-        } else if let Err(errors) = self.semantic(options) {
+        } else if let Err(errors) = self.canonical_semantic(options) {
             let dependency = self
                 .queries
                 .semantic
@@ -5550,7 +5611,7 @@ impl CompilerSession {
         }
         *execution = QueryAttemptExecution::Computed;
         guard.started();
-        let semantic = self.semantic(options);
+        let semantic = self.canonical_semantic(options);
         let definitions = self.stable_definitions(options);
         let definition_universe_state = match &definitions {
             Ok(_) => SemanticDefinitionUniverseState::Complete,
@@ -8401,7 +8462,7 @@ mod tests {
         let mut session = CompilerSession::new();
         session.update(&base()).into_result().unwrap();
         let default = CompileOptions::default();
-        session.semantic(&default).unwrap();
+        session.canonical_semantic(&default).unwrap();
         let diagnostics = session.latest_diagnostics().unwrap().clone();
         let last_good = session.last_good_semantic_diagnostics().unwrap().clone();
         let body_manifest = session
@@ -8430,7 +8491,7 @@ mod tests {
         let mut variant = default.clone();
         variant.opt_level = OptLevel::O1;
         session.cancel_semantic_after_first_mutation = true;
-        assert!(session.semantic(&variant).is_err());
+        assert!(session.canonical_semantic(&variant).is_err());
         assert_eq!(session.queries.semantic.len(), 1);
         assert!(!Arc::ptr_eq(
             session.latest_diagnostics().unwrap(),
@@ -8488,10 +8549,10 @@ mod tests {
             QueryStructuralWork::Semantic(_)
         ));
 
-        let recomputed = session.semantic(&variant).unwrap();
+        let recomputed = session.canonical_semantic(&variant).unwrap();
         assert_eq!(session.queries.semantic.len(), 2);
         assert!(Arc::ptr_eq(
-            &session.semantic(&variant).unwrap(),
+            &session.canonical_semantic(&variant).unwrap(),
             &recomputed
         ));
         assert_eq!(session.work().semantic.executions, 3);
@@ -8526,7 +8587,7 @@ mod tests {
     ) -> ParsedModulesWork {
         let update = session.update(source);
         let work = update.work();
-        let program = update.into_result().unwrap();
+        let program = update.into_owner_result().unwrap();
         if !program.import_directives().is_empty() {
             let graph = crate::test_support::test_fixture_import_graph(&program).unwrap();
             session.adopt_test_import_graph(graph);
@@ -8580,7 +8641,7 @@ mod tests {
         let second = function_modules(128, Some(0));
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        let cold = session.semantic(&options).unwrap();
+        let cold = session.canonical_semantic(&options).unwrap();
         assert_eq!(cold.work().binding.bind_invocations, 1);
         assert_eq!(cold.work().binding.declaration_resolution_invocations, 1);
         assert_eq!(
@@ -8591,7 +8652,7 @@ mod tests {
         );
         assert_eq!(cold.work().manifest.rir_instructions_visited, 256);
         session.update(&second).into_result().unwrap();
-        let reused = session.semantic(&options).unwrap();
+        let reused = session.canonical_semantic(&options).unwrap();
 
         assert_eq!(reused.work().binding.declaration_resolution_invocations, 0);
         assert_eq!(reused.work().binding.bind_invocations, 1);
@@ -8613,7 +8674,7 @@ mod tests {
         );
         let mut fresh = CompilerSession::new();
         fresh.update(&second).into_result().unwrap();
-        let ordinary = fresh.semantic(&options).unwrap();
+        let ordinary = fresh.canonical_semantic(&options).unwrap();
         assert_eq!(
             ordinary.work().binding.declaration_resolution_invocations,
             1
@@ -8664,7 +8725,7 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         publish_with_test_imports(&mut session, &original);
-        let cold = session.semantic(&options).unwrap();
+        let cold = session.canonical_semantic(&options).unwrap();
         assert_eq!(cold.work().binding.declaration_resolution_invocations, 1);
         assert_eq!(
             cold.work()
@@ -8687,7 +8748,7 @@ mod tests {
         ));
 
         publish_with_test_imports(&mut session, &relocated_edit);
-        let reused = session.semantic(&options).unwrap();
+        let reused = session.canonical_semantic(&options).unwrap();
         assert_eq!(reused.work().binding.declaration_resolution_invocations, 0);
         assert_eq!(reused.work().binding.durable_payloads_installed, 3);
         assert_eq!(reused.work().declaration_reuse.durable_records_reused, 3);
@@ -8702,7 +8763,7 @@ mod tests {
 
         let mut fresh = CompilerSession::new();
         publish_with_test_imports(&mut fresh, &relocated_edit);
-        let ordinary = fresh.semantic(&options).unwrap();
+        let ordinary = fresh.canonical_semantic(&options).unwrap();
         assert_semantic_artifact_parity(&session, &reused, &ordinary);
         assert_diagnostic_parity(&session, &fresh);
     }
@@ -8730,7 +8791,7 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         publish_with_test_imports(&mut session, &first);
-        session.semantic(&options).unwrap();
+        session.canonical_semantic(&options).unwrap();
         let cache = session.durable_declaration_cache.as_mut().unwrap();
         let mut records = cache.semantics.to_vec();
         let module = records
@@ -8743,7 +8804,7 @@ mod tests {
         cache.semantics = records.into();
 
         publish_with_test_imports(&mut session, &edited);
-        let fallback = session.semantic(&options).unwrap();
+        let fallback = session.canonical_semantic(&options).unwrap();
         assert_eq!(
             fallback.work().binding.declaration_resolution_invocations,
             1
@@ -8755,7 +8816,7 @@ mod tests {
 
         let mut fresh = CompilerSession::new();
         publish_with_test_imports(&mut fresh, &edited);
-        let ordinary = fresh.semantic(&options).unwrap();
+        let ordinary = fresh.canonical_semantic(&options).unwrap();
         assert_semantic_artifact_parity(&session, &fallback, &ordinary);
         assert_diagnostic_parity(&session, &fresh);
     }
@@ -8786,11 +8847,11 @@ mod tests {
         };
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        let cold = session.semantic(&options).unwrap();
+        let cold = session.canonical_semantic(&options).unwrap();
         assert_eq!(cold.work().cfg.cfg_builds_attempted, 3);
         assert_eq!(cold.work().cfg.optimization_attempts, 3);
         session.update(&second).into_result().unwrap();
-        let warm = session.semantic(&options).unwrap();
+        let warm = session.canonical_semantic(&options).unwrap();
         assert_eq!(warm.work().cfg.cfg_reuses, 2);
         assert_eq!(warm.work().cfg.cfg_import_successes, 2);
         assert_eq!(warm.work().cfg.cfg_builds_attempted, 1);
@@ -8799,7 +8860,7 @@ mod tests {
 
         let mut fresh = CompilerSession::new();
         fresh.update(&second).into_result().unwrap();
-        let fresh = fresh.semantic(&options).unwrap();
+        let fresh = fresh.canonical_semantic(&options).unwrap();
         assert_eq!(
             format!("{:?}", warm.functions()),
             format!("{:?}", fresh.functions())
@@ -8845,7 +8906,7 @@ mod tests {
         };
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.semantic(&options).unwrap();
+        session.canonical_semantic(&options).unwrap();
         let cache = Arc::make_mut(session.last_successful_cfg_cache.as_mut().unwrap());
         let specialization = cache
             .iter_mut()
@@ -8853,7 +8914,7 @@ mod tests {
             .unwrap();
         specialization.semantic_schema_version.implementation_epoch += 1;
         session.update(&second).into_result().unwrap();
-        let warm = session.semantic(&options).unwrap();
+        let warm = session.canonical_semantic(&options).unwrap();
         assert_eq!(warm.work().cfg.cfg_import_failures, 2);
         assert_eq!(warm.work().cfg.cfg_schema_version_rejections, 1);
         assert_eq!(warm.work().cfg.cfg_fallbacks, 2);
@@ -8862,7 +8923,7 @@ mod tests {
         assert_eq!(warm.work().cfg.optimization_attempts, 3);
         assert_eq!(warm.work().cfg.optimized_level_attempts, 0);
         session.update(&third).into_result().unwrap();
-        let repaired = session.semantic(&options).unwrap();
+        let repaired = session.canonical_semantic(&options).unwrap();
         assert_eq!(repaired.work().cfg.cfg_reuses, 1);
         assert_eq!(repaired.work().cfg.cfg_builds_attempted, 2);
     }
@@ -8905,19 +8966,19 @@ mod tests {
         };
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.semantic(&first_options).unwrap();
-        let cross_target = session.semantic(&other_options).unwrap();
+        session.canonical_semantic(&first_options).unwrap();
+        let cross_target = session.canonical_semantic(&other_options).unwrap();
         assert_eq!(cross_target.work().cfg.cfg_reuses, 0);
         assert_eq!(cross_target.work().cfg.cfg_builds_attempted, 3);
         assert!(cross_target.work().cfg.cfg_import_failures >= 2);
         session.update(&renamed).into_result().unwrap();
-        let changed = session.semantic(&other_options).unwrap();
+        let changed = session.canonical_semantic(&other_options).unwrap();
         assert_eq!(changed.work().cfg.cfg_reuses, 1);
         assert_eq!(changed.work().cfg.cfg_builds_attempted, 2);
         assert_eq!(changed.work().cfg.cfg_import_failures, 1);
         let mut fresh = CompilerSession::new();
         fresh.update(&renamed).into_result().unwrap();
-        let fresh = fresh.semantic(&other_options).unwrap();
+        let fresh = fresh.canonical_semantic(&other_options).unwrap();
         assert_eq!(
             format!("{:?}", changed.functions()),
             format!("{:?}", fresh.functions())
@@ -8950,14 +9011,14 @@ mod tests {
         };
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.semantic(&options).unwrap();
+        session.canonical_semantic(&options).unwrap();
         session.update(&second).into_result().unwrap();
-        let warm = session.semantic(&options).unwrap();
+        let warm = session.canonical_semantic(&options).unwrap();
         assert_eq!(warm.work().cfg.cfg_reuses, 1);
         assert!(warm.work().cfg.cfg_import_failures >= 1);
         let mut fresh = CompilerSession::new();
         fresh.update(&second).into_result().unwrap();
-        let fresh = fresh.semantic(&options).unwrap();
+        let fresh = fresh.canonical_semantic(&options).unwrap();
         assert_eq!(
             format!("{:?}", warm.functions()),
             format!("{:?}", fresh.functions())
@@ -8990,14 +9051,14 @@ mod tests {
         };
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.semantic(&options).unwrap();
+        session.canonical_semantic(&options).unwrap();
         session.update(&second).into_result().unwrap();
-        let warm = session.semantic(&options).unwrap();
+        let warm = session.canonical_semantic(&options).unwrap();
         assert_eq!(warm.work().cfg.cfg_reuses, 1);
         assert!(warm.work().cfg.cfg_import_failures >= 1);
         let mut fresh = CompilerSession::new();
         fresh.update(&second).into_result().unwrap();
-        let fresh = fresh.semantic(&options).unwrap();
+        let fresh = fresh.canonical_semantic(&options).unwrap();
         assert_eq!(
             format!("{:?}", warm.functions()),
             format!("{:?}", fresh.functions())
@@ -9018,7 +9079,7 @@ mod tests {
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
         let output = session
-            .semantic(&CompileOptions {
+            .canonical_semantic(&CompileOptions {
                 opt_level: OptLevel::O0,
                 ..CompileOptions::default()
             })
@@ -9054,13 +9115,13 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        let first_output = session.semantic(&options).unwrap();
+        let first_output = session.canonical_semantic(&options).unwrap();
         let first_issuer = first_output.analyzed_body_owners()[0]
             .token()
             .unwrap()
             .issuer();
         session.update(&second).into_result().unwrap();
-        let output = session.semantic(&options).unwrap();
+        let output = session.canonical_semantic(&options).unwrap();
         let second_issuer = output.analyzed_body_owners()[0].token().unwrap().issuer();
         assert_ne!(first_issuer, second_issuer);
         assert_eq!(output.work().binding.declaration_resolution_invocations, 1);
@@ -9153,10 +9214,10 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.semantic(&options).unwrap();
+        session.canonical_semantic(&options).unwrap();
 
         session.update(&edited).into_result().unwrap();
-        let reused = session.semantic(&options).unwrap();
+        let reused = session.canonical_semantic(&options).unwrap();
         assert_eq!(reused.work().binding.declaration_resolution_invocations, 0);
         assert_eq!(reused.work().binding.durable_payloads_installed, 2);
         assert_eq!(reused.work().declaration_reuse.durable_records_reused, 2);
@@ -9164,7 +9225,7 @@ mod tests {
 
         let mut fresh = CompilerSession::new();
         fresh.update(&edited).into_result().unwrap();
-        let ordinary = fresh.semantic(&options).unwrap();
+        let ordinary = fresh.canonical_semantic(&options).unwrap();
         assert_semantic_artifact_parity(&session, &reused, &ordinary);
         assert_diagnostic_parity(&session, &fresh);
     }
@@ -9189,10 +9250,10 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.semantic(&options).unwrap();
+        session.canonical_semantic(&options).unwrap();
 
         session.update(&relocated_edit).into_result().unwrap();
-        let reused = session.semantic(&options).unwrap();
+        let reused = session.canonical_semantic(&options).unwrap();
         assert_eq!(reused.work().binding.declaration_resolution_invocations, 0);
         assert_eq!(reused.work().binding.durable_payloads_installed, 2);
         assert_eq!(reused.work().declaration_reuse.durable_records_reused, 2);
@@ -9200,7 +9261,7 @@ mod tests {
 
         let mut fresh = CompilerSession::new();
         fresh.update(&relocated_edit).into_result().unwrap();
-        let ordinary = fresh.semantic(&options).unwrap();
+        let ordinary = fresh.canonical_semantic(&options).unwrap();
         assert_semantic_artifact_parity(&session, &reused, &ordinary);
         assert_diagnostic_parity(&session, &fresh);
     }
@@ -9225,7 +9286,7 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.semantic(&options).unwrap();
+        session.canonical_semantic(&options).unwrap();
 
         let cache = session.durable_declaration_cache.as_mut().unwrap();
         let mut declarations = cache.semantics.to_vec();
@@ -9249,7 +9310,7 @@ mod tests {
         cache.semantics = declarations.into();
 
         session.update(&edited).into_result().unwrap();
-        let fallback = session.semantic(&options).unwrap();
+        let fallback = session.canonical_semantic(&options).unwrap();
         assert_eq!(
             fallback.work().binding.declaration_resolution_invocations,
             1
@@ -9266,7 +9327,7 @@ mod tests {
 
         let mut fresh = CompilerSession::new();
         fresh.update(&edited).into_result().unwrap();
-        let ordinary = fresh.semantic(&options).unwrap();
+        let ordinary = fresh.canonical_semantic(&options).unwrap();
         assert_semantic_artifact_parity(&session, &fallback, &ordinary);
         assert_eq!(fallback.type_pool().stats(), ordinary.type_pool().stats());
         assert_diagnostic_parity(&session, &fresh);
@@ -9290,13 +9351,13 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.semantic(&options).unwrap();
+        session.canonical_semantic(&options).unwrap();
 
         let cache = session.durable_declaration_cache.as_mut().unwrap();
         cache.schema_version.implementation_epoch += 1;
 
         session.update(&edited).into_result().unwrap();
-        let fallback = session.semantic(&options).unwrap();
+        let fallback = session.canonical_semantic(&options).unwrap();
         assert_eq!(
             fallback.work().declaration_reuse.schema_version_rejections,
             1
@@ -9313,7 +9374,7 @@ mod tests {
 
         let mut fresh = CompilerSession::new();
         fresh.update(&edited).into_result().unwrap();
-        let ordinary = fresh.semantic(&options).unwrap();
+        let ordinary = fresh.canonical_semantic(&options).unwrap();
         assert_semantic_artifact_parity(&session, &fallback, &ordinary);
         assert_diagnostic_parity(&session, &fresh);
     }
@@ -9332,12 +9393,12 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        let cold = session.semantic(&options).unwrap();
+        let cold = session.canonical_semantic(&options).unwrap();
         assert_eq!(cold.work().binding.declaration_resolution_invocations, 1);
         assert_eq!(cold.work().binding.durable_install_invocations, 0);
 
         session.update(&edited).into_result().unwrap();
-        let ordinary = session.semantic(&options).unwrap();
+        let ordinary = session.canonical_semantic(&options).unwrap();
         assert_eq!(
             ordinary.work().binding.declaration_resolution_invocations,
             0
@@ -9348,17 +9409,17 @@ mod tests {
         assert_eq!(ordinary.work().declaration_reuse.fallback_epochs_started, 0);
         let mut fresh = CompilerSession::new();
         fresh.update(&edited).into_result().unwrap();
-        let expected = fresh.semantic(&options).unwrap();
+        let expected = fresh.canonical_semantic(&options).unwrap();
         assert_semantic_artifact_parity(&session, &ordinary, &expected);
 
         // Moving to a different declaration universe seeds a new baseline, and
         // its next body edit can reuse normally.
         session.update(&supported).into_result().unwrap();
-        let seeded = session.semantic(&options).unwrap();
+        let seeded = session.canonical_semantic(&options).unwrap();
         assert_eq!(seeded.work().binding.declaration_resolution_invocations, 1);
         assert_eq!(seeded.work().binding.durable_install_invocations, 0);
         session.update(&supported_edit).into_result().unwrap();
-        let recovered = session.semantic(&options).unwrap();
+        let recovered = session.canonical_semantic(&options).unwrap();
         assert_eq!(
             recovered.work().binding.declaration_resolution_invocations,
             0
@@ -9389,12 +9450,12 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        let cold = session.semantic(&options).unwrap();
+        let cold = session.canonical_semantic(&options).unwrap();
         assert_eq!(cold.work().binding.declaration_resolution_invocations, 1);
         assert_eq!(cold.work().binding.durable_install_invocations, 0);
 
         session.update(&edited).into_result().unwrap();
-        let ordinary = session.semantic(&options).unwrap();
+        let ordinary = session.canonical_semantic(&options).unwrap();
         assert_eq!(
             ordinary.work().binding.declaration_resolution_invocations,
             0
@@ -9405,7 +9466,7 @@ mod tests {
         assert_eq!(ordinary.work().declaration_reuse.fallback_epochs_started, 0);
         let mut fresh = CompilerSession::new();
         fresh.update(&edited).into_result().unwrap();
-        let expected = fresh.semantic(&options).unwrap();
+        let expected = fresh.canonical_semantic(&options).unwrap();
         assert_semantic_artifact_parity(&session, &ordinary, &expected);
 
         let supported = snapshot(
@@ -9417,11 +9478,11 @@ mod tests {
             1,
         );
         session.update(&supported).into_result().unwrap();
-        let seeded = session.semantic(&options).unwrap();
+        let seeded = session.canonical_semantic(&options).unwrap();
         assert_eq!(seeded.work().binding.declaration_resolution_invocations, 1);
         assert_eq!(seeded.work().binding.durable_install_invocations, 0);
         session.update(&supported_edit).into_result().unwrap();
-        let recovered = session.semantic(&options).unwrap();
+        let recovered = session.canonical_semantic(&options).unwrap();
         assert_eq!(
             recovered.work().binding.declaration_resolution_invocations,
             0
@@ -9470,16 +9531,16 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&base).into_result().unwrap();
-        session.semantic(&options).unwrap();
+        session.canonical_semantic(&options).unwrap();
 
         session.update(&signature).into_result().unwrap();
-        let changed = session.semantic(&options).unwrap();
+        let changed = session.canonical_semantic(&options).unwrap();
         assert_eq!(changed.work().binding.declaration_resolution_invocations, 1);
 
         session.update(&broken_body).into_result().unwrap();
-        assert!(session.semantic(&options).is_err());
+        assert!(session.canonical_semantic(&options).is_err());
         session.update(&recovered).into_result().unwrap();
-        let recovered = session.semantic(&options).unwrap();
+        let recovered = session.canonical_semantic(&options).unwrap();
         assert_eq!(
             recovered.work().binding.declaration_resolution_invocations,
             0
@@ -9491,7 +9552,7 @@ mod tests {
             .iter()
             .find(|target| **target != options.target)
             .unwrap();
-        let target_changed = session.semantic(&other_target).unwrap();
+        let target_changed = session.canonical_semantic(&other_target).unwrap();
         assert_eq!(
             target_changed
                 .work()
@@ -9510,25 +9571,25 @@ mod tests {
 
         let source = base();
         let mut session = CompilerSession::new();
-        let first_program = session.update(&source).into_result().unwrap();
+        let first_program = session.update(&source).into_owner_result().unwrap();
         let first_merge = session.merge().unwrap();
         let second_merge = session.merge().unwrap();
-        let first_rir = session.rir().unwrap();
-        let second_rir = session.rir().unwrap();
+        let first_rir = session.canonical_rir().unwrap();
+        let second_rir = session.canonical_rir().unwrap();
         assert!(Arc::ptr_eq(&first_merge, &second_merge));
         assert!(Arc::ptr_eq(&first_rir, &second_rir));
 
         let noop = session.update(&source);
         assert!(!noop.downstream_invalidated());
-        let second_program = noop.into_result().unwrap();
+        let second_program = noop.into_owner_result().unwrap();
         assert!(Arc::ptr_eq(&first_program, &second_program));
         assert!(Arc::ptr_eq(&first_merge, &session.merge().unwrap()));
-        assert!(Arc::ptr_eq(&first_rir, &session.rir().unwrap()));
+        assert!(Arc::ptr_eq(&first_rir, &session.canonical_rir().unwrap()));
         assert_eq!(session.work().merge.executions, 1);
         assert_eq!(session.work().rir.executions, 1);
         assert_eq!(session.work().downstream_invalidations, 0);
 
-        let published = session.published().unwrap().clone();
+        let published = session.published_owner().unwrap().clone();
         let merged = first_merge.clone();
         let rir = first_rir.clone();
         std::thread::spawn(move || {
@@ -9566,7 +9627,7 @@ mod tests {
         };
         let mut session = CompilerSession::new();
         session.update(&make(false)).into_result().unwrap();
-        session.rir().unwrap();
+        session.canonical_rir().unwrap();
         let first_shards = session
             .definition_shard_baseline
             .as_ref()
@@ -9577,7 +9638,7 @@ mod tests {
         assert!(update.downstream_invalidated());
         assert_eq!(update.work().modules_reused, 127);
         assert_eq!(update.work().modules_reparsed, 1);
-        session.rir().unwrap();
+        session.canonical_rir().unwrap();
         let second_shards = session.definition_shard_baseline.as_ref().unwrap().shards();
         assert!(
             first_shards
@@ -9588,7 +9649,7 @@ mod tests {
         assert_eq!(session.work().last_merge.definition_shards_indexed, 128);
         assert_eq!(session.work().last_merge.definition_shards_reused, 128);
         assert_eq!(session.work().last_merge.definition_shards_rebuilt, 0);
-        session.rir().unwrap();
+        session.canonical_rir().unwrap();
         assert_eq!(session.work().merge.executions, 2);
         assert_eq!(session.work().rir.executions, 2);
         assert_eq!(session.work().downstream_invalidations, 1);
@@ -9667,15 +9728,15 @@ mod tests {
             7,
         );
         let mut session = CompilerSession::new();
-        let program = session.update(&source).into_result().unwrap();
+        let program = session.update(&source).into_owner_result().unwrap();
         let merged = session.merge().unwrap();
-        let rir = session.rir().unwrap();
+        let rir = session.canonical_rir().unwrap();
         let failed = session.update(&broken);
         assert!(failed.result().is_err());
         assert!(!failed.downstream_invalidated());
-        assert!(Arc::ptr_eq(session.published().unwrap(), &program));
+        assert!(Arc::ptr_eq(session.published_owner().unwrap(), &program));
         assert!(Arc::ptr_eq(&session.merge().unwrap(), &merged));
-        assert!(Arc::ptr_eq(&session.rir().unwrap(), &rir));
+        assert!(Arc::ptr_eq(&session.canonical_rir().unwrap(), &rir));
     }
 
     #[test]
@@ -9698,8 +9759,12 @@ mod tests {
         let first = session.merge().unwrap_err();
         let second = session.merge().unwrap_err();
         assert_eq!(format!("{first:?}"), format!("{second:?}"));
-        assert!(session.rir().is_err());
-        assert!(session.semantic(&CompileOptions::default()).is_err());
+        assert!(session.canonical_rir().is_err());
+        assert!(
+            session
+                .canonical_semantic(&CompileOptions::default())
+                .is_err()
+        );
         assert_eq!(session.work().merge.executions, 1);
         assert_eq!(session.work().rir.executions, 0);
         assert_eq!(session.work().semantic.executions, 0);
@@ -9746,7 +9811,7 @@ mod tests {
         let update = session.update(&fixed);
         assert!(update.downstream_invalidated());
         update.into_result().unwrap();
-        assert!(session.rir().is_ok());
+        assert!(session.canonical_rir().is_ok());
         assert_eq!(session.work().merge.executions, 2);
         assert_eq!(session.work().rir.executions, 1);
     }
@@ -9904,23 +9969,23 @@ mod tests {
         );
         let mut session = CompilerSession::new();
         session.update(&base).into_result().unwrap();
-        session.rir().unwrap();
+        session.canonical_rir().unwrap();
 
         let root = session.update(&root_only);
         assert!(root.downstream_invalidated());
         assert_eq!(root.work().modules_reused, 2);
         root.into_result().unwrap();
-        session.rir().unwrap();
+        session.canonical_rir().unwrap();
         let moved = session.update(&relocated);
         assert!(moved.downstream_invalidated());
         assert_eq!(moved.work().modules_rebound, 2);
         moved.into_result().unwrap();
-        session.rir().unwrap();
+        session.canonical_rir().unwrap();
         let ids = session.update(&reassigned);
         assert!(ids.downstream_invalidated());
         assert_eq!(ids.work().modules_reparsed, 2);
         ids.into_result().unwrap();
-        session.rir().unwrap();
+        session.canonical_rir().unwrap();
         let rename = session.update(&renamed);
         assert!(rename.downstream_invalidated());
         assert_eq!(rename.invalidation().added.len(), 1);
@@ -9937,8 +10002,8 @@ mod tests {
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
         let options = CompileOptions::default();
-        let first = session.semantic(&options).unwrap();
-        let second = session.semantic(&options).unwrap();
+        let first = session.canonical_semantic(&options).unwrap();
+        let second = session.canonical_semantic(&options).unwrap();
         assert!(Arc::ptr_eq(&first, &second));
 
         let linker_only = CompileOptions {
@@ -9947,7 +10012,7 @@ mod tests {
         };
         assert!(Arc::ptr_eq(
             &first,
-            &session.semantic(&linker_only).unwrap()
+            &session.canonical_semantic(&linker_only).unwrap()
         ));
         assert_eq!(session.work().semantic.executions, 1);
         assert_eq!(session.work().semantic.reuses, 2);
@@ -9969,9 +10034,9 @@ mod tests {
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
         let default = CompileOptions::default();
-        session.semantic(&default).unwrap();
+        session.canonical_semantic(&default).unwrap();
         session
-            .semantic(&CompileOptions {
+            .canonical_semantic(&CompileOptions {
                 opt_level: OptLevel::O1,
                 ..default.clone()
             })
@@ -9981,13 +10046,13 @@ mod tests {
             .find(|&&target| target != default.target)
             .expect("multiple compiler targets");
         session
-            .semantic(&CompileOptions {
+            .canonical_semantic(&CompileOptions {
                 target: other_target,
                 ..default.clone()
             })
             .unwrap();
         session
-            .semantic(&CompileOptions {
+            .canonical_semantic(&CompileOptions {
                 preview_features: PreviewFeatures::from([PreviewFeature::TestInfra]),
                 ..default
             })
@@ -10021,9 +10086,9 @@ mod tests {
             opt_level: OptLevel::O1,
             ..a.clone()
         };
-        session.semantic(&a).unwrap();
-        session.semantic(&b).unwrap();
-        session.semantic(&a).unwrap();
+        session.canonical_semantic(&a).unwrap();
+        session.canonical_semantic(&b).unwrap();
+        session.canonical_semantic(&a).unwrap();
         let attempts = session
             .metrics
             .attempts()
@@ -10053,7 +10118,7 @@ mod tests {
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
         let options = CompileOptions::default();
-        session.semantic(&options).unwrap();
+        session.canonical_semantic(&options).unwrap();
         let origin = session
             .metrics
             .attempts()
@@ -10065,7 +10130,7 @@ mod tests {
         for _ in 0..(QUERY_ATTEMPT_RETENTION_LIMIT + 44) {
             session.import_graph(None).unwrap();
         }
-        session.semantic(&options).unwrap();
+        session.canonical_semantic(&options).unwrap();
         let attempts = session.metrics.attempts();
         assert!(
             attempts
@@ -10120,7 +10185,7 @@ mod tests {
         let variants = retention_variants();
 
         for options in &variants {
-            session.semantic(options).unwrap();
+            session.canonical_semantic(options).unwrap();
         }
         assert_eq!(session.work().semantic.calls, variants.len());
         assert_eq!(session.work().semantic.executions, variants.len());
@@ -10131,13 +10196,13 @@ mod tests {
         );
         assert_eq!(session.work().retention.semantic_query_evictions, 1);
 
-        session.semantic(&variants[0]).unwrap();
+        session.canonical_semantic(&variants[0]).unwrap();
         assert_eq!(session.work().semantic.calls, variants.len() + 1);
         assert_eq!(session.work().semantic.executions, variants.len() + 1);
         assert_eq!(session.work().semantic.reuses, 0);
         assert_eq!(session.work().retention.semantic_query_evictions, 2);
 
-        session.semantic(&variants[0]).unwrap();
+        session.canonical_semantic(&variants[0]).unwrap();
         assert_eq!(session.work().semantic.calls, variants.len() + 2);
         assert_eq!(session.work().semantic.executions, variants.len() + 1);
         assert_eq!(session.work().semantic.reuses, 1);
@@ -10165,13 +10230,16 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let first = session.semantic(&options).unwrap();
+        let first = session.canonical_semantic(&options).unwrap();
         assert!(session.update(&broken).result().is_err());
-        assert!(Arc::ptr_eq(&first, &session.semantic(&options).unwrap()));
+        assert!(Arc::ptr_eq(
+            &first,
+            &session.canonical_semantic(&options).unwrap()
+        ));
         let update = session.update(&edited);
         assert!(update.downstream_invalidated());
         update.into_result().unwrap();
-        let second = session.semantic(&options).unwrap();
+        let second = session.canonical_semantic(&options).unwrap();
         assert!(!Arc::ptr_eq(&first, &second));
         assert_eq!(session.work().semantic.executions, 2);
         assert_eq!(session.work().semantic_entries_invalidated, 1);
@@ -10190,7 +10258,7 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let first = session.semantic(&options).unwrap();
+        let first = session.canonical_semantic(&options).unwrap();
         let original_key = session
             .queries
             .semantic
@@ -10203,7 +10271,10 @@ mod tests {
 
         let noop = session.update(&source);
         assert!(!noop.downstream_invalidated());
-        assert!(Arc::ptr_eq(&first, &session.semantic(&options).unwrap()));
+        assert!(Arc::ptr_eq(
+            &first,
+            &session.canonical_semantic(&options).unwrap()
+        ));
         assert_eq!(session.work().semantic.executions, 1);
         assert_eq!(session.work().semantic.reuses, 1);
 
@@ -10213,7 +10284,7 @@ mod tests {
         assert!(!original_handle.is_valid(&mut session.queries.graph));
         assert!(original_handle.invalidation_cause_count(&session.queries.graph) > 0);
         assert_eq!(session.work().semantic_entries_invalidated, 1);
-        let second = session.semantic(&options).unwrap();
+        let second = session.canonical_semantic(&options).unwrap();
         assert!(!Arc::ptr_eq(&first, &second));
 
         session.update(&source).into_result().unwrap();
@@ -10222,7 +10293,10 @@ mod tests {
             original_handle.invalidation_cause_count(&session.queries.graph),
             0
         );
-        assert!(Arc::ptr_eq(&first, &session.semantic(&options).unwrap()));
+        assert!(Arc::ptr_eq(
+            &first,
+            &session.canonical_semantic(&options).unwrap()
+        ));
         assert_eq!(session.work().semantic.executions, 2);
         assert_eq!(session.work().semantic.reuses, 2);
         assert_eq!(session.work().merge.executions, 2);
@@ -10247,8 +10321,8 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&invalid).into_result().unwrap();
-        let first = session.semantic(&options).unwrap_err();
-        let second = session.semantic(&options).unwrap_err();
+        let first = session.canonical_semantic(&options).unwrap_err();
+        let second = session.canonical_semantic(&options).unwrap_err();
         assert_eq!(format!("{first:?}"), format!("{second:?}"));
         assert_eq!(session.work().semantic.calls, 2);
         assert_eq!(session.work().semantic.executions, 1);
@@ -10272,7 +10346,7 @@ mod tests {
         let retained_failed_work = session.work().semantic_records[0].work;
 
         session.update(&valid).into_result().unwrap();
-        assert!(session.semantic(&options).is_ok());
+        assert!(session.canonical_semantic(&options).is_ok());
         assert_eq!(session.work().semantic.calls, 3);
         assert_eq!(session.work().semantic.executions, 2);
         assert_eq!(session.work().semantic.reuses, 1);
@@ -10299,11 +10373,11 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&valid).into_result().unwrap();
-        let baseline = session.semantic(&options).unwrap();
+        let baseline = session.canonical_semantic(&options).unwrap();
 
         session.update(&invalid).into_result().unwrap();
-        let first = session.semantic(&options).unwrap_err();
-        let second = session.semantic(&options).unwrap_err();
+        let first = session.canonical_semantic(&options).unwrap_err();
+        let second = session.canonical_semantic(&options).unwrap_err();
         assert_eq!(format!("{first:?}"), format!("{second:?}"));
         let record = session.work().semantic_records.last().unwrap();
         assert_eq!(
@@ -10316,7 +10390,7 @@ mod tests {
         assert_eq!(record.work.cfg.cfg_builds_attempted, 0);
 
         session.update(&valid).into_result().unwrap();
-        let recovered = session.semantic(&options).unwrap();
+        let recovered = session.canonical_semantic(&options).unwrap();
         assert!(
             Arc::ptr_eq(&recovered, &baseline),
             "restoring the exact source leaf must reinstate its retained terminal"
@@ -10336,7 +10410,9 @@ mod tests {
         );
         let mut session = CompilerSession::new();
         session.update(&invalid).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap_err();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap_err();
         let record = session.work().semantic_records.last().unwrap();
         assert_eq!(
             record.failure.unwrap().phase,
@@ -10364,12 +10440,16 @@ mod tests {
         let overflowing = source(64);
         let mut session = CompilerSession::new();
         session.update(&baseline).into_result().unwrap();
-        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        let cold = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(cold.durable_specialized_body_payloads().len(), 64);
         assert_eq!(cold.work().body_analysis.specialization_rounds, 64);
 
         session.update(&overflowing).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap_err();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap_err();
         let failure = session.work().semantic_records.last().unwrap();
         assert_eq!(
             failure.failure.unwrap().phase,
@@ -10384,7 +10464,7 @@ mod tests {
 
         session.update(&baseline).into_result().unwrap();
         let recovered = session
-            .semantic(&CompileOptions {
+            .canonical_semantic(&CompileOptions {
                 opt_level: OptLevel::O2,
                 ..CompileOptions::default()
             })
@@ -10397,7 +10477,7 @@ mod tests {
         );
 
         let third_warm = session
-            .semantic(&CompileOptions {
+            .canonical_semantic(&CompileOptions {
                 opt_level: OptLevel::O3,
                 ..CompileOptions::default()
             })
@@ -10425,10 +10505,14 @@ mod tests {
         );
         let mut session = CompilerSession::new();
         session.update(&valid).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         session.update(&changed_source).into_result().unwrap();
         crate::canonical_semantic::with_test_declaration_failure_injection(|| {
-            session.semantic(&CompileOptions::default()).unwrap_err();
+            session
+                .canonical_semantic(&CompileOptions::default())
+                .unwrap_err();
         });
 
         let record = session.work().semantic_records.last().unwrap();
@@ -10459,7 +10543,9 @@ mod tests {
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap_err();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap_err();
 
         let record = session.work().semantic_records.last().unwrap();
         assert_eq!(
@@ -10493,7 +10579,9 @@ mod tests {
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
         crate::canonical_semantic::with_test_authoritative_key_mismatch(|| {
-            session.semantic(&CompileOptions::default()).unwrap_err();
+            session
+                .canonical_semantic(&CompileOptions::default())
+                .unwrap_err();
         });
 
         let record = session.work().semantic_records.last().unwrap();
@@ -10521,11 +10609,11 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&valid).into_result().unwrap();
-        let baseline = session.semantic(&options).unwrap();
+        let baseline = session.canonical_semantic(&options).unwrap();
 
         session.update(&changed).into_result().unwrap();
         crate::canonical_semantic::with_test_cfg_failure_injection(|| {
-            session.semantic(&options).unwrap_err();
+            session.canonical_semantic(&options).unwrap_err();
         });
         let failed = session.work().semantic_records.last().unwrap();
         assert_eq!(
@@ -10539,7 +10627,7 @@ mod tests {
         assert_eq!(failed.work.cfg.optimization_attempts, 0);
 
         session.update(&valid).into_result().unwrap();
-        let recovered = session.semantic(&options).unwrap();
+        let recovered = session.canonical_semantic(&options).unwrap();
         assert!(
             Arc::ptr_eq(&recovered, &baseline),
             "restoring the exact source leaf must reinstate its retained terminal"
@@ -10559,7 +10647,9 @@ mod tests {
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let errors = session.semantic(&CompileOptions::default()).unwrap_err();
+        let errors = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap_err();
         assert!(
             errors
                 .iter()
@@ -10582,7 +10672,7 @@ mod tests {
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
         let ordinary_options = CompileOptions::default();
-        let ordinary = session.semantic(&ordinary_options).unwrap();
+        let ordinary = session.canonical_semantic(&ordinary_options).unwrap();
         assert_eq!(session.work().definitions.executions, 0);
         assert_eq!(session.work().definition_entries, 0);
 
@@ -10626,7 +10716,7 @@ mod tests {
         session.update(&source).into_result().unwrap();
         session.stable_definitions(&options).unwrap();
         let semantic_executions = session.work().semantic.executions;
-        let ordinary = session.semantic(&options).unwrap();
+        let ordinary = session.canonical_semantic(&options).unwrap();
 
         assert!(!ordinary.functions().is_empty());
         assert_eq!(semantic_executions, 1);
@@ -10646,7 +10736,7 @@ mod tests {
         let source = base();
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
-        let published = session.update(&source).into_result().unwrap();
+        let published = session.update(&source).into_owner_result().unwrap();
 
         let module_id = ModuleId::from_logical_path("a.rue").unwrap();
         let module = published.module(&module_id).expect("module by stable ID");
@@ -10707,7 +10797,7 @@ mod tests {
             1,
         );
         let mut session = CompilerSession::new();
-        let program = session.update(&source).into_result().unwrap();
+        let program = session.update(&source).into_owner_result().unwrap();
         let graph = crate::test_support::test_fixture_import_graph(&program).unwrap();
         session.adopt_test_import_graph(graph);
         assert!(session.import_graph(None).is_ok());
@@ -10733,7 +10823,7 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        session.semantic(&options).unwrap();
+        session.canonical_semantic(&options).unwrap();
 
         let imports = session.accepted_semantic_import_graph().unwrap();
         let successful_key = SemanticQueryKey {
@@ -10778,6 +10868,7 @@ mod tests {
             SemanticCacheEntry {
                 key: failed_key,
                 result: Err(failed_errors),
+                rir: None,
                 diagnostics: failed_diagnostics,
                 successful_body_cache: None,
                 durable_declaration_cache: None,
@@ -12168,7 +12259,7 @@ mod tests {
                 .is_some_and(|cache| cache.bodies.is_empty())
         );
         let warm = session
-            .semantic(&CompileOptions {
+            .canonical_semantic(&CompileOptions {
                 opt_level: OptLevel::O1,
                 ..CompileOptions::default()
             })
@@ -12457,7 +12548,9 @@ mod tests {
         let mut session = CompilerSession::new();
         publish_with_test_imports(&mut session, &source);
         assert!(
-            session.semantic(&CompileOptions::default()).is_err(),
+            session
+                .canonical_semantic(&CompileOptions::default())
+                .is_err(),
             "dotted type-call heads are module-qualified free functions, not associated functions"
         );
     }
@@ -12555,7 +12648,11 @@ mod tests {
         );
         let mut session = CompilerSession::new();
         publish_with_test_imports(&mut session, &source);
-        assert!(session.semantic(&CompileOptions::default()).is_err());
+        assert!(
+            session
+                .canonical_semantic(&CompileOptions::default())
+                .is_err()
+        );
         let manifest = session
             .semantic_dependency_inputs(&CompileOptions::default(), None)
             .unwrap();
@@ -12899,7 +12996,7 @@ mod tests {
         );
         let mut session = CompilerSession::new();
         session.update(&valid).into_result().unwrap();
-        let published = session.published().unwrap().clone();
+        let published = session.published_owner().unwrap().clone();
 
         let failed = session.update(&syntax_bad);
         let syntax_diagnostics = failed.diagnostics().clone();
@@ -12912,7 +13009,7 @@ mod tests {
             syntax_bad.source_revision()
         );
         assert!(!syntax_diagnostics.errors().is_empty());
-        assert!(Arc::ptr_eq(session.published().unwrap(), &published));
+        assert!(Arc::ptr_eq(session.published_owner().unwrap(), &published));
         assert!(Arc::ptr_eq(
             session
                 .diagnostics_for(&syntax_bad, &FrontendDiagnosticIdentity::Syntax)
@@ -12922,14 +13019,14 @@ mod tests {
 
         session.update(&semantic_bad).into_result().unwrap();
         let options = CompileOptions::default();
-        session.semantic(&options).unwrap_err();
+        session.canonical_semantic(&options).unwrap_err();
         let first = session.latest_diagnostics().unwrap().clone();
         let first_fingerprint = first
             .errors()
             .iter()
             .map(ToString::to_string)
             .collect::<Vec<_>>();
-        session.semantic(&options).unwrap_err();
+        session.canonical_semantic(&options).unwrap_err();
         let reused = session.latest_diagnostics().unwrap().clone();
         assert!(Arc::ptr_eq(&first, &reused));
         assert_eq!(
@@ -12946,19 +13043,19 @@ mod tests {
         assert_eq!(input.opt_level(), crate::StableOptLevel::O0);
 
         session.update(&warning_source).into_result().unwrap();
-        session.semantic(&options).unwrap();
+        session.canonical_semantic(&options).unwrap();
         let warning = session.latest_diagnostics().unwrap().clone();
         assert!(warning.is_success());
         assert!(!warning.warnings().is_empty());
         session
-            .semantic(&CompileOptions {
+            .canonical_semantic(&CompileOptions {
                 linker: LinkerMode::Internal,
                 ..options.clone()
             })
             .unwrap();
         assert!(Arc::ptr_eq(&warning, session.latest_diagnostics().unwrap()));
         session
-            .semantic(&CompileOptions {
+            .canonical_semantic(&CompileOptions {
                 opt_level: OptLevel::O1,
                 ..options.clone()
             })
@@ -12966,7 +13063,7 @@ mod tests {
         let optimized = session.latest_diagnostics().unwrap().clone();
         assert!(!Arc::ptr_eq(&warning, &optimized));
         session
-            .semantic(&CompileOptions {
+            .canonical_semantic(&CompileOptions {
                 preview_features: PreviewFeatures::from([PreviewFeature::TestInfra]),
                 ..options.clone()
             })
@@ -12978,7 +13075,7 @@ mod tests {
             .find(|&&target| target != options.target)
             .unwrap();
         session
-            .semantic(&CompileOptions {
+            .canonical_semantic(&CompileOptions {
                 target: other_target,
                 ..options
             })
@@ -13194,7 +13291,7 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let first_errors = session.semantic(&options).unwrap_err();
+        let first_errors = session.canonical_semantic(&options).unwrap_err();
         let origin = session.latest_diagnostics().unwrap().clone();
         let stage = origin.identity().clone();
 
@@ -13207,7 +13304,7 @@ mod tests {
         let publications = session.work().diagnostic_publications;
         let reuses = session.work().diagnostic_reuses;
 
-        let reused_errors = session.semantic(&options).unwrap_err();
+        let reused_errors = session.canonical_semantic(&options).unwrap_err();
 
         assert_eq!(
             first_errors
@@ -13285,10 +13382,10 @@ fn main() -> i32 { selected.value() }"#,
         session.update(&source).into_result().unwrap();
 
         session.adopt_test_import_graph(graph_a.clone());
-        session.semantic(&options).unwrap();
+        session.canonical_semantic(&options).unwrap();
         let diagnostics_a = session.latest_diagnostics().unwrap().clone();
         session.adopt_test_import_graph(graph_b.clone());
-        session.semantic(&options).unwrap();
+        session.canonical_semantic(&options).unwrap();
         let diagnostics_b = session.latest_diagnostics().unwrap().clone();
 
         assert!(!Arc::ptr_eq(&diagnostics_a, &diagnostics_b));
@@ -13310,7 +13407,7 @@ fn main() -> i32 { selected.value() }"#,
         let initial = source("fn main() -> i32 { 0 }");
         let mut session = CompilerSession::new();
         session.update(&initial).into_result().unwrap();
-        session.semantic(&options).unwrap();
+        session.canonical_semantic(&options).unwrap();
         assert_eq!(session.work().retention.diagnostic_entries, 5);
         assert_eq!(session.work().retention.diagnostic_source_attempts, 1);
         assert_eq!(
@@ -13341,7 +13438,7 @@ fn main() -> i32 { selected.value() }"#,
             maximum_attempt_bytes = maximum_attempt_bytes.max(semantic_text.len());
             let semantic_bad = source(&semantic_text);
             session.update(&semantic_bad).into_result().unwrap();
-            session.semantic(&options).unwrap_err();
+            session.canonical_semantic(&options).unwrap_err();
             assert!(Arc::ptr_eq(
                 session.last_good_semantic_diagnostics().unwrap(),
                 &before_semantic_failure
@@ -13352,7 +13449,7 @@ fn main() -> i32 { selected.value() }"#,
             maximum_attempt_bytes = maximum_attempt_bytes.max(valid_text.len());
             let valid = source(&valid_text);
             session.update(&valid).into_result().unwrap();
-            let recovered = session.semantic(&options).unwrap();
+            let recovered = session.canonical_semantic(&options).unwrap();
             let recovered_diagnostics = session.latest_diagnostics().unwrap();
             assert!(recovered_diagnostics.is_success());
             assert!(Arc::ptr_eq(
@@ -13396,8 +13493,8 @@ fn main() -> i32 { selected.value() }"#,
         let final_source = source("fn main() -> i32 { 32 }");
         let mut fresh = CompilerSession::new();
         fresh.update(&final_source).into_result().unwrap();
-        let fresh_output = fresh.semantic(&options).unwrap();
-        let retained_output = session.semantic(&options).unwrap();
+        let fresh_output = fresh.canonical_semantic(&options).unwrap();
+        let retained_output = session.canonical_semantic(&options).unwrap();
         assert_eq!(
             format!("{:?}", retained_output.functions()),
             format!("{:?}", fresh_output.functions())
@@ -13482,7 +13579,7 @@ fn main() -> i32 { selected.value() }"#,
             opt_level: OptLevel::O1,
             ..CompileOptions::default()
         };
-        let reused = session.semantic(&optimized_options).unwrap();
+        let reused = session.canonical_semantic(&optimized_options).unwrap();
         let reused_work = reused.work();
         assert_eq!(reused_work.body_analysis.bodies_attempted, 0);
         assert_eq!(reused_work.body_analysis.bodies_succeeded, 0);
@@ -13494,7 +13591,7 @@ fn main() -> i32 { selected.value() }"#,
 
         let mut fresh = CompilerSession::new();
         fresh.update(&source).into_result().unwrap();
-        let fresh = fresh.semantic(&optimized_options).unwrap();
+        let fresh = fresh.canonical_semantic(&optimized_options).unwrap();
         assert_eq!(
             format!("{:?}", reused.functions()),
             format!("{:?}", fresh.functions())
@@ -13528,7 +13625,9 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        let cold = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(cold.durable_specialized_body_payloads().len(), 1);
         let specialized = &cold.durable_specialized_body_payloads()[0];
         assert_eq!(
@@ -13562,7 +13661,7 @@ fn main() -> i32 { selected.value() }"#,
             opt_level: OptLevel::O1,
             ..CompileOptions::default()
         };
-        let reused = session.semantic(&optimized).unwrap();
+        let reused = session.canonical_semantic(&optimized).unwrap();
         let work = reused.work().body_analysis;
         assert_eq!(work.specialized_body_import_attempts, 1);
         assert_eq!(work.specialized_body_import_successes, 1);
@@ -13598,7 +13697,7 @@ fn main() -> i32 { selected.value() }"#,
 
         let mut fresh_session = CompilerSession::new();
         fresh_session.update(&source).into_result().unwrap();
-        let fresh = fresh_session.semantic(&optimized).unwrap();
+        let fresh = fresh_session.canonical_semantic(&optimized).unwrap();
         assert_eq!(
             format!("{:?}", reused.functions()),
             format!("{:?}", fresh.functions())
@@ -13658,13 +13757,15 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         publish_with_test_imports(&mut session, &original);
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         publish_with_test_imports(&mut session, &relocated);
         let options = CompileOptions {
             opt_level: OptLevel::O1,
             ..CompileOptions::default()
         };
-        let reused = session.semantic(&options).unwrap();
+        let reused = session.canonical_semantic(&options).unwrap();
         assert_eq!(reused.work().durable_bodies.candidate_comparisons, 1);
         assert_eq!(reused.work().durable_bodies.candidate_fallbacks, 0);
         assert_eq!(reused.work().body_analysis.specialized_bodies_reused, 1);
@@ -13672,7 +13773,7 @@ fn main() -> i32 { selected.value() }"#,
 
         let mut fresh_session = CompilerSession::new();
         publish_with_test_imports(&mut fresh_session, &relocated);
-        let fresh = fresh_session.semantic(&options).unwrap();
+        let fresh = fresh_session.canonical_semantic(&options).unwrap();
         assert_body_artifact_parity(&reused, &fresh);
         assert_diagnostic_parity(&session, &fresh_session);
     }
@@ -13691,8 +13792,10 @@ fn main() -> i32 { selected.value() }"#,
         let run = |options: CompileOptions| {
             let mut session = CompilerSession::new();
             session.update(&source).into_result().unwrap();
-            session.semantic(&CompileOptions::default()).unwrap();
-            session.semantic(&options).unwrap()
+            session
+                .canonical_semantic(&CompileOptions::default())
+                .unwrap();
+            session.canonical_semantic(&options).unwrap()
         };
         let other_target = *Target::all()
             .iter()
@@ -13739,14 +13842,16 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        let cold = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(cold.durable_specialized_body_payloads().len(), 0);
         assert_eq!(cold.work().body_analysis.specialized_bodies_attempted, 1);
         assert!(cold.work().body_analysis.specialization_requests_duplicate >= 1);
         assert_eq!(cold.warnings().len(), 1);
 
         let warm = session
-            .semantic(&CompileOptions {
+            .canonical_semantic(&CompileOptions {
                 opt_level: OptLevel::O1,
                 ..CompileOptions::default()
             })
@@ -13775,7 +13880,9 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        let cold = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(cold.durable_specialized_body_payloads().len(), 1);
         assert!(
             !cold.durable_specialized_body_payloads()[0].dependency_boundary_complete,
@@ -13790,7 +13897,7 @@ fn main() -> i32 { selected.value() }"#,
                 .is_empty()
         );
         let warm = session
-            .semantic(&CompileOptions {
+            .canonical_semantic(&CompileOptions {
                 opt_level: OptLevel::O1,
                 ..CompileOptions::default()
             })
@@ -13813,7 +13920,9 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap_err();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap_err();
         let failure = session.work().semantic_records.last().unwrap();
         assert!(failure.failure.is_some());
         assert_eq!(failure.work.durable_bodies.import_attempts, 0);
@@ -13833,7 +13942,9 @@ fn main() -> i32 { selected.value() }"#,
         let source = snapshot(&[(42, "/p/main.rue", "main.rue", source_text)], 42);
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        let cold = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(cold.durable_specialized_body_payloads().len(), 2);
         assert_eq!(cold.work().body_analysis.specialized_bodies_attempted, 2);
         assert!(cold.work().body_analysis.specialization_requests_duplicate >= 1);
@@ -13842,7 +13953,7 @@ fn main() -> i32 { selected.value() }"#,
             opt_level: OptLevel::O1,
             ..CompileOptions::default()
         };
-        let warm = session.semantic(&optimized).unwrap();
+        let warm = session.canonical_semantic(&optimized).unwrap();
         let work = warm.work().body_analysis;
         assert_eq!(work.specialized_body_import_attempts, 2);
         assert_eq!(work.specialized_body_import_successes, 2);
@@ -13857,7 +13968,9 @@ fn main() -> i32 { selected.value() }"#,
             42,
         );
         session.update(&unrelated).into_result().unwrap();
-        let unrelated = session.semantic(&CompileOptions::default()).unwrap();
+        let unrelated = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(unrelated.work().body_analysis.specialized_bodies_reused, 2);
         assert_eq!(
             unrelated.work().body_analysis.specialized_bodies_attempted,
@@ -13870,7 +13983,9 @@ fn main() -> i32 { selected.value() }"#,
              fn unrelated() -> i32 { 7 }";
         let changed = snapshot(&[(42, "/p/main.rue", "main.rue", changed_text)], 42);
         session.update(&changed).into_result().unwrap();
-        let changed = session.semantic(&CompileOptions::default()).unwrap();
+        let changed = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(changed.work().body_analysis.specialized_bodies_reused, 0);
         assert_eq!(changed.work().body_analysis.specialized_bodies_attempted, 2);
     }
@@ -13883,7 +13998,9 @@ fn main() -> i32 { selected.value() }"#,
         let source = snapshot(&[(42, "/p/main.rue", "main.rue", source_text)], 42);
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
 
         let cache = session.last_successful_body_cache.as_mut().unwrap();
         let outer = Arc::make_mut(&mut cache.specialized_bodies)
@@ -13909,7 +14026,7 @@ fn main() -> i32 { selected.value() }"#,
             opt_level: OptLevel::O1,
             ..CompileOptions::default()
         };
-        let recovered = session.semantic(&optimized).unwrap();
+        let recovered = session.canonical_semantic(&optimized).unwrap();
         assert_eq!(recovered.work().durable_bodies.candidate_fallbacks, 1);
         assert_eq!(
             recovered.work().durable_bodies.specialized_mapping_attempts,
@@ -13955,7 +14072,7 @@ fn main() -> i32 { selected.value() }"#,
 
         let mut fresh = CompilerSession::new();
         fresh.update(&source).into_result().unwrap();
-        let fresh = fresh.semantic(&optimized).unwrap();
+        let fresh = fresh.canonical_semantic(&optimized).unwrap();
         assert_eq!(
             format!("{:?}", recovered.functions()),
             format!("{:?}", fresh.functions())
@@ -13971,7 +14088,9 @@ fn main() -> i32 { selected.value() }"#,
         let source = snapshot(&[(42, "/p/main.rue", "main.rue", source_text)], 42);
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
 
         let cache = session.last_successful_body_cache.as_mut().unwrap();
         let outer = Arc::make_mut(&mut cache.specialized_bodies)
@@ -13994,7 +14113,7 @@ fn main() -> i32 { selected.value() }"#,
             opt_level: OptLevel::O1,
             ..CompileOptions::default()
         };
-        let recovered = session.semantic(&optimized).unwrap();
+        let recovered = session.canonical_semantic(&optimized).unwrap();
         let work = recovered.work().body_analysis;
         assert_eq!(recovered.work().durable_bodies.candidate_fallbacks, 0);
         assert_eq!(work.specialized_body_import_attempts, 2);
@@ -14006,7 +14125,7 @@ fn main() -> i32 { selected.value() }"#,
 
         let mut fresh_session = CompilerSession::new();
         fresh_session.update(&source).into_result().unwrap();
-        let fresh = fresh_session.semantic(&optimized).unwrap();
+        let fresh = fresh_session.canonical_semantic(&optimized).unwrap();
         assert_body_artifact_parity(&recovered, &fresh);
         assert_diagnostic_parity(&session, &fresh_session);
     }
@@ -14027,14 +14146,16 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        let cold = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(cold.durable_specialized_body_payloads().len(), 6);
 
         let optimized = CompileOptions {
             opt_level: OptLevel::O1,
             ..CompileOptions::default()
         };
-        let warm = session.semantic(&optimized).unwrap();
+        let warm = session.canonical_semantic(&optimized).unwrap();
         let work = warm.work().body_analysis;
         assert_eq!(work.specialized_body_import_attempts, 6);
         assert_eq!(work.specialized_body_import_successes, 6);
@@ -14055,7 +14176,9 @@ fn main() -> i32 { selected.value() }"#,
         let first = snapshot(&[(42, "/p/main.rue", "main.rue", first_text)], 42);
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        let cold = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(cold.durable_specialized_body_payloads().len(), 2);
         let bool_identities = cold
             .durable_specialized_body_payloads()
@@ -14075,13 +14198,17 @@ fn main() -> i32 { selected.value() }"#,
             42,
         );
         session.update(&changed_source).into_result().unwrap();
-        let changed = session.semantic(&CompileOptions::default()).unwrap();
+        let changed = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(changed.work().body_analysis.specialized_bodies_reused, 1);
         assert_eq!(changed.work().body_analysis.specialized_bodies_attempted, 1);
 
         let mut fresh = CompilerSession::new();
         fresh.update(&changed_source).into_result().unwrap();
-        let fresh = fresh.semantic(&CompileOptions::default()).unwrap();
+        let fresh = fresh
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(
             format!("{:?}", changed.functions()),
             format!("{:?}", fresh.functions())
@@ -14107,7 +14234,9 @@ fn main() -> i32 { selected.value() }"#,
         let first = snapshot(&[(43, "/p/main.rue", "main.rue", first_text)], 43);
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        let cold = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(cold.durable_specialized_body_payloads().len(), 2);
 
         let changed_text = first_text.replace("cleanup();", "cleanup(); let marker = 0;");
@@ -14116,13 +14245,17 @@ fn main() -> i32 { selected.value() }"#,
             43,
         );
         session.update(&changed_source).into_result().unwrap();
-        let changed = session.semantic(&CompileOptions::default()).unwrap();
+        let changed = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(changed.work().body_analysis.specialized_bodies_reused, 1);
         assert_eq!(changed.work().body_analysis.specialized_bodies_attempted, 1);
 
         let mut fresh_session = CompilerSession::new();
         fresh_session.update(&changed_source).into_result().unwrap();
-        let fresh = fresh_session.semantic(&CompileOptions::default()).unwrap();
+        let fresh = fresh_session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_body_artifact_parity(&changed, &fresh);
         assert_diagnostic_parity(&session, &fresh_session);
     }
@@ -14144,7 +14277,9 @@ fn main() -> i32 { selected.value() }"#,
         let source = snapshot(&[(90, "/p/main.rue", "main.rue", &program)], 90);
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let semantic = session.semantic(&CompileOptions::default()).unwrap();
+        let semantic = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         let definitions = semantic.body_owner_issuer();
         let (bodies, work) = build_supported_ordinary_body_cache(
             &semantic,
@@ -14212,7 +14347,9 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        let cold = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(cold.work().body_analysis.bodies_attempted, 6);
         assert_eq!(
             session
@@ -14238,7 +14375,7 @@ fn main() -> i32 { selected.value() }"#,
             opt_level: OptLevel::O1,
             ..CompileOptions::default()
         };
-        let reused = session.semantic(&options).unwrap();
+        let reused = session.canonical_semantic(&options).unwrap();
         assert_eq!(reused.work().durable_bodies.candidate_comparisons, 6);
         assert_eq!(reused.work().durable_bodies.import_attempts, 6);
         assert_eq!(reused.work().durable_bodies.import_successes, 6);
@@ -14247,7 +14384,7 @@ fn main() -> i32 { selected.value() }"#,
 
         let mut fresh_session = CompilerSession::new();
         fresh_session.update(&relocated).into_result().unwrap();
-        let fresh = fresh_session.semantic(&options).unwrap();
+        let fresh = fresh_session.canonical_semantic(&options).unwrap();
         assert_body_artifact_parity(&reused, &fresh);
         assert_diagnostic_parity(&session, &fresh_session);
 
@@ -14261,14 +14398,16 @@ fn main() -> i32 { selected.value() }"#,
             145,
         );
         session.update(&edited).into_result().unwrap();
-        let edited_output = session.semantic(&CompileOptions::default()).unwrap();
+        let edited_output = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(edited_output.work().durable_bodies.candidate_comparisons, 6);
         assert_eq!(edited_output.work().durable_bodies.reused_bodies, 4);
         assert_eq!(edited_output.work().body_analysis.bodies_attempted, 2);
         let mut edited_fresh_session = CompilerSession::new();
         edited_fresh_session.update(&edited).into_result().unwrap();
         let edited_fresh = edited_fresh_session
-            .semantic(&CompileOptions::default())
+            .canonical_semantic(&CompileOptions::default())
             .unwrap();
         assert_body_artifact_parity(&edited_output, &edited_fresh);
         assert_diagnostic_parity(&session, &edited_fresh_session);
@@ -14283,7 +14422,9 @@ fn main() -> i32 { selected.value() }"#,
             145,
         );
         session.update(&destructor_edit).into_result().unwrap();
-        let destructor_output = session.semantic(&CompileOptions::default()).unwrap();
+        let destructor_output = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(destructor_output.work().durable_bodies.reused_bodies, 2);
         assert_eq!(destructor_output.work().body_analysis.bodies_attempted, 4);
 
@@ -14297,7 +14438,9 @@ fn main() -> i32 { selected.value() }"#,
             145,
         );
         session.update(&helper_edit).into_result().unwrap();
-        let helper_output = session.semantic(&CompileOptions::default()).unwrap();
+        let helper_output = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(helper_output.work().durable_bodies.reused_bodies, 3);
         assert_eq!(helper_output.work().body_analysis.bodies_attempted, 3);
         let mut helper_fresh_session = CompilerSession::new();
@@ -14306,7 +14449,7 @@ fn main() -> i32 { selected.value() }"#,
             .into_result()
             .unwrap();
         let helper_fresh = helper_fresh_session
-            .semantic(&CompileOptions::default())
+            .canonical_semantic(&CompileOptions::default())
             .unwrap();
         assert_body_artifact_parity(&helper_output, &helper_fresh);
         assert_diagnostic_parity(&session, &helper_fresh_session);
@@ -14326,7 +14469,9 @@ fn main() -> i32 { selected.value() }"#,
         let edited = source("i64");
         let mut session = CompilerSession::new();
         session.update(&original).into_result().unwrap();
-        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        let cold = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(cold.work().body_analysis.bodies_attempted, 4);
         let retained = session.last_successful_body_cache.as_ref().unwrap();
         assert_eq!(retained.bodies.len(), 4);
@@ -14339,7 +14484,9 @@ fn main() -> i32 { selected.value() }"#,
         );
 
         session.update(&edited).into_result().unwrap();
-        let actual = session.semantic(&CompileOptions::default()).unwrap();
+        let actual = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(actual.work().durable_bodies.candidate_comparisons, 4);
         assert_eq!(actual.work().durable_bodies.reused_bodies, 1);
         assert_eq!(actual.work().durable_bodies.skipped_body_analyses, 1);
@@ -14348,7 +14495,9 @@ fn main() -> i32 { selected.value() }"#,
 
         let mut fresh_session = CompilerSession::new();
         fresh_session.update(&edited).into_result().unwrap();
-        let fresh = fresh_session.semantic(&CompileOptions::default()).unwrap();
+        let fresh = fresh_session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_body_artifact_parity(&actual, &fresh);
         assert_diagnostic_parity(&session, &fresh_session);
     }
@@ -14380,7 +14529,9 @@ fn main() -> i32 { selected.value() }"#,
             .unwrap();
 
         session.update(&edited).into_result().unwrap();
-        let edited_output = session.semantic(&CompileOptions::default()).unwrap();
+        let edited_output = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         let work = edited_output.work();
         assert_eq!(work.durable_bodies.candidate_comparisons, 3);
         assert_eq!(work.durable_bodies.reused_bodies, 1);
@@ -14401,14 +14552,18 @@ fn main() -> i32 { selected.value() }"#,
             51,
         );
         session.update(&invalid).into_result().unwrap();
-        assert!(session.semantic(&CompileOptions::default()).is_err());
+        assert!(
+            session
+                .canonical_semantic(&CompileOptions::default())
+                .is_err()
+        );
 
         session.update(&edited).into_result().unwrap();
         let recovered_options = CompileOptions {
             opt_level: OptLevel::O2,
             ..CompileOptions::default()
         };
-        let recovered = session.semantic(&recovered_options).unwrap();
+        let recovered = session.canonical_semantic(&recovered_options).unwrap();
         assert_eq!(recovered.work().durable_bodies.reused_bodies, 3);
         assert_eq!(recovered.work().body_analysis.bodies_attempted, 0);
     }
@@ -14426,7 +14581,9 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         let cache = session.last_successful_body_cache.as_mut().unwrap();
         let mut bodies = cache.bodies.to_vec();
         let mut instructions = bodies[0].payload.instructions.to_vec();
@@ -14438,7 +14595,7 @@ fn main() -> i32 { selected.value() }"#,
             opt_level: OptLevel::O1,
             ..CompileOptions::default()
         };
-        let output = session.semantic(&options).unwrap();
+        let output = session.canonical_semantic(&options).unwrap();
         let work = output.work();
         assert_eq!(work.durable_bodies.candidate_comparisons, 2);
         assert_eq!(work.durable_bodies.projection_completions, 2);
@@ -14452,7 +14609,7 @@ fn main() -> i32 { selected.value() }"#,
         assert_eq!(work.body_analysis.bodies_succeeded, 1);
         let mut fresh_session = CompilerSession::new();
         fresh_session.update(&source).into_result().unwrap();
-        let fresh = fresh_session.semantic(&options).unwrap();
+        let fresh = fresh_session.canonical_semantic(&options).unwrap();
         assert_body_artifact_parity(&output, &fresh);
         assert_diagnostic_parity(&session, &fresh_session);
     }
@@ -14470,7 +14627,9 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert!(
             session
                 .last_successful_body_cache
@@ -14551,7 +14710,7 @@ fn main() -> i32 { selected.value() }"#,
             opt_level: OptLevel::O1,
             ..CompileOptions::default()
         };
-        let actual = session.semantic(&options).unwrap();
+        let actual = session.canonical_semantic(&options).unwrap();
         assert_eq!(actual.work().durable_bodies.candidate_comparisons, 3);
         assert_eq!(actual.work().durable_bodies.import_attempts, 3);
         assert_eq!(actual.work().durable_bodies.import_successes, 2);
@@ -14577,7 +14736,7 @@ fn main() -> i32 { selected.value() }"#,
 
         let mut fresh_session = CompilerSession::new();
         fresh_session.update(&source).into_result().unwrap();
-        let fresh = fresh_session.semantic(&options).unwrap();
+        let fresh = fresh_session.canonical_semantic(&options).unwrap();
         assert_eq!(
             symbols_before,
             fresh_session
@@ -14611,7 +14770,9 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        let cold = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert!(!cold.warnings().is_empty());
         assert!(
             session
@@ -14624,7 +14785,7 @@ fn main() -> i32 { selected.value() }"#,
             opt_level: OptLevel::O1,
             ..CompileOptions::default()
         };
-        let warm = session.semantic(&options).unwrap();
+        let warm = session.canonical_semantic(&options).unwrap();
         assert_eq!(warm.work().durable_bodies.reused_bodies, 0);
         assert_eq!(warm.work().body_analysis.bodies_attempted, 1);
         assert_eq!(
@@ -14655,16 +14816,22 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&original).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         session.update(&edited).into_result().unwrap();
-        let reused = session.semantic(&CompileOptions::default()).unwrap();
+        let reused = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(reused.work().durable_bodies.candidate_comparisons, 2);
         assert_eq!(reused.work().durable_bodies.import_attempts, 0);
         assert_eq!(reused.work().durable_bodies.reused_bodies, 0);
 
         let mut fresh = CompilerSession::new();
         fresh.update(&edited).into_result().unwrap();
-        let fresh = fresh.semantic(&CompileOptions::default()).unwrap();
+        let fresh = fresh
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(
             format!("{:?}", reused.functions()),
             format!("{:?}", fresh.functions())
@@ -14680,7 +14847,9 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         let cache = session.last_successful_body_cache.as_mut().unwrap();
         let mut bodies = cache.bodies.to_vec();
         bodies[0].payload.return_type =
@@ -14696,14 +14865,14 @@ fn main() -> i32 { selected.value() }"#,
             opt_level: OptLevel::O1,
             ..CompileOptions::default()
         };
-        let reused = session.semantic(&options).unwrap();
+        let reused = session.canonical_semantic(&options).unwrap();
         assert_eq!(reused.work().durable_bodies.import_attempts, 1);
         assert_eq!(reused.work().durable_bodies.import_failures, 1);
         assert_eq!(reused.work().durable_bodies.atomic_discards, 1);
 
         let mut fresh = CompilerSession::new();
         fresh.update(&source).into_result().unwrap();
-        let fresh = fresh.semantic(&options).unwrap();
+        let fresh = fresh.canonical_semantic(&options).unwrap();
         assert_eq!(
             format!("{:?}", reused.functions()),
             format!("{:?}", fresh.functions())
@@ -14742,13 +14911,21 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&a).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         session.update(&b).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         session.update(&a).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         session.update(&a_prime).into_result().unwrap();
-        let output = session.semantic(&CompileOptions::default()).unwrap();
+        let output = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(output.work().durable_bodies.reused_bodies, 1);
         assert_eq!(output.work().durable_bodies.import_successes, 1);
     }
@@ -14787,9 +14964,13 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&original).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         session.update(&edited).into_result().unwrap();
-        let actual = session.semantic(&CompileOptions::default()).unwrap();
+        let actual = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         let work = actual.work();
         assert_eq!(work.durable_bodies.candidate_comparisons, 5);
         assert_eq!(work.durable_bodies.import_attempts, 1);
@@ -14801,7 +14982,9 @@ fn main() -> i32 { selected.value() }"#,
 
         let mut fresh_session = CompilerSession::new();
         fresh_session.update(&edited).into_result().unwrap();
-        let fresh = fresh_session.semantic(&CompileOptions::default()).unwrap();
+        let fresh = fresh_session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_body_artifact_parity(&actual, &fresh);
         assert_diagnostic_parity(&session, &fresh_session);
     }
@@ -14838,9 +15021,13 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&original).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         session.update(&edited).into_result().unwrap();
-        let actual = session.semantic(&CompileOptions::default()).unwrap();
+        let actual = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(actual.work().durable_bodies.candidate_comparisons, 4);
         assert_eq!(actual.work().durable_bodies.reused_bodies, 1);
         assert_eq!(actual.work().durable_bodies.candidate_fallbacks, 3);
@@ -14848,7 +15035,9 @@ fn main() -> i32 { selected.value() }"#,
 
         let mut fresh_session = CompilerSession::new();
         fresh_session.update(&edited).into_result().unwrap();
-        let fresh = fresh_session.semantic(&CompileOptions::default()).unwrap();
+        let fresh = fresh_session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_body_artifact_parity(&actual, &fresh);
         assert_diagnostic_parity(&session, &fresh_session);
     }
@@ -14875,16 +15064,22 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&original).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         session.update(&edited).into_result().unwrap();
-        let actual = session.semantic(&CompileOptions::default()).unwrap();
+        let actual = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(actual.work().durable_bodies.candidate_comparisons, 3);
         assert_eq!(actual.work().durable_bodies.reused_bodies, 1);
         assert_eq!(actual.work().durable_bodies.candidate_fallbacks, 2);
         assert_eq!(actual.work().body_analysis.bodies_attempted, 2);
         let mut fresh_session = CompilerSession::new();
         fresh_session.update(&edited).into_result().unwrap();
-        let fresh = fresh_session.semantic(&CompileOptions::default()).unwrap();
+        let fresh = fresh_session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_body_artifact_parity(&actual, &fresh);
         assert_diagnostic_parity(&session, &fresh_session);
     }
@@ -14917,13 +15112,15 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&original).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         session.update(&relocated).into_result().unwrap();
         let options = CompileOptions {
             opt_level: OptLevel::O1,
             ..CompileOptions::default()
         };
-        let actual = session.semantic(&options).unwrap();
+        let actual = session.canonical_semantic(&options).unwrap();
         assert_eq!(actual.work().durable_bodies.candidate_comparisons, 2);
         assert_eq!(actual.work().durable_bodies.import_attempts, 2);
         assert_eq!(actual.work().durable_bodies.reused_bodies, 2);
@@ -14932,7 +15129,7 @@ fn main() -> i32 { selected.value() }"#,
 
         let mut fresh_session = CompilerSession::new();
         fresh_session.update(&relocated).into_result().unwrap();
-        let fresh = fresh_session.semantic(&options).unwrap();
+        let fresh = fresh_session.canonical_semantic(&options).unwrap();
         assert_body_artifact_parity(&actual, &fresh);
         assert_diagnostic_parity(&session, &fresh_session);
     }
@@ -14960,9 +15157,11 @@ fn main() -> i32 { selected.value() }"#,
         let run = |options: CompileOptions, next: &SourceSnapshot| {
             let mut session = CompilerSession::new();
             session.update(&source).into_result().unwrap();
-            session.semantic(&CompileOptions::default()).unwrap();
+            session
+                .canonical_semantic(&CompileOptions::default())
+                .unwrap();
             session.update(next).into_result().unwrap();
-            session.semantic(&options).unwrap()
+            session.canonical_semantic(&options).unwrap()
         };
         let other_target = *Target::all()
             .iter()
@@ -15013,9 +15212,13 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&both_roots).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         session.update(&other_root).into_result().unwrap();
-        let root = session.semantic(&CompileOptions::default()).unwrap();
+        let root = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(root.work().durable_bodies.reused_bodies, 0);
         assert_eq!(root.work().durable_bodies.import_attempts, 0);
         assert_eq!(root.work().durable_bodies.candidate_fallbacks, 1);
@@ -15043,13 +15246,15 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         session.update(&valid).into_result().unwrap();
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         let cache = session.last_successful_body_cache.as_mut().unwrap();
         let mut bodies = cache.bodies.to_vec();
         bodies[0].payload.schema_version = u32::MAX;
         cache.bodies = bodies.into();
         let projected = session
-            .semantic(&CompileOptions {
+            .canonical_semantic(&CompileOptions {
                 opt_level: OptLevel::O1,
                 ..CompileOptions::default()
             })
@@ -15067,12 +15272,18 @@ fn main() -> i32 { selected.value() }"#,
         };
         let mut fresh_session = CompilerSession::new();
         fresh_session.update(&valid).into_result().unwrap();
-        let fresh = fresh_session.semantic(&projected_options).unwrap();
+        let fresh = fresh_session
+            .canonical_semantic(&projected_options)
+            .unwrap();
         assert_body_artifact_parity(&projected, &fresh);
         assert_diagnostic_parity(&session, &fresh_session);
 
         session.update(&broken).into_result().unwrap();
-        assert!(session.semantic(&CompileOptions::default()).is_err());
+        assert!(
+            session
+                .canonical_semantic(&CompileOptions::default())
+                .is_err()
+        );
         let failure = session.work().semantic_records.last().unwrap();
         assert_eq!(
             failure.failure.unwrap().phase,
@@ -15087,7 +15298,7 @@ fn main() -> i32 { selected.value() }"#,
 
         session.update(&valid).into_result().unwrap();
         let recovered = session
-            .semantic(&CompileOptions {
+            .canonical_semantic(&CompileOptions {
                 opt_level: OptLevel::O2,
                 ..CompileOptions::default()
             })
@@ -15105,7 +15316,9 @@ fn main() -> i32 { selected.value() }"#,
             let source = snapshot(&[(id, "/p/main.rue", "main.rue", program)], id);
             let mut session = CompilerSession::new();
             session.update(&source).into_result().unwrap();
-            session.semantic(&CompileOptions::default()).unwrap();
+            session
+                .canonical_semantic(&CompileOptions::default())
+                .unwrap();
             assert!(
                 session
                     .last_successful_body_cache
@@ -15118,13 +15331,13 @@ fn main() -> i32 { selected.value() }"#,
                 opt_level: OptLevel::O1,
                 ..CompileOptions::default()
             };
-            let actual = session.semantic(&options).unwrap();
+            let actual = session.canonical_semantic(&options).unwrap();
             assert_eq!(actual.work().durable_bodies.import_attempts, 0);
             assert_eq!(actual.work().durable_bodies.reused_bodies, 0);
             assert_eq!(actual.work().durable_bodies.candidate_comparisons, 0);
             let mut fresh_session = CompilerSession::new();
             fresh_session.update(&source).into_result().unwrap();
-            let fresh = fresh_session.semantic(&options).unwrap();
+            let fresh = fresh_session.canonical_semantic(&options).unwrap();
             assert_body_artifact_parity(&actual, &fresh);
             assert_diagnostic_parity(&session, &fresh_session);
         }
@@ -15170,7 +15383,9 @@ fn main() -> i32 { selected.value() }"#,
         );
         let mut session = CompilerSession::new();
         publish_with_test_imports(&mut session, &original);
-        session.semantic(&CompileOptions::default()).unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(
             session
                 .last_successful_body_cache
@@ -15181,7 +15396,9 @@ fn main() -> i32 { selected.value() }"#,
             1
         );
         publish_with_test_imports(&mut session, &changed);
-        let actual = session.semantic(&CompileOptions::default()).unwrap();
+        let actual = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_eq!(actual.work().durable_bodies.import_attempts, 0);
         assert_eq!(actual.work().durable_bodies.reused_bodies, 0);
         assert_eq!(actual.work().durable_bodies.candidate_comparisons, 1);
@@ -15189,8 +15406,55 @@ fn main() -> i32 { selected.value() }"#,
 
         let mut fresh_session = CompilerSession::new();
         publish_with_test_imports(&mut fresh_session, &changed);
-        let fresh = fresh_session.semantic(&CompileOptions::default()).unwrap();
+        let fresh = fresh_session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
         assert_body_artifact_parity(&actual, &fresh);
         assert_diagnostic_parity(&session, &fresh_session);
+    }
+
+    #[test]
+    fn semantic_fault_injection_copies_the_stale_results_exact_rir_owner() {
+        let first = SourceSnapshot::single("main.rue", "fn main() -> i32 { 0 }").unwrap();
+        let second = SourceSnapshot::single("main.rue", "fn main() -> i32 { 1 }").unwrap();
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session.update(&first).into_result().unwrap();
+        session.semantic(&options).unwrap();
+        session.update(&second).into_result().unwrap();
+        session.semantic(&options).unwrap();
+
+        let records = session
+            .queries
+            .semantic
+            .records()
+            .cloned()
+            .collect::<Vec<_>>();
+        let current = records.last().unwrap();
+        let stale = records
+            .iter()
+            .rev()
+            .skip(1)
+            .find(|record| record.result.is_ok() && record.key != current.key)
+            .unwrap();
+        let stale_rir = stale.rir.as_ref().unwrap().clone();
+        let stale_semantic = stale.result.as_ref().unwrap().clone();
+
+        assert!(
+            session
+                .inject_stale_query_for_oracle(crate::unstable::DifferentialOracleFault::Semantic)
+        );
+        let injected = session.queries.semantic.records().last().unwrap();
+        assert!(Arc::ptr_eq(
+            injected.result.as_ref().unwrap(),
+            &stale_semantic
+        ));
+        assert!(Arc::ptr_eq(injected.rir.as_ref().unwrap(), &stale_rir));
+
+        let view = session.semantic(&options).unwrap();
+        let view = Arc::try_unwrap(view).unwrap();
+        let (semantic_owner, rir_owner) = view.into_owners();
+        assert!(Arc::ptr_eq(&semantic_owner, &stale_semantic));
+        assert!(Arc::ptr_eq(&rir_owner, &stale_rir));
     }
 }

--- a/crates/rue-compiler/src/syntax.rs
+++ b/crates/rue-compiler/src/syntax.rs
@@ -5,9 +5,7 @@
 
 use tracing::{info, info_span};
 
-use crate::{
-    CompileErrors, Lexer, MultiErrorResult, Parser, SourceSnapshot, SourceView, ThreadedRodeo,
-};
+use crate::{Lexer, MultiErrorResult, Parser, SourceView, ThreadedRodeo};
 
 /// Work performed while lexing and parsing source files.
 ///
@@ -34,11 +32,7 @@ pub struct SyntaxWork {
 pub(crate) struct FileParseOutcome {
     pub(crate) result: MultiErrorResult<std::sync::Arc<rue_parser::Ast>>,
     pub(crate) interner: ThreadedRodeo,
-    pub(crate) work: SyntaxWork,
-}
-
-pub(crate) struct SyntaxPresentationOutcome {
-    pub(crate) result: MultiErrorResult<Vec<std::sync::Arc<rue_parser::Ast>>>,
+    pub(crate) tokens: std::sync::Arc<[rue_lexer::Token]>,
     pub(crate) work: SyntaxWork,
 }
 
@@ -59,6 +53,7 @@ pub(crate) fn parse_file(source: SourceView<'_>, interner: ThreadedRodeo) -> Fil
                 return FileParseOutcome {
                     result: Err(errors),
                     interner,
+                    tokens: std::sync::Arc::from([]),
                     work,
                 };
             }
@@ -68,6 +63,7 @@ pub(crate) fn parse_file(source: SourceView<'_>, interner: ThreadedRodeo) -> Fil
     work.parser_invocations = 1;
     work.tokens = tokens.len();
     info!(token_count = tokens.len(), "lexing complete");
+    let retained_tokens: std::sync::Arc<[rue_lexer::Token]> = tokens.clone().into();
 
     let (ast, interner) = {
         let _span = info_span!("parser").entered();
@@ -78,6 +74,7 @@ pub(crate) fn parse_file(source: SourceView<'_>, interner: ThreadedRodeo) -> Fil
                 return FileParseOutcome {
                     result: Err(errors),
                     interner,
+                    tokens: retained_tokens,
                     work,
                 };
             }
@@ -87,45 +84,9 @@ pub(crate) fn parse_file(source: SourceView<'_>, interner: ThreadedRodeo) -> Fil
     FileParseOutcome {
         result: Ok(std::sync::Arc::new(ast)),
         interner,
+        tokens: retained_tokens,
         work,
     }
-}
-
-/// Parse a snapshot in caller-selected order for syntax presentation only.
-///
-/// This deliberately returns only AST handles, not a second parsed-program
-/// representation. Entry points own the outer span so presentation and
-/// canonical parse queries can expose distinct timing trees while sharing the
-/// per-file parser kernel.
-pub(crate) fn parse_snapshot_for_presentation(
-    snapshot: &SourceSnapshot,
-) -> SyntaxPresentationOutcome {
-    let mut asts = Vec::with_capacity(snapshot.len());
-    let mut interner = ThreadedRodeo::new();
-    let mut errors = CompileErrors::new();
-    let mut work = SyntaxWork::default();
-
-    for source in snapshot.files() {
-        let outcome = parse_file(source, interner);
-        interner = outcome.interner;
-        work.lexer_invocations += outcome.work.lexer_invocations;
-        work.parser_invocations += outcome.work.parser_invocations;
-        work.lexed_bytes += outcome.work.lexed_bytes;
-        work.tokens += outcome.work.tokens;
-
-        match outcome.result {
-            Ok(ast) => asts.push(ast),
-            Err(file_errors) => errors.extend(file_errors),
-        }
-    }
-
-    let result = if errors.is_empty() {
-        Ok(asts)
-    } else {
-        Err(errors)
-    };
-
-    SyntaxPresentationOutcome { result, work }
 }
 
 #[cfg(test)]
@@ -137,7 +98,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        ColorChoice, DiagnosticFormatter, Item, JsonDiagnosticFormatter, SourceInfo, SourceMetadata,
+        ColorChoice, CompilerSession, DiagnosticFormatter, Item, JsonDiagnosticFormatter,
+        SourceInfo, SourceMetadata, SourceSnapshot,
     };
 
     fn snapshot(entries: &[(u32, &str, &str)]) -> SourceSnapshot {
@@ -159,66 +121,6 @@ mod tests {
     }
 
     #[test]
-    fn valid_files_report_one_lexer_and_parser_invocation_each() {
-        let sources = [
-            (7, "first.rue", "fn first() {}"),
-            (3, "empty.rue", ""),
-            (9, "third.rue", "fn third() {}"),
-        ];
-        let snapshot = snapshot(&sources);
-
-        let SyntaxPresentationOutcome { result, work } = parse_snapshot_for_presentation(&snapshot);
-        let asts = result.unwrap();
-
-        assert_eq!(asts.len(), 3);
-        assert_eq!(
-            work,
-            SyntaxWork {
-                lexer_invocations: 3,
-                parser_invocations: 3,
-                lexed_bytes: sources.iter().map(|(_, _, source)| source.len()).sum(),
-                tokens: 15,
-            }
-        );
-    }
-
-    #[test]
-    fn snapshot_collects_lex_and_parse_errors_in_caller_order_and_continues() {
-        let sources = [
-            (30, "lex.rue", "fn lexed() { $ }"),
-            (10, "parse.rue", "fn parsed( { }"),
-            (20, "good.rue", "fn good() {}"),
-        ];
-        let snapshot = snapshot(&sources);
-
-        let SyntaxPresentationOutcome { result, work } = parse_snapshot_for_presentation(&snapshot);
-        let errors = result.unwrap_err();
-
-        assert_eq!(errors.len(), 2);
-        assert!(matches!(
-            errors.as_slice()[0].kind,
-            ErrorKind::UnexpectedCharacter('$')
-        ));
-        assert_eq!(
-            errors
-                .iter()
-                .map(|error| error.span().unwrap().file_id)
-                .collect::<Vec<_>>(),
-            vec![FileId::new(30), FileId::new(10)]
-        );
-        assert_eq!(work.lexer_invocations, 3);
-        assert_eq!(work.parser_invocations, 2);
-        assert_eq!(
-            work.lexed_bytes,
-            sources
-                .iter()
-                .map(|(_, _, source)| source.len())
-                .sum::<usize>()
-        );
-        assert_eq!(work.tokens, 13);
-    }
-
-    #[test]
     fn parser_budget_is_per_file_and_later_files_are_still_parsed() {
         fn malformed_items(prefix: &str) -> String {
             let mut source = String::new();
@@ -236,8 +138,10 @@ mod tests {
             (30, "second.rue", &second),
         ]);
 
-        let SyntaxPresentationOutcome { result, work } = parse_snapshot_for_presentation(&snapshot);
-        let errors = result.unwrap_err();
+        let mut session = CompilerSession::new();
+        let update = session.update(&snapshot);
+        let work = update.work();
+        let errors = update.into_result().unwrap_err();
         let summaries = errors
             .iter()
             .filter(|error| matches!(error.kind, ErrorKind::ParserDiagnosticsOmitted { .. }))
@@ -247,7 +151,7 @@ mod tests {
         assert_eq!(summaries.len(), 2);
         assert_eq!(summaries[0].span().unwrap().file_id, FileId::new(10));
         assert_eq!(summaries[1].span().unwrap().file_id, FileId::new(30));
-        assert_eq!(work.parser_invocations, 3);
+        assert_eq!(work.syntax.parser_invocations, 3);
 
         let source_info = SourceInfo::new(&first, "first.rue");
         let text = DiagnosticFormatter::with_color_choice(&source_info, ColorChoice::Never)
@@ -265,34 +169,6 @@ mod tests {
         assert!(json.contains(
             "\"message\":\"additional parser diagnostics omitted after the first 100 errors\""
         ));
-    }
-
-    #[test]
-    fn one_lex_invocation_preserves_all_lex_errors() {
-        let source = "fn broken() { $ # }";
-        let snapshot = snapshot(&[(1, "broken.rue", source)]);
-
-        let SyntaxPresentationOutcome { result, work } = parse_snapshot_for_presentation(&snapshot);
-        let errors = result.unwrap_err();
-
-        assert_eq!(errors.len(), 2);
-        assert!(matches!(
-            errors.as_slice()[0].kind,
-            ErrorKind::UnexpectedCharacter('$')
-        ));
-        assert!(matches!(
-            errors.as_slice()[1].kind,
-            ErrorKind::UnexpectedCharacter('#')
-        ));
-        assert_eq!(
-            work,
-            SyntaxWork {
-                lexer_invocations: 1,
-                parser_invocations: 0,
-                lexed_bytes: source.len(),
-                tokens: 0,
-            }
-        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/test_support.rs
+++ b/crates/rue-compiler/src/test_support.rs
@@ -54,8 +54,8 @@ pub(crate) fn test_frontend_snapshot(
 )> {
     let mut session = CompilerSession::new();
     publish_test_snapshot(&mut session, snapshot)?;
-    let rir = session.rir()?;
-    let semantic = session.semantic(options)?;
+    let rir = session.canonical_rir()?;
+    let semantic = session.canonical_semantic(options)?;
     let work = session.work().clone();
     drop(session);
     Ok((rir, semantic, work))
@@ -102,7 +102,9 @@ fn publish_test_snapshot(
     session: &mut CompilerSession,
     snapshot: &SourceSnapshot,
 ) -> MultiErrorResult<()> {
-    let program = session.update_for_presentation(snapshot).into_result()?;
+    let program = session
+        .update_for_presentation(snapshot)
+        .into_owner_result()?;
     if !program.import_directives().is_empty() {
         let graph = test_fixture_import_graph(&program)?;
         session.adopt_test_import_graph(graph);

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -6,9 +6,361 @@
 
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
 use std::sync::Arc;
 
 use crate::canonical_semantic::CanonicalSemanticFailurePhase as SemanticFailurePhase;
+
+/// Unstable human-readable compiler stages. These are projections of the
+/// canonical session artifacts, never alternate phase entry points.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PresentationStage {
+    Tokens,
+    Ast,
+    Rir,
+    Air,
+    Cfg,
+    Lowering,
+    Mir,
+    Liveness,
+    RegAlloc,
+    Asm,
+    StackFrame,
+}
+
+/// One explicitly unstable textual presentation request.
+#[derive(Debug, Clone)]
+pub struct PresentationRequest<'a> {
+    pub stage: PresentationStage,
+    pub options: &'a crate::CompileOptions,
+    pub file_order: &'a [crate::FileId],
+}
+
+/// Owned unstable presentation text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PresentationOutput {
+    text: String,
+}
+
+/// Publish a source snapshot with caller-selected diagnostic presentation
+/// order. This is a tooling adapter over the canonical parse query, not a
+/// second parser or supported session operation.
+pub fn update_for_presentation(
+    session: &mut crate::CompilerSession,
+    snapshot: &crate::SourceSnapshot,
+) -> crate::CompilerSessionUpdate {
+    session.update_for_presentation(snapshot)
+}
+
+/// Force the canonical merge query for in-tree query-metrics tooling without
+/// exposing its raw owner.
+pub fn query_merge(session: &mut crate::CompilerSession) -> Result<(), crate::CompileErrors> {
+    session.merge().map(drop)
+}
+
+impl PresentationOutput {
+    pub fn as_str(&self) -> &str {
+        &self.text
+    }
+}
+
+/// Return semantic instrumentation without exposing the semantic owner.
+pub fn semantic_metrics(view: &crate::SemanticView) -> SemanticMetrics {
+    view.unstable_metrics()
+}
+
+pub fn semantic_input_debug(view: &crate::SemanticView) -> String {
+    view.owner().unstable_input_debug()
+}
+
+pub fn semantic_durable_artifact_status(view: &crate::SemanticView) -> DurableArtifactStatus {
+    view.owner().unstable_durable_artifact_status()
+}
+
+/// Exact, owned semantic-state projection used by in-tree cold-vs-reused
+/// differential tooling. Its contents and formatting are deliberately
+/// unstable and are not an artifact that can be fed back into the compiler.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticParitySnapshot {
+    details: String,
+}
+
+impl SemanticParitySnapshot {
+    pub(crate) fn new(details: String) -> Self {
+        Self { details }
+    }
+}
+
+pub fn semantic_parity_snapshot(view: &crate::SemanticView) -> SemanticParitySnapshot {
+    view.owner().unstable_parity_snapshot()
+}
+
+/// Raw owner-crate state for the in-tree CFG differential model. This is an
+/// explicitly unstable consuming bridge; ordinary compiler clients use views.
+pub struct OracleSemanticState {
+    pub interner: lasso::ThreadedRodeo,
+    pub functions: Vec<UnstableSemanticFunction>,
+    pub type_pool: rue_air::FrozenTypeInternPool,
+    pub strings: Vec<String>,
+    pub rir_payload_storage_stats: rue_rir::RirPayloadStorageStats,
+}
+
+/// Raw function state for in-tree differential and storage-profile tooling.
+pub struct UnstableSemanticFunction {
+    pub analyzed: rue_air::AnalyzedFunction,
+    pub cfg: rue_cfg::ValidatedCfg,
+}
+
+pub fn into_oracle_semantic_state(
+    semantic: Arc<crate::SemanticView>,
+) -> Result<OracleSemanticState, &'static str> {
+    let semantic = Arc::try_unwrap(semantic).map_err(|_| "semantic view is still shared")?;
+    let (semantic_owner, rir_owner) = semantic.into_owners();
+    let rir_owner = Arc::try_unwrap(rir_owner).map_err(|_| "RIR owner is still shared")?;
+    let semantic_owner =
+        Arc::try_unwrap(semantic_owner).map_err(|_| "semantic owner is still shared")?;
+    let rir_payload_storage_stats = rir_owner.rir().payload_storage_stats();
+    let (_, symbols) = rir_owner.into_parts();
+    let (functions, type_pool, strings, _) = semantic_owner.into_parts();
+    Ok(OracleSemanticState {
+        interner: symbols.into_interner(),
+        functions: functions
+            .into_iter()
+            .map(|function| UnstableSemanticFunction {
+                analyzed: function.analyzed,
+                cfg: function.cfg,
+            })
+            .collect(),
+        type_pool,
+        strings,
+        rir_payload_storage_stats,
+    })
+}
+
+/// Inject one typed stale-query fault for in-tree differential testing.
+pub fn inject_stale_query_for_oracle(
+    session: &mut crate::CompilerSession,
+    fault: DifferentialOracleFault,
+) -> bool {
+    session.inject_stale_query_for_oracle(fault)
+}
+
+impl crate::CompilerSession {
+    /// Format one compiler stage from this session's canonical artifacts.
+    pub fn unstable_present(
+        &mut self,
+        request: PresentationRequest<'_>,
+    ) -> Result<PresentationOutput, crate::CompileErrors> {
+        let invalid_input = |message: String| {
+            crate::CompileErrors::from(crate::CompileError::without_span(
+                crate::ErrorKind::InvalidCompilerInput(message),
+            ))
+        };
+        let program = self.published_owner().cloned().ok_or_else(|| {
+            invalid_input("presentation requires a published source revision".into())
+        })?;
+        let mut seen = std::collections::HashSet::with_capacity(request.file_order.len());
+        for file_id in request.file_order {
+            if !seen.insert(*file_id) {
+                return Err(invalid_input(format!(
+                    "presentation order contains duplicate file id {file_id:?}"
+                )));
+            }
+            if !program
+                .modules()
+                .iter()
+                .any(|module| module.file_id() == *file_id)
+            {
+                return Err(invalid_input(format!(
+                    "presentation order contains unknown file id {file_id:?}"
+                )));
+            }
+        }
+        if !matches!(
+            request.stage,
+            PresentationStage::Tokens | PresentationStage::Ast
+        ) && seen.len() != program.modules().len()
+        {
+            return Err(invalid_input(format!(
+                "presentation order must contain every published file exactly once (expected {}, got {})",
+                program.modules().len(),
+                seen.len()
+            )));
+        }
+
+        let mut text = String::new();
+        match request.stage {
+            PresentationStage::Tokens => {
+                for file_id in request.file_order {
+                    let module = program
+                        .modules()
+                        .iter()
+                        .find(|module| module.file_id() == *file_id)
+                        .ok_or_else(|| {
+                            invalid_input(format!(
+                                "presentation order contains unknown file id {file_id:?}"
+                            ))
+                        })?;
+                    for token in module.tokens() {
+                        writeln!(&mut text, "{token}").expect("write to String");
+                    }
+                }
+            }
+            PresentationStage::Ast => {
+                for file_id in request.file_order {
+                    let module = program
+                        .modules()
+                        .iter()
+                        .find(|module| module.file_id() == *file_id)
+                        .ok_or_else(|| {
+                            invalid_input(format!(
+                                "presentation order contains unknown file id {file_id:?}"
+                            ))
+                        })?;
+                    write!(&mut text, "{}", module.ast()).expect("write to String");
+                }
+            }
+            PresentationStage::Rir => {
+                let rir = self.canonical_rir()?;
+                let order = rir.presentation_order(request.file_order.iter().copied());
+                write!(
+                    &mut text,
+                    "{}",
+                    rue_rir::RirPrinter::with_presentation_order(
+                        rir.rir(),
+                        rir.semantic_symbols().interner(),
+                        order.instructions,
+                        order.extra,
+                    )
+                )
+                .expect("write to String");
+            }
+            stage => {
+                let semantic = self.canonical_semantic(request.options)?;
+                let rir = self
+                    .selected_semantic_rir_owner()
+                    .expect("successful semantic query retains canonical RIR");
+                let interner = rir.semantic_symbols().interner();
+                for function in semantic.functions() {
+                    match stage {
+                        PresentationStage::Air => {
+                            writeln!(&mut text, "function {}:", function.analyzed.name)
+                                .expect("write to String");
+                            writeln!(
+                                &mut text,
+                                "{}",
+                                function.analyzed.air.display_with_interner(interner)
+                            )
+                            .expect("write to String");
+                        }
+                        PresentationStage::Cfg => {
+                            writeln!(
+                                &mut text,
+                                "{}",
+                                function.cfg.display_with_interner(interner)
+                            )
+                            .expect("write to String");
+                        }
+                        PresentationStage::Lowering => {
+                            write!(
+                                &mut text,
+                                "{}",
+                                crate::backend::generate_lowering_info(
+                                    &function.cfg,
+                                    semantic.type_pool(),
+                                    interner,
+                                    request.options.target,
+                                )?
+                            )
+                            .expect("write to String");
+                        }
+                        PresentationStage::Mir => {
+                            writeln!(&mut text, "function {}:", function.analyzed.name)
+                                .expect("write to String");
+                            writeln!(
+                                &mut text,
+                                "{}",
+                                crate::backend::generate_mir(
+                                    &function.cfg,
+                                    semantic.type_pool(),
+                                    interner,
+                                    request.options.target,
+                                )?
+                            )
+                            .expect("write to String");
+                        }
+                        PresentationStage::Liveness => {
+                            writeln!(&mut text, "function {}:", function.analyzed.name)
+                                .expect("write to String");
+                            writeln!(
+                                &mut text,
+                                "{}",
+                                crate::backend::generate_liveness_info(
+                                    &function.cfg,
+                                    semantic.type_pool(),
+                                    interner,
+                                    request.options.target,
+                                )?
+                            )
+                            .expect("write to String");
+                        }
+                        PresentationStage::RegAlloc => {
+                            writeln!(&mut text, "function {}:", function.analyzed.name)
+                                .expect("write to String");
+                            write!(
+                                &mut text,
+                                "{}",
+                                crate::backend::generate_regalloc_info(
+                                    &function.cfg,
+                                    semantic.type_pool(),
+                                    interner,
+                                    request.options.target,
+                                )?
+                            )
+                            .expect("write to String");
+                        }
+                        PresentationStage::Asm => {
+                            writeln!(&mut text, ".globl {}", function.analyzed.name)
+                                .expect("write to String");
+                            writeln!(&mut text, "{}:", function.analyzed.name)
+                                .expect("write to String");
+                            write!(
+                                &mut text,
+                                "{}",
+                                crate::backend::generate_emitted_asm(
+                                    &function.cfg,
+                                    semantic.type_pool(),
+                                    semantic.strings(),
+                                    interner,
+                                    request.options.target,
+                                )?
+                            )
+                            .expect("write to String");
+                        }
+                        PresentationStage::StackFrame => {
+                            writeln!(
+                                &mut text,
+                                "{}",
+                                rue_codegen::generate_stack_frame_info(
+                                    &function.cfg,
+                                    &function.analyzed.name,
+                                    semantic.type_pool(),
+                                    interner,
+                                    request.options.target,
+                                )?
+                            )
+                            .expect("write to String");
+                        }
+                        PresentationStage::Tokens
+                        | PresentationStage::Ast
+                        | PresentationStage::Rir => unreachable!(),
+                    }
+                }
+            }
+        }
+        Ok(PresentationOutput { text })
+    }
+}
 
 /// Opaque equality status for session-owned durable artifacts.
 ///

--- a/crates/rue-compiler/tests/differential_oracle.rs
+++ b/crates/rue-compiler/tests/differential_oracle.rs
@@ -11,12 +11,15 @@
 use std::{collections::HashMap, fmt::Write as _, sync::Arc};
 
 use rue_cfg::OptLevel;
-use rue_compiler::unstable::DifferentialOracleFault;
+use rue_compiler::unstable::{
+    DifferentialOracleFault, PresentationRequest, PresentationStage, inject_stale_query_for_oracle,
+    semantic_input_debug,
+};
 use rue_compiler::{
     AcceptedImportSource, AcceptedReadManifestEntry, CompileOptions, CompilerSession,
     DiscoverySourceAssembler, FileMetadataFingerprint, FrontendDiagnosticSnapshot,
     ImportDiscoveryContext, ImportObservation, ImportObservationLedger, PhysicalFileIdentity,
-    PreviewFeature, PreviewFeatures, SourceMetadata, SourceSnapshot, generate_emitted_asm,
+    PreviewFeature, PreviewFeatures, SourceMetadata, SourceSnapshot,
 };
 use rue_span::FileId;
 use rue_target::Target;
@@ -203,40 +206,69 @@ fn observe_with_fault(
         let update = session.update(&step.snapshot);
         format!(
             "result={:?};diagnostics={:?}",
-            update.result().map(|program| program.source_revision()),
+            update
+                .result()
+                .map(|syntax| syntax.source_revision().clone()),
             update.diagnostics().errors()
         )
     };
     let mut imports = close_discovery(session, step);
     if fault == Some(DifferentialOracleFault::Semantic) {
         let _ = session.semantic(&step.options);
-        assert!(session.inject_stale_query_for_oracle(DifferentialOracleFault::Semantic));
+        assert!(inject_stale_query_for_oracle(
+            session,
+            DifferentialOracleFault::Semantic
+        ));
     }
     let semantic = session.semantic(&step.options);
     let (semantic, semantic_hash, executable_hash, identities) = match semantic {
         Ok(output) => {
+            let functions = output
+                .function_views()
+                .map(|function| {
+                    (
+                        function.name().to_owned(),
+                        function.instruction_count(),
+                        function.cfg().block_count(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            let strings = output.string_literals().collect::<Vec<_>>();
+            let file_order = step
+                .snapshot
+                .files()
+                .map(|source| source.file_id)
+                .collect::<Vec<_>>();
+            let air = session
+                .unstable_present(PresentationRequest {
+                    stage: PresentationStage::Air,
+                    options: &step.options,
+                    file_order: &file_order,
+                })
+                .expect("oracle corpus must have stable AIR presentation");
+            let cfg = session
+                .unstable_present(PresentationRequest {
+                    stage: PresentationStage::Cfg,
+                    options: &step.options,
+                    file_order: &file_order,
+                })
+                .expect("oracle corpus must have stable CFG presentation");
             let artifact = format!(
-                "functions={:?};strings={:?};warnings={:?}",
-                output.functions(),
-                output.strings(),
+                "functions={:?};air={};cfg={};strings={:?};warnings={:?}",
+                functions,
+                air.as_str(),
+                cfg.as_str(),
+                strings,
                 output.warnings()
             );
-            let rir = session
-                .rir()
-                .expect("successful semantic query retains RIR");
-            let mut emitted = String::new();
-            for function in output.functions() {
-                let assembly = generate_emitted_asm(
-                    &function.cfg,
-                    output.type_pool(),
-                    output.strings(),
-                    rir.semantic_symbols().interner(),
-                    step.options.target,
-                )
+            let emitted = session
+                .unstable_present(PresentationRequest {
+                    stage: PresentationStage::Asm,
+                    options: &step.options,
+                    file_order: &file_order,
+                })
                 .expect("oracle corpus must have platform-stable assembly emission");
-                writeln!(&mut emitted, "{}:\n{}", function.analyzed.name, assembly).unwrap();
-            }
-            let hash = format!("{:x}", Sha256::digest(emitted.as_bytes()));
+            let hash = format!("{:x}", Sha256::digest(emitted.as_str().as_bytes()));
             let executable_hash = match session.oracle_executable(&step.snapshot, &step.options) {
                 Ok(executable) => format!("{:x}", Sha256::digest(&executable.elf)),
                 Err(errors) => format!("error:{errors:?}"),
@@ -248,7 +280,7 @@ fn observe_with_fault(
                 format!(
                     "source={:?};codegen={:?}",
                     step.snapshot.source_revision(),
-                    output.unstable_input_debug()
+                    semantic_input_debug(&output)
                 ),
             )
         }
@@ -260,7 +292,10 @@ fn observe_with_fault(
         ),
     };
     if fault == Some(DifferentialOracleFault::Diagnostic) {
-        assert!(session.inject_stale_query_for_oracle(DifferentialOracleFault::Diagnostic));
+        assert!(inject_stale_query_for_oracle(
+            session,
+            DifferentialOracleFault::Diagnostic
+        ));
     }
     // Capture the semantic request's selected batch before the manifest query
     // performs its own supporting diagnostic work.
@@ -288,7 +323,10 @@ fn observe_with_fault(
         Err(errors) => format!("error:{errors:?}"),
     };
     if fault == Some(DifferentialOracleFault::Import) {
-        assert!(session.inject_stale_query_for_oracle(DifferentialOracleFault::Import));
+        assert!(inject_stale_query_for_oracle(
+            session,
+            DifferentialOracleFault::Import
+        ));
         imports = render_selected_import(session);
     }
     Observation {
@@ -561,7 +599,7 @@ fn option_leaves_reuse_source_terminals_and_restore_exact_semantic_variants() {
     assert_eq!(session.unstable_metrics().merge().executions, 1);
     assert_eq!(session.unstable_metrics().rir().executions, 1);
     assert_eq!(session.unstable_metrics().semantic().executions, 4);
-    assert!(Arc::ptr_eq(&first, &session.semantic(&default).unwrap()));
+    assert!(first.shares_owner(&session.semantic(&default).unwrap()));
     assert_eq!(session.unstable_metrics().semantic().executions, 4);
     assert_eq!(session.unstable_metrics().semantic().reuses, 1);
 }

--- a/crates/rue-compiler/tests/payload_schemas.rs
+++ b/crates/rue-compiler/tests/payload_schemas.rs
@@ -185,13 +185,11 @@ fn observe(source: &str) -> Vec<String> {
     let mut session = CompilerSession::new();
     session.update(&snapshot).into_result().unwrap();
     let semantic = session.semantic(&CompileOptions::default()).unwrap();
-    assert!(
-        session.rir().is_ok(),
-        "semantic publication retained no RIR"
-    );
-    semantic
-        .functions()
-        .iter()
+    drop(session);
+    rue_compiler::unstable::into_oracle_semantic_state(semantic)
+        .expect("one-shot payload verification uniquely owns its frontend artifacts")
+        .functions
+        .into_iter()
         .map(|function| {
             let before = function.cfg.to_string();
             let cloned = function.cfg.clone();

--- a/crates/rue-compiler/tests/public_api.rs
+++ b/crates/rue-compiler/tests/public_api.rs
@@ -1,36 +1,357 @@
 use std::sync::Arc;
 
-use rue_compiler::unstable::MetricsSnapshot;
+use rue_compiler::unstable::{
+    MetricsSnapshot, OracleSemanticState, PresentationRequest, PresentationStage,
+    into_oracle_semantic_state,
+};
 use rue_compiler::{
-    CanonicalRirOutput, CanonicalSemanticOutput, CompileOptions, CompileOutput, CompilerSession,
-    CompilerSessionUpdate, DiagnosticStage, FileId, FrontendDiagnosticSnapshot, MultiErrorResult,
-    SourceMetadata, SourceSnapshot, SourceView, compile_snapshot,
+    CompileOptions, CompileOutput, CompilerSession, CompilerSessionUpdate, DiagnosticStage,
+    ErrorKind, FileId, FrontendDiagnosticSnapshot, MultiErrorResult, RirView, SemanticView,
+    SourceLocationView, SourceMetadata, SourceSnapshot, SourceView, SyntaxNodeView,
+    compile_snapshot,
 };
 
 #[test]
 fn curated_facade_compiles_for_an_external_consumer() {
     let snapshot = SourceSnapshot::single("main.rue", "fn main() -> i32 { 0 }").unwrap();
     let mut session = CompilerSession::new();
-    let update: CompilerSessionUpdate = session.update_for_presentation(&snapshot);
+    let update: CompilerSessionUpdate = session.update(&snapshot);
     update.into_result().unwrap();
 
-    let rir: Arc<CanonicalRirOutput> = session.rir().unwrap();
-    let semantic: Arc<CanonicalSemanticOutput> =
-        session.semantic(&CompileOptions::default()).unwrap();
+    let syntax = session.published().unwrap();
+    let rir: Arc<RirView> = session.rir().unwrap();
+    let semantic: Arc<SemanticView> = session.semantic(&CompileOptions::default()).unwrap();
     let work: MetricsSnapshot = session.unstable_metrics();
     let diagnostics: Option<&Arc<FrontendDiagnosticSnapshot>> = session.latest_diagnostics();
     let views: Vec<SourceView<'_>> = snapshot.files().collect();
     assert_eq!(views[0].file_id, FileId::DEFAULT);
-    let _rir_view = rir.rir();
-    assert_eq!(semantic.functions().len(), 1);
+    assert!(!rir.is_empty());
+    let rir_instruction = rir.instructions().next().unwrap();
+    assert!(!rir_instruction.kind().is_empty());
+    let rir_location: SourceLocationView = rir_instruction.location();
+    assert!(rir_location.is_valid());
+    assert!(
+        rir_location.source_identity().same_source(
+            &syntax
+                .modules()
+                .next()
+                .unwrap()
+                .nodes()
+                .next()
+                .unwrap()
+                .location()
+                .source_identity()
+        )
+    );
+    let function = semantic.function_views().next().unwrap();
+    assert_eq!(function.name(), "main");
+    assert!(function.instruction_count() > 0);
+    let block = function.cfg().blocks().next().unwrap();
+    assert!(!block.terminator_kind().is_empty());
+    assert!(block.instruction_count() > 0);
+    assert_eq!(block.instructions().len(), block.instruction_count());
+    assert_eq!(block.successors().len(), block.successor_count());
+    assert_eq!(
+        syntax
+            .modules()
+            .next()
+            .unwrap()
+            .tokens()
+            .next()
+            .unwrap()
+            .kind(),
+        "FN"
+    );
     assert_eq!(work.updates(), 1);
     assert!(diagnostics.is_some());
     assert_eq!(diagnostics.unwrap().stage(), DiagnosticStage::Semantic);
+    for debug in [format!("{rir:?}"), format!("{semantic:?}")] {
+        assert!(!debug.contains("CanonicalRirOutput"));
+        assert!(!debug.contains("CanonicalSemanticOutput"));
+        assert!(!debug.contains("ThreadedRodeo"));
+    }
 
     let adapter: fn(&SourceSnapshot, &CompileOptions) -> MultiErrorResult<CompileOutput> =
         compile_snapshot;
     let _ = adapter;
     let _metadata: &SourceMetadata = snapshot.metadata();
+}
+
+fn find_syntax_value(node: &SyntaxNodeView, kind: &str, value: &str) -> bool {
+    (node.kind() == kind && node.value() == Some(value))
+        || node
+            .children()
+            .any(|child| find_syntax_value(&child, kind, value))
+}
+
+#[test]
+fn syntax_nodes_resolve_names_and_retain_their_owner_across_updates() {
+    let first = SourceSnapshot::single("main.rue", "fn main() -> i32 { 0 }").unwrap();
+    let second = SourceSnapshot::single("main.rue", "fn replacement() -> i32 { 1 }").unwrap();
+    let mut session = CompilerSession::new();
+    let retained = session.update(&first).into_result().unwrap();
+    let function = retained.modules().next().unwrap().nodes().next().unwrap();
+    let retained_location = function.location();
+    let token_location = retained
+        .modules()
+        .next()
+        .unwrap()
+        .tokens()
+        .next()
+        .unwrap()
+        .location();
+
+    session.update(&second).into_result().unwrap();
+
+    assert_eq!(function.kind(), "function");
+    assert_eq!(function.name(), Some("main"));
+    assert!(function.child_count() >= 2);
+    assert!(find_syntax_value(&function, "integer_literal", "0"));
+    assert!(retained_location.is_valid());
+    assert!(
+        retained_location
+            .source_identity()
+            .same_source(&token_location.source_identity())
+    );
+    let debug = format!("{function:?}");
+    assert!(!debug.contains("ParsedModule"));
+    assert!(!debug.contains("Ast"));
+}
+
+fn find_syntax_node(
+    node: &SyntaxNodeView,
+    kind: &str,
+    name: Option<&str>,
+    value: Option<&str>,
+) -> bool {
+    (node.kind() == kind && node.name() == name && node.value() == value)
+        || node
+            .children()
+            .any(|child| find_syntax_node(&child, kind, name, value))
+}
+
+fn has_direct_syntax_node(
+    node: &SyntaxNodeView,
+    kind: &str,
+    name: Option<&str>,
+    value: Option<&str>,
+) -> bool {
+    node.children()
+        .any(|child| child.kind() == kind && child.name() == name && child.value() == value)
+}
+
+#[test]
+fn syntax_projection_preserves_modifiers_receivers_and_argument_modes() {
+    let source = r#"
+pub unchecked fn dangerous(inout x: i32, borrow y: i32) -> i32 {
+    let mut z = 0;
+    take(z, inout z, borrow y);
+    z
+}
+fn safe() -> i32 { 0 }
+pub linear struct Box {
+    value: i32,
+    fn by_value(mut self) -> i32 { self.value }
+    fn borrowed(borrow self) -> i32 { self.value }
+    fn exclusive(inout self) -> i32 { self.value }
+    fn associated() -> i32 { 0 }
+}
+pub enum Choice { A, B(i32) }
+pub const ANSWER: i32 = 42;
+drop fn Box(self) {}
+"#;
+    let snapshot = SourceSnapshot::single("main.rue", source).unwrap();
+    let mut session = CompilerSession::new();
+    let syntax = session.update(&snapshot).into_result().unwrap();
+    let roots = syntax.modules().next().unwrap().nodes().collect::<Vec<_>>();
+    let has = |kind, name, value| {
+        roots
+            .iter()
+            .any(|node| find_syntax_node(node, kind, name, value))
+    };
+
+    let root = |name| roots.iter().find(|node| node.name() == Some(name)).unwrap();
+    assert!(has_direct_syntax_node(
+        root("dangerous"),
+        "modifier",
+        Some("visibility"),
+        Some("public")
+    ));
+    assert!(has_direct_syntax_node(
+        root("dangerous"),
+        "modifier",
+        Some("unchecked"),
+        Some("true")
+    ));
+    assert!(has_direct_syntax_node(
+        root("safe"),
+        "modifier",
+        Some("visibility"),
+        Some("private")
+    ));
+    assert!(has_direct_syntax_node(
+        root("safe"),
+        "modifier",
+        Some("unchecked"),
+        Some("false")
+    ));
+    assert!(has_direct_syntax_node(
+        root("Box"),
+        "modifier",
+        Some("visibility"),
+        Some("public")
+    ));
+    assert!(has_direct_syntax_node(
+        root("Box"),
+        "modifier",
+        Some("linear"),
+        Some("true")
+    ));
+    assert!(has_direct_syntax_node(
+        root("Choice"),
+        "modifier",
+        Some("visibility"),
+        Some("public")
+    ));
+    assert!(has_direct_syntax_node(
+        root("ANSWER"),
+        "modifier",
+        Some("visibility"),
+        Some("public")
+    ));
+    assert!(has("modifier", Some("mutable"), Some("true")));
+    assert!(has(
+        "receiver",
+        Some("self"),
+        Some("mode=normal;mutable=true")
+    ));
+    assert!(has(
+        "receiver",
+        Some("self"),
+        Some("mode=borrow;mutable=false")
+    ));
+    assert!(has(
+        "receiver",
+        Some("self"),
+        Some("mode=inout;mutable=false")
+    ));
+    assert!(has(
+        "receiver",
+        Some("self"),
+        Some("mode=normal;mutable=false")
+    ));
+    assert!(has("argument", None, Some("normal")));
+    assert!(has("argument", None, Some("inout")));
+    assert!(has("argument", None, Some("borrow")));
+
+    let associated = roots
+        .iter()
+        .flat_map(SyntaxNodeView::children)
+        .find(|node| node.kind() == "method" && node.name() == Some("associated"))
+        .unwrap();
+    assert!(!associated.children().any(|node| node.kind() == "receiver"));
+}
+
+#[test]
+fn rir_match_operands_are_checked_and_include_pattern_heads() {
+    let source = r#"
+fn inspect(value: i32) -> i32 {
+    match value {
+        pkg.Result(i32, i32).Ok(v) => v,
+        _ => 0,
+    }
+}
+"#;
+    let snapshot = SourceSnapshot::single("main.rue", source).unwrap();
+    let mut session = CompilerSession::new();
+    session.update(&snapshot).into_result().unwrap();
+    let rir = session.rir().unwrap();
+    let matched = rir
+        .instructions()
+        .find(|instruction| instruction.kind() == "match")
+        .unwrap();
+    let operands = matched.operands().collect::<Vec<_>>();
+    let roles = operands
+        .iter()
+        .map(|operand| operand.role())
+        .collect::<Vec<_>>();
+
+    assert_eq!(matched.operand_count(), operands.len());
+    assert!(roles.contains(&"scrutinee"));
+    assert!(roles.contains(&"pattern_module"));
+    assert!(roles.contains(&"pattern_constructor"));
+    assert!(roles.contains(&"arm_body"));
+    for operand in operands {
+        assert!(operand.target_ordinal() < rir.len());
+        assert_eq!(operand.target().ordinal(), operand.target_ordinal());
+    }
+}
+
+#[test]
+fn cfg_blocks_expose_checked_instructions_and_every_successor_edge() {
+    let source = r#"
+fn choose(value: i32) -> i32 {
+    match value {
+        0 => 1,
+        _ => if value > 0 { 2 } else { 3 },
+    }
+}
+fn main() -> i32 { choose(0) }
+"#;
+    let snapshot = SourceSnapshot::single("main.rue", source).unwrap();
+    let mut session = CompilerSession::new();
+    session.update(&snapshot).into_result().unwrap();
+    let semantic = session.semantic(&CompileOptions::default()).unwrap();
+    let cfg = semantic
+        .function_views()
+        .find(|function| function.name() == "choose")
+        .unwrap()
+        .cfg();
+    let blocks = cfg.blocks().collect::<Vec<_>>();
+    let mut edge_count = 0;
+
+    for block in &blocks {
+        assert_eq!(block.instruction_count(), block.instructions().len());
+        for instruction in block.instructions() {
+            assert!(!instruction.kind().is_empty());
+        }
+        assert_eq!(block.successor_count(), block.successors().len());
+        for successor in block.successors() {
+            edge_count += 1;
+            assert!(successor.target_ordinal() < blocks.len());
+            assert_eq!(successor.target().ordinal(), successor.target_ordinal());
+        }
+    }
+    assert!(edge_count >= 2);
+}
+
+#[test]
+fn presentation_file_order_rejects_unknown_duplicate_and_incomplete_inputs() {
+    let snapshot = SourceSnapshot::single("main.rue", "fn main() -> i32 { 0 }").unwrap();
+    let options = CompileOptions::default();
+    let mut session = CompilerSession::new();
+    session.update(&snapshot).into_result().unwrap();
+
+    for (stage, file_order) in [
+        (PresentationStage::Tokens, vec![FileId::new(99)]),
+        (
+            PresentationStage::Tokens,
+            vec![FileId::DEFAULT, FileId::DEFAULT],
+        ),
+        (PresentationStage::Rir, Vec::new()),
+    ] {
+        let errors = session
+            .unstable_present(PresentationRequest {
+                stage,
+                options: &options,
+                file_order: &file_order,
+            })
+            .unwrap_err();
+        assert!(matches!(
+            errors.first().map(|error| &error.kind),
+            Some(ErrorKind::InvalidCompilerInput(_))
+        ));
+    }
 }
 
 #[test]
@@ -51,4 +372,11 @@ fn dependency_baselines_cannot_cross_session_ownership() {
             .is_err()
     );
     assert_eq!(first.unstable_metrics().invalidation_plans(), before);
+}
+
+#[test]
+fn oracle_consumption_accepts_only_the_semantic_views_embedded_rir_owner() {
+    let bridge: fn(Arc<SemanticView>) -> Result<OracleSemanticState, &'static str> =
+        into_oracle_semantic_state;
+    let _ = bridge;
 }

--- a/crates/rue-fuzz/src/targets.rs
+++ b/crates/rue-fuzz/src/targets.rs
@@ -59,7 +59,7 @@ mod ice_classification_tests {
 
 fn query_semantics(
     source: &str,
-) -> rue_compiler::MultiErrorResult<std::sync::Arc<rue_compiler::CanonicalSemanticOutput>> {
+) -> rue_compiler::MultiErrorResult<std::sync::Arc<rue_compiler::SemanticView>> {
     let snapshot = rue_compiler::SourceSnapshot::single("<fuzz>", source)
         .map_err(rue_compiler::CompileErrors::from)?;
     let mut session = rue_compiler::CompilerSession::new();

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -66,8 +66,7 @@ use lasso::ThreadedRodeo;
 use rue_air::{FrozenTypeInternPool, RuntimeCallKind, Type, TypeKind, parse_array_type_syntax};
 use rue_cfg::{Cfg, CfgArgMode, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator};
 use rue_compiler::{
-    CompileErrors, CompileOptions, CompilerSession, FunctionWithCfg, PreviewFeatures,
-    SourceSnapshot,
+    CompileErrors, CompileOptions, CompilerSession, PreviewFeatures, SourceSnapshot,
 };
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -75,9 +74,13 @@ use std::fmt;
 
 struct CompileState {
     interner: ThreadedRodeo,
-    functions: Vec<FunctionWithCfg>,
+    functions: Vec<OracleFunction>,
     type_pool: FrozenTypeInternPool,
     strings: Vec<String>,
+}
+
+struct OracleFunction {
+    cfg: rue_cfg::ValidatedCfg,
 }
 
 fn query_cfg_state(source: &str) -> Result<CompileState, CompileErrors> {
@@ -118,20 +121,19 @@ fn query_cfg_state_from_session(
     mut session: CompilerSession,
     options: &CompileOptions,
 ) -> Result<CompileState, CompileErrors> {
-    let rir = session.rir()?;
     let semantic = session.semantic(options)?;
     drop(session);
-    let rir = std::sync::Arc::try_unwrap(rir)
-        .expect("one-shot oracle session uniquely owns its RIR artifact");
-    let semantic = std::sync::Arc::try_unwrap(semantic)
-        .expect("one-shot oracle session uniquely owns its semantic artifact");
-    let (_, symbols) = rir.into_parts();
-    let (functions, type_pool, strings, _) = semantic.into_parts();
+    let state = rue_compiler::unstable::into_oracle_semantic_state(semantic)
+        .expect("one-shot oracle session uniquely owns its frontend artifacts");
     Ok(CompileState {
-        interner: symbols.into_interner(),
-        functions,
-        type_pool,
-        strings,
+        interner: state.interner,
+        functions: state
+            .functions
+            .into_iter()
+            .map(|function| OracleFunction { cfg: function.cfg })
+            .collect(),
+        type_pool: state.type_pool,
+        strings: state.strings,
     })
 }
 

--- a/crates/rue/src/emit.rs
+++ b/crates/rue/src/emit.rs
@@ -1,19 +1,16 @@
-use std::fmt::Write as _;
-use std::sync::Arc;
-
 #[cfg(test)]
 use rue_compiler::unstable::MetricsSnapshot;
+#[cfg(test)]
+use rue_compiler::unstable::update_for_presentation;
 use rue_compiler::unstable::{
-    ImportDiscoveryRevision, ImportDiscoveryStatus, LowerMetrics, ParseMetrics, SemanticMetrics,
+    ImportDiscoveryRevision, ImportDiscoveryStatus, LowerMetrics, ParseMetrics,
+    PresentationRequest, PresentationStage, SemanticMetrics, semantic_metrics,
 };
 use rue_compiler::{
-    Ast, CanonicalRirOutput, CanonicalSemanticOutput, CompileError, CompileErrors, CompileOptions,
-    CompileWarning, CompilerSession, DependencyEnvelope, DependencyEnvelopeStatus, ErrorKind,
-    FrozenTypeInternPool, Lexer, SourceSnapshot, Token, generate_emitted_asm,
-    generate_liveness_info, generate_lowering_info, generate_mir, generate_regalloc_info,
-    generate_stack_frame_info, parse_source_snapshot_for_ast_presentation,
+    CompileError, CompileErrors, CompileOptions, CompileWarning, CompilerSession,
+    DependencyEnvelope, DependencyEnvelopeStatus, ErrorKind, RirView, SemanticView, SourceSnapshot,
+    SyntaxView,
 };
-use rue_rir::RirPrinter;
 use tracing::info_span;
 
 use crate::DiagnosticOutput;
@@ -48,9 +45,9 @@ pub(crate) enum EmitStage {
 }
 
 pub(crate) struct EmitFrontend {
-    parsed: Arc<rue_compiler::ParsedProgram>,
-    rir: Arc<CanonicalRirOutput>,
-    semantic: Arc<CanonicalSemanticOutput>,
+    parsed: SyntaxView,
+    _rir: std::sync::Arc<RirView>,
+    semantic: std::sync::Arc<SemanticView>,
     pub(crate) work: EmitWork,
     #[cfg(test)]
     pub(crate) session_work: MetricsSnapshot,
@@ -97,7 +94,7 @@ pub(crate) fn build_emit_frontend_in_session(
     session: &mut CompilerSession,
     options: CompileOptions,
 ) -> Result<EmitFrontend, CompileErrors> {
-    let parsed = session.published().cloned().ok_or_else(|| {
+    let parsed = session.published().ok_or_else(|| {
         CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
             "emit requires a published closed discovery revision".into(),
         )))
@@ -110,12 +107,12 @@ pub(crate) fn build_emit_frontend_in_session(
     let session_work = session.unstable_metrics();
     Ok(EmitFrontend {
         parsed,
-        rir,
+        _rir: rir,
         semantic: semantic.clone(),
         work: EmitWork {
             parsed: session_work.parse_metrics(),
             lowered: session_work.lower_metrics(),
-            semantic: semantic.unstable_metrics(),
+            semantic: semantic_metrics(&semantic),
         },
         #[cfg(test)]
         session_work,
@@ -128,33 +125,11 @@ pub(crate) fn build_emit_frontend(
     options: CompileOptions,
 ) -> Result<EmitFrontend, CompileErrors> {
     let mut session = CompilerSession::new();
-    session
-        .update_for_presentation(source_snapshot)
-        .into_result()?;
+    update_for_presentation(&mut session, source_snapshot).into_result()?;
     build_emit_frontend_in_session(&mut session, options)
 }
 
 impl EmitFrontend {
-    fn rir(&self) -> &rue_compiler::Rir {
-        self.rir.rir()
-    }
-
-    fn interner(&self) -> &rue_compiler::ThreadedRodeo {
-        self.rir.semantic_symbols().interner()
-    }
-
-    fn functions(&self) -> &[rue_compiler::FunctionWithCfg] {
-        self.semantic.functions()
-    }
-
-    fn type_pool(&self) -> &FrozenTypeInternPool {
-        self.semantic.type_pool()
-    }
-
-    fn strings(&self) -> &[String] {
-        self.semantic.strings()
-    }
-
     fn warnings(&self) -> &[CompileWarning] {
         self.semantic.warnings()
     }
@@ -253,55 +228,7 @@ pub(crate) fn execute(request: EmitRequest<'_, '_>) -> Result<(), ()> {
         diagnostics.print_errors(discovery_revision.diagnostics());
         return Err(());
     }
-    // Determine which stages we need
-    let needs_tokens = stages.contains(&EmitStage::Tokens);
-    let needs_ast = stages.contains(&EmitStage::Ast);
-
-    // For tokens, we need to lex each file separately (before parsing merges interners)
-    // We'll collect per-file tokens if needed
-    let per_file_tokens: Option<Vec<(String, Vec<Token>)>> = if needs_tokens {
-        let mut file_tokens = Vec::with_capacity(source_snapshot.len());
-        for source in source_snapshot.files() {
-            // Lex with the file's real FileId so a lex error in the Nth file
-            // is attributed to that file, not to the first one (RUE-38).
-            let lexer = Lexer::with_file_id(source.source, source.file_id);
-            match lexer.tokenize_preserving_interner() {
-                Ok((tokens, _interner)) => {
-                    file_tokens.push((source.path.to_string(), tokens));
-                }
-                Err((errors, _interner)) => {
-                    diagnostics.print_errors(&errors);
-                    return Err(());
-                }
-            }
-        }
-        Some(file_tokens)
-    } else {
-        None
-    };
-
     let frontend_route = emit_frontend_route(stages);
-    // AST-only preserves its syntax-only behavior (duplicates are printable).
-    // Combined AST+later canonical modes reuse the unit's once-only projection.
-    let mut per_file_asts: Option<Vec<(String, std::sync::Arc<Ast>)>> =
-        if frontend_route == EmitFrontendRoute::AstOnlySyntax {
-            match parse_source_snapshot_for_ast_presentation(source_snapshot) {
-                Ok(presentation) => {
-                    debug_assert_eq!(
-                        presentation.work().parsed.syntax.parser_invocations,
-                        source_snapshot.len()
-                    );
-                    Some(presentation.files().to_vec())
-                }
-                Err(errors) => {
-                    diagnostics.print_errors(&errors);
-                    return Err(());
-                }
-            }
-        } else {
-            None
-        };
-
     let frontend_state = if frontend_route == EmitFrontendRoute::SessionQuery {
         let frontend = match build_emit_frontend_in_session(session, compile_options.clone()) {
             Ok(frontend) => frontend,
@@ -310,22 +237,6 @@ pub(crate) fn execute(request: EmitRequest<'_, '_>) -> Result<(), ()> {
                 return Err(());
             }
         };
-        if needs_ast {
-            per_file_asts = Some(
-                source_snapshot
-                    .files()
-                    .map(|source| {
-                        let module = frontend
-                            .parsed
-                            .modules()
-                            .iter()
-                            .find(|module| module.file_id() == source.file_id)
-                            .expect("frontend parsed every snapshot source");
-                        (source.path.to_string(), module.shared_ast())
-                    })
-                    .collect(),
-            );
-        }
         Some(frontend)
     } else {
         None
@@ -341,224 +252,98 @@ pub(crate) fn execute(request: EmitRequest<'_, '_>) -> Result<(), ()> {
         debug_assert_eq!(work.semantic.manifest.build_invocations, 1);
     }
 
-    // Now emit in order
+    let file_order = source_snapshot
+        .files()
+        .map(|source| source.file_id)
+        .collect::<Vec<_>>();
+
     for stage in stages {
+        let unstable_stage = match stage {
+            EmitStage::Tokens => PresentationStage::Tokens,
+            EmitStage::Ast => PresentationStage::Ast,
+            EmitStage::Rir => PresentationStage::Rir,
+            EmitStage::Air => PresentationStage::Air,
+            EmitStage::Cfg => PresentationStage::Cfg,
+            EmitStage::Lowering => PresentationStage::Lowering,
+            EmitStage::Mir => PresentationStage::Mir,
+            EmitStage::Liveness => PresentationStage::Liveness,
+            EmitStage::RegAlloc => PresentationStage::RegAlloc,
+            EmitStage::Asm => PresentationStage::Asm,
+            EmitStage::StackFrame => PresentationStage::StackFrame,
+            EmitStage::Deps => continue,
+        };
+        if matches!(stage, EmitStage::Tokens | EmitStage::Ast) {
+            for source in source_snapshot.files() {
+                match stage {
+                    EmitStage::Tokens => println!("=== Tokens ({}) ===", source.path),
+                    EmitStage::Ast => println!("=== AST ({}) ===", source.path),
+                    _ => unreachable!(),
+                }
+                let output = match session.unstable_present(PresentationRequest {
+                    stage: unstable_stage,
+                    options: &compile_options,
+                    file_order: &[source.file_id],
+                }) {
+                    Ok(output) => output,
+                    Err(errors) => {
+                        diagnostics.print_errors(&errors);
+                        return Err(());
+                    }
+                };
+                print!("{}", output.as_str());
+                println!();
+            }
+            continue;
+        }
+        let output = match session.unstable_present(PresentationRequest {
+            stage: unstable_stage,
+            options: &compile_options,
+            file_order: &file_order,
+        }) {
+            Ok(output) => output,
+            Err(errors) => {
+                diagnostics.print_errors(&errors);
+                return Err(());
+            }
+        };
         match stage {
-            EmitStage::Tokens => {
-                if let Some(ref file_tokens) = per_file_tokens {
-                    for (path, tokens) in file_tokens {
-                        println!("=== Tokens ({}) ===", path);
-                        for token in tokens {
-                            println!("{}", token);
-                        }
-                        println!();
-                    }
-                }
-            }
-            EmitStage::Ast => {
-                if let Some(ref asts) = per_file_asts {
-                    for (path, ast) in asts {
-                        println!("=== AST ({}) ===", path);
-                        print!("{}", ast);
-                        println!();
-                    }
-                }
-            }
+            EmitStage::Tokens | EmitStage::Ast => unreachable!(),
             EmitStage::Rir => {
                 println!("=== RIR ===");
-                if let Some(ref state) = frontend_state {
-                    let order = state
-                        .rir
-                        .presentation_order(source_snapshot.files().map(|source| source.file_id));
-                    let printer = RirPrinter::with_presentation_order(
-                        state.rir(),
-                        state.interner(),
-                        order.instructions,
-                        order.extra,
-                    );
-                    println!("{}", printer);
-                }
+                println!("{}", output.as_str());
                 println!();
             }
             EmitStage::Air => {
                 println!("=== AIR ===");
-                if let Some(ref state) = frontend_state {
-                    for func in state.functions() {
-                        println!("function {}:", func.analyzed.name);
-                        println!(
-                            "{}",
-                            func.analyzed.air.display_with_interner(state.interner())
-                        );
-                    }
-                }
+                print!("{}", output.as_str());
                 println!();
             }
             EmitStage::Cfg => {
                 println!("=== CFG ===");
-                if let Some(ref state) = frontend_state {
-                    for func in state.functions() {
-                        println!("{}", func.cfg.display_with_interner(state.interner()));
-                    }
-                }
+                print!("{}", output.as_str());
                 println!();
             }
             EmitStage::Lowering => {
-                let mut output = String::new();
-                if let Some(ref state) = frontend_state {
-                    for func in state.functions() {
-                        let lowering_info = match generate_lowering_info(
-                            &func.cfg,
-                            state.type_pool(),
-                            state.interner(),
-                            compile_options.target,
-                        ) {
-                            Ok(info) => info,
-                            Err(e) => {
-                                diagnostics.print_error(&e);
-                                return Err(());
-                            }
-                        };
-                        write!(&mut output, "{}", lowering_info).expect("write to String");
-                    }
-                }
-                output.push('\n');
-                print!("{}", output);
+                println!("{}", output.as_str());
             }
             EmitStage::Mir => {
-                let mut output = String::new();
-                writeln!(&mut output, "=== MIR ({}) ===", compile_options.target)
-                    .expect("write to String");
-                if let Some(ref state) = frontend_state {
-                    for func in state.functions() {
-                        let mir = match generate_mir(
-                            &func.cfg,
-                            state.type_pool(),
-                            state.interner(),
-                            compile_options.target,
-                        ) {
-                            Ok(mir) => mir,
-                            Err(e) => {
-                                diagnostics.print_error(&e);
-                                return Err(());
-                            }
-                        };
-                        writeln!(&mut output, "function {}:", func.analyzed.name)
-                            .expect("write to String");
-                        writeln!(&mut output, "{}", mir).expect("write to String");
-                    }
-                }
-                output.push('\n');
-                print!("{}", output);
+                println!("=== MIR ({}) ===", compile_options.target);
+                println!("{}", output.as_str());
             }
             EmitStage::Liveness => {
-                let mut output = String::new();
-                writeln!(
-                    &mut output,
-                    "=== Liveness Analysis ({}) ===",
-                    compile_options.target
-                )
-                .expect("write to String");
-                if let Some(ref state) = frontend_state {
-                    for func in state.functions() {
-                        let liveness_info = match generate_liveness_info(
-                            &func.cfg,
-                            state.type_pool(),
-                            state.interner(),
-                            compile_options.target,
-                        ) {
-                            Ok(info) => info,
-                            Err(e) => {
-                                diagnostics.print_error(&e);
-                                return Err(());
-                            }
-                        };
-                        writeln!(&mut output, "function {}:", func.analyzed.name)
-                            .expect("write to String");
-                        writeln!(&mut output, "{}", liveness_info).expect("write to String");
-                    }
-                }
-                output.push('\n');
-                print!("{}", output);
+                println!("=== Liveness Analysis ({}) ===", compile_options.target);
+                println!("{}", output.as_str());
             }
             EmitStage::RegAlloc => {
-                let mut output = String::new();
-                writeln!(
-                    &mut output,
-                    "=== Register Allocation ({}) ===",
-                    compile_options.target
-                )
-                .expect("write to String");
-                if let Some(ref state) = frontend_state {
-                    for func in state.functions() {
-                        let regalloc_info = match generate_regalloc_info(
-                            &func.cfg,
-                            state.type_pool(),
-                            state.interner(),
-                            compile_options.target,
-                        ) {
-                            Ok(info) => info,
-                            Err(e) => {
-                                diagnostics.print_error(&e);
-                                return Err(());
-                            }
-                        };
-                        writeln!(&mut output, "function {}:", func.analyzed.name)
-                            .expect("write to String");
-                        write!(&mut output, "{}", regalloc_info).expect("write to String");
-                    }
-                }
-                output.push('\n');
-                print!("{}", output);
+                println!("=== Register Allocation ({}) ===", compile_options.target);
+                println!("{}", output.as_str());
             }
             EmitStage::Asm => {
-                let mut output = String::new();
-                writeln!(&mut output, "=== Assembly ({}) ===", compile_options.target)
-                    .expect("write to String");
-                if let Some(ref state) = frontend_state {
-                    for func in state.functions() {
-                        let asm = match generate_emitted_asm(
-                            &func.cfg,
-                            state.type_pool(),
-                            state.strings(),
-                            state.interner(),
-                            compile_options.target,
-                        ) {
-                            Ok(asm) => asm,
-                            Err(e) => {
-                                diagnostics.print_error(&e);
-                                return Err(());
-                            }
-                        };
-                        writeln!(&mut output, ".globl {}", func.analyzed.name)
-                            .expect("write to String");
-                        writeln!(&mut output, "{}:", func.analyzed.name).expect("write to String");
-                        write!(&mut output, "{}", asm).expect("write to String");
-                    }
-                }
-                output.push('\n');
-                print!("{}", output);
+                println!("=== Assembly ({}) ===", compile_options.target);
+                println!("{}", output.as_str());
             }
             EmitStage::StackFrame => {
-                let mut output = String::new();
-                if let Some(ref state) = frontend_state {
-                    for func in state.functions() {
-                        let frame_info = match generate_stack_frame_info(
-                            &func.cfg,
-                            &func.analyzed.name,
-                            state.type_pool(),
-                            state.interner(),
-                            compile_options.target,
-                        ) {
-                            Ok(info) => info,
-                            Err(e) => {
-                                diagnostics.print_error(&e);
-                                return Err(());
-                            }
-                        };
-                        writeln!(&mut output, "{}", frame_info).expect("write to String");
-                    }
-                }
-                print!("{}", output);
+                print!("{}", output.as_str());
             }
             // Dependency presentation returns before frontend planning above.
             EmitStage::Deps => {}

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -19,9 +19,9 @@ mod timing;
 use emit::EmitStage;
 #[cfg(test)]
 use emit::{EmitFrontendRoute, build_emit_frontend, emit_frontend_route};
-#[cfg(test)]
-use rue_compiler::parse_source_snapshot_for_ast_presentation;
 use rue_compiler::unstable::ImportDiscoveryStatus;
+#[cfg(test)]
+use rue_compiler::unstable::update_for_presentation;
 use source_loader::{SourceLoadError, SourceLoadRequest};
 #[cfg(test)]
 use source_loader::{
@@ -35,7 +35,7 @@ use rue_compiler::{
     SourceInfo, configure_thread_pool,
 };
 #[cfg(test)]
-use rue_compiler::{SourceMetadata, SourceSnapshot};
+use rue_compiler::{CompilerSession, SourceMetadata, SourceSnapshot};
 use rue_target::Target;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum LogLevel {
@@ -1687,21 +1687,32 @@ mod tests {
         assert_eq!(session_work.rir().executions, 1);
         assert_eq!(session_work.semantic().executions, 1);
 
-        let presentation = parse_source_snapshot_for_ast_presentation(&snapshot).unwrap();
+        let mut presentation_session = CompilerSession::new();
+        let presentation = update_for_presentation(&mut presentation_session, &snapshot);
+        let ast_work = presentation.unstable_metrics();
+        presentation.into_result().unwrap();
+        let syntax = presentation_session.published().unwrap();
         assert_eq!(
-            presentation
+            snapshot
                 .files()
-                .iter()
-                .map(|(path, ast)| (path.as_str(), ast.items.len()))
+                .map(|source| {
+                    let module = syntax
+                        .modules()
+                        .find(|module| module.file_id() == source.file_id)
+                        .unwrap();
+                    (module.path().to_owned(), module.item_count())
+                })
                 .collect::<Vec<_>>(),
-            [("/checkout/main.rue", 1), ("/checkout/helper.rue", 1)]
+            [
+                ("/checkout/main.rue".to_owned(), 1),
+                ("/checkout/helper.rue".to_owned(), 1)
+            ]
         );
-        let ast_work = presentation.work();
-        assert_eq!(ast_work.parsed.syntax.parser_invocations, 2);
-        assert_eq!(ast_work.merge_invocations, 0);
-        assert_eq!(ast_work.astgen_invocations, 0);
-        assert_eq!(ast_work.bind_invocations, 0);
-        assert_eq!(ast_work.manifest_invocations, 0);
+        assert_eq!(ast_work.parser_invocations, 2);
+        let presentation_work = presentation_session.unstable_metrics();
+        assert_eq!(presentation_work.merge().executions, 0);
+        assert_eq!(presentation_work.rir().executions, 0);
+        assert_eq!(presentation_work.semantic().executions, 0);
     }
 
     #[test]
@@ -1742,10 +1753,21 @@ mod tests {
     fn ast_presentation_prints_duplicates_without_merging() {
         let snapshot =
             SourceSnapshot::single("main.rue", "fn duplicate() {} fn duplicate() {}").unwrap();
-        let presentation = parse_source_snapshot_for_ast_presentation(&snapshot).unwrap();
-
-        assert_eq!(presentation.files()[0].1.items.len(), 2);
-        assert_eq!(presentation.work().merge_invocations, 0);
+        let mut session = CompilerSession::new();
+        update_for_presentation(&mut session, &snapshot)
+            .into_result()
+            .unwrap();
+        assert_eq!(
+            session
+                .published()
+                .unwrap()
+                .modules()
+                .next()
+                .unwrap()
+                .item_count(),
+            2
+        );
+        assert_eq!(session.unstable_metrics().merge().executions, 0);
     }
 
     #[test]

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -705,9 +705,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use rue_compiler::{
-        CompileOptions, CompilerSession, SourceSnapshot, parse_source_snapshot_for_ast_presentation,
-    };
+    use rue_compiler::unstable::update_for_presentation;
+    use rue_compiler::{CompileOptions, CompilerSession, SourceSnapshot};
     use tracing_subscriber::layer::SubscriberExt as _;
 
     use super::*;
@@ -736,14 +735,13 @@ mod tests {
         let direct_subscriber =
             tracing_subscriber::registry().with(TimingLayer::new(direct_data.clone()));
         tracing::subscriber::with_default(direct_subscriber, || {
-            parse_source_snapshot_for_ast_presentation(&snapshot).unwrap();
+            let mut session = CompilerSession::new();
+            update_for_presentation(&mut session, &snapshot)
+                .into_result()
+                .unwrap();
         });
 
         let direct_edges = direct_data.parent_edges();
-        assert!(
-            direct_edges.contains(&("parse".to_owned(), "parse_file".to_owned())),
-            "direct parse edges: {direct_edges:?}"
-        );
         assert!(
             direct_edges.contains(&("parse_file".to_owned(), "lexer".to_owned())),
             "direct parse edges: {direct_edges:?}"
@@ -769,7 +767,7 @@ mod tests {
         let direct_parse = direct_timing
             .passes
             .iter()
-            .find(|pass| pass.name == "parse")
+            .find(|pass| pass.name == "parse_file")
             .unwrap();
         assert_eq!(direct_parse.invocations, 1);
         assert_eq!(direct_parse.root_invocations, 1);
@@ -901,7 +899,10 @@ mod tests {
             let data = TimingData::new();
             let subscriber = tracing_subscriber::registry().with(TimingLayer::new(data.clone()));
             tracing::subscriber::with_default(subscriber, || {
-                parse_source_snapshot_for_ast_presentation(&snapshot).unwrap_err();
+                let mut session = CompilerSession::new();
+                update_for_presentation(&mut session, &snapshot)
+                    .into_result()
+                    .unwrap_err();
             });
             data.parent_edges()
         };

--- a/scripts/validate-type-architecture.py
+++ b/scripts/validate-type-architecture.py
@@ -95,6 +95,7 @@ PUBLIC_TYPE_DECLARATION_ALLOWLIST = {
     ("rue-air", "sema/output.rs", "BuiltinTypeCallHead"): "dependency metadata",
     ("rue-air", "sema/output.rs", "DeclarationBuiltinTypeCallHeadDependencyEvent"): "dependency metadata",
     ("rue-compiler", "bound_definitions.rs", "StableNamedTypeKey"): "stable definition lookup key",
+    ("rue-compiler", "artifact_views.rs", "TypeView"): "owner-bound stable compiler facade view",
     ("rue-compiler", "durable_semantics.rs", "DurableType"): "cross-epoch durable type schema",
     ("rue-compiler", "source_identity.rs", "ModuleId"): "stable logical source-module identity",
     ("rue-compiler", "session.rs", "StableDeclarationTypeDependency"): "stable dependency metadata",


### PR DESCRIPTION
## Summary

- replace phase-owned compiler outputs at the stable facade with owner-bound syntax, RIR, semantic, CFG, type, source, and function views
- route CLI presentation and oracle consumers through canonical `CompilerSession` artifacts while keeping raw phase access explicitly unstable
- enforce the curated facade with ownership, traversal, cross-session, and repository-inventory tests

## Why

Milestone 10 requires one canonical compiler query graph with a narrow public boundary. This removes raw lexer/parser/RIR/AIR/CFG ownership from stable consumers and prevents alternate frontend and mismatched-artifact paths.

## Validation

- `scripts/rue fmt`
- `scripts/rue quick`
- `scripts/rue test` (all compiler and heavy corpora green; the newly required type-architecture inventory entry was then added and its validator rerun successfully)
- `./buck2 test //crates/rue-compiler/...`
- `scripts/rue cli emit_pipeline`
- `./buck2 test //crates/rue-compiler-session-bench/...`
- `./buck2 test //:type-architecture-inventory-validation //:type-architecture-inventory-tool-tests`
- `scripts/rue build`

Fixes RUE-868
