### PR TITLE
RUE-662: link ADR-0062 phases to their tracking issues

### DIFF
--- a/docs/designs/0062-place-returning-borrow-accessors.md
+++ b/docs/designs/0062-place-returning-borrow-accessors.md
@@ -254,16 +254,19 @@ sugar can still be layered on top later without disturbing this choice.)
 
 ## Implementation Phases
 
+Tracked in Linear under the RUE-1015 epic:
+
 - [ ] **Phase 0: Ratify syntax; spec + grammar + preview gate scaffolding** — RUE-662
 - [ ] **Phase 1: Read accessors** (`borrow self` → shared result; parser,
       sema/AIR loan checking, mandatory inlining, formal-core amendment,
       spec coverage) — RUE-662
 - [ ] **Phase 2: Mutable accessors** (`inout self` → exclusive result;
-      assignment through the result) — new issue at phase 1 exit
+      assignment through the result) — RUE-1016 (blocked by RUE-662)
 - [ ] **Phase 3: std adoption** (`ArrayBuf.get_ref` + E0711 diagnostic
       pointing at it; grid/deque/intmap accessors; owned-children tree
-      example replacing an arena) — new issue at phase 1 exit
-- [ ] **Phase 4: preview-gate removal** after dogfooding — new issue
+      example replacing an arena) — RUE-1017 (blocked by RUE-662)
+- [ ] **Phase 4: preview-gate removal** after dogfooding — RUE-1018
+      (blocked by RUE-1016 and RUE-1017)
 
 Each phase follows the `docs/designs/0005-preview-features.md` layer
 checklist under the single `borrow-accessors` flag.


### PR DESCRIPTION
Follow-up to #1818: the ADR's phase list said "new issue at phase 1 exit" for phases 2–4, which invites duplicate filing now that the rollout is fully tracked in Linear. Names the real issues — the RUE-1015 epic with RUE-662 (phases 0–1), RUE-1016 (mutable accessors), RUE-1017 (std adoption), RUE-1018 (preview-gate removal) — with their blocking relations, so the ADR and the tracker agree on where the work lives.

Docs-only; ADR registry validated (63 records).

---
_Generated by [Claude Code](https://claude.ai/code/session_012sry9TQ8S8i6ESkzN3myZz)_