### PR TITLE
RUE-1014: variant-dependent enum images and compact arrays (ADR-0052 phase 5.10)

### DIFF
--- a/crates/rue-cli-tests/cases/aggregate_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout.toml
@@ -324,21 +324,26 @@ exit_code = 0
 # RUE-987 image path admits a struct only when every leaf flattens to a scalar
 # position (no array, no imageless enum).
 [[case]]
-name = "array_bearing_struct_through_pointer_still_fails"
-description = "A struct containing a fixed array has no compact image and is still refused through a pointer, not miscompiled."
+name = "array_bearing_struct_through_pointer_roundtrip"
+description = "A struct containing a fixed array marshals whole through a pointer: the array field flattens into the compact image at the compact element stride (RUE-1014)."
+differential_opt = true
 args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct HasArr { xs: [i32; 2] }
 fn main() -> i32 {
-    checked {
+    let r = checked {
         let p: ptr mut HasArr = @alloc(1);
-        @ptr_write(p, HasArr { xs: [1, 2] });
+        @ptr_write(p, HasArr { xs: [10, 20] });
+        let v = @ptr_read(p);
+        @free(p, 1);
+        v.xs[0] + v.xs[1]
     };
+    @dbg(r);
     0
 }
 """ }]
-compile_fail = true
-error_contains = ["aggregate_layout", "not yet implemented"]
+stdout = "30\n"
+exit_code = 0
 
 # ADR-0052 phase 5.6 (RUE-1000): compact enum memory. A compact enum has a
 # smallest-sufficient unsigned tag at offset 0 and its payload placed at the
@@ -554,22 +559,31 @@ error_contains = ["aggregate_layout", "not yet implemented"]
 # RUE-1000 keeps refusing a nested-aggregate enum payload through a pointer:
 # a struct payload has no single-slot scalar memory image in this phase.
 [[case]]
-name = "compact_enum_struct_payload_still_fails"
-description = "An enum with a struct payload marshalled through a pointer is still refused under --preview aggregate_layout."
+name = "compact_enum_struct_payload_roundtrip"
+description = "An enum with a struct payload marshals whole through a pointer: the struct payload flattens to a variant-independent image (RUE-1014)."
+differential_opt = true
 args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Res { id: i32 }
 enum Holder { Full(Res), Nothing }
 fn main() -> i32 {
-    checked {
+    let r = checked {
         let p: ptr mut Holder = @alloc(1);
         @ptr_write(p, Holder.Full(Res { id: 7 }));
+        let a = @ptr_read(p);
+        @ptr_write(p, Holder.Nothing);
+        let b = @ptr_read(p);
+        @free(p, 1);
+        let av: i32 = match a { Holder.Full(res) => res.id, Holder.Nothing => 0 - 1 };
+        let bv: i32 = match b { Holder.Full(res) => res.id, Holder.Nothing => 0 - 1 };
+        av * 10 + bv
     };
+    @dbg(r);
     0
 }
 """ }]
-compile_fail = true
-error_contains = ["aggregate_layout", "not yet implemented"]
+stdout = "69\n"
+exit_code = 0
 
 # An IMAGELESS compact enum crossing a CALL boundary by value stays refused
 # (RUE-1005): overlapping union payload slots (`A(i64)` versus `B(i32, i32)`)
@@ -819,18 +833,20 @@ exit_code = 0
 # from the slot stride, so it has no variant-independent compact image and call
 # marshalling for it is not implemented.
 [[case]]
-name = "compact_array_by_value_arg_still_fails"
-description = "A by-value fixed array crossing a call is still refused under --preview aggregate_layout (no variant-independent compact image)."
+name = "compact_array_by_value_arg_roundtrip"
+description = "A by-value fixed array crossing a call marshals through its compact image (compact element stride) and is indexed in the callee at the slot stride (RUE-1014)."
+differential_opt = true
 args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn sum(a: [i32; 3]) -> i32 { a[0] + a[1] + a[2] }
 fn main() -> i32 {
-    let xs = [1, 2, 3];
-    sum(xs)
+    let xs = [10, 20, 30];
+    @dbg(sum(xs));
+    0
 }
 """ }]
-compile_fail = true
-error_contains = ["aggregate_layout", "not yet implemented"]
+stdout = "60\n"
+exit_code = 0
 
 # RUE-1004 prize: a std-like generic `ArrayBuf(i32)` compiles and runs under
 # --preview aggregate_layout. `ArrayBuf(T)` is `{ buf: ptr mut T, len: u64,
@@ -1048,4 +1064,60 @@ pub fn ArrayBuf(comptime T: type) -> type {
 """ },
 ]
 stdout = "3\n3\n4\n90\n91\n5\n6\n2\n"
+exit_code = 0
+
+# ===========================================================================
+# RUE-1014: variant-dependent enum images. An enum whose payload is an
+# aggregate (Option(Point)) has no single scalar-union image in RUE-1000's
+# sense, but its per-variant payloads flatten to leaves that overlay one
+# variant-independent image, so it marshals through every boundary. Here the
+# enum crosses the sret return boundary (make -> Opt) and is matched.
+# ===========================================================================
+[[case]]
+name = "variant_dependent_enum_struct_payload_sret"
+description = "An Option(struct) enum returned by value marshals through the compact sret image and matches on both variants (RUE-1014)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+enum Opt { Some(Point), None }
+fn make(v: bool) -> Opt { if v { Opt.Some(Point { x: 40, y: 2 }) } else { Opt.None } }
+fn main() -> i32 {
+    match make(true) { Opt.Some(p) => @dbg(p.x + p.y), Opt.None => @dbg(0 - 1) };
+    match make(false) { Opt.Some(p) => @dbg(p.x + p.y), Opt.None => @dbg(0 - 1) };
+    0
+}
+""" }]
+stdout = "42\n-1\n"
+exit_code = 0
+
+# RUE-1014 / RUE-1007: a shorter variant's construction zeroes the payload
+# slots it does not write, so a variant-independent image marshalled to memory
+# carries no residue from a wider variant. Write the wide variant `Big(-1, -1)`
+# to a heap enum, overwrite it with the narrow `Small(7)`, read the second
+# payload word back via a byte pointer: it must be 0, not the wide variant's
+# residue. With the construction zeroing disabled this reads back 0xFF... .
+[[case]]
+name = "compact_enum_variant_overwrite_leaves_no_residue"
+description = "Overwriting a heap enum with a shorter variant leaves no residue from the wider variant's payload (RUE-1014 / RUE-1007 ruling 5)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "--preview", "raw_bytes", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum E { Big(i64, i64), Small(u8) }
+fn main() -> i32 {
+    let hi = checked {
+        let p: ptr mut E = @alloc(1);
+        @ptr_write(p, E.Big(0 - 1, 0 - 1));
+        @ptr_write(p, E.Small(7));
+        let bytes: ptr mut u8 = @int_to_ptr(@ptr_to_int(p));
+        let b: u8 = @ptr_read(@ptr_offset(bytes, 16));
+        @free(p, 1);
+        let z: i32 = @intCast(b);
+        z
+    };
+    @dbg(hi);
+    0
+}
+""" }]
+stdout = "0\n"
 exit_code = 0

--- a/crates/rue-cli-tests/cases/aggregate_layout_std_sweep.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout_std_sweep.toml
@@ -1,24 +1,27 @@
-# std-under-aggregate_layout sweep (ADR-0052, RUE-987).
+# std-under-aggregate_layout sweep (ADR-0052, RUE-987 / RUE-1014).
 #
 # The compact physical layout (`--preview aggregate_layout`) is only useful if the
 # standard library's data-structure PATTERNS compile and run correctly under it.
-# This suite is the permanent CI home for that sweep: each case is a self-contained
-# program that exercises a real std shape — heap-backed containers, byte buffers,
-# nested records, and struct elements — through the compact-layout machinery
-# (narrow scalar access RUE-989, compact enum memory RUE-1000, call-boundary
-# marshalling RUE-1004/1005, zero-padding RUE-1007, and whole compact-struct
-# marshalling through typed pointers RUE-987). Every `stdout`/`exit_code` here is
-# the gate-OFF oracle: the compact-layout run must be byte-identical, so a
-# miscompile changes the pinned output and fails. `differential_opt` additionally
-# pins identical behavior across every optimization level.
+# This suite is the permanent CI home for that sweep: each case exercises a real
+# std shape — heap-backed containers, byte buffers, nested records, struct
+# elements, and now variant-dependent enum images and compact arrays — through the
+# compact-layout machinery (narrow scalar access RUE-989, compact enum memory
+# RUE-1000, call-boundary marshalling RUE-1004/1005, zero-padding RUE-1007, whole
+# compact-struct marshalling through typed pointers RUE-987, and variant-dependent
+# enum images plus compact arrays through pointers and across calls RUE-1014).
+# Every `stdout`/`exit_code` here is the gate-OFF oracle: the compact-layout run
+# must be byte-identical, so a miscompile changes the pinned output and fails.
+# `differential_opt` additionally pins identical behavior across every
+# optimization level.
 #
-# Programs are self-contained rather than `@import("std")` because importing the
-# real std root eagerly code-generates every module including `std.json`, whose
-# `Json` enum has variant-dependent aggregate payloads (an imageless enum) that
-# marshalling through a pointer does not yet support — so a full-std import is
-# still refused under the gate (see the refusal sentinels at the end and
-# rue-sweep.meta). These programs mirror the std container/string patterns exactly
-# while staying within what the gate supports today.
+# Most programs are self-contained mirrors of the std container/string/record
+# patterns; the RUE-1014 additions at the end drive the REAL std via
+# `@import("std")` (RUE_STD_PATH), because a full-std import — including
+# `std.json`, whose `Json` enum has variant-dependent aggregate payloads — now
+# COMPILES under the gate: the `Json` payloads overlay a single variant-
+# independent scalar image, so the imageless-enum blocker RUE-987 recorded is
+# cleared. An enum whose per-variant payloads genuinely overlap or disagree on
+# leaf offset has no such image and stays loudly refused (see the sentinel).
 
 [section]
 id = "cli.aggregate_layout_std_sweep"
@@ -195,19 +198,22 @@ stdout = "3\n4\n90\n91\n5\n6\n"
 exit_code = 0
 
 # ---------------------------------------------------------------------------
-# Refusal sentinels: constructs still staged for a follow-up must fail LOUDLY
-# (a clear diagnostic), never miscompile. If a future change lifts one of these,
-# the sentinel flips to a hard failure and forces a deliberate update here.
+# RUE-1014: variant-dependent enum images and compact arrays. The two shapes the
+# earlier rungs left refused now execute — an enum with a struct payload
+# (Option(struct)) whose per-variant payloads overlay one variant-independent
+# scalar image, and a fixed array crossing a call by value (marshalled at the
+# compact element stride). Both are pinned to the gate-OFF oracle.
 # ---------------------------------------------------------------------------
 
-# An enum with a struct (aggregate) payload has no variant-independent memory
-# image — the payload's leaves are not a scalar union that agrees across variants —
-# so returning Option(struct) by value across a call is still refused. This is the
-# `ArrayBuf(struct).get -> Option(T)` shape; use a by-value `get -> T` /
-# `pop_or -> T` accessor (see arraybuf_compact_struct_element) under the gate.
+# An enum with a struct (aggregate) payload now has a variant-independent memory
+# image: the payload's leaves flatten to a scalar union that agrees across
+# variants, so returning Option(struct) by value across a call marshals through
+# the compact sret image (RUE-1014). This is the `ArrayBuf(struct).get -> Option(T)`
+# shape, now supported under the gate.
 [[case]]
-name = "option_struct_return_still_refuses"
-description = "Returning an enum with a struct payload (Option(struct)) by value is still refused under the gate, not miscompiled (imageless enum)."
+name = "option_struct_return_roundtrip"
+description = "Returning an enum with a struct payload (Option(struct)) by value round-trips under the gate: the struct payload flattens to a variant-independent image (RUE-1014)."
+differential_opt = true
 args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct P { x: i32, y: i32 }
@@ -215,18 +221,22 @@ enum Opt { Some(P), None }
 fn make(v: bool) -> Opt { if v { Opt.Some(P { x: 1, y: 2 }) } else { Opt.None } }
 fn main() -> i32 {
     match make(true) { Opt.Some(p) => @dbg(p.x + p.y), Opt.None => @dbg(-1) };
+    match make(false) { Opt.Some(p) => @dbg(p.x + p.y), Opt.None => @dbg(-1) };
     0
 }
 """ }]
-compile_fail = true
-error_contains = ["aggregate_layout", "not yet implemented"]
+stdout = "3\n-1\n"
+exit_code = 0
 
-# A fixed array crossing a call by value (return) has no variant-independent
-# compact image — its compact stride differs from the slot stride — so it is still
-# refused. This is the std.binary `u32_to_be_bytes -> [u8; 4]` shape.
+# A fixed array crossing a call by value (return) now marshals through the
+# caller's sret buffer as its compact image — `count` elements at the compact
+# element stride, each extended from its physical width (RUE-1014). This is the
+# std.binary `u32_to_be_bytes -> [u8; 4]` shape. The returned array is then
+# `[]`-indexed as a frame value at the slot stride.
 [[case]]
-name = "array_crossing_call_still_refuses"
-description = "A fixed array returned by value across a call is still refused under the gate, not miscompiled (compact stride != slot stride)."
+name = "array_crossing_call_roundtrip"
+description = "A fixed array returned by value across a call marshals through its compact image and is then indexed as a frame value (RUE-1014)."
+differential_opt = true
 args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn make() -> [u8; 4] { [1, 2, 3, 4] }
@@ -234,6 +244,111 @@ fn main() -> i32 {
     let a = make();
     let s: i32 = @intCast(a[0]) + @intCast(a[3]);
     @dbg(s);
+    0
+}
+""" }]
+stdout = "5\n"
+exit_code = 0
+
+# The REAL std.json parser under the gate: `parse` returns
+# `Result(Json, ParseError)` by value across a call, and `Json` — an enum with
+# variant-dependent aggregate payloads (StrBuf / ArrayBuf(Json) / Object) — is
+# marshalled through its variant-independent scalar image at every boundary
+# (heap pointer, sret, by-value). This is the exact full-`@import("std")`
+# construct RUE-987 recorded as the last blocker; classifying the parsed value
+# pins the top-level variant (an array -> 5).
+[[case]]
+name = "std_json_parse_variant_under_gate"
+description = "The real std.json parser compiles and runs under the gate: Json's variant-dependent aggregate payloads marshal through one variant-independent image (RUE-1014)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "--preview", "raw_bytes", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const json = std.json;
+const result = std.result;
+const StrBuf = std.strbuf.StrBuf;
+const PR = result.Result(json.Json, json.ParseError);
+fn classify(v: json.Json) -> i32 {
+    match v {
+        json.Json.Null => 0,
+        json.Json.Bool(b) => if b { 1 } else { 2 },
+        json.Json.Number(n) => 3,
+        json.Json.String(s) => 4,
+        json.Json.Array(a) => 5,
+        json.Json.Object(o) => 6,
+    }
+}
+fn main() -> i32 {
+    let src: str = "[true,null,42]";
+    let input = StrBuf.from_str(borrow src);
+    let code = match json.parse(input) {
+        PR.Ok(v) => classify(v),
+        PR.Err(e) => 0 - 1,
+    };
+    @dbg(code);
+    0
+}
+""" }]
+stdout = "5\n"
+exit_code = 0
+
+# The REAL std PriorityQueue(i32, i32) under the gate: its backing
+# ArrayBuf(Pair(i32, i32)) stores whole compact structs through the heap pointer
+# (RUE-987) and its `get`/`pop` return `Option(Pair)` by value — a variant-
+# dependent enum image (RUE-1014) — across the sret boundary. A four-element
+# min-heap pops in ascending priority order, pinning the whole pipeline.
+[[case]]
+name = "std_priority_queue_option_pair_under_gate"
+description = "The real std PriorityQueue(i32,i32) runs under the gate: ArrayBuf(Pair) struct elements plus Option(Pair) variant-dependent enum returns (RUE-1014)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "--preview", "raw_bytes", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const bh = std.binary_heap;
+const option = std.option;
+const tuple = std.tuple;
+fn main() -> i32 {
+    let PQ = bh.PriorityQueue(i32, i32);
+    let Item = tuple.Pair(i32, i32);
+    let O = option.Option(Item);
+    let mut q = PQ.new();
+    q.push(5, 50);
+    q.push(1, 10);
+    q.push(3, 30);
+    q.push(2, 20);
+    let mut n: u64 = 0;
+    while n < 4 {
+        match q.pop() {
+            O.Some(it) => { @dbg(it.first); @dbg(it.second); },
+            O.None => @dbg(0 - 1),
+        };
+        n = n + 1;
+    }
+    0
+}
+""" }]
+stdout = "1\n10\n2\n20\n3\n30\n5\n50\n"
+exit_code = 0
+
+# Refusal sentinel: an enum whose per-variant payloads genuinely overlap (no
+# single variant-independent image) must still fail LOUDLY, never miscompile. If
+# a future change lifts this, the sentinel flips to a hard failure and forces a
+# deliberate update. `A(u16, u16)` versus `B(u32)`: leaf 0 merges to a 4-byte
+# slot at the payload start, but `A`'s leaf 1 sits at payload+2, overlapping it.
+[[case]]
+name = "overlapping_union_enum_still_refuses"
+description = "An enum whose per-variant payloads overlap has no variant-independent image and is still refused under the gate, not miscompiled (RUE-1014 boundary)."
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Ov { A(u16, u16), B(u32) }
+fn make(v: bool) -> Ov { if v { Ov.A(1, 2) } else { Ov.B(3) } }
+fn main() -> i32 {
+    match make(true) {
+        Ov.A(a, b) => { let s: i32 = @intCast(a) + @intCast(b); @dbg(s); },
+        Ov.B(c) => { let s: i32 = @intCast(c); @dbg(s); }
+    };
     0
 }
 """ }]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1205,6 +1205,7 @@ impl<'a> CfgLower<'a> {
                 variant_index,
                 payload,
                 total_slots,
+                zero_unused_payload,
                 ..
             } => {
                 slots = (0..total_slots).map(|_| self.mir.alloc_vreg()).collect();
@@ -1230,6 +1231,17 @@ impl<'a> CfgLower<'a> {
                             });
                             offset += 1;
                         }
+                    }
+                }
+                // Zero the payload slots this (shorter) variant does not write, so a
+                // compact memory image marshalled from the value carries no residue
+                // from a wider variant (ADR-0052 ruling 5). Only under the gate.
+                if zero_unused_payload {
+                    for slot in slots.iter().skip(offset) {
+                        self.mir.push(Aarch64Inst::MovImm {
+                            dst: Operand::Virtual(*slot),
+                            imm: 0,
+                        });
                     }
                 }
                 let dst = slots[0];
@@ -3275,22 +3287,19 @@ mod tests {
         .lower()
     }
 
-    /// Under `aggregate_layout`, a non-slot-identical **array** value is still
-    /// refused loudly on AArch64 too, in lockstep with x86-64 (ADR-0052; RUE-989
-    /// narrows the refusal to aggregates through pointers/calls, arrays, enums).
+    /// RUE-1014: under `aggregate_layout`, a non-slot-identical **array** frame
+    /// value now lowers on AArch64 too, in lockstep with x86-64: array `[]`
+    /// indexing strides by the *slot* stride (`abi_slot_count(element) *
+    /// SLOT_BYTES`) against the slot-shaped frame storage (RUE-975).
     #[test]
-    fn aggregate_layout_refuses_unimplemented_aggregate_codegen() {
+    fn aggregate_layout_allows_frame_array_slot_stride_indexing() {
         let mut preview = PreviewFeatures::new();
         preview.insert(PreviewFeature::AggregateLayout);
-        let err = try_lower_first_fn(
-            "fn main() -> i32 { let a: [i32; 3] = [1, 2, 3]; a[0] }",
+        try_lower_first_fn(
+            "fn main() -> i32 { let a: [i32; 3] = [1, 2, 3]; let i: u64 = 1; a[i] }",
             preview,
         )
-        .expect_err("a narrow array value must refuse compact codegen, not miscompile");
-        assert!(
-            format!("{err:?}").contains("aggregate_layout"),
-            "refusal must name the feature, got: {err:?}"
-        );
+        .expect("a frame array indexed at the slot stride must lower under compact layout");
     }
 
     /// RUE-989: under `aggregate_layout`, narrow scalar access through a typed
@@ -3417,18 +3426,71 @@ mod tests {
         );
     }
 
-    /// RUE-987: a struct WITHOUT a variant-independent compact image (a field is a
-    /// fixed array, whose compact stride differs from the slot stride) is still
-    /// refused loudly through a pointer on AArch64, not miscompiled.
+    /// RUE-1014: a struct containing a fixed array now HAS a variant-independent
+    /// compact image — the array flattens to its elements at the compact stride —
+    /// so it marshals whole through a pointer on AArch64. Gate-off emits no narrow
+    /// access.
+    #[test]
+    fn aggregate_layout_allows_array_bearing_struct_memory() {
+        let source = "struct HasArr { tag: u8, xs: [i32; 2] } \
+                      fn main() -> i32 { let r = checked { let p: ptr mut HasArr = @alloc(1); \
+                      @ptr_write(p, HasArr { tag: 5, xs: [10, 20] }); let v = @ptr_read(p); \
+                      @free(p, 1); v.xs[0] + v.xs[1] }; @dbg(r); 0 }";
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let mir = try_lower_first_fn(source, preview)
+            .expect("a struct with a compact array image must lower under compact layout");
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::NarrowStoreIndexed { width: 4, .. })),
+            "the array elements must store narrow (4-byte i32) at their compact stride"
+        );
+        let off = try_lower_first_fn(source, PreviewFeatures::new())
+            .expect("the same program lowers under the default slot model");
+        assert!(
+            off.instructions().iter().all(|inst| !matches!(
+                inst,
+                Aarch64Inst::NarrowStoreIndexed { .. } | Aarch64Inst::NarrowLoadIndexed { .. }
+            )),
+            "gate-off must not emit any narrow access"
+        );
+    }
+
+    /// RUE-1014: a variant-dependent enum whose per-variant aggregate payloads
+    /// overlay one variant-independent scalar image (`Option(Point)`) marshals
+    /// whole through a pointer on AArch64.
+    #[test]
+    fn aggregate_layout_allows_variant_dependent_enum_image() {
+        let source = "struct Point { x: i32, y: i32 } enum Opt { Some(Point), None } \
+                      fn main() -> i32 { let r = checked { let p: ptr mut Opt = @alloc(1); \
+                      @ptr_write(p, Opt.Some(Point { x: 40, y: 2 })); let v = @ptr_read(p); \
+                      @free(p, 1); match v { Opt.Some(pt) => pt.x + pt.y, Opt.None => 0 - 1 } }; \
+                      @dbg(r); 0 }";
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let mir = try_lower_first_fn(source, preview)
+            .expect("an enum with a variant-independent struct-payload image must lower");
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::NarrowStoreIndexed { width: 4, .. })),
+            "the struct-payload leaves must store narrow (4-byte i32) at their compact offsets"
+        );
+    }
+
+    /// RUE-1014: a struct WITHOUT a variant-independent compact image — it embeds
+    /// an enum whose union payloads overlap (`A(i64)` versus `B(i32, i32)`) — is
+    /// still refused loudly through a pointer on AArch64, not miscompiled.
     #[test]
     fn aggregate_layout_refuses_image_less_struct_memory() {
-        let source = "struct HasArr { xs: [i32; 2] } \
-                      fn main() -> i32 { checked { let p: ptr mut HasArr = @alloc(1); \
-                      @ptr_write(p, HasArr { xs: [1, 2] }); }; 0 }";
+        let source = "enum Bad { A(i64), B(i32, i32) } struct HasBad { b: Bad } \
+                      fn main() -> i32 { checked { let p: ptr mut HasBad = @alloc(1); \
+                      @ptr_write(p, HasBad { b: Bad.A(5) }); }; 0 }";
         let mut preview = PreviewFeatures::new();
         preview.insert(PreviewFeature::AggregateLayout);
         let err = try_lower_first_fn(source, preview)
-            .expect_err("a struct with no compact image must refuse, not miscompile");
+            .expect_err("a struct embedding an imageless enum must refuse, not miscompile");
         assert!(
             format!("{err:?}").contains("aggregate_layout"),
             "refusal must name the feature, got: {err:?}"

--- a/crates/rue-codegen/src/allocation.rs
+++ b/crates/rue-codegen/src/allocation.rs
@@ -125,13 +125,24 @@ pub const fn scale_kind(bytes: u64) -> ScaleKind {
     }
 }
 
-/// Build the scaling plan used for an array projection.
+/// Build the scaling plan used for an array `[]` projection.
+///
+/// Array values are stored slot-shaped in the frame (RUE-975), so element
+/// addressing strides by the *slot* stride — `abi_slot_count(element) *
+/// SLOT_BYTES` — not the compact element size. Under the slot model the two are
+/// identical (every leaf is eight bytes); under the compact layout (ADR-0052)
+/// they diverge, and the slot stride is the physically correct one because
+/// `[]`-indexed arrays only ever address slot-based storage (a frame value or a
+/// by-reference pointer into the caller's slot-based frame). Heap element
+/// stepping uses `@ptr_offset` (`pointer_offset_scale_plan`), which strides by
+/// the compact element size against a compact heap image (RUE-1014).
 #[inline]
 pub fn index_scale_plan(type_pool: &FrozenTypeInternPool, array_type: Type) -> ScalePlan {
     let (element_type, _) =
         types::array_type_def_from_type(type_pool, array_type).unwrap_or((array_type, 0));
+    let slot_stride = u64::from(types::type_slot_count(type_pool, element_type)) * SLOT_BYTES;
     ScalePlan {
-        kind: scale_kind(type_width(type_pool, element_type).bytes),
+        kind: scale_kind(slot_stride),
         purpose: ScalePurpose::IndexOffset,
         overflow: OverflowBehavior::Wrap,
     }

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -403,7 +403,16 @@ pub(crate) fn enum_physical_slot_map(
         }),
     }];
 
-    // Payload union positions, one per scalar field position across all variants.
+    // Payload union positions, one per flattened scalar LEAF position across all
+    // variants. Each variant's payload is flattened to its scalar leaves at their
+    // compact byte offsets (a struct or array payload field flattens recursively
+    // via [`push_physical_slots`], mirroring the internal value decomposition of
+    // [`aggregate_leaf_types`]); the leaves are then merged by position index so a
+    // variant-dependent enum (e.g. `Option(Point)` or `Json`) whose per-variant
+    // aggregate payloads still overlay a single, agreeing scalar image gets one
+    // marshalling map (RUE-1014). Positions that disagree on byte offset, overlap,
+    // or carry an imageless leaf (an imageless nested enum, or an array without a
+    // compact image) yield `None` and keep the enum loudly refused.
     #[derive(Clone, Copy)]
     struct Position {
         offset: i32,
@@ -414,14 +423,25 @@ pub(crate) fn enum_physical_slot_map(
     let mut positions: Vec<Position> = Vec::new();
     for variant in 0..def.variant_count() {
         let payload = def.variant_payload(variant);
+        // Flatten this variant's whole payload into its scalar leaves at their
+        // compact byte offsets (enum-base-relative), in internal-slot order. A
+        // struct/array payload field recurses; an imageless leaf bails to `None`.
+        let mut leaves: Vec<PhysicalEnumSlot> = Vec::new();
         for (field_index, &field_ty) in payload.iter().enumerate() {
-            // Only scalar payload fields have a single-slot memory image; a
-            // nested aggregate payload has no variant-independent slot map.
-            let (width, signed) = scalar_physical_access(field_ty)?;
-            let offset = i32::try_from(variant_offsets[variant][field_index]).ok()?;
-            if let Some(pos) = positions.get_mut(field_index) {
+            let field_offset =
+                i32::try_from(*variant_offsets.get(variant)?.get(field_index)?).ok()?;
+            push_physical_slots(type_pool, field_ty, field_offset, &mut leaves)?;
+        }
+        // Merge the flattened leaves into the union positions by leaf index.
+        for (leaf_index, leaf) in leaves.iter().enumerate() {
+            let (width, signed) = match leaf.access {
+                None => (8u8, false),
+                Some(access) => (access.width, access.signed),
+            };
+            let offset = leaf.byte_offset;
+            if let Some(pos) = positions.get_mut(leaf_index) {
                 if pos.offset != offset {
-                    // Variant-dependent field offset: not a single memory image.
+                    // Variant-dependent leaf offset: not a single memory image.
                     return None;
                 }
                 match width.cmp(&pos.width) {
@@ -546,9 +566,20 @@ fn push_physical_slots(
             }
             Some(())
         }
-        // A fixed array's compact stride differs from the slot stride; array call
-        // marshalling is not implemented, so the whole aggregate stays refused.
-        TypeKind::Array(_) => None,
+        // A fixed array flattens to its `count` elements laid out at the compact
+        // element stride, each recursively flattened (RUE-1014). The internal
+        // slot order matches [`aggregate_leaf_types`] (element leaves repeated per
+        // element). An element without a compact image bails to `None`.
+        TypeKind::Array(array_id) => {
+            let (element, count) = type_pool.array_def(array_id);
+            let stride = i32::try_from(type_pool.layout(element).stride).ok()?;
+            for k in 0..count {
+                let element_base =
+                    base_offset.checked_add(i32::try_from(k).ok()?.checked_mul(stride)?)?;
+                push_physical_slots(type_pool, element, element_base, out)?;
+            }
+            Some(())
+        }
         _ => {
             let (width, signed) = scalar_physical_access(ty)?;
             out.push(PhysicalEnumSlot {
@@ -572,7 +603,12 @@ pub(crate) fn pointer_image_slot_map(
 ) -> Option<Vec<PhysicalEnumSlot>> {
     match ty.kind() {
         TypeKind::Enum(_) => enum_physical_slot_map(type_pool, ty),
-        TypeKind::Struct(_) if !is_slot_identical_layout(type_pool, ty) => {
+        // A compact (non-slot-identical) struct or array marshals its whole value
+        // through the pointer via its internal-slot → physical-byte image (RUE-987
+        // struct, RUE-1014 array). A slot-identical aggregate keeps the
+        // byte-identical full-slot path; one without a compact image (an imageless
+        // enum leaf) returns `None` and stays refused.
+        TypeKind::Struct(_) | TypeKind::Array(_) if !is_slot_identical_layout(type_pool, ty) => {
             aggregate_physical_slot_map(type_pool, ty)
         }
         _ => None,
@@ -670,17 +706,16 @@ pub(crate) fn compact_physical_access_unsupported(
     let unimplemented_through_pointer = |ty: Type| -> bool {
         match ty.kind() {
             TypeKind::Enum(_) => enum_physical_slot_map(type_pool, ty).is_none(),
-            // A compact (non-slot-identical) struct WITH a variant-independent
-            // memory image marshals its whole value through the pointer via its
-            // internal-slot → physical-byte map (RUE-987), exactly like a compact
-            // enum (RUE-1000). A slot-identical struct keeps the byte-identical
-            // full-slot path; a struct WITHOUT an image (it contains an array or
-            // an imageless enum) stays refused.
-            TypeKind::Struct(_) => {
+            // A compact (non-slot-identical) struct or array WITH a variant-
+            // independent memory image marshals its whole value through the pointer
+            // via its internal-slot → physical-byte map (RUE-987 struct, RUE-1014
+            // array), exactly like a compact enum (RUE-1000). A slot-identical
+            // aggregate keeps the byte-identical full-slot path; one WITHOUT an
+            // image (it contains an imageless enum) stays refused.
+            TypeKind::Struct(_) | TypeKind::Array(_) => {
                 !is_slot_identical_layout(type_pool, ty)
                     && aggregate_physical_slot_map(type_pool, ty).is_none()
             }
-            TypeKind::Array(_) => !is_slot_identical_layout(type_pool, ty),
             _ => false,
         }
     };
@@ -696,20 +731,16 @@ pub(crate) fn compact_physical_access_unsupported(
         let value = CfgValue::from_raw(raw as u32);
         let inst = cfg.get_inst(value);
 
-        // A non-slot-identical ARRAY value is refused outright: dynamic array
-        // indexing strides by the compact element size while the frame is
-        // slot-based. A non-slot-identical STRUCT or ENUM value, by contrast, is
-        // allowed to exist in the frame — a struct uses static slot-offset field
-        // access and narrow scalar field pointers, and an enum keeps its
-        // slot-based value decomposition (discriminant slot + payload slots)
-        // untouched by the compact layout (RUE-975). The boundary checks below
-        // still refuse either aggregate crossing a pointer (unless the enum has
-        // a variant-independent memory image), call, return, or by-ref boundary.
-        if matches!(inst.ty.kind(), TypeKind::Array(_))
-            && !is_slot_identical_layout(type_pool, inst.ty)
-        {
-            return Some(inst.ty);
-        }
+        // A non-slot-identical ARRAY, STRUCT, or ENUM value may exist in the
+        // frame. Array `[]` indexing strides by the *slot* stride
+        // (`abi_slot_count(element) * SLOT_BYTES`, RUE-1014) because the frame
+        // stores every array element slot-shaped (RUE-975), so element addressing
+        // is physically correct; a struct uses static slot-offset field access and
+        // narrow scalar field pointers; an enum keeps its slot-based value
+        // decomposition (discriminant slot + payload slots) untouched by the
+        // compact layout. The boundary checks below still refuse an aggregate
+        // crossing a pointer, call, return, or by-ref boundary when it has no
+        // variant-independent compact memory image.
 
         // A pointer to a non-slot-identical aggregate: whole-aggregate
         // marshalling through a pointer is unimplemented (except a compact enum
@@ -802,13 +833,14 @@ pub(crate) fn ensure_compact_layout_codegen_supported(
             rue_error::ErrorKind::InternalCodegenError(format!(
                 "aggregate_layout: physical-layout code generation for type `{name}` (in function \
                  `{}`) is not yet implemented. Narrow scalar access through typed pointers \
-                 (RUE-989), compact enum memory for enums with a variant-independent memory image \
-                 (RUE-1000), and call-boundary marshalling of a compact aggregate through its \
-                 memory image — sret returns and `inout`/`borrow` parameters (RUE-1004), and \
-                 by-value arguments (RUE-1005), and whole compact-struct marshalling through \
-                 typed pointers (RUE-987) — are lowered, but whole-array marshalling through \
-                 pointers, arrays crossing a call, and enums (and structs) without a \
-                 variant-independent memory image are still staged for a follow-up.",
+                 (RUE-989), compact enum memory (RUE-1000), call-boundary marshalling of a compact \
+                 aggregate through its memory image — sret returns and `inout`/`borrow` parameters \
+                 (RUE-1004), by-value arguments (RUE-1005) — whole compact-struct marshalling \
+                 through typed pointers (RUE-987), and variant-dependent enum images plus compact \
+                 arrays through pointers and across calls (RUE-1014) are lowered, but an aggregate \
+                 whose compact memory image is not variant-independent — an enum whose per-variant \
+                 payloads overlap or disagree on leaf offset, or an aggregate containing such an \
+                 enum — is still refused for a follow-up.",
                 cfg.fn_name()
             )),
         ));

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -128,6 +128,12 @@ pub enum ResidualValuePlan {
         variant_index: u32,
         payload: Vec<(MaterializedValue, ValueShape)>,
         total_slots: u32,
+        /// Under the compact layout (ADR-0052 ruling 5, RUE-1007/RUE-1014), the
+        /// payload slots not written by this (shorter) variant are zeroed so a
+        /// variant-independent memory image marshalled from this value carries no
+        /// residue from a wider variant. `false` with the gate off, keeping the
+        /// slot-model construction byte-identical.
+        zero_unused_payload: bool,
     },
     EnumPayloadGet {
         base_slots: Vec<VReg>,
@@ -1081,6 +1087,7 @@ fn residual_plan<A: ValueLowerAdapter>(
                 })
                 .collect(),
             total_slots: ctx.type_slot_count(ctx.cfg.get_inst(value).ty),
+            zero_unused_payload: ctx.type_pool.compact_layout(),
         },
         ResidualInput::EnumPayloadGet {
             base,

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1427,6 +1427,7 @@ impl<'a> CfgLower<'a> {
                 variant_index,
                 payload,
                 total_slots,
+                zero_unused_payload,
                 ..
             } => {
                 slots = (0..total_slots).map(|_| self.mir.alloc_vreg()).collect();
@@ -1452,6 +1453,17 @@ impl<'a> CfgLower<'a> {
                             });
                             offset += 1;
                         }
+                    }
+                }
+                // Zero the payload slots this (shorter) variant does not write, so a
+                // compact memory image marshalled from the value carries no residue
+                // from a wider variant (ADR-0052 ruling 5). Only under the gate.
+                if zero_unused_payload {
+                    for slot in slots.iter().skip(offset) {
+                        self.mir.push(X86Inst::MovRI32 {
+                            dst: Operand::Virtual(*slot),
+                            imm: 0,
+                        });
                     }
                 }
                 let dst = slots[0];
@@ -3133,24 +3145,20 @@ mod tests {
         CfgLower::new(cfg_output.cfg.as_ref().unwrap(), type_pool, &interner).lower()
     }
 
-    /// Under `aggregate_layout`, a non-slot-identical **array** value is still
-    /// refused loudly rather than miscompiled: dynamic indexing strides by the
-    /// compact element size while the slot-based frame stores elements at the
-    /// slot stride (ADR-0052; RUE-989 narrows the refusal to what remains
-    /// unimplemented — aggregates through pointers/calls, arrays, and enums).
+    /// RUE-1014: under `aggregate_layout`, a non-slot-identical **array** frame
+    /// value now lowers: array `[]` indexing strides by the *slot* stride
+    /// (`abi_slot_count(element) * SLOT_BYTES`) because the frame stores every
+    /// element slot-shaped (RUE-975), so element addressing is physically correct
+    /// even when the compact element size diverges from the slot stride.
     #[test]
-    fn aggregate_layout_refuses_unimplemented_aggregate_codegen() {
+    fn aggregate_layout_allows_frame_array_slot_stride_indexing() {
         let mut preview = PreviewFeatures::new();
         preview.insert(PreviewFeature::AggregateLayout);
-        let err = try_lower_first_fn(
-            "fn main() -> i32 { let a: [i32; 3] = [1, 2, 3]; a[0] }",
+        try_lower_first_fn(
+            "fn main() -> i32 { let a: [i32; 3] = [1, 2, 3]; let i: u64 = 1; a[i] }",
             preview,
         )
-        .expect_err("a narrow array value must refuse compact codegen, not miscompile");
-        assert!(
-            format!("{err:?}").contains("aggregate_layout"),
-            "refusal must name the feature, got: {err:?}"
-        );
+        .expect("a frame array indexed at the slot stride must lower under compact layout");
     }
 
     /// RUE-989: under `aggregate_layout`, narrow scalar access through a typed
@@ -3279,18 +3287,71 @@ mod tests {
         );
     }
 
-    /// RUE-987: a struct WITHOUT a variant-independent compact image (a field is a
-    /// fixed array, whose compact stride differs from the slot stride) is still
-    /// refused loudly through a pointer on x86-64, not miscompiled.
+    /// RUE-1014: a struct containing a fixed array now HAS a variant-independent
+    /// compact image — the array flattens to its elements at the compact stride —
+    /// so it marshals whole through a pointer on x86-64. The narrow element
+    /// stores/loads land at the compact byte offsets; gate-off emits none.
+    #[test]
+    fn aggregate_layout_allows_array_bearing_struct_memory() {
+        let source = "struct HasArr { tag: u8, xs: [i32; 2] } \
+                      fn main() -> i32 { let r = checked { let p: ptr mut HasArr = @alloc(1); \
+                      @ptr_write(p, HasArr { tag: 5, xs: [10, 20] }); let v = @ptr_read(p); \
+                      @free(p, 1); v.xs[0] + v.xs[1] }; @dbg(r); 0 }";
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let mir = try_lower_first_fn(source, preview)
+            .expect("a struct with a compact array image must lower under compact layout");
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::NarrowStoreIndexed { width: 4, .. })),
+            "the array elements must store narrow (4-byte i32) at their compact stride"
+        );
+        let off = try_lower_first_fn(source, PreviewFeatures::new())
+            .expect("the same program lowers under the default slot model");
+        assert!(
+            off.instructions().iter().all(|inst| !matches!(
+                inst,
+                X86Inst::NarrowStoreIndexed { .. } | X86Inst::NarrowLoadIndexed { .. }
+            )),
+            "gate-off must not emit any narrow access"
+        );
+    }
+
+    /// RUE-1014: a variant-dependent enum whose per-variant aggregate payloads
+    /// overlay one variant-independent scalar image (`Option(Point)`) marshals
+    /// whole through a pointer on x86-64, extending each payload leaf narrow.
+    #[test]
+    fn aggregate_layout_allows_variant_dependent_enum_image() {
+        let source = "struct Point { x: i32, y: i32 } enum Opt { Some(Point), None } \
+                      fn main() -> i32 { let r = checked { let p: ptr mut Opt = @alloc(1); \
+                      @ptr_write(p, Opt.Some(Point { x: 40, y: 2 })); let v = @ptr_read(p); \
+                      @free(p, 1); match v { Opt.Some(pt) => pt.x + pt.y, Opt.None => 0 - 1 } }; \
+                      @dbg(r); 0 }";
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let mir = try_lower_first_fn(source, preview)
+            .expect("an enum with a variant-independent struct-payload image must lower");
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::NarrowStoreIndexed { width: 4, .. })),
+            "the struct-payload leaves must store narrow (4-byte i32) at their compact offsets"
+        );
+    }
+
+    /// RUE-1014: a struct WITHOUT a variant-independent compact image — it embeds
+    /// an enum whose union payloads overlap (`A(i64)` versus `B(i32, i32)`) — is
+    /// still refused loudly through a pointer on x86-64, not miscompiled.
     #[test]
     fn aggregate_layout_refuses_image_less_struct_memory() {
-        let source = "struct HasArr { xs: [i32; 2] } \
-                      fn main() -> i32 { checked { let p: ptr mut HasArr = @alloc(1); \
-                      @ptr_write(p, HasArr { xs: [1, 2] }); }; 0 }";
+        let source = "enum Bad { A(i64), B(i32, i32) } struct HasBad { b: Bad } \
+                      fn main() -> i32 { checked { let p: ptr mut HasBad = @alloc(1); \
+                      @ptr_write(p, HasBad { b: Bad.A(5) }); }; 0 }";
         let mut preview = PreviewFeatures::new();
         preview.insert(PreviewFeature::AggregateLayout);
         let err = try_lower_first_fn(source, preview)
-            .expect_err("a struct with no compact image must refuse, not miscompile");
+            .expect_err("a struct embedding an imageless enum must refuse, not miscompile");
         assert!(
             format!("{err:?}").contains("aggregate_layout"),
             "refusal must name the feature, got: {err:?}"

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -638,6 +638,42 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
     ),
+    // ADR-0052 phase 5.10 (RUE-1014): the variant-dependent-enum-image and
+    // compact-array heap round-trips reach memory through `@alloc`, outside the
+    // oracle model (same gap as the enum/struct heap cases above).
+    Entry::new(
+        "cli.aggregate_layout",
+        "array_bearing_struct_through_pointer_roundtrip",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_layout",
+        "compact_enum_struct_payload_roundtrip",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_layout",
+        "compact_enum_variant_overwrite_leaves_no_residue",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    // RUE-1014: the real-std json/priority-queue cases under the gate reach memory
+    // through the std allocators (`@alloc_bytes` in StrBuf, `@int_to_ptr` in
+    // ArrayBuf.new()), outside the oracle model.
+    Entry::new(
+        "cli.aggregate_layout_std_sweep",
+        "std_json_parse_variant_under_gate",
+        intrinsic(UnsupportedIntrinsicKind::AllocateBytes),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_layout_std_sweep",
+        "std_priority_queue_option_pair_under_gate",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
     Entry::new(
         "cli.partial_move_depth",
         "disjoint_sibling_after_subfield_move_ok",


### PR DESCRIPTION
## Summary

**Full std under the gate.** This lifts the last refusals std exercises under `--preview aggregate_layout` — `@import("std")`'s full root now compiles gated, a real std.json parse classifies correctly, PriorityQueue pops in order, and `Option(struct)` round-trips through heap and sret. Gate-off is byte-identical.

- **The enum insight**: struct/array-payload enums looked imageless (no single slot→byte map), but flattening each variant's payload into scalar leaves at compact offsets and merging by position shows most are variant-*independent* after all — every variant lays its payload ascending from the payload offset, so merged leaves agree. The generalized `enum_physical_slot_map` yields one image composing with the entire existing marshalling stack: **no new marshalling code, no tag dispatch**. Genuinely overlapping/disagreeing variants (e.g. `{A(i64), B(i32,i32)}`) return no image and stay loudly refused, with sentinel tests keeping them so. RUE-1007 zeroing composes — variant overwrites leave no residue (execution-tested).
- **Compact arrays** cross memory and call boundaries: whole-array pointer round-trips, by-value args, returns, arrays-in-structs, nested arrays, at ascending compact stride.
- One pre-existing *ungated* std.json `to_string` bug surfaced and was left alone — it fails identically gate-off.

With this, RUE-987's prerequisite 3 is fully met: nothing std exercises refuses under the gate, and everything that compiles is oracle-verified byte-identical in behavior to gate-off.

## Verification

Re-verified by execution at integration: `Option(Point)` heap + sret round-trip (42/−1) gated and ungated. codegen 587; cli `aggregate_layout`+`std_sweep` 45 (now-working refusal sentinels flipped to executing round-trips; overlap sentinels kept); `arraybuf` 21, `enum_payloads` 24, `abi` 59; air 502; oracle-diff corpus audit green (five new ledger entries); full `test.sh` green except the four known uid-0 environmental failures, both harness failure formats checked.

Fixes RUE-1014

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_