### PR TITLE
RUE-978: raw-byte family fold-in and packed-str unification (ADR-0052 phase 7)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1460,14 +1460,15 @@ impl<'a> ConstraintGenerator<'a> {
                         self.generate(*arg_ref, ctx);
                     }
                     InferType::Concrete(Type::U64)
-                } else if intrinsic_name == "ptr_write" {
-                    // @ptr_write: takes a pointer and value, returns unit
+                } else if intrinsic_name == "ptr_write" || intrinsic_name == "ptr_write_unaligned" {
+                    // @ptr_write / @ptr_write_unaligned: takes a pointer and
+                    // value, returns unit (ADR-0059 Phase 4, RUE-978).
                     for arg_ref in args.iter() {
                         self.generate(*arg_ref, ctx);
                     }
                     InferType::Concrete(Type::UNIT)
-                } else if intrinsic_name == "ptr_read" {
-                    // @ptr_read: takes ptr const T or ptr mut T, returns T
+                } else if intrinsic_name == "ptr_read" || intrinsic_name == "ptr_read_unaligned" {
+                    // @ptr_read / @ptr_read_unaligned: takes ptr const T or ptr mut T, returns T
                     // The return type depends on the pointee type of the argument.
                     // We create a fresh type variable that will be resolved during
                     // semantic analysis when the actual pointer type is known.

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -250,6 +250,8 @@ impl<'a> BodySema<'a> {
         if ctx.checked_depth == 0
             && (name == known.ptr_read
                 || name == known.ptr_write
+                || name == known.ptr_read_unaligned
+                || name == known.ptr_write_unaligned
                 || name == known.ptr_offset
                 || name == known.ptr_to_int
                 || name == known.int_to_ptr
@@ -392,9 +394,13 @@ impl<'a> BodySema<'a> {
         {
             self.analyze_wrapping_arith_intrinsic(air, name, &args, span, ctx)
         } else if name == known.ptr_read {
-            self.analyze_ptr_read_intrinsic(air, name, inst_ref, &args, span, ctx)
+            self.analyze_ptr_read_intrinsic(air, name, inst_ref, &args, span, ctx, false)
         } else if name == known.ptr_write {
-            self.analyze_ptr_write_intrinsic(air, name, &args, span, ctx)
+            self.analyze_ptr_write_intrinsic(air, name, &args, span, ctx, false)
+        } else if name == known.ptr_read_unaligned {
+            self.analyze_ptr_read_intrinsic(air, name, inst_ref, &args, span, ctx, true)
+        } else if name == known.ptr_write_unaligned {
+            self.analyze_ptr_write_intrinsic(air, name, &args, span, ctx, true)
         } else if name == known.ptr_offset {
             self.analyze_ptr_offset_intrinsic(air, name, &args, span, ctx)
         } else if name == known.ptr_to_int {

--- a/crates/rue-air/src/sema/analysis/pointers.rs
+++ b/crates/rue-air/src/sema/analysis/pointers.rs
@@ -6,8 +6,15 @@
 use super::*;
 
 impl<'a> BodySema<'a> {
-    /// Analyze @ptr_read intrinsic: reads value through pointer.
-    /// Signature: @ptr_read(ptr: ptr const T) -> T
+    /// Analyze @ptr_read / @ptr_read_unaligned intrinsic: reads value through
+    /// pointer. Signature: `@ptr_read(ptr: ptr const T) -> T`.
+    ///
+    /// `unaligned` selects `@ptr_read_unaligned` (ADR-0059 Phase 4, RUE-978):
+    /// same pointee-typed shape, but the caller does not promise the address is
+    /// aligned. It is part of the interim byte surface and so requires the
+    /// `raw_bytes` preview. On x86-64 and AArch64 the emitted access is
+    /// identical to the aligned variant (both tolerate unaligned scalars); the
+    /// distinction is the semantic contract of spec 9.2:14k.
     pub(super) fn analyze_ptr_read_intrinsic(
         &mut self,
         air: &mut Air,
@@ -16,11 +23,24 @@ impl<'a> BodySema<'a> {
         args: &[RirCallArg],
         span: Span,
         ctx: &mut AnalysisContext,
+        unaligned: bool,
     ) -> CompileResult<AnalysisResult> {
+        let diag = if unaligned {
+            "ptr_read_unaligned"
+        } else {
+            "ptr_read"
+        };
+        if unaligned {
+            self.require_preview(
+                PreviewFeature::RawBytes,
+                "@ptr_read_unaligned intrinsic",
+                span,
+            )?;
+        }
         if args.len() != 1 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
-                    name: "ptr_read".to_string(),
+                    name: diag.to_string(),
                     expected: 1,
                     found: args.len(),
                 },
@@ -38,7 +58,7 @@ impl<'a> BodySema<'a> {
             _ => {
                 return Err(CompileError::new(
                     ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
-                        name: "ptr_read".to_string(),
+                        name: diag.to_string(),
                         expected: "ptr const T or ptr mut T".to_string(),
                         found: self.format_type_name(ptr_type),
                     })),
@@ -69,8 +89,11 @@ impl<'a> BodySema<'a> {
         Ok(AnalysisResult::new(air_ref, pointee_type))
     }
 
-    /// Analyze @ptr_write intrinsic: writes value through pointer.
-    /// Signature: @ptr_write(ptr: ptr mut T, value: T) -> ()
+    /// Analyze @ptr_write / @ptr_write_unaligned intrinsic: writes value through
+    /// pointer. Signature: `@ptr_write(ptr: ptr mut T, value: T) -> ()`.
+    ///
+    /// `unaligned` selects `@ptr_write_unaligned` (ADR-0059 Phase 4, RUE-978);
+    /// see [`Self::analyze_ptr_read_intrinsic`] for the aligned/unaligned split.
     pub(super) fn analyze_ptr_write_intrinsic(
         &mut self,
         air: &mut Air,
@@ -78,11 +101,24 @@ impl<'a> BodySema<'a> {
         args: &[RirCallArg],
         span: Span,
         ctx: &mut AnalysisContext,
+        unaligned: bool,
     ) -> CompileResult<AnalysisResult> {
+        let diag = if unaligned {
+            "ptr_write_unaligned"
+        } else {
+            "ptr_write"
+        };
+        if unaligned {
+            self.require_preview(
+                PreviewFeature::RawBytes,
+                "@ptr_write_unaligned intrinsic",
+                span,
+            )?;
+        }
         if args.len() != 2 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
-                    name: "ptr_write".to_string(),
+                    name: diag.to_string(),
                     expected: 2,
                     found: args.len(),
                 },
@@ -102,7 +138,7 @@ impl<'a> BodySema<'a> {
             TypeKind::PtrConst(_) => {
                 return Err(CompileError::new(
                     ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
-                        name: "ptr_write".to_string(),
+                        name: diag.to_string(),
                         expected: "ptr mut T (cannot write through ptr const)".to_string(),
                         found: self.format_type_name(ptr_type),
                     })),
@@ -112,7 +148,7 @@ impl<'a> BodySema<'a> {
             _ => {
                 return Err(CompileError::new(
                     ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
-                        name: "ptr_write".to_string(),
+                        name: diag.to_string(),
                         expected: "ptr mut T".to_string(),
                         found: self.format_type_name(ptr_type),
                     })),

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -111,6 +111,12 @@ pub struct KnownSymbols {
     pub ptr_read: Spur,
     /// The `ptr_write` intrinsic symbol - writes value through pointer.
     pub ptr_write: Spur,
+    /// The `ptr_read_unaligned` / `ptr_write_unaligned` intrinsics: the
+    /// explicit unaligned scalar access pair for packed/parsed data
+    /// (ADR-0059 Phase 4, RUE-978/RUE-962). Gated behind `raw_bytes` with the
+    /// rest of the interim byte surface until RUE-971 stabilizes.
+    pub ptr_read_unaligned: Spur,
+    pub ptr_write_unaligned: Spur,
     /// The `ptr_offset` intrinsic symbol - pointer arithmetic.
     pub ptr_offset: Spur,
     /// The `ptr_to_int` intrinsic symbol - converts pointer to usize.
@@ -194,6 +200,8 @@ impl KnownSymbols {
             // Pointer intrinsics
             ptr_read: interner.get_or_intern_static("ptr_read"),
             ptr_write: interner.get_or_intern_static("ptr_write"),
+            ptr_read_unaligned: interner.get_or_intern_static("ptr_read_unaligned"),
+            ptr_write_unaligned: interner.get_or_intern_static("ptr_write_unaligned"),
             ptr_offset: interner.get_or_intern_static("ptr_offset"),
             ptr_to_int: interner.get_or_intern_static("ptr_to_int"),
             int_to_ptr: interner.get_or_intern_static("int_to_ptr"),
@@ -277,6 +285,14 @@ mod tests {
         assert_eq!(interner.resolve(&known.env_len), "env_len");
         assert_eq!(interner.resolve(&known.ptr_read), "ptr_read");
         assert_eq!(interner.resolve(&known.ptr_write), "ptr_write");
+        assert_eq!(
+            interner.resolve(&known.ptr_read_unaligned),
+            "ptr_read_unaligned"
+        );
+        assert_eq!(
+            interner.resolve(&known.ptr_write_unaligned),
+            "ptr_write_unaligned"
+        );
         assert_eq!(interner.resolve(&known.ptr_offset), "ptr_offset");
         assert_eq!(interner.resolve(&known.ptr_to_int), "ptr_to_int");
         assert_eq!(interner.resolve(&known.int_to_ptr), "int_to_ptr");

--- a/crates/rue-cli-tests/cases/raw_bytes_degate_readiness.toml
+++ b/crates/rue-cli-tests/cases/raw_bytes_degate_readiness.toml
@@ -1,0 +1,167 @@
+# De-gate readiness: raw_bytes alone vs raw_bytes + aggregate_layout (RUE-978,
+# evidence for the RUE-937 gate-removal decision).
+#
+# ADR-0059 folds the raw-byte access family into the ordinary typed `ptr u8`
+# path under `aggregate_layout` (phase 7): gated, `@byte_read`/`@byte_write`
+# lower through the same one-byte narrow scalar access a typed `ptr u8` takes,
+# and the byte allocators share the general allocator helper. The question
+# RUE-937 flagged is whether that fold-in changes the OBSERVABLE behavior of the
+# byte surface — i.e. does turning `aggregate_layout` on alongside `raw_bytes`
+# alter what a byte-intrinsic program computes?
+#
+# It must not. The byte family is byte-granular in BOTH gate states (a
+# `@byte_read` reads one physical byte, `@alloc_bytes(n, a)` reserves n physical
+# bytes, offsets are never scaled by the slot size), so the fold-in only changes
+# which instruction carries the access, never its result. Each program below
+# therefore appears TWICE — once under `raw_bytes`, once under
+# `raw_bytes,aggregate_layout` — pinned to the SAME `stdout`/`exit_code`. A
+# divergence (a fold-in that shifted a byte, a stride that leaked into the byte
+# surface) flips one half of a pair and fails.
+#
+# Note: the byte surface deliberately avoids `@ptr_offset` for byte addressing
+# (it strides by the slot size, which is 8 gate-off and 1 gate-on — the one
+# element that is NOT byte-identical across the gate), addressing sub-ranges
+# through `@ptr_to_int`/`@int_to_ptr` exactly as `std/strbuf.rue` does. That is
+# why these programs are byte-identical and a naive `@ptr_offset`-based one would
+# not be.
+
+[section]
+id = "cli.raw_bytes_degate_readiness"
+name = "raw-byte surface behaves identically with and without aggregate_layout"
+description = "Byte-intrinsic programs produce identical output under `raw_bytes` alone and under `raw_bytes,aggregate_layout`, evidencing that the RUE-978 fold-in is behavior-preserving (RUE-937 de-gate readiness)."
+
+# The whole byte family — @alloc_bytes/@byte_set/@byte_write/@realloc_bytes/
+# @byte_copy/@byte_read/@free_bytes — in one round-trip. Baseline: raw_bytes only.
+[[case]]
+name = "byte_family_roundtrip_raw_bytes"
+description = "Full byte-family round-trip under raw_bytes alone (bespoke packed lowering)."
+differential_opt = true
+args = ["main.rue", "--preview", "raw_bytes", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc_bytes(6, 1);
+        @byte_set(p, 0, 6);
+        @byte_write(p, 0, 10);
+        @byte_write(p, 1, 20);
+        @byte_write(p, 2, 30);
+        let q: ptr mut u8 = @realloc_bytes(p, 6, 1, 8);
+        @byte_write(q, 3, 40);
+        let dst: ptr mut u8 = @alloc_bytes(8, 1);
+        @byte_copy(dst, q, 8);
+        let sum: i32 = @intCast(@byte_read(dst, 0)) + @intCast(@byte_read(dst, 1))
+            + @intCast(@byte_read(dst, 2)) + @intCast(@byte_read(dst, 3))
+            + @intCast(@byte_read(dst, 4));
+        @dbg(sum);
+        @free_bytes(q, 8, 1);
+        @free_bytes(dst, 8, 1);
+    };
+    0
+}
+""" }]
+stdout = "100\n"
+exit_code = 0
+
+# The identical program under raw_bytes + aggregate_layout. The fold-in routes
+# @byte_read/@byte_write through the narrow typed path; the output must not move.
+[[case]]
+name = "byte_family_roundtrip_aggregate_layout"
+description = "The same byte-family round-trip under raw_bytes + aggregate_layout (folded into the narrow typed path); output must be byte-identical."
+differential_opt = true
+args = ["main.rue", "--preview", "raw_bytes", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc_bytes(6, 1);
+        @byte_set(p, 0, 6);
+        @byte_write(p, 0, 10);
+        @byte_write(p, 1, 20);
+        @byte_write(p, 2, 30);
+        let q: ptr mut u8 = @realloc_bytes(p, 6, 1, 8);
+        @byte_write(q, 3, 40);
+        let dst: ptr mut u8 = @alloc_bytes(8, 1);
+        @byte_copy(dst, q, 8);
+        let sum: i32 = @intCast(@byte_read(dst, 0)) + @intCast(@byte_read(dst, 1))
+            + @intCast(@byte_read(dst, 2)) + @intCast(@byte_read(dst, 3))
+            + @intCast(@byte_read(dst, 4));
+        @dbg(sum);
+        @free_bytes(q, 8, 1);
+        @free_bytes(dst, 8, 1);
+    };
+    0
+}
+""" }]
+stdout = "100\n"
+exit_code = 0
+
+# StrBuf's packed sub-range copy idiom: byte offsets folded into the address via
+# @ptr_to_int/@int_to_ptr (never @ptr_offset), then @byte_copy. Baseline.
+[[case]]
+name = "packed_subrange_copy_raw_bytes"
+description = "StrBuf-style packed sub-range @byte_copy addressed through @ptr_to_int/@int_to_ptr, under raw_bytes alone."
+differential_opt = true
+args = ["main.rue", "--preview", "raw_bytes", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    checked {
+        let src: ptr mut u8 = @alloc_bytes(5, 1);
+        let mut i: u64 = 0;
+        while i < 5 {
+            @byte_write(src, i, @intCast(i + 1));
+            i = i + 1;
+        }
+        let dst: ptr mut u8 = @alloc_bytes(5, 1);
+        @byte_set(dst, 0, 5);
+        let sp: ptr mut u8 = @int_to_ptr(@ptr_to_int(src) + 1);
+        let dp: ptr mut u8 = @int_to_ptr(@ptr_to_int(dst) + 2);
+        @byte_copy(dp, sp, 3);
+        let mut sum: i32 = 0;
+        let mut j: u64 = 0;
+        while j < 5 {
+            sum = sum + @intCast(@byte_read(dst, j));
+            j = j + 1;
+        }
+        @dbg(sum);
+        @free_bytes(src, 5, 1);
+        @free_bytes(dst, 5, 1);
+    };
+    0
+}
+""" }]
+stdout = "9\n"
+exit_code = 0
+
+[[case]]
+name = "packed_subrange_copy_aggregate_layout"
+description = "The same packed sub-range copy under raw_bytes + aggregate_layout; output must be byte-identical."
+differential_opt = true
+args = ["main.rue", "--preview", "raw_bytes", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    checked {
+        let src: ptr mut u8 = @alloc_bytes(5, 1);
+        let mut i: u64 = 0;
+        while i < 5 {
+            @byte_write(src, i, @intCast(i + 1));
+            i = i + 1;
+        }
+        let dst: ptr mut u8 = @alloc_bytes(5, 1);
+        @byte_set(dst, 0, 5);
+        let sp: ptr mut u8 = @int_to_ptr(@ptr_to_int(src) + 1);
+        let dp: ptr mut u8 = @int_to_ptr(@ptr_to_int(dst) + 2);
+        @byte_copy(dp, sp, 3);
+        let mut sum: i32 = 0;
+        let mut j: u64 = 0;
+        while j < 5 {
+            sum = sum + @intCast(@byte_read(dst, j));
+            j = j + 1;
+        }
+        @dbg(sum);
+        @free_bytes(src, 5, 1);
+        @free_bytes(dst, 5, 1);
+    };
+    0
+}
+""" }]
+stdout = "9\n"
+exit_code = 0

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1703,10 +1703,16 @@ impl<'a> CfgLower<'a> {
                     src2: Operand::Virtual(plan.args[1].primary),
                 });
                 let dst = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::LdrbIndexed {
-                    dst: Operand::Virtual(dst),
-                    base: addr,
-                });
+                if let Some(narrow) = plan.narrow_access {
+                    // Gate-on: fold into the typed `ptr u8` narrow load (RUE-978).
+                    self.emit_narrow_load_through_ptr(dst, addr, 0, narrow);
+                } else {
+                    // Gate-off: the bespoke packed byte load, byte-for-byte.
+                    self.mir.push(Aarch64Inst::LdrbIndexed {
+                        dst: Operand::Virtual(dst),
+                        base: addr,
+                    });
+                }
                 dst
             }
             crate::value_plan::IntrinsicOperation::ByteWrite => {
@@ -1716,10 +1722,16 @@ impl<'a> CfgLower<'a> {
                     src1: Operand::Virtual(plan.args[0].primary),
                     src2: Operand::Virtual(plan.args[1].primary),
                 });
-                self.mir.push(Aarch64Inst::StrbIndexed {
-                    src: Operand::Virtual(plan.args[2].primary),
-                    base: addr,
-                });
+                if let Some(narrow) = plan.narrow_access {
+                    // Gate-on: fold into the typed `ptr u8` narrow store (RUE-978).
+                    self.emit_narrow_store_through_ptr(plan.args[2].primary, addr, 0, narrow);
+                } else {
+                    // Gate-off: the bespoke packed byte store, byte-for-byte.
+                    self.mir.push(Aarch64Inst::StrbIndexed {
+                        src: Operand::Virtual(plan.args[2].primary),
+                        base: addr,
+                    });
+                }
                 let dst = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::MovImm {
                     dst: Operand::Virtual(dst),
@@ -3813,5 +3825,48 @@ mod tests {
         let free = runtime_call_index(&mir, rue_runtime_abi::RuntimeHelperId::Free);
         assert_eq!(immediate_call_arg(&mir, free, Reg::X1), Some(5));
         assert_eq!(immediate_call_arg(&mir, free, Reg::X2), Some(1));
+    }
+
+    /// RUE-978: under the compact layout the raw-byte access family folds into
+    /// the ordinary typed `ptr u8` narrow path — `@byte_read`/`@byte_write`
+    /// emit the same one-byte `NarrowLoadIndexed`/`NarrowStoreIndexed` a typed
+    /// `@ptr_read`/`@ptr_write` of a `u8` pointee does, not the bespoke
+    /// `Ldrb`/`Strb`. Gate-off keeps the bespoke path.
+    #[test]
+    fn aggregate_layout_folds_byte_access_into_narrow_typed_path() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::RawBytes);
+        preview.insert(PreviewFeature::AggregateLayout);
+        let mir = lower_function_to_mir_with_preview(
+            "fn main() -> i32 { checked { let p = @alloc_bytes(2, 1); \
+             @byte_write(p, 0, 65); let b = @byte_read(p, 1); \
+             @free_bytes(p, 2, 1); @intCast(b) } }",
+            "main",
+            preview,
+        );
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::NarrowStoreIndexed { width: 1, .. })),
+            "gated @byte_write must fold into the one-byte narrow store"
+        );
+        assert!(
+            mir.instructions().iter().any(|inst| matches!(
+                inst,
+                Aarch64Inst::NarrowLoadIndexed {
+                    width: 1,
+                    signed: false,
+                    ..
+                }
+            )),
+            "gated @byte_read must fold into the one-byte zero-extended narrow load"
+        );
+        assert!(
+            mir.instructions().iter().all(|inst| !matches!(
+                inst,
+                Aarch64Inst::LdrbIndexed { .. } | Aarch64Inst::StrbIndexed { .. }
+            )),
+            "the bespoke packed byte load/store must not survive the fold-in"
+        );
     }
 }

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -1562,8 +1562,14 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     "random_u64" => IntrinsicOperation::RandomU64,
                     "ptr_to_int" => IntrinsicOperation::PtrToInt,
                     "int_to_ptr" => IntrinsicOperation::IntToPtr,
-                    "ptr_read" => IntrinsicOperation::PtrRead,
-                    "ptr_write" => IntrinsicOperation::PtrWrite,
+                    // The `_unaligned` scalar access pair (ADR-0059 Phase 4,
+                    // RUE-978/RUE-962) shares the aligned lowering: on x86-64 and
+                    // AArch64 a scalar load/store tolerates any address, so the
+                    // interim distinction is a semantic contract (spec 9.2:14k),
+                    // not a distinct instruction. Folding the names here keeps the
+                    // narrow-access and image-marshalling plans identical.
+                    "ptr_read" | "ptr_read_unaligned" => IntrinsicOperation::PtrRead,
+                    "ptr_write" | "ptr_write_unaligned" => IntrinsicOperation::PtrWrite,
                     "ptr_offset" => IntrinsicOperation::PtrOffset,
                     "alloc" => IntrinsicOperation::Alloc {
                         element_size: crate::allocation::pointer_element_align(
@@ -1635,6 +1641,17 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                         ctx.type_pool,
                         ctx.cfg.get_inst(args[1]).ty,
                     ),
+                    // Under the compact layout (`aggregate_layout`) the raw-byte
+                    // family folds into the ordinary typed `ptr u8` path: a byte
+                    // access is exactly the one-byte narrow scalar access
+                    // (RUE-989) that `@ptr_read`/`@ptr_write` of a `u8` pointee
+                    // take, so `@byte_read`/`@byte_write` reuse that single
+                    // emission path (ADR-0052 phase 7, RUE-978). Keying on
+                    // `Type::U8` makes the gate the sole switch: gate-off this is
+                    // `None`, preserving the bespoke byte load/store byte-for-byte.
+                    IntrinsicOperation::ByteRead | IntrinsicOperation::ByteWrite => {
+                        crate::types::narrow_scalar_access(ctx.type_pool, Type::U8)
+                    }
                     _ => None,
                 };
                 // A compact aggregate pointee marshals its whole value through the

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1963,11 +1963,17 @@ impl<'a> CfgLower<'a> {
                     src: Operand::Virtual(plan.args[1].primary),
                 });
                 let dst = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::Movzx8RMIndexed {
-                    dst: Operand::Virtual(dst),
-                    base: addr,
-                    offset: 0,
-                });
+                if let Some(narrow) = plan.narrow_access {
+                    // Gate-on: fold into the typed `ptr u8` narrow load (RUE-978).
+                    self.emit_narrow_load_through_ptr(dst, addr, 0, narrow);
+                } else {
+                    // Gate-off: the bespoke packed byte load, byte-for-byte.
+                    self.mir.push(X86Inst::Movzx8RMIndexed {
+                        dst: Operand::Virtual(dst),
+                        base: addr,
+                        offset: 0,
+                    });
+                }
                 dst
             }
             crate::value_plan::IntrinsicOperation::ByteWrite => {
@@ -1980,11 +1986,17 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(addr),
                     src: Operand::Virtual(plan.args[1].primary),
                 });
-                self.mir.push(X86Inst::MovMR8Indexed {
-                    base: addr,
-                    offset: 0,
-                    src: Operand::Virtual(plan.args[2].primary),
-                });
+                if let Some(narrow) = plan.narrow_access {
+                    // Gate-on: fold into the typed `ptr u8` narrow store (RUE-978).
+                    self.emit_narrow_store_through_ptr(plan.args[2].primary, addr, 0, narrow);
+                } else {
+                    // Gate-off: the bespoke packed byte store, byte-for-byte.
+                    self.mir.push(X86Inst::MovMR8Indexed {
+                        base: addr,
+                        offset: 0,
+                        src: Operand::Virtual(plan.args[2].primary),
+                    });
+                }
                 let dst = self.mir.alloc_vreg();
                 self.mir.push(X86Inst::MovRI32 {
                     dst: Operand::Virtual(dst),
@@ -3788,5 +3800,46 @@ mod tests {
         let free = runtime_call_index(&mir, rue_runtime_abi::RuntimeHelperId::Free);
         assert_eq!(immediate_call_arg(&mir, free, Reg::Rsi), Some(5));
         assert_eq!(immediate_call_arg(&mir, free, Reg::Rdx), Some(1));
+    }
+
+    /// RUE-978: under the compact layout the raw-byte access family folds into
+    /// the ordinary typed `ptr u8` narrow path — `@byte_read`/`@byte_write`
+    /// emit the same one-byte `NarrowLoadIndexed`/`NarrowStoreIndexed` a typed
+    /// `@ptr_read`/`@ptr_write` of a `u8` pointee does, not the bespoke
+    /// `Movzx8RMIndexed`/`MovMR8Indexed`. Gate-off keeps the bespoke path
+    /// (asserted by `raw_bytes_runtime_helper_identity_and_slots_match_shared_plan`).
+    #[test]
+    fn aggregate_layout_folds_byte_access_into_narrow_typed_path() {
+        let source = "fn main() -> i32 { checked { let p = @alloc_bytes(2, 1); \
+             @byte_write(p, 0, 65); let b = @byte_read(p, 1); \
+             @free_bytes(p, 2, 1); @intCast(b) } }";
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::RawBytes);
+        preview.insert(PreviewFeature::AggregateLayout);
+        let mir = lower_to_mir_with_preview(source, preview);
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::NarrowStoreIndexed { width: 1, .. })),
+            "gated @byte_write must fold into the one-byte narrow store"
+        );
+        assert!(
+            mir.instructions().iter().any(|inst| matches!(
+                inst,
+                X86Inst::NarrowLoadIndexed {
+                    width: 1,
+                    signed: false,
+                    ..
+                }
+            )),
+            "gated @byte_read must fold into the one-byte zero-extended narrow load"
+        );
+        assert!(
+            mir.instructions().iter().all(|inst| !matches!(
+                inst,
+                X86Inst::Movzx8RMIndexed { .. } | X86Inst::MovMR8Indexed { .. }
+            )),
+            "the bespoke packed byte load/store must not survive the fold-in"
+        );
     }
 }

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -674,6 +674,32 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::IntToPointer),
         &[],
     ),
+    // ADR-0052 phase 7 (RUE-978): the de-gate readiness differential cases
+    // allocate through @alloc_bytes, which the oracle model does not model.
+    Entry::new(
+        "cli.raw_bytes_degate_readiness",
+        "byte_family_roundtrip_aggregate_layout",
+        intrinsic(UnsupportedIntrinsicKind::AllocateBytes),
+        &[],
+    ),
+    Entry::new(
+        "cli.raw_bytes_degate_readiness",
+        "byte_family_roundtrip_raw_bytes",
+        intrinsic(UnsupportedIntrinsicKind::AllocateBytes),
+        &[],
+    ),
+    Entry::new(
+        "cli.raw_bytes_degate_readiness",
+        "packed_subrange_copy_aggregate_layout",
+        intrinsic(UnsupportedIntrinsicKind::AllocateBytes),
+        &[],
+    ),
+    Entry::new(
+        "cli.raw_bytes_degate_readiness",
+        "packed_subrange_copy_raw_bytes",
+        intrinsic(UnsupportedIntrinsicKind::AllocateBytes),
+        &[],
+    ),
     Entry::new(
         "cli.partial_move_depth",
         "disjoint_sibling_after_subfield_move_ok",

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -748,6 +748,14 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::AllocateBytes),
         &[],
     ),
+    // ADR-0052 phase 7 (RUE-978): the unaligned-access round trip allocates
+    // through @alloc, which the oracle model does not model.
+    Entry::new(
+        "runtime.raw_bytes",
+        "ptr_unaligned_round_trip",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
     Entry::new(
         "runtime.pointers",
         "field_ptr_first_field",

--- a/crates/rue-spec/cases/runtime/raw-bytes.toml
+++ b/crates/rue-spec/cases/runtime/raw-bytes.toml
@@ -524,3 +524,61 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "[E0701]"
+
+# Unaligned typed scalar access (ADR-0059 Phase 4, RUE-978). Same shape as the
+# aligned pair but the address need not satisfy @align_of(T).
+[[case]]
+name = "ptr_unaligned_round_trip"
+spec = ["9.2:14k", "9.2:14m"]
+preview = "raw_bytes"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut i32 = @alloc(1);
+        @ptr_write_unaligned(p, 1234);
+        let v: i32 = @ptr_read_unaligned(p);
+        @free(p, 1);
+        @intCast(v % 200)
+    }
+}
+"""
+exit_code = 34
+
+[[case]]
+name = "ptr_unaligned_requires_preview"
+spec = ["9.2:14a", "9.2:14l"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut i32 = @alloc(1);
+        @ptr_write_unaligned(p, 7);
+        @free(p, 1);
+    };
+    0
+}
+"""
+compile_fail = true
+error_contains = "--preview raw_bytes"
+
+[[case]]
+name = "ptr_unaligned_requires_checked"
+spec = ["9.2:14l"]
+preview = "raw_bytes"
+preview_should_pass = true
+source = """
+fn read(p: ptr mut i32) -> i32 {
+    @ptr_read_unaligned(p)
+}
+fn main() -> i32 {
+    checked {
+        let p: ptr mut i32 = @alloc(1);
+        @ptr_write(p, 0);
+        let v: i32 = read(p);
+        @free(p, 1);
+    };
+    0
+}
+"""
+compile_fail = true
+error_contains = "[E1300]"

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -159,11 +159,12 @@ fn main() -> i32 {
 {{ rule(id="9.2:14a", cat="normative") }}
 
 The `@alloc_bytes`, `@realloc_bytes`, `@free_bytes`, `@byte_read`,
-`@byte_write`, `@byte_copy`, and `@byte_set` intrinsics provide raw access to
-packed physical bytes. They are enabled by the `raw_bytes` preview feature and
-may only appear inside a `checked` block. They do not change the element-scaled
-semantics of `@alloc`, `@realloc`, `@free`, `@ptr_offset`, `@ptr_read`, or
-`@ptr_write`.
+`@byte_write`, `@byte_copy`, `@byte_set`, `@ptr_read_unaligned`, and
+`@ptr_write_unaligned` intrinsics provide raw access to packed physical bytes
+and to potentially unaligned typed scalars. They are enabled by the `raw_bytes`
+preview feature and may only appear inside a `checked` block. They do not change
+the element-scaled semantics of `@alloc`, `@realloc`, `@free`, `@ptr_offset`,
+`@ptr_read`, or `@ptr_write`.
 
 {{ rule(id="9.2:14b", cat="dynamic-semantics") }}
 
@@ -269,6 +270,40 @@ that is zero or not a power of two, the program is rejected at compile time.
 A non-constant `align` is not checked at compile time; supplying a value that is
 zero or not a power of two is then undefined behavior (§9.1, ADR-0028), like the
 other unchecked contracts of this family.
+
+{{ rule(id="9.2:14k", cat="dynamic-semantics") }}
+
+`@ptr_read_unaligned(p)` and `@ptr_write_unaligned(p, value)` are the unaligned
+counterparts of `@ptr_read`/`@ptr_write` (ADR-0059). Their pointee type,
+operands, result, and value semantics are exactly those of the aligned pair —
+`p` is `ptr const T` or `ptr mut T` for the read and `ptr mut T` for the write,
+the read returns `T` and the write returns `()` — except that the caller does
+not promise the address satisfies `@align_of(T)`. Reading or writing an
+underaligned address is well defined for these two intrinsics and undefined
+behavior (§9.1, ADR-0028) for the aligned pair. They exist to access packed and
+parsed data (integers embedded in a byte buffer) without a per-byte assembly.
+
+{{ rule(id="9.2:14l", cat="legality-rule") }}
+
+`@ptr_read_unaligned` and `@ptr_write_unaligned` each require both
+`--preview raw_bytes` and an enclosing `checked` block. Aside from the alignment
+obligation they carry the same legality rules as `@ptr_read`/`@ptr_write`: the
+write pointer is `ptr mut T`, the read pointer is `ptr const T` or `ptr mut T`,
+and a written value has type `T`.
+
+{{ rule(id="9.2:14m", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    checked {
+        let p: ptr mut i32 = @alloc(1);
+        @ptr_write_unaligned(p, 1234);
+        let v: i32 = @ptr_read_unaligned(p);
+        @free(p, 1);
+        v // 1234
+    }
+}
+```
 
 ## Field Pointer Intrinsic
 


### PR DESCRIPTION
## Summary

The transitional-cleanup phase ADR-0059 consumes — the final engineering rung of the ADR-0052 migration:

- **Fold-in**: under `aggregate_layout`, `@byte_read`/`@byte_write` lower through the *same* narrow-scalar path as typed `u8` `@ptr_read`/`@ptr_write` — one implementation, the preview gate as the sole switch. This is simultaneously the **packed-str unification**: std's `read_packed_byte`/`write_packed_byte` (the RUE-879 mismatch) become ordinary byte-correct access gated, staying bespoke gate-off (pinned by the existing byte-identity test).
- **Unaligned access** (ADR-0059 Phase 4 / ruling 7 interim): `@ptr_read_unaligned`/`@ptr_write_unaligned` land behind `raw_bytes`, Rust-style split; on both targets they lower identically to the aligned pair — the distinction is the semantic contract, spec'd in new 9.2 rules.
- **De-gate readiness evidence for RUE-937** (which removes the gate — deliberately *not* this PR): the `raw_bytes_degate_readiness` differential corpus proves byte-intrinsic programs behave identically under `raw_bytes` alone vs `raw_bytes`+`aggregate_layout` — the byte surface does not change shape under the migration, answering RUE-937's "resolve first" question. The one non-identical element (`@ptr_offset` stride on `ptr u8`) is outside the byte family.
- RUE-962's lowering-level fold is subsumed here; its source-level intrinsic removal rides RUE-937, and RUE-961's `@alloc` reshape remains future work.

## Verification

codegen 592; air 502; spec `raw_bytes` 30; the new differential corpus 4/4; ui 195; both oracle-diff audits green (five new ledger entries for the new corpus cases, caught by the corpus-omission audit at integration); full `test.sh` green except the four known uid-0 environmental failures, both harness failure formats checked.

Fixes RUE-978

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_