### PR TITLE
RUE-1019: shorten CI critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,16 +141,11 @@ jobs:
           restore-keys: |
             dotslash-${{ matrix.name }}-
 
-      # BuildBuddy remote action cache (RUE-316/RUE-1006); see the clippy job
-      # for the secret-availability contract. NOT on linux-x64: that lane runs
-      # the compiler reproducibility check, whose guard requires a cache-free,
-      # .buckconfig-only configuration so the reference and relocated candidate
-      # builds are identically configured — a `.buckconfig.local` is a hard
-      # error in scripts/check-reproducible-compiler.sh. Warming that lane by
-      # dropping the config before the repro step is a possible follow-up once
-      # cache behavior is proven in the queue (RUE-1006).
+      # BuildBuddy remote action cache (RUE-316/RUE-1006/RUE-1019); see the
+      # clippy job for the secret-availability contract. Compiler
+      # reproducibility now has its own strictly cache-free job, so every
+      # ordinary platform lane can consume and upload shared actions.
       - name: Provision remote build cache
-        if: matrix.name != 'linux-x64'
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
@@ -164,29 +159,93 @@ jobs:
       # Uses hermetic Rust toolchain downloaded by Buck2
       # First verify everything builds (catches issues tests might miss)
       - name: Build all targets
-        run: ./buck2 build //crates/...
+        run: scripts/ci-timed "${{ matrix.name }} build" -- ./buck2 build //crates/...
 
-      # RUE-617: the compiler built above is the first half of this comparison.
-      # On the required Linux x64 lane, rebuild Rue locally with remote caching
-      # disabled from a relocated clean source tree and compare the complete
-      # compiler artifacts.  Limiting the extra cold build to one lane keeps the
-      # merge queue moving while still turning path/scheduling/environment leaks
-      # into a required failure.
+      - name: Run tests
+        # macOS owns the broad pass and the smaller heavy suites here; its CLI
+        # and spec corpora run on explicit required shards below. Local full
+        # suites and the Linux lanes continue to own every discovered target.
+        env:
+          RUE_CI_DEFER_HEAVY_SUITES: ${{ matrix.name == 'macos' && '//:cli-tests //:spec-tests' || '' }}
+        run: scripts/ci-timed "${{ matrix.name }} tests" -- ./test.sh
+
+  # RUE-617/RUE-1019: keep the byte-reproducibility proof independent of the
+  # cache-enabled Linux test lane. Both reference and relocated candidate are
+  # built locally, cache-free, under identical configuration; the job overlaps
+  # ordinary tests instead of delaying them.
+  compiler-reproducibility:
+    runs-on: ubuntu-latest
+    name: compiler reproducibility (linux-x64)
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dotslash
+        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
+
+      - name: Cache dotslash artifacts
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/dotslash
+          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          restore-keys: |
+            dotslash-linux-x64-
+
       - name: Verify compiler build reproducibility
         id: compiler_repro
-        if: matrix.name == 'linux-x64'
-        run: ./scripts/check-reproducible-compiler.sh
+        run: scripts/ci-timed "compiler reproducibility" -- ./scripts/check-reproducible-compiler.sh
 
       - name: Upload compiler reproducibility diagnostics
-        if: failure() && matrix.name == 'linux-x64' && steps.compiler_repro.outcome == 'failure'
+        if: failure() && steps.compiler_repro.outcome == 'failure'
         uses: actions/upload-artifact@v6
         with:
           name: compiler-reproducibility-diagnostics
           path: ${{ runner.temp }}/rue-compiler-repro-artifacts
           if-no-files-found: ignore
 
-      - name: Run tests
-        run: ./test.sh
+  # The macOS CLI and spec corpora dominate that platform's wall clock even
+  # though each harness already uses every available core. Run them on separate
+  # machines while the main macOS lane retains broad discovery, UI, oracle,
+  # reproducible-program, tutorial, and omission-audit coverage.
+  macos-corpus:
+    strategy:
+      matrix:
+        include:
+          - target: //:cli-tests
+            name: cli
+          - target: //:spec-tests
+            name: spec
+    runs-on: macos-15
+    name: test (macos-${{ matrix.name }})
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+
+      - name: Install dotslash
+        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
+
+      - name: Cache dotslash artifacts
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/dotslash
+          key: dotslash-macos-${{ hashFiles('buck2') }}
+          restore-keys: |
+            dotslash-macos-
+
+      - name: Provision remote build cache
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          if [ -z "${BUILDBUDDY_API_KEY:-}" ]; then
+            echo "BUILDBUDDY_API_KEY unavailable (fork PR or unset); building without the remote cache."
+            exit 0
+          fi
+          scripts/provision-build-cache install
+          scripts/provision-build-cache apply
+
+      - name: Run ${{ matrix.name }} corpus
+        run: scripts/ci-timed "macos ${{ matrix.name }} corpus" -- scripts/ci-heavy-suite "${{ matrix.target }}"
 
   # Release-mode build + test (RUE-45). Every other job builds the compiler in
   # debug, so release-only miscompiles — the ones previously masked by a
@@ -234,11 +293,17 @@ jobs:
           scripts/provision-build-cache install
           scripts/provision-build-cache apply
 
+      # Build every crate optimized (catches build breaks that only surface with
+      # optimizations on). Do this before the debug comparison: on cache-miss
+      # changes it gives the parallel sanitizer job time to publish the Linux
+      # debug compiler instead of racing two cold builds of the same graph.
+      - name: Build all targets (release)
+        run: scripts/ci-timed "release build" -- ./buck2 build //crates/... --target-platforms //platforms:release
+
       # Regression guard for RUE-277: `//platforms:release` must produce a
-      # genuinely-optimized binary that differs from the debug build. If the
-      # opt-level constraint ever silently reverts to a no-op (debug == release,
-      # as it was before RUE-277), `cmp -s` succeeds and we fail — the release
-      # suite below would otherwise be a pointless re-run of the debug build.
+      # genuinely-optimized binary that differs from the debug build. The
+      # release artifact is already materialized above; the debug artifact may
+      # now be served by the shared cache after another required job uploads it.
       - name: Assert release build is distinct from debug
         run: |
           debug_bin="$(./scripts/rue-bin --target-platforms //platforms:debug)"
@@ -249,12 +314,9 @@ jobs:
           fi
           echo "release build differs from debug build (optimized) — OK"
 
-      # Build every crate optimized (catches build breaks that only surface with
-      # optimizations on), then run the full suite — including the spec/UI/CLI
-      # sh_tests, which spawn the release-configured rue binary — so any
-      # cfg(debug_assertions)-off miscompile is caught.
-      - name: Build all targets (release)
-        run: ./buck2 build //crates/... --target-platforms //platforms:release
+      # Run the full suite — including the spec/UI/CLI sh_tests, which spawn
+      # the release-configured rue binary — so cfg(debug_assertions)-off and
+      # ThinLTO miscompiles remain required coverage.
 
       - name: Run tests (release)
-        run: ./buck2 test //... --target-platforms //platforms:release
+        run: scripts/ci-timed "release tests" -- ./buck2 test //... --target-platforms //platforms:release

--- a/BUCK
+++ b/BUCK
@@ -404,6 +404,8 @@ filegroup(
     name = "wrapper-script-inputs",
     srcs = [
         "fmt.sh",
+        "scripts/ci-heavy-suite",
+        "scripts/ci-timed",
         "scripts/rue",
         "scripts/rue-bin",
         "scripts/provision-build-cache",

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -116,9 +116,10 @@ for default-on RE.
 ## CI
 
 CI reads the key from the `BUILDBUDDY_API_KEY` repo secret (never from a file).
-The cache is provisioned (RUE-1006) in the `CI` workflow's `clippy`, `release`,
-and non-x64 `test` jobs, and in the sanitizer `valgrind` job, via
-`scripts/provision-build-cache install && apply` gated on secret presence.
+The cache is provisioned (RUE-1006/RUE-1019) in the `CI` workflow's `clippy`,
+`release`, ordinary platform-test, and macOS corpus jobs, and in the sanitizer
+`valgrind` job, via `scripts/provision-build-cache install && apply` gated on
+secret presence.
 
 Availability rules, which the workflow steps must respect:
 
@@ -131,13 +132,13 @@ Availability rules, which the workflow steps must respect:
   bottleneck, so this is where the warm cache pays off. These runs execute
   already-approved, queued code, which is also why letting them write to the
   shared cache (`allow_cache_uploads`) is acceptable.
-- **The linux-x64 `test` lane is intentionally cache-free.** It runs
-  `scripts/check-reproducible-compiler.sh` (RUE-617), which hard-errors on a
-  `.buckconfig.local`: the reference and relocated candidate builds must be
+- **The dedicated compiler-reproducibility job is intentionally cache-free.**
+  It runs `scripts/check-reproducible-compiler.sh` (RUE-617), which hard-errors
+  on a `.buckconfig.local`: the reference and relocated candidate builds must be
   identically configured for the byte comparison to indict path/scheduling/
-  environment leaks rather than configuration drift. Warming that lane by
-  removing the config before the repro step is a possible follow-up once the
-  queue has demonstrated real hit-rates.
+  environment leaks rather than configuration drift. Keeping that proof in an
+  independent job lets the ordinary linux-x64 build and tests use the shared
+  cache without changing the reproducibility contract.
 
 The `cache-probe` workflow (`.github/workflows/cache-probe.yml`) remains the
 measurement tool: it writes a transient config from the secret, does a cold
@@ -145,6 +146,13 @@ release build of `//crates/...` then a clean-and-rebuild, and reports buck2's
 `Commands: (cached / remote / local)` line. It fails when the warm build does
 not convert any cold local actions into cache hits. Run it with
 `gh workflow run cache-probe.yml`.
+
+Required CI also records per-step wall time and aggregate cached/remote/local
+command counts in each job summary via `scripts/ci-timed`. The probe answers
+whether unchanged actions are reusable; the job summaries answer the different
+question of how expensive a real change's remaining local actions were. Both
+signals matter: a central Rust or ThinLTO change can have a high numerical hit
+rate while a few invalidated actions remain on the critical path.
 
 ## Toward a fully hermetic linker
 

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -15,11 +15,28 @@ because per-commit measurement on trunk is its purpose.
 
 The build jobs use the shared BuildBuddy remote action cache when the
 `BUILDBUDDY_API_KEY` secret is available (merge_group runs; fork PRs build
-cold) — see `docs/process/build-cache.md` for the availability rules,
-including why the linux-x64 test lane stays cache-free. Containers executed by that workflow must use a reviewed,
-human-readable release tag and the immutable OCI index digest for that tag. The
-repository gate `//:required-ci-container-pin-validation` rejects a moving
-`latest` image reference, and the normal `./test.sh` run includes that gate.
+cold) — see `docs/process/build-cache.md` for the availability rules. The
+compiler-reproducibility job is the deliberate exception: its two independently
+materialized compiler builds stay local and cache-free, while the ordinary
+linux-x64 test lane may use BuildBuddy.
+
+The platform test lanes all retain broad target discovery. On macOS, the main
+lane defers the two longest heavy targets (`//:cli-tests` and `//:spec-tests`)
+to explicit required jobs so those corpora overlap. `test.sh` accepts that
+deferral only under `CI=true`, validates each target against Buck's live
+`rue_heavy_suite` query, and continues to audit every corpus target it owns.
+Local full suites never defer coverage.
+
+Major Buck commands run through `scripts/ci-timed`, which preserves output and
+the exact command exit status while appending wall time and aggregate
+`Commands: (cached / remote / local)` counters to the GitHub job summary. Read
+wall time together with hit count: a small number of invalidated ThinLTO actions
+can dominate a release build even when its hit rate is above 90 percent.
+
+Containers executed by the workflow must use a reviewed, human-readable
+release tag and the immutable OCI index digest for that tag. The repository
+gate `//:required-ci-container-pin-validation` rejects a moving `latest` image
+reference, and the normal `./test.sh` run includes that gate.
 
 ## Updating actionlint
 

--- a/scripts/ci-heavy-suite
+++ b/scripts/ci-heavy-suite
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Run one explicitly assigned CI heavy suite and fail if Buck omits its result.
+set -uo pipefail
+
+if [[ $# -ne 1 || "$1" != //:* ]]; then
+    echo "usage: scripts/ci-heavy-suite //:TARGET" >&2
+    exit 2
+fi
+target="$1"
+
+if ! ./buck2 uquery 'attrfilter(labels, rue_heavy_suite, //...)' |
+    grep -Fxq "root$target"; then
+    echo "error: CI shard target is not labeled rue_heavy_suite: $target" >&2
+    exit 1
+fi
+
+log="$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/rue-ci-heavy-suite.XXXXXX")"
+cleanup() {
+    rm -f "$log"
+}
+trap cleanup EXIT
+
+./buck2 test "$target" 2>&1 | tee "$log"
+status=${PIPESTATUS[0]}
+if [[ "$status" -ne 0 ]]; then
+    exit "$status"
+fi
+
+if ! grep -qE "(Pass|Fail|Skip|Timeout|Fatal|Omit|Flaky): root${target} " "$log"; then
+    echo "error: explicit CI shard produced no result for $target" >&2
+    exit 1
+fi

--- a/scripts/ci-timed
+++ b/scripts/ci-timed
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Run one CI command without changing its output or exit status, and append a
+# compact wall-time/action-cache summary to GitHub's job summary.
+set -uo pipefail
+
+if [[ $# -lt 3 || "$2" != "--" ]]; then
+    echo "usage: scripts/ci-timed LABEL -- COMMAND [ARG ...]" >&2
+    exit 2
+fi
+
+label="$1"
+shift 2
+
+log="$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/rue-ci-timed.XXXXXX")"
+cleanup() {
+    rm -f "$log"
+}
+trap cleanup EXIT
+
+started="$(date +%s)"
+"$@" 2>&1 | tee "$log"
+status=${PIPESTATUS[0]}
+finished="$(date +%s)"
+elapsed=$((finished - started))
+
+invocations=0
+commands=0
+cached=0
+remote=0
+local_actions=0
+while IFS= read -r line; do
+    if [[ "$line" =~ Commands:[[:space:]]+([0-9]+)[[:space:]]+\(cached:[[:space:]]+([0-9]+),[[:space:]]+remote:[[:space:]]+([0-9]+),[[:space:]]+local:[[:space:]]+([0-9]+)\) ]]; then
+        ((invocations += 1))
+        ((commands += BASH_REMATCH[1]))
+        ((cached += BASH_REMATCH[2]))
+        ((remote += BASH_REMATCH[3]))
+        ((local_actions += BASH_REMATCH[4]))
+    fi
+done <"$log"
+
+result="passed"
+if [[ "$status" -ne 0 ]]; then
+    result="failed ($status)"
+fi
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    safe_label="${label//|/\\|}"
+    {
+        echo "### CI timing: $safe_label"
+        echo
+        echo "| Result | Wall time | Buck invocations | Commands | Cached | Remote | Local |"
+        echo "| --- | ---: | ---: | ---: | ---: | ---: | ---: |"
+        echo "| $result | ${elapsed}s | $invocations | $commands | $cached | $remote | $local_actions |"
+        echo
+    } >>"$GITHUB_STEP_SUMMARY"
+fi
+
+exit "$status"

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -237,7 +237,7 @@ EOF
 }
 
 test_full_suite_orchestration() {
-    local sb rc=0
+    local sb out rc=0
     sb="$(mktemp -d)"
     mkdir -p "$sb/scripts"
     cp "$SRC_ROOT/test.sh" "$sb/test.sh"
@@ -266,7 +266,14 @@ elif [[ "${1:-}" == "test" ]]; then
 fi
 EOF
     chmod +x "$sb/buck2"
-    BUCK_LOG="$sb/calls" RUE_FULL_SUITE_LOCK_DIR="$sb/lock" "$sb/test.sh" >/dev/null 2>&1 || rc=$?
+    # The required macOS job sets this variable for its outer test.sh. Keep
+    # this fixture's baseline full-suite contract independent of that caller
+    # environment; deferral behavior has its own focused tests.
+    out="$(BUCK_LOG="$sb/calls" RUE_CI_DEFER_HEAVY_SUITES= \
+        RUE_FULL_SUITE_LOCK_DIR="$sb/lock" "$sb/test.sh" 2>&1)" || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        printf '%s\n' "$out" >&2
+    fi
     check "suite: unfiltered orchestration succeeds" "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
     check "suite: broad discovery excludes opaque heavy tests" \
         "$(grep -Fxq 'test //... --exclude rue_heavy_suite --always-exclude' "$sb/calls" && echo 0 || echo 1)"

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -652,6 +652,82 @@ test_rue_unit_unknown_crate_errors_cleanly() {
   rm -rf "$sb"
 }
 
+# CI timing summaries must preserve the wrapped command's output and exact exit
+# status while aggregating every Buck command summary emitted by a multi-step
+# wrapper such as test.sh.
+test_ci_timed_preserves_status_and_summarizes_actions() {
+  local sb; sb="$(mktemp -d)"
+  cp "$SRC_ROOT/scripts/ci-timed" "$sb/ci-timed"; chmod +x "$sb/ci-timed"
+  cat >"$sb/fake-command" <<'EOF'
+#!/usr/bin/env bash
+echo 'first line'
+echo 'Commands: 10 (cached: 7, remote: 1, local: 2)'
+echo 'Commands: 5 (cached: 3, remote: 1, local: 1)'
+exit "${FAKE_EXIT:-0}"
+EOF
+  chmod +x "$sb/fake-command"
+
+  local rc=0 out
+  out="$(GITHUB_STEP_SUMMARY="$sb/summary" "$sb/ci-timed" "wrapper test" -- "$sb/fake-command" 2>&1)" || rc=$?
+  check "ci-timed: wrapped output remains visible" \
+    "$(grep -Fq 'first line' <<<"$out" && echo 0 || echo 1)"
+  check "ci-timed: successful command exit is preserved" \
+    "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
+  check "ci-timed: all Buck summaries are aggregated" \
+    "$(grep -Fq '| passed |' "$sb/summary" && grep -Fq '| 2 | 15 | 10 | 2 | 3 |' "$sb/summary" && echo 0 || echo 1)"
+
+  : >"$sb/summary"; rc=0
+  GITHUB_STEP_SUMMARY="$sb/summary" FAKE_EXIT=23 \
+    "$sb/ci-timed" "failing wrapper" -- "$sb/fake-command" >/dev/null 2>&1 || rc=$?
+  check "ci-timed: wrapped failure exit is preserved" \
+    "$([ "$rc" -eq 23 ] && echo 0 || echo 1)"
+  check "ci-timed: failed result is recorded" \
+    "$(grep -Fq '| failed (23) |' "$sb/summary" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+# An explicit heavy-suite shard must still prove that Buck discovered and
+# reported its assigned target; a green command with no result is a RUE-924
+# false green even when the target pattern was explicit.
+test_ci_heavy_suite_audits_its_target() {
+  local sb; sb="$(mktemp -d)"
+  cp "$SRC_ROOT/scripts/ci-heavy-suite" "$sb/ci-heavy-suite"; chmod +x "$sb/ci-heavy-suite"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "uquery" ]; then
+  echo 'root//:cli-tests'
+  exit 0
+fi
+if [ "$1" = "test" ]; then
+  if [ "${FAKE_OMIT:-0}" != 1 ]; then echo 'Pass: root//:cli-tests (0.1s)'; fi
+  exit "${FAKE_EXIT:-0}"
+fi
+exit 90
+EOF
+  chmod +x "$sb/buck2"
+
+  local rc=0 out
+  (cd "$sb" && ./ci-heavy-suite //:cli-tests) >/dev/null 2>&1 || rc=$?
+  check "ci-heavy-suite: labeled target with a result succeeds" \
+    "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
+
+  rc=0
+  out="$(cd "$sb" && ./ci-heavy-suite //:spec-tests 2>&1)" || rc=$?
+  check "ci-heavy-suite: unlabeled shard target fails closed" \
+    "$([ "$rc" -ne 0 ] && grep -Fq 'not labeled rue_heavy_suite' <<<"$out" && echo 0 || echo 1)"
+
+  rc=0
+  out="$(cd "$sb" && FAKE_OMIT=1 ./ci-heavy-suite //:cli-tests 2>&1)" || rc=$?
+  check "ci-heavy-suite: omitted explicit result fails closed" \
+    "$([ "$rc" -ne 0 ] && grep -Fq 'produced no result' <<<"$out" && echo 0 || echo 1)"
+
+  rc=0
+  (cd "$sb" && FAKE_EXIT=29 ./ci-heavy-suite //:cli-tests) >/dev/null 2>&1 || rc=$?
+  check "ci-heavy-suite: Buck failure exit is preserved" \
+    "$([ "$rc" -eq 29 ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
 # ===========================================================================
 # RUE-924 — an unfiltered test.sh must FAIL LOUDLY when a corpus harness is
 # silently omitted from the run's results, instead of reporting a green tally
@@ -672,10 +748,11 @@ test_testsh_unfiltered_audits_corpus_presence() {
   cat >"$sb/buck2" <<'EOF'
 #!/usr/bin/env bash
 if [ "$1" = "uquery" ]; then
-  for t in $FAKE_HEAVY_SUITES; do printf '%s\n' "$t"; done
+  for t in $FAKE_HEAVY_SUITES; do printf 'root%s\n' "$t"; done
   exit 0
 fi
 if [ "$1" = "test" ]; then
+  if [ -n "${FAKE_CALL_LOG:-}" ]; then printf '%s\n' "$*" >>"$FAKE_CALL_LOG"; fi
   tgt="$2"
   if [ "$tgt" = "//..." ]; then
     printf 'Pass: root//crates/rue-lexer:rue-lexer-test (0.1s)\n'
@@ -683,7 +760,7 @@ if [ "$1" = "test" ]; then
     exit "${FAKE_BUCK_EXIT:-0}"
   fi
   for t in $FAKE_PASS_TARGETS; do
-    if [ "$t" = "$tgt" ]; then printf 'Pass: root%s (0.1s)\n' "$t"; fi
+    if [ "$t" = "${tgt#root}" ]; then printf 'Pass: root%s (0.1s)\n' "$t"; fi
   done
   printf 'Tests finished: Pass 1. Fail 0. Skip 0.\n'
   exit 0
@@ -696,7 +773,7 @@ EOF
 
   # (1) Full corpus present + buck2 green -> test.sh reports success.
   local rc=0 out
-  out="$(cd "$sb" && RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
+  out="$(cd "$sb" && RUE_CI_DEFER_HEAVY_SUITES= RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
   check "test.sh: unfiltered run with the full corpus reports success" \
     "$([ "$rc" -eq 0 ] && grep -Fxq '=== TEST SUITE: PASSED ===' <<< "$out" && echo 0 || echo 1)"
 
@@ -704,7 +781,7 @@ EOF
   #     the RUE-924 false-green: it must become a hard failure naming the suite.
   local partial="//:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests"
   rc=0
-  out="$(cd "$sb" && RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$partial" ./test.sh 2>&1)" || rc=$?
+  out="$(cd "$sb" && RUE_CI_DEFER_HEAVY_SUITES= RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$partial" ./test.sh 2>&1)" || rc=$?
   check "test.sh: a silently omitted corpus harness fails the run" \
     "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
   check "test.sh: the omission message names the missing harness" \
@@ -715,9 +792,38 @@ EOF
   # (3) A genuine buck2 failure with the full corpus present is still
   #     propagated verbatim (the audit must not mask real failures).
   rc=0
-  out="$(cd "$sb" && RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" FAKE_BUCK_EXIT=17 ./test.sh 2>&1)" || rc=$?
+  out="$(cd "$sb" && RUE_CI_DEFER_HEAVY_SUITES= RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" FAKE_BUCK_EXIT=17 ./test.sh 2>&1)" || rc=$?
   check "test.sh: unfiltered buck2 failure exit code is propagated" \
     "$([ "$rc" -eq 17 ] && echo 0 || echo 1)"
+
+  # (4) Required CI may explicitly defer known live heavy targets to separate
+  # jobs. The owning invocation must skip and stop auditing exactly those
+  # targets while retaining every other corpus assertion.
+  local owned="//:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests"
+  : >"$sb/calls.log"; rc=0
+  out="$(cd "$sb" && CI=true RUE_FULL_SUITE_LOCK_HELD=1 \
+      RUE_CI_DEFER_HEAVY_SUITES='//:cli-tests //:spec-tests' \
+      FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$owned" \
+      FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
+  check "test.sh: required CI may defer live heavy suites" \
+    "$([ "$rc" -eq 0 ] && grep -Fq 'Deferring heavy suite root//:cli-tests' <<<"$out" && echo 0 || echo 1)"
+  check "test.sh: deferred suites are not executed by the owning shard" \
+    "$(! grep -Eq '^test (root)?//:(cli|spec)-tests' "$sb/calls.log" && echo 0 || echo 1)"
+
+  # (5) A stale shard name or local attempt to suppress coverage fails closed.
+  rc=0
+  out="$(cd "$sb" && CI=true RUE_FULL_SUITE_LOCK_HELD=1 \
+      RUE_CI_DEFER_HEAVY_SUITES='//:missing-suite' \
+      FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
+  check "test.sh: unknown deferred CI suite fails closed" \
+    "$([ "$rc" -ne 0 ] && grep -Fq 'not labeled rue_heavy_suite' <<<"$out" && echo 0 || echo 1)"
+
+  rc=0
+  out="$(cd "$sb" && CI= RUE_FULL_SUITE_LOCK_HELD=1 \
+      RUE_CI_DEFER_HEAVY_SUITES='//:cli-tests' \
+      FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
+  check "test.sh: local callers cannot defer corpus coverage" \
+    "$([ "$rc" -ne 0 ] && grep -Fq 'reserved for required CI' <<<"$out" && echo 0 || echo 1)"
 
   rm -rf "$sb"
 }
@@ -737,6 +843,8 @@ test_rue_unit_maps_crate_and_forwards_args
 test_rue_unit_zero_match_fails_loud
 test_rue_unit_failing_test_propagates_exit
 test_rue_unit_unknown_crate_errors_cleanly
+test_ci_timed_preserves_status_and_summarizes_actions
+test_ci_heavy_suite_audits_its_target
 test_testsh_unfiltered_audits_corpus_presence
 test_sanitizer_defaults_std_path
 test_sanitizer_recursive_discovery_contract

--- a/test.sh
+++ b/test.sh
@@ -107,6 +107,44 @@ if [[ $# -eq 0 ]]; then
         exit 1
     fi
 
+    # Required CI may move selected heavy suites to their own platform runner
+    # so expensive corpus harnesses overlap instead of serializing the merge
+    # queue. This is deliberately CI-only: an ordinary local `./test.sh` still
+    # owns and audits the complete corpus in one invocation. Every deferred
+    # target must be present in Buck's live heavy-suite query; a stale or
+    # misspelled shard therefore fails here instead of becoming a false green.
+    DEFERRED_HEAVY_SUITES=()
+    if [[ -n "${RUE_CI_DEFER_HEAVY_SUITES:-}" ]]; then
+        if [[ "${CI:-}" != "true" ]]; then
+            echo "error: RUE_CI_DEFER_HEAVY_SUITES is reserved for required CI" >&2
+            exit 1
+        fi
+        read -r -a DEFERRED_HEAVY_SUITES <<<"$RUE_CI_DEFER_HEAVY_SUITES"
+        for deferred in "${DEFERRED_HEAVY_SUITES[@]}"; do
+            found=0
+            for suite in "${HEAVY_SUITES[@]}"; do
+                [[ "${suite#root}" == "${deferred#root}" ]] && found=1
+            done
+            if [[ "$found" -ne 1 ]]; then
+                echo "error: deferred CI suite is not labeled rue_heavy_suite: $deferred" >&2
+                exit 1
+            fi
+        done
+    fi
+
+    suite_is_deferred() {
+        local candidate="$1" deferred
+        # Bash 3.2 treats an empty array expansion as an unbound variable under
+        # `set -u`. macOS runners normally provide a newer Bash, but keeping the
+        # no-deferral path portable also makes relocated/cache-free validation
+        # behave exactly like the canonical worktree.
+        [[ -z "${RUE_CI_DEFER_HEAVY_SUITES:-}" ]] && return 1
+        for deferred in "${DEFERRED_HEAVY_SUITES[@]}"; do
+            [[ "${candidate#root}" == "${deferred#root}" ]] && return 0
+        done
+        return 1
+    }
+
     # Stream every invocation live AND capture it into one log, so we can audit
     # afterward that no corpus harness was silently omitted (RUE-924).
     # PIPESTATUS[0] is buck2's real exit code (tee always exits 0), preserving
@@ -120,6 +158,10 @@ if [[ $# -eq 0 ]]; then
     step_status=${PIPESTATUS[0]}
     [[ "$step_status" -ne 0 && "$overall_status" -eq 0 ]] && overall_status=$step_status
     for suite in "${HEAVY_SUITES[@]}"; do
+        if suite_is_deferred "$suite"; then
+            echo "Deferring heavy suite $suite to its required CI shard..."
+            continue
+        fi
         echo "Running heavy suite $suite..."
         ./buck2 test "$suite" 2>&1 | tee -a "$run_log"
         step_status=${PIPESTATUS[0]}
@@ -133,6 +175,9 @@ if [[ $# -eq 0 ]]; then
     # — neither in the broad pass nor as a heavy suite.
     missing_corpus=()
     for target in "${REQUIRED_CORPUS_HARNESSES[@]}"; do
+        if suite_is_deferred "$target"; then
+            continue
+        fi
         if ! grep -qE "(Pass|Fail|Skip|Timeout|Fatal|Omit|Flaky): root${target} " "$run_log"; then
             missing_corpus+=("$target")
         fi


### PR DESCRIPTION
## Summary

- let every ordinary platform lane use the BuildBuddy action cache while moving the byte-for-byte compiler reproducibility proof into an independent, strictly cache-free job
- move the macOS CLI and specification corpora onto parallel jobs, with live `rue_heavy_suite` validation and fail-closed result auditing so the main lane cannot silently drop coverage
- start the optimized release build before materializing the debug comparison artifact, while retaining the complete release/ThinLTO suite
- record wall time and aggregate cached/remote/local Buck command counts in GitHub job summaries

## Why

The release lane could still spend more than eleven minutes on a small set of invalidated local ThinLTO actions despite a 94% cache-hit count. The macOS lane also serialized its two largest independent corpora behind the broad test pass.

A cache-free macOS validation measured CLI at 3m43s (1,627 passed) and spec at 4m22s (2,135 passed). Running those on separate machines removes roughly eight minutes of serialized corpus work on a true cache miss, subject to runner startup and shared-cache availability.

The dedicated timing summaries make the remaining expensive local actions visible; the separate cache probe remains the unchanged-action reuse diagnostic.

## Validation

- complete cache-free `./test.sh` in a relocated checkout: passed, including 51 broad targets and every CLI/spec/UI/oracle/reproducibility corpus
- `//:wrapper-script-tests` (66 checks) and `//:build-sharing-tests` (29 checks) under the exact sharded CI environment with remote caching disabled
- relocated system Bash 3.2 compatibility for the full-suite orchestration path
- pinned actionlint + ShellCheck container across all workflows
- real cache-free `//:ui-tests` shard: 195 passed

Fixes RUE-1019
