### PR TITLE
RUE-869: enforce the supported compiler facade

### DIFF
--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -7,15 +7,14 @@ use std::{collections::HashMap, env, process, sync::Arc, time::Instant};
 #[cfg(test)]
 use rue_air::{FrozenTypeInternPool, TypeKind};
 use rue_compiler::unstable::{
-    DependencyBaseline, DependencyIncompleteReason, DependencySurface, FullInvalidationReason,
-    InvalidationMetrics, InvalidationScope, MetricsSnapshot, ParseMetrics, query_merge,
-    semantic_parity_snapshot,
+    DependencyBaseline, DependencyIncompleteReason, DependencySurface, DiscoverySourceAssembler,
+    FullInvalidationReason, InvalidationMetrics, InvalidationScope, MetricsSnapshot, ParseMetrics,
+    prepare_stable_definitions, query_merge, semantic_parity_snapshot,
 };
 use rue_compiler::{
-    AcceptedReadManifestEntry, CompileOptions, CompilerSession, DiscoverySourceAssembler,
-    FileMetadataFingerprint, FrontendDiagnosticSnapshot, ImportDiscoveryContext,
-    ImportObservationLedger, OptLevel, PhysicalFileIdentity, SemanticView, SourceMetadata,
-    SourceSnapshot,
+    AcceptedReadManifestEntry, CompileOptions, CompilerSession, FileMetadataFingerprint,
+    FrontendDiagnosticSnapshot, ImportDiscoveryContext, ImportObservationLedger, OptLevel,
+    PhysicalFileIdentity, SemanticView, SourceMetadata, SourceSnapshot,
 };
 use rue_span::FileId;
 use serde_json::{Value, json};
@@ -1072,14 +1071,14 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
         "stable_definitions_cold",
         measure(&mut stable, |session| {
             let parse = session.update(&fixture.base).unstable_metrics();
-            session.stable_definitions(&options).unwrap();
+            prepare_stable_definitions(session, &options).unwrap();
             parse
         }),
     ));
     scenarios.push(named(
         "stable_definitions_reuse",
         measure(&mut stable, |session| {
-            session.stable_definitions(&options).unwrap();
+            prepare_stable_definitions(session, &options).unwrap();
             ParseMetrics::default()
         }),
     ));

--- a/crates/rue-compiler-session-bench/src/representative.rs
+++ b/crates/rue-compiler-session-bench/src/representative.rs
@@ -6,10 +6,11 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
+use rue_compiler::unstable::{DiscoverySourceAssembler, committed_import_discovery};
 use rue_compiler::{
     AcceptedImportSource, AcceptedReadManifestEntry, CompileOptions, CompilerSession,
-    DiscoverySourceAssembler, FileMetadataFingerprint, ImportDiscoveryContext, ImportObservation,
-    ImportObservationLedger, PhysicalFileIdentity, SemanticView, SourceSnapshot,
+    FileMetadataFingerprint, ImportDiscoveryContext, ImportObservation, ImportObservationLedger,
+    PhysicalFileIdentity, SemanticView, SourceSnapshot,
 };
 use serde_json::{Value, json};
 
@@ -121,8 +122,7 @@ fn snapshot(variant: Variant) -> SourceSnapshot {
 }
 
 fn close_discovery(session: &mut CompilerSession, source: &SourceSnapshot) {
-    if session
-        .committed_import_discovery()
+    if committed_import_discovery(session)
         .is_some_and(|artifact| artifact.source_revision() == source.source_revision())
     {
         return;

--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -52,7 +52,10 @@ rust_test(
     name = "rue-compiler-public-api-test",
     srcs = ["tests/public_api.rs"],
     crate_root = "tests/public_api.rs",
-    deps = [":rue-compiler"],
+    deps = [
+        ":rue-compiler",
+        "//crates/rue-error:rue-error",
+    ],
 )
 
 # A bounded, deterministic corpus comparing a long-lived session with

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1,4 +1,10 @@
-//! RUE-736 review gate for the curated compiler facade.
+//! Semantic review gate for the curated compiler facade.
+//!
+//! RUE-869 replaces the old source-line budget with an exact inventory of
+//! every root export and every public `CompilerSession`/
+//! `CompilerSessionUpdate` signature. The inventory records ownership,
+//! stability, category, and approved consumers so intentional API changes are
+//! reviewed as semantic one-line diffs.
 
 const PRODUCTION_MODULES: &[(&str, &str)] = &[
     ("artifact_views", include_str!("artifact_views.rs")),
@@ -66,6 +72,40 @@ const RUE_868_RAW_FACADE_VOCABULARY: &[&str] = &[
     "LoweringDebugInfo",
     "RegAllocDebugInfo",
     "StackFrameInfo",
+];
+
+const RUE_869_INTERNAL_ROOT_VOCABULARY: &[&str] = &[
+    "BoundDefinitionId",
+    "BoundDefinitionRecord",
+    "BoundDefinitionSet",
+    "DefinitionId",
+    "DefinitionKind",
+    "DefinitionNameKey",
+    "DefinitionNamespace",
+    "DefinitionOccurrenceId",
+    "DefinitionRecord",
+    "DefinitionShard",
+    "DefinitionSnapshot",
+    "DependencyAcceptedRead",
+    "DependencyContext",
+    "DependencyObservation",
+    "DependencyObservationOutcome",
+    "DependencyRequest",
+    "DiscoverySourceAssembler",
+    "IMPORT_DISCOVERY_POLICY_VERSION",
+    "DiagnosticFormatter",
+    "JsonDiagnostic",
+    "JsonDiagnosticFormatter",
+    "MultiFileFormatter",
+    "MultiFileJsonFormatter",
+    "CompileError",
+    "CompileResult",
+    "Diagnostic",
+    "ErrorCode",
+    "ErrorKind",
+    "Suggestion",
+    "WarningKind",
+    "Span",
 ];
 
 fn code_identifiers(source: &str) -> Vec<&str> {
@@ -203,9 +243,20 @@ const RUE_867_DURABLE_VOCABULARY: &[&str] = &[
 fn public_declarations(source: &str) -> Vec<String> {
     let mut declarations = Vec::new();
     let mut lines = source.lines();
+    let mut api_attributes = Vec::new();
     while let Some(line) = lines.next() {
         let trimmed = line.trim_start();
+        if trimmed.starts_with("#[") {
+            if trimmed.starts_with("#[cfg(") || trimmed.starts_with("#[cfg_attr(") {
+                api_attributes.push(trimmed.to_owned());
+            }
+            continue;
+        }
+        if trimmed.is_empty() || trimmed.starts_with("///") || trimmed.starts_with("//!") {
+            continue;
+        }
         if !trimmed.starts_with("pub ") || trimmed.starts_with("pub(crate)") {
+            api_attributes.clear();
             continue;
         }
 
@@ -230,7 +281,11 @@ fn public_declarations(source: &str) -> Vec<String> {
                     | "mod"
             )
         });
-        let mut declaration = String::new();
+        let mut declaration = api_attributes.join("\n");
+        api_attributes.clear();
+        if !declaration.is_empty() {
+            declaration.push('\n');
+        }
         let mut brace_depth = 0isize;
         let mut opened_body = false;
         let mut current = Some(line);
@@ -329,6 +384,39 @@ fn impl_blocks(source: &str) -> Vec<&str> {
     blocks
 }
 
+fn macro_blocks(source: &str) -> Vec<&str> {
+    let mut blocks = Vec::new();
+    let mut offset = 0;
+    for line in source.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("macro_rules!") || trimmed.starts_with("pub macro ") {
+            let leading = line.len() - trimmed.len();
+            let start = offset + leading;
+            let rest = &source[start..];
+            let Some(open) = rest.find('{') else {
+                offset += line.len();
+                continue;
+            };
+            let mut depth = 0usize;
+            for (index, byte) in rest[open..].bytes().enumerate() {
+                match byte {
+                    b'{' => depth += 1,
+                    b'}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            blocks.push(&rest[..open + index + 1]);
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        offset += line.len();
+    }
+    blocks
+}
+
 fn supported_public_surface(facade: &str, modules: &[(&str, &str)]) -> String {
     let root_declarations = public_declarations(facade);
     let public_module_names = root_declarations
@@ -395,6 +483,98 @@ fn public_use_declarations(source: &str) -> Vec<String> {
     declarations
 }
 
+fn macro_invocation_path(line: &str) -> Option<&str> {
+    let (path, _) = line.split_once('!')?;
+    let path = path.trim();
+    if path == "macro_rules" || path.is_empty() {
+        return None;
+    }
+    path.chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == ':')
+        .then_some(path)
+}
+
+fn unsupported_api_layout(source: &str, root: bool) -> Option<String> {
+    let mut conditional_export = false;
+    let mut test_only_condition = false;
+    for line in source.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("#[cfg(") || trimmed.starts_with("#[cfg_attr(") {
+            if !trimmed.ends_with(']') {
+                return Some(trimmed.to_owned());
+            }
+            test_only_condition = !conditional_export && trimmed == "#[cfg(test)]";
+            conditional_export = true;
+            continue;
+        }
+        if trimmed.starts_with("#[macro_export") {
+            return Some(trimmed.to_owned());
+        }
+        if trimmed.starts_with("#[") {
+            continue;
+        }
+        if trimmed.is_empty() || trimmed.starts_with("///") || trimmed.starts_with("//!") {
+            continue;
+        }
+        if trimmed == "pub"
+            || trimmed.starts_with("pub\t")
+            || trimmed.starts_with("pub/*")
+            || trimmed == "impl"
+            || trimmed.starts_with("impl\t")
+            || trimmed.starts_with("impl/*")
+        {
+            return Some(trimmed.to_owned());
+        }
+        if trimmed.starts_with("include!(") || trimmed.starts_with("pub macro ") {
+            return Some(trimmed.to_owned());
+        }
+        if line.len() == trimmed.len()
+            && let Some(path) = macro_invocation_path(trimmed)
+        {
+            let name = path.rsplit("::").next().unwrap_or(path);
+            if root || !matches!(name, "thread_local" | "session_query_metrics_family") {
+                return Some(trimmed.to_owned());
+            }
+        }
+        if root && conditional_export && trimmed.starts_with("pub use ") {
+            return Some(trimmed.to_owned());
+        }
+        let identifiers = code_identifiers(trimmed);
+        if conditional_export
+            && !test_only_condition
+            && (trimmed.starts_with("impl ") || trimmed.starts_with("impl<"))
+            && (identifiers.contains(&"CompilerSession")
+                || identifiers.contains(&"CompilerSessionUpdate"))
+        {
+            return Some(trimmed.to_owned());
+        }
+        conditional_export = false;
+        test_only_condition = false;
+    }
+    for block in macro_blocks(source) {
+        if root || code_identifiers(block).contains(&"pub") {
+            return Some(block.lines().next().unwrap_or("macro_rules!").to_owned());
+        }
+    }
+    for implementation in impl_blocks(source) {
+        if impl_owner(implementation).is_none() {
+            continue;
+        }
+        for line in implementation.lines().skip(1) {
+            let Some(direct) = line.strip_prefix("    ") else {
+                continue;
+            };
+            if direct.chars().next().is_some_and(char::is_whitespace) {
+                continue;
+            }
+            if macro_invocation_path(direct).is_some() {
+                return Some(direct.to_owned());
+            }
+        }
+    }
+    None
+}
+
 fn assert_no_public_use_globs(source: &str) {
     for declaration in public_use_declarations(source) {
         assert!(
@@ -409,6 +589,362 @@ fn public_use_is_glob(declaration: &str) -> bool {
         .split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_' || ch == '*'))
         .filter(|token| !token.is_empty())
         .any(|token| token == "*")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ApiInventoryEntry {
+    stability: String,
+    owner: String,
+    class: String,
+    consumer: String,
+    symbol: String,
+    signature: String,
+}
+
+impl ApiInventoryEntry {
+    fn new(
+        stability: &str,
+        owner: impl Into<String>,
+        class: &str,
+        consumer: &str,
+        symbol: impl Into<String>,
+        signature: impl Into<String>,
+    ) -> Self {
+        Self {
+            stability: stability.to_owned(),
+            owner: owner.into(),
+            class: class.to_owned(),
+            consumer: consumer.to_owned(),
+            symbol: symbol.into(),
+            signature: signature.into(),
+        }
+    }
+
+    fn render(&self) -> String {
+        for field in [
+            &self.stability,
+            &self.owner,
+            &self.class,
+            &self.consumer,
+            &self.symbol,
+            &self.signature,
+        ] {
+            assert!(
+                !field.contains('|') && !field.contains('\n'),
+                "semantic API inventory fields must remain one-line and pipe-free: {field:?}"
+            );
+        }
+        format!(
+            "{}|{}|{}|{}|{}|{}",
+            self.stability, self.owner, self.class, self.consumer, self.symbol, self.signature
+        )
+    }
+}
+
+fn canonical_signature(declaration: &str) -> String {
+    let declaration = declaration
+        .lines()
+        .map(|line| line.split_once("//").map_or(line, |(code, _)| code))
+        .collect::<String>();
+    let end = declaration
+        .find('{')
+        .or_else(|| declaration.find(';'))
+        .unwrap_or(declaration.len());
+    let source = &declaration[..end];
+    let bytes = source.as_bytes();
+    let mut tokens = Vec::<(String, bool)>::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if byte.is_ascii_whitespace() {
+            index += 1;
+            continue;
+        }
+        if byte.is_ascii_alphanumeric() || byte == b'_' {
+            let start = index;
+            index += 1;
+            while index < bytes.len()
+                && (bytes[index].is_ascii_alphanumeric() || bytes[index] == b'_')
+            {
+                index += 1;
+            }
+            tokens.push((source[start..index].to_owned(), true));
+            continue;
+        }
+        if byte == b'\'' && index + 1 < bytes.len() && bytes[index + 1].is_ascii_alphabetic() {
+            let start = index;
+            index += 2;
+            while index < bytes.len()
+                && (bytes[index].is_ascii_alphanumeric() || bytes[index] == b'_')
+            {
+                index += 1;
+            }
+            tokens.push((source[start..index].to_owned(), true));
+            continue;
+        }
+        let two = (index + 1 < bytes.len()).then(|| &source[index..index + 2]);
+        if matches!(
+            two,
+            Some("->" | "::" | "=>" | ".." | "<=" | ">=" | "==" | "!=")
+        ) {
+            tokens.push((two.unwrap().to_owned(), false));
+            index += 2;
+        } else {
+            tokens.push((source[index..index + 1].to_owned(), false));
+            index += 1;
+        }
+    }
+
+    let mut rendered = String::new();
+    let mut previous_word = false;
+    for (token, word) in tokens {
+        if previous_word && word {
+            rendered.push(' ');
+        }
+        rendered.push_str(&token);
+        previous_word = word;
+    }
+    rendered
+}
+
+fn root_export_metadata(owner: &str, symbol: &str) -> (&'static str, &'static str) {
+    match owner {
+        "artifact_views" => ("artifact-view", "embedders+tooling"),
+        "dependency_envelope" => match symbol {
+            "DependencyEnvelope"
+            | "DependencyEnvelopeStatus"
+            | "DependencyResolutionOutcome"
+            | "DependencyTopology"
+            | "DependencyTopologyRecord" => ("dependency-artifact", "source-loaders+embedders"),
+            _ => panic!("unclassified dependency facade export: {symbol}"),
+        },
+        "import_discovery" => match symbol {
+            "AcceptedImportSource"
+            | "AcceptedReadManifestEntry"
+            | "FileMetadataFingerprint"
+            | "ImportCandidateRole"
+            | "ImportDiscoveryContext"
+            | "ImportDiscoveryPlan"
+            | "ImportDiscoveryRequest"
+            | "ImportObservation"
+            | "ImportObservationLedger"
+            | "ImportObservationStatus"
+            | "ImportOccurrenceKey"
+            | "PhysicalFileIdentity" => ("dependency-artifact", "source-loaders+embedders"),
+            _ => panic!("unclassified import-discovery facade export: {symbol}"),
+        },
+        "import_graph" => match symbol {
+            "CanonicalImportCycle"
+            | "CanonicalImportGraph"
+            | "CanonicalImportGraphProblem"
+            | "CanonicalImportGraphValidation"
+            | "CanonicalImportRecord"
+            | "CanonicalImportResolution"
+            | "ImportDirective"
+            | "ImportDirectives" => ("dependency-artifact", "source-loaders+embedders"),
+            _ => panic!("unclassified import-graph facade export: {symbol}"),
+        },
+        "diagnostic_attempt_store" => ("diagnostic", "cli+embedders"),
+        "rue_error" => match symbol {
+            "CompileErrors" | "CompileWarning" | "MultiErrorResult" | "PreviewFeature"
+            | "PreviewFeatures" | "VERSION" => ("diagnostic", "cli+embedders"),
+            _ => panic!("raw diagnostic type returned to the stable facade: {symbol}"),
+        },
+        "queries" => match symbol {
+            "CompileOptions" | "LinkerMode" => ("compilation-config", "cli+embedders"),
+            "compile_snapshot" => ("one-shot-operation", "cli+embedders"),
+            "CompileOutput" | "SourceView" => ("compile-artifact", "cli+embedders"),
+            _ => panic!("unclassified queries facade export: {symbol}"),
+        },
+        "session" => match symbol {
+            "CompilerSession" | "CompilerSessionUpdate" => ("session-owner", "embedders"),
+            "CanonicalImportGraphOutput" => ("dependency-artifact", "source-loaders+embedders"),
+            _ => panic!("unclassified session facade export: {symbol}"),
+        },
+        "source_identity" | "source_metadata" | "source_snapshot" | "rue_span" => {
+            ("source-input", "cli+embedders")
+        }
+        "rue_cfg" | "rue_target" => ("compilation-config", "cli+embedders"),
+        _ => panic!("unclassified facade export owner: {owner}::{symbol}"),
+    }
+}
+
+fn root_use_exports(facade: &str) -> Vec<ApiInventoryEntry> {
+    let mut entries = Vec::new();
+    for declaration in public_use_declarations(facade) {
+        assert!(
+            !public_use_is_glob(&declaration),
+            "public glob reexports bypass the semantic API inventory: {declaration}"
+        );
+        assert!(
+            !code_identifiers(&declaration).contains(&"as"),
+            "public aliases require explicit semantic inventory support: {declaration}"
+        );
+        let compact = declaration
+            .chars()
+            .filter(|ch| !ch.is_whitespace())
+            .collect::<String>();
+        let path = compact
+            .strip_prefix("pubuse")
+            .and_then(|path| path.strip_suffix(';'))
+            .expect("public-use scanner returns complete declarations");
+        let (owner, symbols) = if let Some((owner, symbols)) = path.split_once("::{") {
+            let symbols = symbols
+                .strip_suffix('}')
+                .expect("grouped public use closes its brace")
+                .split(',')
+                .filter(|symbol| !symbol.is_empty())
+                .collect::<Vec<_>>();
+            (owner, symbols)
+        } else {
+            let (owner, symbol) = path
+                .rsplit_once("::")
+                .expect("public reexport has an owning path");
+            (owner, vec![symbol])
+        };
+        for symbol in symbols {
+            let (class, consumer) = root_export_metadata(owner, symbol);
+            entries.push(ApiInventoryEntry::new(
+                "stable",
+                owner,
+                class,
+                consumer,
+                symbol,
+                format!("pub use {owner}::{symbol}"),
+            ));
+        }
+    }
+    entries
+}
+
+fn impl_owner(implementation: &str) -> Option<&'static str> {
+    let header = implementation.split_once('{')?.0;
+    let identifiers = code_identifiers(header);
+    if identifiers.contains(&"CompilerSessionUpdate") {
+        Some("CompilerSessionUpdate")
+    } else if identifiers.contains(&"CompilerSession") {
+        Some("CompilerSession")
+    } else {
+        None
+    }
+}
+
+fn session_method_metadata(
+    owner: &str,
+    module: &str,
+    symbol: &str,
+    _signature: &str,
+) -> (&'static str, &'static str, &'static str) {
+    let unstable = module == "unstable" || symbol.starts_with("unstable_");
+    if unstable {
+        return ("unstable", "debug-tooling", "in-tree-tooling");
+    }
+    let class = if owner == "CompilerSessionUpdate" {
+        match symbol {
+            "result" | "into_result" | "diagnostics" => "artifact-result",
+            "downstream_invalidated" => "session-status",
+            _ => panic!("unclassified stable CompilerSessionUpdate method: {symbol}"),
+        }
+    } else {
+        match symbol {
+            "new" | "update" | "stage_import_discovery" | "close_import_discovery" => {
+                "session-operation"
+            }
+            "published"
+            | "committed_import_graph"
+            | "import_diagnostics"
+            | "import_graph"
+            | "rir"
+            | "semantic"
+            | "executable" => "artifact-query",
+            "import_discovery_plan" => "dependency-query",
+            "latest_diagnostics"
+            | "latest_successful_diagnostics"
+            | "last_good_semantic_diagnostics" => "diagnostic-query",
+            _ => panic!("unclassified stable CompilerSession method: {symbol}"),
+        }
+    };
+    ("stable", class, "embedders")
+}
+
+fn semantic_api_inventory(facade: &str, modules: &[(&str, &str)]) -> Vec<ApiInventoryEntry> {
+    assert!(
+        unsupported_api_layout(facade, true).is_none(),
+        "root API uses a visibility, impl, include, or macro form the exact inventory does not parse"
+    );
+    for (module, source) in modules {
+        assert!(
+            unsupported_api_layout(source, false).is_none(),
+            "{module} uses a split visibility or impl form the exact inventory does not parse"
+        );
+    }
+    let mut entries = root_use_exports(facade);
+    for declaration in public_declarations(facade) {
+        let signature = canonical_signature(&declaration);
+        if signature.starts_with("pub use ") || signature.starts_with("pub use") {
+            continue;
+        }
+        let symbol = public_declaration_name(&declaration)
+            .expect("every direct root declaration has a name");
+        if signature == "pub mod unstable" {
+            entries.push(ApiInventoryEntry::new(
+                "unstable",
+                "unstable",
+                "debug-module",
+                "in-tree-tooling",
+                symbol,
+                signature,
+            ));
+        } else if symbol == "configure_thread_pool" {
+            entries.push(ApiInventoryEntry::new(
+                "stable",
+                "lib",
+                "runtime-config",
+                "cli+embedders",
+                symbol,
+                signature,
+            ));
+        } else {
+            panic!("unclassified direct root public declaration: {signature}");
+        }
+    }
+
+    for (module, source) in modules {
+        for implementation in impl_blocks(source) {
+            let Some(owner) = impl_owner(implementation) else {
+                continue;
+            };
+            for declaration in public_declarations(implementation) {
+                let symbol = public_declaration_name(&declaration)
+                    .expect("every public session declaration has a name");
+                let signature = canonical_signature(&declaration);
+                let (stability, class, consumer) =
+                    session_method_metadata(owner, module, symbol, &signature);
+                entries.push(ApiInventoryEntry::new(
+                    stability, owner, class, consumer, symbol, signature,
+                ));
+            }
+        }
+    }
+
+    entries.sort();
+    let mut rendered = std::collections::BTreeSet::new();
+    for entry in &entries {
+        assert!(
+            rendered.insert(entry.render()),
+            "duplicate semantic API inventory entry: {}",
+            entry.render()
+        );
+    }
+    entries
+}
+
+fn render_semantic_api_inventory(facade: &str, modules: &[(&str, &str)]) -> String {
+    semantic_api_inventory(facade, modules)
+        .into_iter()
+        .map(|entry| entry.render())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn inherent_impl<'a>(source: &'a str, owner: &str) -> &'a str {
@@ -434,11 +970,6 @@ fn inherent_impl<'a>(source: &'a str, owner: &str) -> &'a str {
 #[test]
 fn facade_stays_small_and_session_centered() {
     let facade = include_str!("lib.rs");
-    assert!(
-        facade.lines().count() <= 260,
-        "rue-compiler's facade grew beyond its reviewed inventory"
-    );
-
     let mut declared_modules = facade
         .lines()
         .filter_map(|line| {
@@ -457,6 +988,7 @@ fn facade_stays_small_and_session_centered() {
             "durable_compatibility_tests",
             "integration_tests",
             "pipeline_tests",
+            "supported_api_inventory",
             "test_support",
         ])
         .collect::<Vec<_>>();
@@ -492,6 +1024,105 @@ fn facade_stays_small_and_session_centered() {
 }
 
 #[test]
+fn semantic_api_inventory_matches_every_root_export_and_session_signature() {
+    let actual = render_semantic_api_inventory(include_str!("lib.rs"), PRODUCTION_MODULES);
+    let approved = crate::supported_api_inventory::APPROVED.trim();
+    assert_eq!(
+        actual, approved,
+        "the public compiler facade changed without a reviewed semantic inventory diff; \
+         classify the owner, stability, category, and approved consumer in \
+         supported_api_inventory.rs\n\nactual inventory:\n{actual}"
+    );
+}
+
+#[test]
+fn semantic_inventory_detects_root_and_signature_changes() {
+    let facade = "pub use queries::CompileOptions;";
+    let expanded = "pub use queries::{CompileOptions, LinkerMode};";
+    assert_eq!(root_use_exports(facade).len(), 1);
+    assert_eq!(root_use_exports(expanded).len(), 2);
+
+    let original = render_semantic_api_inventory(
+        "pub use session::CompilerSession;",
+        &[(
+            "session",
+            "impl CompilerSession {\n    pub fn new() -> Self { todo!() }\n}",
+        )],
+    );
+    let changed = render_semantic_api_inventory(
+        "pub use session::CompilerSession;",
+        &[(
+            "session",
+            "impl CompilerSession {\n    pub fn new(capacity: usize) -> Self { todo!() }\n}",
+        )],
+    );
+    assert_ne!(
+        original, changed,
+        "public signature changes must alter the inventory"
+    );
+    assert!(original.contains("pub fn new()->Self"));
+    assert!(changed.contains("pub fn new(capacity:usize)->Self"));
+    assert!(render_semantic_api_inventory(facade, &[]).contains("CompileOptions"));
+}
+
+#[test]
+fn semantic_inventory_rejects_aliases_and_globs() {
+    let alias = public_use_declarations("pub use queries::CompileOptions as Options;");
+    assert!(code_identifiers(&alias[0]).contains(&"as"));
+    let glob = public_use_declarations("pub use queries::*;");
+    assert!(public_use_is_glob(&glob[0]));
+}
+
+#[test]
+fn semantic_inventory_rejects_unparsed_layouts_and_records_cfg_attributes() {
+    for source in [
+        "pub\nfn hidden() {}",
+        "pub\tfn hidden() {}",
+        "impl\nCompilerSession {}",
+        "impl\tCompilerSession {}",
+    ] {
+        assert!(
+            unsupported_api_layout(source, false).is_some(),
+            "split API syntax bypassed the fail-closed layout guard: {source:?}"
+        );
+    }
+    for source in [
+        "include!(\"api.rs\");",
+        "macro_rules! api { () => {} }",
+        "generated_api!();",
+        "crate::generated_api!();",
+        "foo::bar!();",
+    ] {
+        assert!(unsupported_api_layout(source, true).is_some());
+    }
+    for source in [
+        "include!(\"session_api.rs\");",
+        "macro_rules! api { () => { pub fn escaped() {} } }",
+        "generated_session_impl!();",
+        "#[macro_export]\nmacro_rules! api { () => {} }",
+        "#[macro_export(local_inner_macros)]\nmacro_rules! api { () => {} }",
+        "impl CompilerSession {\n    generated_methods!();\n}",
+        "#[cfg(any(\nunix,\nwindows\n))]\npub fn escaped() {}",
+        "#[cfg(unix)]\nimpl CompilerSession {\n    pub fn new() -> Self { todo!() }\n}",
+        "#[cfg(unix)]\nimpl crate::CompilerSession {\n    pub fn new() -> Self { todo!() }\n}",
+    ] {
+        assert!(unsupported_api_layout(source, false).is_some());
+    }
+    assert!(
+        unsupported_api_layout("#[cfg(unix)]\npub use session::CompilerSession;", true).is_some()
+    );
+
+    let inventory = render_semantic_api_inventory(
+        "pub use session::CompilerSession;",
+        &[(
+            "session",
+            "impl CompilerSession {\n#[cfg(unix)]\npub fn new() -> Self { todo!() }\n}",
+        )],
+    );
+    assert!(inventory.contains("#[cfg(unix)]pub fn new()->Self"));
+}
+
+#[test]
 fn raw_phase_owners_and_backend_drivers_cannot_return_to_the_stable_facade() {
     let facade = include_str!("lib.rs");
     let root_exports = public_use_declarations(facade).concat();
@@ -514,6 +1145,7 @@ fn raw_phase_owners_and_backend_drivers_cannot_return_to_the_stable_facade() {
     let session_methods = code_identifiers(&session);
     for internal in [
         "merge",
+        "stable_definitions",
         "update_for_presentation",
         "inject_stale_query_for_oracle",
     ] {
@@ -572,6 +1204,18 @@ fn raw_phase_owners_and_backend_drivers_cannot_return_to_the_stable_facade() {
         assert!(
             !code_identifiers(&signatures).contains(&"Span"),
             "stable owner-bound view exposes a raw Span: {view}"
+        );
+    }
+}
+
+#[test]
+fn final_internal_records_and_presenters_cannot_return_to_the_stable_root() {
+    let root_exports = public_use_declarations(include_str!("lib.rs")).concat();
+    let identifiers = code_identifiers(&root_exports);
+    for forbidden in RUE_869_INTERNAL_ROOT_VOCABULARY {
+        assert!(
+            !identifiers.contains(forbidden),
+            "RUE-869 internal record or presenter returned to the stable root: {forbidden}"
         );
     }
 }
@@ -652,12 +1296,24 @@ fn query_engine_records_cannot_return_to_the_supported_root() {
 #[test]
 fn unstable_views_do_not_alias_query_engine_records() {
     let unstable = include_str!("unstable.rs");
-    assert!(
-        !unstable.contains("pub use crate::"),
-        "unstable views must own their projections instead of aliasing compiler records"
-    );
     assert!(!unstable.contains("pub type "));
-    assert!(!unstable.contains("pub use "));
+    let reexports = public_use_declarations(unstable)
+        .into_iter()
+        .map(|declaration| {
+            declaration
+                .chars()
+                .filter(|ch| !ch.is_whitespace())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        reexports,
+        [
+            "pubusecrate::diagnostic::{ColorChoice,DiagnosticFormatter,JsonDiagnostic,JsonDiagnosticFormatter,JsonSpan,JsonSuggestion,MultiFileFormatter,MultiFileJsonFormatter,SourceInfo,};",
+            "pubusecrate::import_discovery::DiscoverySourceAssembler;",
+        ],
+        "unstable may reexport only reviewed presentation and source-assembly helpers"
+    );
 
     let facade = include_str!("lib.rs");
     assert_no_public_use_globs(facade);

--- a/crates/rue-compiler/src/artifact_views.rs
+++ b/crates/rue-compiler/src/artifact_views.rs
@@ -8,6 +8,50 @@ use std::{borrow::Cow, fmt, sync::Arc};
 
 use crate::{CanonicalRirOutput, CanonicalSemanticOutput, ParsedProgram};
 
+/// Opaque import-discovery product retained by the session.
+#[derive(Debug, Clone)]
+pub struct ImportDiscoveryView {
+    pub(crate) inner: Arc<crate::session::ImportDiscoveryRevisionArtifact>,
+}
+
+/// Read-only status of an import-discovery product.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportDiscoveryStatus {
+    Open,
+    ClosedAttempted,
+    ClosedValid,
+}
+
+impl ImportDiscoveryView {
+    pub(crate) fn new(inner: Arc<crate::session::ImportDiscoveryRevisionArtifact>) -> Self {
+        Self { inner }
+    }
+
+    pub fn status(&self) -> ImportDiscoveryStatus {
+        match self.inner.status() {
+            crate::session::ImportDiscoveryRevisionStatus::Open => ImportDiscoveryStatus::Open,
+            crate::session::ImportDiscoveryRevisionStatus::ClosedAttempted => {
+                ImportDiscoveryStatus::ClosedAttempted
+            }
+            crate::session::ImportDiscoveryRevisionStatus::ClosedValid => {
+                ImportDiscoveryStatus::ClosedValid
+            }
+        }
+    }
+
+    pub fn source_revision(&self) -> &crate::SourceRevision {
+        self.inner.source_revision()
+    }
+
+    pub fn diagnostics(&self) -> &crate::CompileErrors {
+        self.inner.diagnostics()
+    }
+
+    pub fn diagnostic_snapshot(&self) -> Option<&Arc<crate::FrontendDiagnosticSnapshot>> {
+        self.inner.diagnostic_snapshot()
+    }
+}
+
 #[derive(Clone)]
 #[allow(dead_code)] // Variant payloads deliberately pin the authorizing owner.
 enum SourceLocationOwner {

--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -192,12 +192,14 @@ pub(crate) enum BoundDefinitionInputPartition {
 }
 
 impl BoundDefinitionRecord {
+    #[cfg(test)]
     pub fn id(&self) -> &BoundDefinitionId {
         &self.id
     }
     pub fn stable_key(&self) -> &StableDefinitionKey {
         self.id.stable_key()
     }
+    #[cfg(test)]
     pub fn occurrence(&self) -> Option<DefinitionOccurrenceId> {
         self.occurrence
     }
@@ -508,6 +510,7 @@ impl BoundDefinitionSet {
             .map(|index| &self.definitions[index])
     }
 
+    #[cfg(test)]
     pub fn definition<'a>(
         &'a self,
         id: &BoundDefinitionId,

--- a/crates/rue-compiler/src/definition_snapshot.rs
+++ b/crates/rue-compiler/src/definition_snapshot.rs
@@ -70,18 +70,21 @@ impl DefinitionNameKey {
 
     /// The durable module containing this definition.
     #[inline]
+    #[cfg(test)]
     pub fn module(&self) -> &ModuleId {
         &self.module
     }
 
     /// The name-resolution namespace containing this candidate.
     #[inline]
+    #[cfg(test)]
     pub fn namespace(&self) -> DefinitionNamespace {
         self.namespace
     }
 
     /// The resolved, owned source name.
     #[inline]
+    #[cfg(test)]
     pub fn name(&self) -> &str {
         self.name.as_ref()
     }
@@ -101,20 +104,6 @@ pub struct DefinitionOccurrenceId {
 
 /// Compatibility name; occurrence IDs are always snapshot-local.
 pub type DefinitionId = DefinitionOccurrenceId;
-
-impl DefinitionOccurrenceId {
-    /// The issuing snapshot's logical-module index.
-    #[inline]
-    pub fn module_index(self) -> usize {
-        self.module_index
-    }
-
-    /// The record's source-ordered index within its module.
-    #[inline]
-    pub fn definition_index(self) -> usize {
-        self.definition_index
-    }
-}
 
 /// One definition candidate paired with its current request's source locator.
 ///
@@ -141,6 +130,7 @@ impl DefinitionRecord {
 
     /// The durable name-binding key shared by colliding candidates.
     #[inline]
+    #[cfg(test)]
     pub fn name_key(&self) -> &DefinitionNameKey {
         &self.name_key
     }
@@ -158,18 +148,6 @@ impl DefinitionRecord {
     #[inline]
     pub fn visibility(&self) -> Option<Visibility> {
         self.visibility
-    }
-
-    /// The file ID assigned to this module in the current request.
-    #[inline]
-    pub fn file_id(&self) -> FileId {
-        self.file_id
-    }
-
-    /// The current request's span for the definition name.
-    #[inline]
-    pub fn name_span(&self) -> Span {
-        self.name_span
     }
 
     /// The current request's span for the complete declaration.
@@ -215,15 +193,6 @@ struct DefinitionShardRecord {
 }
 
 impl DefinitionShard {
-    pub fn key(&self) -> &ModuleId {
-        &self.key
-    }
-    pub fn len(&self) -> usize {
-        self.records.len()
-    }
-    pub fn is_empty(&self) -> bool {
-        self.records.is_empty()
-    }
     fn matches(&self, module: &crate::parsed_modules::ParsedModule) -> bool {
         self.file_id == module.file_id()
             && self.records.len() == module.definitions().candidates().len()
@@ -245,30 +214,21 @@ impl DefinitionShard {
 impl ModuleDefinition {
     /// The durable logical identity of this module.
     #[inline]
+    #[cfg(test)]
     pub fn key(&self) -> &ModuleId {
         &self.key
     }
 
     /// The file ID assigned to this module in the current request.
     #[inline]
+    #[cfg(test)]
     pub fn file_id(&self) -> FileId {
         self.file_id
     }
 
-    /// Top-level definitions in deterministic source-position order.
-    #[inline]
-    pub fn definitions(&self) -> &[DefinitionRecord] {
-        &self.definitions
-    }
-
-    /// The number of top-level definitions in this module.
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.definitions.len()
-    }
-
     /// Whether this module contains no top-level definitions.
     #[inline]
+    #[cfg(test)]
     pub fn is_empty(&self) -> bool {
         self.definitions.is_empty()
     }
@@ -289,9 +249,9 @@ impl ModuleDefinition {
 #[derive(Debug, Clone)]
 pub struct DefinitionSnapshot {
     source_snapshot: SourceSnapshot,
+    #[cfg(test)]
     root_module: ModuleId,
     modules: Vec<ModuleDefinition>,
-    definition_count: usize,
     definitions_by_name: HashMap<DefinitionNameKey, Vec<DefinitionId>>,
     shards: Arc<[Arc<DefinitionShard>]>,
 }
@@ -301,6 +261,7 @@ impl DefinitionSnapshot {
     ///
     /// Names are already owned values in each module's definition index; this
     /// path performs no interner lookup, AST traversal, or source-byte hashing.
+    #[cfg(test)]
     pub fn from_parsed_modules(
         program: &crate::parsed_modules::ParsedProgram,
     ) -> CompileResult<Self> {
@@ -403,9 +364,9 @@ impl DefinitionSnapshot {
         Ok((
             Self {
                 source_snapshot,
+                #[cfg(test)]
                 root_module: program.root().clone(),
                 modules,
-                definition_count,
                 definitions_by_name,
                 shards: shards.into(),
             },
@@ -421,27 +382,25 @@ impl DefinitionSnapshot {
 
     /// The explicitly designated root module identity.
     #[inline]
+    #[cfg(test)]
     pub fn root_module(&self) -> &ModuleId {
         &self.root_module
     }
 
-    /// The explicitly designated root module identity.
-    #[inline]
-    pub fn root_key(&self) -> &ModuleId {
-        self.root_module()
-    }
-
     /// All modules in canonical logical-path order, including empty modules.
     #[inline]
+    #[cfg(test)]
     pub fn modules(&self) -> &[ModuleDefinition] {
         &self.modules
     }
 
+    #[cfg(test)]
     pub fn shards(&self) -> &[Arc<DefinitionShard>] {
         &self.shards
     }
 
     /// Find a module by its durable identity.
+    #[cfg(test)]
     pub fn module(&self, id: &ModuleId) -> Option<&ModuleDefinition> {
         self.modules
             .binary_search_by(|module| module.key.cmp(id))
@@ -450,6 +409,7 @@ impl DefinitionSnapshot {
     }
 
     /// Iterate all definitions in module-path then source-position order.
+    #[cfg(test)]
     pub fn definitions(&self) -> impl DoubleEndedIterator<Item = &DefinitionRecord> + '_ {
         self.modules
             .iter()
@@ -490,26 +450,11 @@ impl DefinitionSnapshot {
             })
     }
 
-    /// The total number of top-level definitions in all modules.
-    #[inline]
-    pub fn definition_count(&self) -> usize {
-        self.definition_count
-    }
-
     /// The number of modules, including empty modules.
     #[inline]
+    #[cfg(test)]
     pub fn module_count(&self) -> usize {
         self.modules.len()
-    }
-
-    /// Whether the snapshot contains no modules.
-    ///
-    /// Valid source metadata is nonempty, so successfully built snapshots are
-    /// never empty. This method is provided as the conventional companion to
-    /// [`Self::module_count`].
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.modules.is_empty()
     }
 }
 

--- a/crates/rue-compiler/src/dependency_envelope.rs
+++ b/crates/rue-compiler/src/dependency_envelope.rs
@@ -23,19 +23,19 @@ pub struct DependencyEnvelope {
     pub version: u32,
     pub status: DependencyEnvelopeStatus,
     pub revision: String,
-    pub context: DependencyContext,
+    pub(crate) context: DependencyContext,
     pub topology: DependencyTopology,
-    pub observations: Vec<DependencyObservation>,
-    pub accepted_reads: Vec<DependencyAcceptedRead>,
+    pub(crate) observations: Vec<DependencyObservation>,
+    pub(crate) accepted_reads: Vec<DependencyAcceptedRead>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct DependencyContext {
-    pub import_policy_version: u32,
-    pub epoch: String,
-    pub project_root: String,
-    pub std_root: Option<String>,
-    pub read_policy_revision: String,
+pub(crate) struct DependencyContext {
+    pub(crate) import_policy_version: u32,
+    pub(crate) epoch: String,
+    pub(crate) project_root: String,
+    pub(crate) std_root: Option<String>,
+    pub(crate) read_policy_revision: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -66,32 +66,32 @@ pub enum DependencyResolutionOutcome {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct DependencyObservation {
-    pub request: DependencyRequest,
-    pub outcome: DependencyObservationOutcome,
+pub(crate) struct DependencyObservation {
+    pub(crate) request: DependencyRequest,
+    pub(crate) outcome: DependencyObservationOutcome,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct DependencyRequest {
-    pub policy_version: u32,
-    pub epoch: String,
-    pub read_policy_revision: String,
-    pub importer: String,
-    pub source_offset: u32,
-    pub source_end: u32,
-    pub exact_specifier: String,
-    pub normalized_specifier: String,
-    pub importer_anchor: String,
-    pub root_anchor: String,
-    pub group: u32,
-    pub position: u32,
-    pub requested_path: String,
-    pub role: &'static str,
+pub(crate) struct DependencyRequest {
+    pub(crate) policy_version: u32,
+    pub(crate) epoch: String,
+    pub(crate) read_policy_revision: String,
+    pub(crate) importer: String,
+    pub(crate) source_offset: u32,
+    pub(crate) source_end: u32,
+    pub(crate) exact_specifier: String,
+    pub(crate) normalized_specifier: String,
+    pub(crate) importer_anchor: String,
+    pub(crate) root_anchor: String,
+    pub(crate) group: u32,
+    pub(crate) position: u32,
+    pub(crate) requested_path: String,
+    pub(crate) role: &'static str,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
-pub enum DependencyObservationOutcome {
+pub(crate) enum DependencyObservationOutcome {
     Absent,
     PresentReadable {
         canonical_path: String,
@@ -116,22 +116,20 @@ pub enum DependencyObservationOutcome {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct DependencyAcceptedRead {
-    pub module: String,
-    pub requested_path: String,
-    pub canonical_path: String,
-    pub physical_identity: String,
-    pub metadata_fingerprint: String,
-    pub content_fingerprint: String,
+pub(crate) struct DependencyAcceptedRead {
+    pub(crate) module: String,
+    pub(crate) requested_path: String,
+    pub(crate) canonical_path: String,
+    pub(crate) physical_identity: String,
+    pub(crate) metadata_fingerprint: String,
+    pub(crate) content_fingerprint: String,
 }
 
 impl DependencyEnvelope {
     /// Project the compiler-owned graph and ledgers without rediscovering an
     /// import edge or consulting semantic analysis.
     #[cfg(not(test))]
-    pub fn from_closed_revision(
-        revision: &crate::unstable::ImportDiscoveryRevision,
-    ) -> Option<Self> {
+    pub fn from_closed_revision(revision: &crate::ImportDiscoveryView) -> Option<Self> {
         Self::from_artifact(&revision.inner)
     }
 

--- a/crates/rue-compiler/src/diagnostic.rs
+++ b/crates/rue-compiler/src/diagnostic.rs
@@ -6,7 +6,7 @@
 //! # Example
 //!
 //! ```ignore
-//! use rue_compiler::{DiagnosticFormatter, SourceInfo};
+//! use rue_compiler::unstable::{DiagnosticFormatter, SourceInfo};
 //!
 //! let source_info = SourceInfo::new(&source, "example.rue");
 //! let formatter = DiagnosticFormatter::new(&source_info);
@@ -586,7 +586,8 @@ impl<'a> DiagnosticFormatter<'a> {
 /// # Example
 ///
 /// ```ignore
-/// use rue_compiler::{MultiFileFormatter, SourceInfo, FileId};
+/// use rue_compiler::FileId;
+/// use rue_compiler::unstable::{MultiFileFormatter, SourceInfo};
 ///
 /// // Create source infos for each file
 /// let sources = vec![
@@ -1259,7 +1260,8 @@ impl<'a> JsonDiagnosticFormatter<'a> {
 /// # Example
 ///
 /// ```ignore
-/// use rue_compiler::{MultiFileJsonFormatter, SourceInfo, FileId};
+/// use rue_compiler::FileId;
+/// use rue_compiler::unstable::{MultiFileJsonFormatter, SourceInfo};
 ///
 /// let sources = vec![
 ///     (FileId::new(1), SourceInfo::new(&source1, "main.rue")),

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -29,6 +29,9 @@
 //!
 //! Callers that only need a final executable may use [`compile_snapshot`], the
 //! sole one-shot adapter. Filesystem discovery remains the caller's job.
+//! Stable additions are reviewed against the semantic facade inventory. Debug
+//! presentation, instrumentation, and in-tree driver adapters live under
+//! [`unstable`] and carry no compatibility promise.
 
 mod artifact_views;
 mod backend;
@@ -73,28 +76,25 @@ mod api_inventory;
 mod durable_compatibility_tests;
 #[cfg(test)]
 mod integration_tests;
+#[cfg(test)]
+mod supported_api_inventory;
 
 // Supported source, identity, option, session, and diagnostic surface.
 pub use artifact_views::{
-    CfgBlockView, CfgInstructionView, CfgSuccessorView, CfgView, FunctionView, RirInstructionView,
-    RirOperandView, RirView, SemanticView, SourceIdentityView, SourceLocationView,
-    SyntaxModuleView, SyntaxNodeView, SyntaxView, TokenView, TypeView,
+    CfgBlockView, CfgInstructionView, CfgSuccessorView, CfgView, FunctionView,
+    ImportDiscoveryStatus, ImportDiscoveryView, RirInstructionView, RirOperandView, RirView,
+    SemanticView, SourceIdentityView, SourceLocationView, SyntaxModuleView, SyntaxNodeView,
+    SyntaxView, TokenView, TypeView,
 };
 pub use dependency_envelope::{
-    DependencyAcceptedRead, DependencyContext, DependencyEnvelope, DependencyEnvelopeStatus,
-    DependencyObservation, DependencyObservationOutcome, DependencyRequest,
-    DependencyResolutionOutcome, DependencyTopology, DependencyTopologyRecord,
-};
-pub use diagnostic::{
-    ColorChoice, DiagnosticFormatter, JsonDiagnostic, JsonDiagnosticFormatter, JsonSpan,
-    JsonSuggestion, MultiFileFormatter, MultiFileJsonFormatter, SourceInfo,
+    DependencyEnvelope, DependencyEnvelopeStatus, DependencyResolutionOutcome, DependencyTopology,
+    DependencyTopologyRecord,
 };
 #[cfg(test)]
 pub(crate) use diagnostic_attempt_store::FrontendDiagnosticIdentity;
 pub use diagnostic_attempt_store::{DiagnosticStage, FrontendDiagnosticSnapshot};
 pub use import_discovery::{
-    AcceptedImportSource, AcceptedReadManifestEntry, DiscoverySourceAssembler,
-    FileMetadataFingerprint, IMPORT_DISCOVERY_POLICY_VERSION, ImportCandidateRole,
+    AcceptedImportSource, AcceptedReadManifestEntry, FileMetadataFingerprint, ImportCandidateRole,
     ImportDiscoveryContext, ImportDiscoveryPlan, ImportDiscoveryRequest, ImportObservation,
     ImportObservationLedger, ImportObservationStatus, ImportOccurrenceKey, PhysicalFileIdentity,
 };
@@ -130,6 +130,9 @@ pub(crate) use canonical_semantic::{
 pub(crate) use definition_snapshot::DefinitionShardWork;
 #[allow(unused_imports)]
 pub(crate) use durable_body::DurableBodyWork;
+#[cfg(test)]
+pub(crate) use import_discovery::DiscoverySourceAssembler;
+pub(crate) use import_discovery::IMPORT_DISCOVERY_POLICY_VERSION;
 #[allow(unused_imports)]
 pub(crate) use parsed_modules::{ParseInvalidationSummary, ParsedModulesWork};
 pub(crate) use queries::{PipelineWork, SourceStats};
@@ -161,16 +164,16 @@ pub(crate) use source_identity::{
 // Immutable query artifacts and stable identities returned by CompilerSession.
 #[cfg(test)]
 pub(crate) use backend::generate_mir;
-pub use bound_definitions::{
-    BoundDefinitionId, BoundDefinitionRecord, BoundDefinitionSet, SnapshotBoundDefinitionId,
-    StableDefinitionKey, StableDefinitionKind, StableDefinitionNamespace, StableNamedTypeKey,
+pub(crate) use bound_definitions::{
+    BoundDefinitionRecord, BoundDefinitionSet, StableDefinitionKey, StableDefinitionKind,
+    StableDefinitionNamespace,
 };
 pub(crate) use canonical_lower::CanonicalRirOutput;
 pub(crate) use canonical_merge::CanonicalMergedProgram;
 pub(crate) use canonical_semantic::CanonicalSemanticOutput;
-pub use definition_snapshot::{
-    DefinitionId, DefinitionKind, DefinitionNameKey, DefinitionNamespace, DefinitionOccurrenceId,
-    DefinitionRecord, DefinitionShard, DefinitionSnapshot, ModuleDefinition,
+pub(crate) use definition_snapshot::{
+    DefinitionKind, DefinitionNameKey, DefinitionNamespace, DefinitionOccurrenceId,
+    DefinitionRecord, DefinitionSnapshot,
 };
 #[cfg(test)]
 pub(crate) use durable_body::DurableBodyProjectionFailure;
@@ -193,13 +196,15 @@ pub(crate) use durable_semantics::{
 // Small foundational types callers need to configure or inspect the facade.
 pub(crate) use rue_air::FrozenTypeInternPool;
 pub use rue_cfg::OptLevel;
+pub(crate) use rue_error::{CompileError, CompileResult, Diagnostic, ErrorCode, ErrorKind};
 pub use rue_error::{
-    Applicability, CompileError, CompileErrors, CompileResult, CompileWarning, Diagnostic,
-    ErrorCode, ErrorKind, MultiErrorResult, PreviewFeature, PreviewFeatures, Suggestion, VERSION,
-    WarningKind,
+    CompileErrors, CompileWarning, MultiErrorResult, PreviewFeature, PreviewFeatures, VERSION,
 };
+#[cfg(test)]
+pub(crate) use rue_error::{Suggestion, WarningKind};
 pub(crate) use rue_lexer::Lexer;
-pub use rue_span::{FileId, Span};
+pub use rue_span::FileId;
+pub(crate) use rue_span::Span;
 pub use rue_target::{Arch, Target};
 
 // Internal phase vocabulary. These are intentionally not part of the facade.

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -4,11 +4,13 @@
 //! universe, while [`ParsedProgram`] provides the sole parsed-program
 //! representation used by semantic compilation.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 #[cfg(test)]
 use std::cell::Cell;
+#[cfg(test)]
+use std::collections::BTreeMap;
 
 #[cfg(test)]
 use lasso::Key;
@@ -81,9 +83,11 @@ struct ProvenancedAst {
 }
 
 /// Snapshot-local occurrence of one parsed definition candidate.
+#[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ParsedDefinitionOccurrence(u32);
 
+#[cfg(test)]
 impl ParsedDefinitionOccurrence {
     pub fn index(self) -> usize {
         self.0 as usize
@@ -93,17 +97,20 @@ impl ParsedDefinitionOccurrence {
 /// One presemantic definition candidate; duplicates remain distinct values.
 #[derive(Debug, Clone)]
 pub struct ParsedDefinitionCandidate {
+    #[cfg(test)]
     occurrence: ParsedDefinitionOccurrence,
     namespace: DefinitionNamespace,
     kind: DefinitionKind,
     visibility: Option<Visibility>,
     name: Arc<str>,
+    #[cfg(test)]
     symbol: ParsedSymbol,
     name_span: Span,
     declaration_span: Span,
 }
 
 impl ParsedDefinitionCandidate {
+    #[cfg(test)]
     pub fn occurrence(&self) -> ParsedDefinitionOccurrence {
         self.occurrence
     }
@@ -119,6 +126,7 @@ impl ParsedDefinitionCandidate {
     pub fn name(&self) -> &str {
         &self.name
     }
+    #[cfg(test)]
     pub fn symbol(&self) -> &ParsedSymbol {
         &self.symbol
     }
@@ -134,6 +142,7 @@ impl ParsedDefinitionCandidate {
 #[derive(Debug, Clone)]
 pub struct ParsedDefinitionIndex {
     candidates: Arc<[ParsedDefinitionCandidate]>,
+    #[cfg(test)]
     by_name: BTreeMap<(DefinitionNamespace, Arc<str>), Arc<[ParsedDefinitionOccurrence]>>,
 }
 
@@ -142,6 +151,7 @@ impl ParsedDefinitionIndex {
         &self.candidates
     }
 
+    #[cfg(test)]
     pub fn candidates_named(
         &self,
         namespace: DefinitionNamespace,
@@ -169,9 +179,6 @@ pub enum InvalidImportShape {
 }
 
 impl ParsedInvalidImport {
-    pub fn importer(&self) -> &ModuleId {
-        &self.importer
-    }
     pub fn span(&self) -> Span {
         self.span
     }
@@ -239,25 +246,22 @@ impl ParsedAstView {
         self.module.module_id()
     }
 
-    pub fn ast(&self) -> &Ast {
-        self.module.ast()
-    }
-
+    #[cfg(test)]
     pub fn items(&self) -> impl ExactSizeIterator<Item = ParsedItemView> + '_ {
-        (0..self.module.ast().items.len()).map(|index| ParsedItemView {
+        (0..self.module.ast().items.len()).map(|_| ParsedItemView {
             module: self.module.clone(),
-            index,
         })
     }
 }
 
-/// One parsed item paired with the module that owns its local symbols.
+/// Test-only proof that item traversal retains the exact parsed owner.
+#[cfg(test)]
 #[derive(Debug, Clone)]
 pub struct ParsedItemView {
     module: Arc<ParsedModule>,
-    index: usize,
 }
 
+#[cfg(test)]
 impl ParsedItemView {
     pub fn module(&self) -> &Arc<ParsedModule> {
         &self.module
@@ -265,10 +269,6 @@ impl ParsedItemView {
 
     pub fn module_id(&self) -> &ModuleId {
         self.module.module_id()
-    }
-
-    pub fn item(&self) -> &Item {
-        &self.module.ast().items[self.index]
     }
 }
 
@@ -320,11 +320,6 @@ impl ParsedModule {
     }
     pub fn ast(&self) -> &Ast {
         &self.payload.ast.ast
-    }
-    /// Retain the immutable AST payload without projecting it into another
-    /// syntax representation.
-    pub fn shared_ast(&self) -> Arc<Ast> {
-        self.payload.ast.ast.clone()
     }
     pub fn definitions(&self) -> &ParsedDefinitionIndex {
         &self.payload.definitions
@@ -467,6 +462,7 @@ impl ParsedProgram {
     }
 
     /// Traverse module-qualified ASTs in canonical logical-module order.
+    #[cfg(test)]
     pub fn ast_views(&self) -> impl ExactSizeIterator<Item = ParsedAstView> + '_ {
         self.modules
             .iter()
@@ -1363,33 +1359,45 @@ fn build_definition_index(
                 right_name,
             ))
     });
+    #[cfg(test)]
     let mut by_name = BTreeMap::<_, Vec<_>>::new();
     let mut candidates = Vec::with_capacity(pending.len());
     for (index, (parts, symbol, name)) in pending.into_iter().enumerate() {
+        #[cfg(not(test))]
+        let _ = index;
+        #[cfg(not(test))]
+        let _ = symbol;
+        #[cfg(test)]
         let index = u32::try_from(index)
             .map_err(|_| invalid_input("parsed definition occurrence count exceeds u32"))?;
+        #[cfg(test)]
         let occurrence = ParsedDefinitionOccurrence(index);
+        #[cfg(test)]
         by_name
             .entry((parts.namespace, name.clone()))
             .or_default()
             .push(occurrence);
         candidates.push(ParsedDefinitionCandidate {
+            #[cfg(test)]
             occurrence,
             namespace: parts.namespace,
             kind: parts.kind,
             visibility: parts.visibility,
             name,
+            #[cfg(test)]
             symbol,
             name_span: parts.name.span,
             declaration_span: parts.declaration_span,
         });
     }
+    #[cfg(test)]
     let by_name = by_name
         .into_iter()
         .map(|(key, value)| (key, value.into()))
         .collect();
     Ok(ParsedDefinitionIndex {
         candidates: candidates.into(),
+        #[cfg(test)]
         by_name,
     })
 }

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -538,8 +538,7 @@ impl CompilerSession {
     /// Run the fresh backend tail for the exact published snapshot used by the
     /// cold-versus-reused differential oracle, including direct no-discovery
     /// sessions. Production filesystem callers use [`Self::executable`].
-    #[doc(hidden)]
-    pub fn oracle_executable(
+    pub(crate) fn oracle_executable(
         &mut self,
         snapshot: &SourceSnapshot,
         options: &CompileOptions,
@@ -567,7 +566,7 @@ impl CompilerSession {
     /// The filesystem driver uses this after import discovery so the exact
     /// discovery parse and the later query pipeline share one timing root.
     /// Other callers should use [`Self::executable`], which owns that root.
-    pub fn executable_in_compile_scope(
+    pub(crate) fn executable_in_compile_scope(
         &mut self,
         options: &CompileOptions,
     ) -> MultiErrorResult<CompileOutput> {

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1607,6 +1607,11 @@ impl ImportDiscoveryRevisionArtifact {
     pub(crate) fn source_revision(&self) -> &SourceRevision {
         &self.source_revision
     }
+
+    #[cfg(test)]
+    pub(crate) fn parse_work(&self) -> ParsedModulesWork {
+        self.parse_work
+    }
     pub(crate) fn context(&self) -> &crate::ImportDiscoveryContext {
         &self.context
     }
@@ -1618,9 +1623,6 @@ impl ImportDiscoveryRevisionArtifact {
         self.program.as_ref()
     }
     /// Exact parse work performed by this bounded discovery lifecycle.
-    pub(crate) fn parse_work(&self) -> ParsedModulesWork {
-        self.parse_work
-    }
     #[cfg(test)]
     pub(crate) fn plan(&self) -> Option<&crate::ImportDiscoveryPlan> {
         self.plan.as_ref()
@@ -2873,15 +2875,6 @@ impl CompilerSession {
         })?;
         crate::ImportDiscoveryPlan::new(program, context)
     }
-    #[cfg(not(test))]
-    pub fn discovery_attempt(&self) -> Option<Arc<crate::unstable::ImportDiscoveryRevision>> {
-        self.discovery_attempt_artifact().map(|artifact| {
-            Arc::new(crate::unstable::ImportDiscoveryRevision::new(
-                artifact.clone(),
-            ))
-        })
-    }
-
     #[cfg(test)]
     pub(crate) fn discovery_attempt(&self) -> Option<&Arc<ImportDiscoveryRevisionArtifact>> {
         self.discovery_attempt_artifact()
@@ -2905,15 +2898,6 @@ impl CompilerSession {
                     .map(|record| &record.artifact)
             })
     }
-    #[cfg(not(test))]
-    pub fn last_good_discovery(&self) -> Option<Arc<crate::unstable::ImportDiscoveryRevision>> {
-        self.last_good_discovery_artifact().map(|artifact| {
-            Arc::new(crate::unstable::ImportDiscoveryRevision::new(
-                artifact.clone(),
-            ))
-        })
-    }
-
     #[cfg(test)]
     pub(crate) fn last_good_discovery(&self) -> Option<&Arc<ImportDiscoveryRevisionArtifact>> {
         self.last_good_discovery_artifact()
@@ -2926,22 +2910,6 @@ impl CompilerSession {
             .import_closures
             .last_good_record()
             .map(|record| &record.artifact)
-    }
-
-    /// The exact closed-valid discovery revision adopted by this session.
-    ///
-    /// Downstream compilation must consume this artifact (or queries that
-    /// delegate to it), rather than reconstructing import or standard-library
-    /// resolution from the source snapshot alone.
-    #[cfg(not(test))]
-    pub fn committed_import_discovery(
-        &self,
-    ) -> Option<Arc<crate::unstable::ImportDiscoveryRevision>> {
-        self.committed_import_discovery_artifact().map(|artifact| {
-            Arc::new(crate::unstable::ImportDiscoveryRevision::new(
-                artifact.clone(),
-            ))
-        })
     }
 
     pub(crate) fn committed_import_discovery_artifact(
@@ -3283,9 +3251,9 @@ impl CompilerSession {
     pub fn close_import_discovery(
         &mut self,
         ledger: crate::ImportObservationLedger,
-    ) -> Result<Arc<crate::unstable::ImportDiscoveryRevision>, CompileErrors> {
+    ) -> Result<Arc<crate::ImportDiscoveryView>, CompileErrors> {
         self.close_import_discovery_artifact(ledger)
-            .map(|artifact| Arc::new(crate::unstable::ImportDiscoveryRevision::new(artifact)))
+            .map(|artifact| Arc::new(crate::ImportDiscoveryView::new(artifact)))
     }
 
     #[cfg(test)]
@@ -5231,7 +5199,7 @@ impl CompilerSession {
     /// manifest. Retaining that mutable, RIR-borrowing value would duplicate
     /// substantial semantic state, so this query performs one explicit second
     /// declaration bind after reusing a successful ordinary body analysis.
-    pub fn stable_definitions(
+    pub(crate) fn stable_definitions(
         &mut self,
         options: &CompileOptions,
     ) -> Result<Arc<BoundDefinitionSet>, CompileErrors> {

--- a/crates/rue-compiler/src/supported_api_inventory.rs
+++ b/crates/rue-compiler/src/supported_api_inventory.rs
@@ -1,0 +1,104 @@
+//! Reviewed semantic inventory for Rue's compiler facade.
+//!
+//! One line represents one root export or public session signature:
+//! `stability|owner|class|approved-consumer|symbol|canonical-signature`.
+//! Intentional API changes update the relevant line instead of weakening a
+//! source-size budget or adding another forbidden-name exception.
+
+pub(crate) const APPROVED: &str = r#"stable|CompilerSession|artifact-query|embedders|committed_import_graph|pub fn committed_import_graph(&self)->Result<Arc<CanonicalImportGraphOutput>,CompileErrors>
+stable|CompilerSession|artifact-query|embedders|executable|pub fn executable(&mut self,options:&CompileOptions)->MultiErrorResult<CompileOutput>
+stable|CompilerSession|artifact-query|embedders|import_diagnostics|pub fn import_diagnostics(&mut self)->Result<Arc<FrontendDiagnosticSnapshot>,CompileErrors>
+stable|CompilerSession|artifact-query|embedders|import_graph|pub fn import_graph(&mut self,std_dir:Option<&str>,)->Result<Arc<CanonicalImportGraphOutput>,CompileErrors>
+stable|CompilerSession|artifact-query|embedders|published|pub fn published(&self)->Option<crate::SyntaxView>
+stable|CompilerSession|artifact-query|embedders|rir|pub fn rir(&mut self)->Result<Arc<crate::RirView>,CompileErrors>
+stable|CompilerSession|artifact-query|embedders|semantic|pub fn semantic(&mut self,options:&CompileOptions,)->Result<Arc<crate::SemanticView>,CompileErrors>
+stable|CompilerSession|dependency-query|embedders|import_discovery_plan|pub fn import_discovery_plan(&self,context:crate::ImportDiscoveryContext,)->crate::CompileResult<crate::ImportDiscoveryPlan>
+stable|CompilerSession|diagnostic-query|embedders|last_good_semantic_diagnostics|pub fn last_good_semantic_diagnostics(&self)->Option<&Arc<FrontendDiagnosticSnapshot>>
+stable|CompilerSession|diagnostic-query|embedders|latest_diagnostics|pub fn latest_diagnostics(&self)->Option<&Arc<FrontendDiagnosticSnapshot>>
+stable|CompilerSession|diagnostic-query|embedders|latest_successful_diagnostics|pub fn latest_successful_diagnostics(&self)->Option<&Arc<FrontendDiagnosticSnapshot>>
+stable|CompilerSession|session-operation|embedders|close_import_discovery|#[cfg(not(test))]pub fn close_import_discovery(&mut self,ledger:crate::ImportObservationLedger,)->Result<Arc<crate::ImportDiscoveryView>,CompileErrors>
+stable|CompilerSession|session-operation|embedders|new|pub fn new()->Self
+stable|CompilerSession|session-operation|embedders|stage_import_discovery|pub fn stage_import_discovery(&mut self,snapshot:&SourceSnapshot,context:crate::ImportDiscoveryContext,accepted_reads:Arc<[crate::AcceptedReadManifestEntry]>,carried_ledger:crate::ImportObservationLedger,)->Result<crate::ImportDiscoveryPlan,CompileErrors>
+stable|CompilerSession|session-operation|embedders|update|pub fn update(&mut self,snapshot:&SourceSnapshot)->CompilerSessionUpdate
+stable|CompilerSessionUpdate|artifact-result|embedders|diagnostics|pub fn diagnostics(&self)->&Arc<FrontendDiagnosticSnapshot>
+stable|CompilerSessionUpdate|artifact-result|embedders|into_result|pub fn into_result(self)->Result<crate::SyntaxView,CompileErrors>
+stable|CompilerSessionUpdate|artifact-result|embedders|result|pub fn result(&self)->Result<crate::SyntaxView,&CompileErrors>
+stable|CompilerSessionUpdate|session-status|embedders|downstream_invalidated|pub fn downstream_invalidated(&self)->bool
+stable|artifact_views|artifact-view|embedders+tooling|CfgBlockView|pub use artifact_views::CfgBlockView
+stable|artifact_views|artifact-view|embedders+tooling|CfgInstructionView|pub use artifact_views::CfgInstructionView
+stable|artifact_views|artifact-view|embedders+tooling|CfgSuccessorView|pub use artifact_views::CfgSuccessorView
+stable|artifact_views|artifact-view|embedders+tooling|CfgView|pub use artifact_views::CfgView
+stable|artifact_views|artifact-view|embedders+tooling|FunctionView|pub use artifact_views::FunctionView
+stable|artifact_views|artifact-view|embedders+tooling|ImportDiscoveryStatus|pub use artifact_views::ImportDiscoveryStatus
+stable|artifact_views|artifact-view|embedders+tooling|ImportDiscoveryView|pub use artifact_views::ImportDiscoveryView
+stable|artifact_views|artifact-view|embedders+tooling|RirInstructionView|pub use artifact_views::RirInstructionView
+stable|artifact_views|artifact-view|embedders+tooling|RirOperandView|pub use artifact_views::RirOperandView
+stable|artifact_views|artifact-view|embedders+tooling|RirView|pub use artifact_views::RirView
+stable|artifact_views|artifact-view|embedders+tooling|SemanticView|pub use artifact_views::SemanticView
+stable|artifact_views|artifact-view|embedders+tooling|SourceIdentityView|pub use artifact_views::SourceIdentityView
+stable|artifact_views|artifact-view|embedders+tooling|SourceLocationView|pub use artifact_views::SourceLocationView
+stable|artifact_views|artifact-view|embedders+tooling|SyntaxModuleView|pub use artifact_views::SyntaxModuleView
+stable|artifact_views|artifact-view|embedders+tooling|SyntaxNodeView|pub use artifact_views::SyntaxNodeView
+stable|artifact_views|artifact-view|embedders+tooling|SyntaxView|pub use artifact_views::SyntaxView
+stable|artifact_views|artifact-view|embedders+tooling|TokenView|pub use artifact_views::TokenView
+stable|artifact_views|artifact-view|embedders+tooling|TypeView|pub use artifact_views::TypeView
+stable|dependency_envelope|dependency-artifact|source-loaders+embedders|DependencyEnvelope|pub use dependency_envelope::DependencyEnvelope
+stable|dependency_envelope|dependency-artifact|source-loaders+embedders|DependencyEnvelopeStatus|pub use dependency_envelope::DependencyEnvelopeStatus
+stable|dependency_envelope|dependency-artifact|source-loaders+embedders|DependencyResolutionOutcome|pub use dependency_envelope::DependencyResolutionOutcome
+stable|dependency_envelope|dependency-artifact|source-loaders+embedders|DependencyTopology|pub use dependency_envelope::DependencyTopology
+stable|dependency_envelope|dependency-artifact|source-loaders+embedders|DependencyTopologyRecord|pub use dependency_envelope::DependencyTopologyRecord
+stable|diagnostic_attempt_store|diagnostic|cli+embedders|DiagnosticStage|pub use diagnostic_attempt_store::DiagnosticStage
+stable|diagnostic_attempt_store|diagnostic|cli+embedders|FrontendDiagnosticSnapshot|pub use diagnostic_attempt_store::FrontendDiagnosticSnapshot
+stable|import_discovery|dependency-artifact|source-loaders+embedders|AcceptedImportSource|pub use import_discovery::AcceptedImportSource
+stable|import_discovery|dependency-artifact|source-loaders+embedders|AcceptedReadManifestEntry|pub use import_discovery::AcceptedReadManifestEntry
+stable|import_discovery|dependency-artifact|source-loaders+embedders|FileMetadataFingerprint|pub use import_discovery::FileMetadataFingerprint
+stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportCandidateRole|pub use import_discovery::ImportCandidateRole
+stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportDiscoveryContext|pub use import_discovery::ImportDiscoveryContext
+stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportDiscoveryPlan|pub use import_discovery::ImportDiscoveryPlan
+stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportDiscoveryRequest|pub use import_discovery::ImportDiscoveryRequest
+stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportObservation|pub use import_discovery::ImportObservation
+stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportObservationLedger|pub use import_discovery::ImportObservationLedger
+stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportObservationStatus|pub use import_discovery::ImportObservationStatus
+stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportOccurrenceKey|pub use import_discovery::ImportOccurrenceKey
+stable|import_discovery|dependency-artifact|source-loaders+embedders|PhysicalFileIdentity|pub use import_discovery::PhysicalFileIdentity
+stable|import_graph|dependency-artifact|source-loaders+embedders|CanonicalImportCycle|pub use import_graph::CanonicalImportCycle
+stable|import_graph|dependency-artifact|source-loaders+embedders|CanonicalImportGraph|pub use import_graph::CanonicalImportGraph
+stable|import_graph|dependency-artifact|source-loaders+embedders|CanonicalImportGraphProblem|pub use import_graph::CanonicalImportGraphProblem
+stable|import_graph|dependency-artifact|source-loaders+embedders|CanonicalImportGraphValidation|pub use import_graph::CanonicalImportGraphValidation
+stable|import_graph|dependency-artifact|source-loaders+embedders|CanonicalImportRecord|pub use import_graph::CanonicalImportRecord
+stable|import_graph|dependency-artifact|source-loaders+embedders|CanonicalImportResolution|pub use import_graph::CanonicalImportResolution
+stable|import_graph|dependency-artifact|source-loaders+embedders|ImportDirective|pub use import_graph::ImportDirective
+stable|import_graph|dependency-artifact|source-loaders+embedders|ImportDirectives|pub use import_graph::ImportDirectives
+stable|lib|runtime-config|cli+embedders|configure_thread_pool|pub fn configure_thread_pool(jobs:usize)
+stable|queries|compilation-config|cli+embedders|CompileOptions|pub use queries::CompileOptions
+stable|queries|compilation-config|cli+embedders|LinkerMode|pub use queries::LinkerMode
+stable|queries|compile-artifact|cli+embedders|CompileOutput|pub use queries::CompileOutput
+stable|queries|compile-artifact|cli+embedders|SourceView|pub use queries::SourceView
+stable|queries|one-shot-operation|cli+embedders|compile_snapshot|pub use queries::compile_snapshot
+stable|rue_cfg|compilation-config|cli+embedders|OptLevel|pub use rue_cfg::OptLevel
+stable|rue_error|diagnostic|cli+embedders|CompileErrors|pub use rue_error::CompileErrors
+stable|rue_error|diagnostic|cli+embedders|CompileWarning|pub use rue_error::CompileWarning
+stable|rue_error|diagnostic|cli+embedders|MultiErrorResult|pub use rue_error::MultiErrorResult
+stable|rue_error|diagnostic|cli+embedders|PreviewFeature|pub use rue_error::PreviewFeature
+stable|rue_error|diagnostic|cli+embedders|PreviewFeatures|pub use rue_error::PreviewFeatures
+stable|rue_error|diagnostic|cli+embedders|VERSION|pub use rue_error::VERSION
+stable|rue_span|source-input|cli+embedders|FileId|pub use rue_span::FileId
+stable|rue_target|compilation-config|cli+embedders|Arch|pub use rue_target::Arch
+stable|rue_target|compilation-config|cli+embedders|Target|pub use rue_target::Target
+stable|session|dependency-artifact|source-loaders+embedders|CanonicalImportGraphOutput|pub use session::CanonicalImportGraphOutput
+stable|session|session-owner|embedders|CompilerSession|pub use session::CompilerSession
+stable|session|session-owner|embedders|CompilerSessionUpdate|pub use session::CompilerSessionUpdate
+stable|source_identity|source-input|cli+embedders|ModuleId|pub use source_identity::ModuleId
+stable|source_identity|source-input|cli+embedders|ModuleRevision|pub use source_identity::ModuleRevision
+stable|source_identity|source-input|cli+embedders|SourceId|pub use source_identity::SourceId
+stable|source_identity|source-input|cli+embedders|SourceIdVersion|pub use source_identity::SourceIdVersion
+stable|source_identity|source-input|cli+embedders|SourceRevision|pub use source_identity::SourceRevision
+stable|source_metadata|source-input|cli+embedders|SourceMetadata|pub use source_metadata::SourceMetadata
+stable|source_snapshot|source-input|cli+embedders|MAX_SOURCE_BYTES|pub use source_snapshot::MAX_SOURCE_BYTES
+stable|source_snapshot|source-input|cli+embedders|SourceSnapshot|pub use source_snapshot::SourceSnapshot
+unstable|CompilerSession|debug-tooling|in-tree-tooling|unstable_dependency_baseline|pub fn unstable_dependency_baseline(&mut self,options:&CompileOptions,std_dir:Option<&str>,)->Result<Arc<crate::unstable::DependencyBaseline>,CompileErrors>
+unstable|CompilerSession|debug-tooling|in-tree-tooling|unstable_invalidation_metrics|pub fn unstable_invalidation_metrics(&mut self,previous:&crate::unstable::DependencyBaseline,current:&crate::unstable::DependencyBaseline,)->Result<crate::unstable::InvalidationMetrics,CompileErrors>
+unstable|CompilerSession|debug-tooling|in-tree-tooling|unstable_metrics|pub fn unstable_metrics(&self)->crate::unstable::MetricsSnapshot
+unstable|CompilerSession|debug-tooling|in-tree-tooling|unstable_present|pub fn unstable_present(&mut self,request:PresentationRequest<'_>,)->Result<PresentationOutput,crate::CompileErrors>
+unstable|CompilerSessionUpdate|debug-tooling|in-tree-tooling|unstable_metrics|pub fn unstable_metrics(&self)->crate::unstable::ParseMetrics
+unstable|unstable|debug-module|in-tree-tooling|unstable|pub mod unstable"#;

--- a/crates/rue-compiler/src/syntax.rs
+++ b/crates/rue-compiler/src/syntax.rs
@@ -97,10 +97,8 @@ mod tests {
     use rue_span::FileId;
 
     use super::*;
-    use crate::{
-        ColorChoice, CompilerSession, DiagnosticFormatter, Item, JsonDiagnosticFormatter,
-        SourceInfo, SourceMetadata, SourceSnapshot,
-    };
+    use crate::unstable::{ColorChoice, DiagnosticFormatter, JsonDiagnosticFormatter, SourceInfo};
+    use crate::{CompilerSession, Item, SourceMetadata, SourceSnapshot};
 
     fn snapshot(entries: &[(u32, &str, &str)]) -> SourceSnapshot {
         let physical_paths: HashMap<_, _> = entries

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -11,6 +11,12 @@ use std::sync::Arc;
 
 use crate::canonical_semantic::CanonicalSemanticFailurePhase as SemanticFailurePhase;
 
+pub use crate::diagnostic::{
+    ColorChoice, DiagnosticFormatter, JsonDiagnostic, JsonDiagnosticFormatter, JsonSpan,
+    JsonSuggestion, MultiFileFormatter, MultiFileJsonFormatter, SourceInfo,
+};
+pub use crate::import_discovery::DiscoverySourceAssembler;
+
 /// Unstable human-readable compiler stages. These are projections of the
 /// canonical session artifacts, never alternate phase entry points.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -56,6 +62,80 @@ pub fn update_for_presentation(
 /// exposing its raw owner.
 pub fn query_merge(session: &mut crate::CompilerSession) -> Result<(), crate::CompileErrors> {
     session.merge().map(drop)
+}
+
+/// Execute the definition-binding query for benchmark instrumentation without
+/// exposing its compiler-owned records.
+pub fn prepare_stable_definitions(
+    session: &mut crate::CompilerSession,
+    options: &crate::CompileOptions,
+) -> Result<(), crate::CompileErrors> {
+    session.stable_definitions(options).map(drop)
+}
+
+/// Return the latest attempted discovery revision for in-tree source-loading
+/// diagnostics. Stable consumers query committed graph and diagnostic views.
+pub fn discovery_attempt(
+    session: &crate::CompilerSession,
+) -> Option<Arc<crate::ImportDiscoveryView>> {
+    session
+        .discovery_attempt_artifact()
+        .map(|artifact| Arc::new(crate::ImportDiscoveryView::new(artifact.clone())))
+}
+
+/// Return the last closed-valid discovery revision for diagnostics tooling.
+pub fn last_good_discovery(
+    session: &crate::CompilerSession,
+) -> Option<Arc<crate::ImportDiscoveryView>> {
+    session
+        .last_good_discovery_artifact()
+        .map(|artifact| Arc::new(crate::ImportDiscoveryView::new(artifact.clone())))
+}
+
+/// Return the closed-valid discovery revision selected by the session.
+pub fn committed_import_discovery(
+    session: &crate::CompilerSession,
+) -> Option<Arc<crate::ImportDiscoveryView>> {
+    session
+        .committed_import_discovery_artifact()
+        .map(|artifact| Arc::new(crate::ImportDiscoveryView::new(artifact.clone())))
+}
+
+/// Debug rendering of the import-graph query input retained by a discovery view.
+pub fn import_discovery_graph_input_debug(view: &crate::ImportDiscoveryView) -> Option<String> {
+    view.inner
+        .graph()
+        .map(|graph| format!("{:?}", graph.input()))
+}
+
+/// Debug rendering of accepted reads retained by a discovery view.
+pub fn import_discovery_accepted_reads_debug(view: &crate::ImportDiscoveryView) -> String {
+    format!("{:?}", view.inner.accepted_read_manifest())
+}
+
+/// Debug rendering of the observation ledger retained by a discovery view.
+pub fn import_discovery_observation_ledger_debug(view: &crate::ImportDiscoveryView) -> String {
+    format!("{:?}", view.inner.ledger())
+}
+
+/// Run the fresh backend tail used by the cold-versus-reused differential
+/// oracle. Stable callers use `CompilerSession::executable`.
+pub fn oracle_executable(
+    session: &mut crate::CompilerSession,
+    snapshot: &crate::SourceSnapshot,
+    options: &crate::CompileOptions,
+) -> crate::MultiErrorResult<crate::CompileOutput> {
+    session.oracle_executable(snapshot, options)
+}
+
+/// Produce an executable inside a compile span owned by the filesystem
+/// driver. Stable callers use `CompilerSession::executable`, which owns its
+/// tracing root.
+pub fn executable_in_compile_scope(
+    session: &mut crate::CompilerSession,
+    options: &crate::CompileOptions,
+) -> crate::MultiErrorResult<crate::CompileOutput> {
+    session.executable_in_compile_scope(options)
 }
 
 impl PresentationOutput {
@@ -881,69 +961,6 @@ fn definition_work_json(work: &crate::session::CompilerSessionWork, from: usize)
         "manifest_bindings_visited": records.iter().map(|record| record.issuance.manifest_bindings_visited).sum::<usize>(),
         "ids_issued": records.iter().map(|record| record.issuance.ids_issued).sum::<usize>(),
     })
-}
-
-/// Opaque import-discovery product retained by the session.
-#[derive(Debug, Clone)]
-pub struct ImportDiscoveryRevision {
-    pub(crate) inner: Arc<crate::session::ImportDiscoveryRevisionArtifact>,
-}
-
-/// Read-only status of an import-discovery product.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ImportDiscoveryStatus {
-    Open,
-    ClosedAttempted,
-    ClosedValid,
-}
-
-impl ImportDiscoveryRevision {
-    #[cfg(not(test))]
-    pub(crate) fn new(inner: Arc<crate::session::ImportDiscoveryRevisionArtifact>) -> Self {
-        Self { inner }
-    }
-
-    pub fn status(&self) -> ImportDiscoveryStatus {
-        match self.inner.status() {
-            crate::session::ImportDiscoveryRevisionStatus::Open => ImportDiscoveryStatus::Open,
-            crate::session::ImportDiscoveryRevisionStatus::ClosedAttempted => {
-                ImportDiscoveryStatus::ClosedAttempted
-            }
-            crate::session::ImportDiscoveryRevisionStatus::ClosedValid => {
-                ImportDiscoveryStatus::ClosedValid
-            }
-        }
-    }
-
-    pub fn source_revision(&self) -> &crate::SourceRevision {
-        self.inner.source_revision()
-    }
-
-    pub fn diagnostics(&self) -> &crate::CompileErrors {
-        self.inner.diagnostics()
-    }
-
-    pub fn diagnostic_snapshot(&self) -> Option<&Arc<crate::FrontendDiagnosticSnapshot>> {
-        self.inner.diagnostic_snapshot()
-    }
-
-    pub fn unstable_metrics(&self) -> ParseMetrics {
-        ParseMetrics::from_work(self.inner.parse_work())
-    }
-
-    pub fn graph_input_debug(&self) -> Option<String> {
-        self.inner
-            .graph()
-            .map(|graph| format!("{:?}", graph.input()))
-    }
-
-    pub fn accepted_reads_debug(&self) -> String {
-        format!("{:?}", self.inner.accepted_read_manifest())
-    }
-
-    pub fn observation_ledger_debug(&self) -> String {
-        format!("{:?}", self.inner.ledger())
-    }
 }
 
 /// Deliberate fault selection for the differential incremental oracle.

--- a/crates/rue-compiler/tests/differential_oracle.rs
+++ b/crates/rue-compiler/tests/differential_oracle.rs
@@ -12,14 +12,16 @@ use std::{collections::HashMap, fmt::Write as _, sync::Arc};
 
 use rue_cfg::OptLevel;
 use rue_compiler::unstable::{
-    DifferentialOracleFault, PresentationRequest, PresentationStage, inject_stale_query_for_oracle,
+    DifferentialOracleFault, DiscoverySourceAssembler, PresentationRequest, PresentationStage,
+    discovery_attempt, import_discovery_accepted_reads_debug, import_discovery_graph_input_debug,
+    import_discovery_observation_ledger_debug, inject_stale_query_for_oracle, oracle_executable,
     semantic_input_debug,
 };
 use rue_compiler::{
     AcceptedImportSource, AcceptedReadManifestEntry, CompileOptions, CompilerSession,
-    DiscoverySourceAssembler, FileMetadataFingerprint, FrontendDiagnosticSnapshot,
-    ImportDiscoveryContext, ImportObservation, ImportObservationLedger, PhysicalFileIdentity,
-    PreviewFeature, PreviewFeatures, SourceMetadata, SourceSnapshot,
+    FileMetadataFingerprint, FrontendDiagnosticSnapshot, ImportDiscoveryContext, ImportObservation,
+    ImportObservationLedger, PhysicalFileIdentity, PreviewFeature, PreviewFeatures, SourceMetadata,
+    SourceSnapshot,
 };
 use rue_span::FileId;
 use rue_target::Target;
@@ -171,27 +173,24 @@ fn close_discovery(session: &mut CompilerSession, step: &Step) -> String {
         ledger.record(observation).unwrap();
     }
     match session.close_import_discovery(ledger) {
-        Ok(artifact) => format!(
-            "status={:?};input={:?};reads={:?};ledger={:?}",
-            artifact.status(),
-            artifact.graph_input_debug(),
-            artifact.accepted_reads_debug(),
-            artifact.observation_ledger_debug()
-        ),
+        Ok(artifact) => render_import_discovery(&artifact),
         Err(errors) => format!("close-error:{errors:?}"),
     }
 }
 
 fn render_selected_import(session: &CompilerSession) -> String {
-    let artifact = session
-        .discovery_attempt()
+    let artifact = discovery_attempt(session)
         .expect("injected import fault retains a selected closure artifact");
+    render_import_discovery(&artifact)
+}
+
+fn render_import_discovery(artifact: &rue_compiler::ImportDiscoveryView) -> String {
     format!(
         "status={:?};input={:?};reads={:?};ledger={:?}",
         artifact.status(),
-        artifact.graph_input_debug(),
-        artifact.accepted_reads_debug(),
-        artifact.observation_ledger_debug()
+        import_discovery_graph_input_debug(artifact),
+        import_discovery_accepted_reads_debug(artifact),
+        import_discovery_observation_ledger_debug(artifact)
     )
 }
 
@@ -269,7 +268,7 @@ fn observe_with_fault(
                 })
                 .expect("oracle corpus must have platform-stable assembly emission");
             let hash = format!("{:x}", Sha256::digest(emitted.as_str().as_bytes()));
-            let executable_hash = match session.oracle_executable(&step.snapshot, &step.options) {
+            let executable_hash = match oracle_executable(session, &step.snapshot, &step.options) {
                 Ok(executable) => format!("{:x}", Sha256::digest(&executable.elf)),
                 Err(errors) => format!("error:{errors:?}"),
             };

--- a/crates/rue-compiler/tests/public_api.rs
+++ b/crates/rue-compiler/tests/public_api.rs
@@ -5,14 +5,24 @@ use rue_compiler::unstable::{
     into_oracle_semantic_state,
 };
 use rue_compiler::{
-    CompileOptions, CompileOutput, CompilerSession, CompilerSessionUpdate, DiagnosticStage,
-    ErrorKind, FileId, FrontendDiagnosticSnapshot, MultiErrorResult, RirView, SemanticView,
-    SourceLocationView, SourceMetadata, SourceSnapshot, SourceView, SyntaxNodeView,
-    compile_snapshot,
+    CompileErrors, CompileOptions, CompileOutput, CompilerSession, CompilerSessionUpdate,
+    DependencyEnvelope, DiagnosticStage, FileId, FrontendDiagnosticSnapshot, ImportDiscoveryStatus,
+    ImportDiscoveryView, MultiErrorResult, RirView, SemanticView, SourceLocationView,
+    SourceMetadata, SourceRevision, SourceSnapshot, SourceView, SyntaxNodeView, compile_snapshot,
 };
+use rue_error::ErrorKind;
 
 #[test]
 fn curated_facade_compiles_for_an_external_consumer() {
+    fn inspect_import_discovery(view: &ImportDiscoveryView) {
+        let _: ImportDiscoveryStatus = view.status();
+        let _: &SourceRevision = view.source_revision();
+        let _: &CompileErrors = view.diagnostics();
+        let _: Option<&Arc<FrontendDiagnosticSnapshot>> = view.diagnostic_snapshot();
+        let _: Option<DependencyEnvelope> = DependencyEnvelope::from_closed_revision(view);
+    }
+    let _ = inspect_import_discovery as fn(&ImportDiscoveryView);
+
     let snapshot = SourceSnapshot::single("main.rue", "fn main() -> i32 { 0 }").unwrap();
     let mut session = CompilerSession::new();
     let update: CompilerSessionUpdate = session.update(&snapshot);

--- a/crates/rue-fuzz/BUCK
+++ b/crates/rue-fuzz/BUCK
@@ -9,6 +9,7 @@ rue_binary(
         "//crates/rue-cfg:rue-cfg",
         "//crates/rue-cfg:rue-cfg-fuzz-support",
         "//crates/rue-compiler:rue-compiler",
+        "//crates/rue-error:rue-error",
         "//crates/rue-lexer:rue-lexer",
         "//crates/rue-parser:rue-parser",
         "//crates/rue-rir:rue-rir",

--- a/crates/rue-fuzz/src/targets.rs
+++ b/crates/rue-fuzz/src/targets.rs
@@ -31,19 +31,19 @@ fn assert_no_ice<T>(result: &rue_compiler::MultiErrorResult<T>) {
     }
 }
 
-fn is_ice(kind: &rue_compiler::ErrorKind) -> bool {
+fn is_ice(kind: &rue_error::ErrorKind) -> bool {
     matches!(
         kind,
-        rue_compiler::ErrorKind::CompilerProducerInvariant(_)
-            | rue_compiler::ErrorKind::InternalError(_)
-            | rue_compiler::ErrorKind::InternalCodegenError(_)
+        rue_error::ErrorKind::CompilerProducerInvariant(_)
+            | rue_error::ErrorKind::InternalError(_)
+            | rue_error::ErrorKind::InternalCodegenError(_)
     )
 }
 
 #[cfg(test)]
 mod ice_classification_tests {
     use super::is_ice;
-    use rue_compiler::ErrorKind;
+    use rue_error::ErrorKind;
 
     #[test]
     fn resource_failures_are_not_ices_but_producer_invariants_are() {

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -47,9 +47,10 @@ mod generator;
 mod model_gaps;
 mod trap;
 
+use rue_compiler::unstable::DiscoverySourceAssembler;
 use rue_compiler::{
-    AcceptedImportSource, CompilerSession, DiscoverySourceAssembler, FileMetadataFingerprint,
-    ImportDiscoveryContext, ImportObservation, ImportObservationLedger, PhysicalFileIdentity,
+    AcceptedImportSource, CompilerSession, FileMetadataFingerprint, ImportDiscoveryContext,
+    ImportObservation, ImportObservationLedger, PhysicalFileIdentity,
 };
 use rue_error::{PreviewFeature, PreviewFeatures};
 use rue_oracle::{

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -1144,9 +1144,10 @@ fn option_returning_intrinsics_require_the_exact_payload_type() {
 
 #[test]
 fn read_line_requires_trusted_source_strbuf_payload_metadata() {
+    use rue_compiler::unstable::DiscoverySourceAssembler;
     use rue_compiler::{
-        AcceptedImportSource, CompilerSession, DiscoverySourceAssembler, FileMetadataFingerprint,
-        ImportDiscoveryContext, ImportObservation, ImportObservationLedger, PhysicalFileIdentity,
+        AcceptedImportSource, CompilerSession, FileMetadataFingerprint, ImportDiscoveryContext,
+        ImportObservation, ImportObservationLedger, PhysicalFileIdentity,
     };
     use std::sync::Arc;
 

--- a/crates/rue/BUCK
+++ b/crates/rue/BUCK
@@ -2,6 +2,7 @@ load("//crates:defs.bzl", "rue_binary")
 
 _DEPS = [
     "//crates/rue-compiler:rue-compiler",
+    "//crates/rue-error:rue-error",
     "//crates/rue-rir:rue-rir",
     "//crates/rue-target:rue-target",
     "//third-party:libc",

--- a/crates/rue/src/compile.rs
+++ b/crates/rue/src/compile.rs
@@ -1,4 +1,4 @@
-use rue_compiler::unstable::OneShotMetrics;
+use rue_compiler::unstable::{OneShotMetrics, executable_in_compile_scope};
 use rue_compiler::{CompileErrors, CompileOptions, CompileWarning, CompilerSession};
 
 use crate::output::{PublicationDestination, PublishRequest, publish_executable};
@@ -30,9 +30,7 @@ pub(crate) struct PublicationAttempt {
 
 /// Execute the canonical compiler session through linking.
 pub(crate) fn execute(request: CompileRequest<'_>) -> Result<LinkedExecutable, CompileErrors> {
-    let output = request
-        .session
-        .executable_in_compile_scope(&request.options)?;
+    let output = executable_in_compile_scope(request.session, &request.options)?;
     let metrics = output.unstable_metrics();
     Ok(LinkedExecutable {
         target: request.options.target,

--- a/crates/rue/src/emit.rs
+++ b/crates/rue/src/emit.rs
@@ -3,14 +3,15 @@ use rue_compiler::unstable::MetricsSnapshot;
 #[cfg(test)]
 use rue_compiler::unstable::update_for_presentation;
 use rue_compiler::unstable::{
-    ImportDiscoveryRevision, ImportDiscoveryStatus, LowerMetrics, ParseMetrics,
-    PresentationRequest, PresentationStage, SemanticMetrics, semantic_metrics,
+    LowerMetrics, ParseMetrics, PresentationRequest, PresentationStage, SemanticMetrics,
+    semantic_metrics,
 };
 use rue_compiler::{
-    CompileError, CompileErrors, CompileOptions, CompileWarning, CompilerSession,
-    DependencyEnvelope, DependencyEnvelopeStatus, ErrorKind, RirView, SemanticView, SourceSnapshot,
-    SyntaxView,
+    CompileErrors, CompileOptions, CompileWarning, CompilerSession, DependencyEnvelope,
+    DependencyEnvelopeStatus, ImportDiscoveryStatus, ImportDiscoveryView, RirView, SemanticView,
+    SourceSnapshot, SyntaxView,
 };
+use rue_error::{CompileError, ErrorKind};
 use tracing::info_span;
 
 use crate::DiagnosticOutput;
@@ -218,7 +219,7 @@ pub(crate) struct EmitRequest<'a, 'diagnostics> {
     pub(crate) source_snapshot: &'a SourceSnapshot,
     pub(crate) session: &'a mut CompilerSession,
     pub(crate) stages: &'a [EmitStage],
-    pub(crate) discovery_revision: &'a ImportDiscoveryRevision,
+    pub(crate) discovery_revision: &'a ImportDiscoveryView,
     pub(crate) compile_options: CompileOptions,
     pub(crate) diagnostics: &'a DiagnosticOutput<'diagnostics>,
 }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -19,9 +19,9 @@ mod timing;
 use emit::EmitStage;
 #[cfg(test)]
 use emit::{EmitFrontendRoute, build_emit_frontend, emit_frontend_route};
-use rue_compiler::unstable::ImportDiscoveryStatus;
 #[cfg(test)]
 use rue_compiler::unstable::update_for_presentation;
+use rue_compiler::unstable::{MultiFileFormatter, MultiFileJsonFormatter, SourceInfo};
 use source_loader::{SourceLoadError, SourceLoadRequest};
 #[cfg(test)]
 use source_loader::{
@@ -30,12 +30,12 @@ use source_loader::{
 };
 
 use rue_compiler::{
-    CompileError, CompileErrors, CompileOptions, CompileWarning, FileId, LinkerMode,
-    MultiFileFormatter, MultiFileJsonFormatter, OptLevel, PreviewFeature, PreviewFeatures,
-    SourceInfo, configure_thread_pool,
+    CompileErrors, CompileOptions, CompileWarning, FileId, ImportDiscoveryStatus, LinkerMode,
+    OptLevel, PreviewFeature, PreviewFeatures, configure_thread_pool,
 };
 #[cfg(test)]
 use rue_compiler::{CompilerSession, SourceMetadata, SourceSnapshot};
+use rue_error::CompileError;
 use rue_target::Target;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum LogLevel {
@@ -1275,10 +1275,11 @@ mod tests {
             );
             {
                 let _compile = compile_span.enter();
-                discovery
-                    .session
-                    .executable_in_compile_scope(&CompileOptions::default())
-                    .unwrap();
+                rue_compiler::unstable::executable_in_compile_scope(
+                    &mut discovery.session,
+                    &CompileOptions::default(),
+                )
+                .unwrap();
             }
             drop(compile_span);
         });

--- a/crates/rue/src/output.rs
+++ b/crates/rue/src/output.rs
@@ -4,7 +4,7 @@ use std::io::{self, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
-use rue_compiler::{CompileError, ErrorKind};
+use rue_error::{CompileError, ErrorKind};
 use rue_target::Target;
 
 use crate::platform_signing::{SigningError, SigningRequest, sign_executable};

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -5,11 +5,11 @@ use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
-use rue_compiler::unstable::ImportDiscoveryRevision;
+use rue_compiler::unstable::{DiscoverySourceAssembler, discovery_attempt};
 use rue_compiler::{
     AcceptedImportSource, AcceptedReadManifestEntry, CompileErrors, CompilerSession,
-    DependencyEnvelope, DiscoverySourceAssembler, FileId, FileMetadataFingerprint,
-    ImportDiscoveryContext, ImportObservation, ImportObservationLedger, ImportObservationStatus,
+    DependencyEnvelope, FileId, FileMetadataFingerprint, ImportDiscoveryContext,
+    ImportDiscoveryView, ImportObservation, ImportObservationLedger, ImportObservationStatus,
     PhysicalFileIdentity, SourceMetadata, SourceSnapshot,
 };
 
@@ -414,7 +414,7 @@ pub(crate) struct ImportDiscoveryResult {
     /// Canonical physical reads accepted while assembling `source_snapshot`.
     pub(crate) read_manifest: Arc<[AcceptedReadManifestEntry]>,
     /// Canonical import topology and diagnostics published by the compiler.
-    pub(crate) revision: Arc<ImportDiscoveryRevision>,
+    pub(crate) revision: Arc<ImportDiscoveryView>,
     pub(crate) session: CompilerSession,
 }
 
@@ -626,10 +626,8 @@ pub(crate) fn discover_and_load_imports(
     let closed = match staging.close_import_discovery(ledger) {
         Ok(closed) => closed,
         Err(_) => {
-            let attempted = staging
-                .discovery_attempt()
-                .expect("failed closure publishes an attempted import revision")
-                .clone();
+            let attempted = discovery_attempt(&staging)
+                .expect("failed closure publishes an attempted import revision");
             if DependencyEnvelope::from_closed_revision(&attempted).is_some() {
                 // Missing and ambiguous resolution are structurally closed and
                 // therefore have canonical topology for `--emit deps`. The

--- a/docs/designs/0061-supported-compiler-facade.md
+++ b/docs/designs/0061-supported-compiler-facade.md
@@ -6,7 +6,7 @@ tags: [architecture, compiler, tooling, api, incremental]
 feature-flag: null
 created: 2026-07-17
 accepted: 2026-07-17
-implemented:
+implemented: 2026-07-18
 spec-sections: []
 superseded-by:
 relates: ["RUE-865", "RUE-866", "RUE-867", "RUE-868", "RUE-869", "RUE-439", "RUE-749", "ADR-0053", "ADR-0058"]
@@ -16,8 +16,8 @@ relates: ["RUE-865", "RUE-866", "RUE-867", "RUE-868", "RUE-869", "RUE-439", "RUE
 
 ## Status
 
-Accepted under RUE-865 on 2026-07-17. RUE-866 through RUE-869 implement the
-boundary. This is an API and ownership decision; it does not change Rue
+Accepted under RUE-865 on 2026-07-17 and implemented by RUE-866 through RUE-869
+on 2026-07-18. This is an API and ownership decision; it does not change Rue
 language semantics.
 
 ## Summary
@@ -119,8 +119,9 @@ operations:
 
 views/results:
   CompileOutput
-  DiagnosticView, DiagnosticSetView, SourceLocationView, SuggestionView
-  TokenView, SyntaxView, DefinitionView, DependencyGraphView
+  CompileErrors, CompileWarning, FrontendDiagnosticSnapshot, DiagnosticStage
+  ImportDiscoveryView, DependencyEnvelope, CanonicalImportGraphOutput
+  TokenView, SyntaxView, SourceLocationView
   RirView, SemanticView, FunctionView, CfgView
   PresentationRequest/PresentationOutput only in the unstable tooling surface
 ```
@@ -225,9 +226,10 @@ of the supported API.
 | Disposition | Exact current exports | Final class / reason |
 | --- | --- | --- |
 | Keep | `CompileOutput` | Stable final one-shot result, narrowed so its fields use stable diagnostic views/owned output. Current `source_stats` and `work` fields move to the unstable metrics result. |
-| View-wrap | `FrontendDiagnosticSnapshot`, `FrontendDiagnosticStage`, `CompileError`, `CompileErrors`, `CompileWarning`, `Diagnostic`, `ErrorCode`, `ErrorKind`, `WarningKind`, `Suggestion`, `Applicability`, `Span`, `CompileResult`, `MultiErrorResult` | `DiagnosticSetView`, `DiagnosticView`, `SuggestionView`, checked source locations, and stable result aliases over an opaque failure. Raw diagnostic enums remain owned by `rue-error` for direct users. |
+| Keep/narrow | `FrontendDiagnosticSnapshot`, `DiagnosticStage`, `CompileErrors`, `CompileWarning`, `MultiErrorResult` | Stable diagnostic snapshots and aggregate result types remain available. Granular diagnostic records are named through their direct `rue-error` owner rather than reexported by the compiler facade. |
+| Move direct owner | `CompileError`, `Diagnostic`, `ErrorCode`, `ErrorKind`, `WarningKind`, `Suggestion`, `Applicability`, `CompileResult`, `Span` | Raw diagnostic and span records remain available from `rue-error` or `rue-span` for direct users; checked compiler artifact locations use `SourceLocationView`. |
 | Keep | `VERSION` | Compiler version. Machine schemas carry their own independent versions. |
-| View-wrap | `DependencyEnvelope`, `DependencyEnvelopeStatus`, `DependencyTopology`, `DependencyTopologyRecord`, `DependencyResolutionOutcome` | Stable dependency graph/status view used by `--emit deps` and machine tooling. |
+| Keep/narrow | `ImportDiscoveryView`, `ImportDiscoveryStatus`, `DependencyEnvelope`, `DependencyEnvelopeStatus`, `DependencyTopology`, `DependencyTopologyRecord`, `DependencyResolutionOutcome` | Stable owner-retaining discovery status and dependency graph/status outputs used by the source loader, `--emit deps`, and machine tooling. |
 | Move internal | `DependencyAcceptedRead`, `DependencyContext`, `DependencyObservation`, `DependencyObservationOutcome`, `DependencyRequest` | Closure evidence and query request records are engine/source-loader implementation. |
 | View-wrap | `CanonicalImportGraphOutput`, `CanonicalImportGraph`, `CanonicalImportCycle`, `CanonicalImportGraphProblem`, `CanonicalImportGraphValidation`, `CanonicalImportRecord`, `CanonicalImportResolution`, `ImportDirective`, `ImportDirectives` | One immutable dependency/import graph view. Validation and resolution records stay behind the owner. |
 | Move internal | `ResolvedCodegenRevision`, `ResolvedLinkRevision`, `ResolvedProgramRevision` | Query publication/revision joins are not artifact facts for callers. |
@@ -238,10 +240,8 @@ of the supported API.
 | View-wrap | `CanonicalRirOutput`, `CanonicalSemanticOutput`, `FunctionWithCfg` | Private owners publish `RirView`, `SemanticView`, `FunctionView`, and `CfgView`; no raw phase storage leaks. |
 | Move internal/direct owner | `SourceStats` | The explicitly unstable metrics owner replaces this root export; metrics are not a language/tooling compatibility contract. |
 | Move internal | `CanonicalMergeWork`, `CanonicalRirWork`, `CanonicalSemanticFailurePhase`, `CanonicalSemanticFailureWork`, `CanonicalSemanticWork`, `PipelineWork` | Work/failure-path bookkeeping is exposed only through the unstable metrics view where needed. |
-| View-wrap | `DefinitionId`, `DefinitionKind`, `DefinitionNameKey`, `DefinitionNamespace`, `DefinitionOccurrenceId`, `DefinitionRecord`, `DefinitionSnapshot`, `ModuleDefinition` | Opaque definition IDs and immutable definition views. Parsed occurrence identity remains owner-bound. |
-| Move internal | `DefinitionShard`, `DefinitionShardWork` | Storage partitioning and reuse bookkeeping. |
-| View-wrap | `BoundDefinitionId`, `BoundDefinitionRecord`, `BoundDefinitionSet`, `StableDefinitionKey`, `StableDefinitionKind`, `StableDefinitionNamespace`, `StableNamedTypeKey` | Stable semantic identity appears only through opaque IDs and definition views; callers cannot issue or authorize IDs. |
-| Move internal | `SnapshotBoundDefinitionId`, `BoundDefinitionWork` | Issuer-scoped authorization and work records. |
+| Move internal | `DefinitionId`, `DefinitionKind`, `DefinitionNameKey`, `DefinitionNamespace`, `DefinitionOccurrenceId`, `DefinitionRecord`, `DefinitionSnapshot`, `ModuleDefinition`, `DefinitionShard`, `DefinitionShardWork` | No current external consumer uses the raw definition owner. A future navigation consumer must request an owner-retaining definition view rather than reopening these parser records. |
+| Move internal | `BoundDefinitionId`, `BoundDefinitionRecord`, `BoundDefinitionSet`, `StableDefinitionKey`, `StableDefinitionKind`, `StableDefinitionNamespace`, `StableNamedTypeKey`, `SnapshotBoundDefinitionId`, `BoundDefinitionWork` | Definition binding, issuer-scoped authorization, and reuse bookkeeping remain session-owned. A future stable definition identity is introduced only with its immutable view. |
 
 #### Query, invalidation, and durable implementation
 
@@ -277,11 +277,11 @@ operations have these dispositions:
 | --- | --- | --- |
 | Keep | `new`, `update`, `executable` | Stable session lifecycle and final-output query. |
 | Keep | `import_discovery_plan`, `stage_import_discovery`, `close_import_discovery`, `import_graph` | Host-driven import closure remains canonical session orchestration; plans, requests, status, and graphs use immutable views. |
-| View-wrap | `published`, `committed_import_graph`, `rir`, `semantic`, `stable_definitions` | Stable artifact queries return private owners exposing syntax/dependency/RIR/semantic/definition views. |
+| View-wrap | `published`, `committed_import_graph`, `rir`, `semantic` | Stable artifact queries return private owners exposing syntax/dependency/RIR/semantic views. |
 | View-wrap | `latest_diagnostics`, `latest_successful_diagnostics`, `last_good_semantic_diagnostics`, `most_recent_diagnostics_for`, `diagnostics_for`, `import_diagnostics` | Return stable diagnostic views with explicit current/last-good provenance. |
 | Move internal/direct owner | `update_for_presentation`, `work` | Presentation selection and metrics move to explicit unstable requests/snapshots. |
 | Move internal/direct owner | `oracle_executable`, `inject_stale_query_for_oracle` | Crate-private test support preserves differential validation without making fault injection or oracle knobs a supported compiler API. |
-| Move internal | `discovery_attempt`, `last_good_discovery`, `committed_import_discovery`, `merge`, `semantic_dependency_inputs`, `semantic_invalidation_plan`, `executable_in_compile_scope` | Query attempts, canonical merge, durable reuse decisions, invalidation, and scoped orchestration stay session-owned. |
+| Move internal | `discovery_attempt`, `last_good_discovery`, `committed_import_discovery`, `stable_definitions`, `merge`, `semantic_dependency_inputs`, `semantic_invalidation_plan`, `executable_in_compile_scope` | Query attempts, definition binding, canonical merge, durable reuse decisions, invalidation, and scoped orchestration stay session-owned. Benchmarks may trigger them through record-free unstable adapters. |
 
 `CompilerSessionUpdate` likewise keeps only success/diagnostic/view access needed
 to publish a source request. Raw parse work and invalidation accessors move to
@@ -333,10 +333,13 @@ staged rather than silently broken:
   syntax/token/RIR/semantic/type views, migrate CLI/fuzz/oracle users, and
   remove lexer, parser AST, RIR, interner, raw symbol, raw pool, and backend
   presentation exports from their post-M8 owners.
-- **RUE-869:** replace the line-count guard with a mechanically checked semantic
-  inventory of every root export and public session signature. The inventory
-  records owner, class, stability, and approved consumer; CI rejects unreviewed
-  additions and forbidden implementation categories.
+- **RUE-869:** replaced the line-count guard with the mechanically checked
+  `supported_api_inventory.rs` inventory of every root export and public
+  session signature. Each line records owner, class, stability, approved
+  consumer, symbol, and canonical signature; CI rejects unreviewed additions,
+  aliases, globs, and forbidden implementation categories. The maintainer
+  workflow for extending the facade is documented in
+  `docs/process/compiler-facade.md`.
 
 RUE-866 and RUE-867 may proceed after this ADR on their existing prerequisites.
 RUE-868 explicitly waits for RUE-860 and performs the source-boundary recheck

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -29,6 +29,7 @@ Each step has a corresponding document in this directory and a Claude Code comma
 | Review | [code-review.md](code-review.md) | `/code-review` | Check quality before committing |
 | Commit | [committing.md](committing.md) | `/commit` | Create well-formed commits |
 | - | [ci.md](ci.md) | - | Maintain required CI and its pinned tools |
+| - | [compiler-facade.md](compiler-facade.md) | - | Review compiler API and tooling-view changes |
 | - | [tutorial.md](tutorial.md) | - | Maintain tutorial outline, style, and snippet checks |
 | - | [issue-tracking.md](issue-tracking.md) | Linear MCP tools | Track work with Linear |
 

--- a/docs/process/compiler-facade.md
+++ b/docs/process/compiler-facade.md
@@ -1,0 +1,63 @@
+# Compiler Facade Changes
+
+`rue-compiler` exposes one session-centered public facade. Its supported root
+contains owned requests, `CompilerSession`, the one-shot `compile_snapshot`
+adapter, and immutable artifact views. Query records, durable payloads,
+interners, parser and raw IR owners, backend state, and alternate phase entry
+points are implementation details.
+
+The reviewed inventory lives in
+`crates/rue-compiler/src/supported_api_inventory.rs`. Every root export and
+every public `CompilerSession` or `CompilerSessionUpdate` signature has one
+line with this form:
+
+```text
+stability|owner|class|approved-consumer|symbol|canonical-signature
+```
+
+The compiler unit tests mechanically extract the current surface and compare
+it with that file. They also reject root glob exports and aliases, public
+additions without a classification, forbidden implementation categories, and
+additional one-shot compiler entry points. An intentional API change therefore
+produces a small inventory diff that reviewers can assess semantically.
+
+## Requesting a tooling view
+
+Start from the structured fact the consumer needs and find the canonical
+session artifact that already owns it. Extend an existing immutable view, or
+add a new owner-retaining view, when the fact is a durable compiler concept for
+embedders or machine tooling. Views must use checked references, opaque stable
+identities, and borrowed iterators; they must not reveal owner-indexed storage
+or permit compiler state to be installed or mutated.
+
+Presentation text, metrics, tracing adapters, benchmark data, differential
+oracle hooks, and driver-specific operations belong under
+`rue_compiler::unstable`. An unstable adapter still consumes canonical session
+artifacts and must not create a peer parser, semantic path, or backend path.
+Specialized in-tree phase tools may depend directly on the crate that owns a
+raw phase type instead of making `rue-compiler` an umbrella crate.
+
+Import discovery follows the same split: the stable `ImportDiscoveryView`
+reports closure status, source revision, and structured diagnostics, while
+debug renderings of accepted reads, graph inputs, ledgers, and source-assembly
+policy live under `rue_compiler::unstable`.
+
+For a stable addition, document why an existing view cannot answer the request,
+name the owning module and approved consumers, and update the classification in
+`api_inventory.rs` together with the exact reviewed inventory line. Signature
+changes and removals receive the same review as root export changes. Do not
+weaken the scanner or add a compatibility wrapper that computes the artifact a
+second way.
+
+Run the focused guard while iterating:
+
+```bash
+scripts/rue unit compiler api_inventory::semantic_api_inventory_matches_every_root_export_and_session_signature --exact --nocapture
+```
+
+Before publication, run `scripts/rue fmt`, the full compiler API-inventory unit
+group, the affected consumer tests, and `scripts/rue quick`. Cross-cutting
+facade changes also require the repository's full serialized test suite.
+
+The compatibility and ownership rationale is recorded in
+[ADR-0061](../designs/0061-supported-compiler-facade.md).


### PR DESCRIPTION
## Summary

- replace the compiler-facade line budget with an exact semantic inventory of every supported root export and public session signature
- narrow the supported facade to session-owned artifact views, moving diagnostics, definition records, import-discovery internals, and driver adapters to their direct or unstable owners
- migrate in-tree CLI, fuzz, oracle, benchmark, and API consumers and document the facade-extension workflow

## Why

RUE-869 completes ADR-0061 and M10 by making unreviewed public API additions fail mechanically. The supported compiler boundary is now session-centered and artifact-oriented, while query-engine, parser, raw IR, interner, durable payload, backend, and presentation internals remain outside the compatibility contract.

## Validation

- `scripts/rue fmt`
- compiler API inventory: 18/18
- compiler public API: 8/8
- compiler differential oracle: 4/4
- focused CLI module/dependency suite: 123/123
- `scripts/rue quick`: 33/33 after rebasing onto current trunk
- `scripts/rue test`: full serialized suite passed
- adversarial review: no findings

Fixes RUE-869
