### PR TITLE
RUE-320: scope linker to remote execution

### DIFF
--- a/.buckconfig.local.example
+++ b/.buckconfig.local.example
@@ -14,10 +14,8 @@
 # With this config, the repository's `./buck2` wrapper adds `--prefer-local` to
 # normal execution commands: the remote action cache is queried first, then
 # misses execute locally. Adding an explicit execution-mode flag overrides the
-# wrapper, but full remote execution is not supported until RUE-320. It was
-# previously demonstrated for compilation, but complete builds still need the
-# platform-scoped linker fix. Remote execution is
-# possible because the rust toolchain ships its own tree (rustc finds its libs via
+# wrapper. Remote execution is possible because the Rust toolchain ships its own
+# tree (rustc finds its libs via
 # $ORIGIN under RE) and links via `cc`+lld; the remote_cache platform pins the
 # rbe-ubuntu22-04 container image (Python 3.10 for the prelude's rustc wrapper).
 #
@@ -42,6 +40,6 @@ default_allow_cache_upload = true
 
 [build]
 # Route commands through the remote-cache platform. The repository ./buck2
-# wrapper adds --prefer-local for ordinary execution commands; RUE-320 must land
-# before full remote execution is supported.
+# wrapper adds --prefer-local for ordinary execution commands. Pass
+# --prefer-remote explicitly to exercise full remote execution.
 execution_platforms = root//platforms:remote_cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,40 @@ jobs:
         # update and verification procedure.
         run: docker run --rm -v "$PWD:/repo:ro" -w /repo rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color -shellcheck=/usr/local/bin/shellcheck
 
+  # RUE-320: merge-group-only proof that the compiler can be built on the
+  # BuildBuddy worker. Fork PRs cannot access the key. Disabling action-cache
+  # reads forces real remote execution; the strict platform forbids a failed
+  # remote action from being retried locally, so a missing worker linker cannot
+  # hide behind hybrid fallback.
+  remote-execution:
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    name: remote execution (linux-x64)
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dotslash
+        uses: facebook/install-dotslash@v2
+
+      - name: Require and provision remote execution
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          if [ -z "${BUILDBUDDY_API_KEY:-}" ]; then
+            echo "::error::BUILDBUDDY_API_KEY is required for the merge-group remote-execution canary."
+            exit 1
+          fi
+          scripts/provision-build-cache install
+          scripts/provision-build-cache apply
+
+      - name: Build compiler remotely
+        env:
+          RUE_CI_REQUIRE_REMOTE_ACTIONS: 1
+        run: >-
+          scripts/ci-timed "remote compiler build" --
+          ./buck2 build //crates/rue:rue --prefer-remote --no-remote-cache
+          -c build.execution_platforms=root//platforms:remote_execution
+
   rust-project:
     runs-on: ubuntu-latest
     steps:

--- a/constraints/BUCK
+++ b/constraints/BUCK
@@ -31,3 +31,17 @@ constraint_value(
     constraint_setting = ":opt-level",
     visibility = ["PUBLIC"],
 )
+
+# Execution-environment marker used only by the opt-in BuildBuddy platform.
+# Toolchains configured for that execution platform may select remote-worker
+# compatible tools without changing the native/default toolchain.
+constraint_setting(
+    name = "execution-environment",
+    visibility = ["PUBLIC"],
+)
+
+constraint_value(
+    name = "remote-execution",
+    constraint_setting = ":execution-environment",
+    visibility = ["PUBLIC"],
+)

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -3,29 +3,24 @@
 Buck2 rebuilds everything from scratch in each `buck-out`, and OSS buck2 has **no
 persistent action cache across daemon restarts** (noted in `ci.yml`). Every CI run
 and every isolated worktree rebuilds unchanged crates. We use **BuildBuddy** (free
-tier) for a shared remote action cache. Remote execution experiments established
-the remaining toolchain requirements, but complete remote builds are not a
-supported workflow while RUE-320 remains open.
+tier) for a shared remote action cache and opt-in remote execution.
 
-> **Status (RUE-316 landed the groundwork; RUE-320 finishes it).** The remote
-> platform + the `$ORIGIN` toolchain-tree fix are in place, but full RE is **not
-> enabled by default and not yet landable as-is**. It needs the linker driver to
-> be `cc` (so lld, not the absent `clang++`, links on the remote worker) — and
-> that override can only be applied to the **remote platform**, not globally:
-> making it the toolchain-wide default (`linker = "cc"` in `toolchains/BUCK`)
-> breaks native CI, whose system builds rely on the default linker path
-> (`collect2: cannot find 'ld'`). Platform-scoped linker selection is tracked as
-> **RUE-320**. Until then the `remote_cache` platform is opt-in/experimental and
-> its remote-execution actions require that linker override locally.
+> **Status (RUE-316/RUE-320).** The remote platform, `$ORIGIN` toolchain-tree
+> fix, and execution-platform-scoped linker are in place. Native/default builds
+> keep `clang++`; the BuildBuddy execution configuration selects the ubiquitous
+> `cc` driver through an exec-dep while Rust's bundled lld performs the real
+> Linux link via `-fuse-ld=lld`. Full remote execution is supported as an
+> explicit `--prefer-remote` mode, not the default local-development policy.
 
 - **Remote action cache**: the repository `./buck2` wrapper supplies
   `--prefer-local`, so cache misses execute locally while hits are shared across
   machines + daemon restarts. The cache can only affect *speed*, never
   correctness.
 - **`--prefer-remote`**: full remote **execution** — compiles + links on
-  BuildBuddy's container (~80 free-tier cores). Blocked on RUE-320.
+  BuildBuddy's container (~80 free-tier cores). Required merge-group CI runs a
+  cache-disabled canary so worker-toolchain regressions cannot hide as hits.
 
-Tracking: RUE-316 (groundwork), RUE-320 (platform-scoped linker to finish RE).
+Tracking: RUE-316 (groundwork), RUE-320 (platform-scoped linker).
 
 ## Local development across worktrees
 
@@ -48,10 +43,11 @@ insecure, Rue warns and continues without provisioning it. Existing local paths,
 including broken or unrelated symlinks, are left untouched. This keeps cache
 setup opt-in and prevents a credential problem from making local builds unusable.
 
-The setup is for the shared **action cache**. Do not add `--prefer-remote` to
-normal commands: full remote execution remains blocked on RUE-320. The checked-in
-`.buckconfig.local.example` remains a reference for the generated configuration,
-not the recommended per-worktree setup.
+The default setup is for the shared **action cache**. Normal commands stay on
+`--prefer-local`; add `--prefer-remote` explicitly when remote execution is the
+intended experiment. The checked-in `.buckconfig.local.example` remains a
+reference for the generated configuration, not the recommended per-worktree
+setup.
 
 ## Full-suite host coordination
 
@@ -100,18 +96,22 @@ they're recorded here so a future config change doesn't silently regress:
 5. **Container** (`platforms/remote_cache.bzl`): pinned to `rbe-ubuntu22-04`
    (Python 3.10 — the prelude's rustc wrapper needs ≥3.9; the default image ships
    3.6).
-6. **Linker** (RUE-320, NOT landed): the remote worker needs the linker driver to
-   be **`cc`** instead of `clang++` (lld — `-fuse-ld=lld`, shipped with rust — does
-   the real linking; the driver just needs to exist, and `cc` is everywhere while
-   `clang++` is not). This was proven with `linker = "cc"` in `toolchains/BUCK`, but
-   that override is **global** and breaks native CI (`cc` → `collect2` → `cannot
-   find 'ld'` when the hermetic lld flags aren't on the command). It has to be
-   **scoped to the remote platform** instead — tracked as RUE-320.
+6. **Linker** (RUE-320): the remote worker needs **`cc`** instead of the absent
+   `clang++`. A `remote-execution` constraint is inserted only into the explicit
+   full-remote execution configuration. The cache-only configuration omits it
+   because its misses execute natively under `--prefer-local`. The C++ tools
+   provider is an exec-dep, so its linker select sees that constraint and
+   chooses `cc`; native/default and cache-only execution configurations retain
+   the prelude's `clang++`. The pinned prelude adds `-fuse-ld=lld` for Linux,
+   keeping the actual linker hermetic.
+7. **Rust action memory** (RUE-320): a cache-disabled cold graph exceeded
+   BuildBuddy's default per-action memory estimate and the executor OOM-killed
+   rustc. The remote platform requests 4 GB per action; this is an execution
+   scheduling hint and does not affect native or cache-only builds.
 
-Change 4 (`$ORIGIN` toolchain-tree) is global and local-safe (verified: local
-build + suite green). 1, 2, 3, and 5 live in the opt-in
-`.buckconfig.local` / the `remote_cache` platform. 6 is the remaining blocker
-for default-on RE.
+Change 4 (`$ORIGIN` toolchain-tree) is global and local-safe. Changes 1, 2, 3,
+5, 6, and 7 live in the opt-in `.buckconfig.local` / `remote_cache` execution
+path.
 
 ## CI
 
@@ -153,6 +153,12 @@ whether unchanged actions are reusable; the job summaries answer the different
 question of how expensive a real change's remaining local actions were. Both
 signals matter: a central Rust or ThinLTO change can have a high numerical hit
 rate while a few invalidated actions remain on the critical path.
+
+RUE-320 also adds a merge-group-only remote-execution canary. It disables action
+cache reads, selects the no-fallback `//platforms:remote_execution` executor, and
+requires Buck to report remotely executed actions. This is deliberately
+separate from the cache probe: one proves worker execution, the other proves
+unchanged-action reuse.
 
 ## Toward a fully hermetic linker
 

--- a/platforms/BUCK
+++ b/platforms/BUCK
@@ -43,3 +43,13 @@ remote_cache_platform(
     name = "remote_cache",
     visibility = ["PUBLIC"],
 )
+
+# Required merge-group canaries use the same remote executor without masking a
+# failed remote action by retrying it locally. Ordinary cache users retain the
+# forgiving hybrid platform above.
+remote_cache_platform(
+    name = "remote_execution",
+    allow_hybrid_fallbacks_on_failure = False,
+    mark_remote_execution = True,
+    visibility = ["PUBLIC"],
+)

--- a/platforms/remote_cache.bzl
+++ b/platforms/remote_cache.bzl
@@ -2,30 +2,53 @@
 # connection (required even for cache-only use in OSS buck2). Limited hybrid
 # prefers remote execution; the repository's ./buck2 wrapper therefore adds
 # --prefer-local for ordinary execution commands. Explicit execution-mode flags
-# still override it. Full remote execution remains blocked on RUE-320.
+# still override it. RUE-320's full-remote platform adds an execution constraint
+# that selects the worker's linker driver; the cache-only platform deliberately
+# omits it because cache misses still execute with the native toolchain.
 def _remote_cache_platform_impl(ctx):
     base = ctx.attrs.base[ExecutionPlatformRegistrationInfo]
-    platforms = [
-        ExecutionPlatformInfo(
+    remote_execution = ctx.attrs.remote_execution[ConstraintValueInfo]
+    platforms = []
+    for p in base.platforms:
+        configuration = p.configuration.copy()
+        if ctx.attrs.mark_remote_execution:
+            configuration.insert(remote_execution)
+        platforms.append(ExecutionPlatformInfo(
             label = ctx.label.raw_target(),
-            configuration = p.configuration,
+            configuration = configuration,
             executor_config = CommandExecutorConfig(
                 local_enabled = True,
                 remote_enabled = True,
                 remote_cache_enabled = True,
                 allow_cache_uploads = True,
                 use_limited_hybrid = True,
-                allow_hybrid_fallbacks_on_failure = True,
-                remote_execution_properties = {"OSFamily": "Linux", "container-image": "docker://gcr.io/flame-public/rbe-ubuntu22-04:latest"},
+                allow_hybrid_fallbacks_on_failure = ctx.attrs.allow_hybrid_fallbacks_on_failure,
+                # A cold Rust graph can exceed BuildBuddy's default per-action
+                # memory estimate. Request enough headroom to keep rustc actions
+                # out of the executor OOM killer (RUE-320).
+                remote_execution_properties = {
+                    "EstimatedMemory": "4GB",
+                    "OSFamily": "Linux",
+                    "container-image": "docker://gcr.io/flame-public/rbe-ubuntu22-04:latest",
+                },
                 remote_execution_use_case = "buck2-default",
                 remote_output_paths = "output_paths",
             ),
-        )
-        for p in base.platforms
+        ))
+    return [
+        DefaultInfo(),
+        ExecutionPlatformRegistrationInfo(
+            platforms = platforms,
+            exec_marker_constraint = base.exec_marker_constraint,
+        ),
     ]
-    return [DefaultInfo(), ExecutionPlatformRegistrationInfo(platforms = platforms)]
 
 remote_cache_platform = rule(
     impl = _remote_cache_platform_impl,
-    attrs = {"base": attrs.dep(providers = [ExecutionPlatformRegistrationInfo], default = "prelude//platforms:default")},
+    attrs = {
+        "base": attrs.dep(providers = [ExecutionPlatformRegistrationInfo], default = "prelude//platforms:default"),
+        "allow_hybrid_fallbacks_on_failure": attrs.bool(default = True),
+        "mark_remote_execution": attrs.bool(default = False),
+        "remote_execution": attrs.dep(providers = [ConstraintValueInfo], default = "root//constraints:remote-execution"),
+    },
 )

--- a/scripts/ci-timed
+++ b/scripts/ci-timed
@@ -38,6 +38,11 @@ while IFS= read -r line; do
     fi
 done <"$log"
 
+if [[ "$status" -eq 0 && "${RUE_CI_REQUIRE_REMOTE_ACTIONS:-0}" == "1" && "$remote" -eq 0 ]]; then
+    echo "::error::remote-execution canary completed without any remotely executed Buck actions" >&2
+    status=1
+fi
+
 result="passed"
 if [[ "$status" -ne 0 ]]; then
     result="failed ($status)"

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -676,6 +676,23 @@ EOF
   check "ci-timed: all Buck summaries are aggregated" \
     "$(grep -Fq '| passed |' "$sb/summary" && grep -Fq '| 2 | 15 | 10 | 2 | 3 |' "$sb/summary" && echo 0 || echo 1)"
 
+  rc=0
+  RUE_CI_REQUIRE_REMOTE_ACTIONS=1 "$sb/ci-timed" "remote wrapper" -- "$sb/fake-command" >/dev/null 2>&1 || rc=$?
+  check "ci-timed: remote canary accepts remotely executed actions" \
+    "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
+
+  cat >"$sb/local-command" <<'EOF'
+#!/usr/bin/env bash
+echo 'Commands: 4 (cached: 0, remote: 0, local: 4)'
+EOF
+  chmod +x "$sb/local-command"
+  rc=0
+  out="$(RUE_CI_REQUIRE_REMOTE_ACTIONS=1 "$sb/ci-timed" "local wrapper" -- "$sb/local-command" 2>&1)" || rc=$?
+  check "ci-timed: remote canary rejects a local-only success" \
+    "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+  check "ci-timed: remote canary explains a local-only success" \
+    "$(grep -Fq 'without any remotely executed Buck actions' <<<"$out" && echo 0 || echo 1)"
+
   : >"$sb/summary"; rc=0
   GITHUB_STEP_SUMMARY="$sb/summary" FAKE_EXIT=23 \
     "$sb/ci-timed" "failing wrapper" -- "$sb/fake-command" >/dev/null 2>&1 || rc=$?

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -12,14 +12,24 @@
 # - Linux x86_64/ARM64: Fully hermetic (uses internal ELF linker)
 # - macOS ARM64/x86_64: Requires Xcode Command Line Tools (uses system clang)
 
-load("@prelude//toolchains:cxx.bzl", "system_cxx_toolchain")
+load("@prelude//toolchains:cxx.bzl", "cxx_tools_info_toolchain")
 load("@prelude//toolchains:genrule.bzl", "system_genrule_toolchain")
 load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain")
 load("@prelude//tests:test_toolchain.bzl", "noop_test_toolchain")
+load(":cxx_tools.bzl", "cxx_tools_with_linker")
 load(":remote_test_execution.bzl", "noop_remote_test_execution_toolchain")
 
-system_cxx_toolchain(
+cxx_tools_with_linker(
+    name = "cxx-tools",
+    linker = select({
+        "DEFAULT": None,
+        "root//constraints:remote-execution": "cc",
+    }),
+)
+
+cxx_tools_info_toolchain(
     name = "cxx",
+    cxx_tools_info = ":cxx-tools",
     visibility = ["PUBLIC"],
 )
 

--- a/toolchains/cxx_tools.bzl
+++ b/toolchains/cxx_tools.bzl
@@ -1,0 +1,34 @@
+load("@prelude//toolchains:cxx.bzl", "CxxToolsInfo")
+
+def _cxx_tools_with_linker_impl(ctx):
+    base = ctx.attrs.base[CxxToolsInfo]
+    return [
+        DefaultInfo(),
+        CxxToolsInfo(
+            compiler = base.compiler,
+            compiler_type = base.compiler_type,
+            cxx_compiler = base.cxx_compiler,
+            asm_compiler = base.asm_compiler,
+            asm_compiler_type = base.asm_compiler_type,
+            rc_compiler = base.rc_compiler,
+            cvtres_compiler = base.cvtres_compiler,
+            archiver = base.archiver,
+            archiver_type = base.archiver_type,
+            linker = base.linker if ctx.attrs.linker == None else ctx.attrs.linker,
+            linker_type = base.linker_type,
+        ),
+    ]
+
+# cxx_tools_info_toolchain consumes this target as an exec-dep. Its selectable
+# linker attribute therefore sees the resolved execution-platform constraints,
+# unlike an attribute on the output-configured C++ toolchain itself.
+cxx_tools_with_linker = rule(
+    impl = _cxx_tools_with_linker_impl,
+    attrs = {
+        "base": attrs.dep(
+            providers = [CxxToolsInfo],
+            default = "prelude//toolchains/msvc:msvc_tools" if host_info().os.is_windows else "prelude//toolchains/cxx/clang:path_clang_tools",
+        ),
+        "linker": attrs.option(attrs.string(), default = None),
+    },
+)


### PR DESCRIPTION
## Summary
- add a remote-execution constraint to the BuildBuddy execution platforms and preserve the base exec marker
- make the C++ tools provider an exec-dep so the real configured graph selects `cc` remotely and retains `clang++` natively
- add a merge-group-only, cache-disabled remote execution canary with hybrid fallback disabled
- document supported opt-in `--prefer-remote` behavior

## Why
A direct `select()` on `system_cxx_toolchain` does not see execution-platform constraints; the toolchain itself remains output-target configured. Moving the selectable linker into `CxxToolsInfo`, which `cxx_tools_info_toolchain` consumes as an exec-dep, puts the selection in the resolved execution configuration.

The pinned Buck2 prelude now adds `-fuse-ld=lld` on Linux even with `cc`, so the worker only needs the ubiquitous driver and Rust's bundled lld does the actual link.

## Validation
- configured-provider audit: native execution resolves `clang++`; fake Linux BuildBuddy execution resolves `cc` with `-fuse-ld=lld`
- cache-disabled native `//crates/rue:rue` build: 231 local actions, green
- all crate unit targets: 34 passed, 152 local actions
- wrapper-script tests: 69/69 checks
- build-sharing tests: 29/29 checks
- pinned actionlint + ShellCheck: green
- merge-group canary will run a real cache-disabled remote build and reject remote fallback/local-only false greens

Fixes RUE-320
