### PR TITLE
RUE-1022: prototype parallel query runtime

### DIFF
--- a/crates/rue-query-bench/BUCK
+++ b/crates/rue-query-bench/BUCK
@@ -1,0 +1,9 @@
+load("//crates:defs.bzl", "rue_binary")
+
+# The benchmark is exercised through its deterministic JSON output; an empty
+# libtest binary would add no coverage.
+rue_binary(
+    name = "rue-query-bench",
+    tests = False,
+    deps = ["//crates/rue-query:rue-query"],
+)

--- a/crates/rue-query-bench/src/main.rs
+++ b/crates/rue-query-bench/src/main.rs
@@ -1,0 +1,219 @@
+//! Reproducible structural and latency microbenchmark for `rue-query`.
+
+use std::env;
+use std::process;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Instant;
+
+use rue_query::{
+    CancellationToken, QueryDiagnostic, QueryKey, QueryOutput, QueryRuntime, Revision, WorkItem,
+};
+
+const DEFAULT_KEYS: usize = 256;
+const DEFAULT_WORKERS: usize = 4;
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct Key(usize);
+
+impl QueryKey for Key {
+    fn stable_identity(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+fn main() {
+    let (keys, workers) = parse_args();
+    let runtime = QueryRuntime::new(workers);
+    let family = runtime
+        .family::<Key, u64>("prototype-benchmark", keys * 2 + 1)
+        .expect("benchmark family has a unique name");
+    let checksum = AtomicU64::new(0);
+
+    let started = Instant::now();
+    run_batch(
+        &runtime,
+        &family,
+        Revision::new(1, 1),
+        keys,
+        workers,
+        &checksum,
+    );
+    let cold_micros = started.elapsed().as_micros();
+
+    let started = Instant::now();
+    run_batch(
+        &runtime,
+        &family,
+        Revision::new(2, 1),
+        keys,
+        workers,
+        &checksum,
+    );
+    let reuse_micros = started.elapsed().as_micros();
+
+    let started = Instant::now();
+    run_batch(
+        &runtime,
+        &family,
+        Revision::new(3, 3),
+        keys,
+        workers,
+        &checksum,
+    );
+    let red_micros = started.elapsed().as_micros();
+
+    let started = Instant::now();
+    let join_stamp = run_hot_join(&runtime, &family, keys, workers);
+    let join_micros = started.elapsed().as_micros();
+
+    let metrics = runtime.metrics();
+    let retention = family.retention();
+    println!(
+        concat!(
+            "{{\"schema\":1,\"keys\":{},\"workers\":{},",
+            "\"cold_micros\":{},\"reuse_micros\":{},\"red_micros\":{},\"join_micros\":{},",
+            "\"checksum\":{},\"join_stamp\":{},\"claims\":{},\"joins\":{},\"reuses\":{},",
+            "\"green_publications\":{},\"red_publications\":{},",
+            "\"peak_active_bodies\":{},\"retained_terminals\":{},",
+            "\"retained_nodes\":{},\"evictions\":{}}}"
+        ),
+        keys,
+        workers,
+        cold_micros,
+        reuse_micros,
+        red_micros,
+        join_micros,
+        checksum.load(Ordering::Relaxed),
+        join_stamp,
+        metrics.claims,
+        metrics.joins,
+        metrics.reuses,
+        metrics.green_publications,
+        metrics.red_publications,
+        metrics.peak_active_bodies,
+        retention.terminals,
+        retention.memo_nodes,
+        metrics.evictions,
+    );
+}
+
+fn run_hot_join(
+    runtime: &QueryRuntime,
+    family: &rue_query::QueryFamily<Key, u64>,
+    keys: usize,
+    workers: usize,
+) -> u64 {
+    let revision = Revision::new(4, 4);
+    let key = Key(keys);
+    let (started_tx, started_rx) = mpsc::channel();
+    let (finish_tx, finish_rx) = mpsc::channel();
+    let owner_runtime = runtime.clone();
+    let owner_family = family.clone();
+    let owner_key = key.clone();
+    let owner = thread::spawn(move || {
+        owner_runtime.query(
+            &owner_family,
+            revision,
+            owner_key,
+            CancellationToken::new(),
+            |_| {
+                started_tx.send(()).expect("benchmark coordinator is live");
+                finish_rx.recv().expect("benchmark coordinator is live");
+                Ok(QueryOutput::success(1))
+            },
+        )
+    });
+    started_rx.recv().expect("benchmark owner started");
+    let joins_before = runtime.metrics().joins;
+    let mut joiners = Vec::new();
+    for _ in 0..workers {
+        let runtime = runtime.clone();
+        let family = family.clone();
+        let key = key.clone();
+        joiners.push(thread::spawn(move || {
+            runtime.query(&family, revision, key, CancellationToken::new(), |_| {
+                panic!("hot-key joiner must not compute")
+            })
+        }));
+    }
+    while runtime.metrics().joins < joins_before + workers as u64 {
+        thread::yield_now();
+    }
+    finish_tx.send(()).expect("benchmark owner is live");
+    let owner = owner.join().expect("owner thread did not panic").unwrap();
+    let stamp = owner.stamp();
+    for joiner in joiners {
+        let terminal = joiner.join().expect("joiner thread did not panic").unwrap();
+        assert_eq!(terminal.stamp(), stamp);
+    }
+    stamp
+}
+
+fn run_batch(
+    runtime: &QueryRuntime,
+    family: &rue_query::QueryFamily<Key, u64>,
+    revision: Revision,
+    keys: usize,
+    workers: usize,
+    checksum: &AtomicU64,
+) {
+    let next = AtomicUsize::new(0);
+    thread::scope(|scope| {
+        for _ in 0..workers {
+            scope.spawn(|| {
+                loop {
+                    let key = next.fetch_add(1, Ordering::Relaxed);
+                    if key >= keys {
+                        break;
+                    }
+                    let terminal = runtime
+                        .query(family, revision, Key(key), CancellationToken::new(), |_| {
+                            Ok(QueryOutput::success(key as u64)
+                                .with_diagnostics(vec![QueryDiagnostic::new(
+                                    format!("key-{key}"),
+                                    "representative",
+                                    None,
+                                )])
+                                .with_work(vec![
+                                    WorkItem::new("key", 1),
+                                    WorkItem::new("operations", (key % 7 + 1) as u64),
+                                ]))
+                        })
+                        .expect("benchmark queries do not cancel or cycle");
+                    checksum.fetch_add(terminal.stamp() + key as u64, Ordering::Relaxed);
+                }
+            });
+        }
+    });
+}
+
+fn parse_args() -> (usize, usize) {
+    let mut keys = DEFAULT_KEYS;
+    let mut workers = DEFAULT_WORKERS;
+    let mut args = env::args().skip(1);
+    while let Some(argument) = args.next() {
+        let value = args.next().unwrap_or_else(|| usage(&argument));
+        match argument.as_str() {
+            "--keys" => keys = parse_positive(&argument, &value),
+            "--workers" => workers = parse_positive(&argument, &value),
+            _ => usage(&argument),
+        }
+    }
+    (keys, workers)
+}
+
+fn parse_positive(flag: &str, value: &str) -> usize {
+    value
+        .parse::<usize>()
+        .ok()
+        .filter(|value| *value > 0)
+        .unwrap_or_else(|| usage(flag))
+}
+
+fn usage(argument: &str) -> ! {
+    eprintln!("invalid argument {argument:?}");
+    eprintln!("usage: rue-query-bench [--keys N] [--workers N]");
+    process::exit(2);
+}

--- a/crates/rue-query/BUCK
+++ b/crates/rue-query/BUCK
@@ -1,0 +1,5 @@
+load("//crates:defs.bzl", "rue_crate")
+
+rue_crate(
+    name = "rue-query",
+)

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -1,0 +1,2147 @@
+//! Parallel, demand-driven query execution primitives.
+//!
+//! This crate owns execution mechanics only. Compiler query families keep
+//! their typed keys, results, equality, and algorithms outside the runtime.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::fmt;
+use std::hash::Hash;
+use std::marker::PhantomData;
+use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
+use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard, Weak};
+
+static NEXT_RUNTIME_ID: AtomicU64 = AtomicU64::new(1);
+
+/// A logical key suitable for a retained query family.
+pub trait QueryKey: Clone + Eq + Hash + Send + Sync + 'static {
+    /// A stable, collision-free textual identity within the family.
+    fn stable_identity(&self) -> String;
+}
+
+/// An immutable input revision pinned by one request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Revision {
+    id: u64,
+    compatibility: u64,
+}
+
+impl Revision {
+    /// Creates a revision. Equal compatibility tokens assert equivalent inputs.
+    pub const fn new(id: u64, compatibility: u64) -> Self {
+        Self { id, compatibility }
+    }
+
+    /// The immutable publication identity.
+    pub const fn id(self) -> u64 {
+        self.id
+    }
+
+    /// Returns whether retained work may be validated across two revisions.
+    pub const fn is_compatible_with(self, other: Self) -> bool {
+        self.compatibility == other.compatibility
+    }
+}
+
+/// Stable identity of one logical memo node.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NodeIdentity {
+    family: Arc<str>,
+    key: Arc<str>,
+}
+
+impl NodeIdentity {
+    /// Stable family name.
+    pub fn family(&self) -> &str {
+        &self.family
+    }
+
+    /// Family-defined stable key identity.
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+}
+
+/// Identity observed by a dependent query.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Observation {
+    /// Logical dependency node.
+    pub node: NodeIdentity,
+    /// Opaque session-local node incarnation, preventing stamp ABA after eviction.
+    pub incarnation: u64,
+    /// Red/green terminal publication stamp.
+    pub stamp: u64,
+}
+
+/// A deterministic query failure which is safe to retain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryFailure {
+    /// Stable failure class.
+    pub code: Arc<str>,
+    /// Canonical failure payload.
+    pub payload: Arc<str>,
+}
+
+impl QueryFailure {
+    /// Creates a retained failure.
+    pub fn new(code: impl Into<Arc<str>>, payload: impl Into<Arc<str>>) -> Self {
+        Self {
+            code: code.into(),
+            payload: payload.into(),
+        }
+    }
+}
+
+/// A semantic diagnostic plus a separately replaceable presentation position.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryDiagnostic {
+    /// Stable producer-defined identity.
+    pub identity: Arc<str>,
+    /// Canonical semantic payload.
+    pub payload: Arc<str>,
+    /// Current presentation position, excluded from red/green equality.
+    pub presentation: Option<PresentationPosition>,
+}
+
+impl QueryDiagnostic {
+    /// Creates a diagnostic.
+    pub fn new(
+        identity: impl Into<Arc<str>>,
+        payload: impl Into<Arc<str>>,
+        presentation: Option<PresentationPosition>,
+    ) -> Self {
+        Self {
+            identity: identity.into(),
+            payload: payload.into(),
+            presentation,
+        }
+    }
+}
+
+/// Current source position used only when presenting a diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PresentationPosition {
+    /// Stable source identity.
+    pub source: Arc<str>,
+    /// Current byte offset.
+    pub offset: u32,
+}
+
+impl PresentationPosition {
+    /// Creates a presentation position.
+    pub fn new(source: impl Into<Arc<str>>, offset: u32) -> Self {
+        Self {
+            source: source.into(),
+            offset,
+        }
+    }
+}
+
+/// One deterministic structural-work contribution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkItem {
+    /// Stable metric identity.
+    pub identity: Arc<str>,
+    /// Additive amount.
+    pub amount: u64,
+}
+
+impl WorkItem {
+    /// Creates one contribution.
+    pub fn new(identity: impl Into<Arc<str>>, amount: u64) -> Self {
+        Self {
+            identity: identity.into(),
+            amount,
+        }
+    }
+}
+
+/// Canonical success or retained deterministic failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryOutcome<V> {
+    /// Successfully computed value.
+    Success(V),
+    /// Deterministic family failure.
+    Failure(QueryFailure),
+}
+
+/// Private computation output awaiting atomic publication.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryOutput<V> {
+    outcome: QueryOutcome<V>,
+    diagnostics: Vec<QueryDiagnostic>,
+    work: Vec<WorkItem>,
+}
+
+impl<V> QueryOutput<V> {
+    /// Creates a successful output.
+    pub fn success(value: V) -> Self {
+        Self {
+            outcome: QueryOutcome::Success(value),
+            diagnostics: Vec::new(),
+            work: Vec::new(),
+        }
+    }
+
+    /// Creates a deterministic terminal failure.
+    pub fn failure(failure: QueryFailure) -> Self {
+        Self {
+            outcome: QueryOutcome::Failure(failure),
+            diagnostics: Vec::new(),
+            work: Vec::new(),
+        }
+    }
+
+    /// Attaches diagnostics. Publication sorts them deterministically.
+    pub fn with_diagnostics(mut self, diagnostics: Vec<QueryDiagnostic>) -> Self {
+        self.diagnostics = diagnostics;
+        self
+    }
+
+    /// Attaches structural work. Publication reduces it by stable identity.
+    pub fn with_work(mut self, work: Vec<WorkItem>) -> Self {
+        self.work = work;
+        self
+    }
+}
+
+/// An immutable published terminal.
+#[derive(Debug)]
+pub struct QueryTerminal<V> {
+    family_token: FamilyToken,
+    node: NodeIdentity,
+    node_incarnation: u64,
+    revision: Revision,
+    stamp: u64,
+    outcome: QueryOutcome<V>,
+    diagnostics: Arc<[QueryDiagnostic]>,
+    work: Arc<[(Arc<str>, u64)]>,
+    dependencies: Arc<[Observation]>,
+    pins: AtomicUsize,
+}
+
+impl<V> QueryTerminal<V> {
+    /// Logical node which owns this attempt.
+    pub fn node(&self) -> &NodeIdentity {
+        &self.node
+    }
+
+    /// Exact revision under which the computing task ran.
+    pub const fn revision(&self) -> Revision {
+        self.revision
+    }
+
+    /// Red/green publication identity.
+    pub const fn stamp(&self) -> u64 {
+        self.stamp
+    }
+
+    /// Canonical success or deterministic failure.
+    pub fn outcome(&self) -> &QueryOutcome<V> {
+        &self.outcome
+    }
+
+    /// Deterministically sorted diagnostics with current positions.
+    pub fn diagnostics(&self) -> &[QueryDiagnostic] {
+        &self.diagnostics
+    }
+
+    /// Deterministically reduced structural work.
+    pub fn work(&self) -> &[(Arc<str>, u64)] {
+        &self.work
+    }
+
+    /// Exact dependency observations made by the computing task.
+    pub fn dependencies(&self) -> &[Observation] {
+        &self.dependencies
+    }
+}
+
+/// A non-terminal query-control result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryAbort {
+    /// This request was canceled. No terminal was published.
+    Canceled,
+    /// Exact nodes participating in a true dependency cycle.
+    Cycle(Arc<[NodeIdentity]>),
+    /// The family belongs to a different runtime.
+    ForeignRuntime,
+}
+
+/// Cooperative request cancellation.
+#[derive(Debug, Clone, Default)]
+pub struct CancellationToken {
+    inner: Arc<CancellationInner>,
+}
+
+#[derive(Debug, Default)]
+struct CancellationInner {
+    canceled: AtomicBool,
+    watchers: Mutex<Vec<Weak<WaitCell>>>,
+}
+
+impl CancellationToken {
+    /// Creates a live token.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Cancels this waiter/request and wakes its parked joins.
+    pub fn cancel(&self) {
+        if self.inner.canceled.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let mut watchers = lock(&self.inner.watchers);
+        watchers.retain(|watcher| {
+            let Some(waiter) = watcher.upgrade() else {
+                return false;
+            };
+            waiter.cv.notify_all();
+            true
+        });
+    }
+
+    /// Whether cancellation has been requested.
+    pub fn is_canceled(&self) -> bool {
+        self.inner.canceled.load(Ordering::Acquire)
+    }
+
+    fn watch(&self, waiter: &Arc<WaitCell>) {
+        lock(&self.inner.watchers).push(Arc::downgrade(waiter));
+        if self.is_canceled() {
+            waiter.cv.notify_all();
+        }
+    }
+}
+
+/// Deterministic structural execution counters.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RuntimeMetrics {
+    /// New computations claimed.
+    pub claims: u64,
+    /// Compatible in-flight requests joined.
+    pub joins: u64,
+    /// Compatible retained terminals reused.
+    pub reuses: u64,
+    /// Query bodies which completed before publication checks.
+    pub body_completions: u64,
+    /// Recomputations whose observable stamp stayed red.
+    pub red_publications: u64,
+    /// New or observably changed green publications.
+    pub green_publications: u64,
+    /// Canceled computations or waiters.
+    pub cancellations: u64,
+    /// True dependency cycles reported.
+    pub cycles: u64,
+    /// Retained terminal attempts evicted.
+    pub evictions: u64,
+    /// Current retained terminal attempts.
+    pub retained_terminals: u64,
+    /// Peak simultaneously executing query bodies.
+    pub peak_active_bodies: u64,
+    /// Times a parked joiner released its permit.
+    pub donated_permits: u64,
+}
+
+/// Bounded retained ownership for one query family.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FamilyRetention {
+    /// Logical memo nodes currently owned by the family.
+    pub memo_nodes: usize,
+    /// Terminal attempts currently retained across those nodes.
+    pub terminals: usize,
+    /// Configured terminal bound. Protected roots may exceed it temporarily.
+    pub terminal_limit: usize,
+}
+
+#[derive(Debug, Default)]
+struct Metrics {
+    claims: AtomicU64,
+    joins: AtomicU64,
+    reuses: AtomicU64,
+    body_completions: AtomicU64,
+    red_publications: AtomicU64,
+    green_publications: AtomicU64,
+    cancellations: AtomicU64,
+    cycles: AtomicU64,
+    evictions: AtomicU64,
+    retained_terminals: AtomicU64,
+    active_bodies: AtomicU64,
+    peak_active_bodies: AtomicU64,
+    donated_permits: AtomicU64,
+}
+
+impl Metrics {
+    fn snapshot(&self) -> RuntimeMetrics {
+        RuntimeMetrics {
+            claims: self.claims.load(Ordering::Relaxed),
+            joins: self.joins.load(Ordering::Relaxed),
+            reuses: self.reuses.load(Ordering::Relaxed),
+            body_completions: self.body_completions.load(Ordering::Relaxed),
+            red_publications: self.red_publications.load(Ordering::Relaxed),
+            green_publications: self.green_publications.load(Ordering::Relaxed),
+            cancellations: self.cancellations.load(Ordering::Relaxed),
+            cycles: self.cycles.load(Ordering::Relaxed),
+            evictions: self.evictions.load(Ordering::Relaxed),
+            retained_terminals: self.retained_terminals.load(Ordering::Relaxed),
+            peak_active_bodies: self.peak_active_bodies.load(Ordering::Relaxed),
+            donated_permits: self.donated_permits.load(Ordering::Relaxed),
+        }
+    }
+
+    fn body_entered(&self) {
+        let active = self.active_bodies.fetch_add(1, Ordering::AcqRel) + 1;
+        self.peak_active_bodies.fetch_max(active, Ordering::AcqRel);
+    }
+
+    fn body_left(&self) {
+        self.active_bodies.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+/// Shared execution substrate for all query families in one database.
+#[derive(Debug, Clone)]
+pub struct QueryRuntime {
+    core: Arc<RuntimeCore>,
+}
+
+#[derive(Debug)]
+struct RuntimeCore {
+    identity: u64,
+    permits: PermitBudget,
+    wait_graph: Mutex<BTreeMap<TaskId, WaitEdge>>,
+    family_names: Mutex<BTreeSet<Arc<str>>>,
+    next_task: AtomicU64,
+    next_family: AtomicU64,
+    next_node: AtomicU64,
+    metrics: Metrics,
+    #[cfg(test)]
+    test_events: TestEvents,
+}
+
+#[cfg(test)]
+#[allow(dead_code)]
+#[derive(Debug, Default)]
+struct TestEvents {
+    generation: Mutex<u64>,
+    changed: Condvar,
+}
+
+impl QueryRuntime {
+    /// Creates a runtime with one shared structured concurrency budget.
+    pub fn new(max_concurrency: usize) -> Self {
+        assert!(max_concurrency > 0, "query concurrency must be nonzero");
+        Self {
+            core: Arc::new(RuntimeCore {
+                identity: NEXT_RUNTIME_ID.fetch_add(1, Ordering::Relaxed),
+                permits: PermitBudget::new(max_concurrency),
+                wait_graph: Mutex::new(BTreeMap::new()),
+                family_names: Mutex::new(BTreeSet::new()),
+                next_task: AtomicU64::new(1),
+                next_family: AtomicU64::new(1),
+                next_node: AtomicU64::new(1),
+                metrics: Metrics::default(),
+                #[cfg(test)]
+                test_events: TestEvents::default(),
+            }),
+        }
+    }
+
+    /// Creates a typed family with deterministic FIFO terminal retention.
+    pub fn family<K, V>(
+        &self,
+        stable_name: impl Into<Arc<str>>,
+        retention_limit: usize,
+    ) -> Result<QueryFamily<K, V>, FamilyError>
+    where
+        K: QueryKey,
+        V: Clone + Eq + Send + Sync + 'static,
+    {
+        let name = stable_name.into();
+        if name.is_empty() {
+            return Err(FamilyError::EmptyName);
+        }
+        if !lock(&self.core.family_names).insert(name.clone()) {
+            return Err(FamilyError::DuplicateName(name));
+        }
+        Ok(QueryFamily {
+            core: self.core.clone(),
+            inner: Arc::new(FamilyInner {
+                name,
+                token: FamilyToken {
+                    runtime: self.core.identity,
+                    family: self.core.next_family.fetch_add(1, Ordering::Relaxed),
+                },
+                retention_limit,
+                nodes: Mutex::new(HashMap::new()),
+                retention: Mutex::new(VecDeque::new()),
+                retained_count: AtomicUsize::new(0),
+                retained_nodes: AtomicUsize::new(0),
+                retained_revisions: Mutex::new(BTreeMap::new()),
+            }),
+        })
+    }
+
+    /// Executes or reuses one top-level query in a newly allocated task.
+    pub fn query<K, V, F>(
+        &self,
+        family: &QueryFamily<K, V>,
+        revision: Revision,
+        key: K,
+        cancellation: CancellationToken,
+        compute: F,
+    ) -> Result<Arc<QueryTerminal<V>>, QueryAbort>
+    where
+        K: QueryKey,
+        V: Clone + Eq + Send + Sync + 'static,
+        F: FnOnce(&QueryContext) -> Result<QueryOutput<V>, QueryAbort>,
+    {
+        if !Arc::ptr_eq(&self.core, &family.core) {
+            return Err(QueryAbort::ForeignRuntime);
+        }
+        let task = Arc::new(Task {
+            id: TaskId(self.core.next_task.fetch_add(1, Ordering::Relaxed)),
+            core: self.core.clone(),
+            revision,
+            cancellation,
+            owns_permit: AtomicBool::new(false),
+            stack: Mutex::new(Vec::new()),
+        });
+        family.query_task(task, key, compute)
+    }
+
+    /// Returns a point-in-time structural metrics snapshot.
+    pub fn metrics(&self) -> RuntimeMetrics {
+        self.core.metrics.snapshot()
+    }
+
+    #[cfg(test)]
+    #[allow(dead_code)]
+    fn wait_for_metrics(&self, predicate: impl Fn(RuntimeMetrics) -> bool) {
+        let mut generation = lock(&self.core.test_events.generation);
+        while !predicate(self.metrics()) {
+            generation = wait(&self.core.test_events.changed, generation);
+        }
+    }
+}
+
+/// Invalid family declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FamilyError {
+    /// Family names are stable identities and cannot be empty.
+    EmptyName,
+    /// A runtime already owns this stable family name.
+    DuplicateName(Arc<str>),
+}
+
+/// A typed memo table sharing its runtime's scheduler and wait graph.
+pub struct QueryFamily<K: QueryKey, V: Clone + Eq + Send + Sync + 'static> {
+    core: Arc<RuntimeCore>,
+    inner: Arc<FamilyInner<K, V>>,
+}
+
+impl<K, V> fmt::Debug for QueryFamily<K, V>
+where
+    K: QueryKey,
+    V: Clone + Eq + Send + Sync + 'static,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("QueryFamily")
+            .field("name", &self.inner.name)
+            .field("retention_limit", &self.inner.retention_limit)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<K, V> Clone for QueryFamily<K, V>
+where
+    K: QueryKey,
+    V: Clone + Eq + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            core: self.core.clone(),
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FamilyInner<K: QueryKey, V: Clone + Eq + Send + Sync + 'static> {
+    name: Arc<str>,
+    token: FamilyToken,
+    retention_limit: usize,
+    nodes: Mutex<HashMap<K, Arc<Node<V>>>>,
+    retention: Mutex<VecDeque<RetentionEntry<V>>>,
+    retained_count: AtomicUsize,
+    retained_nodes: AtomicUsize,
+    retained_revisions: Mutex<BTreeMap<Revision, usize>>,
+}
+
+#[derive(Debug)]
+struct Node<V> {
+    identity: NodeIdentity,
+    incarnation: u64,
+    users: AtomicUsize,
+    wait: Arc<WaitCell>,
+    state: Mutex<NodeState<V>>,
+}
+
+#[derive(Debug)]
+struct WaitCell {
+    cv: Condvar,
+}
+
+#[derive(Debug)]
+struct NodeState<V> {
+    next_attempt: u64,
+    next_stamp: u64,
+    attempts: VecDeque<Attempt<V>>,
+}
+
+#[derive(Debug)]
+struct Attempt<V> {
+    id: u64,
+    revision: Revision,
+    state: AttemptState<V>,
+}
+
+#[derive(Debug)]
+enum AttemptState<V> {
+    Computing {
+        owner: TaskId,
+        waiters: usize,
+    },
+    Terminal {
+        terminal: Arc<QueryTerminal<V>>,
+        waiters: usize,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FamilyToken {
+    runtime: u64,
+    family: u64,
+}
+
+#[derive(Debug)]
+struct RetentionEntry<V> {
+    node: Weak<Node<V>>,
+    attempt: u64,
+}
+
+struct NodeLease<K: QueryKey, V: Clone + Eq + Send + Sync + 'static> {
+    family: Weak<FamilyInner<K, V>>,
+    key: K,
+    node: Arc<Node<V>>,
+}
+
+impl<K, V> Drop for NodeLease<K, V>
+where
+    K: QueryKey,
+    V: Clone + Eq + Send + Sync + 'static,
+{
+    fn drop(&mut self) {
+        if self.node.users.fetch_sub(1, Ordering::AcqRel) != 1 {
+            return;
+        }
+        if !lock(&self.node.state).attempts.is_empty() {
+            return;
+        }
+        let Some(family) = self.family.upgrade() else {
+            return;
+        };
+        let mut nodes = lock(&family.nodes);
+        if self.node.users.load(Ordering::Acquire) == 0
+            && lock(&self.node.state).attempts.is_empty()
+            && nodes
+                .get(&self.key)
+                .is_some_and(|candidate| Arc::ptr_eq(candidate, &self.node))
+        {
+            nodes.remove(&self.key);
+            family.retained_nodes.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+}
+
+impl<K, V> QueryFamily<K, V>
+where
+    K: QueryKey,
+    V: Clone + Eq + Send + Sync + 'static,
+{
+    /// Returns deterministic retained-ownership gauges for this family.
+    pub fn retention(&self) -> FamilyRetention {
+        FamilyRetention {
+            memo_nodes: self.inner.retained_nodes.load(Ordering::Relaxed),
+            terminals: self.inner.retained_count.load(Ordering::Relaxed),
+            terminal_limit: self.inner.retention_limit,
+        }
+    }
+
+    fn node(&self, key: K) -> NodeLease<K, V> {
+        let mut nodes = lock(&self.inner.nodes);
+        let mut created = false;
+        let node = nodes
+            .entry(key.clone())
+            .or_insert_with(|| {
+                created = true;
+                Arc::new(Node {
+                    identity: NodeIdentity {
+                        family: self.inner.name.clone(),
+                        key: key.stable_identity().into(),
+                    },
+                    incarnation: self.core.next_node.fetch_add(1, Ordering::Relaxed),
+                    users: AtomicUsize::new(0),
+                    wait: Arc::new(WaitCell { cv: Condvar::new() }),
+                    state: Mutex::new(NodeState {
+                        next_attempt: 1,
+                        next_stamp: 1,
+                        attempts: VecDeque::new(),
+                    }),
+                })
+            })
+            .clone();
+        if created {
+            self.inner.retained_nodes.fetch_add(1, Ordering::Relaxed);
+        }
+        node.users.fetch_add(1, Ordering::AcqRel);
+        NodeLease {
+            family: Arc::downgrade(&self.inner),
+            key,
+            node,
+        }
+    }
+
+    fn query_task<F>(
+        &self,
+        task: Arc<Task>,
+        key: K,
+        compute: F,
+    ) -> Result<Arc<QueryTerminal<V>>, QueryAbort>
+    where
+        F: FnOnce(&QueryContext) -> Result<QueryOutput<V>, QueryAbort>,
+    {
+        let lease = self.node(key);
+        let node = &lease.node;
+        if let Some(cycle) = task.stack_cycle(&node.identity) {
+            self.core.metrics.cycles.fetch_add(1, Ordering::Relaxed);
+            return Err(QueryAbort::Cycle(cycle));
+        }
+        let mut compute = Some(compute);
+        loop {
+            if task.cancellation.is_canceled() {
+                self.core
+                    .metrics
+                    .cancellations
+                    .fetch_add(1, Ordering::Relaxed);
+                return Err(QueryAbort::Canceled);
+            }
+
+            enum Action<V> {
+                Return(Arc<QueryTerminal<V>>),
+                Join { attempt: u64, owner: TaskId },
+                Compute { attempt: u64 },
+            }
+
+            let action = {
+                let mut state = lock(&node.state);
+                let mut action = None;
+                for attempt in state.attempts.iter_mut().rev() {
+                    if !attempt.revision.is_compatible_with(task.revision) {
+                        continue;
+                    }
+                    match &mut attempt.state {
+                        AttemptState::Terminal { terminal, .. } => {
+                            action = Some(Action::Return(terminal.clone()));
+                        }
+                        AttemptState::Computing { owner, waiters } => {
+                            *waiters += 1;
+                            action = Some(Action::Join {
+                                attempt: attempt.id,
+                                owner: *owner,
+                            });
+                        }
+                    }
+                    break;
+                }
+                action.unwrap_or_else(|| {
+                    let attempt = state.next_attempt;
+                    state.next_attempt += 1;
+                    state.attempts.push_back(Attempt {
+                        id: attempt,
+                        revision: task.revision,
+                        state: AttemptState::Computing {
+                            owner: task.id,
+                            waiters: 0,
+                        },
+                    });
+                    Action::Compute { attempt }
+                })
+            };
+
+            match action {
+                Action::Return(terminal) => {
+                    self.core.metrics.reuses.fetch_add(1, Ordering::Relaxed);
+                    task.observe(&terminal);
+                    return Ok(terminal);
+                }
+                Action::Join { attempt, owner } => {
+                    self.core.metrics.joins.fetch_add(1, Ordering::Relaxed);
+                    #[cfg(test)]
+                    self.core.test_changed();
+                    match self.join(&task, node, attempt, owner)? {
+                        Some(terminal) => {
+                            task.observe(&terminal);
+                            return Ok(terminal);
+                        }
+                        None => continue,
+                    }
+                }
+                Action::Compute { attempt } => {
+                    self.core.metrics.claims.fetch_add(1, Ordering::Relaxed);
+                    #[cfg(test)]
+                    self.core.test_changed();
+                    let acquired_here = task.acquire_permit(&self.core);
+                    task.push(node.identity.clone());
+                    self.core.metrics.body_entered();
+                    let context = QueryContext {
+                        task: task.clone(),
+                        not_send_or_sync: PhantomData,
+                    };
+                    let body = catch_unwind(AssertUnwindSafe(|| {
+                        compute.take().expect("query body executes at most once")(&context)
+                    }));
+                    self.core.metrics.body_left();
+                    self.core
+                        .metrics
+                        .body_completions
+                        .fetch_add(1, Ordering::Relaxed);
+                    let dependencies = task.pop(&node.identity);
+
+                    let result = match body {
+                        Ok(result) if !task.cancellation.is_canceled() => result,
+                        Ok(_) => Err(QueryAbort::Canceled),
+                        Err(payload) => {
+                            self.abort_attempt(node, attempt);
+                            if acquired_here {
+                                task.release_permit(&self.core);
+                            }
+                            resume_unwind(payload)
+                        }
+                    };
+
+                    match result {
+                        Ok(output) => {
+                            let terminal =
+                                self.publish(node, attempt, task.revision, output, dependencies);
+                            if acquired_here {
+                                task.release_permit(&self.core);
+                            }
+                            task.observe(&terminal);
+                            return Ok(terminal);
+                        }
+                        Err(abort) => {
+                            self.abort_attempt(node, attempt);
+                            if acquired_here {
+                                task.release_permit(&self.core);
+                            }
+                            if matches!(abort, QueryAbort::Canceled) {
+                                self.core
+                                    .metrics
+                                    .cancellations
+                                    .fetch_add(1, Ordering::Relaxed);
+                            }
+                            return Err(abort);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn join(
+        &self,
+        task: &Arc<Task>,
+        node: &Arc<Node<V>>,
+        attempt_id: u64,
+        owner: TaskId,
+    ) -> Result<Option<Arc<QueryTerminal<V>>>, QueryAbort> {
+        let mut state = lock(&node.state);
+        if task.cancellation.is_canceled() {
+            decrement_waiter(&mut state, attempt_id);
+            self.core
+                .metrics
+                .cancellations
+                .fetch_add(1, Ordering::Relaxed);
+            return Err(QueryAbort::Canceled);
+        }
+        let Some(attempt) = state.attempts.iter_mut().find(|item| item.id == attempt_id) else {
+            return Ok(None);
+        };
+        match &mut attempt.state {
+            AttemptState::Terminal { terminal, waiters } => {
+                let terminal = terminal.clone();
+                *waiters -= 1;
+                drop(state);
+                self.enforce_retention();
+                return Ok(Some(terminal));
+            }
+            AttemptState::Computing {
+                owner: actual_owner,
+                ..
+            } => assert_eq!(*actual_owner, owner),
+        }
+        if let Err(cycle) = self.core.begin_wait(task.id, owner, node.identity.clone()) {
+            decrement_waiter(&mut state, attempt_id);
+            self.core.metrics.cycles.fetch_add(1, Ordering::Relaxed);
+            return Err(QueryAbort::Cycle(cycle));
+        }
+        task.cancellation.watch(&node.wait);
+        let donated = task.release_permit(&self.core);
+        if donated {
+            self.core
+                .metrics
+                .donated_permits
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        let result = loop {
+            if task.cancellation.is_canceled() {
+                decrement_waiter(&mut state, attempt_id);
+                break Err(QueryAbort::Canceled);
+            }
+            let Some(attempt) = state.attempts.iter_mut().find(|item| item.id == attempt_id) else {
+                break Ok(None);
+            };
+            match &mut attempt.state {
+                AttemptState::Computing { .. } => {
+                    state = wait(&node.wait.cv, state);
+                }
+                AttemptState::Terminal { terminal, waiters } => {
+                    let terminal = terminal.clone();
+                    *waiters -= 1;
+                    break Ok(Some(terminal));
+                }
+            }
+        };
+        drop(state);
+        self.core.end_wait(task.id);
+        if donated {
+            task.acquire_permit(&self.core);
+        }
+        if matches!(result, Err(QueryAbort::Canceled)) {
+            self.core
+                .metrics
+                .cancellations
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        self.enforce_retention();
+        result
+    }
+
+    fn abort_attempt(&self, node: &Arc<Node<V>>, attempt_id: u64) {
+        let mut state = lock(&node.state);
+        if let Some(index) = state.attempts.iter().position(|item| item.id == attempt_id) {
+            state.attempts.remove(index);
+        }
+        drop(state);
+        node.wait.cv.notify_all();
+    }
+
+    fn publish(
+        &self,
+        node: &Arc<Node<V>>,
+        attempt_id: u64,
+        revision: Revision,
+        output: QueryOutput<V>,
+        dependencies: Vec<Observation>,
+    ) -> Arc<QueryTerminal<V>> {
+        let diagnostics = canonical_diagnostics(output.diagnostics);
+        let work = canonical_work(output.work);
+        let mut state = lock(&node.state);
+        let previous = state
+            .attempts
+            .iter()
+            .rev()
+            .find_map(|attempt| match &attempt.state {
+                AttemptState::Terminal { terminal, .. } => Some(terminal.clone()),
+                AttemptState::Computing { .. } => None,
+            });
+        let red = previous.as_ref().is_some_and(|terminal| {
+            terminal.outcome == output.outcome
+                && semantic_diagnostics_equal(&terminal.diagnostics, &diagnostics)
+                && terminal.dependencies.as_ref() == dependencies.as_slice()
+        });
+        let stamp = if red {
+            previous.expect("red publication has a predecessor").stamp
+        } else {
+            let stamp = state.next_stamp;
+            state.next_stamp += 1;
+            stamp
+        };
+        let terminal = Arc::new(QueryTerminal {
+            family_token: self.inner.token,
+            node: node.identity.clone(),
+            node_incarnation: node.incarnation,
+            revision,
+            stamp,
+            outcome: output.outcome,
+            diagnostics: diagnostics.into(),
+            work: work.into(),
+            dependencies: dependencies.into(),
+            pins: AtomicUsize::new(0),
+        });
+        let attempt = state
+            .attempts
+            .iter_mut()
+            .find(|attempt| attempt.id == attempt_id)
+            .expect("only the claiming task may publish its attempt");
+        let waiters = match &attempt.state {
+            AttemptState::Computing { waiters, .. } => *waiters,
+            AttemptState::Terminal { .. } => panic!("only a computing attempt may publish"),
+        };
+        attempt.state = AttemptState::Terminal {
+            terminal: terminal.clone(),
+            waiters,
+        };
+        drop(state);
+
+        if red {
+            self.core
+                .metrics
+                .red_publications
+                .fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.core
+                .metrics
+                .green_publications
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        self.core
+            .metrics
+            .retained_terminals
+            .fetch_add(1, Ordering::Relaxed);
+        self.inner.retained_count.fetch_add(1, Ordering::Relaxed);
+        lock(&self.inner.retention).push_back(RetentionEntry {
+            node: Arc::downgrade(node),
+            attempt: attempt_id,
+        });
+        node.wait.cv.notify_all();
+        self.enforce_retention();
+        terminal
+    }
+
+    fn enforce_retention(&self) {
+        let mut retention = lock(&self.inner.retention);
+        let mut remaining = retention.len();
+        while self.inner.retained_count.load(Ordering::Relaxed) > self.inner.retention_limit
+            && remaining > 0
+        {
+            remaining -= 1;
+            let entry = retention.pop_front().expect("retention scan is nonempty");
+            let Some(node) = entry.node.upgrade() else {
+                continue;
+            };
+            let mut state = lock(&node.state);
+            let Some(index) = state
+                .attempts
+                .iter()
+                .position(|item| item.id == entry.attempt)
+            else {
+                continue;
+            };
+            let protected = match &state.attempts[index].state {
+                AttemptState::Computing { .. } => true,
+                AttemptState::Terminal { terminal, waiters } => {
+                    *waiters > 0
+                        || terminal.pins.load(Ordering::Acquire) > 0
+                        || lock(&self.inner.retained_revisions).contains_key(&terminal.revision)
+                }
+            };
+            if protected {
+                drop(state);
+                retention.push_back(entry);
+                continue;
+            }
+            state.attempts.remove(index);
+            let empty = state.attempts.is_empty();
+            drop(state);
+            self.core.metrics.evictions.fetch_add(1, Ordering::Relaxed);
+            self.core
+                .metrics
+                .retained_terminals
+                .fetch_sub(1, Ordering::Relaxed);
+            self.inner.retained_count.fetch_sub(1, Ordering::Relaxed);
+            if empty && node.users.load(Ordering::Acquire) == 0 {
+                let mut nodes = lock(&self.inner.nodes);
+                let key = nodes.iter().find_map(|(key, candidate)| {
+                    Arc::ptr_eq(candidate, &node).then(|| key.clone())
+                });
+                if let Some(key) = key
+                    && node.users.load(Ordering::Acquire) == 0
+                    && lock(&node.state).attempts.is_empty()
+                    && nodes
+                        .get(&key)
+                        .is_some_and(|candidate| Arc::ptr_eq(candidate, &node))
+                {
+                    nodes.remove(&key);
+                    self.inner.retained_nodes.fetch_sub(1, Ordering::Relaxed);
+                }
+            }
+        }
+    }
+
+    /// Pins a retained terminal against eviction.
+    pub fn pin_terminal(
+        &self,
+        terminal: &Arc<QueryTerminal<V>>,
+    ) -> Result<TerminalPin<K, V>, PinError> {
+        if terminal.family_token != self.inner.token {
+            return Err(PinError::ForeignFamily);
+        }
+        terminal.pins.fetch_add(1, Ordering::AcqRel);
+        Ok(TerminalPin {
+            family: self.clone(),
+            terminal: terminal.clone(),
+        })
+    }
+
+    /// Pins terminals computed under this exact retained revision.
+    pub fn retain_revision(&self, revision: Revision) -> RevisionPin<K, V> {
+        *lock(&self.inner.retained_revisions)
+            .entry(revision)
+            .or_default() += 1;
+        RevisionPin {
+            family: self.clone(),
+            revision,
+        }
+    }
+}
+
+/// An explicit retained terminal root.
+pub struct TerminalPin<K: QueryKey, V: Clone + Eq + Send + Sync + 'static> {
+    family: QueryFamily<K, V>,
+    terminal: Arc<QueryTerminal<V>>,
+}
+
+/// A terminal cannot be pinned by a different family or runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PinError {
+    /// The terminal's unforgeable family token does not match.
+    ForeignFamily,
+}
+
+impl<K, V> Drop for TerminalPin<K, V>
+where
+    K: QueryKey,
+    V: Clone + Eq + Send + Sync + 'static,
+{
+    fn drop(&mut self) {
+        self.terminal.pins.fetch_sub(1, Ordering::AcqRel);
+        self.family.enforce_retention();
+    }
+}
+
+/// An explicit current/last-good revision root.
+pub struct RevisionPin<K: QueryKey, V: Clone + Eq + Send + Sync + 'static> {
+    family: QueryFamily<K, V>,
+    revision: Revision,
+}
+
+impl<K, V> Drop for RevisionPin<K, V>
+where
+    K: QueryKey,
+    V: Clone + Eq + Send + Sync + 'static,
+{
+    fn drop(&mut self) {
+        let mut revisions = lock(&self.family.inner.retained_revisions);
+        let count = revisions
+            .get_mut(&self.revision)
+            .expect("revision pin owns a retained root");
+        *count -= 1;
+        if *count == 0 {
+            revisions.remove(&self.revision);
+        }
+        drop(revisions);
+        self.family.enforce_retention();
+    }
+}
+
+/// Task-scoped access to nested dependency queries.
+#[derive(Debug)]
+pub struct QueryContext {
+    task: Arc<Task>,
+    not_send_or_sync: PhantomData<Rc<()>>,
+}
+
+impl QueryContext {
+    /// Exact immutable revision pinned by this task.
+    pub fn revision(&self) -> Revision {
+        self.task.revision
+    }
+
+    /// Fails cooperatively when the request is canceled.
+    pub fn check_canceled(&self) -> Result<(), QueryAbort> {
+        if self.task.cancellation.is_canceled() {
+            Err(QueryAbort::Canceled)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Requests a dependency in the same task and pinned revision.
+    pub fn query<K, V, F>(
+        &self,
+        family: &QueryFamily<K, V>,
+        key: K,
+        compute: F,
+    ) -> Result<Arc<QueryTerminal<V>>, QueryAbort>
+    where
+        K: QueryKey,
+        V: Clone + Eq + Send + Sync + 'static,
+        F: FnOnce(&QueryContext) -> Result<QueryOutput<V>, QueryAbort>,
+    {
+        if !Arc::ptr_eq(&self.task_runtime(), &family.core) {
+            return Err(QueryAbort::ForeignRuntime);
+        }
+        family.query_task(self.task.clone(), key, compute)
+    }
+
+    fn task_runtime(&self) -> Arc<RuntimeCore> {
+        self.task.core.clone()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct TaskId(u64);
+
+#[derive(Debug)]
+struct Task {
+    id: TaskId,
+    core: Arc<RuntimeCore>,
+    revision: Revision,
+    cancellation: CancellationToken,
+    owns_permit: AtomicBool,
+    stack: Mutex<Vec<TaskFrame>>,
+}
+
+#[derive(Debug)]
+struct TaskFrame {
+    node: NodeIdentity,
+    dependencies: BTreeMap<NodeIdentity, (u64, u64)>,
+}
+
+impl Task {
+    fn acquire_permit(&self, core: &Arc<RuntimeCore>) -> bool {
+        if self.owns_permit.load(Ordering::Acquire) {
+            return false;
+        }
+        core.permits.acquire();
+        assert!(!self.owns_permit.swap(true, Ordering::AcqRel));
+        true
+    }
+
+    fn release_permit(&self, core: &Arc<RuntimeCore>) -> bool {
+        if !self.owns_permit.swap(false, Ordering::AcqRel) {
+            return false;
+        }
+        core.permits.release();
+        true
+    }
+
+    fn push(&self, node: NodeIdentity) {
+        lock(&self.stack).push(TaskFrame {
+            node,
+            dependencies: BTreeMap::new(),
+        });
+    }
+
+    fn pop(&self, expected: &NodeIdentity) -> Vec<Observation> {
+        let frame = lock(&self.stack)
+            .pop()
+            .expect("query computation owns one dependency frame");
+        assert_eq!(&frame.node, expected);
+        frame
+            .dependencies
+            .into_iter()
+            .map(|(node, (incarnation, stamp))| Observation {
+                node,
+                incarnation,
+                stamp,
+            })
+            .collect()
+    }
+
+    fn observe<V>(&self, terminal: &QueryTerminal<V>) {
+        if let Some(frame) = lock(&self.stack).last_mut() {
+            frame.dependencies.insert(
+                terminal.node.clone(),
+                (terminal.node_incarnation, terminal.stamp),
+            );
+        }
+    }
+
+    fn stack_cycle(&self, node: &NodeIdentity) -> Option<Arc<[NodeIdentity]>> {
+        let stack = lock(&self.stack);
+        let start = stack.iter().position(|frame| &frame.node == node)?;
+        Some(canonical_cycle(
+            stack[start..]
+                .iter()
+                .map(|frame| frame.node.clone())
+                .chain(std::iter::once(node.clone())),
+        ))
+    }
+}
+
+#[derive(Debug)]
+struct WaitEdge {
+    owner: TaskId,
+    node: NodeIdentity,
+}
+
+impl RuntimeCore {
+    #[cfg(test)]
+    fn test_changed(&self) {
+        *lock(&self.test_events.generation) += 1;
+        self.test_events.changed.notify_all();
+    }
+
+    fn begin_wait(
+        &self,
+        waiter: TaskId,
+        owner: TaskId,
+        node: NodeIdentity,
+    ) -> Result<(), Arc<[NodeIdentity]>> {
+        let mut graph = lock(&self.wait_graph);
+        graph.insert(waiter, WaitEdge { owner, node });
+        let mut cursor = owner;
+        let mut nodes = Vec::new();
+        while let Some(edge) = graph.get(&cursor) {
+            nodes.push(edge.node.clone());
+            cursor = edge.owner;
+            if cursor == waiter {
+                nodes.push(
+                    graph
+                        .get(&waiter)
+                        .expect("new wait edge is present")
+                        .node
+                        .clone(),
+                );
+                graph.remove(&waiter);
+                return Err(canonical_cycle(nodes));
+            }
+        }
+        Ok(())
+    }
+
+    fn end_wait(&self, waiter: TaskId) {
+        lock(&self.wait_graph).remove(&waiter);
+    }
+}
+
+#[derive(Debug)]
+struct PermitBudget {
+    maximum: usize,
+    used: Mutex<usize>,
+    available: Condvar,
+}
+
+impl PermitBudget {
+    fn new(maximum: usize) -> Self {
+        Self {
+            maximum,
+            used: Mutex::new(0),
+            available: Condvar::new(),
+        }
+    }
+
+    fn acquire(&self) {
+        let mut used = lock(&self.used);
+        while *used == self.maximum {
+            used = wait(&self.available, used);
+        }
+        *used += 1;
+    }
+
+    fn release(&self) {
+        let mut used = lock(&self.used);
+        assert!(*used > 0, "cannot release an unowned query permit");
+        *used -= 1;
+        drop(used);
+        self.available.notify_one();
+    }
+}
+
+fn decrement_waiter<V>(state: &mut NodeState<V>, attempt_id: u64) {
+    if let Some(attempt) = state.attempts.iter_mut().find(|item| item.id == attempt_id) {
+        match &mut attempt.state {
+            AttemptState::Computing { waiters, .. } | AttemptState::Terminal { waiters, .. } => {
+                *waiters -= 1
+            }
+        }
+    }
+}
+
+fn canonical_diagnostics(mut diagnostics: Vec<QueryDiagnostic>) -> Vec<QueryDiagnostic> {
+    diagnostics.sort_by(|left, right| {
+        (&left.identity, &left.payload, &left.presentation).cmp(&(
+            &right.identity,
+            &right.payload,
+            &right.presentation,
+        ))
+    });
+    diagnostics
+}
+
+fn semantic_diagnostics_equal(left: &[QueryDiagnostic], right: &[QueryDiagnostic]) -> bool {
+    left.len() == right.len()
+        && left
+            .iter()
+            .zip(right)
+            .all(|(left, right)| left.identity == right.identity && left.payload == right.payload)
+}
+
+fn canonical_work(work: Vec<WorkItem>) -> Vec<(Arc<str>, u64)> {
+    let mut aggregate = BTreeMap::<Arc<str>, u64>::new();
+    for item in work {
+        *aggregate.entry(item.identity).or_default() += item.amount;
+    }
+    aggregate.into_iter().collect()
+}
+
+fn canonical_cycle(nodes: impl IntoIterator<Item = NodeIdentity>) -> Arc<[NodeIdentity]> {
+    let mut nodes = nodes.into_iter().collect::<Vec<_>>();
+    nodes.sort();
+    nodes.dedup();
+    nodes.into()
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn wait<'a, T>(condvar: &Condvar, guard: MutexGuard<'a, T>) -> MutexGuard<'a, T> {
+    condvar
+        .wait(guard)
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Barrier;
+    use std::sync::mpsc;
+    use std::thread;
+
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    struct Key(&'static str);
+
+    impl QueryKey for Key {
+        fn stable_identity(&self) -> String {
+            self.0.to_owned()
+        }
+    }
+
+    fn revision(id: u64) -> Revision {
+        Revision::new(id, id)
+    }
+
+    #[test]
+    fn compatible_exact_key_is_computed_once_and_joined_by_many_waiters() {
+        let runtime = QueryRuntime::new(8);
+        let family = runtime.family::<Key, u64>("join", 16).unwrap();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (finish_tx, finish_rx) = mpsc::channel();
+        let owner_runtime = runtime.clone();
+        let owner_family = family.clone();
+        let owner = thread::spawn(move || {
+            owner_runtime.query(
+                &owner_family,
+                revision(1),
+                Key("same"),
+                CancellationToken::new(),
+                |_| {
+                    started_tx.send(()).unwrap();
+                    finish_rx.recv().unwrap();
+                    Ok(QueryOutput::success(42))
+                },
+            )
+        });
+        started_rx.recv().unwrap();
+
+        let mut joiners = Vec::new();
+        for _ in 0..7 {
+            let runtime = runtime.clone();
+            let family = family.clone();
+            joiners.push(thread::spawn(move || {
+                runtime.query(
+                    &family,
+                    revision(1),
+                    Key("same"),
+                    CancellationToken::new(),
+                    |_| panic!("a compatible joiner must not compute"),
+                )
+            }));
+        }
+        runtime.wait_for_metrics(|metrics| metrics.joins == 7);
+        finish_tx.send(()).unwrap();
+
+        let terminal = owner.join().unwrap().unwrap();
+        assert_eq!(terminal.outcome(), &QueryOutcome::Success(42));
+        for joiner in joiners {
+            assert!(Arc::ptr_eq(&terminal, &joiner.join().unwrap().unwrap()));
+        }
+        assert_eq!(runtime.metrics().claims, 1);
+        assert_eq!(runtime.metrics().body_completions, 1);
+    }
+
+    #[test]
+    fn different_ready_keys_execute_concurrently() {
+        let runtime = QueryRuntime::new(2);
+        let family = runtime.family::<Key, u64>("overlap", 4).unwrap();
+        let barrier = Arc::new(Barrier::new(2));
+        let handles = [Key("a"), Key("b")].map(|key| {
+            let runtime = runtime.clone();
+            let family = family.clone();
+            let barrier = barrier.clone();
+            thread::spawn(move || {
+                runtime.query(&family, revision(1), key, CancellationToken::new(), |_| {
+                    barrier.wait();
+                    Ok(QueryOutput::success(1))
+                })
+            })
+        });
+        for handle in handles {
+            handle.join().unwrap().unwrap();
+        }
+        assert_eq!(runtime.metrics().peak_active_bodies, 2);
+    }
+
+    #[test]
+    fn one_permit_joiner_donates_to_already_claimed_owner() {
+        let runtime = QueryRuntime::new(1);
+        let outer = runtime.family::<Key, u64>("outer", 4).unwrap();
+        let target = runtime.family::<Key, u64>("target", 4).unwrap();
+        let (outer_started_tx, outer_started_rx) = mpsc::channel();
+        let (enter_join_tx, enter_join_rx) = mpsc::channel();
+        let (target_ran_tx, target_ran_rx) = mpsc::channel();
+
+        let outer_runtime = runtime.clone();
+        let outer_family = outer.clone();
+        let outer_target = target.clone();
+        let outer_thread = thread::spawn(move || {
+            outer_runtime.query(
+                &outer_family,
+                revision(1),
+                Key("outer"),
+                CancellationToken::new(),
+                |context| {
+                    outer_started_tx.send(()).unwrap();
+                    enter_join_rx.recv().unwrap();
+                    let dependency = context.query(&outer_target, Key("queued"), |_| {
+                        panic!("the previously claimed owner must compute")
+                    })?;
+                    assert_eq!(dependency.outcome(), &QueryOutcome::Success(7));
+                    Ok(QueryOutput::success(8))
+                },
+            )
+        });
+        outer_started_rx.recv().unwrap();
+
+        let owner_runtime = runtime.clone();
+        let owner_target = target.clone();
+        let owner = thread::spawn(move || {
+            owner_runtime.query(
+                &owner_target,
+                revision(1),
+                Key("queued"),
+                CancellationToken::new(),
+                |_| {
+                    target_ran_tx.send(()).unwrap();
+                    Ok(QueryOutput::success(7))
+                },
+            )
+        });
+        runtime.wait_for_metrics(|metrics| metrics.claims == 2);
+        enter_join_tx.send(()).unwrap();
+        target_ran_rx.recv().unwrap();
+        assert_eq!(
+            owner.join().unwrap().unwrap().outcome(),
+            &QueryOutcome::Success(7)
+        );
+        assert_eq!(
+            outer_thread.join().unwrap().unwrap().outcome(),
+            &QueryOutcome::Success(8)
+        );
+        assert_eq!(runtime.metrics().donated_permits, 1);
+    }
+
+    #[test]
+    fn one_permit_cross_task_cycle_is_distinct_from_queued_owner_starvation() {
+        let runtime = QueryRuntime::new(1);
+        let left = runtime.family::<Key, u64>("one-cycle-left", 4).unwrap();
+        let right = runtime.family::<Key, u64>("one-cycle-right", 4).unwrap();
+        let (left_started_tx, left_started_rx) = mpsc::channel();
+        let (enter_wait_tx, enter_wait_rx) = mpsc::channel();
+
+        let left_runtime = runtime.clone();
+        let left_root = left.clone();
+        let left_dependency = right.clone();
+        let left_task = thread::spawn(move || {
+            left_runtime.query(
+                &left_root,
+                revision(1),
+                Key("a"),
+                CancellationToken::new(),
+                |context| {
+                    left_started_tx.send(()).unwrap();
+                    enter_wait_rx.recv().unwrap();
+                    context.query(&left_dependency, Key("b"), |_| Ok(QueryOutput::success(2)))?;
+                    Ok(QueryOutput::success(1))
+                },
+            )
+        });
+        left_started_rx.recv().unwrap();
+
+        let right_runtime = runtime.clone();
+        let right_root = right.clone();
+        let right_dependency = left.clone();
+        let right_task = thread::spawn(move || {
+            right_runtime.query(
+                &right_root,
+                revision(1),
+                Key("b"),
+                CancellationToken::new(),
+                |context| {
+                    context.query(&right_dependency, Key("a"), |_| {
+                        panic!("the left root is already owned")
+                    })?;
+                    Ok(QueryOutput::success(2))
+                },
+            )
+        });
+        runtime.wait_for_metrics(|metrics| metrics.claims == 2);
+        enter_wait_tx.send(()).unwrap();
+
+        assert_eq!(
+            left_task.join().unwrap().unwrap().outcome(),
+            &QueryOutcome::Success(1)
+        );
+        let QueryAbort::Cycle(nodes) = right_task.join().unwrap().unwrap_err() else {
+            panic!("the queued owner must observe the true cross-task cycle");
+        };
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(runtime.metrics().cycles, 1);
+        assert_eq!(runtime.metrics().donated_permits, 1);
+    }
+
+    #[test]
+    fn exact_stack_cycle_is_not_reported_as_starvation() {
+        let runtime = QueryRuntime::new(1);
+        let family = runtime.family::<Key, u64>("self-cycle", 4).unwrap();
+        let nested = family.clone();
+        let result = runtime.query(
+            &family,
+            revision(1),
+            Key("a"),
+            CancellationToken::new(),
+            move |context| {
+                context.query(&nested, Key("a"), |_| Ok(QueryOutput::success(1)))?;
+                Ok(QueryOutput::success(2))
+            },
+        );
+        let QueryAbort::Cycle(nodes) = result.unwrap_err() else {
+            panic!("expected a true cycle");
+        };
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].key(), "a");
+    }
+
+    #[test]
+    fn cross_task_wait_cycle_is_detected_without_deadlock() {
+        let runtime = QueryRuntime::new(2);
+        let left = runtime.family::<Key, u64>("cycle-left", 4).unwrap();
+        let right = runtime.family::<Key, u64>("cycle-right", 4).unwrap();
+        let barrier = Arc::new(Barrier::new(2));
+
+        let left_runtime = runtime.clone();
+        let left_root = left.clone();
+        let left_dependency = right.clone();
+        let left_barrier = barrier.clone();
+        let a = thread::spawn(move || {
+            left_runtime.query(
+                &left_root,
+                revision(1),
+                Key("a"),
+                CancellationToken::new(),
+                |context| {
+                    left_barrier.wait();
+                    context.query(&left_dependency, Key("b"), |_| Ok(QueryOutput::success(2)))?;
+                    Ok(QueryOutput::success(1))
+                },
+            )
+        });
+
+        let right_runtime = runtime.clone();
+        let right_root = right.clone();
+        let right_dependency = left.clone();
+        let right_barrier = barrier;
+        let b = thread::spawn(move || {
+            right_runtime.query(
+                &right_root,
+                revision(1),
+                Key("b"),
+                CancellationToken::new(),
+                |context| {
+                    right_barrier.wait();
+                    context.query(&right_dependency, Key("a"), |_| Ok(QueryOutput::success(1)))?;
+                    Ok(QueryOutput::success(2))
+                },
+            )
+        });
+        let results = [a.join().unwrap(), b.join().unwrap()];
+        assert!(
+            results
+                .iter()
+                .any(|result| matches!(result, Err(QueryAbort::Cycle(_))))
+        );
+        assert!(runtime.metrics().cycles >= 1);
+    }
+
+    #[test]
+    fn incompatible_revisions_do_not_join_and_can_overlap() {
+        let runtime = QueryRuntime::new(2);
+        let family = runtime.family::<Key, u64>("revisions", 4).unwrap();
+        let barrier = Arc::new(Barrier::new(2));
+        let handles = [revision(1), revision(2)].map(|revision| {
+            let runtime = runtime.clone();
+            let family = family.clone();
+            let barrier = barrier.clone();
+            thread::spawn(move || {
+                runtime.query(
+                    &family,
+                    revision,
+                    Key("same"),
+                    CancellationToken::new(),
+                    |_| {
+                        barrier.wait();
+                        Ok(QueryOutput::success(revision.id()))
+                    },
+                )
+            })
+        });
+        let values = handles.map(|handle| handle.join().unwrap().unwrap());
+        assert_eq!(values[0].revision(), revision(1));
+        assert_eq!(values[1].revision(), revision(2));
+        assert_eq!(runtime.metrics().claims, 2);
+        assert_eq!(runtime.metrics().joins, 0);
+        assert_eq!(runtime.metrics().peak_active_bodies, 2);
+    }
+
+    #[test]
+    fn red_publication_preserves_stamp_across_revision_and_position_changes() {
+        let runtime = QueryRuntime::new(1);
+        let leaf = runtime.family::<Key, u64>("red-leaf", 8).unwrap();
+        let parent = runtime.family::<Key, u64>("red-parent", 8).unwrap();
+
+        let run = |revision, value, offset| {
+            let leaf = leaf.clone();
+            runtime.query(
+                &parent,
+                revision,
+                Key("parent"),
+                CancellationToken::new(),
+                move |context| {
+                    let _child = context.query(&leaf, Key("leaf"), |_| {
+                        Ok(QueryOutput::success(value).with_diagnostics(vec![
+                            QueryDiagnostic::new(
+                                "leaf-warning",
+                                "same semantic payload",
+                                Some(PresentationPosition::new("main.rue", offset)),
+                            ),
+                        ]))
+                    })?;
+                    Ok(QueryOutput::success(10).with_work(vec![WorkItem::new("visited", 1)]))
+                },
+            )
+        };
+
+        let first = run(revision(1), 5, 1).unwrap();
+        let second = run(revision(2), 5, 99).unwrap();
+        assert_eq!(first.stamp(), second.stamp());
+        assert_eq!(first.dependencies(), second.dependencies());
+        let leaf_second = runtime
+            .query(
+                &leaf,
+                revision(2),
+                Key("leaf"),
+                CancellationToken::new(),
+                |_| panic!("compatible terminal is retained"),
+            )
+            .unwrap();
+        assert_eq!(
+            leaf_second.diagnostics()[0]
+                .presentation
+                .as_ref()
+                .unwrap()
+                .offset,
+            99
+        );
+
+        let third = run(revision(3), 6, 100).unwrap();
+        assert_ne!(second.stamp(), third.stamp());
+        assert_ne!(second.dependencies(), third.dependencies());
+        assert!(runtime.metrics().red_publications >= 2);
+    }
+
+    #[test]
+    fn canceling_a_waiter_does_not_cancel_shared_work() {
+        let runtime = QueryRuntime::new(2);
+        let family = runtime.family::<Key, u64>("waiter-cancel", 4).unwrap();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (finish_tx, finish_rx) = mpsc::channel();
+        let owner_runtime = runtime.clone();
+        let owner_family = family.clone();
+        let owner = thread::spawn(move || {
+            owner_runtime.query(
+                &owner_family,
+                revision(1),
+                Key("shared"),
+                CancellationToken::new(),
+                |_| {
+                    started_tx.send(()).unwrap();
+                    finish_rx.recv().unwrap();
+                    Ok(QueryOutput::success(1))
+                },
+            )
+        });
+        started_rx.recv().unwrap();
+        let waiter_token = CancellationToken::new();
+        let waiter_runtime = runtime.clone();
+        let waiter_family = family.clone();
+        let waiter_cancel = waiter_token.clone();
+        let waiter = thread::spawn(move || {
+            waiter_runtime.query(
+                &waiter_family,
+                revision(1),
+                Key("shared"),
+                waiter_token,
+                |_| panic!("waiter cannot become owner while shared work is live"),
+            )
+        });
+        runtime.wait_for_metrics(|metrics| metrics.joins == 1);
+        waiter_cancel.cancel();
+        assert_eq!(waiter.join().unwrap().unwrap_err(), QueryAbort::Canceled);
+        finish_tx.send(()).unwrap();
+        assert_eq!(
+            owner.join().unwrap().unwrap().outcome(),
+            &QueryOutcome::Success(1)
+        );
+    }
+
+    #[test]
+    fn canceled_owner_does_not_publish_and_live_waiter_reclaims() {
+        let runtime = QueryRuntime::new(2);
+        let family = runtime.family::<Key, u64>("owner-cancel", 4).unwrap();
+        let owner_token = CancellationToken::new();
+        let owner_cancel = owner_token.clone();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (finish_tx, finish_rx) = mpsc::channel();
+        let owner_runtime = runtime.clone();
+        let owner_family = family.clone();
+        let owner = thread::spawn(move || {
+            owner_runtime.query(
+                &owner_family,
+                revision(1),
+                Key("shared"),
+                owner_token,
+                |_| {
+                    started_tx.send(()).unwrap();
+                    finish_rx.recv().unwrap();
+                    Ok(QueryOutput::success(1))
+                },
+            )
+        });
+        started_rx.recv().unwrap();
+
+        let waiter_runtime = runtime.clone();
+        let waiter_family = family.clone();
+        let waiter = thread::spawn(move || {
+            waiter_runtime.query(
+                &waiter_family,
+                revision(1),
+                Key("shared"),
+                CancellationToken::new(),
+                |_| Ok(QueryOutput::success(2)),
+            )
+        });
+        runtime.wait_for_metrics(|metrics| metrics.joins == 1);
+        owner_cancel.cancel();
+        finish_tx.send(()).unwrap();
+        assert_eq!(owner.join().unwrap().unwrap_err(), QueryAbort::Canceled);
+        assert_eq!(
+            waiter.join().unwrap().unwrap().outcome(),
+            &QueryOutcome::Success(2)
+        );
+        assert_eq!(runtime.metrics().green_publications, 1);
+    }
+
+    #[test]
+    fn failures_are_reused_and_retention_respects_pins() {
+        let runtime = QueryRuntime::new(1);
+        let family = runtime.family::<Key, u64>("retention", 2).unwrap();
+        let failed = runtime
+            .query(
+                &family,
+                revision(1),
+                Key("failure"),
+                CancellationToken::new(),
+                |_| Ok(QueryOutput::failure(QueryFailure::new("E1", "broken"))),
+            )
+            .unwrap();
+        let reused_failure = runtime
+            .query(
+                &family,
+                Revision::new(99, 1),
+                Key("failure"),
+                CancellationToken::new(),
+                |_| panic!("a retained failure validates like a success"),
+            )
+            .unwrap();
+        assert!(Arc::ptr_eq(&failed, &reused_failure));
+        let terminal_pin = family.pin_terminal(&failed).unwrap();
+        let second_pin = family.retain_revision(revision(2));
+        let third_pin = family.retain_revision(revision(3));
+        for (id, key) in [(2, "second"), (3, "third"), (4, "fourth")] {
+            runtime
+                .query(
+                    &family,
+                    revision(id),
+                    Key(key),
+                    CancellationToken::new(),
+                    |_| Ok(QueryOutput::success(id)),
+                )
+                .unwrap();
+        }
+        assert_eq!(
+            failed.outcome(),
+            &QueryOutcome::Failure(QueryFailure::new("E1", "broken"))
+        );
+        assert!(runtime.metrics().retained_terminals >= 3);
+        drop(terminal_pin);
+        drop(second_pin);
+        drop(third_pin);
+        assert_eq!(runtime.metrics().retained_terminals, 2);
+        assert!(runtime.metrics().evictions >= 2);
+    }
+
+    #[test]
+    fn terminal_diagnostics_and_work_are_worker_order_independent() {
+        fn run(workers: usize, reverse: bool) -> Arc<QueryTerminal<u64>> {
+            let runtime = QueryRuntime::new(workers);
+            let family = runtime.family::<Key, u64>("determinism", 2).unwrap();
+            runtime
+                .query(
+                    &family,
+                    revision(1),
+                    Key("root"),
+                    CancellationToken::new(),
+                    move |_| {
+                        let mut diagnostics = vec![
+                            QueryDiagnostic::new("b", "two", None),
+                            QueryDiagnostic::new("a", "one", None),
+                        ];
+                        let mut work = vec![
+                            WorkItem::new("lowered", 2),
+                            WorkItem::new("visited", 1),
+                            WorkItem::new("lowered", 3),
+                        ];
+                        if reverse {
+                            diagnostics.reverse();
+                            work.reverse();
+                        }
+                        Ok(QueryOutput::success(7)
+                            .with_diagnostics(diagnostics)
+                            .with_work(work))
+                    },
+                )
+                .unwrap()
+        }
+
+        let serial = run(1, false);
+        let parallel = run(8, true);
+        assert_eq!(serial.outcome(), parallel.outcome());
+        assert_eq!(serial.diagnostics(), parallel.diagnostics());
+        assert_eq!(serial.work(), parallel.work());
+        assert_eq!(serial.dependencies(), parallel.dependencies());
+        assert_eq!(serial.stamp(), parallel.stamp());
+    }
+
+    #[test]
+    fn family_names_and_key_text_form_collision_free_node_identities() {
+        let runtime = QueryRuntime::new(1);
+        let left = runtime.family::<Key, u64>("left", 2).unwrap();
+        let right = runtime.family::<Key, u64>("right", 2).unwrap();
+        assert!(matches!(
+            runtime.family::<Key, u64>("left", 2),
+            Err(FamilyError::DuplicateName(_))
+        ));
+        let left = runtime
+            .query(
+                &left,
+                revision(1),
+                Key("same"),
+                CancellationToken::new(),
+                |_| Ok(QueryOutput::success(1)),
+            )
+            .unwrap();
+        let right = runtime
+            .query(
+                &right,
+                revision(1),
+                Key("same"),
+                CancellationToken::new(),
+                |_| Ok(QueryOutput::success(1)),
+            )
+            .unwrap();
+        assert_ne!(left.node(), right.node());
+        assert_eq!(left.node().key(), right.node().key());
+    }
+
+    #[test]
+    fn active_joiner_protects_terminal_until_wake_with_zero_retention() {
+        let runtime = QueryRuntime::new(2);
+        let family = runtime
+            .family::<Key, u64>("zero-retention-join", 0)
+            .unwrap();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (finish_tx, finish_rx) = mpsc::channel();
+        let owner_runtime = runtime.clone();
+        let owner_family = family.clone();
+        let owner = thread::spawn(move || {
+            owner_runtime.query(
+                &owner_family,
+                revision(1),
+                Key("shared"),
+                CancellationToken::new(),
+                |_| {
+                    started_tx.send(()).unwrap();
+                    finish_rx.recv().unwrap();
+                    Ok(QueryOutput::success(11))
+                },
+            )
+        });
+        started_rx.recv().unwrap();
+        let join_runtime = runtime.clone();
+        let join_family = family.clone();
+        let joiner = thread::spawn(move || {
+            join_runtime.query(
+                &join_family,
+                revision(1),
+                Key("shared"),
+                CancellationToken::new(),
+                |_| panic!("active waiter must receive the owner's terminal"),
+            )
+        });
+        runtime.wait_for_metrics(|metrics| metrics.joins == 1);
+        finish_tx.send(()).unwrap();
+        let owner = owner.join().unwrap().unwrap();
+        let joined = joiner.join().unwrap().unwrap();
+        assert!(Arc::ptr_eq(&owner, &joined));
+        assert_eq!(joined.outcome(), &QueryOutcome::Success(11));
+        assert_eq!(family.retention().terminals, 0);
+        assert_eq!(family.retention().memo_nodes, 0);
+    }
+
+    #[test]
+    fn zero_retention_reclaims_empty_nodes_under_key_churn() {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        struct NumberKey(u64);
+
+        impl QueryKey for NumberKey {
+            fn stable_identity(&self) -> String {
+                self.0.to_string()
+            }
+        }
+
+        let runtime = QueryRuntime::new(1);
+        let family = runtime.family::<NumberKey, u64>("key-churn", 0).unwrap();
+        for key in 0..256 {
+            runtime
+                .query(
+                    &family,
+                    revision(key + 1),
+                    NumberKey(key),
+                    CancellationToken::new(),
+                    |_| Ok(QueryOutput::success(key)),
+                )
+                .unwrap();
+        }
+        assert_eq!(
+            family.retention(),
+            FamilyRetention {
+                memo_nodes: 0,
+                terminals: 0,
+                terminal_limit: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn foreign_same_named_family_cannot_pin_terminal() {
+        let first_runtime = QueryRuntime::new(1);
+        let first = first_runtime.family::<Key, u64>("same-name", 1).unwrap();
+        let terminal = first_runtime
+            .query(
+                &first,
+                revision(1),
+                Key("key"),
+                CancellationToken::new(),
+                |_| Ok(QueryOutput::success(1)),
+            )
+            .unwrap();
+        let second_runtime = QueryRuntime::new(1);
+        let second = second_runtime.family::<Key, u64>("same-name", 1).unwrap();
+        assert!(matches!(
+            second.pin_terminal(&terminal),
+            Err(PinError::ForeignFamily)
+        ));
+        assert_eq!(first.retention().terminals, 1);
+        assert_eq!(second.retention().terminals, 0);
+    }
+
+    #[test]
+    fn evicted_and_recreated_node_cannot_repeat_an_old_observation() {
+        let runtime = QueryRuntime::new(1);
+        let leaf = runtime.family::<Key, u64>("aba-leaf", 0).unwrap();
+        let parent = runtime.family::<Key, u64>("aba-parent", 4).unwrap();
+        let run = |revision, leaf_value| {
+            let leaf = leaf.clone();
+            runtime.query(
+                &parent,
+                revision,
+                Key("parent"),
+                CancellationToken::new(),
+                move |context| {
+                    context.query(&leaf, Key("leaf"), |_| Ok(QueryOutput::success(leaf_value)))?;
+                    Ok(QueryOutput::success(9))
+                },
+            )
+        };
+        let first = run(revision(1), 1).unwrap();
+        assert_eq!(leaf.retention().memo_nodes, 0);
+        let second = run(revision(2), 2).unwrap();
+        assert_eq!(first.dependencies()[0].stamp, 1);
+        assert_eq!(second.dependencies()[0].stamp, 1);
+        assert_ne!(
+            first.dependencies()[0].incarnation,
+            second.dependencies()[0].incarnation
+        );
+        assert_ne!(first.dependencies(), second.dependencies());
+        assert_ne!(first.stamp(), second.stamp());
+    }
+}

--- a/docs/process/query-runtime-prototype.md
+++ b/docs/process/query-runtime-prototype.md
@@ -1,0 +1,134 @@
+# Query runtime prototype
+
+RUE-1022 tested the execution substrate required by ADR-0063 before any
+production `CompilerSession` query family depends on it. The selected substrate
+is the dependency-free `rue-query` crate. Phase 1 should integrate the existing
+typed compiler families with this crate; it must not keep the current selected-
+key executor as a peer database or add another compiler path.
+
+## Decision
+
+Rue needs attempt semantics which are more specific than a generic task pool:
+
+- each request pins one immutable input revision, while compatibility is an
+  explicit validation claim rather than equality of revision counters;
+- a typed family atomically claims or joins an exact logical key, retains both
+  successes and deterministic failures, and publishes cancellation only as a
+  non-terminal abort;
+- current and last-good selection remains a request/session concern above the
+  immutable terminal store;
+- dependency observations, semantic diagnostics, structural work, red/green
+  stamps, and bounded retention are one atomic publication contract;
+- query tasks share one permit budget, including nested dependency work, and a
+  parked joiner releases its permit so a queued owner can run with a budget of
+  one; and
+- imports and other external inputs remain compiler-produced demands. Query
+  bodies never acquire filesystem authority, and a pinned attempt cannot see an
+  observation published into a successor revision.
+
+The prototype implements these mechanics directly with standard-library
+mutexes, condition variables, atomics, and typed family tables. A query body
+runs with no runtime, family, or node lock held. `QueryContext` is deliberately
+neither `Send` nor `Sync`: one task owns one dependency stack and one permit.
+Parallelism comes from independent tasks, not concurrent mutation of a task.
+
+Salsa is not vendored in Rue. Introducing it for this phase would create a
+second database beside `CompilerSession` before proving how Rue's attempted and
+last-good terminals, round-based import revisions, semantic/presentation
+diagnostic split, shared-work cancellation, red/green equality, and protected
+bounded retention map onto it. The focused in-house crate is therefore the
+smaller Phase 1 integration surface. This is a substrate decision, not
+authorization to preserve two query authorities: production families move to
+`rue-query`, after which their superseded selected-state execution machinery is
+removed.
+
+## Prototype contract
+
+`QueryRuntime` owns the permit budget, cross-task wait graph, task identities,
+and structural metrics. `QueryFamily<K, V>` owns exact `K`-keyed memo nodes and
+bounded FIFO attempts. `QueryRuntime::query` creates a task pinned to a
+`Revision`; `QueryContext::query` requests typed dependencies in that same task
+and revision.
+
+Logical node identity is the collision-free pair of a unique stable family name
+and the `QueryKey` implementation's stable identity. It is never a hash. The
+runtime also assigns each retained node incarnation an opaque session-local
+generation. Dependency observations include that generation so evicting and
+recreating a logical node cannot repeat `(node, stamp)` and falsely validate an
+old dependent. The generation is query-control metadata; it does not enter a
+canonical compiler artifact or user-visible ordering.
+
+Same-key compatible attempts share one terminal. Incompatible revisions may
+compute concurrently. Wait edges are exact task-to-owner edges annotated with
+the awaited logical node. A cycle is reported only when adding an edge closes a
+path; lack of an execution permit is not a cycle. A task which joins while it
+owns a permit releases it before parking and reacquires it before returning to
+its body. Nested work by the same task reuses its existing permit.
+
+Publication sorts diagnostics and reduces work by stable identity. Red equality
+compares the canonical success/failure outcome, semantic diagnostic identities
+and payloads, and exact dependency observations. Presentation positions,
+revision numbers, attempt order, and structural work are excluded. A red
+recomputation publishes current positions and work while preserving its prior
+terminal stamp.
+
+Cancellation is cooperative. Canceling a waiter removes only that waiter. If a
+computing owner is canceled, its attempt is removed without publication; a live
+waiter wakes, claims, and computes. Panics also remove the in-flight claim before
+unwinding.
+
+Retention protects computations, parked waiters, explicit terminal pins, and
+explicit current/last-good revision pins. Protected entries may temporarily
+exceed the configured limit. The last departing waiter or pin reruns eviction.
+Empty nodes are reclaimed after their last active user leaves, so unique-key
+churn is bounded. Failures use the same validation, pinning, and eviction rules
+as successes. Family and runtime tokens prevent a same-named foreign family
+from pinning a terminal it does not own.
+
+## Reproduction and evidence
+
+Run the deterministic adversarial suite and the repository unit suite with:
+
+```text
+./buck2 test //crates/rue-query:rue-query-test
+scripts/rue quick
+```
+
+The focused tests cover exact-key one/many joins, independent-key overlap,
+incompatible revisions, a same-task cycle, a cross-task cycle, the adversarial
+one-permit queued-owner schedule both with and without a true cross-task cycle,
+cancellation of both waiter and owner,
+retained failures, terminal/revision pins, zero-retention active waiters,
+unique-key churn, eviction/recreation stamp ABA, foreign pins, red publication,
+and one-worker/many-worker diagnostic/work equivalence. They use barriers,
+channels, and structural counters instead of latency assertions.
+
+Run the representative microbenchmark with:
+
+```text
+./buck2 run //crates/rue-query-bench:rue-query-bench -- --keys 64 --workers 1
+./buck2 run //crates/rue-query-bench:rue-query-bench -- --keys 64 --workers 8
+```
+
+On an Apple Silicon macOS 26.5.1 development host with Rust 1.92.0, a sample run
+produced these JSON records:
+
+```json
+{"schema":1,"keys":64,"workers":1,"cold_micros":191,"reuse_micros":42,"red_micros":131,"join_micros":55,"checksum":6240,"join_stamp":1,"claims":129,"joins":1,"reuses":64,"green_publications":65,"red_publications":64,"peak_active_bodies":1,"retained_terminals":129,"retained_nodes":65,"evictions":0}
+{"schema":1,"keys":64,"workers":8,"cold_micros":418,"reuse_micros":153,"red_micros":177,"join_micros":190,"checksum":6240,"join_stamp":1,"claims":129,"joins":8,"reuses":64,"green_publications":65,"red_publications":64,"peak_active_bodies":5,"retained_terminals":129,"retained_nodes":65,"evictions":0}
+```
+
+The structural evidence is the contract: checksum, claims, reuses, green/red
+publication counts, retained ownership, and evictions are identical across the
+worker counts. The hot-key phase records one join per configured joining worker,
+and every waiter observes `join_stamp` 1 from the single owner computation. The
+many-worker run also overlapped independent bodies. The microsecond fields are
+descriptive samples, not a platform promise. This tiny workload is
+synchronization-heavy and is not a claim that more workers improve its elapsed
+time.
+
+Phase 1 must map compiler family equality and attempt/current/last-good
+publication onto this API, then run the existing differential oracle against
+the integrated path. Later phases should replace caller-created worker threads
+with Rue's structured scheduler and migrate existing Rayon work into the same
+permit budget without changing the claim/join or publication contract.

--- a/rust-project.json
+++ b/rust-project.json
@@ -19,19 +19,19 @@
           "name": "rue_compiler"
         },
         {
-          "crate": 19,
+          "crate": 21,
           "name": "rue_rir"
         },
         {
-          "crate": 23,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 65,
+          "crate": 67,
           "name": "lasso"
         },
         {
-          "crate": 103,
+          "crate": 105,
           "name": "serde_json"
         }
       ],
@@ -63,23 +63,23 @@
           "name": "rue_error"
         },
         {
-          "crate": 19,
+          "crate": 21,
           "name": "rue_rir"
         },
         {
-          "crate": 21,
+          "crate": 23,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 23,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 25,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 65,
+          "crate": 67,
           "name": "lasso"
         }
       ],
@@ -119,27 +119,27 @@
           "name": "rue_parser"
         },
         {
-          "crate": 19,
+          "crate": 21,
           "name": "rue_rir"
         },
         {
-          "crate": 21,
+          "crate": 23,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 23,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 25,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 65,
+          "crate": 67,
           "name": "lasso"
         },
         {
-          "crate": 95,
+          "crate": 97,
           "name": "rayon"
         }
       ],
@@ -163,7 +163,7 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 21,
+          "crate": 23,
           "name": "rue_runtime_abi"
         }
       ],
@@ -195,11 +195,11 @@
           "name": "rue_error"
         },
         {
-          "crate": 23,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 65,
+          "crate": 67,
           "name": "lasso"
         }
       ],
@@ -231,11 +231,11 @@
           "name": "rue_error"
         },
         {
-          "crate": 23,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 65,
+          "crate": 67,
           "name": "lasso"
         }
       ],
@@ -259,27 +259,27 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 25,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 26,
+          "crate": 28,
           "name": "rue_test_runner"
         },
         {
-          "crate": 74,
+          "crate": 76,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 101,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 109,
+          "crate": 111,
           "name": "tempfile"
         },
         {
-          "crate": 112,
+          "crate": 114,
           "name": "toml"
         }
       ],
@@ -319,23 +319,23 @@
           "name": "rue_error"
         },
         {
-          "crate": 21,
+          "crate": 23,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 23,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 25,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 56,
+          "crate": 58,
           "name": "fixedbitset"
         },
         {
-          "crate": 65,
+          "crate": 67,
           "name": "lasso"
         }
       ],
@@ -367,15 +367,15 @@
           "name": "rue_compiler"
         },
         {
-          "crate": 23,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 103,
+          "crate": 105,
           "name": "serde_json"
         },
         {
-          "crate": 105,
+          "crate": 107,
           "name": "sha2"
         }
       ],
@@ -431,55 +431,55 @@
           "name": "rue_parser"
         },
         {
-          "crate": 19,
+          "crate": 21,
           "name": "rue_rir"
         },
         {
-          "crate": 21,
+          "crate": 23,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 23,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 25,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 37,
+          "crate": 39,
           "name": "annotate_snippets"
         },
         {
-          "crate": 65,
+          "crate": 67,
           "name": "lasso"
         },
         {
-          "crate": 70,
+          "crate": 72,
           "name": "libc"
         },
         {
-          "crate": 95,
+          "crate": 97,
           "name": "rayon"
         },
         {
-          "crate": 101,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 103,
+          "crate": 105,
           "name": "serde_json"
         },
         {
-          "crate": 105,
+          "crate": 107,
           "name": "sha2"
         },
         {
-          "crate": 109,
+          "crate": 111,
           "name": "tempfile"
         },
         {
-          "crate": 116,
+          "crate": 118,
           "name": "tracing"
         }
       ],
@@ -503,11 +503,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 23,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 110,
+          "crate": 112,
           "name": "thiserror"
         }
       ],
@@ -539,15 +539,15 @@
           "name": "rue_parser"
         },
         {
-          "crate": 26,
+          "crate": 28,
           "name": "rue_test_runner"
         },
         {
-          "crate": 65,
+          "crate": 67,
           "name": "lasso"
         },
         {
-          "crate": 109,
+          "crate": 111,
           "name": "tempfile"
         }
       ],
@@ -603,23 +603,23 @@
           "name": "rue_parser"
         },
         {
-          "crate": 19,
+          "crate": 21,
           "name": "rue_rir"
         },
         {
-          "crate": 20,
+          "crate": 22,
           "name": "rue_rir_fuzz_support"
         },
         {
-          "crate": 40,
+          "crate": 42,
           "name": "anyhow"
         },
         {
-          "crate": 70,
+          "crate": 72,
           "name": "libc"
         },
         {
-          "crate": 88,
+          "crate": 90,
           "name": "proptest"
         }
       ],
@@ -647,15 +647,15 @@
           "name": "rue_error"
         },
         {
-          "crate": 23,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 65,
+          "crate": 67,
           "name": "lasso"
         },
         {
-          "crate": 77,
+          "crate": 79,
           "name": "logos"
         }
       ],
@@ -679,11 +679,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 25,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 116,
+          "crate": 118,
           "name": "tracing"
         }
       ],
@@ -719,19 +719,19 @@
           "name": "rue_oracle"
         },
         {
-          "crate": 26,
+          "crate": 28,
           "name": "rue_test_runner"
         },
         {
-          "crate": 101,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 109,
+          "crate": 111,
           "name": "tempfile"
         },
         {
-          "crate": 112,
+          "crate": 114,
           "name": "toml"
         }
       ],
@@ -767,7 +767,7 @@
           "name": "rue_compiler"
         },
         {
-          "crate": 65,
+          "crate": 67,
           "name": "lasso"
         }
       ],
@@ -799,15 +799,15 @@
           "name": "rue_parser"
         },
         {
-          "crate": 23,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 65,
+          "crate": 67,
           "name": "lasso"
         },
         {
-          "crate": 103,
+          "crate": 105,
           "name": "serde_json"
         }
       ],
@@ -839,19 +839,19 @@
           "name": "rue_lexer"
         },
         {
-          "crate": 23,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 65,
+          "crate": 67,
           "name": "lasso"
         },
         {
-          "crate": 107,
+          "crate": 109,
           "name": "smallvec"
         },
         {
-          "crate": 116,
+          "crate": 118,
           "name": "tracing"
         }
       ],
@@ -859,6 +859,49 @@
       "source": {
         "include_dirs": [
           "crates/rue-parser/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-query-bench",
+      "root_module": "crates/rue-query-bench/src/main.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 20,
+          "name": "rue_query"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-query-bench/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-query",
+      "root_module": "crates/rue-query/src/lib.rs",
+      "edition": "2024",
+      "deps": [],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-query/src"
         ],
         "exclude_dirs": []
       },
@@ -883,11 +926,11 @@
           "name": "rue_parser"
         },
         {
-          "crate": 23,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 65,
+          "crate": 67,
           "name": "lasso"
         }
       ],
@@ -919,11 +962,11 @@
           "name": "rue_parser"
         },
         {
-          "crate": 23,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 65,
+          "crate": 67,
           "name": "lasso"
         }
       ],
@@ -966,7 +1009,7 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 21,
+          "crate": 23,
           "name": "rue_runtime_abi"
         }
       ],
@@ -1009,15 +1052,15 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 26,
+          "crate": 28,
           "name": "rue_test_runner"
         },
         {
-          "crate": 74,
+          "crate": 76,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 109,
+          "crate": 111,
           "name": "tempfile"
         }
       ],
@@ -1064,23 +1107,23 @@
           "name": "rue_error"
         },
         {
-          "crate": 25,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 70,
+          "crate": 72,
           "name": "libc"
         },
         {
-          "crate": 101,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 109,
+          "crate": 111,
           "name": "tempfile"
         },
         {
-          "crate": 112,
+          "crate": 114,
           "name": "toml"
         }
       ],
@@ -1104,11 +1147,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 26,
+          "crate": 28,
           "name": "rue_test_runner"
         },
         {
-          "crate": 74,
+          "crate": 76,
           "name": "libtest2_mimic"
         }
       ],
@@ -1136,35 +1179,35 @@
           "name": "rue_compiler"
         },
         {
-          "crate": 19,
+          "crate": 21,
           "name": "rue_rir"
         },
         {
-          "crate": 25,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 70,
+          "crate": 72,
           "name": "libc"
         },
         {
-          "crate": 101,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 103,
+          "crate": 105,
           "name": "serde_json"
         },
         {
-          "crate": 105,
+          "crate": 107,
           "name": "sha2"
         },
         {
-          "crate": 116,
+          "crate": 118,
           "name": "tracing"
         },
         {
-          "crate": 120,
+          "crate": 122,
           "name": "tracing_subscriber"
         }
       ],
@@ -1192,35 +1235,35 @@
           "name": "rue_compiler"
         },
         {
-          "crate": 19,
+          "crate": 21,
           "name": "rue_rir"
         },
         {
-          "crate": 25,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 70,
+          "crate": 72,
           "name": "libc"
         },
         {
-          "crate": 101,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 103,
+          "crate": 105,
           "name": "serde_json"
         },
         {
-          "crate": 105,
+          "crate": 107,
           "name": "sha2"
         },
         {
-          "crate": 116,
+          "crate": 118,
           "name": "tracing"
         },
         {
-          "crate": 120,
+          "crate": 122,
           "name": "tracing_subscriber"
         }
       ],
@@ -1244,7 +1287,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 78,
+          "crate": 80,
           "name": "logos_codegen"
         }
       ],
@@ -1268,15 +1311,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 87,
+          "crate": 89,
           "name": "proc_macro2"
         },
         {
-          "crate": 90,
+          "crate": 92,
           "name": "quote"
         },
         {
-          "crate": 108,
+          "crate": 110,
           "name": "syn"
         }
       ],
@@ -1301,15 +1344,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 87,
+          "crate": 89,
           "name": "proc_macro2"
         },
         {
-          "crate": 90,
+          "crate": 92,
           "name": "quote"
         },
         {
-          "crate": 108,
+          "crate": 110,
           "name": "syn"
         }
       ],
@@ -1333,15 +1376,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 87,
+          "crate": 89,
           "name": "proc_macro2"
         },
         {
-          "crate": 90,
+          "crate": 92,
           "name": "quote"
         },
         {
-          "crate": 108,
+          "crate": 110,
           "name": "syn"
         }
       ],
@@ -1365,15 +1408,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 46,
+          "crate": 48,
           "name": "cfg_if"
         },
         {
-          "crate": 83,
+          "crate": 85,
           "name": "once_cell"
         },
         {
-          "crate": 127,
+          "crate": 129,
           "name": "zerocopy"
         }
       ],
@@ -1397,7 +1440,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 80,
+          "crate": 82,
           "name": "memchr"
         }
       ],
@@ -1443,11 +1486,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 39,
+          "crate": 41,
           "name": "anstyle"
         },
         {
-          "crate": 124,
+          "crate": 126,
           "name": "unicode_width"
         }
       ],
@@ -1556,7 +1599,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 43,
+          "crate": 45,
           "name": "bit_vec"
         }
       ],
@@ -1624,7 +1667,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 58,
+          "crate": 60,
           "name": "generic_array"
         }
       ],
@@ -1686,11 +1729,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 49,
+          "crate": 51,
           "name": "crossbeam_epoch"
         },
         {
-          "crate": 50,
+          "crate": 52,
           "name": "crossbeam_utils"
         }
       ],
@@ -1716,7 +1759,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 50,
+          "crate": 52,
           "name": "crossbeam_utils"
         }
       ],
@@ -1763,11 +1806,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 58,
+          "crate": 60,
           "name": "generic_array"
         },
         {
-          "crate": 121,
+          "crate": 123,
           "name": "typenum"
         }
       ],
@@ -1791,27 +1834,27 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 46,
+          "crate": 48,
           "name": "cfg_if"
         },
         {
-          "crate": 50,
+          "crate": 52,
           "name": "crossbeam_utils"
         },
         {
-          "crate": 60,
+          "crate": 62,
           "name": "hashbrown"
         },
         {
-          "crate": 75,
+          "crate": 77,
           "name": "lock_api"
         },
         {
-          "crate": 83,
+          "crate": 85,
           "name": "once_cell"
         },
         {
-          "crate": 84,
+          "crate": 86,
           "name": "parking_lot_core"
         }
       ],
@@ -1836,11 +1879,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 45,
+          "crate": 47,
           "name": "block_buffer"
         },
         {
-          "crate": 51,
+          "crate": 53,
           "name": "crypto_common"
         }
       ],
@@ -1947,7 +1990,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 121,
+          "crate": 123,
           "name": "typenum"
         }
       ],
@@ -1992,11 +2035,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 34,
+          "crate": 36,
           "name": "ahash"
         },
         {
-          "crate": 36,
+          "crate": 38,
           "name": "allocator_api2"
         }
       ],
@@ -2044,11 +2087,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 55,
+          "crate": 57,
           "name": "equivalent"
         },
         {
-          "crate": 61,
+          "crate": 63,
           "name": "hashbrown"
         }
       ],
@@ -2115,11 +2158,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 52,
+          "crate": 54,
           "name": "dashmap"
         },
         {
-          "crate": 60,
+          "crate": 62,
           "name": "hashbrown"
         }
       ],
@@ -2165,11 +2208,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 68,
+          "crate": 70,
           "name": "lexarg_error"
         },
         {
-          "crate": 69,
+          "crate": 71,
           "name": "lexarg_parser"
         }
       ],
@@ -2194,7 +2237,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 69,
+          "crate": 71,
           "name": "lexarg_parser"
         }
       ],
@@ -2260,7 +2303,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 64,
+          "crate": 66,
           "name": "json_write"
         }
       ],
@@ -2286,11 +2329,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 67,
+          "crate": 69,
           "name": "lexarg"
         },
         {
-          "crate": 68,
+          "crate": 70,
           "name": "lexarg_error"
         }
       ],
@@ -2315,27 +2358,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 38,
+          "crate": 40,
           "name": "anstream"
         },
         {
-          "crate": 39,
+          "crate": 41,
           "name": "anstyle"
         },
         {
-          "crate": 68,
+          "crate": 70,
           "name": "lexarg_error"
         },
         {
-          "crate": 69,
+          "crate": 71,
           "name": "lexarg_parser"
         },
         {
-          "crate": 71,
+          "crate": 73,
           "name": "libtest_json"
         },
         {
-          "crate": 72,
+          "crate": 74,
           "name": "libtest_lexarg"
         }
       ],
@@ -2362,11 +2405,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 71,
+          "crate": 73,
           "name": "libtest_json"
         },
         {
-          "crate": 73,
+          "crate": 75,
           "name": "libtest2_harness"
         }
       ],
@@ -2393,7 +2436,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 100,
+          "crate": 102,
           "name": "scopeguard"
         }
       ],
@@ -2439,7 +2482,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 30,
+          "crate": 32,
           "name": "logos_derive"
         }
       ],
@@ -2467,31 +2510,31 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 41,
+          "crate": 43,
           "name": "beef"
         },
         {
-          "crate": 57,
+          "crate": 59,
           "name": "fnv"
         },
         {
-          "crate": 66,
+          "crate": 68,
           "name": "lazy_static"
         },
         {
-          "crate": 87,
+          "crate": 89,
           "name": "proc_macro2"
         },
         {
-          "crate": 90,
+          "crate": 92,
           "name": "quote"
         },
         {
-          "crate": 98,
+          "crate": 100,
           "name": "regex_syntax"
         },
         {
-          "crate": 108,
+          "crate": 110,
           "name": "syn"
         }
       ],
@@ -2515,7 +2558,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 97,
+          "crate": 99,
           "name": "regex_automata"
         }
       ],
@@ -2662,7 +2705,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 127,
+          "crate": 129,
           "name": "zerocopy"
         }
       ],
@@ -2688,7 +2731,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 123,
+          "crate": 125,
           "name": "unicode_ident"
         }
       ],
@@ -2714,47 +2757,47 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 42,
+          "crate": 44,
           "name": "bit_set"
         },
         {
-          "crate": 43,
+          "crate": 45,
           "name": "bit_vec"
         },
         {
-          "crate": 44,
+          "crate": 46,
           "name": "bitflags"
         },
         {
-          "crate": 82,
+          "crate": 84,
           "name": "num_traits"
         },
         {
-          "crate": 91,
+          "crate": 93,
           "name": "rand"
         },
         {
-          "crate": 92,
+          "crate": 94,
           "name": "rand_chacha"
         },
         {
-          "crate": 94,
+          "crate": 96,
           "name": "rand_xorshift"
         },
         {
-          "crate": 98,
+          "crate": 100,
           "name": "regex_syntax"
         },
         {
-          "crate": 99,
+          "crate": 101,
           "name": "rusty_fork"
         },
         {
-          "crate": 109,
+          "crate": 111,
           "name": "tempfile"
         },
         {
-          "crate": 122,
+          "crate": 124,
           "name": "unarray"
         }
       ],
@@ -2805,7 +2848,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 87,
+          "crate": 89,
           "name": "proc_macro2"
         }
       ],
@@ -2831,7 +2874,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 93,
+          "crate": 95,
           "name": "rand_core"
         }
       ],
@@ -2858,11 +2901,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 86,
+          "crate": 88,
           "name": "ppv_lite86"
         },
         {
-          "crate": 93,
+          "crate": 95,
           "name": "rand_core"
         }
       ],
@@ -2887,7 +2930,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 59,
+          "crate": 61,
           "name": "getrandom"
         }
       ],
@@ -2913,7 +2956,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 93,
+          "crate": 95,
           "name": "rand_core"
         }
       ],
@@ -2937,11 +2980,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 54,
+          "crate": 56,
           "name": "either"
         },
         {
-          "crate": 96,
+          "crate": 98,
           "name": "rayon_core"
         }
       ],
@@ -2965,11 +3008,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 48,
+          "crate": 50,
           "name": "crossbeam_deque"
         },
         {
-          "crate": 50,
+          "crate": 52,
           "name": "crossbeam_utils"
         }
       ],
@@ -2993,15 +3036,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 35,
+          "crate": 37,
           "name": "aho_corasick"
         },
         {
-          "crate": 80,
+          "crate": 82,
           "name": "memchr"
         },
         {
-          "crate": 98,
+          "crate": 100,
           "name": "regex_syntax"
         }
       ],
@@ -3078,19 +3121,19 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 57,
+          "crate": 59,
           "name": "fnv"
         },
         {
-          "crate": 89,
+          "crate": 91,
           "name": "quick_error"
         },
         {
-          "crate": 109,
+          "crate": 111,
           "name": "tempfile"
         },
         {
-          "crate": 125,
+          "crate": 127,
           "name": "wait_timeout"
         }
       ],
@@ -3135,11 +3178,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 31,
+          "crate": 33,
           "name": "serde_derive"
         },
         {
-          "crate": 102,
+          "crate": 104,
           "name": "serde_core"
         }
       ],
@@ -3188,19 +3231,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 63,
+          "crate": 65,
           "name": "itoa"
         },
         {
-          "crate": 80,
+          "crate": 82,
           "name": "memchr"
         },
         {
-          "crate": 102,
+          "crate": 104,
           "name": "serde_core"
         },
         {
-          "crate": 128,
+          "crate": 130,
           "name": "zmij"
         }
       ],
@@ -3226,7 +3269,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 101,
+          "crate": 103,
           "name": "serde"
         }
       ],
@@ -3251,15 +3294,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 46,
+          "crate": 48,
           "name": "cfg_if"
         },
         {
-          "crate": 47,
+          "crate": 49,
           "name": "cpufeatures"
         },
         {
-          "crate": 53,
+          "crate": 55,
           "name": "digest"
         }
       ],
@@ -3283,7 +3326,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 66,
+          "crate": 68,
           "name": "lazy_static"
         }
       ],
@@ -3326,15 +3369,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 87,
+          "crate": 89,
           "name": "proc_macro2"
         },
         {
-          "crate": 90,
+          "crate": 92,
           "name": "quote"
         },
         {
-          "crate": 123,
+          "crate": 125,
           "name": "unicode_ident"
         }
       ],
@@ -3388,7 +3431,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 32,
+          "crate": 34,
           "name": "thiserror_impl"
         }
       ],
@@ -3414,7 +3457,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 46,
+          "crate": 48,
           "name": "cfg_if"
         }
       ],
@@ -3438,19 +3481,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 101,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 104,
+          "crate": 106,
           "name": "serde_spanned"
         },
         {
-          "crate": 113,
+          "crate": 115,
           "name": "toml_datetime"
         },
         {
-          "crate": 114,
+          "crate": 116,
           "name": "toml_edit"
         }
       ],
@@ -3477,7 +3520,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 101,
+          "crate": 103,
           "name": "serde"
         }
       ],
@@ -3502,27 +3545,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 62,
+          "crate": 64,
           "name": "indexmap"
         },
         {
-          "crate": 101,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 104,
+          "crate": 106,
           "name": "serde_spanned"
         },
         {
-          "crate": 113,
+          "crate": 115,
           "name": "toml_datetime"
         },
         {
-          "crate": 115,
+          "crate": 117,
           "name": "toml_write"
         },
         {
-          "crate": 126,
+          "crate": 128,
           "name": "winnow"
         }
       ],
@@ -3571,15 +3614,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 33,
+          "crate": 35,
           "name": "tracing_attributes"
         },
         {
-          "crate": 85,
+          "crate": 87,
           "name": "pin_project_lite"
         },
         {
-          "crate": 117,
+          "crate": 119,
           "name": "tracing_core"
         }
       ],
@@ -3607,7 +3650,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 83,
+          "crate": 85,
           "name": "once_cell"
         }
       ],
@@ -3634,15 +3677,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 76,
+          "crate": 78,
           "name": "log"
         },
         {
-          "crate": 83,
+          "crate": 85,
           "name": "once_cell"
         },
         {
-          "crate": 117,
+          "crate": 119,
           "name": "tracing_core"
         }
       ],
@@ -3668,11 +3711,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 101,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 117,
+          "crate": 119,
           "name": "tracing_core"
         }
       ],
@@ -3696,55 +3739,55 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 79,
+          "crate": 81,
           "name": "matchers"
         },
         {
-          "crate": 81,
+          "crate": 83,
           "name": "nu_ansi_term"
         },
         {
-          "crate": 83,
+          "crate": 85,
           "name": "once_cell"
         },
         {
-          "crate": 97,
+          "crate": 99,
           "name": "regex_automata"
         },
         {
-          "crate": 101,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 103,
+          "crate": 105,
           "name": "serde_json"
         },
         {
-          "crate": 106,
+          "crate": 108,
           "name": "sharded_slab"
         },
         {
-          "crate": 107,
+          "crate": 109,
           "name": "smallvec"
         },
         {
-          "crate": 111,
+          "crate": 113,
           "name": "thread_local"
         },
         {
-          "crate": 116,
+          "crate": 118,
           "name": "tracing"
         },
         {
-          "crate": 117,
+          "crate": 119,
           "name": "tracing_core"
         },
         {
-          "crate": 118,
+          "crate": 120,
           "name": "tracing_log"
         },
         {
-          "crate": 119,
+          "crate": 121,
           "name": "tracing_serde"
         }
       ],


### PR DESCRIPTION
## Summary

- add a reusable std-only `rue-query` runtime with immutable revisions, exact-key claim-or-join, task-local dependencies, cross-task cycle detection, cancellation, red/green publication, and bounded retention
- prove one-permit progress, deterministic one/many-worker behavior, retained failure/pin/eviction semantics, and stamp-ABA safety with 17 adversarial tests
- add a machine-readable microbenchmark and record the Phase 1 substrate decision and handoff

## Validation

- `./buck2 test --isolation-dir codex-rue1022-review --local-only --no-remote-cache //crates/rue-query:rue-query-test //:fmt-check` — 17/17 and formatting pass
- focused Buck Clippy subtargets for the library, test, and benchmark — all diagnostics empty
- benchmark at 64 keys with one and eight workers — matching checksum, claims, reuse, red/green publications, retention, and join stamp; 1 versus 8 joined waiters
- serialized full suite — CLI 1,639 pass, spec 2,138 pass, UI 195 pass, generated oracle 64/64, and reproducibility pass

The default local BuildBuddy cache materialized a non-relocatable cached Rust sysroot for the newly added test link action (`can't find crate for std`). The same target and the full 285-target unit graph pass in a fresh local-only isolation directory; CI's clean environment remains authoritative.

Fixes RUE-1022
