### PR TITLE
RUE-1034: prove cache population in each probe

### DIFF
--- a/.github/workflows/cache-probe.yml
+++ b/.github/workflows/cache-probe.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   probe:
     runs-on: ubuntu-latest
+    env:
+      # A rerun gets a fresh namespace too, so its first build must be cold.
+      CACHE_PROBE_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v6
 
@@ -39,7 +42,7 @@ jobs:
       - name: Cold release build (populates the remote cache)
         run: |
           set +e
-          /usr/bin/time -v ./buck2 build --prefer-local //crates/... --target-platforms //platforms:release >cold.log 2>&1
+          /usr/bin/time -v ./buck2 build --prefer-local //crates/... --target-platforms //platforms:release -c "rue.cache_probe_nonce=$CACHE_PROBE_NONCE" >cold.log 2>&1
           status=$?
           set -e
           if [ "$status" -ne 0 ]; then
@@ -55,7 +58,7 @@ jobs:
         run: |
           ./buck2 clean
           set +e
-          /usr/bin/time -v ./buck2 build --prefer-local //crates/... --target-platforms //platforms:release >warm.log 2>&1
+          /usr/bin/time -v ./buck2 build --prefer-local //crates/... --target-platforms //platforms:release -c "rue.cache_probe_nonce=$CACHE_PROBE_NONCE" >warm.log 2>&1
           status=$?
           set -e
           if [ "$status" -ne 0 ]; then
@@ -67,27 +70,7 @@ jobs:
           fi
           grep -E '(Cache hits:|Commands:|Network:)' warm.log | tail -3 || tail -10 warm.log
 
-          command_field() {
-            grep -oE 'Commands: [0-9]+ \(cached: [0-9]+, remote: [0-9]+, local: [0-9]+\)' "$1" |
-              tail -1 |
-              sed -E "s/.*$2: ([0-9]+).*/\\1/"
-          }
-          cold_local="$(command_field cold.log local)"
-          warm_cached="$(command_field warm.log cached)"
-          warm_local="$(command_field warm.log local)"
-          if [ -z "$cold_local" ] || [ -z "$warm_cached" ] || [ -z "$warm_local" ]; then
-            echo "::error::Could not parse Buck command counters from the cache-probe logs."
-            exit 1
-          fi
-          if [ "$warm_cached" -eq 0 ]; then
-            echo "::error::Warm build reported zero remote-cache hits."
-            exit 1
-          fi
-          if [ "$cold_local" -gt 0 ] && [ "$warm_local" -ge "$cold_local" ]; then
-            echo "::error::Warm build did not convert any cold local actions into cache hits (cold local: $cold_local; warm local: $warm_local)."
-            exit 1
-          fi
-          echo "Warm cache reused cold results (cold local: $cold_local; warm cached: $warm_cached; warm local: $warm_local)."
+          scripts/check-cache-probe cold.log warm.log
 
       - name: Upload probe logs
         if: always()
@@ -115,5 +98,5 @@ jobs:
             echo "COLD: $(command_summary cold.log)"
             echo "WARM: $(command_summary warm.log)"
             echo '```'
-            echo "The probe step verifies that WARM converts cold local actions into cache hits."
+            echo "The per-attempt nonce makes COLD unique; the probe verifies that WARM reuses results populated by COLD."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/BUCK
+++ b/BUCK
@@ -406,6 +406,7 @@ filegroup(
         "fmt.sh",
         "scripts/ci-heavy-suite",
         "scripts/ci-timed",
+        "scripts/check-cache-probe",
         "scripts/rue",
         "scripts/rue-bin",
         "scripts/provision-build-cache",

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -143,8 +143,10 @@ Availability rules, which the workflow steps must respect:
 The `cache-probe` workflow (`.github/workflows/cache-probe.yml`) remains the
 measurement tool: it writes a transient config from the secret, does a cold
 release build of `//crates/...` then a clean-and-rebuild, and reports buck2's
-`Commands: (cached / remote / local)` line. It fails when the warm build does
-not convert any cold local actions into cache hits. Run it with
+`Commands: (cached / remote / local)` line. Each workflow attempt injects a
+unique, otherwise-unused Rust cfg so prior runs cannot satisfy the nominal cold
+phase. The probe fails unless that phase executes local actions and the warm
+phase increases cache hits while reducing local actions. Run it with
 `gh workflow run cache-probe.yml`.
 
 Required CI also records per-step wall time and aggregate cached/remote/local

--- a/scripts/check-cache-probe
+++ b/scripts/check-cache-probe
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Prove that one cache-probe attempt populated reusable remote action results.
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: scripts/check-cache-probe COLD_LOG WARM_LOG" >&2
+    exit 2
+fi
+
+parse_counts() {
+    local line
+    line="$(grep -oE 'Commands: [0-9]+ \(cached: [0-9]+, remote: [0-9]+, local: [0-9]+\)' "$1" | tail -1 || true)"
+    if [[ ! "$line" =~ Commands:[[:space:]]+([0-9]+)[[:space:]]+\(cached:[[:space:]]+([0-9]+),[[:space:]]+remote:[[:space:]]+([0-9]+),[[:space:]]+local:[[:space:]]+([0-9]+)\) ]]; then
+        return 1
+    fi
+    printf '%s %s %s %s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}" "${BASH_REMATCH[4]}"
+}
+
+cold_counts="$(parse_counts "$1")" || {
+    echo "::error::Could not parse Buck command counters from cold cache-probe log $1." >&2
+    exit 1
+}
+warm_counts="$(parse_counts "$2")" || {
+    echo "::error::Could not parse Buck command counters from warm cache-probe log $2." >&2
+    exit 1
+}
+
+read -r cold_commands cold_cached cold_remote cold_local <<<"$cold_counts"
+read -r warm_commands warm_cached warm_remote warm_local <<<"$warm_counts"
+
+if [[ "$cold_local" -eq 0 ]]; then
+    echo "::error::Cold build reported zero local actions; the probe nonce did not create a unique cold namespace." >&2
+    exit 1
+fi
+if [[ "$warm_cached" -eq 0 ]]; then
+    echo "::error::Warm build reported zero remote-cache hits." >&2
+    exit 1
+fi
+if [[ "$warm_cached" -le "$cold_cached" ]]; then
+    echo "::error::Warm build did not increase cache hits (cold cached: $cold_cached; warm cached: $warm_cached)." >&2
+    exit 1
+fi
+if [[ "$warm_local" -ge "$cold_local" ]]; then
+    echo "::error::Warm build did not convert cold local actions into cache hits (cold local: $cold_local; warm local: $warm_local)." >&2
+    exit 1
+fi
+
+echo "Warm cache reused cold results (cold commands: $cold_commands; cold cached: $cold_cached; cold remote: $cold_remote; cold local: $cold_local; warm commands: $warm_commands; warm cached: $warm_cached; warm remote: $warm_remote; warm local: $warm_local)."

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -703,6 +703,41 @@ EOF
   rm -rf "$sb"
 }
 
+# The cache probe must distinguish a genuine same-run cold-to-warm conversion
+# from an already-warm shared cache or a second build that did no better.
+test_cache_probe_counter_validation() {
+  local sb; sb="$(mktemp -d)"
+  cp "$SRC_ROOT/scripts/check-cache-probe" "$sb/check-cache-probe"; chmod +x "$sb/check-cache-probe"
+
+  printf '%s\n' 'Commands: 100 (cached: 10, remote: 0, local: 90)' >"$sb/cold.log"
+  printf '%s\n' 'Commands: 100 (cached: 95, remote: 0, local: 5)' >"$sb/warm.log"
+  local rc=0 out
+  out="$("$sb/check-cache-probe" "$sb/cold.log" "$sb/warm.log" 2>&1)" || rc=$?
+  check "cache probe: accepts a genuine cold-to-warm conversion" \
+    "$([ "$rc" -eq 0 ] && grep -Fq 'Warm cache reused cold results' <<<"$out" && echo 0 || echo 1)"
+
+  printf '%s\n' 'Commands: 100 (cached: 100, remote: 0, local: 0)' >"$sb/cold.log"
+  rc=0
+  out="$("$sb/check-cache-probe" "$sb/cold.log" "$sb/warm.log" 2>&1)" || rc=$?
+  check "cache probe: rejects an already-warm cold phase" \
+    "$([ "$rc" -ne 0 ] && grep -Fq 'zero local actions' <<<"$out" && echo 0 || echo 1)"
+
+  printf '%s\n' 'Commands: 100 (cached: 10, remote: 0, local: 90)' >"$sb/cold.log"
+  printf '%s\n' 'Commands: 100 (cached: 10, remote: 0, local: 90)' >"$sb/warm.log"
+  rc=0
+  out="$("$sb/check-cache-probe" "$sb/cold.log" "$sb/warm.log" 2>&1)" || rc=$?
+  check "cache probe: rejects a warm phase with no improvement" \
+    "$([ "$rc" -ne 0 ] && grep -Fq 'did not increase cache hits' <<<"$out" && echo 0 || echo 1)"
+
+  printf '%s\n' 'no Buck summary' >"$sb/warm.log"
+  rc=0
+  out="$("$sb/check-cache-probe" "$sb/cold.log" "$sb/warm.log" 2>&1)" || rc=$?
+  check "cache probe: rejects an unparseable summary" \
+    "$([ "$rc" -ne 0 ] && grep -Fq 'Could not parse' <<<"$out" && echo 0 || echo 1)"
+
+  rm -rf "$sb"
+}
+
 # An explicit heavy-suite shard must still prove that Buck discovered and
 # reported its assigned target; a green command with no result is a RUE-924
 # false green even when the target pattern was explicit.
@@ -861,6 +896,7 @@ test_rue_unit_zero_match_fails_loud
 test_rue_unit_failing_test_propagates_exit
 test_rue_unit_unknown_crate_errors_cleanly
 test_ci_timed_preserves_status_and_summarizes_actions
+test_cache_probe_counter_validation
 test_ci_heavy_suite_audits_its_target
 test_testsh_unfiltered_audits_corpus_presence
 test_sanitizer_defaults_std_path

--- a/toolchains/rust/BUCK
+++ b/toolchains/rust/BUCK
@@ -97,6 +97,14 @@ _OPT_FLAGS = select({
     "root//constraints:release": ["-Copt-level=3", "-Clto=thin"],
 })
 
+# The manual cache probe supplies a unique value for each workflow attempt so
+# its first build cannot reuse Rust actions populated by an earlier run. The
+# value is an otherwise-unused cfg, so it changes Rust action keys without
+# overriding the prelude's target-unique crate metadata. Ordinary builds leave
+# the setting empty and retain their existing flags and action keys (RUE-1034).
+_CACHE_PROBE_NONCE = read_root_config("rue", "cache_probe_nonce", "")
+_CACHE_PROBE_FLAGS = ['--cfg=rue_cache_probe_nonce="{}"'.format(_CACHE_PROBE_NONCE)] if _CACHE_PROBE_NONCE else []
+
 # macOS linker flags to work around Xcode linker bugs
 # The new ld-prime linker in Xcode 15+ has a bug where it crashes on very long
 # symbol names (ld: Assertion failed: name.size() <= maxLength).
@@ -180,7 +188,7 @@ hermetic_rust_toolchain(
     default_edition = "2024",
     deny_lints = ["warnings"],
     allow_lints = _CLIPPY_ALLOW,
-    rustc_flags = _OPT_FLAGS,
+    rustc_flags = _OPT_FLAGS + _CACHE_PROBE_FLAGS,
     visibility = ["PUBLIC"],
 )
 
@@ -192,7 +200,7 @@ hermetic_rust_toolchain(
     default_edition = "2024",
     deny_lints = ["warnings"],
     allow_lints = _CLIPPY_ALLOW,
-    rustc_flags = _OPT_FLAGS,
+    rustc_flags = _OPT_FLAGS + _CACHE_PROBE_FLAGS,
     visibility = ["PUBLIC"],
 )
 
@@ -204,7 +212,7 @@ hermetic_rust_toolchain(
     default_edition = "2024",
     deny_lints = ["warnings"],
     allow_lints = _CLIPPY_ALLOW,
-    rustc_flags = _OPT_FLAGS + _MACOS_LINKER_FLAGS,
+    rustc_flags = _OPT_FLAGS + _MACOS_LINKER_FLAGS + _CACHE_PROBE_FLAGS,
     visibility = ["PUBLIC"],
 )
 
@@ -216,7 +224,7 @@ hermetic_rust_toolchain(
     default_edition = "2024",
     deny_lints = ["warnings"],
     allow_lints = _CLIPPY_ALLOW,
-    rustc_flags = _OPT_FLAGS + _MACOS_LINKER_FLAGS,
+    rustc_flags = _OPT_FLAGS + _MACOS_LINKER_FLAGS + _CACHE_PROBE_FLAGS,
     visibility = ["PUBLIC"],
 )
 


### PR DESCRIPTION
## Summary
- give every cache-probe attempt a unique Rust action namespace using an otherwise-unused cfg
- validate cold and warm Buck counters in a tested helper script
- fail if the cold phase is already warm, the warm phase has no hits, or local work does not decrease
- document the stronger cold-to-warm proof

## Why
The shared cache can already contain the entire release graph. In that case the old workflow's nominal cold phase reports all hits and the workflow passes without proving that its first build uploaded anything reusable. Conversely, a historical run reported the same 360 local actions in both phases and still completed successfully.

The workflow now derives a nonce from `github.run_id` plus `github.run_attempt` and passes it to both builds. The Rust toolchain turns it into an unused `--cfg` value, changing Rust action keys without overriding the prelude's target-unique crate metadata. Ordinary builds omit the setting and keep their existing flags and keys.

## Validation
- wrapper-script suite: 73/73 checks
- cache-probe validator accepts a genuine conversion and rejects already-warm, no-improvement, and unparseable logs
- all 33 crate test targets passed with the cfg-based nonce (585 cache-disabled local actions)
- ordinary small build passed without the nonce; its rustc arguments contain no probe cfg
- pinned actionlint + ShellCheck: green
- after merge, a manual probe run will provide the authoritative remote upload/reuse measurement

Fixes RUE-1034
