### PR TITLE
RUE-1035: fix single-slot by-value, frame @raw, and array drop-glue compact miscompiles

### DIFF
--- a/crates/rue-air/src/call_abi.rs
+++ b/crates/rue-air/src/call_abi.rs
@@ -273,12 +273,26 @@ impl<'a> NativeCallAbi<'a> {
 
     /// The memory-first transitional rule (ADR-0052 ruling 9): under the compact
     /// layout, an aggregate whose compact representation is not slot-identical
-    /// cannot cross the preserved register convention and must go indirect.
+    /// cannot cross the preserved register convention and must go indirect —
+    /// *unless it occupies exactly one ABI slot* (RUE-1035).
+    ///
+    /// A single-slot aggregate carries its whole value in one eight-byte slot: a
+    /// narrow leaf lives in that slot's low bytes under both the compact image
+    /// and the slot-based frame, so one register transports it losslessly and the
+    /// callee's one-slot decomposition view is identical either way. Forcing such
+    /// a value indirect gained nothing and drove the not-yet-correct single-slot
+    /// indirect marshalling (garbage by-value args, RUE-1035 M1); classifying it
+    /// Direct instead routes it through the proven one-slot path — byte-for-byte
+    /// the same classification the gate-off slot model already produces for it, on
+    /// both backends and in the oracle. Returns stay consistent: a single-slot
+    /// aggregate return is `Registers { slot_count: 1 }` (never sret), so no
+    /// caller-side image read-back is implied.
     ///
     /// Always false with the gate off (`compact_layout()` is false), so every
     /// classification is byte-for-byte the historical slot decision.
     fn crosses_indirectly_under_compact(&self, ty: Type, slot_count: u32) -> bool {
         self.type_pool.compact_layout()
+            && slot_count > 1
             && self.is_multislot_aggregate(ty, slot_count)
             && !is_slot_identical_layout(self.type_pool, ty)
     }

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -253,6 +253,15 @@ pub struct CfgBuilder<'a> {
     anonymous_destructor_dependency_incomplete: bool,
 }
 
+/// Whether `fn_name` is a cleanup callee reached only through the direct
+/// flattened-slot drop convention (`CallPlan::from_slot_values`): synthesized
+/// drop glue (`__rue_drop_*`) or a user/anon destructor (`<Type>.__drop`).
+/// These reserved synthetic symbols cannot collide with a source function, and
+/// codegen already resolves the same names for cleanup calls (RUE-1035).
+fn is_cleanup_slot_callee(fn_name: &str) -> bool {
+    fn_name.starts_with("__rue_drop_") || fn_name.ends_with(".__drop")
+}
+
 /// Derive the grouped per-source-parameter ABI descriptors (ADR-0052 phase 5.8,
 /// RUE-1005) from the AIR and the per-slot by-reference vector.
 ///
@@ -273,6 +282,21 @@ fn derive_source_param_abi(builder: &CfgBuilder<'_>) -> Vec<SourceParamAbi> {
     let num_params = builder.cfg.num_params();
     let by_ref: Vec<bool> = builder.cfg.param_modes().to_vec();
     let abi = NativeCallAbi::for_arguments(type_pool);
+
+    // Drop glue and destructors are invoked exclusively through the cleanup
+    // call convention (`CallPlan::from_slot_values`), which passes an
+    // aggregate's already-materialized slots DIRECTLY and flattened (RUE-998 /
+    // RUE-311), never the ordinary indirect compact-aggregate transport
+    // (RUE-1005). Their by-value parameters must therefore home one incoming
+    // register per slot; letting the compact classifier force a multi-slot
+    // element parameter indirect (one pointer) desynchronizes the direct-slot
+    // caller from an indirect-unmarshalling callee and miscompiles — an array
+    // drop glue dereferenced its element values as addresses and overflowed the
+    // stack (RUE-1035 M3). These synthetic symbols are compiler-reserved
+    // (`__rue_drop_*` glue, `<Type>.__drop` destructors), so this is the same
+    // identity codegen already resolves them by. Gate-off the classifier is
+    // already Direct, so this is inert there.
+    let direct_slot_abi = is_cleanup_slot_callee(builder.cfg.fn_name());
 
     // Slot -> source type. `param_drops` covers every Normal by-value parameter
     // (including unused ones); `Param` instructions supplement any used
@@ -298,10 +322,15 @@ fn derive_source_param_abi(builder: &CfgBuilder<'_>) -> Vec<SourceParamAbi> {
             (1, 1, None)
         } else if let Some(&ty) = ty_at.get(&slot) {
             let width = type_pool.abi_slot_count(ty).max(1);
-            let crossing = abi
-                .classify_arg(ty, ArgConvention::ByValue)
-                .crossing_slots()
-                .max(1);
+            let crossing = if direct_slot_abi {
+                // Cleanup-slot callees receive every slot directly (see above),
+                // so the incoming-register width is the full decomposition.
+                width
+            } else {
+                abi.classify_arg(ty, ArgConvention::ByValue)
+                    .crossing_slots()
+                    .max(1)
+            };
             // Carry the type only when the parameter crosses indirectly (one
             // pointer over a multi-slot span), so a direct parameter's CFG stays
             // layout-independent.
@@ -3288,6 +3317,21 @@ mod tests {
 
     fn build_cfg(source: &str) -> Cfg {
         build_cfg_for(source, 0)
+    }
+
+    #[test]
+    fn cleanup_slot_callees_are_the_reserved_drop_symbols() {
+        // Drop glue and destructors are reached only through the direct
+        // flattened-slot cleanup convention, so their by-value params must home
+        // directly under compact layout (RUE-1035 M3).
+        assert!(is_cleanup_slot_callee("__rue_drop_D"));
+        assert!(is_cleanup_slot_callee("__rue_drop_array_D_3"));
+        assert!(is_cleanup_slot_callee("D.__drop"));
+        assert!(is_cleanup_slot_callee("__anon_struct_7.__drop"));
+        // Ordinary user functions keep the standard call ABI.
+        assert!(!is_cleanup_slot_callee("main"));
+        assert!(!is_cleanup_slot_callee("consume"));
+        assert!(!is_cleanup_slot_callee("drop_helper"));
     }
 
     /// Build the CFG for the `index`-th analyzed function in `source`

--- a/crates/rue-cli-tests/cases/aggregate_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout.toml
@@ -1121,3 +1121,114 @@ fn main() -> i32 {
 """ }]
 stdout = "0\n"
 exit_code = 0
+
+# --- RUE-1035: single-slot by-value, array drop glue, and frame @raw ---------
+# Three compact-codegen miscompiles reachable under --preview aggregate_layout,
+# each reproduced then fixed. M1/M3 now execute correctly across optimization
+# levels; M2 converts a silent miscompile into a loud construct-level refusal.
+
+# M1: a single-narrow-field struct passed BY VALUE. The classifier used to force
+# ANY non-slot-identical aggregate indirect; a one-slot struct went through the
+# not-yet-correct single-slot indirect marshalling and returned garbage
+# (nondeterministic). A single-slot compact aggregate now classifies Direct (its
+# whole value rides one register in the slot's low bytes), exactly as gate-off.
+[[case]]
+name = "compact_single_field_struct_by_value"
+description = "A single-i32-field struct passed by value returns its field, not garbage (RUE-1035 M1)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+fn c(d: D) -> i32 { d.v }
+fn main() -> i32 {
+    let d = D { v: 42 };
+    @dbg(c(d));
+    0
+}
+""" }]
+stdout = "42\n"
+exit_code = 0
+
+# M1 return side: a single-slot struct returned by value stays a one-register
+# `Registers` return (never sret), so no caller-side image read-back is implied.
+[[case]]
+name = "compact_single_field_struct_returned"
+description = "A single-i32-field struct returned by value round-trips (RUE-1035 M1, return side)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+fn mk() -> D { D { v: 7 } }
+fn main() -> i32 {
+    let d = mk();
+    @dbg(d.v);
+    0
+}
+""" }]
+stdout = "7\n"
+exit_code = 0
+
+# M3: drop glue over an array of a non-slot-identical struct with a destructor.
+# The array drop glue is called with the array's flattened slots DIRECTLY, but
+# its element parameters were classified indirect (RUE-1005) and dereferenced
+# their by-value element data as pointers, overflowing the stack. Cleanup-slot
+# callees now home every slot directly, matching the direct-slot drop call.
+[[case]]
+name = "compact_array_element_drop_glue"
+description = "Array-element drop glue over a struct with a destructor drops each element in order (RUE-1035 M3)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct D { a: i32, b: i32 }
+drop fn D(self) { @dbg(self.a); @dbg(self.b); }
+fn main() -> i32 {
+    let _arr: [D; 3] = [D{a:10,b:11}, D{a:20,b:21}, D{a:30,b:31}];
+    0
+}
+""" }]
+stdout = "10\n11\n20\n21\n30\n31\n"
+exit_code = 0
+
+# M2 (refuse): @raw_mut of a whole non-slot-identical FRAME struct. The frame
+# stores the struct slot-shaped while @ptr_write/@ptr_read address it by the
+# compact image, so a whole-value round trip scrambled the fields (printed
+# 5 0 7 40 60 9). Frames are not yet compact; the construct is refused loudly.
+[[case]]
+name = "compact_frame_raw_whole_struct_refused"
+description = "@raw_mut of a non-slot-identical frame struct is refused with a construct-level error (RUE-1035 M2)."
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct P { x: i32, y: i32, z: i32 }
+fn main() -> i32 {
+    let mut v: P = P { x: 5, y: 7, z: 9 };
+    checked {
+        let p: ptr mut P = @raw_mut(v);
+        @ptr_write(p, P { x: 40, y: 50, z: 60 });
+    };
+    @dbg(v.x);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["raw pointer", "frame-resident aggregate", "@alloc"]
+
+# M2 (refuse): @raw of an element of a non-slot-identical FRAME array. The frame
+# array strides 8 while @ptr_offset strides the compact size 4, so an element
+# walk read 0 instead of 20. Refused loudly; the heap alternative (@alloc) works.
+[[case]]
+name = "compact_frame_raw_array_element_refused"
+description = "@raw of a frame array element (a non-slot-identical array) is refused (RUE-1035 M2)."
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut arr: [i32; 3] = [10, 20, 30];
+    checked {
+        let base: ptr const i32 = @raw(arr[0]);
+        let p1: ptr const i32 = @ptr_offset(base, 1);
+        @dbg(@ptr_read(p1));
+    };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["raw pointer", "frame-resident aggregate"]

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -817,6 +817,90 @@ pub(crate) fn compact_physical_access_unsupported(
     None
 }
 
+/// Under the compact layout, an `@raw`/`@raw_mut`/`@field_ptr` pointer into a
+/// **frame** aggregate that would then be accessed as a whole non-slot-identical
+/// aggregate, or strided across a non-slot-identical array, is unsupported and
+/// must be refused loudly (RUE-1035 M2).
+///
+/// `@raw`-family intrinsics take the address of a place, whose base is always a
+/// frame local or a parameter (never a heap block — a `Place` base is only
+/// `Local`/`Param`). Frames stay slot-shaped (RUE-975): a struct/array/enum sits
+/// one eight-byte slot per leaf. But `@ptr_read`/`@ptr_write` address a whole
+/// aggregate by its packed *compact image*, and `@ptr_offset` strides by the
+/// compact element size. For a non-slot-identical aggregate the two disagree, so
+/// the raw pointer silently mixes representations. Exactly two shapes break:
+///
+/// - the pointer's **pointee is a non-slot-identical aggregate** (`@raw_mut(v)`
+///   of a whole struct/array): a whole-value round trip through it scrambles
+///   fields (M2a); and
+/// - the addressed place **indexes into a non-slot-identical array**
+///   (`@raw(arr[i])` of a frame array element): the resulting element pointer
+///   strides by the compact size while the frame array strides by the slot size
+///   (M2b).
+///
+/// Everything else stays allowed and correct: a **narrow scalar field** pointer
+/// (`@field_ptr(p.b)` → `ptr i32`) addresses the field's slot and hits its low
+/// bytes (RUE-989); a **bare scalar local** (`@raw_mut(n)` on `i32`) is not an
+/// aggregate; a **slot-identical** array/struct strides and round-trips
+/// identically to the slot model. Heap provenance is untouched: `@alloc` never
+/// flows through `@raw`, so every heap `@ptr_read`/`@ptr_write` round trip keeps
+/// working. Returns the offending frame aggregate type, or `None`.
+fn frame_raw_aggregate_pointer_unsupported(
+    cfg: &Cfg,
+    type_pool: &FrozenTypeInternPool,
+    interner: &ThreadedRodeo,
+) -> Option<Type> {
+    if !type_pool.compact_layout() {
+        return None;
+    }
+
+    let non_slot_identical_aggregate = |ty: Type| -> bool {
+        matches!(
+            ty.kind(),
+            TypeKind::Struct(_) | TypeKind::Array(_) | TypeKind::Enum(_)
+        ) && !is_slot_identical_layout(type_pool, ty)
+    };
+
+    for raw in 0..cfg.value_count() {
+        let value = CfgValue::from_raw(raw as u32);
+        let inst = cfg.get_inst(value);
+        let CfgInstData::Intrinsic { name, .. } = &inst.data else {
+            continue;
+        };
+        if !matches!(interner.resolve(name), "raw" | "raw_mut" | "field_ptr") {
+            continue;
+        }
+
+        // (a) The pointer addresses a whole non-slot-identical aggregate: reading
+        // or writing it through the pointer marshals the compact image against
+        // slot-shaped frame storage (M2a). A narrow scalar field pointer has a
+        // scalar pointee and is not caught here (RUE-989 handles it).
+        let pointee = pointee_or_self(type_pool, inst.ty);
+        if non_slot_identical_aggregate(pointee) {
+            return Some(pointee);
+        }
+
+        // (b) The addressed place indexes into a non-slot-identical frame array:
+        // the element pointer would stride by the compact element size while the
+        // frame array strides by the slot size (M2b). A field projection into a
+        // struct is not an array stride and stays allowed.
+        let Some(&operand) = cfg.get_intrinsic_args(&inst.data).first() else {
+            continue;
+        };
+        if let CfgInstData::PlaceRead { place } = &cfg.get_inst(operand).data {
+            for projection in cfg.get_place_projections(place) {
+                if let rue_cfg::Projection::Index { array_type, .. } = projection
+                    && non_slot_identical_aggregate(*array_type)
+                {
+                    return Some(*array_type);
+                }
+            }
+        }
+    }
+
+    None
+}
+
 /// Refuse code generation with a clear diagnostic when the compact physical
 /// layout is active but the function needs narrow physical memory access that is
 /// not yet implemented (see [`compact_physical_access_unsupported`]). Both
@@ -827,6 +911,25 @@ pub(crate) fn ensure_compact_layout_codegen_supported(
     type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
 ) -> rue_error::CompileResult<()> {
+    // A raw pointer into a non-slot-identical frame aggregate mixes the frame's
+    // slot layout with compact-image pointer semantics (RUE-1035 M2). Name the
+    // construct — not the preview — and point at the working heap alternative.
+    if let Some(ty) = frame_raw_aggregate_pointer_unsupported(cfg, type_pool, interner) {
+        let name = type_name(ty, type_pool);
+        return Err(rue_error::CompileError::without_span(
+            rue_error::ErrorKind::InternalCodegenError(format!(
+                "taking a raw pointer with `@raw`/`@raw_mut`/`@field_ptr` into the \
+                 frame-resident aggregate `{name}` (in function `{}`) is not supported: the \
+                 stack frame stores the aggregate slot-shaped (one eight-byte slot per leaf), \
+                 while `@ptr_read`/`@ptr_write`/`@ptr_offset` address memory by its packed \
+                 compact image, so the pointer would stride across mismatched field and element \
+                 layouts. Allocate the aggregate on the heap with `@alloc`, whose storage is the \
+                 compact image, to round-trip it through a raw pointer.",
+                cfg.fn_name()
+            )),
+        ));
+    }
+
     if let Some(ty) = compact_physical_access_unsupported(cfg, type_pool, interner) {
         let name = type_name(ty, type_pool);
         return Err(rue_error::CompileError::without_span(


### PR DESCRIPTION
## Summary

The three miscompiles the RUE-987 flip attempt exposed — all reachable today under `--preview aggregate_layout`, none covered by the gated corpus until now. Each was reproduced first, then fixed, then proven. Gate-off is byte-identical.

- **M1** (single-narrow-field struct by value → nondeterministic garbage): fixed at the classifier authority — a single-slot aggregate now classifies `Direct`, exactly its gate-off classification; symmetric args/returns, shared by both backends and the oracle. Verified: 42 across five consecutive runs (previously 240/16/144/208/0).
- **M2** (`@raw` of non-slot-identical *frame* aggregates mixing slot storage with compact-image pointer semantics): chose the **loud refusal**, provenance-precise so `@alloc` heap pointers (where the compact image is real) are untouched; the diagnostic names the construct and points at `@alloc`. A silent miscompile becomes a loud error until frames go compact.
- **M3** (array-element drop glue over such structs → stack overflow): cleanup callees (`__rue_drop_*`) now home every slot directly instead of dereferencing by-value data as indirect pointers. The repro prints its six drop values in order.

This unblocks the parked RUE-987 flip, which re-runs on top of this base.

## Verification

Five new gated CLI regression cases + a cfg unit test; four representative move-semantics/destructor spec programs hand-run green under the gate. cli `aggregate_layout` 52, `std_sweep` 9, `aggregate_slots` 38, `abi` 59; spec 2138; air 502, codegen 589; both oracle-diff audits green; full `test.sh` green except the four known uid-0 environmental failures, both harness failure formats checked. M1/M3 re-verified by execution at integration.

Fixes RUE-1035

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_