### PR TITLE
RUE-774: derive --emit stack-frame AArch64 layout from the emitter

### DIFF
--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -627,7 +627,6 @@ impl<'a> Emitter<'a> {
             Reg::X6,
             Reg::X7,
         ];
-        let callee_saved_size = self.callee_saved_stack_size();
         let abi_shift = self.has_sret as u32;
         // Home incoming argument registers into the frame parameter area. Each
         // source parameter consumes `reg_count` consecutive incoming registers
@@ -643,8 +642,11 @@ impl<'a> Emitter<'a> {
                 // slots): CfgLower generated the body's param reads against the
                 // pre-spill count. (RUE-129)
                 let slot = self.num_locals_original + homing.start_slot + k;
-                // Skip past callee-saved registers in the offset calculation
-                let offset = -callee_saved_size + crate::frame_layout::slot_offset_pre_saved(slot);
+                // Slot location past the callee-saved area — the single
+                // AArch64 authority shared with the `--emit stackframe`
+                // reporter (RUE-774).
+                let offset =
+                    crate::frame_layout::aarch64_slot_offset(self.callee_saved.len(), slot);
 
                 if abi_index < param_regs.len() {
                     self.begin_inst();
@@ -669,7 +671,7 @@ impl<'a> Emitter<'a> {
         // loads it back to store the result through.
         if self.has_sret {
             let slot = self.num_locals_original + self.num_params;
-            let offset = -callee_saved_size + crate::frame_layout::slot_offset_pre_saved(slot);
+            let offset = crate::frame_layout::aarch64_slot_offset(self.callee_saved.len(), slot);
             self.begin_inst();
             self.emit_str(param_regs[0], Reg::Fp, offset);
             end_inst!(self, "str {}, [x29, #{}] ; sret ptr", param_regs[0], offset);

--- a/crates/rue-codegen/src/frame_layout.rs
+++ b/crates/rue-codegen/src/frame_layout.rs
@@ -53,6 +53,34 @@ pub fn slot_region_bytes(num_slots: u32) -> i32 {
     frame_cell_bytes() as i32 * num_slots as i32
 }
 
+/// FP-relative byte offset of frame slot `slot` on AArch64, matching the
+/// backend prologue exactly.
+///
+/// AArch64 sets its frame pointer *at* the saved FP/LR pair
+/// (`stp x29, x30, [sp, #-16]!; mov x29, sp`), so the FP/LR bytes sit at and
+/// above `fp`; only the callee-saved pair region lies between `fp` and the slot
+/// region. Unlike [`FrameLayout::slot_offset`], the FP/LR 16 bytes are therefore
+/// *not* subtracted here. The emitter's parameter homing / sret store and the
+/// `--emit stackframe` reporter both derive slot locations from this one
+/// function so they cannot drift (RUE-774).
+#[inline]
+pub fn aarch64_slot_offset(num_callee_saved: usize, slot: u32) -> i32 {
+    -(aarch64_callee_saved_pairs_bytes(num_callee_saved) as i32) + slot_offset_pre_saved(slot)
+}
+
+/// FP-relative byte offset of the low register of callee-saved pair
+/// `pair_index` (0-based) on AArch64.
+///
+/// The prologue stores the first pair at `[fp, #-16]` via `stp .., [sp, #-16]!`
+/// (after `fp` is set) and each subsequent pair another 16 bytes down; the high
+/// register of a pair sits 8 bytes above this offset, and a trailing odd
+/// register occupies the low half of the next 16-byte pair slot. Shared by the
+/// emitter's prologue and the `--emit stackframe` reporter (RUE-774).
+#[inline]
+pub fn aarch64_callee_saved_pair_offset(pair_index: usize) -> i32 {
+    -(STACK_FRAME_ALIGNMENT as i32) * (pair_index as i32 + 1)
+}
+
 /// Round a frame byte size up to [`STACK_FRAME_ALIGNMENT`].
 #[inline]
 pub fn align_frame_size(bytes: i32) -> i32 {
@@ -197,6 +225,33 @@ mod tests {
         // saved = 8, slots = 16 -> round16(24) = 32.
         assert_eq!(layout.frame_size(), 32);
         assert_eq!(layout.slot_offset(0), -8 - 8);
+    }
+
+    #[test]
+    fn aarch64_slot_offset_excludes_the_fp_lr_pair() {
+        // The emitter homes slots at `-callee_saved_pairs_bytes + -(slot+1)*8`;
+        // the FP/LR 16 is NOT subtracted (FP points at the FP/LR save). These
+        // are the offsets observed in gcd's emitted prologue (4 callee-saved
+        // regs -> 32 pair bytes): locals at -40/-48/-56, params at -64/-72.
+        assert_eq!(aarch64_slot_offset(4, 0), -40);
+        assert_eq!(aarch64_slot_offset(4, 1), -48);
+        assert_eq!(aarch64_slot_offset(4, 2), -56);
+        assert_eq!(aarch64_slot_offset(4, 3), -64);
+        assert_eq!(aarch64_slot_offset(4, 4), -72);
+        // No callee-saved registers: only the slot region sits below FP.
+        assert_eq!(aarch64_slot_offset(0, 0), -8);
+        assert_eq!(aarch64_slot_offset(0, 1), -16);
+        // Odd callee-saved count still reserves a full 16-byte pair slot.
+        assert_eq!(aarch64_slot_offset(1, 0), -16 - 8);
+        assert_eq!(aarch64_slot_offset(3, 0), -32 - 8);
+    }
+
+    #[test]
+    fn aarch64_callee_saved_pairs_descend_from_minus_sixteen() {
+        // First pair at [fp -16]/[fp -8], each subsequent pair another 16 down.
+        assert_eq!(aarch64_callee_saved_pair_offset(0), -16);
+        assert_eq!(aarch64_callee_saved_pair_offset(1), -32);
+        assert_eq!(aarch64_callee_saved_pair_offset(2), -48);
     }
 
     #[test]

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -448,39 +448,46 @@ fn generate_aarch64_stack_frame(
     );
     let frame_size = frame.frame_size() as usize;
 
-    // FP and LR are saved separately (16 bytes) at the very top of the frame.
-    let fp_lr_size = 16;
+    // Every FP-relative location below is derived from the same frame-layout
+    // authority the emitter uses (RUE-774), so the reported slots match the
+    // prologue/body instructions exactly. AArch64 sets FP *at* the saved FP/LR
+    // pair, so the FP/LR bytes sit at and above FP and are not part of the
+    // below-FP saved area — only the callee-saved pairs are.
+    use crate::frame_layout::{aarch64_callee_saved_pair_offset, aarch64_slot_offset};
+    let num_callee_saved = used_callee_saved.len();
+    let slot_offset = |slot: u32| aarch64_slot_offset(num_callee_saved, slot);
 
     let mut slots = Vec::new();
 
-    // Add callee-saved registers (in pairs, starting after FP/LR save area)
-    // Note: FP/LR are at [SP, #-16]! at the very top of the frame
-    let mut reg_offset = -(fp_lr_size as i32); // Start after FP/LR
+    // Callee-saved registers, stored in pairs by the prologue starting at
+    // `[fp -16]`; a trailing odd register occupies the low half of the next
+    // pair slot.
     let mut i = 0;
-    while i + 1 < used_callee_saved.len() {
-        reg_offset -= 16;
+    let mut pair_index = 0;
+    while i + 1 < num_callee_saved {
+        let base = aarch64_callee_saved_pair_offset(pair_index);
         slots.push(StackSlot {
             name: Some(format!("saved {}", used_callee_saved[i])),
-            offset: reg_offset,
+            offset: base,
             size: 8,
             ty: "i64".to_string(),
             kind: StackSlotKind::CalleeSaved,
         });
         slots.push(StackSlot {
             name: Some(format!("saved {}", used_callee_saved[i + 1])),
-            offset: reg_offset + 8,
+            offset: base + 8,
             size: 8,
             ty: "i64".to_string(),
             kind: StackSlotKind::CalleeSaved,
         });
         i += 2;
+        pair_index += 1;
     }
     // Handle odd register
-    if i < used_callee_saved.len() {
-        reg_offset -= 16;
+    if i < num_callee_saved {
         slots.push(StackSlot {
             name: Some(format!("saved {}", used_callee_saved[i])),
-            offset: reg_offset,
+            offset: aarch64_callee_saved_pair_offset(pair_index),
             size: 8,
             ty: "i64".to_string(),
             kind: StackSlotKind::CalleeSaved,
@@ -491,7 +498,7 @@ fn generate_aarch64_stack_frame(
     for i in 0..num_locals {
         slots.push(StackSlot {
             name: None,
-            offset: frame.slot_offset(i),
+            offset: slot_offset(i),
             size: frame.slot_size(i) as usize,
             ty: "i64".to_string(),
             kind: StackSlotKind::Local,
@@ -504,7 +511,7 @@ fn generate_aarch64_stack_frame(
         let slot = num_locals + i;
         slots.push(StackSlot {
             name: None,
-            offset: frame.slot_offset(slot),
+            offset: slot_offset(slot),
             size: frame.slot_size(slot) as usize,
             ty: "i64".to_string(),
             kind: StackSlotKind::Parameter,
@@ -516,7 +523,7 @@ fn generate_aarch64_stack_frame(
         let slot = num_locals + num_params;
         slots.push(StackSlot {
             name: Some("sret ptr".to_string()),
-            offset: frame.slot_offset(slot),
+            offset: slot_offset(slot),
             size: frame.slot_size(slot) as usize,
             ty: "ptr".to_string(),
             kind: StackSlotKind::Parameter,
@@ -528,7 +535,7 @@ fn generate_aarch64_stack_frame(
         let slot = num_locals + num_params + sret_slots + i;
         slots.push(StackSlot {
             name: None,
-            offset: frame.slot_offset(slot),
+            offset: slot_offset(slot),
             size: frame.slot_size(slot) as usize,
             ty: "i64".to_string(),
             kind: StackSlotKind::Spill,
@@ -656,5 +663,125 @@ mod tests {
         assert!(output.contains("saved rbx"));
         assert!(output.contains("rdi"));
         assert!(output.contains("rax"));
+    }
+
+    /// Compile a Rue function to a validated CFG for the codegen tests.
+    fn compile_named_fn(
+        source: &str,
+        name: &str,
+    ) -> (rue_cfg::ValidatedCfg, FrozenTypeInternPool, ThreadedRodeo) {
+        use rue_air::Sema;
+        use rue_error::PreviewFeatures;
+        use rue_lexer::Lexer;
+        use rue_parser::Parser;
+        use rue_rir::AstGen;
+
+        let (tokens, interner) = Lexer::new(source).tokenize().unwrap();
+        let (ast, mut interner) = Parser::new(tokens, interner).parse().unwrap();
+        let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
+        astgen.append_items(&ast.items);
+        let rir = astgen.finish();
+        let output = Sema::new_synthetic(&rir, &mut interner, PreviewFeatures::new())
+            .analyze_all()
+            .unwrap();
+        let func = output
+            .functions
+            .iter()
+            .find(|f| f.name == name)
+            .expect("requested test function should exist");
+        let cfg = CfgBuilder::build(
+            &func.air,
+            func.num_locals,
+            func.num_param_slots,
+            &func.name,
+            &output.type_pool,
+            func.param_modes.clone(),
+            &interner,
+            func.allow_unreachable_code,
+        )
+        .cfg
+        .expect("test function CFG must build");
+        (cfg, output.type_pool, interner)
+    }
+
+    /// RUE-774: the reported AArch64 slots must match the offsets in the emitted
+    /// prologue/body. `gcd`'s iterative body forces callee-saved registers and
+    /// homes both parameters, so it exercises callee-saved, local, and parameter
+    /// slots together.
+    #[test]
+    fn aarch64_reported_slots_match_emitted_instructions() {
+        let source = "\
+fn gcd(a: i32, b: i32) -> i32 {
+    let mut x = a;
+    let mut y = b;
+    while y != 0 {
+        let temp = y;
+        y = x % y;
+        x = temp;
+    }
+    x
+}
+
+fn main() -> i32 {
+    gcd(1071, 462)
+}
+";
+        let (cfg, type_pool, interner) = compile_named_fn(source, "gcd");
+        let target = Target::Aarch64Linux;
+
+        let info = generate_stack_frame_info(&cfg, "gcd", &type_pool, &interner, target).unwrap();
+        let (_machine_code, asm) =
+            crate::aarch64::generate_with_asm(&cfg, &type_pool, &[], &interner, target).unwrap();
+
+        // Parameters are homed into the frame by explicit `str x*, [x29, #N]`
+        // prologue stores; every reported parameter slot must appear at that
+        // exact FP-relative offset in the emitted assembly.
+        let params: Vec<i32> = info
+            .slots
+            .iter()
+            .filter(|s| s.kind == StackSlotKind::Parameter)
+            .map(|s| s.offset)
+            .collect();
+        assert_eq!(params.len(), 2, "gcd homes two parameters");
+        for offset in &params {
+            let needle = format!("[x29, #{offset}]");
+            assert!(
+                asm.contains(&needle),
+                "reported parameter slot at fp{offset} is not homed at that offset in:\n{asm}"
+            );
+        }
+
+        // Callee-saved registers are pushed in `stp .., [sp, #-16]!` pairs after
+        // the FP/LR pair; the reported count must match the emitted pushes and
+        // the first pair must land at [fp -16] (the pre-RUE-774 bug reported
+        // [fp -32]).
+        let saved: Vec<i32> = info
+            .slots
+            .iter()
+            .filter(|s| s.kind == StackSlotKind::CalleeSaved)
+            .map(|s| s.offset)
+            .collect();
+        assert!(
+            !saved.is_empty(),
+            "gcd must allocate callee-saved registers"
+        );
+        assert_eq!(saved[0], -16, "first callee-saved slot must be at [fp -16]");
+        let predecrement_pushes = asm.matches("[sp, #-16]!").count();
+        let callee_saved_pairs = saved.len().div_ceil(2);
+        assert_eq!(
+            predecrement_pushes,
+            1 + callee_saved_pairs,
+            "one FP/LR push plus one push per callee-saved pair must be emitted"
+        );
+
+        // Nothing should still be reported below the frame's own size.
+        for slot in &info.slots {
+            assert!(
+                slot.offset >= -(info.frame_size as i32),
+                "slot offset {} escapes the {}-byte frame",
+                slot.offset,
+                info.frame_size
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

`generate_aarch64_stack_frame` reconstructed the frame layout with its own
formula and reported every non-positive FP-relative slot **16 bytes too low**:

- it started the callee-saved offset at `-fp_lr_size` and subtracted another 16
  before recording the first pair, and
- it read slot offsets from `FrameLayout::slot_offset`, which subtracts the
  FP/LR pair — but AArch64 sets FP *at* that pair (`stp x29, x30, [sp, #-16]!;
  mov x29, sp`), so the FP/LR bytes sit at and above FP, not between FP and the
  slots.

So `gcd` reported its first saved pair at `[fp -32]` and parameters at
`[fp -80]`, while the emitter saves them at `[fp -16]` and `[fp -64]`.

## Changes

- Add the AArch64 offset authority the emitter already implied to
  `frame_layout`:
  - `aarch64_slot_offset(num_callee_saved, slot)` — callee-saved pairs only, no
    FP/LR subtraction.
  - `aarch64_callee_saved_pair_offset(pair_index)` — first pair at `[fp -16]`,
    descending by 16.
- The emitter's parameter/sret homing (`aarch64/emit.rs`) and the
  `--emit stackframe` reporter now both derive their offsets from these
  functions, so presentation and emission cannot drift. The emitter change is
  byte-identical (it already computed `-callee_saved_pairs_bytes +
  slot_offset_pre_saved`).
- x86-64 presentation is unchanged (it still uses `FrameLayout::slot_offset`,
  which is correct there).

## Testing

- End-to-end: `rue --target aarch64-linux --emit stackframe examples/gcd.rue`
  now reports callee-saved at `[fp -16]/[fp -8]/[fp -32]/[fp -24]`, locals at
  `[fp -40/-48/-56]`, and params at `[fp -64/-72]` — matching the emitted
  prologue/body exactly.
- New `frame_layout` unit tests for both helpers (odd and even callee-saved
  sets, zero callee-saved).
- New parity test (`aarch64_reported_slots_match_emitted_instructions`):
  compiles `gcd`, then asserts each reported parameter slot appears as a
  `[x29, #N]` home store in the emitted asm and that the callee-saved slot count
  and first offset match the emitted `stp .., [sp, #-16]!` pushes.
- `./buck2 test //crates/rue-codegen:rue-codegen-test` → 592 passed.

Both AArch64 targets share this presentation path; x86-64 behavior is preserved.

Fixes RUE-774


---
_Generated by [Claude Code](https://claude.ai/code/session_016y4YDUmk7Gcbo1nKaXiXFR)_