### PR TITLE
RUE-1023: add demand-driven import input protocol

### DIFF
--- a/crates/rue-compiler-session-bench/src/representative.rs
+++ b/crates/rue-compiler-session-bench/src/representative.rs
@@ -6,11 +6,15 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use rue_compiler::unstable::{DiscoverySourceAssembler, committed_import_discovery};
+use rue_compiler::unstable::{
+    DiscoverySourceAssembler, ImportDemandMode, begin_import_input_request,
+    committed_import_discovery, import_demand_frontier, import_observation_ledger,
+    publish_import_observation_batch,
+};
 use rue_compiler::{
     AcceptedImportSource, AcceptedReadManifestEntry, CompileOptions, CompilerSession,
-    FileMetadataFingerprint, ImportDiscoveryContext, ImportObservation, ImportObservationLedger,
-    PhysicalFileIdentity, SemanticView, SourceSnapshot,
+    FileMetadataFingerprint, ImportDiscoveryContext, ImportObservation, PhysicalFileIdentity,
+    SemanticView, SourceSnapshot,
 };
 use serde_json::{Value, json};
 
@@ -140,8 +144,15 @@ fn close_discovery(session: &mut CompilerSession, source: &SourceSnapshot) {
         .collect::<BTreeMap<_, _>>();
     let (discovered, context, accepted_reads) = assemble(&sources);
     assert_eq!(discovered.source_revision(), source.source_revision());
-    let mut ledger = ImportObservationLedger::default();
+    let mut revision = begin_import_input_request(
+        session,
+        &discovered,
+        context.clone(),
+        accepted_reads.clone(),
+    )
+    .unwrap();
     loop {
+        let ledger = import_observation_ledger(session, revision).unwrap();
         let plan = session
             .stage_import_discovery(
                 &discovered,
@@ -150,33 +161,46 @@ fn close_discovery(session: &mut CompilerSession, source: &SourceSnapshot) {
                 ledger.clone(),
             )
             .unwrap();
-        let pending = plan.pending_requests(&ledger);
-        if pending.is_empty() {
+        let frontier =
+            import_demand_frontier(session, revision, &plan, ImportDemandMode::Rooted).unwrap();
+        if frontier.requests().is_empty() {
+            session.close_import_discovery(ledger).unwrap();
             break;
         }
-        for request in pending {
-            let requested_path = request.requested_path().to_owned();
-            let observation = if let Some(source) = sources.get(&requested_path) {
-                let identity = identity_for_path(&requested_path);
-                ImportObservation::accepted(
-                    request,
-                    AcceptedImportSource::new(
-                        requested_path.as_str(),
-                        requested_path.as_str(),
-                        PhysicalFileIdentity::new(901, identity),
-                        FileMetadataFingerprint::new(source.len() as u64, 0, identity),
-                        source.clone(),
+        let observations = frontier
+            .requests()
+            .iter()
+            .cloned()
+            .map(|request| {
+                let requested_path = request.requested_path().to_owned();
+                if let Some(source) = sources.get(&requested_path) {
+                    let identity = identity_for_path(&requested_path);
+                    ImportObservation::accepted(
+                        request,
+                        AcceptedImportSource::new(
+                            requested_path.as_str(),
+                            requested_path.as_str(),
+                            PhysicalFileIdentity::new(901, identity),
+                            FileMetadataFingerprint::new(source.len() as u64, 0, identity),
+                            source.clone(),
+                        )
+                        .unwrap(),
                     )
-                    .unwrap(),
-                )
-                .unwrap()
-            } else {
-                ImportObservation::absent(request)
-            };
-            ledger.record(observation).unwrap();
-        }
+                    .unwrap()
+                } else {
+                    ImportObservation::absent(request)
+                }
+            })
+            .collect();
+        revision = publish_import_observation_batch(
+            session,
+            &frontier,
+            &discovered,
+            accepted_reads.clone(),
+            observations,
+        )
+        .unwrap();
     }
-    session.close_import_discovery(ledger).unwrap();
 }
 
 fn measured_project_semantic(

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -724,15 +724,15 @@ fn root_export_metadata(owner: &str, symbol: &str) -> (&'static str, &'static st
         },
         "import_discovery" => match symbol {
             "AcceptedImportSource"
-            | "AcceptedReadManifestEntry"
-            | "FileMetadataFingerprint"
-            | "ImportCandidateRole"
-            | "ImportDiscoveryContext"
             | "ImportDiscoveryPlan"
             | "ImportDiscoveryRequest"
             | "ImportObservation"
             | "ImportObservationLedger"
-            | "ImportObservationStatus"
+            | "ImportObservationStatus" => ("compatibility-boundary", "legacy-embedders"),
+            "AcceptedReadManifestEntry"
+            | "FileMetadataFingerprint"
+            | "ImportCandidateRole"
+            | "ImportDiscoveryContext"
             | "ImportOccurrenceKey"
             | "PhysicalFileIdentity" => ("dependency-artifact", "source-loaders+embedders"),
             _ => panic!("unclassified import-discovery facade export: {symbol}"),
@@ -851,8 +851,9 @@ fn session_method_metadata(
         }
     } else {
         match symbol {
-            "new" | "update" | "stage_import_discovery" | "close_import_discovery" => {
-                "session-operation"
+            "new" | "update" => "session-operation",
+            "import_discovery_plan" | "stage_import_discovery" | "close_import_discovery" => {
+                return ("stable", "compatibility-boundary", "legacy-embedders");
             }
             "published"
             | "committed_import_graph"
@@ -861,7 +862,6 @@ fn session_method_metadata(
             | "rir"
             | "semantic"
             | "executable" => "artifact-query",
-            "import_discovery_plan" => "dependency-query",
             "latest_diagnostics"
             | "latest_successful_diagnostics"
             | "last_good_semantic_diagnostics" => "diagnostic-query",
@@ -1314,9 +1314,9 @@ fn unstable_views_do_not_alias_query_engine_records() {
         reexports,
         [
             "pubusecrate::diagnostic::{ColorChoice,DiagnosticFormatter,JsonDiagnostic,JsonDiagnosticFormatter,JsonSpan,JsonSuggestion,MultiFileFormatter,MultiFileJsonFormatter,SourceInfo,};",
-            "pubusecrate::import_discovery::DiscoverySourceAssembler;",
+            "pubusecrate::import_discovery::{DiscoverySourceAssembler,ImportDemandFrontier,ImportDemandMode,ImportDemandRoots,ImportInputRevision,};",
         ],
-        "unstable may reexport only reviewed presentation and source-assembly helpers"
+        "unstable may reexport only reviewed presentation, source-assembly, and Phase-2 demand helpers"
     );
 
     let facade = include_str!("lib.rs");

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -1,8 +1,10 @@
 //! Compiler-owned import discovery protocol.
 //!
-//! Candidate policy is pure compiler state. Hosts execute only requests returned
-//! by [`ImportDiscoveryPlan::pending_requests`] and report typed observations;
-//! they never recognize imports or choose resolution precedence.
+//! Candidate policy is pure compiler state. Rooted consumers ask the revisioned
+//! database for an import demand frontier, execute that exact ordered batch,
+//! and publish typed observations into an immutable successor revision. Hosts
+//! never recognize imports or choose resolution precedence. Plans remain a
+//! whole-graph compatibility projection for diagnostics and closure.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Component, Path, PathBuf};
@@ -144,10 +146,57 @@ impl ImportDiscoveryRequest {
     pub fn role(&self) -> ImportCandidateRole {
         self.role
     }
+
+    pub(crate) fn runtime_input_key(&self) -> Arc<str> {
+        fn field(output: &mut String, value: &str) {
+            use std::fmt::Write as _;
+            write!(output, "{}:{value}", value.len()).unwrap();
+        }
+        use std::fmt::Write as _;
+        let mut key = String::new();
+        write!(
+            key,
+            "v1:{}:{}:{}:{}:{}:",
+            self.context.epoch,
+            self.occurrence.source_offset,
+            self.occurrence.source_end,
+            self.group,
+            self.position
+        )
+        .unwrap();
+        field(&mut key, self.context.project_root());
+        field(&mut key, self.context.std_root().unwrap_or(""));
+        field(&mut key, self.context.read_policy_revision());
+        field(&mut key, self.occurrence.importer().as_str());
+        field(&mut key, self.exact_specifier());
+        field(&mut key, self.normalized_specifier());
+        field(&mut key, self.importer_anchor());
+        field(&mut key, self.root_anchor());
+        field(&mut key, self.requested_path());
+        field(
+            &mut key,
+            match self.role {
+                ImportCandidateRole::ExactFile => "exact-file",
+                ImportCandidateRole::FileModule => "file-module",
+                ImportCandidateRole::DirectoryFacade => "directory-facade",
+                ImportCandidateRole::StandardLibraryFacade => "standard-library-facade",
+            },
+        );
+        key.into()
+    }
 }
+
+// RUE-1033 DELETION/REPLACEMENT GATE: retire the entire legacy supported
+// host-driven import path together once a freshness- and speculation-safe
+// replacement is stable. Its exact public bypass surface is inventoried by
+// `legacy_import_authority_is_one_explicit_compatibility_boundary`.
 
 /// Result of one host transaction. Denial and absence are intentionally
 /// distinct from an accepted source read.
+///
+/// Public construction participates in the legacy RUE-1033 compatibility
+/// boundary. New consumers must use the unstable begin/frontier/publish
+/// protocol and construct statuses only for requests emitted by its frontier.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ImportObservationStatus {
     Absent,
@@ -225,6 +274,9 @@ impl ImportObservationStatus {
 }
 
 /// Accepted source bytes paired with their transaction observation.
+///
+/// Public construction participates in the legacy RUE-1033 compatibility
+/// boundary and is not independently freshness- or speculation-safe.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AcceptedImportSource {
     requested_path: Arc<str>,
@@ -236,6 +288,11 @@ pub struct AcceptedImportSource {
 }
 
 impl AcceptedImportSource {
+    /// Construct legacy host-observed source evidence.
+    ///
+    /// This constructor is part of the RUE-1033 compatibility boundary. New
+    /// consumers may use it only while answering a request emitted by the
+    /// unstable canonical frontier protocol.
     pub fn new(
         requested_path: impl Into<Arc<str>>,
         canonical_path: impl Into<Arc<str>>,
@@ -283,6 +340,10 @@ pub struct ImportObservation {
 }
 
 impl ImportObservation {
+    /// Construct a legacy absence observation.
+    ///
+    /// This is part of the RUE-1033 compatibility boundary and carries no
+    /// independent freshness authority.
     pub fn absent(request: ImportDiscoveryRequest) -> Self {
         Self {
             request,
@@ -290,6 +351,10 @@ impl ImportObservation {
             accepted_source: None,
         }
     }
+    /// Construct a legacy accepted-source observation.
+    ///
+    /// This is part of the RUE-1033 compatibility boundary and carries no
+    /// independent freshness authority.
     pub fn accepted(
         request: ImportDiscoveryRequest,
         source: AcceptedImportSource,
@@ -310,6 +375,10 @@ impl ImportObservation {
             accepted_source: Some(source),
         })
     }
+    /// Construct a legacy terminal-failure observation.
+    ///
+    /// This is part of the RUE-1033 compatibility boundary and carries no
+    /// independent freshness authority.
     pub fn failure(
         request: ImportDiscoveryRequest,
         status: ImportObservationStatus,
@@ -337,13 +406,37 @@ impl ImportObservation {
     pub fn accepted_source(&self) -> Option<&AcceptedImportSource> {
         self.accepted_source.as_ref()
     }
+
+    pub(crate) fn fanout_to(&self, request: ImportDiscoveryRequest) -> CompileResult<Self> {
+        if request.context() != self.request.context()
+            || request.requested_path() != self.request.requested_path()
+        {
+            return Err(invalid_input(
+                "one host import result can fan out only to the same candidate operation",
+            ));
+        }
+        Ok(Self {
+            request,
+            status: self.status.clone(),
+            accepted_source: self.accepted_source.clone(),
+        })
+    }
 }
 
 /// Deterministically ordered observations from one immutable epoch.
+///
+/// Public `Default` construction and mutation are retained only for the
+/// RUE-1033 legacy compatibility boundary. A freely constructed ledger is not
+/// freshness- or speculation-safe and must not seed a new canonical request.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct ImportObservationLedger(BTreeMap<ImportDiscoveryRequest, ImportObservation>);
 
 impl ImportObservationLedger {
+    /// Record legacy host evidence.
+    ///
+    /// This mutator is part of the RUE-1033 compatibility boundary. New
+    /// consumers publish compiler-ordered batches through the unstable
+    /// canonical protocol instead.
     pub fn record(&mut self, observation: ImportObservation) -> CompileResult<()> {
         let request = observation.request.clone();
         if let Some(previous) = self.0.get(&request) {
@@ -368,6 +461,94 @@ impl ImportObservationLedger {
     }
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+}
+
+/// Authority allowed to expose missing external-input requests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ImportDemandMode {
+    /// Observable rooted work may emit one ordered host batch.
+    Rooted,
+    /// Speculative work may consume existing leaves but never emit demands.
+    Speculative,
+}
+
+/// Opaque immutable input revision for one discovery request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ImportInputRevision {
+    pub(crate) revision_id: u64,
+    pub(crate) request_generation: u64,
+    pub(crate) frontier_round: u64,
+}
+
+impl ImportInputRevision {
+    /// Runtime revision publication identity.
+    pub fn id(self) -> u64 {
+        self.revision_id
+    }
+    /// Number of rooted host batches published since the initial request view.
+    pub fn frontier_round(self) -> u64 {
+        self.frontier_round
+    }
+}
+
+/// One compiler-produced, deduplicated external-input frontier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportDemandFrontier {
+    pub(crate) revision: ImportInputRevision,
+    pub(crate) mode: ImportDemandMode,
+    pub(crate) requests: Arc<[ImportDiscoveryRequest]>,
+    /// Per-operation occurrence requests receiving the representative host
+    /// result. Aligned one-to-one with `requests`.
+    pub(crate) fanout: Arc<[Arc<[ImportDiscoveryRequest]>]>,
+    pub(crate) speculative_blocked: bool,
+}
+
+impl ImportDemandFrontier {
+    pub fn revision(&self) -> ImportInputRevision {
+        self.revision
+    }
+    pub fn mode(&self) -> ImportDemandMode {
+        self.mode
+    }
+    /// Exact compiler policy order the host must preserve in its result batch.
+    pub fn requests(&self) -> &[ImportDiscoveryRequest] {
+        &self.requests
+    }
+    /// Whether speculation encountered absent leaves and parked without a host
+    /// request or publishable missing-input failure.
+    pub fn speculative_blocked(&self) -> bool {
+        self.speculative_blocked
+    }
+}
+
+/// Exact parser-owned import occurrences demanded by canonical query
+/// consumers. This type performs no reachability inference.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ImportDemandRoots {
+    occurrences: Arc<[ImportOccurrenceKey]>,
+}
+
+impl ImportDemandRoots {
+    pub fn new(occurrences: impl IntoIterator<Item = ImportOccurrenceKey>) -> Self {
+        let mut occurrences = occurrences.into_iter().collect::<Vec<_>>();
+        occurrences.sort();
+        occurrences.dedup();
+        Self {
+            occurrences: occurrences.into(),
+        }
+    }
+
+    pub fn occurrences(&self) -> &[ImportOccurrenceKey] {
+        &self.occurrences
+    }
+
+    pub(crate) fn whole_plan(plan: &ImportDiscoveryPlan) -> Self {
+        Self::new(
+            plan.groups
+                .iter()
+                .map(|group| group[0].occurrence().clone()),
+        )
     }
 }
 
@@ -406,6 +587,7 @@ impl ImportDiscoveryPlan {
         let root_dir = context.project_root().to_owned();
         let mut groups = Vec::new();
         for site in program.import_directives().iter() {
+            let occurrence = ImportOccurrenceKey::from_directive(site);
             let importer_path = requested_path_for_module(&context, site.importer())?;
             let importer_dir = parent_dir(&importer_path);
             let mut bases = vec![importer_dir];
@@ -414,7 +596,6 @@ impl ImportDiscoveryPlan {
             }
             let candidate_groups =
                 discovery_candidate_groups(site.specifier(), &bases, context.std_root());
-            let occurrence = ImportOccurrenceKey::from_directive(site);
             let normalized_specifier = normalize_path(site.specifier());
             for (group_index, candidates) in candidate_groups.into_iter().enumerate() {
                 let group_index = u32::try_from(group_index)
@@ -457,8 +638,30 @@ impl ImportDiscoveryPlan {
     pub fn context(&self) -> &ImportDiscoveryContext {
         &self.context
     }
+    /// Expose legacy host-driven candidate groups.
+    ///
+    /// This bypass is retained only for the RUE-1033 compatibility boundary.
+    /// It is not freshness- or speculation-safe; new consumers must request a
+    /// compiler-produced frontier through the unstable canonical protocol.
     pub fn groups(&self) -> &[Arc<[ImportDiscoveryRequest]>] {
         &self.groups
+    }
+
+    pub(crate) fn groups_for_demand(
+        &self,
+        module: &ModuleId,
+        roots: &ImportDemandRoots,
+    ) -> Arc<[Arc<[ImportDiscoveryRequest]>]> {
+        let demanded = roots.occurrences.iter().collect::<BTreeSet<_>>();
+        self.groups
+            .iter()
+            .filter(|group| {
+                group[0].occurrence().importer() == module
+                    && demanded.contains(group[0].occurrence())
+            })
+            .cloned()
+            .collect::<Vec<_>>()
+            .into()
     }
 
     pub(crate) fn validate_ledger(&self, ledger: &ImportObservationLedger) -> CompileResult<()> {
@@ -547,7 +750,7 @@ impl ImportDiscoveryPlan {
     }
 
     /// Return exactly the next operations allowed by candidate precedence.
-    pub fn pending_requests(
+    pub(crate) fn pending_requests(
         &self,
         ledger: &ImportObservationLedger,
     ) -> Vec<ImportDiscoveryRequest> {

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -99,6 +99,9 @@ pub use import_discovery::{
     ImportDiscoveryContext, ImportDiscoveryPlan, ImportDiscoveryRequest, ImportObservation,
     ImportObservationLedger, ImportObservationStatus, ImportOccurrenceKey, PhysicalFileIdentity,
 };
+pub(crate) use import_discovery::{
+    ImportDemandFrontier, ImportDemandMode, ImportDemandRoots, ImportInputRevision,
+};
 pub use import_graph::{
     CanonicalImportCycle, CanonicalImportGraph, CanonicalImportGraphProblem,
     CanonicalImportGraphValidation, CanonicalImportRecord, CanonicalImportResolution,

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -7,13 +7,20 @@
 //! 12 deletes this selected-state-shaped shim after every family calls the
 //! runtime directly.
 
-use std::collections::VecDeque;
-use std::sync::Arc;
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::{Arc, Mutex};
 
 use rue_query::{
     CancellationToken, InputIdentity, QueryAbort, QueryFamily, QueryKey, QueryOutput,
     QueryRequestAttempt, QueryRuntime, QuerySelection, QueryTerminalKind, RequestExecution,
     Revision,
+};
+
+use crate::{
+    AcceptedReadManifestEntry, CompileError, CompileResult, ErrorKind, ImportDemandFrontier,
+    ImportDemandMode, ImportDemandRoots, ImportDiscoveryContext, ImportDiscoveryPlan,
+    ImportDiscoveryRequest, ImportInputRevision, ImportObservation, ImportObservationLedger,
+    ModuleId, ModuleRevision, SourceSnapshot,
 };
 
 use crate::session::{AttemptId, QueryStructuralWork};
@@ -22,6 +29,8 @@ use crate::typed_query_store::{
     AttemptView, RuntimeObservation,
 };
 use crate::typed_query_store::{TerminalKind, TypedQueryFamily};
+
+const IMPORT_INPUT_REVISION_RETENTION: usize = 64;
 
 #[derive(Debug, Clone)]
 pub(crate) struct CompatibilityKey<K> {
@@ -368,24 +377,512 @@ pub(crate) struct RevisionedQueryDatabase {
     next_revision: u64,
     next_source_stamp: u64,
     source_stamps: VecDeque<(super::session::ExactSourceInput, u64)>,
+    import_store: Arc<Mutex<ImportInputStore>>,
+    import_frontiers: QueryFamily<ImportModuleDemandKey, ImportModuleDemandValue>,
+    next_import_request: u64,
+    current_import_revision: Option<ImportInputRevision>,
     pub(crate) parse: RevisionedFamily<super::session::ParseQuery>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ImportModuleDemandKey {
+    module: ModuleId,
+    groups: Arc<[Arc<[ImportDiscoveryRequest]>]>,
+    mode: ImportDemandMode,
+}
+
+impl QueryKey for ImportModuleDemandKey {
+    fn stable_identity(&self) -> String {
+        self.module.as_str().to_owned()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ImportModuleDemandValue {
+    requests: Arc<[ImportDiscoveryRequest]>,
+    speculative_blocked: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ImportHostOperationKey {
+    context: ImportDiscoveryContext,
+    requested_path: Arc<str>,
+}
+
+impl ImportHostOperationKey {
+    fn new(request: &ImportDiscoveryRequest) -> Self {
+        Self {
+            context: request.context().clone(),
+            requested_path: Arc::from(request.requested_path()),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ImportInputView {
+    revision: Revision,
+    generation: u64,
+    context: ImportDiscoveryContext,
+    sources: Arc<[ModuleRevision]>,
+    accepted_reads: Arc<[AcceptedReadManifestEntry]>,
+    ledger: ImportObservationLedger,
+}
+
+#[derive(Debug)]
+struct ImportInputStore {
+    revisions: VecDeque<Arc<ImportInputView>>,
+    next_stamp: u64,
+    source_stamps: Vec<(ModuleRevision, u64)>,
+    provenance_stamps: Vec<(AcceptedReadManifestEntry, u64)>,
+    observation_stamps: Vec<(ImportObservation, u64)>,
+}
+
+impl Default for ImportInputStore {
+    fn default() -> Self {
+        Self {
+            revisions: VecDeque::new(),
+            next_stamp: 1,
+            source_stamps: Vec::new(),
+            provenance_stamps: Vec::new(),
+            observation_stamps: Vec::new(),
+        }
+    }
+}
+
+fn module_source_input(module: &ModuleId) -> InputIdentity {
+    InputIdentity::new("module-source", Arc::<str>::from(module.as_str()))
+}
+
+fn accepted_read_input(module: &ModuleId) -> InputIdentity {
+    InputIdentity::new(
+        "accepted-read-provenance",
+        Arc::<str>::from(module.as_str()),
+    )
+}
+
+fn import_observation_input(request: &ImportDiscoveryRequest) -> InputIdentity {
+    InputIdentity::new("import-observation", request.runtime_input_key())
+}
+
+fn import_input_error(message: impl Into<String>) -> CompileError {
+    CompileError::without_span(ErrorKind::InvalidCompilerInput(message.into()))
+}
+
+fn exact_value_stamp<T: Clone + Eq>(
+    next_stamp: &mut u64,
+    values: &mut Vec<(T, u64)>,
+    value: &T,
+) -> u64 {
+    values
+        .iter()
+        .find_map(|(candidate, stamp)| (candidate == value).then_some(*stamp))
+        .unwrap_or_else(|| {
+            let stamp = *next_stamp;
+            *next_stamp += 1;
+            values.push((value.clone(), stamp));
+            stamp
+        })
+}
+
+fn lock_import_store(
+    store: &Mutex<ImportInputStore>,
+) -> std::sync::MutexGuard<'_, ImportInputStore> {
+    store
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn pending_module_requests(
+    groups: &[Arc<[ImportDiscoveryRequest]>],
+    ledger: &ImportObservationLedger,
+) -> Vec<ImportDiscoveryRequest> {
+    let mut pending = Vec::new();
+    let mut by_site = BTreeMap::<_, Vec<_>>::new();
+    for group in groups {
+        by_site
+            .entry(group[0].occurrence())
+            .or_default()
+            .push(group);
+    }
+    for groups in by_site.values() {
+        for group in groups {
+            let observations = group
+                .iter()
+                .map(|request| ledger.get(request))
+                .collect::<Vec<_>>();
+            if observations
+                .iter()
+                .any(|observation| observation.is_some_and(|value| value.status().is_failure()))
+            {
+                break;
+            }
+            let missing = group
+                .iter()
+                .zip(&observations)
+                .filter_map(|(request, observation)| {
+                    observation.is_none().then_some(request.clone())
+                })
+                .collect::<Vec<_>>();
+            if !missing.is_empty() {
+                pending.extend(missing);
+                break;
+            }
+            if observations.iter().any(|observation| {
+                observation.is_some_and(|value| value.accepted_source().is_some())
+            }) {
+                break;
+            }
+        }
+    }
+    pending
 }
 
 impl Default for RevisionedQueryDatabase {
     fn default() -> Self {
         let runtime = QueryRuntime::new(1);
+        let import_store = Arc::new(Mutex::new(ImportInputStore::default()));
+        let evaluator_store = import_store.clone();
+        let import_frontiers = runtime
+            .family_with_evaluator(
+                "compiler.import-module-frontier",
+                IMPORT_INPUT_REVISION_RETENTION,
+                move |context, _, key: &ImportModuleDemandKey| {
+                    let view = {
+                        let store = lock_import_store(&evaluator_store);
+                        store
+                            .revisions
+                            .iter()
+                            .find(|view| view.revision == context.revision())
+                            .cloned()
+                    }
+                    .ok_or_else(|| QueryAbort::UnpublishedRevision(context.revision()))?;
+                    context.input(module_source_input(&key.module))?;
+                    context.input(accepted_read_input(&key.module))?;
+                    for request in key.groups.iter().flat_map(|group| group.iter()) {
+                        let present = context
+                            .optional_input(import_observation_input(request))
+                            .is_some();
+                        assert_eq!(present, view.ledger.get(request).is_some());
+                    }
+                    let pending = pending_module_requests(&key.groups, &view.ledger);
+                    let speculative_blocked =
+                        key.mode == ImportDemandMode::Speculative && !pending.is_empty();
+                    Ok(QueryOutput::success(ImportModuleDemandValue {
+                        requests: if speculative_blocked {
+                            Arc::from([])
+                        } else {
+                            pending.into()
+                        },
+                        speculative_blocked,
+                    }))
+                },
+            )
+            .expect("the import frontier family has one canonical name");
         Self {
             parse: RevisionedFamily::new(&runtime, "compiler.parse"),
             runtime,
             next_revision: 1,
             next_source_stamp: 1,
             source_stamps: VecDeque::new(),
+            import_store,
+            import_frontiers,
+            next_import_request: 0,
+            current_import_revision: None,
         }
     }
 }
 
 impl RevisionedQueryDatabase {
     pub(crate) const SOURCE_INPUT: &'static str = "selected-source";
+
+    pub(crate) fn begin_import_inputs(
+        &mut self,
+        snapshot: &SourceSnapshot,
+        context: ImportDiscoveryContext,
+        accepted_reads: Arc<[AcceptedReadManifestEntry]>,
+    ) -> CompileResult<ImportInputRevision> {
+        self.next_import_request += 1;
+        let generation = self.next_import_request;
+        self.current_import_revision = None;
+        // A new request generation is a fresh filesystem observation epoch.
+        // Reuse requires a future explicit watch/read-policy proof token. The
+        // API deliberately has no carried-ledger input that could be mistaken
+        // for freshness authority.
+        self.publish_import_view(
+            snapshot,
+            context,
+            accepted_reads,
+            ImportObservationLedger::default(),
+            generation,
+            0,
+        )
+    }
+
+    pub(crate) fn import_frontier(
+        &mut self,
+        revision: ImportInputRevision,
+        plan: &ImportDiscoveryPlan,
+        mode: ImportDemandMode,
+        roots: &ImportDemandRoots,
+    ) -> CompileResult<ImportDemandFrontier> {
+        if self.current_import_revision != Some(revision) {
+            return Err(import_input_error(
+                "import demand requested from a non-current immutable revision",
+            ));
+        }
+        let runtime_revision = Revision::new(revision.revision_id, revision.request_generation);
+        let view = {
+            let store = lock_import_store(&self.import_store);
+            store
+                .revisions
+                .iter()
+                .find(|view| view.revision == runtime_revision)
+                .cloned()
+        }
+        .ok_or_else(|| import_input_error("import input revision is no longer retained"))?;
+        if plan.context() != &view.context
+            || plan.source_revision().modules() != view.sources.as_ref()
+        {
+            return Err(import_input_error(
+                "import plan does not match its pinned granular input revision",
+            ));
+        }
+        if roots.occurrences().iter().any(|occurrence| {
+            !plan
+                .groups()
+                .iter()
+                .any(|group| group[0].occurrence() == occurrence)
+        }) {
+            return Err(import_input_error(
+                "import demand roots contain an occurrence outside the pinned plan",
+            ));
+        }
+        let mut requests = Vec::new();
+        let mut fanout = Vec::<Vec<ImportDiscoveryRequest>>::new();
+        let mut operation_indices = BTreeMap::<ImportHostOperationKey, usize>::new();
+        let mut speculative_blocked = false;
+        for source in plan.source_revision().modules() {
+            let groups = plan.groups_for_demand(&source.module, roots);
+            if groups.is_empty() {
+                continue;
+            }
+            let key = ImportModuleDemandKey {
+                module: source.module.clone(),
+                groups,
+                mode,
+            };
+            // RUE-1026 DELETION GATE: this selected-revision compatibility
+            // shim owns one synchronous request and therefore has no caller
+            // cancellation token to thread yet. Canonical multi-request
+            // consumers must supply their token when this shim is deleted.
+            let attempt = self.runtime.request_registered(
+                &self.import_frontiers,
+                runtime_revision,
+                key,
+                CancellationToken::new(),
+            );
+            let terminal = attempt.terminal().ok_or_else(|| {
+                import_input_error(format!(
+                    "import module demand query aborted: {:?}",
+                    attempt.abort()
+                ))
+            })?;
+            let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+                unreachable!("import frontier family publishes typed success values")
+            };
+            speculative_blocked |= value.speculative_blocked;
+            for request in value.requests.iter() {
+                let operation = ImportHostOperationKey::new(request);
+                if let Some(index) = operation_indices.get(&operation).copied() {
+                    fanout[index].push(request.clone());
+                } else {
+                    let index = requests.len();
+                    operation_indices.insert(operation, index);
+                    requests.push(request.clone());
+                    fanout.push(vec![request.clone()]);
+                }
+            }
+        }
+        Ok(ImportDemandFrontier {
+            revision,
+            mode,
+            requests: requests.into(),
+            fanout: fanout
+                .into_iter()
+                .map(|requests| Arc::<[ImportDiscoveryRequest]>::from(requests))
+                .collect::<Vec<_>>()
+                .into(),
+            speculative_blocked,
+        })
+    }
+
+    pub(crate) fn publish_import_batch(
+        &mut self,
+        frontier: &ImportDemandFrontier,
+        snapshot: &SourceSnapshot,
+        accepted_reads: Arc<[AcceptedReadManifestEntry]>,
+        observations: Vec<ImportObservation>,
+    ) -> CompileResult<ImportInputRevision> {
+        if frontier.mode != ImportDemandMode::Rooted {
+            return Err(import_input_error(
+                "speculative import work cannot publish host observations",
+            ));
+        }
+        if self.current_import_revision != Some(frontier.revision) {
+            return Err(import_input_error(
+                "import batch belongs to a stale immutable revision",
+            ));
+        }
+        if observations.len() != frontier.requests.len()
+            || observations
+                .iter()
+                .zip(frontier.requests.iter())
+                .any(|(observation, request)| observation.request() != request)
+        {
+            return Err(import_input_error(
+                "host import results must exactly preserve the compiler-produced batch order",
+            ));
+        }
+        let (context, mut ledger) = {
+            let store = lock_import_store(&self.import_store);
+            let view = store
+                .revisions
+                .iter()
+                .find(|view| view.revision.id() == frontier.revision.revision_id)
+                .ok_or_else(|| import_input_error("import input revision is no longer retained"))?;
+            (view.context.clone(), view.ledger.clone())
+        };
+        for (observation, fanout) in observations.into_iter().zip(frontier.fanout.iter()) {
+            for request in fanout.iter().cloned() {
+                ledger.record(observation.fanout_to(request)?)?;
+            }
+        }
+        self.publish_import_view(
+            snapshot,
+            context,
+            accepted_reads,
+            ledger,
+            frontier.revision.request_generation,
+            frontier.revision.frontier_round + 1,
+        )
+    }
+
+    pub(crate) fn import_ledger(
+        &self,
+        revision: ImportInputRevision,
+    ) -> CompileResult<ImportObservationLedger> {
+        let store = lock_import_store(&self.import_store);
+        store
+            .revisions
+            .iter()
+            .find(|view| {
+                view.revision.id() == revision.revision_id
+                    && view.generation == revision.request_generation
+            })
+            .map(|view| view.ledger.clone())
+            .ok_or_else(|| import_input_error("import input revision is no longer retained"))
+    }
+
+    fn publish_import_view(
+        &mut self,
+        snapshot: &SourceSnapshot,
+        context: ImportDiscoveryContext,
+        accepted_reads: Arc<[AcceptedReadManifestEntry]>,
+        ledger: ImportObservationLedger,
+        generation: u64,
+        frontier_round: u64,
+    ) -> CompileResult<ImportInputRevision> {
+        let sources: Arc<[ModuleRevision]> = snapshot.source_revision().modules().to_vec().into();
+        let provenance = accepted_reads
+            .iter()
+            .map(|entry| (entry.module(), entry))
+            .collect::<BTreeMap<_, _>>();
+        if sources
+            .iter()
+            .any(|source| !provenance.contains_key(&source.module))
+        {
+            return Err(import_input_error(
+                "every module source leaf requires accepted-read provenance",
+            ));
+        }
+        if ledger
+            .iter()
+            .any(|observation| observation.request().context() != &context)
+        {
+            return Err(import_input_error(
+                "import observation belongs to a different discovery epoch",
+            ));
+        }
+        let revision = Revision::new(self.next_revision, generation);
+        self.next_revision += 1;
+        let mut leaves = Vec::new();
+        {
+            let mut store = lock_import_store(&self.import_store);
+            let ImportInputStore {
+                next_stamp,
+                source_stamps,
+                provenance_stamps,
+                observation_stamps,
+                ..
+            } = &mut *store;
+            for source in sources.iter() {
+                leaves.push((
+                    module_source_input(&source.module),
+                    exact_value_stamp(next_stamp, source_stamps, source),
+                ));
+                let accepted = provenance[&source.module];
+                leaves.push((
+                    accepted_read_input(&source.module),
+                    exact_value_stamp(next_stamp, provenance_stamps, accepted),
+                ));
+            }
+            for observation in ledger.iter() {
+                leaves.push((
+                    import_observation_input(observation.request()),
+                    exact_value_stamp(next_stamp, observation_stamps, observation),
+                ));
+            }
+        }
+        self.runtime
+            .publish_revision(revision, leaves)
+            .map_err(|error| {
+                import_input_error(format!("cannot publish import revision: {error:?}"))
+            })?;
+        let view = Arc::new(ImportInputView {
+            revision,
+            generation,
+            context,
+            sources,
+            accepted_reads,
+            ledger,
+        });
+        let mut store = lock_import_store(&self.import_store);
+        store.revisions.push_back(view);
+        while store.revisions.len() > IMPORT_INPUT_REVISION_RETENTION {
+            store.revisions.pop_front();
+        }
+        let retained = store.revisions.iter().cloned().collect::<Vec<_>>();
+        store
+            .source_stamps
+            .retain(|(candidate, _)| retained.iter().any(|view| view.sources.contains(candidate)));
+        store.provenance_stamps.retain(|(candidate, _)| {
+            retained
+                .iter()
+                .any(|view| view.accepted_reads.contains(candidate))
+        });
+        store.observation_stamps.retain(|(candidate, _)| {
+            retained
+                .iter()
+                .any(|view| view.ledger.iter().any(|value| value == candidate))
+        });
+        let published = ImportInputRevision {
+            revision_id: revision.id(),
+            request_generation: generation,
+            frontier_round,
+        };
+        self.current_import_revision = Some(published);
+        Ok(published)
+    }
 
     pub(crate) fn source_revision(
         &mut self,
@@ -448,6 +945,54 @@ pub(crate) fn execution(attempt: &QueryRequestAttempt<impl Sized>) -> RequestExe
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        CompilerSession, DiscoverySourceAssembler, FileMetadataFingerprint, ImportDiscoveryContext,
+        ImportObservation, PhysicalFileIdentity,
+    };
+    use std::collections::BTreeSet;
+
+    fn import_fixture(
+        epoch: u64,
+        source: &str,
+    ) -> (
+        CompilerSession,
+        DiscoverySourceAssembler,
+        ImportDiscoveryContext,
+    ) {
+        let context =
+            ImportDiscoveryContext::new(epoch, "/project", Some("/sdk"), "test-policy").unwrap();
+        let assembler = DiscoverySourceAssembler::new(
+            context.clone(),
+            "/project/main.rue",
+            "/physical/main.rue",
+            PhysicalFileIdentity::new(1, 1),
+            FileMetadataFingerprint::new(1, 2, 3),
+            Arc::new(source.to_owned()),
+        )
+        .unwrap();
+        (CompilerSession::new(), assembler, context)
+    }
+
+    fn begin_and_plan(
+        session: &mut CompilerSession,
+        assembler: &DiscoverySourceAssembler,
+        context: ImportDiscoveryContext,
+    ) -> (ImportInputRevision, ImportDiscoveryPlan) {
+        let snapshot = assembler.snapshot().unwrap();
+        let reads = assembler.accepted_read_manifest();
+        let revision = session
+            .begin_import_input_request(&snapshot, context.clone(), reads.clone())
+            .unwrap();
+        let plan = session
+            .stage_import_discovery(
+                &snapshot,
+                context,
+                reads,
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        (revision, plan)
+    }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct Key(&'static str);
@@ -491,6 +1036,338 @@ mod tests {
         fn record_is_consistent(record: &Self::Record) -> bool {
             !record.key.0.is_empty()
         }
+    }
+
+    #[test]
+    fn wide_root_imports_form_one_exact_compiler_frontier() {
+        let source = r#"
+            const a = @import("a");
+            const b = @import("b");
+            const c = @import("c");
+            const d = @import("d");
+            fn main() -> i32 { 0 }
+        "#;
+        let (mut session, assembler, context) = import_fixture(1, source);
+        let (revision, plan) = begin_and_plan(&mut session, &assembler, context);
+        let frontier = session
+            .import_demand_frontier(revision, &plan, ImportDemandMode::Rooted)
+            .unwrap();
+        assert_eq!(frontier.revision(), revision);
+        assert_eq!(frontier.revision().frontier_round(), 0);
+        assert!(!frontier.requests().is_empty());
+        assert_eq!(
+            frontier
+                .requests()
+                .iter()
+                .map(|request| request.occurrence())
+                .collect::<BTreeSet<_>>()
+                .len(),
+            4,
+            "all same-depth roots must be returned in one host batch"
+        );
+
+        let mut reversed = frontier
+            .requests()
+            .iter()
+            .cloned()
+            .map(ImportObservation::absent)
+            .collect::<Vec<_>>();
+        reversed.reverse();
+        assert!(
+            session
+                .publish_import_observation_batch(
+                    &frontier,
+                    &assembler.snapshot().unwrap(),
+                    assembler.accepted_read_manifest(),
+                    reversed,
+                )
+                .unwrap_err()
+                .to_string()
+                .contains("exactly preserve")
+        );
+
+        let observations = frontier
+            .requests()
+            .iter()
+            .cloned()
+            .map(ImportObservation::absent)
+            .collect();
+        let successor = session
+            .publish_import_observation_batch(
+                &frontier,
+                &assembler.snapshot().unwrap(),
+                assembler.accepted_read_manifest(),
+                observations,
+            )
+            .unwrap();
+        assert_eq!(successor.frontier_round(), 1);
+        assert_eq!(
+            session
+                .import_observation_ledger(successor)
+                .unwrap()
+                .iter()
+                .count(),
+            frontier.requests().len()
+        );
+    }
+
+    #[test]
+    fn speculative_frontiers_are_effect_free_and_cannot_publish_host_results() {
+        let (mut session, assembler, context) = import_fixture(
+            2,
+            r#"const helper = @import("helper"); fn main() -> i32 { 0 }"#,
+        );
+        let (revision, plan) = begin_and_plan(&mut session, &assembler, context);
+        let speculative = session
+            .import_demand_frontier(revision, &plan, ImportDemandMode::Speculative)
+            .unwrap();
+        assert!(speculative.requests().is_empty());
+        assert!(speculative.speculative_blocked());
+        assert_eq!(
+            session
+                .import_observation_ledger(revision)
+                .unwrap()
+                .iter()
+                .count(),
+            0
+        );
+        assert!(
+            session
+                .publish_import_observation_batch(
+                    &speculative,
+                    &assembler.snapshot().unwrap(),
+                    assembler.accepted_read_manifest(),
+                    Vec::new(),
+                )
+                .unwrap_err()
+                .to_string()
+                .contains("speculative")
+        );
+
+        let rooted = session
+            .import_demand_frontier(revision, &plan, ImportDemandMode::Rooted)
+            .unwrap();
+        assert!(!rooted.requests().is_empty());
+        assert_eq!(rooted.revision(), revision);
+    }
+
+    #[test]
+    fn explicit_occurrence_roots_select_one_of_twenty_seven_without_speculative_io() {
+        let mut source = String::new();
+        for index in 0..27 {
+            source.push_str(&format!(
+                "pub const m{index} = @import(\"m{index}.rue\");\n"
+            ));
+        }
+        source.push_str("fn main() -> i32 { 0 }\n");
+        let (mut session, assembler, context) = import_fixture(21, &source);
+        let (revision, plan) = begin_and_plan(&mut session, &assembler, context);
+        let selected = plan
+            .groups()
+            .iter()
+            .find(|group| group[0].exact_specifier() == "m7.rue")
+            .unwrap()[0]
+            .occurrence()
+            .clone();
+        let roots = ImportDemandRoots::new([selected.clone()]);
+
+        let speculative = session
+            .import_demand_frontier_for_roots(
+                revision,
+                &plan,
+                ImportDemandMode::Speculative,
+                &roots,
+            )
+            .unwrap();
+        assert!(speculative.requests().is_empty());
+        assert!(speculative.speculative_blocked());
+        assert!(
+            session
+                .import_observation_ledger(revision)
+                .unwrap()
+                .is_empty()
+        );
+
+        let rooted = session
+            .import_demand_frontier_for_roots(revision, &plan, ImportDemandMode::Rooted, &roots)
+            .unwrap();
+        assert!(!rooted.requests().is_empty());
+        assert!(
+            rooted
+                .requests()
+                .iter()
+                .all(|request| request.occurrence() == &selected)
+        );
+    }
+
+    #[test]
+    fn new_request_generation_has_no_carried_ledger_authority() {
+        let (mut session, assembler, context) = import_fixture(
+            22,
+            r#"const missing = @import("missing.rue"); fn main() -> i32 { 0 }"#,
+        );
+        let (first_revision, first_plan) =
+            begin_and_plan(&mut session, &assembler, context.clone());
+        let first = session
+            .import_demand_frontier(first_revision, &first_plan, ImportDemandMode::Rooted)
+            .unwrap();
+        let successor = session
+            .publish_import_observation_batch(
+                &first,
+                &assembler.snapshot().unwrap(),
+                assembler.accepted_read_manifest(),
+                first
+                    .requests()
+                    .iter()
+                    .cloned()
+                    .map(ImportObservation::absent)
+                    .collect(),
+            )
+            .unwrap();
+        let stale = session.import_observation_ledger(successor).unwrap();
+        assert!(!stale.is_empty());
+
+        let snapshot = assembler.snapshot().unwrap();
+        let reads = assembler.accepted_read_manifest();
+        let fresh_revision = session
+            .begin_import_input_request(&snapshot, context.clone(), reads.clone())
+            .unwrap();
+        let fresh_ledger = session.import_observation_ledger(fresh_revision).unwrap();
+        assert!(fresh_ledger.is_empty());
+        let fresh_plan = session
+            .stage_import_discovery(&snapshot, context, reads, fresh_ledger)
+            .unwrap();
+        let reread = session
+            .import_demand_frontier(fresh_revision, &fresh_plan, ImportDemandMode::Rooted)
+            .unwrap();
+        assert_eq!(
+            reread
+                .requests()
+                .iter()
+                .map(ImportDiscoveryRequest::requested_path)
+                .collect::<Vec<_>>(),
+            first
+                .requests()
+                .iter()
+                .map(ImportDiscoveryRequest::requested_path)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn duplicate_occurrences_share_one_host_operation_and_fan_out_typed_results() {
+        let (mut session, assembler, context) = import_fixture(
+            23,
+            r#"
+                const first = @import("shared.rue");
+                const second = @import("shared.rue");
+                fn main() -> i32 { 0 }
+            "#,
+        );
+        let (revision, plan) = begin_and_plan(&mut session, &assembler, context);
+        let frontier = session
+            .import_demand_frontier(revision, &plan, ImportDemandMode::Rooted)
+            .unwrap();
+        assert_eq!(frontier.requests().len(), 1, "one host candidate operation");
+
+        let successor = session
+            .publish_import_observation_batch(
+                &frontier,
+                &assembler.snapshot().unwrap(),
+                assembler.accepted_read_manifest(),
+                vec![ImportObservation::absent(frontier.requests()[0].clone())],
+            )
+            .unwrap();
+        let ledger = session.import_observation_ledger(successor).unwrap();
+        assert_eq!(
+            ledger.len(),
+            2,
+            "result fans out to both source occurrences"
+        );
+        assert_eq!(
+            ledger
+                .iter()
+                .map(|observation| observation.request().occurrence())
+                .collect::<BTreeSet<_>>()
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn successor_revisions_carry_observations_but_new_epochs_reread() {
+        let source = r#"const helper = @import("helper"); fn main() -> i32 { 0 }"#;
+        let (mut session, assembler, context) = import_fixture(3, source);
+        let (revision, plan) = begin_and_plan(&mut session, &assembler, context);
+        let first = session
+            .import_demand_frontier(revision, &plan, ImportDemandMode::Rooted)
+            .unwrap();
+        let first_paths = first
+            .requests()
+            .iter()
+            .map(|request| request.requested_path().to_owned())
+            .collect::<BTreeSet<_>>();
+        let successor = session
+            .publish_import_observation_batch(
+                &first,
+                &assembler.snapshot().unwrap(),
+                assembler.accepted_read_manifest(),
+                first
+                    .requests()
+                    .iter()
+                    .cloned()
+                    .map(ImportObservation::absent)
+                    .collect(),
+            )
+            .unwrap();
+        let carried = session.import_observation_ledger(successor).unwrap();
+        assert_eq!(carried.iter().count(), first.requests().len());
+        let successor_plan = session
+            .stage_import_discovery(
+                &assembler.snapshot().unwrap(),
+                plan.context().clone(),
+                assembler.accepted_read_manifest(),
+                carried,
+            )
+            .unwrap();
+        let next = session
+            .import_demand_frontier(successor, &successor_plan, ImportDemandMode::Rooted)
+            .unwrap();
+        assert!(
+            next.requests()
+                .iter()
+                .all(|request| !first_paths.contains(request.requested_path()))
+        );
+
+        let new_context =
+            ImportDiscoveryContext::new(4, "/project", Some("/sdk"), "test-policy").unwrap();
+        let new_snapshot = assembler.snapshot().unwrap();
+        let new_revision = session
+            .begin_import_input_request(
+                &new_snapshot,
+                new_context.clone(),
+                assembler.accepted_read_manifest(),
+            )
+            .unwrap();
+        let new_plan = session
+            .stage_import_discovery(
+                &new_snapshot,
+                new_context,
+                assembler.accepted_read_manifest(),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let reread = session
+            .import_demand_frontier(new_revision, &new_plan, ImportDemandMode::Rooted)
+            .unwrap();
+        assert_eq!(
+            reread
+                .requests()
+                .iter()
+                .map(|request| request.requested_path().to_owned())
+                .collect::<BTreeSet<_>>(),
+            first_paths
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1726,6 +1726,9 @@ struct FrontendQueryDatabase {
     /// Canonical Phase 1 execution substrate. The legacy stores below are
     /// removed family-by-family as callers move through its selected-state shim.
     revisioned: crate::revisioned_query_database::RevisionedQueryDatabase,
+    // RUE-1024 DELETION GATE: Phase 3 must delete these whole-snapshot import
+    // plan/closure stores and their leaf stores after their remaining
+    // diagnostic and projection consumers query the granular runtime directly.
     import_plans: TypedQueryStore<ImportPlanQuery>,
     import_closures: TypedQueryStore<ImportClosureQuery>,
     import_diagnostics: TypedQueryStore<ImportDiagnosticQuery>,
@@ -2851,7 +2854,11 @@ impl CompilerSession {
         self.supplied_test_import_graph = Some(graph);
     }
     /// Derive the pre-closure import plan for the session's current parsed
-    /// revision. Hosts may execute only the requests carried by this query.
+    /// revision.
+    ///
+    /// This is retained only as part of the RUE-1033 legacy supported import
+    /// path. It is not freshness- or speculation-safe, and new consumers must
+    /// use the unstable begin/frontier/publish protocol.
     pub fn import_discovery_plan(
         &self,
         context: crate::ImportDiscoveryContext,
@@ -2862,6 +2869,71 @@ impl CompilerSession {
             ))
         })?;
         crate::ImportDiscoveryPlan::new(program, context)
+    }
+
+    /// Begins one fresh rooted external-input request with granular immutable
+    /// module source, accepted-read provenance, and observation leaves.
+    /// Successor carry is available only through batch publication.
+    pub(crate) fn begin_import_input_request(
+        &mut self,
+        snapshot: &SourceSnapshot,
+        context: crate::ImportDiscoveryContext,
+        accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
+    ) -> crate::CompileResult<crate::ImportInputRevision> {
+        self.queries
+            .revisioned
+            .begin_import_inputs(snapshot, context, accepted_reads)
+    }
+
+    /// Evaluates every currently demanded module against one pinned revision
+    /// and returns one deduplicated compiler-ordered frontier.
+    pub(crate) fn import_demand_frontier(
+        &mut self,
+        revision: crate::ImportInputRevision,
+        plan: &crate::ImportDiscoveryPlan,
+        mode: crate::ImportDemandMode,
+    ) -> crate::CompileResult<crate::ImportDemandFrontier> {
+        let roots = crate::ImportDemandRoots::whole_plan(plan);
+        self.queries
+            .revisioned
+            .import_frontier(revision, plan, mode, &roots)
+    }
+
+    pub(crate) fn import_demand_frontier_for_roots(
+        &mut self,
+        revision: crate::ImportInputRevision,
+        plan: &crate::ImportDiscoveryPlan,
+        mode: crate::ImportDemandMode,
+        roots: &crate::ImportDemandRoots,
+    ) -> crate::CompileResult<crate::ImportDemandFrontier> {
+        self.queries
+            .revisioned
+            .import_frontier(revision, plan, mode, roots)
+    }
+
+    /// Publishes exactly one compiler-produced rooted host batch as one
+    /// successor immutable revision.
+    pub(crate) fn publish_import_observation_batch(
+        &mut self,
+        frontier: &crate::ImportDemandFrontier,
+        snapshot: &SourceSnapshot,
+        accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
+        observations: Vec<crate::ImportObservation>,
+    ) -> crate::CompileResult<crate::ImportInputRevision> {
+        self.queries.revisioned.publish_import_batch(
+            frontier,
+            snapshot,
+            accepted_reads,
+            observations,
+        )
+    }
+
+    /// Returns the immutable canonical ledger carried by one input revision.
+    pub(crate) fn import_observation_ledger(
+        &self,
+        revision: crate::ImportInputRevision,
+    ) -> crate::CompileResult<crate::ImportObservationLedger> {
+        self.queries.revisioned.import_ledger(revision)
     }
     #[cfg(test)]
     pub(crate) fn discovery_attempt(&self) -> Option<&Arc<ImportDiscoveryRevisionArtifact>> {
@@ -3036,6 +3108,11 @@ impl CompilerSession {
 
     /// Parse an immutable staging snapshot without publishing it to semantic
     /// or dependency queries.
+    ///
+    /// The carried ledger and this operation are retained only for the
+    /// RUE-1033 legacy compatibility boundary. They are not freshness- or
+    /// speculation-safe; new consumers must use the unstable canonical
+    /// begin/frontier/publish protocol.
     pub fn stage_import_discovery(
         &mut self,
         snapshot: &SourceSnapshot,
@@ -3235,6 +3312,10 @@ impl CompilerSession {
     /// Close the current staging revision. Missing, ambiguous, and malformed
     /// imports retain a closed attempted artifact; only a diagnostic-free graph
     /// is atomically adopted as the committed compiler revision.
+    ///
+    /// Caller-supplied closure is retained only for the RUE-1033 legacy
+    /// compatibility boundary. It is not freshness- or speculation-safe; new
+    /// consumers must publish compiler-ordered canonical frontier batches.
     #[cfg(not(test))]
     pub fn close_import_discovery(
         &mut self,
@@ -8264,6 +8345,134 @@ mod tests {
         CanonicalSemanticFailurePhase, LinkerMode, ModuleId, OptLevel, PreviewFeature,
         PreviewFeatures, SourceMetadata, SourceSnapshot, Target,
     };
+
+    #[test]
+    fn phase_two_import_compatibility_has_an_exact_phase_three_deletion_gate() {
+        let production = include_str!("session.rs")
+            .split("\n#[cfg(test)]\nmod tests {")
+            .next()
+            .unwrap();
+        let gate = "RUE-1024 DELETION GATE: Phase 3 must delete these whole-snapshot import";
+        assert_eq!(production.matches(gate).count(), 1);
+        let discovery = include_str!("import_discovery.rs");
+        assert!(!discovery.contains("pub fn pending_requests("));
+        let revisioned = include_str!("revisioned_query_database.rs");
+        assert_eq!(
+            revisioned
+                .matches("RUE-1026 DELETION GATE: this selected-revision compatibility")
+                .count(),
+            1
+        );
+        let unstable = include_str!("unstable.rs");
+        assert_eq!(
+            unstable
+                .matches("Phase-2 full-plan compatibility adapter. RUE-1024/RUE-1026")
+                .count(),
+            1
+        );
+        for transitional_authority in [
+            "import_plans: TypedQueryStore<ImportPlanQuery>",
+            "import_closures: TypedQueryStore<ImportClosureQuery>",
+            "import_plan_inputs: crate::query_graph::TypedLeafStore<ImportPlanQueryKey>",
+            "import_closure_inputs: crate::query_graph::TypedLeafStore<ImportClosureQueryKey>",
+        ] {
+            assert!(
+                production.contains(transitional_authority),
+                "deletion gate inventory drifted: {transitional_authority}"
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_import_authority_is_one_explicit_compatibility_boundary() {
+        let discovery = include_str!("import_discovery.rs")
+            .split("\n#[cfg(test)]\nmod tests {")
+            .next()
+            .unwrap();
+        let session = include_str!("session.rs")
+            .split("\n#[cfg(test)]\nmod tests {")
+            .next()
+            .unwrap();
+        let gate = "RUE-1033 DELETION/REPLACEMENT GATE: retire the entire legacy supported";
+        assert_eq!(discovery.matches(gate).count(), 1);
+        assert_eq!(session.matches(gate).count(), 0);
+
+        // ADR-0061 keeps this legacy host-driven surface stable for now. Every
+        // listed item can participate in bypassing canonical
+        // begin/frontier/publish freshness or speculation authority, so the
+        // inventory must change atomically when RUE-1033 replaces it.
+        for (surface, declaration) in [
+            (
+                "ImportObservationStatus construction",
+                "pub enum ImportObservationStatus {",
+            ),
+            (
+                "AcceptedImportSource::new",
+                "pub fn new(\n        requested_path: impl Into<Arc<str>>",
+            ),
+            (
+                "ImportObservation::absent",
+                "pub fn absent(request: ImportDiscoveryRequest)",
+            ),
+            (
+                "ImportObservation::accepted",
+                "pub fn accepted(\n        request: ImportDiscoveryRequest",
+            ),
+            (
+                "ImportObservation::failure",
+                "pub fn failure(\n        request: ImportDiscoveryRequest",
+            ),
+            (
+                "ImportObservationLedger::default",
+                "derive(Debug, Clone, Default, PartialEq, Eq, Hash)",
+            ),
+            (
+                "ImportObservationLedger::record",
+                "pub fn record(&mut self, observation: ImportObservation)",
+            ),
+            (
+                "ImportDiscoveryPlan::groups",
+                "pub fn groups(&self) -> &[Arc<[ImportDiscoveryRequest]>]",
+            ),
+        ] {
+            assert_eq!(
+                discovery.matches(declaration).count(),
+                1,
+                "RUE-1033 discovery bypass inventory drifted at {surface}"
+            );
+        }
+        for (surface, declaration) in [
+            (
+                "CompilerSession::import_discovery_plan",
+                "pub fn import_discovery_plan(",
+            ),
+            (
+                "CompilerSession::stage_import_discovery",
+                "pub fn stage_import_discovery(",
+            ),
+            (
+                "CompilerSession::close_import_discovery",
+                "pub fn close_import_discovery(",
+            ),
+        ] {
+            assert_eq!(
+                session.matches(declaration).count(),
+                1,
+                "RUE-1033 session bypass inventory drifted at {surface}"
+            );
+        }
+
+        let unstable = include_str!("unstable.rs");
+        let begin = unstable
+            .split_once("pub fn begin_import_input_request(")
+            .unwrap()
+            .1
+            .split_once(") -> crate::CompileResult<ImportInputRevision>")
+            .unwrap()
+            .0;
+        assert!(!begin.contains("ImportObservationLedger"));
+        assert!(!begin.contains("carried_ledger"));
+    }
 
     fn snapshot(entries: &[(u32, &str, &str, &str)], root: u32) -> SourceSnapshot {
         let physical = entries

--- a/crates/rue-compiler/src/supported_api_inventory.rs
+++ b/crates/rue-compiler/src/supported_api_inventory.rs
@@ -12,13 +12,13 @@ stable|CompilerSession|artifact-query|embedders|import_graph|pub fn import_graph
 stable|CompilerSession|artifact-query|embedders|published|pub fn published(&self)->Option<crate::SyntaxView>
 stable|CompilerSession|artifact-query|embedders|rir|pub fn rir(&mut self)->Result<Arc<crate::RirView>,CompileErrors>
 stable|CompilerSession|artifact-query|embedders|semantic|pub fn semantic(&mut self,options:&CompileOptions,)->Result<Arc<crate::SemanticView>,CompileErrors>
-stable|CompilerSession|dependency-query|embedders|import_discovery_plan|pub fn import_discovery_plan(&self,context:crate::ImportDiscoveryContext,)->crate::CompileResult<crate::ImportDiscoveryPlan>
+stable|CompilerSession|compatibility-boundary|legacy-embedders|close_import_discovery|#[cfg(not(test))]pub fn close_import_discovery(&mut self,ledger:crate::ImportObservationLedger,)->Result<Arc<crate::ImportDiscoveryView>,CompileErrors>
+stable|CompilerSession|compatibility-boundary|legacy-embedders|import_discovery_plan|pub fn import_discovery_plan(&self,context:crate::ImportDiscoveryContext,)->crate::CompileResult<crate::ImportDiscoveryPlan>
+stable|CompilerSession|compatibility-boundary|legacy-embedders|stage_import_discovery|pub fn stage_import_discovery(&mut self,snapshot:&SourceSnapshot,context:crate::ImportDiscoveryContext,accepted_reads:Arc<[crate::AcceptedReadManifestEntry]>,carried_ledger:crate::ImportObservationLedger,)->Result<crate::ImportDiscoveryPlan,CompileErrors>
 stable|CompilerSession|diagnostic-query|embedders|last_good_semantic_diagnostics|pub fn last_good_semantic_diagnostics(&self)->Option<&Arc<FrontendDiagnosticSnapshot>>
 stable|CompilerSession|diagnostic-query|embedders|latest_diagnostics|pub fn latest_diagnostics(&self)->Option<&Arc<FrontendDiagnosticSnapshot>>
 stable|CompilerSession|diagnostic-query|embedders|latest_successful_diagnostics|pub fn latest_successful_diagnostics(&self)->Option<&Arc<FrontendDiagnosticSnapshot>>
-stable|CompilerSession|session-operation|embedders|close_import_discovery|#[cfg(not(test))]pub fn close_import_discovery(&mut self,ledger:crate::ImportObservationLedger,)->Result<Arc<crate::ImportDiscoveryView>,CompileErrors>
 stable|CompilerSession|session-operation|embedders|new|pub fn new()->Self
-stable|CompilerSession|session-operation|embedders|stage_import_discovery|pub fn stage_import_discovery(&mut self,snapshot:&SourceSnapshot,context:crate::ImportDiscoveryContext,accepted_reads:Arc<[crate::AcceptedReadManifestEntry]>,carried_ledger:crate::ImportObservationLedger,)->Result<crate::ImportDiscoveryPlan,CompileErrors>
 stable|CompilerSession|session-operation|embedders|update|pub fn update(&mut self,snapshot:&SourceSnapshot)->CompilerSessionUpdate
 stable|CompilerSessionUpdate|artifact-result|embedders|diagnostics|pub fn diagnostics(&self)->&Arc<FrontendDiagnosticSnapshot>
 stable|CompilerSessionUpdate|artifact-result|embedders|into_result|pub fn into_result(self)->Result<crate::SyntaxView,CompileErrors>
@@ -49,16 +49,16 @@ stable|dependency_envelope|dependency-artifact|source-loaders+embedders|Dependen
 stable|dependency_envelope|dependency-artifact|source-loaders+embedders|DependencyTopologyRecord|pub use dependency_envelope::DependencyTopologyRecord
 stable|diagnostic_attempt_store|diagnostic|cli+embedders|DiagnosticStage|pub use diagnostic_attempt_store::DiagnosticStage
 stable|diagnostic_attempt_store|diagnostic|cli+embedders|FrontendDiagnosticSnapshot|pub use diagnostic_attempt_store::FrontendDiagnosticSnapshot
-stable|import_discovery|dependency-artifact|source-loaders+embedders|AcceptedImportSource|pub use import_discovery::AcceptedImportSource
+stable|import_discovery|compatibility-boundary|legacy-embedders|AcceptedImportSource|pub use import_discovery::AcceptedImportSource
+stable|import_discovery|compatibility-boundary|legacy-embedders|ImportDiscoveryPlan|pub use import_discovery::ImportDiscoveryPlan
+stable|import_discovery|compatibility-boundary|legacy-embedders|ImportDiscoveryRequest|pub use import_discovery::ImportDiscoveryRequest
+stable|import_discovery|compatibility-boundary|legacy-embedders|ImportObservation|pub use import_discovery::ImportObservation
+stable|import_discovery|compatibility-boundary|legacy-embedders|ImportObservationLedger|pub use import_discovery::ImportObservationLedger
+stable|import_discovery|compatibility-boundary|legacy-embedders|ImportObservationStatus|pub use import_discovery::ImportObservationStatus
 stable|import_discovery|dependency-artifact|source-loaders+embedders|AcceptedReadManifestEntry|pub use import_discovery::AcceptedReadManifestEntry
 stable|import_discovery|dependency-artifact|source-loaders+embedders|FileMetadataFingerprint|pub use import_discovery::FileMetadataFingerprint
 stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportCandidateRole|pub use import_discovery::ImportCandidateRole
 stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportDiscoveryContext|pub use import_discovery::ImportDiscoveryContext
-stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportDiscoveryPlan|pub use import_discovery::ImportDiscoveryPlan
-stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportDiscoveryRequest|pub use import_discovery::ImportDiscoveryRequest
-stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportObservation|pub use import_discovery::ImportObservation
-stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportObservationLedger|pub use import_discovery::ImportObservationLedger
-stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportObservationStatus|pub use import_discovery::ImportObservationStatus
 stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportOccurrenceKey|pub use import_discovery::ImportOccurrenceKey
 stable|import_discovery|dependency-artifact|source-loaders+embedders|PhysicalFileIdentity|pub use import_discovery::PhysicalFileIdentity
 stable|import_graph|dependency-artifact|source-loaders+embedders|CanonicalImportCycle|pub use import_graph::CanonicalImportCycle

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -15,7 +15,61 @@ pub use crate::diagnostic::{
     ColorChoice, DiagnosticFormatter, JsonDiagnostic, JsonDiagnosticFormatter, JsonSpan,
     JsonSuggestion, MultiFileFormatter, MultiFileJsonFormatter, SourceInfo,
 };
-pub use crate::import_discovery::DiscoverySourceAssembler;
+pub use crate::import_discovery::{
+    DiscoverySourceAssembler, ImportDemandFrontier, ImportDemandMode, ImportDemandRoots,
+    ImportInputRevision,
+};
+
+/// Begin a fresh external-input observation generation.
+///
+/// Prior observations can flow only through
+/// [`publish_import_observation_batch`]; no caller ledger can seed freshness.
+pub fn begin_import_input_request(
+    session: &mut crate::CompilerSession,
+    snapshot: &crate::SourceSnapshot,
+    context: crate::ImportDiscoveryContext,
+    accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
+) -> crate::CompileResult<ImportInputRevision> {
+    session.begin_import_input_request(snapshot, context, accepted_reads)
+}
+
+/// Phase-2 full-plan compatibility adapter. RUE-1024/RUE-1026 delete this
+/// once canonical syntax/name queries originate exact occurrence roots.
+pub fn import_demand_frontier(
+    session: &mut crate::CompilerSession,
+    revision: ImportInputRevision,
+    plan: &crate::ImportDiscoveryPlan,
+    mode: ImportDemandMode,
+) -> crate::CompileResult<ImportDemandFrontier> {
+    session.import_demand_frontier(revision, plan, mode)
+}
+
+pub fn import_demand_frontier_for_roots(
+    session: &mut crate::CompilerSession,
+    revision: ImportInputRevision,
+    plan: &crate::ImportDiscoveryPlan,
+    mode: ImportDemandMode,
+    roots: &ImportDemandRoots,
+) -> crate::CompileResult<ImportDemandFrontier> {
+    session.import_demand_frontier_for_roots(revision, plan, mode, roots)
+}
+
+pub fn publish_import_observation_batch(
+    session: &mut crate::CompilerSession,
+    frontier: &ImportDemandFrontier,
+    snapshot: &crate::SourceSnapshot,
+    accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
+    observations: Vec<crate::ImportObservation>,
+) -> crate::CompileResult<ImportInputRevision> {
+    session.publish_import_observation_batch(frontier, snapshot, accepted_reads, observations)
+}
+
+pub fn import_observation_ledger(
+    session: &crate::CompilerSession,
+    revision: ImportInputRevision,
+) -> crate::CompileResult<crate::ImportObservationLedger> {
+    session.import_observation_ledger(revision)
+}
 
 /// Unstable human-readable compiler stages. These are projections of the
 /// canonical session artifacts, never alternate phase entry points.

--- a/crates/rue-compiler/tests/differential_oracle.rs
+++ b/crates/rue-compiler/tests/differential_oracle.rs
@@ -12,16 +12,17 @@ use std::{collections::HashMap, fmt::Write as _, sync::Arc};
 
 use rue_cfg::OptLevel;
 use rue_compiler::unstable::{
-    DifferentialOracleFault, DiscoverySourceAssembler, PresentationRequest, PresentationStage,
-    discovery_attempt, import_discovery_accepted_reads_debug, import_discovery_graph_input_debug,
-    import_discovery_observation_ledger_debug, inject_stale_query_for_oracle, oracle_executable,
+    DifferentialOracleFault, DiscoverySourceAssembler, ImportDemandMode, PresentationRequest,
+    PresentationStage, begin_import_input_request, discovery_attempt, import_demand_frontier,
+    import_discovery_accepted_reads_debug, import_discovery_graph_input_debug,
+    import_discovery_observation_ledger_debug, import_observation_ledger,
+    inject_stale_query_for_oracle, oracle_executable, publish_import_observation_batch,
     semantic_input_debug,
 };
 use rue_compiler::{
     AcceptedImportSource, AcceptedReadManifestEntry, CompileOptions, CompilerSession,
     FileMetadataFingerprint, FrontendDiagnosticSnapshot, ImportDiscoveryContext, ImportObservation,
-    ImportObservationLedger, PhysicalFileIdentity, PreviewFeature, PreviewFeatures, SourceMetadata,
-    SourceSnapshot,
+    PhysicalFileIdentity, PreviewFeature, PreviewFeatures, SourceMetadata, SourceSnapshot,
 };
 use rue_span::FileId;
 use rue_target::Target;
@@ -134,47 +135,74 @@ fn close_discovery(session: &mut CompilerSession, step: &Step) -> String {
     let Some(discovery) = &step.discovery else {
         return "direct".to_owned();
     };
-    let plan = match session.stage_import_discovery(
+    let mut revision = begin_import_input_request(
+        session,
         &step.snapshot,
         discovery.context.clone(),
         discovery.accepted_reads.clone(),
-        ImportObservationLedger::default(),
-    ) {
-        Ok(plan) => plan,
-        Err(errors) => return format!("stage-error:{errors:?}"),
-    };
-    let mut ledger = ImportObservationLedger::default();
-    for request in plan.pending_requests(&ledger) {
-        let accepted = discovery
-            .accepted_reads
-            .iter()
-            .find(|read| read.requested_path() == request.requested_path());
-        let observation = if let Some(read) = accepted {
-            let source = step
-                .snapshot
-                .files()
-                .find(|source| step.snapshot.module_id(source.file_id) == Some(read.module()))
-                .expect("accepted manifest path belongs to the snapshot");
-            ImportObservation::accepted(
-                request.clone(),
-                AcceptedImportSource::new(
-                    request.requested_path(),
-                    read.canonical_path(),
-                    read.metadata_identity(),
-                    read.metadata_fingerprint(),
-                    Arc::new(source.source.to_owned()),
-                )
-                .unwrap(),
-            )
-            .unwrap()
-        } else {
-            ImportObservation::absent(request.clone())
+    )
+    .unwrap();
+    loop {
+        let ledger = import_observation_ledger(session, revision).unwrap();
+        let plan = match session.stage_import_discovery(
+            &step.snapshot,
+            discovery.context.clone(),
+            discovery.accepted_reads.clone(),
+            ledger.clone(),
+        ) {
+            Ok(plan) => plan,
+            Err(errors) => return format!("stage-error:{errors:?}"),
         };
-        ledger.record(observation).unwrap();
-    }
-    match session.close_import_discovery(ledger) {
-        Ok(artifact) => render_import_discovery(&artifact),
-        Err(errors) => format!("close-error:{errors:?}"),
+        let frontier =
+            import_demand_frontier(session, revision, &plan, ImportDemandMode::Rooted).unwrap();
+        if frontier.requests().is_empty() {
+            return match session.close_import_discovery(ledger) {
+                Ok(artifact) => render_import_discovery(&artifact),
+                Err(errors) => format!("close-error:{errors:?}"),
+            };
+        }
+        let observations = frontier
+            .requests()
+            .iter()
+            .cloned()
+            .map(|request| {
+                let accepted = discovery
+                    .accepted_reads
+                    .iter()
+                    .find(|read| read.requested_path() == request.requested_path());
+                if let Some(read) = accepted {
+                    let source = step
+                        .snapshot
+                        .files()
+                        .find(|source| {
+                            step.snapshot.module_id(source.file_id) == Some(read.module())
+                        })
+                        .expect("accepted manifest path belongs to the snapshot");
+                    ImportObservation::accepted(
+                        request.clone(),
+                        AcceptedImportSource::new(
+                            request.requested_path(),
+                            read.canonical_path(),
+                            read.metadata_identity(),
+                            read.metadata_fingerprint(),
+                            Arc::new(source.source.to_owned()),
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap()
+                } else {
+                    ImportObservation::absent(request)
+                }
+            })
+            .collect();
+        revision = publish_import_observation_batch(
+            session,
+            &frontier,
+            &step.snapshot,
+            discovery.accepted_reads.clone(),
+            observations,
+        )
+        .unwrap();
     }
 }
 

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -47,10 +47,13 @@ mod generator;
 mod model_gaps;
 mod trap;
 
-use rue_compiler::unstable::DiscoverySourceAssembler;
+use rue_compiler::unstable::{
+    DiscoverySourceAssembler, ImportDemandMode, begin_import_input_request, import_demand_frontier,
+    import_observation_ledger, publish_import_observation_batch,
+};
 use rue_compiler::{
     AcceptedImportSource, CompilerSession, FileMetadataFingerprint, ImportDiscoveryContext,
-    ImportObservation, ImportObservationLedger, PhysicalFileIdentity,
+    ImportObservation, PhysicalFileIdentity,
 };
 use rue_error::{PreviewFeature, PreviewFeatures};
 use rue_oracle::{
@@ -688,12 +691,21 @@ fn run_source_with_real_std(
         root_source,
     )
     .map_err(|error| error.to_string())?;
-    let mut ledger = ImportObservationLedger::default();
     let mut session = CompilerSession::new();
     let mut identities = BTreeMap::<PathBuf, PhysicalFileIdentity>::new();
+    let initial = assembler.snapshot().map_err(|error| error.to_string())?;
+    let mut revision = begin_import_input_request(
+        &mut session,
+        &initial,
+        context.clone(),
+        assembler.accepted_read_manifest(),
+    )
+    .map_err(|error| error.to_string())?;
 
     loop {
         let snapshot = assembler.snapshot().map_err(|error| error.to_string())?;
+        let ledger =
+            import_observation_ledger(&session, revision).map_err(|error| error.to_string())?;
         let plan = session
             .stage_import_discovery(
                 &snapshot,
@@ -702,7 +714,17 @@ fn run_source_with_real_std(
                 ledger.clone(),
             )
             .map_err(|errors| format!("{errors:#?}"))?;
-        for request in plan.pending_requests(&ledger) {
+        let frontier =
+            import_demand_frontier(&mut session, revision, &plan, ImportDemandMode::Rooted)
+                .map_err(|error| error.to_string())?;
+        if frontier.requests().is_empty() {
+            session
+                .close_import_discovery(ledger)
+                .map_err(|errors| format!("{errors:#?}"))?;
+            return Ok(run_session_with_preview_features(session, preview_features));
+        }
+        let mut observations = Vec::new();
+        for request in frontier.requests().iter().cloned() {
             let requested = request.requested_path().to_owned();
             let path = Path::new(&requested);
             let observation = match path.canonicalize() {
@@ -731,22 +753,26 @@ fn run_source_with_real_std(
                 }
                 _ => ImportObservation::absent(request),
             };
-            ledger
+            observations.push(observation);
+        }
+        let mut assembly_ledger = ledger;
+        for observation in observations.iter().cloned() {
+            assembly_ledger
                 .record(observation)
                 .map_err(|error| error.to_string())?;
         }
-        if plan.failures(&ledger).next().is_some() {
-            return Err("real-std import discovery failed".to_string());
-        }
-        let added = assembler
-            .add_plan_reads(&plan, &ledger)
+        assembler
+            .add_plan_reads(&plan, &assembly_ledger)
             .map_err(|error| error.to_string())?;
-        if added == 0 {
-            session
-                .close_import_discovery(ledger)
-                .map_err(|errors| format!("{errors:#?}"))?;
-            return Ok(run_session_with_preview_features(session, preview_features));
-        }
+        let successor = assembler.snapshot().map_err(|error| error.to_string())?;
+        revision = publish_import_observation_batch(
+            &mut session,
+            &frontier,
+            &successor,
+            assembler.accepted_read_manifest(),
+            observations,
+        )
+        .map_err(|error| error.to_string())?;
     }
 }
 

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -1144,10 +1144,13 @@ fn option_returning_intrinsics_require_the_exact_payload_type() {
 
 #[test]
 fn read_line_requires_trusted_source_strbuf_payload_metadata() {
-    use rue_compiler::unstable::DiscoverySourceAssembler;
+    use rue_compiler::unstable::{
+        DiscoverySourceAssembler, ImportDemandMode, begin_import_input_request,
+        import_demand_frontier, import_observation_ledger, publish_import_observation_batch,
+    };
     use rue_compiler::{
         AcceptedImportSource, CompilerSession, FileMetadataFingerprint, ImportDiscoveryContext,
-        ImportObservation, ImportObservationLedger, PhysicalFileIdentity,
+        ImportObservation, PhysicalFileIdentity,
     };
     use std::sync::Arc;
 
@@ -1192,9 +1195,17 @@ fn read_line_requires_trusted_source_strbuf_payload_metadata() {
         (3, "/project/std/option.rue", option),
     ];
     let mut session = CompilerSession::new();
-    let mut ledger = ImportObservationLedger::default();
+    let initial = assembler.snapshot().expect("trusted std root snapshot");
+    let mut revision = begin_import_input_request(
+        &mut session,
+        &initial,
+        context.clone(),
+        assembler.accepted_read_manifest(),
+    )
+    .expect("begin trusted std request");
     loop {
         let snapshot = assembler.snapshot().expect("trusted std snapshot");
+        let ledger = import_observation_ledger(&session, revision).expect("current std ledger");
         let plan = session
             .stage_import_discovery(
                 &snapshot,
@@ -1203,37 +1214,55 @@ fn read_line_requires_trusted_source_strbuf_payload_metadata() {
                 ledger.clone(),
             )
             .expect("valid trusted std discovery plan");
-        for request in plan.pending_requests(&ledger) {
-            let requested = request.requested_path();
-            let (index, canonical, source) = standard_sources
-                .iter()
-                .find(|(_, path, _)| *path == requested)
-                .unwrap_or_else(|| panic!("unexpected import request {requested}"));
-            let accepted = AcceptedImportSource::new(
-                requested,
-                *canonical,
-                PhysicalFileIdentity::new(1, *index),
-                FileMetadataFingerprint::new(source.len() as u64, 0, 0),
-                source.clone(),
-            )
-            .expect("accepted trusted standard-library source");
-            let observation = ImportObservation::accepted(request, accepted)
-                .expect("observation matches discovery request");
-            ledger
-                .record(observation)
-                .expect("unique import observation");
-        }
-        assert!(plan.failures(&ledger).next().is_none());
-        if assembler
-            .add_plan_reads(&plan, &ledger)
-            .expect("assemble accepted std reads")
-            == 0
-        {
+        let frontier =
+            import_demand_frontier(&mut session, revision, &plan, ImportDemandMode::Rooted)
+                .expect("trusted std frontier");
+        if frontier.requests().is_empty() {
             session
                 .close_import_discovery(ledger)
                 .expect("close valid import discovery revision");
             break;
         }
+        let observations = frontier
+            .requests()
+            .iter()
+            .cloned()
+            .map(|request| {
+                let requested = request.requested_path();
+                let (index, canonical, source) = standard_sources
+                    .iter()
+                    .find(|(_, path, _)| *path == requested)
+                    .unwrap_or_else(|| panic!("unexpected import request {requested}"));
+                let accepted = AcceptedImportSource::new(
+                    requested,
+                    *canonical,
+                    PhysicalFileIdentity::new(1, *index),
+                    FileMetadataFingerprint::new(source.len() as u64, 0, 0),
+                    source.clone(),
+                )
+                .expect("accepted trusted standard-library source");
+                ImportObservation::accepted(request, accepted)
+                    .expect("observation matches discovery request")
+            })
+            .collect::<Vec<_>>();
+        let mut assembly_ledger = ledger;
+        for observation in observations.iter().cloned() {
+            assembly_ledger
+                .record(observation)
+                .expect("unique representative observation");
+        }
+        assembler
+            .add_plan_reads(&plan, &assembly_ledger)
+            .expect("assemble accepted std reads");
+        let successor = assembler.snapshot().expect("successor std snapshot");
+        revision = publish_import_observation_batch(
+            &mut session,
+            &frontier,
+            &successor,
+            assembler.accepted_read_manifest(),
+            observations,
+        )
+        .expect("publish std observation batch");
     }
     let state = query_cfg_state_from_session(session, &CompileOptions::default())
         .expect("trusted Option(StrBuf) @read_line probe must compile");

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -882,6 +882,9 @@ impl QueryRuntime {
     ) -> Result<(), RevisionError> {
         let mut exact = BTreeMap::new();
         for (input, stamp) in inputs {
+            if stamp == 0 {
+                return Err(RevisionError::ReservedInputStamp(input));
+            }
             if let Some(previous) = exact.insert(input.clone(), stamp)
                 && previous != stamp
             {
@@ -1139,6 +1142,8 @@ pub enum RevisionError {
     AlreadyPublished(Revision),
     /// One publication supplied two different values for the same exact leaf.
     ConflictingInput(InputIdentity),
+    /// Stamp zero is reserved for a recorded absent optional leaf.
+    ReservedInputStamp(InputIdentity),
     /// This publication identity is older than the bounded retired watermark.
     Retired(Revision),
 }
@@ -2224,6 +2229,19 @@ impl QueryContext {
         Ok(stamp)
     }
 
+    /// Reads and records an optional exact leaf from this task's revision.
+    ///
+    /// Absence is recorded as a negative observation. A successor which adds
+    /// the leaf therefore invalidates the terminal without turning absence
+    /// into a query failure. External-input coordinators use this to publish a
+    /// typed demand terminal; speculative work can instead park on the same
+    /// negative observation without emitting a host request.
+    pub fn optional_input(&self, input: InputIdentity) -> Option<u64> {
+        let stamp = self.task.core.revision_input(self.task.revision, &input);
+        self.task.observe_input(input, stamp.unwrap_or(0));
+        stamp
+    }
+
     /// Records structural work as it is completed by the active body.
     ///
     /// Unlike terminal-attached output work, this prefix survives cancellation
@@ -2546,10 +2564,13 @@ impl RuntimeCore {
         else {
             return Ok(false);
         };
-        let direct_inputs_valid = terminal
-            .inputs
-            .iter()
-            .all(|observed| entry.inputs.get(&observed.input) == Some(&observed.stamp));
+        let direct_inputs_valid = terminal.inputs.iter().all(|observed| {
+            if observed.stamp == 0 {
+                !entry.inputs.contains_key(&observed.input)
+            } else {
+                entry.inputs.get(&observed.input) == Some(&observed.stamp)
+            }
+        });
         drop(revisions);
         if !direct_inputs_valid {
             return Ok(false);
@@ -4082,6 +4103,78 @@ mod tests {
         assert_eq!(first.node(), second.node());
         assert!(!Arc::ptr_eq(&first, &second));
         assert_ne!(first.outcome(), second.outcome());
+    }
+
+    #[test]
+    fn optional_inputs_record_negative_observations_and_invalidate_on_publication() {
+        let runtime = QueryRuntime::new(1);
+        let family = runtime.family::<Key, bool>("optional-input", 4).unwrap();
+        let input = InputIdentity::new("candidate", "helper.rue");
+        let absent = revision(20);
+        let present = revision(21);
+        let absent_again = revision(22);
+        runtime.publish_revision(absent, []).unwrap();
+        runtime
+            .publish_revision(present, [(input.clone(), 7)])
+            .unwrap();
+        runtime.publish_revision(absent_again, []).unwrap();
+
+        let first = runtime.request(
+            &family,
+            absent,
+            Key("helper"),
+            CancellationToken::new(),
+            |context| {
+                Ok(QueryOutput::success(
+                    context.optional_input(input.clone()).is_some(),
+                ))
+            },
+        );
+        assert_eq!(first.execution(), RequestExecution::Computed);
+        assert_eq!(
+            first.inputs(),
+            &[InputObservation {
+                input: input.clone(),
+                stamp: 0,
+            }]
+        );
+
+        let changed = runtime.request(
+            &family,
+            present,
+            Key("helper"),
+            CancellationToken::new(),
+            |context| {
+                Ok(QueryOutput::success(
+                    context.optional_input(input.clone()).is_some(),
+                ))
+            },
+        );
+        assert_eq!(changed.execution(), RequestExecution::Computed);
+        assert!(matches!(
+            changed.terminal().unwrap().outcome(),
+            QueryOutcome::Success(true)
+        ));
+
+        let absent_result = runtime.request(
+            &family,
+            absent_again,
+            Key("helper"),
+            CancellationToken::new(),
+            |context| {
+                Ok(QueryOutput::success(
+                    context.optional_input(input.clone()).is_some(),
+                ))
+            },
+        );
+        assert!(matches!(
+            absent_result.terminal().unwrap().outcome(),
+            QueryOutcome::Success(false)
+        ));
+        assert_eq!(
+            runtime.publish_revision(revision(23), [(input.clone(), 0)]),
+            Err(RevisionError::ReservedInputStamp(input))
+        );
     }
 
     #[test]

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -5,11 +5,14 @@ use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
-use rue_compiler::unstable::{DiscoverySourceAssembler, discovery_attempt};
+use rue_compiler::unstable::{
+    DiscoverySourceAssembler, ImportDemandMode, begin_import_input_request, discovery_attempt,
+    import_demand_frontier, import_observation_ledger, publish_import_observation_batch,
+};
 use rue_compiler::{
     AcceptedImportSource, AcceptedReadManifestEntry, CompileErrors, CompilerSession,
     DependencyEnvelope, FileId, FileMetadataFingerprint, ImportDiscoveryContext,
-    ImportDiscoveryView, ImportObservation, ImportObservationLedger, ImportObservationStatus,
+    ImportDiscoveryRequest, ImportDiscoveryView, ImportObservation, ImportObservationStatus,
     PhysicalFileIdentity, SourceMetadata, SourceSnapshot,
 };
 
@@ -230,6 +233,72 @@ fn same_file_observation(left: &fs::Metadata, right: &fs::Metadata) -> bool {
         && left.is_file() == right.is_file()
 }
 
+fn execute_import_request(
+    request: ImportDiscoveryRequest,
+    source_manifest: Option<&SourceManifest>,
+) -> ImportObservation {
+    let candidate = Path::new(request.requested_path());
+    if source_manifest.is_some_and(|manifest| !manifest.declares_path_without_probe(candidate)) {
+        return ImportObservation::failure(request, ImportObservationStatus::DeniedLexical)
+            .expect("lexical denial is a valid terminal observation");
+    }
+
+    match fs::canonicalize(candidate) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            ImportObservation::absent(request)
+        }
+        Err(error) => ImportObservation::failure(
+            request,
+            ImportObservationStatus::PresentUnreadable(Arc::from(error.to_string())),
+        )
+        .expect("unreadable candidates are valid terminal observations"),
+        Ok(canonical)
+            if source_manifest.is_some_and(|manifest| !manifest.allows_canonical(&canonical)) =>
+        {
+            ImportObservation::failure(
+                request,
+                ImportObservationStatus::DeniedCanonical {
+                    canonical_path: Arc::from(canonical.to_string_lossy().into_owned()),
+                },
+            )
+            .expect("canonical denial is a valid terminal observation")
+        }
+        Ok(canonical) if !canonical.is_file() => ImportObservation::failure(
+            request,
+            ImportObservationStatus::InvalidPhysicalType {
+                canonical_path: Arc::from(canonical.to_string_lossy().into_owned()),
+            },
+        )
+        .expect("non-file candidates are valid terminal observations"),
+        Ok(canonical) => match stable_read_to_string(&canonical) {
+            Ok(read) => {
+                let accepted = AcceptedImportSource::new(
+                    Arc::from(request.requested_path()),
+                    Arc::from(canonical.to_string_lossy().into_owned()),
+                    read.identity,
+                    read.fingerprint,
+                    Arc::new(read.source),
+                )
+                .expect("stable file reads satisfy accepted import invariants");
+                ImportObservation::accepted(request, accepted)
+                    .expect("accepted source matches its compiler request")
+            }
+            Err(StableReadError::Io(error)) => ImportObservation::failure(
+                request,
+                ImportObservationStatus::PresentUnreadable(Arc::from(error.to_string())),
+            )
+            .expect("read failures are valid terminal observations"),
+            Err(StableReadError::Changed) => ImportObservation::failure(
+                request,
+                ImportObservationStatus::UnstableRead(Arc::from(
+                    "candidate metadata changed during read",
+                )),
+            )
+            .expect("unstable reads are valid terminal observations"),
+        },
+    }
+}
+
 /// Compute `target` relative to `base` without consulting the filesystem.
 ///
 /// Both inputs are expected to be absolute and lexically normalized. Keeping
@@ -415,6 +484,8 @@ pub(crate) struct ImportDiscoveryResult {
     pub(crate) read_manifest: Arc<[AcceptedReadManifestEntry]>,
     /// Canonical import topology and diagnostics published by the compiler.
     pub(crate) revision: Arc<ImportDiscoveryView>,
+    #[cfg(test)]
+    pub(crate) input_revision: rue_compiler::unstable::ImportInputRevision,
     pub(crate) session: CompilerSession,
 }
 
@@ -501,12 +572,23 @@ pub(crate) fn discover_and_load_imports(
     )
     .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
 
-    let mut ledger = ImportObservationLedger::default();
     let mut staging = CompilerSession::new();
+    let initial_snapshot = assembler
+        .snapshot()
+        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+    let mut input_revision = begin_import_input_request(
+        &mut staging,
+        &initial_snapshot,
+        context.clone(),
+        assembler.accepted_read_manifest(),
+    )
+    .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
     let final_plan;
     loop {
         let snapshot = assembler
             .snapshot()
+            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        let ledger = import_observation_ledger(&staging, input_revision)
             .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
         let plan = match staging.stage_import_discovery(
             &snapshot,
@@ -526,96 +608,43 @@ pub(crate) fn discover_and_load_imports(
                 });
             }
         };
-        loop {
-            let pending = plan.pending_requests(&ledger);
-            if pending.is_empty() {
-                break;
-            }
-            for request in pending {
-                let candidate = Path::new(request.requested_path());
-                let observation = if let Some(manifest) = source_manifest
-                    && !manifest.declares_path_without_probe(candidate)
-                {
-                    ImportObservation::failure(request, ImportObservationStatus::DeniedLexical)
-                        .unwrap()
-                } else {
-                    match fs::canonicalize(candidate) {
-                        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                            ImportObservation::absent(request)
-                        }
-                        Err(error) => ImportObservation::failure(
-                            request,
-                            ImportObservationStatus::PresentUnreadable(Arc::from(
-                                error.to_string(),
-                            )),
-                        )
-                        .unwrap(),
-                        Ok(canonical)
-                            if source_manifest
-                                .is_some_and(|manifest| !manifest.allows_canonical(&canonical)) =>
-                        {
-                            ImportObservation::failure(
-                                request,
-                                ImportObservationStatus::DeniedCanonical {
-                                    canonical_path: Arc::from(
-                                        canonical.to_string_lossy().into_owned(),
-                                    ),
-                                },
-                            )
-                            .unwrap()
-                        }
-                        Ok(canonical) if !canonical.is_file() => ImportObservation::failure(
-                            request,
-                            ImportObservationStatus::InvalidPhysicalType {
-                                canonical_path: Arc::from(canonical.to_string_lossy().into_owned()),
-                            },
-                        )
-                        .unwrap(),
-                        Ok(canonical) => match stable_read_to_string(&canonical) {
-                            Ok(read) => {
-                                let accepted = AcceptedImportSource::new(
-                                    Arc::from(request.requested_path()),
-                                    Arc::from(canonical.to_string_lossy().into_owned()),
-                                    read.identity,
-                                    read.fingerprint,
-                                    Arc::new(read.source),
-                                )
-                                .unwrap();
-                                ImportObservation::accepted(request, accepted).unwrap()
-                            }
-                            Err(StableReadError::Io(error)) => ImportObservation::failure(
-                                request,
-                                ImportObservationStatus::PresentUnreadable(Arc::from(
-                                    error.to_string(),
-                                )),
-                            )
-                            .unwrap(),
-                            Err(StableReadError::Changed) => ImportObservation::failure(
-                                request,
-                                ImportObservationStatus::UnstableRead(Arc::from(
-                                    "candidate metadata changed during read",
-                                )),
-                            )
-                            .unwrap(),
-                        },
-                    }
-                };
-                ledger
-                    .record(observation)
-                    .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-            }
-        }
-        if plan.failures(&ledger).next().is_some() {
+        let frontier = import_demand_frontier(
+            &mut staging,
+            input_revision,
+            &plan,
+            ImportDemandMode::Rooted,
+        )
+        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        if frontier.requests().is_empty() {
             final_plan = plan;
             break;
         }
-        let added = assembler
-            .add_plan_reads(&plan, &ledger)
+        let observations = frontier
+            .requests()
+            .iter()
+            .cloned()
+            .map(|request| execute_import_request(request, source_manifest))
+            .collect::<Vec<_>>();
+        let mut next_ledger = ledger;
+        for observation in observations.iter().cloned() {
+            next_ledger
+                .record(observation)
+                .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        }
+        let _ = assembler
+            .add_plan_reads(&plan, &next_ledger)
             .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-        if added == 0 {
-            final_plan = plan;
-            break;
-        }
+        let successor_snapshot = assembler
+            .snapshot()
+            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        input_revision = publish_import_observation_batch(
+            &mut staging,
+            &frontier,
+            &successor_snapshot,
+            assembler.accepted_read_manifest(),
+            observations,
+        )
+        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
     }
 
     let snapshot = assembler
@@ -623,9 +652,11 @@ pub(crate) fn discover_and_load_imports(
         .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
     let read_manifest = assembler.accepted_read_manifest();
     debug_assert_eq!(final_plan.source_revision(), snapshot.source_revision());
+    let ledger = import_observation_ledger(&staging, input_revision)
+        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
     let closed = match staging.close_import_discovery(ledger) {
         Ok(closed) => closed,
-        Err(_) => {
+        Err(errors) => {
             let attempted = discovery_attempt(&staging)
                 .expect("failed closure publishes an attempted import revision");
             if DependencyEnvelope::from_closed_revision(&attempted).is_some() {
@@ -635,10 +666,6 @@ pub(crate) fn discover_and_load_imports(
                 // can be written first. All other failures have no topology.
                 attempted
             } else {
-                let diagnostics = staging
-                    .import_diagnostics()
-                    .expect("failed closure publishes canonical import diagnostics");
-                let errors = CompileErrors::from(diagnostics.errors().to_vec());
                 return Err(SourceLoadError::Compiler {
                     snapshot: Some(snapshot),
                     errors,
@@ -651,6 +678,8 @@ pub(crate) fn discover_and_load_imports(
         resolution: SourceResolutionInputs { root_path, context },
         read_manifest,
         revision: closed,
+        #[cfg(test)]
+        input_revision,
         session: staging,
     })
 }
@@ -668,7 +697,7 @@ mod architecture_tests {
 
     fn production_before_tests(source: &str) -> &str {
         source
-            .split("\n#[cfg(test)]\nmod tests {")
+            .split("\n#[cfg(test)]\nmod ")
             .next()
             .unwrap_or(source)
     }
@@ -696,6 +725,23 @@ mod architecture_tests {
     }
 
     #[test]
+    fn cli_executes_only_revision_pinned_compiler_frontiers() {
+        let production = production_before_tests(include_str!("source_loader.rs"));
+        assert!(!production.contains(".pending_requests("));
+        for required_boundary in [
+            "begin_import_input_request(",
+            "import_demand_frontier(",
+            "publish_import_observation_batch(",
+        ] {
+            assert_eq!(
+                production.matches(required_boundary).count(),
+                1,
+                "host boundary must have exactly one call: {required_boundary}"
+            );
+        }
+    }
+
+    #[test]
     fn authority_scan_looks_past_test_gated_imports_but_not_into_test_modules() {
         let peer = r#"
 #[cfg(test)]
@@ -718,5 +764,141 @@ mod tests {
             Some("stage_import_discovery")
         );
         assert!(!production_before_tests(peer).contains("close_import_discovery"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let unique = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path =
+                std::env::temp_dir().join(format!("rue-{name}-{}-{unique}", std::process::id()));
+            fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+
+        fn write(&self, relative: &str, source: &str) -> PathBuf {
+            let path = self.path.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(&path, source).unwrap();
+            path
+        }
+    }
+
+    #[test]
+    fn wide_same_depth_imports_use_one_host_frontier_round() {
+        let single = TestDir::new("single-frontier");
+        let single_main = single.write(
+            "main.rue",
+            r#"const a = @import("a.rue"); fn main() -> i32 { 0 }"#,
+        );
+        single.write("a.rue", "pub fn value() -> i32 { 1 }");
+        let single_result =
+            discover_and_load_imports(single_main.to_str().unwrap(), None, None).unwrap();
+
+        let wide = TestDir::new("wide-frontier");
+        let mut source = String::new();
+        for index in 0..24 {
+            source.push_str(&format!("const m{index} = @import(\"m{index}.rue\");\n"));
+            wide.write(
+                &format!("m{index}.rue"),
+                &format!("pub fn value{index}() -> i32 {{ {index} }}"),
+            );
+        }
+        source.push_str("fn main() -> i32 { 0 }\n");
+        let wide_main = wide.write("main.rue", &source);
+        let wide_result =
+            discover_and_load_imports(wide_main.to_str().unwrap(), None, None).unwrap();
+
+        assert_eq!(single_result.input_revision.frontier_round(), 1);
+        assert_eq!(
+            wide_result.input_revision.frontier_round(),
+            single_result.input_revision.frontier_round(),
+            "frontier count must depend on graph depth, not same-depth width"
+        );
+        assert_eq!(wide_result.read_manifest.len(), 25);
+    }
+
+    #[test]
+    fn import_chain_adds_one_frontier_round_per_depth() {
+        let dir = TestDir::new("depth-frontier");
+        let main = dir.write(
+            "main.rue",
+            r#"const a = @import("a.rue"); fn main() -> i32 { a.b.c.value() }"#,
+        );
+        dir.write(
+            "a.rue",
+            r#"pub const b = @import("b.rue"); pub fn a() -> i32 { 1 }"#,
+        );
+        dir.write(
+            "b.rue",
+            r#"pub const c = @import("c.rue"); pub fn b() -> i32 { 2 }"#,
+        );
+        dir.write("c.rue", "pub fn value() -> i32 { 3 }");
+
+        let result = discover_and_load_imports(main.to_str().unwrap(), None, None).unwrap();
+        assert_eq!(result.input_revision.frontier_round(), 3);
+        assert_eq!(result.read_manifest.len(), 4);
+    }
+
+    #[test]
+    fn rooted_std_discovery_does_not_read_unrelated_std_modules() {
+        let project = TestDir::new("std-project");
+        let stdlib = TestDir::new("std-library");
+        let main = project.write(
+            "main.rue",
+            r#"const std = @import("std"); fn main() -> i32 { 0 }"#,
+        );
+        stdlib.write("_std.rue", r#"pub const math = @import("math.rue");"#);
+        stdlib.write("math.rue", "pub fn answer() -> i32 { 42 }");
+        let unrelated =
+            fs::canonicalize(stdlib.write("unrelated.rue", "pub fn unused() -> i32 { 0 }"))
+                .unwrap();
+        let std_root = fs::canonicalize(&stdlib.path).unwrap();
+
+        let result =
+            discover_and_load_imports(main.to_str().unwrap(), None, Some(&std_root)).unwrap();
+        assert_eq!(result.input_revision.frontier_round(), 2);
+        assert_eq!(result.read_manifest.len(), 3);
+        assert!(
+            result
+                .read_manifest
+                .iter()
+                .all(|entry| entry.canonical_path() != unrelated.to_string_lossy())
+        );
+    }
+
+    #[test]
+    fn manifest_denial_remains_a_typed_fail_closed_diagnostic() {
+        let project = TestDir::new("manifest-denial");
+        let main = project.write(
+            "main.rue",
+            r#"const missing = @import("missing"); fn main() -> i32 { 0 }"#,
+        );
+        let manifest_path = project.write("sources.manifest", "main.rue\n");
+        let manifest = SourceManifest::load(manifest_path.to_str().unwrap()).unwrap();
+        match discover_and_load_imports(main.to_str().unwrap(), Some(&manifest), None) {
+            Err(SourceLoadError::Compiler { errors, .. }) => {
+                let rendered = errors.to_string();
+                assert!(rendered.contains("source manifest"), "{rendered}");
+                assert!(rendered.contains("missing.rue"), "{rendered}");
+            }
+            Err(SourceLoadError::Message(message)) => {
+                panic!("policy denial escaped typed diagnostics: {message}")
+            }
+            Ok(_) => panic!("policy denial unexpectedly closed successfully"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

- add granular revision-pinned source, provenance, and optional observation query leaves, including negative-input invalidation
- add explicit rooted and speculative import-demand frontiers with deterministic host-operation deduplication and occurrence fanout
- move CLI, oracle, and benchmark consumers through the revisioned protocol while keeping the new surface unstable and marking exact RUE-1024, RUE-1026, and RUE-1033 compatibility gates
- preserve one canonical syntax and reachability authority; semantic demand origins intentionally arrive in the later query-family tickets

## Validation

- isolated focused Buck2 suite: rue-query 27, rue-compiler 608, rue 171, public API 8, differential oracle 4
- isolated generated oracle 64/64 and UI 195/195
- scripts/rue fmt
- git diff --check
- python3 scripts/validate-rust-project.py

Fixes RUE-1023