### PR TITLE
RUE-1037: heterogeneous enum images via per-variant tag dispatch (ADR-0052 phase 5.12)

### DIFF
--- a/crates/rue-cli-tests/cases/aggregate_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout.toml
@@ -536,25 +536,37 @@ fn main() -> i32 {
 stdout = ""
 exit_code = 0
 
-# RUE-1000 keeps refusing enums whose compact memory image is variant-dependent:
-# A(i64) and B(i32,i32) would need overlapping union slots (the i64 field spans
-# both i32 positions), so there is no single slot->byte map. Refused loudly.
+# RUE-1037: an enum whose per-variant payload layouts DISAGREE (A(i64) overlaps
+# B's two i32 positions, so the flatten-merge finds no single slot->byte map) now
+# marshals through a pointer by dispatching on the tag and running the ACTIVE
+# variant's own map. Both variants round-trip through the heap.
 [[case]]
-name = "compact_enum_overlapping_union_still_fails"
-description = "An enum whose union payload slots overlap (i64 vs two i32) has no variant-independent memory image and is refused."
+name = "compact_enum_overlapping_union_roundtrip"
+description = "A heterogeneous enum (i64 vs two i32, overlapping union positions) round-trips through a heap pointer via per-variant tag dispatch (RUE-1037)."
+differential_opt = true
 args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Bad { A(i64), B(i32, i32) }
+fn first(v: Bad) -> i64 {
+    match v { Bad.A(x) => x, Bad.B(y, z) => @intCast(y + z), }
+}
 fn main() -> i32 {
-    checked {
+    let r = checked {
         let p: ptr mut Bad = @alloc(1);
-        @ptr_write(p, Bad.A(5));
+        @ptr_write(p, Bad.A(0 - 3));
+        let a: Bad = @ptr_read(p);
+        @ptr_write(p, Bad.B(40, 2));
+        let b: Bad = @ptr_read(p);
+        @free(p, 1);
+        first(a) * 100 + first(b)
     };
+    let t: i32 = @intCast(r);
+    @dbg(t);
     0
 }
 """ }]
-compile_fail = true
-error_contains = ["aggregate_layout", "not yet implemented"]
+stdout = "-258\n"
+exit_code = 0
 
 # RUE-1000 keeps refusing a nested-aggregate enum payload through a pointer:
 # a struct payload has no single-slot scalar memory image in this phase.
@@ -585,14 +597,14 @@ fn main() -> i32 {
 stdout = "69\n"
 exit_code = 0
 
-# An IMAGELESS compact enum crossing a CALL boundary by value stays refused
-# (RUE-1005): overlapping union payload slots (`A(i64)` versus `B(i32, i32)`)
-# give no variant-independent memory image, so the caller cannot build a compact
-# buffer and the callee cannot unmarshal one. A compact enum WITH an image now
-# crosses by value (see `compact_enum_by_value_match`).
+# RUE-1037: a heterogeneous compact enum crossing a CALL boundary by value now
+# marshals through its per-variant tag-dispatched image — the caller writes the
+# active variant's image into its buffer, the callee unmarshals it in the
+# prologue. (Previously refused as "imageless" under RUE-1005.)
 [[case]]
-name = "imageless_enum_crossing_call_still_fails"
-description = "A variant-dependent (imageless) compact enum passed by value across a call is still refused under --preview aggregate_layout (RUE-1005)."
+name = "compact_heterogeneous_enum_crossing_call_by_value"
+description = "A heterogeneous compact enum (i64 vs two i32) passed by value across a call marshals through its tag-dispatched image (RUE-1037)."
+differential_opt = true
 args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Bad { A(i64), B(i32, i32) }
@@ -600,11 +612,14 @@ fn first(v: Bad) -> i64 {
     match v { Bad.A(x) => x, Bad.B(y, z) => @intCast(y + z), }
 }
 fn main() -> i32 {
-    @intCast(first(Bad.A(5)))
+    let s: i64 = first(Bad.A(5)) + first(Bad.B(30, 12));
+    let t: i32 = @intCast(s);
+    @dbg(t);
+    0
 }
 """ }]
-compile_fail = true
-error_contains = ["aggregate_layout", "not yet implemented"]
+stdout = "47\n"
+exit_code = 0
 
 # RUE-1004 (ADR-0052 phase 5.7): call-boundary marshalling for compact
 # aggregates. A non-slot-identical aggregate the preserved slot convention
@@ -1232,3 +1247,113 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["raw pointer", "frame-resident aggregate"]
+
+# --- RUE-1037: heterogeneous enum images via per-variant tag dispatch ---------
+# An enum whose variants' payload layouts DISAGREE (e.g. Ok(struct{i32,i32,i32})
+# vs Err(i64)) has no single variant-independent compact image, so the merge in
+# `enum_physical_slot_map` returns None. Each variant's own slot->byte map still
+# exists, so marshalling dispatches on the tag (slot 0 / offset 0) and runs the
+# active variant's map. This is the last construct blocking the compact default.
+
+# Constructed, returned by value (sret), passed by value as an argument, and
+# matched on BOTH variants. exit via @dbg: Ok payload sum 60, Err payload 77.
+[[case]]
+name = "compact_heterogeneous_enum_construct_return_match"
+description = "A heterogeneous enum { Ok(struct{i32,i32,i32}), Err(i64) } is constructed, sret-returned, passed by value, and matched on both variants (RUE-1037)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum R { Ok(Point), Err(i64) }
+struct Point { x: i32, y: i32, z: i32 }
+fn make_ok() -> R { R.Ok(Point { x: 10, y: 20, z: 30 }) }
+fn make_err() -> R { R.Err(77) }
+fn sum(r: R) -> i64 {
+    match r {
+        R.Ok(p) => @intCast(p.x + p.y + p.z),
+        R.Err(e) => e,
+    }
+}
+fn main() -> i32 {
+    let a = sum(make_ok());
+    let b = sum(make_err());
+    let t: i32 = @intCast(a + b);
+    @dbg(t);
+    0
+}
+""" }]
+stdout = "137\n"
+exit_code = 0
+
+# Heap round-trip with variant overwrite + poison read (RUE-1007 ruling 5): write
+# the wider Ok payload, overwrite with the shorter Err, then read a byte where
+# Ok's third field lived — the full-extent zero on the Err store leaves it 0, so
+# no residue. classify(Err) = -5, poison byte = 0, sum = -5.
+[[case]]
+name = "compact_heterogeneous_enum_heap_overwrite_no_residue"
+description = "Overwriting a heap heterogeneous enum with a shorter variant zeroes the wider variant's payload bytes; the round-tripped value classifies correctly (RUE-1037 / RUE-1007)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum R { Ok(Point), Err(i64) }
+struct Point { x: i32, y: i32, z: i32 }
+fn classify(r: R) -> i64 {
+    match r {
+        R.Ok(p) => @intCast(p.x + p.y + p.z),
+        R.Err(e) => e,
+    }
+}
+fn main() -> i32 {
+    let out = checked {
+        let p: ptr mut R = @alloc(1);
+        @ptr_write(p, R.Ok(Point { x: 11, y: 22, z: 33 }));
+        @ptr_write(p, R.Err(0 - 5));
+        let bytes: ptr mut u8 = @int_to_ptr(@ptr_to_int(p));
+        let poison: u8 = @ptr_read(@ptr_offset(bytes, 16));
+        let r: R = @ptr_read(p);
+        @free(p, 1);
+        let z: i32 = @intCast(classify(r)) + @intCast(poison);
+        z
+    };
+    @dbg(out);
+    0
+}
+""" }]
+stdout = "-5\n"
+exit_code = 0
+
+# A heterogeneous enum nested inside a struct that crosses a call boundary both
+# ways (returned by value from `mk`, passed by value into `consume`). The struct
+# image is flat leaves for `tag`/`extra` plus a tag-dispatched region for `r`.
+[[case]]
+name = "compact_heterogeneous_enum_in_struct_across_call"
+description = "A struct containing a heterogeneous enum crosses a call boundary in both directions, marshalled via a nested tag dispatch (RUE-1037)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum R { Ok(Point), Err(i64) }
+struct Point { x: i32, y: i32, z: i32 }
+struct Wrap { tag: i32, r: R, extra: i64 }
+fn mk(v: i32) -> Wrap {
+    if v > 0 {
+        Wrap { tag: 1, r: R.Ok(Point { x: v, y: v * 2, z: v * 3 }), extra: 100 }
+    } else {
+        Wrap { tag: 2, r: R.Err(0 - 9), extra: 200 }
+    }
+}
+fn consume(w: Wrap) -> i64 {
+    let rv = match w.r {
+        R.Ok(p) => @intCast(p.x + p.y + p.z),
+        R.Err(e) => e,
+    };
+    rv + @intCast(w.tag) + w.extra
+}
+fn main() -> i32 {
+    let a = consume(mk(5));
+    let b = consume(mk(0 - 1));
+    let t: i32 = @intCast(a + b);
+    @dbg(t);
+    0
+}
+""" }]
+stdout = "324\n"
+exit_code = 0

--- a/crates/rue-cli-tests/cases/aggregate_layout_std_sweep.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout_std_sweep.toml
@@ -332,25 +332,94 @@ fn main() -> i32 {
 stdout = "1\n10\n2\n20\n3\n30\n5\n50\n"
 exit_code = 0
 
-# Refusal sentinel: an enum whose per-variant payloads genuinely overlap (no
-# single variant-independent image) must still fail LOUDLY, never miscompile. If
-# a future change lifts this, the sentinel flips to a hard failure and forces a
-# deliberate update. `A(u16, u16)` versus `B(u32)`: leaf 0 merges to a 4-byte
-# slot at the payload start, but `A`'s leaf 1 sits at payload+2, overlapping it.
+# RUE-1037: an enum whose per-variant payloads overlap at narrow widths
+# (`A(u16, u16)` at payload+0/+2 versus `B(u32)` at payload+0) now marshals
+# through a per-variant tag dispatch — each variant's own narrow leaves are
+# stored/loaded, and the full-extent zero on a store leaves no residue. Both
+# variants round-trip through the heap.
 [[case]]
-name = "overlapping_union_enum_still_refuses"
-description = "An enum whose per-variant payloads overlap has no variant-independent image and is still refused under the gate, not miscompiled (RUE-1014 boundary)."
+name = "overlapping_union_enum_roundtrips_via_dispatch"
+description = "An enum with overlapping narrow payload positions (u16,u16 vs u32) round-trips through a heap pointer via per-variant tag dispatch (RUE-1037)."
+differential_opt = true
 args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Ov { A(u16, u16), B(u32) }
 fn make(v: bool) -> Ov { if v { Ov.A(1, 2) } else { Ov.B(3) } }
 fn main() -> i32 {
-    match make(true) {
-        Ov.A(a, b) => { let s: i32 = @intCast(a) + @intCast(b); @dbg(s); },
-        Ov.B(c) => { let s: i32 = @intCast(c); @dbg(s); }
+    let r = checked {
+        let p: ptr mut Ov = @alloc(1);
+        @ptr_write(p, make(true));
+        let a: Ov = @ptr_read(p);
+        @ptr_write(p, make(false));
+        let b: Ov = @ptr_read(p);
+        @free(p, 1);
+        let av: i32 = match a { Ov.A(x, y) => @intCast(x) + @intCast(y), Ov.B(c) => @intCast(c) };
+        let bv: i32 = match b { Ov.A(x, y) => @intCast(x) + @intCast(y), Ov.B(c) => @intCast(c) };
+        av * 10 + bv
     };
+    @dbg(r);
     0
 }
 """ }]
-compile_fail = true
-error_contains = ["aggregate_layout", "not yet implemented"]
+stdout = "33\n"
+exit_code = 0
+
+# RUE-1037 SUCCESS GATE: a faithful mirror of std.net's Result(SockAddr,
+# NetworkError) return surface (TcpListener.local_addr) — the exact heterogeneous
+# shape that blocked the compact-layout default. Ok(SockAddr{ IpAddr enum, u16 })
+# and Err(NetworkError enum with an Other(i64) payload) have DISAGREEING payload
+# layouts, so the enum is marshalled by per-variant tag dispatch. Exercised as an
+# sret return, a by-value argument, a heap @ptr_write/@ptr_read round-trip, and a
+# nested-match on both variants. 8208 (Ok) + 111 (Err) + 8208 (heap Ok) = 16527.
+[[case]]
+name = "std_net_result_sockaddr_networkerror_mirror_under_gate"
+description = "A faithful mirror of std.net Result(SockAddr, NetworkError) — the heterogeneous enum blocking the compact default — round-trips by value, by argument, and through the heap under the gate via per-variant tag dispatch (RUE-1037)."
+differential_opt = true
+args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Ipv4Addr { a: u8, b: u8, c: u8, d: u8 }
+enum IpAddr { V4(Ipv4Addr) }
+struct SockAddr { ip: IpAddr, port: u16 }
+enum NetworkError {
+    Unsupported, PermissionDenied, AddressInUse, AddressNotAvailable,
+    ConnectionRefused, ConnectionReset, ConnectionAborted, NotConnected,
+    TimedOut, Interrupted, WouldBlock, InvalidInput, Other(i64),
+}
+enum NetResult { Ok(SockAddr), Err(NetworkError) }
+fn local_addr_ok() -> NetResult {
+    NetResult.Ok(SockAddr { ip: IpAddr.V4(Ipv4Addr { a: 127, b: 0, c: 0, d: 1 }), port: 8080 })
+}
+fn local_addr_err() -> NetResult { NetResult.Err(NetworkError.Other(111)) }
+fn octet_sum(ip: IpAddr) -> i64 {
+    match ip { IpAddr.V4(v4) => @intCast(v4.a) + @intCast(v4.b) + @intCast(v4.c) + @intCast(v4.d), }
+}
+fn err_code(e: NetworkError) -> i64 {
+    match e {
+        NetworkError.ConnectionRefused => 0 - 1,
+        NetworkError.Other(code) => code,
+        _ => 0 - 2,
+    }
+}
+fn classify(r: NetResult) -> i64 {
+    match r {
+        NetResult.Ok(sa) => octet_sum(sa.ip) + @intCast(sa.port),
+        NetResult.Err(e) => err_code(e),
+    }
+}
+fn main() -> i32 {
+    let s1 = classify(local_addr_ok());
+    let s2 = classify(local_addr_err());
+    let s3 = checked {
+        let p: ptr mut NetResult = @alloc(1);
+        @ptr_write(p, local_addr_ok());
+        let back: NetResult = @ptr_read(p);
+        @free(p, 1);
+        classify(back)
+    };
+    let total: i32 = @intCast(s1 + s2 + s3);
+    @dbg(total);
+    0
+}
+""" }]
+stdout = "16527\n"
+exit_code = 0

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -123,6 +123,29 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
         crate::agg_slots::store_enum_slots_through_ptr(self, &slots, pointer, image, padding);
         pointer
     }
+
+    fn materialize_indirect_value_arg_dispatch(
+        &mut self,
+        value: CfgValue,
+        image: &crate::types::DispatchImage,
+        storage_bytes: u32,
+    ) -> VReg {
+        // As `materialize_indirect_value_arg`, but the caller-owned buffer is
+        // written with a per-variant tag dispatch (RUE-1037).
+        self.mir.push(Aarch64Inst::SubImm {
+            dst: Operand::Physical(Reg::Sp),
+            src: Operand::Physical(Reg::Sp),
+            imm: storage_bytes as i32,
+        });
+        let pointer = self.mir.alloc_vreg();
+        self.mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Virtual(pointer),
+            src: Operand::Physical(Reg::Sp),
+        });
+        let slots = self.require_aggregate_slots(value);
+        crate::agg_slots::store_dispatch_image(self, &slots, pointer, image);
+        pointer
+    }
 }
 
 impl<'a> CfgLower<'a> {
@@ -797,6 +820,15 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Physical(Reg::Sp),
                     });
                     crate::agg_slots::load_enum_slots_through_ptr(self, base, map)
+                } else if let Some(image) = &plan.compact_return_dispatch {
+                    // Heterogeneous compact aggregate return (RUE-1037): dispatch on
+                    // the tag and read the active variant's image from the sret buffer.
+                    let base = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Virtual(base),
+                        src: Operand::Physical(Reg::Sp),
+                    });
+                    crate::agg_slots::load_dispatch_image(self, base, image)
                 } else {
                     (0..slot_count)
                         .map(|index| {
@@ -1545,6 +1577,11 @@ impl<'a> CfgLower<'a> {
                     // (RUE-1000).
                     slots = crate::agg_slots::load_enum_slots_through_ptr(self, ptr, map);
                     slots[0]
+                } else if let Some(image) = &plan.dispatch_image {
+                    // A heterogeneous compact aggregate pointee: dispatch on the
+                    // runtime tag and load the active variant's image (RUE-1037).
+                    slots = crate::agg_slots::load_dispatch_image(self, ptr, image);
+                    slots[0]
                 } else if count > 1 {
                     slots = crate::agg_slots::load_slots_through_ptr(self, ptr, count);
                     slots[0]
@@ -1593,6 +1630,16 @@ impl<'a> CfgLower<'a> {
                         map,
                         &plan.image_padding,
                     );
+                } else if let Some(image) = &plan.dispatch_image {
+                    // A heterogeneous compact aggregate value: zero the full image
+                    // extent, then dispatch on the tag and store the active
+                    // variant's leaves (RUE-1037).
+                    let vals = if value.slots.is_empty() {
+                        vec![value.primary]
+                    } else {
+                        value.slots.clone()
+                    };
+                    crate::agg_slots::store_dispatch_image(self, &vals, ptr, image);
                 } else if value.slot_count == 0 {
                     // Zero-sized values have no bytes to write.
                 } else if !value.slots.is_empty() {
@@ -2636,7 +2683,17 @@ impl<'a> CfgLower<'a> {
                                         self, &slots, &map, &padding,
                                     )
                                 }
-                                None => crate::agg_slots::store_slots_to_sret(self, &slots),
+                                None => match crate::types::aggregate_dispatch_image(
+                                    self.ctx.type_pool,
+                                    return_ty,
+                                ) {
+                                    // Heterogeneous compact aggregate return (RUE-1037):
+                                    // write the sret image with a per-variant tag dispatch.
+                                    Some(image) => crate::agg_slots::store_dispatch_image_to_sret(
+                                        self, &slots, &image,
+                                    ),
+                                    None => crate::agg_slots::store_slots_to_sret(self, &slots),
+                                },
                             }
                         } else {
                             for (index, slot) in slots.iter().enumerate() {
@@ -2738,6 +2795,11 @@ impl crate::terminator_plan::CfgLowerAdapter for CfgLower<'_> {
         // projection and whole-value reads see the correct decomposition.
         for (base_slot, map) in crate::value_plan::indirect_value_params(&self.ctx) {
             crate::agg_slots::unmarshal_indirect_value_param(self, base_slot, &map);
+        }
+        // Heterogeneous by-value indirect params unmarshal with a tag dispatch
+        // (RUE-1037).
+        for (base_slot, image) in crate::value_plan::indirect_value_params_dispatch(&self.ctx) {
+            crate::agg_slots::unmarshal_indirect_value_param_dispatch(self, base_slot, &image);
         }
     }
 
@@ -2953,6 +3015,31 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
             imm: 0,
         });
         dst
+    }
+    fn emit_set_zero(&mut self, dst: VReg) {
+        self.mir.push(Aarch64Inst::MovImm {
+            dst: Operand::Virtual(dst),
+            imm: 0,
+        });
+    }
+    fn alloc_marshal_label(&mut self) -> LabelId {
+        self.mir.alloc_label()
+    }
+    fn emit_marshal_branch_if_tag_ne(&mut self, tag: VReg, discriminant: u64, label: LabelId) {
+        self.mir.push(Aarch64Inst::CmpImm {
+            src: Operand::Virtual(tag),
+            imm: discriminant as i32,
+        });
+        self.mir.push(Aarch64Inst::BCond {
+            cond: Cond::Ne,
+            label,
+        });
+    }
+    fn emit_marshal_jump(&mut self, label: LabelId) {
+        self.mir.push(Aarch64Inst::B { label });
+    }
+    fn emit_marshal_label(&mut self, label: LabelId) {
+        self.mir.push(Aarch64Inst::Label { id: label });
     }
 }
 
@@ -3399,6 +3486,45 @@ mod tests {
         );
     }
 
+    /// RUE-1037: on AArch64, a HETEROGENEOUS enum (variants whose payload layouts
+    /// disagree) is marshalled through a pointer by dispatching on the runtime tag
+    /// — the store emits a tag compare per variant plus narrow field stores.
+    /// Gate-off the same `@ptr_write` stores eight-byte slots with no tag dispatch
+    /// and no narrow store.
+    #[test]
+    fn aggregate_layout_heterogeneous_enum_ptr_write_tag_dispatches() {
+        let source = "enum R { Ok(Point), Err(i64) } \
+                      struct Point { x: i32, y: i32, z: i32 } \
+                      fn store_it(p: ptr mut R) { checked { @ptr_write(p, R.Ok(Point { x: 1, y: 2, z: 3 })); }; } \
+                      fn main() -> i32 { checked { let p: ptr mut R = @alloc(1); store_it(p); @free(p, 1); }; 0 }";
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let mir = try_lower_named_fn(source, preview, Some("store_it"))
+            .expect("a heterogeneous enum @ptr_write must lower via tag dispatch");
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::CmpImm { .. })),
+            "the heterogeneous store must compare the tag to dispatch on the variant"
+        );
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::NarrowStoreIndexed { .. })),
+            "the active variant's narrow leaves must be stored narrow"
+        );
+
+        let off = try_lower_named_fn(source, PreviewFeatures::new(), Some("store_it"))
+            .expect("the same program lowers under the default slot model");
+        assert!(
+            off.instructions().iter().all(|inst| !matches!(
+                inst,
+                Aarch64Inst::CmpImm { .. } | Aarch64Inst::NarrowStoreIndexed { .. }
+            )),
+            "gate-off must store eight-byte slots with no tag dispatch and no narrow store"
+        );
+    }
+
     /// RUE-987: a whole compact struct round-trips through a typed pointer on
     /// AArch64, reusing the enum-image slot machinery — `@ptr_write` stores each
     /// field narrow at its compact offset and `@ptr_read` reloads it. Gate-off
@@ -3491,21 +3617,24 @@ mod tests {
         );
     }
 
-    /// RUE-1014: a struct WITHOUT a variant-independent compact image — it embeds
-    /// an enum whose union payloads overlap (`A(i64)` versus `B(i32, i32)`) — is
-    /// still refused loudly through a pointer on AArch64, not miscompiled.
+    /// RUE-1037: a struct embedding a HETEROGENEOUS enum (`A(i64)` versus
+    /// `B(i32, i32)`, whose payload layouts disagree) marshals through a pointer
+    /// on AArch64 via a nested tag dispatch — the store compares the embedded tag
+    /// and stores the active variant's leaves. (Previously refused as imageless.)
     #[test]
-    fn aggregate_layout_refuses_image_less_struct_memory() {
+    fn aggregate_layout_marshals_struct_embedding_heterogeneous_enum() {
         let source = "enum Bad { A(i64), B(i32, i32) } struct HasBad { b: Bad } \
                       fn main() -> i32 { checked { let p: ptr mut HasBad = @alloc(1); \
-                      @ptr_write(p, HasBad { b: Bad.A(5) }); }; 0 }";
+                      @ptr_write(p, HasBad { b: Bad.A(5) }); @free(p, 1); }; 0 }";
         let mut preview = PreviewFeatures::new();
         preview.insert(PreviewFeature::AggregateLayout);
-        let err = try_lower_first_fn(source, preview)
-            .expect_err("a struct embedding an imageless enum must refuse, not miscompile");
+        let mir = try_lower_first_fn(source, preview)
+            .expect("a struct embedding a heterogeneous enum must lower via nested tag dispatch");
         assert!(
-            format!("{err:?}").contains("aggregate_layout"),
-            "refusal must name the feature, got: {err:?}"
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::CmpImm { .. })),
+            "the nested heterogeneous enum store must dispatch on the embedded tag"
         );
     }
 
@@ -3613,23 +3742,25 @@ mod tests {
         );
     }
 
-    /// RUE-1000 keeps refusing a compact enum whose union payload slots would
-    /// overlap (`A(i64)` versus `B(i32, i32)`) on AArch64: no
-    /// variant-independent slot→byte image, so it fails loudly.
+    /// RUE-1037: a compact enum whose union payload slots overlap (`A(i64)`
+    /// versus `B(i32, i32)`, no variant-independent image) now marshals through a
+    /// pointer on AArch64 via per-variant tag dispatch rather than being refused.
     #[test]
-    fn aggregate_layout_refuses_variant_dependent_enum_memory() {
+    fn aggregate_layout_marshals_variant_dependent_enum_memory() {
         let mut preview = PreviewFeatures::new();
         preview.insert(PreviewFeature::AggregateLayout);
-        let err = try_lower_first_fn(
+        let mir = try_lower_first_fn(
             "enum Bad { A(i64), B(i32, i32) } \
              fn main() -> i32 { checked { let p: ptr mut Bad = @alloc(1); \
-             @ptr_write(p, Bad.A(5)); }; 0 }",
+             @ptr_write(p, Bad.A(5)); @free(p, 1); }; 0 }",
             preview,
         )
-        .expect_err("a variant-dependent enum memory image must be refused");
+        .expect("a variant-dependent enum memory image must lower via tag dispatch");
         assert!(
-            format!("{err:?}").contains("aggregate_layout"),
-            "refusal must name the feature, got: {err:?}"
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::CmpImm { .. })),
+            "the heterogeneous enum store must dispatch on the tag"
         );
     }
 

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -85,6 +85,32 @@ pub(crate) trait SlotBackend: BoundsCheckBackend {
     /// Allocate a fresh vreg holding the constant zero, used to clear a compact
     /// image's padding bytes (ADR-0052 ruling 5).
     fn emit_zero_vreg(&mut self) -> VReg;
+
+    /// Set the existing vreg `dst` to the constant zero (RUE-1037). Used on a
+    /// tag-dispatched image load to clear the payload slots the active variant
+    /// does not write, so the loaded value matches the zeroed decomposition of a
+    /// shorter variant.
+    fn emit_set_zero(&mut self, dst: VReg);
+
+    /// Allocate a fresh label for a tag-dispatch marshalling edge (RUE-1037).
+    fn alloc_marshal_label(&mut self) -> crate::vreg::LabelId;
+
+    /// Compare the discriminant in `tag` against `discriminant` and branch to
+    /// `label` when they are NOT equal (RUE-1037): the fall-through path runs the
+    /// matched variant's arm, the branch skips to the next arm.
+    fn emit_marshal_branch_if_tag_ne(
+        &mut self,
+        tag: VReg,
+        discriminant: u64,
+        label: crate::vreg::LabelId,
+    );
+
+    /// Emit an unconditional jump to `label` (RUE-1037), used to leave a matched
+    /// variant's arm for the dispatch's merge point.
+    fn emit_marshal_jump(&mut self, label: crate::vreg::LabelId);
+
+    /// Bind `label` at the current position (RUE-1037).
+    fn emit_marshal_label(&mut self, label: crate::vreg::LabelId);
 }
 
 /// Zero the padding byte `ranges` of a compact memory image reached through
@@ -372,6 +398,170 @@ pub(crate) fn store_slots_to_sret_compact<B: SlotBackend>(
     let sret_slot = b.ctx().sret_ptr_slot();
     b.emit_load_slot(ptr, sret_slot);
     store_enum_slots_through_ptr(b, vals, ptr, map, padding);
+}
+
+// ============================================================================
+// Heterogeneous-enum tag-dispatched image marshalling (ADR-0052 phase 5.12,
+// RUE-1037).
+//
+// A heterogeneous enum (or an aggregate containing one) has no single
+// variant-independent slot->byte map, but its value decomposition IS
+// variant-independent. So marshalling branches on the runtime tag at each
+// dispatched region and runs the ACTIVE variant's leaf stores/loads — reusing
+// the same per-leaf narrow/full emission the single-map path uses. A store
+// zeros the whole image extent first, then writes the active variant's leaves,
+// so every byte outside them is deterministically zero (RUE-1007).
+// ============================================================================
+
+/// Store a whole heterogeneous aggregate value's `vals` (one vreg per internal
+/// slot, slot 0 first) through `ptr` as its tag-dispatched compact image
+/// (RUE-1037). The full image extent is zeroed first, then each `Switch` region
+/// branches on the value's tag slot and stores only the matched variant's leaves.
+pub(crate) fn store_dispatch_image<B: SlotBackend>(
+    b: &mut B,
+    vals: &[VReg],
+    ptr: VReg,
+    image: &crate::types::DispatchImage,
+) {
+    zero_padding_through_ptr(
+        b,
+        ptr,
+        &[PaddingRange {
+            start: 0,
+            end: u64::from(image.image_size),
+        }],
+    );
+    store_image_segs(b, vals, ptr, &image.segs);
+}
+
+fn store_image_segs<B: SlotBackend>(
+    b: &mut B,
+    vals: &[VReg],
+    ptr: VReg,
+    segs: &[crate::types::ImageSeg],
+) {
+    for seg in segs {
+        match seg {
+            crate::types::ImageSeg::Leaf { slot, phys } => {
+                store_leaf(b, vals[*slot as usize], ptr, phys);
+            }
+            crate::types::ImageSeg::Switch(region) => {
+                let tag = vals[region.tag_slot as usize];
+                // The discriminant is a common leaf across every variant.
+                b.emit_narrow_store_through_ptr(tag, ptr, region.tag_offset, region.tag_access);
+                let end = b.alloc_marshal_label();
+                for arm in &region.arms {
+                    let next = b.alloc_marshal_label();
+                    b.emit_marshal_branch_if_tag_ne(tag, arm.discriminant, next);
+                    store_image_segs(b, vals, ptr, &arm.segs);
+                    b.emit_marshal_jump(end);
+                    b.emit_marshal_label(next);
+                }
+                b.emit_marshal_label(end);
+            }
+        }
+    }
+}
+
+fn store_leaf<B: SlotBackend>(
+    b: &mut B,
+    val: VReg,
+    ptr: VReg,
+    phys: &crate::types::PhysicalEnumSlot,
+) {
+    match phys.access {
+        None => b.emit_store_through_ptr(val, ptr, phys.byte_offset),
+        Some(access) => b.emit_narrow_store_through_ptr(val, ptr, phys.byte_offset, access),
+    }
+}
+
+/// Load a whole heterogeneous aggregate value's internal slots from `ptr` as its
+/// tag-dispatched compact image (RUE-1037), returning `total_slots` vregs in
+/// internal slot order. Each `Switch` region reads the tag, zeros its payload
+/// slots, then branches on the tag to load only the matched variant's leaves —
+/// so the unused payload slots read back zero, matching the value decomposition.
+pub(crate) fn load_dispatch_image<B: SlotBackend>(
+    b: &mut B,
+    ptr: VReg,
+    image: &crate::types::DispatchImage,
+) -> Vec<VReg> {
+    let result: Vec<VReg> = (0..image.total_slots).map(|_| b.alloc_vreg()).collect();
+    load_image_segs(b, ptr, &result, &image.segs);
+    result
+}
+
+fn load_image_segs<B: SlotBackend>(
+    b: &mut B,
+    ptr: VReg,
+    result: &[VReg],
+    segs: &[crate::types::ImageSeg],
+) {
+    for seg in segs {
+        match seg {
+            crate::types::ImageSeg::Leaf { slot, phys } => {
+                load_leaf(b, result[*slot as usize], ptr, phys);
+            }
+            crate::types::ImageSeg::Switch(region) => {
+                let tag = result[region.tag_slot as usize];
+                b.emit_narrow_load_through_ptr(tag, ptr, region.tag_offset, region.tag_access);
+                // Zero the payload slots so a shorter variant's unwritten slots
+                // read back zero on every path (matching the value model, and
+                // giving every result slot a definition on all branches).
+                for slot in (region.tag_slot + 1)..(region.tag_slot + region.span) {
+                    b.emit_set_zero(result[slot as usize]);
+                }
+                let end = b.alloc_marshal_label();
+                for arm in &region.arms {
+                    let next = b.alloc_marshal_label();
+                    b.emit_marshal_branch_if_tag_ne(tag, arm.discriminant, next);
+                    load_image_segs(b, ptr, result, &arm.segs);
+                    b.emit_marshal_jump(end);
+                    b.emit_marshal_label(next);
+                }
+                b.emit_marshal_label(end);
+            }
+        }
+    }
+}
+
+fn load_leaf<B: SlotBackend>(
+    b: &mut B,
+    dst: VReg,
+    ptr: VReg,
+    phys: &crate::types::PhysicalEnumSlot,
+) {
+    match phys.access {
+        None => b.emit_load_through_ptr(dst, ptr, phys.byte_offset),
+        Some(access) => b.emit_narrow_load_through_ptr(dst, ptr, phys.byte_offset, access),
+    }
+}
+
+/// Tag-dispatched counterpart of [`store_slots_to_sret_compact`] (RUE-1037):
+/// load the sret buffer pointer and store the return value as its tag-dispatched
+/// compact image.
+pub(crate) fn store_dispatch_image_to_sret<B: SlotBackend>(
+    b: &mut B,
+    vals: &[VReg],
+    image: &crate::types::DispatchImage,
+) {
+    let ptr = b.alloc_vreg();
+    let sret_slot = b.ctx().sret_ptr_slot();
+    b.emit_load_slot(ptr, sret_slot);
+    store_dispatch_image(b, vals, ptr, image);
+}
+
+/// Tag-dispatched counterpart of [`unmarshal_indirect_value_param`] (RUE-1037):
+/// read the homed pointer, load the aggregate's tag-dispatched compact image
+/// through it, and store the slot-shaped values into the parameter's frame region.
+pub(crate) fn unmarshal_indirect_value_param_dispatch<B: SlotBackend>(
+    b: &mut B,
+    base_slot: u32,
+    image: &crate::types::DispatchImage,
+) {
+    let ptr = b.alloc_vreg();
+    b.emit_load_slot(ptr, base_slot);
+    let vals = load_dispatch_image(b, ptr, image);
+    store_slots(b, &vals, base_slot);
 }
 
 /// Load `count` slots through `ptr` at ASCENDING byte offsets (slot k at

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -181,6 +181,11 @@ pub struct CallPlan {
     /// `None` for a slot-identical sret return (read back one slot per eight
     /// bytes, unchanged) and for every non-sret return.
     pub compact_return_image: Option<Vec<crate::types::PhysicalEnumSlot>>,
+    /// For a HETEROGENEOUS compact aggregate returned via sret (no single
+    /// variant-independent map, RUE-1037), the tag-dispatched image the callee
+    /// writes and the caller reads back. Set only when [`Self::compact_return_image`]
+    /// is `None` because the return has no single map; `None` otherwise.
+    pub compact_return_dispatch: Option<crate::types::DispatchImage>,
     /// Result vreg reserved by the shared dispatcher before argument leaves
     /// materialize, preserving the canonical event allocation order.
     pub result: Option<VReg>,
@@ -220,6 +225,16 @@ pub enum CallArgInput {
         padding: Vec<rue_air::layout::PaddingRange>,
         storage_bytes: u32,
     },
+    /// A by-value HETEROGENEOUS compact aggregate argument the classifier forces
+    /// indirect (RUE-1037): the caller writes its tag-dispatched compact `image`
+    /// into a caller-owned buffer and passes one pointer, exactly like
+    /// [`Self::IndirectValue`] but with a per-variant tag dispatch instead of a
+    /// single variant-independent map.
+    IndirectValueDispatch {
+        value: rue_cfg::CfgValue,
+        image: crate::types::DispatchImage,
+        storage_bytes: u32,
+    },
     ByRef {
         mode: ByRefMode,
         address: crate::value_plan::ByRefAddressPlan,
@@ -235,6 +250,9 @@ pub struct CallInputs {
     /// aggregate returned via sret under `aggregate_layout` (RUE-1004). See
     /// [`CallPlan::compact_return_image`].
     pub compact_return_image: Option<Vec<crate::types::PhysicalEnumSlot>>,
+    /// The tag-dispatched sret image for a heterogeneous compact aggregate return
+    /// (RUE-1037). See [`CallPlan::compact_return_dispatch`].
+    pub compact_return_dispatch: Option<crate::types::DispatchImage>,
 }
 
 impl CallInputs {
@@ -268,17 +286,27 @@ impl CallInputs {
                         ArgClass::Indirect
                     )
                 {
-                    let image = types::aggregate_physical_slot_map(type_pool, arg_ty).expect(
-                        "a by-value indirect compact aggregate argument must have a \
-                         variant-independent memory image (guaranteed by the refusal scan)",
-                    );
-                    let padding = type_pool.compact_image_padding_ranges(arg_ty);
                     let storage_bytes =
                         align_up(types::type_size_bytes(type_pool, arg_ty) as u32, 16);
-                    return CallArgInput::IndirectValue {
+                    // A heterogeneous compact aggregate has no single map; it
+                    // marshals its buffer with a per-variant tag dispatch (RUE-1037).
+                    if let Some(image) = types::aggregate_physical_slot_map(type_pool, arg_ty) {
+                        let padding = type_pool.compact_image_padding_ranges(arg_ty);
+                        return CallArgInput::IndirectValue {
+                            value: arg.value,
+                            image,
+                            padding,
+                            storage_bytes,
+                        };
+                    }
+                    let image = types::aggregate_dispatch_image(type_pool, arg_ty).expect(
+                        "a by-value indirect compact aggregate argument must have a \
+                         variant-independent or tag-dispatched memory image (guaranteed by \
+                         the refusal scan)",
+                    );
+                    return CallArgInput::IndirectValueDispatch {
                         value: arg.value,
                         image,
-                        padding,
                         storage_bytes,
                     };
                 }
@@ -300,10 +328,18 @@ impl CallInputs {
         } else {
             None
         };
+        // A heterogeneous compact aggregate return (no single map) marshals its
+        // sret image with a per-variant tag dispatch (RUE-1037).
+        let compact_return_dispatch = if return_plan.uses_sret() && compact_return_image.is_none() {
+            types::aggregate_dispatch_image(type_pool, return_ty)
+        } else {
+            None
+        };
         Self {
             args,
             return_plan,
             compact_return_image,
+            compact_return_dispatch,
         }
     }
 }
@@ -357,6 +393,15 @@ pub trait CallMaterializer {
         padding: &[rue_air::layout::PaddingRange],
         storage_bytes: u32,
     ) -> VReg;
+    /// Tag-dispatched counterpart of [`Self::materialize_indirect_value_arg`] for
+    /// a heterogeneous compact aggregate argument (RUE-1037): reserve the buffer,
+    /// write the tag-dispatched compact `image`, and return the pointer.
+    fn materialize_indirect_value_arg_dispatch(
+        &mut self,
+        value: rue_cfg::CfgValue,
+        image: &crate::types::DispatchImage,
+        storage_bytes: u32,
+    ) -> VReg;
 }
 
 impl CallPlan {
@@ -377,6 +422,7 @@ impl CallPlan {
             target,
             return_plan,
             None,
+            None,
             args,
             arg_reg_budget,
             materializer,
@@ -388,6 +434,7 @@ impl CallPlan {
         target: CallTarget,
         return_plan: ReturnPlan,
         compact_return_image: Option<Vec<crate::types::PhysicalEnumSlot>>,
+        compact_return_dispatch: Option<crate::types::DispatchImage>,
         args: &[CallArgInput],
         arg_reg_budget: usize,
         materializer: &mut M,
@@ -441,6 +488,21 @@ impl CallPlan {
                     );
                     (UserArgMode::Value, vec![pointer])
                 }
+                CallArgInput::IndirectValueDispatch {
+                    value,
+                    image,
+                    storage_bytes,
+                } => {
+                    // As IndirectValue, but the buffer is written with a per-variant
+                    // tag dispatch (RUE-1037).
+                    caller_indirect_bytes += *storage_bytes;
+                    let pointer = materializer.materialize_indirect_value_arg_dispatch(
+                        *value,
+                        image,
+                        *storage_bytes,
+                    );
+                    (UserArgMode::Value, vec![pointer])
+                }
                 CallArgInput::Value {
                     value,
                     slot_count,
@@ -482,6 +544,7 @@ impl CallPlan {
             abi_slots,
             return_plan,
             compact_return_image,
+            compact_return_dispatch,
             result,
             stack_slot_count,
             stack_bytes,
@@ -504,6 +567,7 @@ impl CallPlan {
             abi_slots: slots.to_vec(),
             return_plan: ReturnPlan::ZeroSized,
             compact_return_image: None,
+            compact_return_dispatch: None,
             result: None,
             stack_slot_count,
             stack_bytes: align_up((stack_slot_count * 8) as u32, 16),
@@ -565,6 +629,15 @@ mod tests {
             _storage_bytes: u32,
         ) -> VReg {
             VReg::new(50)
+        }
+
+        fn materialize_indirect_value_arg_dispatch(
+            &mut self,
+            _value: rue_cfg::CfgValue,
+            _image: &crate::types::DispatchImage,
+            _storage_bytes: u32,
+        ) -> VReg {
+            VReg::new(51)
         }
     }
 
@@ -653,6 +726,7 @@ mod tests {
             abi_slots: slots.clone(),
             return_plan: ReturnPlan::ZeroSized,
             compact_return_image: None,
+            compact_return_dispatch: None,
             result: None,
             stack_slot_count: 0,
             stack_bytes: 0,

--- a/crates/rue-codegen/src/runtime_call_plan.rs
+++ b/crates/rue-codegen/src/runtime_call_plan.rs
@@ -229,7 +229,7 @@ impl RuntimeCallPlan {
                 // for a Rue-target call under `aggregate_layout`; the register-
                 // only TargetC memory builtins take scalars and pointers, never a
                 // by-value compact aggregate, so it cannot reach a runtime call.
-                CallArgInput::IndirectValue { .. } => {
+                CallArgInput::IndirectValue { .. } | CallArgInput::IndirectValueDispatch { .. } => {
                     unreachable!(
                         "a compiler-built memory routine cannot take a by-value indirect \
                          compact aggregate argument"

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -615,6 +615,254 @@ pub(crate) fn pointer_image_slot_map(
     }
 }
 
+/// One segment of a heterogeneous aggregate's compact memory image, mapping the
+/// aggregate's internal value-decomposition slots onto physical bytes with a
+/// runtime tag dispatch where the payload layout is variant-dependent (ADR-0052
+/// phase 5.12, RUE-1037).
+///
+/// A [`Leaf`](ImageSeg::Leaf) is a single value slot at a fixed byte position
+/// (exactly a [`PhysicalEnumSlot`], as in the variant-independent maps). A
+/// [`Switch`](ImageSeg::Switch) is a nested enum whose per-variant payload
+/// layouts disagree: the discriminant is read from `tag_slot`/`tag_offset` and
+/// selects one arm's segments. This is the general form the flatten-and-merge
+/// image (`enum_physical_slot_map`) collapses to when every variant agrees; when
+/// they disagree the merge returns `None` and this per-variant form is used
+/// instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImageSeg {
+    /// A scalar leaf: value slot `slot` lives at `phys.byte_offset` accessed at
+    /// `phys.access` width. Present for every non-enum leaf and for a nested
+    /// enum whose payload is variant-independent (it flattens to leaves).
+    Leaf { slot: u32, phys: PhysicalEnumSlot },
+    /// A tag-dispatched enum region whose per-variant payload layouts disagree.
+    Switch(SwitchRegion),
+}
+
+/// A tag-dispatched enum region within a compact memory image (RUE-1037). The
+/// discriminant at `tag_slot` (byte `tag_offset`, accessed `tag_access`) selects
+/// one arm; the region occupies value slots `tag_slot .. tag_slot + span` (the
+/// enum's internal slot count), of which `tag_slot` is the tag and the rest are
+/// the payload union. Slots the active variant does not use are zero.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SwitchRegion {
+    pub tag_slot: u32,
+    pub tag_offset: i32,
+    pub tag_access: NarrowScalar,
+    /// Total value slots the enum occupies (tag + widest payload union).
+    pub span: u32,
+    pub arms: Vec<SwitchArm>,
+}
+
+/// One variant arm of a [`SwitchRegion`]: the runtime `discriminant` (the
+/// variant index) and the image segments for that variant's payload, referencing
+/// the payload's value slots (`tag_slot + 1 ..`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SwitchArm {
+    pub discriminant: u64,
+    pub segs: Vec<ImageSeg>,
+}
+
+/// A whole aggregate's compact memory image expressed as tag-dispatched segments
+/// (RUE-1037). Used for a heterogeneous enum — or any aggregate containing one —
+/// whose variants' payload layouts disagree, so no single variant-independent map
+/// (`aggregate_physical_slot_map`) exists. The value decomposition is still
+/// variant-independent (`total_slots` slots); only the physical marshalling
+/// dispatches on the runtime tag at each `Switch`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DispatchImage {
+    /// The aggregate's internal value-decomposition slot count (`abi_slot_count`).
+    pub total_slots: u32,
+    /// The compact image byte size, used for full-extent zeroing on a store so
+    /// every byte outside the active variant's leaves is deterministically zero
+    /// (ADR-0052 ruling 5 / RUE-1007).
+    pub image_size: u32,
+    pub segs: Vec<ImageSeg>,
+}
+
+/// Build the tag-dispatched compact memory image for `ty` (RUE-1037), or `None`
+/// when `ty` needs no dispatch — a slot-identical aggregate, or one whose compact
+/// image is already variant-independent (`aggregate_physical_slot_map` is
+/// `Some`), both of which use their existing single-map / full-slot paths
+/// unchanged. Also `None` with the gate off.
+///
+/// Returns `Some` only when the aggregate genuinely requires a per-variant tag
+/// dispatch, i.e. it contains at least one heterogeneous enum whose per-variant
+/// payload layouts disagree. Every scalar/pointer/struct/array/enum leaf marshals
+/// (each variant's own layout is a valid compact image), so an enum — or an
+/// aggregate containing one — is no longer refused for heterogeneity.
+pub(crate) fn aggregate_dispatch_image(
+    type_pool: &FrozenTypeInternPool,
+    ty: Type,
+) -> Option<DispatchImage> {
+    if !type_pool.compact_layout() {
+        return None;
+    }
+    // A variant-independent image (or a slot-identical aggregate) needs no
+    // dispatch; those keep their existing single-map / full-slot paths.
+    if aggregate_physical_slot_map(type_pool, ty).is_some() {
+        return None;
+    }
+    let mut segs = Vec::new();
+    let mut cursor = 0u32;
+    push_image_segments(type_pool, ty, 0, &mut cursor, &mut segs)?;
+    if cursor != type_pool.abi_slot_count(ty) {
+        return None;
+    }
+    // Only a genuine tag dispatch belongs here; a switch-free flattening is a
+    // full-slot / slot-identical case handled elsewhere and must not divert.
+    if !segs.iter().any(seg_has_switch) {
+        return None;
+    }
+    let image_size = u32::try_from(type_pool.layout(ty).size).ok()?;
+    Some(DispatchImage {
+        total_slots: cursor,
+        image_size,
+        segs,
+    })
+}
+
+fn seg_has_switch(seg: &ImageSeg) -> bool {
+    match seg {
+        ImageSeg::Leaf { .. } => false,
+        ImageSeg::Switch(_) => true,
+    }
+}
+
+/// Append the compact image segments of `ty` (byte-offset by `base_offset`) to
+/// `out`, advancing `slot_cursor` over the value slots consumed, in internal
+/// value-decomposition slot order. A variant-independent enum flattens to leaves
+/// (via [`enum_physical_slot_map`]); a heterogeneous enum becomes a
+/// [`SwitchRegion`]. Returns `None` for a genuinely imageless leaf (an unusable
+/// tag width — no real enum has one).
+fn push_image_segments(
+    type_pool: &FrozenTypeInternPool,
+    ty: Type,
+    base_offset: i32,
+    slot_cursor: &mut u32,
+    out: &mut Vec<ImageSeg>,
+) -> Option<()> {
+    use rue_air::layout::LayoutKind;
+    match ty.kind() {
+        TypeKind::Unit | TypeKind::Never => Some(()),
+        TypeKind::Struct(struct_id) => {
+            let layout = type_pool.layout(ty);
+            let LayoutKind::Struct { field_offsets, .. } = &layout.kind else {
+                return None;
+            };
+            let def = type_pool.struct_def(struct_id);
+            for (index, field) in def.fields.iter().enumerate() {
+                let field_offset = i32::try_from(*field_offsets.get(index)?).ok()?;
+                push_image_segments(
+                    type_pool,
+                    field.ty,
+                    base_offset + field_offset,
+                    slot_cursor,
+                    out,
+                )?;
+            }
+            Some(())
+        }
+        TypeKind::Array(array_id) => {
+            let (element, count) = type_pool.array_def(array_id);
+            let stride = i32::try_from(type_pool.layout(element).stride).ok()?;
+            for k in 0..count {
+                let element_base =
+                    base_offset.checked_add(i32::try_from(k).ok()?.checked_mul(stride)?)?;
+                push_image_segments(type_pool, element, element_base, slot_cursor, out)?;
+            }
+            Some(())
+        }
+        TypeKind::Enum(enum_id) => {
+            // A variant-independent enum keeps its flat leaves (no dispatch), so a
+            // homogeneous nested enum in a heterogeneous aggregate stays cheap.
+            if let Some(map) = enum_physical_slot_map(type_pool, ty) {
+                for slot in map {
+                    out.push(ImageSeg::Leaf {
+                        slot: *slot_cursor,
+                        phys: PhysicalEnumSlot {
+                            byte_offset: base_offset + slot.byte_offset,
+                            access: slot.access,
+                        },
+                    });
+                    *slot_cursor += 1;
+                }
+                return Some(());
+            }
+
+            // Heterogeneous: dispatch on the tag. The tag is slot 0 of the enum at
+            // its base byte offset (RUE-1000); every variant's payload begins at
+            // the next value slot (matching the value decomposition, which places
+            // payload fields at slots 1.. for every variant).
+            let layout = type_pool.layout(ty);
+            let LayoutKind::Enum {
+                tag,
+                variants: variant_offsets,
+                ..
+            } = &layout.kind
+            else {
+                return None;
+            };
+            let tag_width = u8::try_from(tag.size).ok()?;
+            if !matches!(tag_width, 1 | 2 | 4) {
+                return None;
+            }
+            let span = type_pool.abi_slot_count(ty);
+            let tag_slot = *slot_cursor;
+            let def = type_pool.enum_def(enum_id);
+            let mut arms = Vec::with_capacity(def.variant_count() as usize);
+            for variant in 0..def.variant_count() {
+                let payload = def.variant_payload(variant);
+                let mut arm_cursor = tag_slot + 1;
+                let mut arm_segs = Vec::new();
+                for (field_index, &field_ty) in payload.iter().enumerate() {
+                    let field_offset =
+                        i32::try_from(*variant_offsets.get(variant as usize)?.get(field_index)?)
+                            .ok()?;
+                    push_image_segments(
+                        type_pool,
+                        field_ty,
+                        base_offset + field_offset,
+                        &mut arm_cursor,
+                        &mut arm_segs,
+                    )?;
+                }
+                // A variant's payload must fit within its own value-slot region.
+                if arm_cursor > tag_slot + span {
+                    return None;
+                }
+                arms.push(SwitchArm {
+                    discriminant: variant as u64,
+                    segs: arm_segs,
+                });
+            }
+            out.push(ImageSeg::Switch(SwitchRegion {
+                tag_slot,
+                tag_offset: base_offset,
+                tag_access: NarrowScalar {
+                    width: tag_width,
+                    signed: false,
+                },
+                span,
+                arms,
+            }));
+            *slot_cursor = tag_slot + span;
+            Some(())
+        }
+        _ => {
+            let (width, signed) = scalar_physical_access(ty)?;
+            out.push(ImageSeg::Leaf {
+                slot: *slot_cursor,
+                phys: PhysicalEnumSlot {
+                    byte_offset: base_offset,
+                    access: (width != 8).then_some(NarrowScalar { width, signed }),
+                },
+            });
+            *slot_cursor += 1;
+            Some(())
+        }
+    }
+}
+
 /// The pointee of a pointer type, or the type itself when it is not a pointer.
 fn pointee_or_self(type_pool: &FrozenTypeInternPool, ty: Type) -> Type {
     match ty.kind() {
@@ -695,7 +943,9 @@ pub(crate) fn compact_physical_access_unsupported(
     // caller-owned compact buffer and are allowed; arrays and enums without an
     // image stay refused.
     let call_boundary_unsupported = |ty: Type| -> bool {
-        unimplemented_aggregate(ty) && aggregate_physical_slot_map(type_pool, ty).is_none()
+        unimplemented_aggregate(ty)
+            && aggregate_physical_slot_map(type_pool, ty).is_none()
+            && aggregate_dispatch_image(type_pool, ty).is_none()
     };
 
     // A non-slot-identical aggregate whose whole-value marshalling THROUGH A
@@ -705,7 +955,10 @@ pub(crate) fn compact_physical_access_unsupported(
     // structs and arrays, and enums without such an image, still are.
     let unimplemented_through_pointer = |ty: Type| -> bool {
         match ty.kind() {
-            TypeKind::Enum(_) => enum_physical_slot_map(type_pool, ty).is_none(),
+            TypeKind::Enum(_) => {
+                enum_physical_slot_map(type_pool, ty).is_none()
+                    && aggregate_dispatch_image(type_pool, ty).is_none()
+            }
             // A compact (non-slot-identical) struct or array WITH a variant-
             // independent memory image marshals its whole value through the pointer
             // via its internal-slot → physical-byte map (RUE-987 struct, RUE-1014
@@ -715,6 +968,7 @@ pub(crate) fn compact_physical_access_unsupported(
             TypeKind::Struct(_) | TypeKind::Array(_) => {
                 !is_slot_identical_layout(type_pool, ty)
                     && aggregate_physical_slot_map(type_pool, ty).is_none()
+                    && aggregate_dispatch_image(type_pool, ty).is_none()
             }
             _ => false,
         }
@@ -939,11 +1193,11 @@ pub(crate) fn ensure_compact_layout_codegen_supported(
                  (RUE-989), compact enum memory (RUE-1000), call-boundary marshalling of a compact \
                  aggregate through its memory image — sret returns and `inout`/`borrow` parameters \
                  (RUE-1004), by-value arguments (RUE-1005) — whole compact-struct marshalling \
-                 through typed pointers (RUE-987), and variant-dependent enum images plus compact \
-                 arrays through pointers and across calls (RUE-1014) are lowered, but an aggregate \
-                 whose compact memory image is not variant-independent — an enum whose per-variant \
-                 payloads overlap or disagree on leaf offset, or an aggregate containing such an \
-                 enum — is still refused for a follow-up.",
+                 through typed pointers (RUE-987), variant-dependent enum images plus compact \
+                 arrays through pointers and across calls (RUE-1014), and heterogeneous enums whose \
+                 per-variant payload layouts disagree via per-variant tag dispatch (RUE-1037) are \
+                 lowered, but this aggregate has neither a variant-independent compact image nor a \
+                 tag-dispatched one, so it is refused.",
                 cfg.fn_name()
             )),
         ));

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -336,6 +336,14 @@ pub struct IntrinsicPlan {
     /// `None` for every other operation and gate-off, so the existing
     /// slot-shaped path is unchanged.
     pub physical_slots: Option<Vec<crate::types::PhysicalEnumSlot>>,
+    /// For a typed `@ptr_read`/`@ptr_write` of a HETEROGENEOUS compact aggregate
+    /// pointee (an enum whose per-variant payload layouts disagree, or an
+    /// aggregate containing one) under the compact layout, the tag-dispatched
+    /// image marshalled across the pointer (ADR-0052 phase 5.12, RUE-1037). Set
+    /// only when [`Self::physical_slots`] is `None` because no single
+    /// variant-independent map exists; `None` for every variant-independent
+    /// pointee and gate-off, so the existing paths are unchanged.
+    pub dispatch_image: Option<crate::types::DispatchImage>,
     /// For a typed `@ptr_write` of a compact aggregate pointee, the byte ranges
     /// of its memory image that hold padding (ADR-0052 ruling 5). The backend
     /// zeros these before the field stores so the image is deterministically
@@ -1427,6 +1435,7 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     crate::call_plan::CallTarget::rue(symbol),
                     inputs.return_plan,
                     inputs.compact_return_image.clone(),
+                    inputs.compact_return_dispatch.clone(),
                     &inputs.args,
                     adapter.call_arg_register_budget(),
                     adapter,
@@ -1670,6 +1679,23 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     ),
                     _ => None,
                 };
+                // A heterogeneous compact aggregate pointee (no variant-independent
+                // map) marshals through the pointer with a per-variant tag dispatch
+                // (RUE-1037). Only when the single map above is `None`.
+                let dispatch_image = if physical_slots.is_some() {
+                    None
+                } else {
+                    match operation {
+                        IntrinsicOperation::PtrRead => {
+                            crate::types::aggregate_dispatch_image(ctx.type_pool, inst.ty)
+                        }
+                        IntrinsicOperation::PtrWrite => crate::types::aggregate_dispatch_image(
+                            ctx.type_pool,
+                            ctx.cfg.get_inst(args[1]).ty,
+                        ),
+                        _ => None,
+                    }
+                };
                 // A compact enum `@ptr_write` initializes the whole image, so the
                 // pointee's padding is zeroed before the field stores (ADR-0052
                 // ruling 5). Only the write needs it; the read never stores.
@@ -1688,6 +1714,7 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     scale,
                     narrow_access,
                     physical_slots,
+                    dispatch_image,
                     image_padding,
                 });
                 cache_result(adapter, value, result);
@@ -2205,6 +2232,29 @@ pub(crate) fn indirect_value_params(
             let ty = param.ty?;
             let map = crate::types::aggregate_physical_slot_map(ctx.type_pool, ty)?;
             Some((ctx.num_locals + param.start_slot, map))
+        })
+        .collect()
+}
+
+/// Callee-side by-value indirect aggregate parameters whose compact image is
+/// HETEROGENEOUS (no single variant-independent map, RUE-1037): the frame base
+/// slot and the tag-dispatched image to unmarshal from the homed pointer. The
+/// complement of [`indirect_value_params`] (which handles the single-map case),
+/// so between them every by-value indirect aggregate parameter is unmarshalled.
+pub(crate) fn indirect_value_params_dispatch(
+    ctx: &CfgLowerContext<'_>,
+) -> Vec<(u32, crate::types::DispatchImage)> {
+    ctx.cfg
+        .source_param_abi()
+        .iter()
+        .filter(|param| param.is_by_value_indirect())
+        .filter_map(|param| {
+            let ty = param.ty?;
+            if crate::types::aggregate_physical_slot_map(ctx.type_pool, ty).is_some() {
+                return None;
+            }
+            let image = crate::types::aggregate_dispatch_image(ctx.type_pool, ty)?;
+            Some((ctx.num_locals + param.start_slot, image))
         })
         .collect()
 }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -128,6 +128,28 @@ impl crate::call_plan::CallMaterializer for CfgLower<'_> {
         crate::agg_slots::store_enum_slots_through_ptr(self, &slots, pointer, image, padding);
         pointer
     }
+
+    fn materialize_indirect_value_arg_dispatch(
+        &mut self,
+        value: CfgValue,
+        image: &crate::types::DispatchImage,
+        storage_bytes: u32,
+    ) -> VReg {
+        // As `materialize_indirect_value_arg`, but the caller-owned buffer is
+        // written with a per-variant tag dispatch (RUE-1037).
+        self.mir.push(X86Inst::AddRI {
+            dst: Operand::Physical(Reg::Rsp),
+            imm: -(storage_bytes as i32),
+        });
+        let pointer = self.mir.alloc_vreg();
+        self.mir.push(X86Inst::MovRR {
+            dst: Operand::Virtual(pointer),
+            src: Operand::Physical(Reg::Rsp),
+        });
+        let slots = self.require_aggregate_slots(value);
+        crate::agg_slots::store_dispatch_image(self, &slots, pointer, image);
+        pointer
+    }
 }
 
 impl<'a> CfgLower<'a> {
@@ -994,6 +1016,15 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Physical(Reg::Rsp),
                     });
                     crate::agg_slots::load_enum_slots_through_ptr(self, base, map)
+                } else if let Some(image) = &plan.compact_return_dispatch {
+                    // Heterogeneous compact aggregate return (RUE-1037): dispatch on
+                    // the tag and read the active variant's image from the sret buffer.
+                    let base = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(base),
+                        src: Operand::Physical(Reg::Rsp),
+                    });
+                    crate::agg_slots::load_dispatch_image(self, base, image)
                 } else {
                     (0..slot_count)
                         .map(|index| {
@@ -1797,6 +1828,11 @@ impl<'a> CfgLower<'a> {
                     // (RUE-1000).
                     slots = crate::agg_slots::load_enum_slots_through_ptr(self, ptr, map);
                     slots[0]
+                } else if let Some(image) = &plan.dispatch_image {
+                    // A heterogeneous compact aggregate pointee: dispatch on the
+                    // runtime tag and load the active variant's image (RUE-1037).
+                    slots = crate::agg_slots::load_dispatch_image(self, ptr, image);
+                    slots[0]
                 } else if count > 1 {
                     slots = crate::agg_slots::load_slots_through_ptr(self, ptr, count);
                     slots[0]
@@ -1846,6 +1882,16 @@ impl<'a> CfgLower<'a> {
                         map,
                         &plan.image_padding,
                     );
+                } else if let Some(image) = &plan.dispatch_image {
+                    // A heterogeneous compact aggregate value: zero the full image
+                    // extent, then dispatch on the tag and store the active
+                    // variant's leaves (RUE-1037).
+                    let vals = if value.slots.is_empty() {
+                        vec![value.primary]
+                    } else {
+                        value.slots.clone()
+                    };
+                    crate::agg_slots::store_dispatch_image(self, &vals, ptr, image);
                 } else if value.slot_count == 0 {
                     // Zero-sized values have no bytes to write.
                 } else if !value.slots.is_empty() {
@@ -2467,7 +2513,17 @@ impl<'a> CfgLower<'a> {
                                         self, &slots, &map, &padding,
                                     )
                                 }
-                                None => crate::agg_slots::store_slots_to_sret(self, &slots),
+                                None => match crate::types::aggregate_dispatch_image(
+                                    self.ctx.type_pool,
+                                    return_ty,
+                                ) {
+                                    // Heterogeneous compact aggregate return (RUE-1037):
+                                    // write the sret image with a per-variant tag dispatch.
+                                    Some(image) => crate::agg_slots::store_dispatch_image_to_sret(
+                                        self, &slots, &image,
+                                    ),
+                                    None => crate::agg_slots::store_slots_to_sret(self, &slots),
+                                },
                             }
                         } else {
                             for (index, slot) in slots.iter().enumerate().rev() {
@@ -2569,6 +2625,11 @@ impl crate::terminator_plan::CfgLowerAdapter for CfgLower<'_> {
         // projection and whole-value reads see the correct decomposition.
         for (base_slot, map) in crate::value_plan::indirect_value_params(&self.ctx) {
             crate::agg_slots::unmarshal_indirect_value_param(self, base_slot, &map);
+        }
+        // Heterogeneous by-value indirect params unmarshal with a tag dispatch
+        // (RUE-1037).
+        for (base_slot, image) in crate::value_plan::indirect_value_params_dispatch(&self.ctx) {
+            crate::agg_slots::unmarshal_indirect_value_param_dispatch(self, base_slot, &image);
         }
     }
 
@@ -2790,6 +2851,28 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
             imm: 0,
         });
         dst
+    }
+    fn emit_set_zero(&mut self, dst: VReg) {
+        self.mir.push(X86Inst::MovRI32 {
+            dst: Operand::Virtual(dst),
+            imm: 0,
+        });
+    }
+    fn alloc_marshal_label(&mut self) -> LabelId {
+        self.new_label()
+    }
+    fn emit_marshal_branch_if_tag_ne(&mut self, tag: VReg, discriminant: u64, label: LabelId) {
+        self.mir.push(X86Inst::CmpRI {
+            src: Operand::Virtual(tag),
+            imm: discriminant as i32,
+        });
+        self.mir.push(X86Inst::Jnz { label });
+    }
+    fn emit_marshal_jump(&mut self, label: LabelId) {
+        self.mir.push(X86Inst::Jmp { label });
+    }
+    fn emit_marshal_label(&mut self, label: LabelId) {
+        self.mir.push(X86Inst::Label { id: label });
     }
 }
 
@@ -3352,21 +3435,24 @@ mod tests {
         );
     }
 
-    /// RUE-1014: a struct WITHOUT a variant-independent compact image — it embeds
-    /// an enum whose union payloads overlap (`A(i64)` versus `B(i32, i32)`) — is
-    /// still refused loudly through a pointer on x86-64, not miscompiled.
+    /// RUE-1037: a struct embedding a HETEROGENEOUS enum (`A(i64)` versus
+    /// `B(i32, i32)`, whose payload layouts disagree) marshals through a pointer
+    /// on x86-64 via a nested tag dispatch — the store compares the embedded tag
+    /// and stores the active variant's leaves. (Previously refused as imageless.)
     #[test]
-    fn aggregate_layout_refuses_image_less_struct_memory() {
+    fn aggregate_layout_marshals_struct_embedding_heterogeneous_enum() {
         let source = "enum Bad { A(i64), B(i32, i32) } struct HasBad { b: Bad } \
                       fn main() -> i32 { checked { let p: ptr mut HasBad = @alloc(1); \
-                      @ptr_write(p, HasBad { b: Bad.A(5) }); }; 0 }";
+                      @ptr_write(p, HasBad { b: Bad.A(5) }); @free(p, 1); }; 0 }";
         let mut preview = PreviewFeatures::new();
         preview.insert(PreviewFeature::AggregateLayout);
-        let err = try_lower_first_fn(source, preview)
-            .expect_err("a struct embedding an imageless enum must refuse, not miscompile");
+        let mir = try_lower_first_fn(source, preview)
+            .expect("a struct embedding a heterogeneous enum must lower via nested tag dispatch");
         assert!(
-            format!("{err:?}").contains("aggregate_layout"),
-            "refusal must name the feature, got: {err:?}"
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::CmpRI { .. })),
+            "the nested heterogeneous enum store must dispatch on the embedded tag"
         );
     }
 
@@ -3398,6 +3484,45 @@ mod tests {
                 .iter()
                 .all(|inst| !matches!(inst, X86Inst::NarrowLoadIndexed { .. })),
             "gate-off must not emit any narrow sret read-back"
+        );
+    }
+
+    /// RUE-1037: under `aggregate_layout`, a HETEROGENEOUS enum (variants whose
+    /// payload layouts disagree) is marshalled through a pointer by dispatching on
+    /// the runtime tag — the store emits a tag compare/branch per variant plus
+    /// narrow field stores. Gate-off the same `@ptr_write` stores eight-byte slots
+    /// with no tag dispatch and no narrow store.
+    #[test]
+    fn aggregate_layout_heterogeneous_enum_ptr_write_tag_dispatches() {
+        let source = "enum R { Ok(Point), Err(i64) } \
+                      struct Point { x: i32, y: i32, z: i32 } \
+                      fn store_it(p: ptr mut R) { checked { @ptr_write(p, R.Ok(Point { x: 1, y: 2, z: 3 })); }; } \
+                      fn main() -> i32 { checked { let p: ptr mut R = @alloc(1); store_it(p); @free(p, 1); }; 0 }";
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::AggregateLayout);
+        let mir = try_lower_named_fn(source, preview, Some("store_it"))
+            .expect("a heterogeneous enum @ptr_write must lower via tag dispatch");
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::CmpRI { .. })),
+            "the heterogeneous store must compare the tag to dispatch on the variant"
+        );
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::NarrowStoreIndexed { .. })),
+            "the active variant's narrow leaves must be stored narrow"
+        );
+
+        let off = try_lower_named_fn(source, PreviewFeatures::new(), Some("store_it"))
+            .expect("the same program lowers under the default slot model");
+        assert!(
+            off.instructions().iter().all(|inst| !matches!(
+                inst,
+                X86Inst::CmpRI { .. } | X86Inst::NarrowStoreIndexed { .. }
+            )),
+            "gate-off must store eight-byte slots with no tag dispatch and no narrow store"
         );
     }
 
@@ -3566,23 +3691,26 @@ mod tests {
         );
     }
 
-    /// RUE-1000 keeps refusing a compact enum whose union payload slots would
-    /// overlap (`A(i64)` versus `B(i32, i32)`): there is no variant-independent
-    /// slot→byte memory image, so it must fail loudly rather than miscompile.
+    /// RUE-1037: a compact enum whose union payload slots overlap (`A(i64)`
+    /// versus `B(i32, i32)`, no variant-independent image) now marshals through a
+    /// pointer via per-variant tag dispatch rather than being refused — the store
+    /// dispatches on the tag and writes the active variant's leaves.
     #[test]
-    fn aggregate_layout_refuses_variant_dependent_enum_memory() {
+    fn aggregate_layout_marshals_variant_dependent_enum_memory() {
         let mut preview = PreviewFeatures::new();
         preview.insert(PreviewFeature::AggregateLayout);
-        let err = try_lower_first_fn(
+        let mir = try_lower_first_fn(
             "enum Bad { A(i64), B(i32, i32) } \
              fn main() -> i32 { checked { let p: ptr mut Bad = @alloc(1); \
-             @ptr_write(p, Bad.A(5)); }; 0 }",
+             @ptr_write(p, Bad.A(5)); @free(p, 1); }; 0 }",
             preview,
         )
-        .expect_err("a variant-dependent enum memory image must be refused");
+        .expect("a variant-dependent enum memory image must lower via tag dispatch");
         assert!(
-            format!("{err:?}").contains("aggregate_layout"),
-            "refusal must name the feature, got: {err:?}"
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::CmpRI { .. })),
+            "the heterogeneous enum store must dispatch on the tag"
         );
     }
 

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -659,6 +659,33 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
     ),
+    // ADR-0052 phase 5.12 (RUE-1037): the heterogeneous-enum tag-dispatch heap
+    // round-trips reach memory through `@alloc`, outside the oracle model (same
+    // gap as the enum/struct heap cases above).
+    Entry::new(
+        "cli.aggregate_layout",
+        "compact_heterogeneous_enum_heap_overwrite_no_residue",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_layout",
+        "compact_enum_overlapping_union_roundtrip",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_layout_std_sweep",
+        "overlapping_union_enum_roundtrips_via_dispatch",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_layout_std_sweep",
+        "std_net_result_sockaddr_networkerror_mirror_under_gate",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
     // RUE-1014: the real-std json/priority-queue cases under the gate reach memory
     // through the std allocators (`@alloc_bytes` in StrBuf, `@int_to_ptr` in
     // ArrayBuf.new()), outside the oracle model.


### PR DESCRIPTION
## Summary

The last image refusal under `aggregate_layout` falls: enums whose variants' payload layouts genuinely disagree — the `Result(SockAddr, NetworkError)` shape that blocked the flip's std.net cases — now marshal correctly via per-variant tag dispatch.

- **Design**: `aggregate_dispatch_image` builds a recursive `DispatchImage` — leaves for scalars and variant-independent nested enums, switch regions for heterogeneous ones. The marshaller wraps the *existing* per-leaf store/load loops in a compare/branch tag switch (reused, not forked) behind five new backend leaf ops over existing MIR, both targets, at all six image sites, parallel to the untouched single-map fast path.
- **RUE-1007 composition**: stores zero the full image extent first — inactive-variant bytes deterministic, no residue across overwrite (poison-tested).
- **Nothing image-shaped refuses anymore**: arrays of, structs containing, and enums nesting heterogeneous enums all compose. The only remaining refusal is RUE-1035's unrelated frame-`@raw` contract.
- Gate-off byte-identical (dispatch image is `None` ungated; asserted by units).

This clears the final blocker for the RUE-987 flip, which now re-runs.

## Verification

Verified by execution at integration: heterogeneous `Result(struct,i64)` round-trips both variants by value and `match` (42/−7), gated and ungated; the faithful std.net `SockAddr` mirror, poisoned-heap round-trip, and by-value crossings pass in the gated corpus; `std_net_tcp` stays green ungated. Six new gated CLI cases (three refusal sentinels flipped to round-trips); four codegen units; codegen 591, air 502, `aggregate_layout`+sweep 56, `enum_payloads` 24; spec 2138; both oracle-diff audits green; full `test.sh` green except the four known uid-0 environmental failures, both harness formats checked.

Fixes RUE-1037

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_