### PR TITLE
RUE-987: compact physical layout becomes the default (ADR-0052 stabilization)

### DIFF
--- a/crates/rue-air/src/call_abi.rs
+++ b/crates/rue-air/src/call_abi.rs
@@ -28,9 +28,8 @@
 //! crossing a call is either expressible slot-identically (classified and
 //! marshaled exactly as today), passed indirectly (this rule), or refused
 //! loudly by code generation because the narrow indirect marshaling is not yet
-//! implemented — never silently wrong. With the gate off `compact_layout()` is
-//! false, the rule never fires, and every classification is byte-for-byte the
-//! historical slot decision.
+//! implemented — never silently wrong. Slot-identical aggregates keep the
+//! historical register classification byte-for-byte.
 
 use crate::{FrozenTypeInternPool, Type, TypeKind};
 
@@ -271,10 +270,11 @@ impl<'a> NativeCallAbi<'a> {
             || (ty.is_enum() && slot_count > 1)
     }
 
-    /// The memory-first transitional rule (ADR-0052 ruling 9): under the compact
-    /// layout, an aggregate whose compact representation is not slot-identical
-    /// cannot cross the preserved register convention and must go indirect —
-    /// *unless it occupies exactly one ABI slot* (RUE-1035).
+    /// The memory-first rule (ADR-0052 ruling 9): a multi-slot aggregate whose
+    /// compact representation is not slot-identical cannot cross the preserved
+    /// register convention and must go indirect (by-reference / sret) — *unless
+    /// it occupies exactly one ABI slot* (RUE-1035). Slot-identical aggregates
+    /// keep the historical register decision.
     ///
     /// A single-slot aggregate carries its whole value in one eight-byte slot: a
     /// narrow leaf lives in that slot's low bytes under both the compact image
@@ -283,16 +283,12 @@ impl<'a> NativeCallAbi<'a> {
     /// a value indirect gained nothing and drove the not-yet-correct single-slot
     /// indirect marshalling (garbage by-value args, RUE-1035 M1); classifying it
     /// Direct instead routes it through the proven one-slot path — byte-for-byte
-    /// the same classification the gate-off slot model already produces for it, on
-    /// both backends and in the oracle. Returns stay consistent: a single-slot
-    /// aggregate return is `Registers { slot_count: 1 }` (never sret), so no
-    /// caller-side image read-back is implied.
-    ///
-    /// Always false with the gate off (`compact_layout()` is false), so every
-    /// classification is byte-for-byte the historical slot decision.
+    /// the same classification the slot model produces for it, on both backends
+    /// and in the oracle. Returns stay consistent: a single-slot aggregate return
+    /// is `Registers { slot_count: 1 }` (never sret), so no caller-side image
+    /// read-back is implied.
     fn crosses_indirectly_under_compact(&self, ty: Type, slot_count: u32) -> bool {
-        self.type_pool.compact_layout()
-            && slot_count > 1
+        slot_count > 1
             && self.is_multislot_aggregate(ty, slot_count)
             && !is_slot_identical_layout(self.type_pool, ty)
     }

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -32,7 +32,7 @@ use std::sync::{Arc, PoisonError, RwLock};
 use lasso::Spur;
 use rue_span::FileId;
 
-use crate::layout::{Layout, LayoutKind, PaddingRange, SLOT_BYTES};
+use crate::layout::{Layout, LayoutKind, PaddingRange};
 use crate::path_norm::{mangle_symbol_component, normalize_module_path};
 use crate::type_encoding;
 use crate::types::{
@@ -346,18 +346,6 @@ struct TypeInternPoolInner {
 
     /// Reverse index enforcing one canonical nominal for each language item.
     lang_item_structs: HashMap<LangItem, StructId>,
-
-    /// Whether the compact native physical layout (ADR-0052, the
-    /// `aggregate_layout` preview) is active for this compilation. Set once by
-    /// semantic construction from the compilation's preview features; it
-    /// therefore participates in every cache identity that already keys on
-    /// preview features. When `false` the layout authority reports today's
-    /// flattened eight-byte slot model byte-for-byte; when `true` it reports
-    /// natural scalar widths/alignments, declaration-order struct fields with
-    /// padding, ascending array stride, and tagged-enum layout. The slot
-    /// decomposition [`Self::abi_slot_count`] is unaffected either way — it is
-    /// the internal value representation, not the physical layout.
-    compact_layout: bool,
 }
 
 fn checked_pool_index(index: usize) -> Option<u32> {
@@ -981,87 +969,49 @@ impl TypeInternPoolInner {
         }
     }
 
-    /// Byte size of `ty` under the canonical layout. Zero-sized types are zero
-    /// bytes. Under the slot model this is the slot count times [`SLOT_BYTES`];
-    /// under the compact model (ADR-0052) it is the natural size including tail
-    /// padding.
-    fn layout_size(&self, ty: Type) -> u64 {
-        if self.compact_layout {
-            self.compact_size_align(ty).0
-        } else {
-            u64::from(self.abi_slot_count(ty)) * SLOT_BYTES
-        }
-    }
-
-    /// Byte offset of the field at `field_index` within `struct_id`: the summed
-    /// sizes of every preceding field (slot model) or the field placement
-    /// respecting alignment and interior padding (compact model). Shared by
+    /// Byte offset of the field at `field_index` within `struct_id`: the field
+    /// placement respecting natural alignment and interior padding. Shared by
     /// `@offset_of` and the layout authority so `@offset_of` and physical field
-    /// addressing agree by construction. Note that under the compact model this
-    /// physical byte offset is deliberately *not* the codegen slot offset
-    /// (`struct_field_slot_offset`), which stays a slot-count index into the
-    /// internal value representation (ADR-0052's three-representation split).
+    /// addressing agree by construction. This physical byte offset is
+    /// deliberately *not* the codegen slot offset (`struct_field_slot_offset`),
+    /// which stays a slot-count index into the internal value representation
+    /// (ADR-0052's three-representation split).
     fn struct_field_offset(&self, struct_id: StructId, field_index: u32) -> u64 {
-        if self.compact_layout {
-            return self
-                .compact_struct_layout(struct_id)
-                .field_offsets
-                .get(field_index as usize)
-                .copied()
-                .unwrap_or(0);
-        }
-        let fields = &self.struct_def(struct_id).fields;
-        let mut offset = 0u64;
-        for field in fields.iter().take(field_index as usize) {
-            offset = offset.saturating_add(self.layout_size(field.ty));
-        }
-        offset
+        self.compact_struct_layout(struct_id)
+            .field_offsets
+            .get(field_index as usize)
+            .copied()
+            .unwrap_or(0)
     }
 
     /// Byte offset of payload field `field_index` of `variant_index` within
-    /// `enum_id`. Under the slot model the discriminant occupies the first slot,
-    /// so every payload begins one [`SLOT_BYTES`] slot in and each preceding
-    /// payload field contributes its layout size. Under the compact model the
-    /// payload begins at the tag-plus-alignment offset and preceding fields are
-    /// placed with natural alignment. This mirrors [`Self::layout`]'s
-    /// [`LayoutKind::Enum`] `variants`. Like `struct_field_offset`, the compact
-    /// value here is the physical byte offset, distinct from codegen's slot
-    /// offset into the value representation.
+    /// `enum_id`. The payload begins at the tag-plus-alignment offset and
+    /// preceding fields are placed with natural alignment. This mirrors
+    /// [`Self::layout`]'s [`LayoutKind::Enum`] `variants`. Like
+    /// `struct_field_offset`, this physical byte offset is distinct from
+    /// codegen's slot offset into the value representation.
     fn enum_payload_field_offset(
         &self,
         enum_id: EnumId,
         variant_index: u32,
         field_index: u32,
     ) -> u64 {
-        if self.compact_layout {
-            let enum_layout = self.compact_enum_layout(enum_id);
-            return enum_layout
-                .variants
-                .get(variant_index as usize)
-                .and_then(|fields| fields.get(field_index as usize))
-                .copied()
-                .unwrap_or(enum_layout.payload_offset);
-        }
-        let def = self.enum_def(enum_id);
-        let mut offset = SLOT_BYTES;
-        for &field_ty in def
-            .variant_payload(variant_index as usize)
-            .iter()
-            .take(field_index as usize)
-        {
-            offset = offset.saturating_add(self.layout_size(field_ty));
-        }
-        offset
+        let enum_layout = self.compact_enum_layout(enum_id);
+        enum_layout
+            .variants
+            .get(variant_index as usize)
+            .and_then(|fields| fields.get(field_index as usize))
+            .copied()
+            .unwrap_or(enum_layout.payload_offset)
     }
 
     /// Slot-count offset of struct field `field_index`: the summed
     /// [`Self::abi_slot_count`] of every preceding field. This is the *internal
-    /// value decomposition* offset (ADR-0052 representation 2), deliberately
-    /// independent of the compact-layout flag: code generation's stack/register
-    /// slot model stays slot-based (RUE-975) even when the physical layout
-    /// authority reports compact byte offsets. Under the slot model it equals
-    /// [`Self::struct_field_offset`]` / SLOT_BYTES`; under the compact model the
-    /// two intentionally diverge.
+    /// value decomposition* offset (ADR-0052 representation 2): code
+    /// generation's stack/register slot model stays slot-based (RUE-975) even
+    /// though the physical layout authority reports compact byte offsets, so
+    /// this slot index and [`Self::struct_field_offset`]'s compact byte offset
+    /// intentionally diverge.
     fn struct_field_slot_offset(&self, struct_id: StructId, field_index: u32) -> u32 {
         let fields = &self.struct_def(struct_id).fields;
         let mut slots = 0u32;
@@ -1093,80 +1043,13 @@ impl TypeInternPoolInner {
         slots
     }
 
-    /// Compute the canonical physical [`Layout`] of `ty`.
+    /// Compute the canonical physical [`Layout`] of `ty` (ADR-0052).
     ///
-    /// Under the slot model `size == stride == abi_slot_count * SLOT_BYTES`,
-    /// alignment is `SLOT_BYTES` (or `1` for a zero-sized type), and `kind`
-    /// records slot-derived field/element/payload offsets. Under the compact
-    /// model (ADR-0052) `size` includes tail padding, `stride == size`,
-    /// alignment is the natural alignment, and `kind` records the compact field
-    /// offsets, element stride, tag width, and payload placement.
+    /// `size` includes tail padding, `stride == size`, alignment is the natural
+    /// alignment, and `kind` records the compact field offsets, element stride,
+    /// tag width, and payload placement.
     fn layout(&self, ty: Type) -> Layout {
-        if self.compact_layout {
-            return self.compact_layout_of(ty);
-        }
-        let size = self.layout_size(ty);
-        let alignment = if size == 0 { 1 } else { SLOT_BYTES };
-        let stride = size;
-        let kind = match ty.kind() {
-            TypeKind::Struct(id) => {
-                let fields = &self.struct_def(id).fields;
-                let mut field_offsets = Vec::with_capacity(fields.len());
-                let mut offset = 0u64;
-                for field in fields {
-                    field_offsets.push(offset);
-                    offset = offset.saturating_add(self.layout_size(field.ty));
-                }
-                LayoutKind::Struct {
-                    field_offsets,
-                    // The packed slot model has no interior or tail padding.
-                    padding_ranges: Vec::new(),
-                }
-            }
-            TypeKind::Array(id) => {
-                let (element, count) = self.array_def(id);
-                LayoutKind::Array {
-                    element: Box::new(self.layout(element)),
-                    count,
-                }
-            }
-            TypeKind::Enum(id) => {
-                let def = self.enum_def(id);
-                // The discriminant occupies slot 0; every variant's payload
-                // begins at slot 1.
-                let payload_offset = SLOT_BYTES;
-                let variants = (0..def.variant_count())
-                    .map(|variant| {
-                        let mut offset = payload_offset;
-                        def.variant_payload(variant)
-                            .iter()
-                            .map(|&field_ty| {
-                                let field_offset = offset;
-                                offset = offset.saturating_add(self.layout_size(field_ty));
-                                field_offset
-                            })
-                            .collect()
-                    })
-                    .collect();
-                LayoutKind::Enum {
-                    tag: Box::new(Layout {
-                        size: SLOT_BYTES,
-                        alignment: SLOT_BYTES,
-                        stride: SLOT_BYTES,
-                        kind: LayoutKind::Scalar,
-                    }),
-                    payload_offset,
-                    variants,
-                }
-            }
-            _ => LayoutKind::Scalar,
-        };
-        Layout {
-            size,
-            alignment,
-            stride,
-            kind,
-        }
+        self.compact_layout_of(ty)
     }
 
     // ----- Compact native layout (ADR-0052 "Resolved at acceptance") -----
@@ -1355,13 +1238,8 @@ impl TypeInternPoolInner {
     /// construction) requires cleared wherever a compact image is materialized,
     /// and the complement of the value-decomposition slots the codegen image map
     /// writes — so zeroing these ranges and then storing the fields
-    /// deterministically initializes every byte of the image. Empty under the
-    /// slot model (no padding exists), so a gate-off build derives no ranges and
-    /// emits no zeroing.
+    /// deterministically initializes every byte of the image.
     fn compact_image_padding_ranges(&self, ty: Type) -> Vec<PaddingRange> {
-        if !self.compact_layout {
-            return Vec::new();
-        }
         let (size, _) = self.compact_size_align(ty);
         if size == 0 {
             return Vec::new();
@@ -1559,7 +1437,6 @@ impl TypeInternPool {
                 symbol_paths: HashMap::new(),
                 struct_lang_items: HashMap::new(),
                 lang_item_structs: HashMap::new(),
-                compact_layout: false,
             }),
         }
     }
@@ -1603,27 +1480,6 @@ impl TypeInternPool {
             .symbol_paths = symbol_paths;
     }
 
-    /// Select the physical layout model for this compilation (ADR-0052).
-    ///
-    /// Semantic construction calls this once, before any type is interned, with
-    /// whether the `aggregate_layout` preview feature is enabled. The choice is
-    /// carried through [`Self::freeze`] into the backend-facing pool so the
-    /// layout authority reports one consistent model for the whole compilation.
-    pub(crate) fn set_compact_layout(&self, compact_layout: bool) {
-        self.inner
-            .write()
-            .unwrap_or_else(PoisonError::into_inner)
-            .compact_layout = compact_layout;
-    }
-
-    /// Whether the compact native layout (ADR-0052) is active for this pool.
-    pub fn compact_layout(&self) -> bool {
-        self.inner
-            .read()
-            .unwrap_or_else(PoisonError::into_inner)
-            .compact_layout
-    }
-
     /// Apply a type-pool mutation atomically through an isolated snapshot.
     ///
     /// The live write lock remains held while `operation` works on the
@@ -1656,11 +1512,11 @@ impl TypeInternPool {
     /// Return the flattened runtime ABI width of `ty` in eight-byte slots.
     ///
     /// This is the canonical slot decomposition shared by sema, CFG temporary
-    /// allocation, and code generation. The physical byte layout that observes
-    /// or addresses memory is derived from it by [`Self::layout`], which scales
-    /// this count by [`SLOT_BYTES`]. Aggregate arithmetic saturates; sema
-    /// rejects layouts that exceed the representable slot range before they
-    /// can be materialized.
+    /// allocation, and code generation (ADR-0052 representation 2, the internal
+    /// value model). It is distinct from the compact physical byte layout that
+    /// observes or addresses memory, which [`Self::layout`] reports. Aggregate
+    /// arithmetic saturates; sema rejects layouts that exceed the representable
+    /// slot range before they can be materialized.
     pub fn abi_slot_count(&self, ty: Type) -> u32 {
         self.try_abi_slot_count(ty)
             .expect("layout requires a complete, non-recovery type graph")
@@ -2752,20 +2608,11 @@ impl FrozenTypeInternPool {
         self.inner.abi_slot_count(ty)
     }
 
-    /// Whether the compact native layout (ADR-0052) is active for this pool.
-    ///
-    /// Code generation consults this to keep the internal slot/value/stack
-    /// model coherent while the compact-memory backends are staged: physical
-    /// pointer/heap addressing that would diverge from the slot model is
-    /// refused with a clear diagnostic rather than silently miscompiled
-    /// (RUE-975/RUE-976).
-    pub fn compact_layout(&self) -> bool {
-        self.inner.compact_layout
-    }
-
     /// Canonical physical [`Layout`] of `ty`: the one authority code generation
     /// consumes for byte size, alignment, stride, and field/element/payload
-    /// offsets. Derived from [`Self::abi_slot_count`] scaled by [`SLOT_BYTES`].
+    /// offsets. Reports the compact native layout (ADR-0052): natural scalar
+    /// widths and alignments, declaration-order struct fields with padding,
+    /// ascending array stride, and smallest-sufficient enum tags.
     pub fn layout(&self, ty: Type) -> Layout {
         self.validate_complete_type(ty)
             .expect("backend layout requires a complete, non-recovery type graph");
@@ -2776,8 +2623,8 @@ impl FrozenTypeInternPool {
     /// than a leaf field (ADR-0052 ruling 5). Code generation zeros exactly these
     /// ranges wherever it materializes a compact image — heap enum stores, sret
     /// buffers, and by-value argument buffers — so the padding is deterministically
-    /// zero on construction. Always empty with the compact layout off, keeping
-    /// gate-off code byte-identical.
+    /// zero on construction. Empty for a type with no interior or tail padding
+    /// (all-eight-byte-leaf aggregates and scalars).
     pub fn compact_image_padding_ranges(&self, ty: Type) -> Vec<PaddingRange> {
         self.validate_complete_type(ty)
             .expect("backend layout requires a complete, non-recovery type graph");
@@ -3061,7 +2908,6 @@ impl Clone for TypeInternPool {
                 symbol_paths: inner.symbol_paths.clone(),
                 struct_lang_items: inner.struct_lang_items.clone(),
                 lang_item_structs: inner.lang_item_structs.clone(),
-                compact_layout: inner.compact_layout,
             }),
         }
     }
@@ -4334,78 +4180,7 @@ mod tests {
     // Canonical layout authority (ADR-0052)
     // ========================================================================
 
-    use crate::layout::{LayoutKind, SLOT_BYTES};
-
-    #[test]
-    fn layout_scalars_and_pointers_are_one_slot() {
-        let pool = TypeInternPool::new();
-        let ptr = Type::new_ptr_const(pool.intern_ptr_const_from_type(Type::I32));
-        let frozen = pool.freeze();
-        for ty in [Type::I8, Type::I32, Type::I64, Type::U8, Type::BOOL, ptr] {
-            let layout = frozen.layout(ty);
-            assert_eq!(layout.size, SLOT_BYTES, "{ty:?} size");
-            assert_eq!(layout.alignment, SLOT_BYTES, "{ty:?} align");
-            assert_eq!(layout.stride, layout.size, "{ty:?} stride == size");
-            assert_eq!(layout.kind, LayoutKind::Scalar, "{ty:?} kind");
-        }
-    }
-
-    #[test]
-    fn layout_zero_sized_types_have_unit_alignment_and_zero_stride() {
-        let pool = TypeInternPool::new();
-        let empty_array = Type::new_array(pool.intern_array_from_type(Type::I32, 0));
-        let frozen = pool.freeze();
-        for ty in [Type::UNIT, Type::NEVER, empty_array] {
-            let layout = frozen.layout(ty);
-            assert_eq!(layout.size, 0, "{ty:?} size");
-            assert_eq!(layout.alignment, 1, "{ty:?} align");
-            assert_eq!(layout.stride, 0, "{ty:?} stride");
-        }
-    }
-
-    #[test]
-    fn layout_struct_reports_declaration_order_field_offsets() {
-        let pool = TypeInternPool::new();
-        let interner = ThreadedRodeo::default();
-        let (id, _) = pool.register_struct(
-            interner.get_or_intern("Point"),
-            struct_def(
-                "Point",
-                vec![
-                    StructField {
-                        name: "x".into(),
-                        ty: Type::I32,
-                    },
-                    StructField {
-                        name: "y".into(),
-                        ty: Type::I64,
-                    },
-                ],
-            ),
-        );
-        let struct_ty = Type::new_struct(id);
-        let frozen = pool.freeze();
-
-        let layout = frozen.layout(struct_ty);
-        assert_eq!(layout.size, 2 * SLOT_BYTES);
-        assert_eq!(layout.alignment, SLOT_BYTES);
-        match &layout.kind {
-            LayoutKind::Struct {
-                field_offsets,
-                padding_ranges,
-            } => {
-                assert_eq!(field_offsets, &[0, SLOT_BYTES]);
-                assert!(
-                    padding_ranges.is_empty(),
-                    "packed slot model has no padding"
-                );
-            }
-            other => panic!("expected struct layout, got {other:?}"),
-        }
-        // The dedicated field-offset query agrees with the layout's kind.
-        assert_eq!(frozen.struct_field_offset(id, 0), 0);
-        assert_eq!(frozen.struct_field_offset(id, 1), SLOT_BYTES);
-    }
+    use crate::layout::LayoutKind;
 
     #[test]
     fn layout_empty_struct_is_zero_sized() {
@@ -4420,98 +4195,8 @@ mod tests {
     }
 
     #[test]
-    fn layout_array_strides_by_element_size() {
-        let pool = TypeInternPool::new();
-        let array_ty = pool.try_intern_array(Type::I32, 3).unwrap();
-        let frozen = pool.freeze();
-        let layout = frozen.layout(array_ty);
-        assert_eq!(layout.size, 3 * SLOT_BYTES);
-        assert_eq!(layout.stride, 3 * SLOT_BYTES);
-        match layout.kind {
-            LayoutKind::Array { element, count } => {
-                assert_eq!(count, 3);
-                assert_eq!(element.size, SLOT_BYTES);
-                assert_eq!(
-                    element.stride, SLOT_BYTES,
-                    "indexing strides by element size"
-                );
-            }
-            other => panic!("expected array layout, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn layout_enum_places_payload_after_the_discriminant() {
-        let pool = TypeInternPool::new();
-        let interner = ThreadedRodeo::default();
-        let def = EnumDef {
-            name: "Shape".to_string(),
-            variants: vec!["Pair".to_string(), "One".to_string()],
-            variant_payloads: vec![vec![Type::I32, Type::I64], vec![Type::I32]],
-            is_pub: false,
-            file_id: FileId::DEFAULT,
-        };
-        let (id, _) = pool.register_enum(interner.get_or_intern("Shape"), def);
-        let enum_ty = Type::new_enum(id);
-        let frozen = pool.freeze();
-
-        let layout = frozen.layout(enum_ty);
-        // One tag slot plus the largest payload (two slots).
-        assert_eq!(layout.size, 3 * SLOT_BYTES);
-        match layout.kind {
-            LayoutKind::Enum {
-                tag,
-                payload_offset,
-                variants,
-            } => {
-                assert_eq!(tag.size, SLOT_BYTES);
-                assert_eq!(payload_offset, SLOT_BYTES);
-                assert_eq!(
-                    variants,
-                    vec![vec![SLOT_BYTES, 2 * SLOT_BYTES], vec![SLOT_BYTES]]
-                );
-            }
-            other => panic!("expected enum layout, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn layout_size_agrees_with_slot_count_across_the_pool() {
-        let pool = TypeInternPool::new();
-        let interner = ThreadedRodeo::default();
-        let (id, _) = pool.register_struct(
-            interner.get_or_intern("Mixed"),
-            struct_def(
-                "Mixed",
-                vec![
-                    StructField {
-                        name: "a".into(),
-                        ty: Type::I32,
-                    },
-                    StructField {
-                        name: "b".into(),
-                        ty: Type::BOOL,
-                    },
-                ],
-            ),
-        );
-        let _ = pool.try_intern_array(Type::new_struct(id), 4).unwrap();
-        let frozen = pool.freeze();
-        for ty in frozen.all_types() {
-            assert_eq!(
-                frozen.layout(ty).size,
-                u64::from(frozen.abi_slot_count(ty)) * SLOT_BYTES,
-                "layout size must equal abi_slot_count * SLOT_BYTES for {ty:?}"
-            );
-        }
-    }
-
-    // ----- Compact native layout (ADR-0052 `aggregate_layout`) -----
-
-    #[test]
     fn compact_layout_reports_natural_scalar_widths_and_alignments() {
         let pool = TypeInternPool::new();
-        pool.set_compact_layout(true);
         let ptr = Type::new_ptr_const(pool.intern_ptr_const_from_type(Type::I32));
         let frozen = pool.freeze();
         for (ty, size, align) in [
@@ -4537,7 +4222,6 @@ mod tests {
     #[test]
     fn compact_layout_zero_sized_types_are_size_zero_align_one_stride_zero() {
         let pool = TypeInternPool::new();
-        pool.set_compact_layout(true);
         let empty_array = Type::new_array(pool.intern_array_from_type(Type::I32, 0));
         let frozen = pool.freeze();
         for ty in [Type::UNIT, Type::NEVER, empty_array] {
@@ -4553,7 +4237,6 @@ mod tests {
         // Padded { a: u8, b: i32, c: u8 }: a@0, pad[1,4), b@4, c@8, tail pad
         // [9,12). size 12, align 4.
         let pool = TypeInternPool::new();
-        pool.set_compact_layout(true);
         let interner = ThreadedRodeo::default();
         let (id, _) = pool.register_struct(
             interner.get_or_intern("Padded"),
@@ -4608,7 +4291,6 @@ mod tests {
     fn compact_image_padding_ranges_cover_struct_interior_and_tail_gaps() {
         // Padded { a: u8, b: i32, c: u8 }: a@0, pad[1,4), b@4, c@8, tail[9,12).
         let pool = TypeInternPool::new();
-        pool.set_compact_layout(true);
         let interner = ThreadedRodeo::default();
         let (id, _) = pool.register_struct(
             interner.get_or_intern("Padded"),
@@ -4646,7 +4328,6 @@ mod tests {
         // packs u8@0,i32@4 => u8 abs@4, i32 abs@8; size = align_up(4+8,4) = 12.
         // Padding: tag-to-payload [1,4) and the gap [5,8) after the u8 field.
         let pool = TypeInternPool::new();
-        pool.set_compact_layout(true);
         let interner = ThreadedRodeo::default();
         let def = EnumDef {
             name: "Wide".to_string(),
@@ -4667,40 +4348,9 @@ mod tests {
     }
 
     #[test]
-    fn compact_image_padding_ranges_are_empty_without_the_gate() {
-        // The slot model has no padding, so a gate-off pool derives no ranges —
-        // the property that keeps gate-off code byte-identical.
-        let pool = TypeInternPool::new();
-        let interner = ThreadedRodeo::default();
-        let (id, _) = pool.register_struct(
-            interner.get_or_intern("Padded"),
-            struct_def(
-                "Padded",
-                vec![
-                    StructField {
-                        name: "a".into(),
-                        ty: Type::U8,
-                    },
-                    StructField {
-                        name: "b".into(),
-                        ty: Type::I32,
-                    },
-                ],
-            ),
-        );
-        let frozen = pool.freeze();
-        assert!(
-            frozen
-                .compact_image_padding_ranges(Type::new_struct(id))
-                .is_empty()
-        );
-    }
-
-    #[test]
     fn compact_image_padding_ranges_empty_for_packed_all_i64_struct() {
         // An all-eight-byte-leaf struct is slot-identical: no padding to zero.
         let pool = TypeInternPool::new();
-        pool.set_compact_layout(true);
         let interner = ThreadedRodeo::default();
         let (id, _) = pool.register_struct(
             interner.get_or_intern("Packed"),
@@ -4729,7 +4379,6 @@ mod tests {
     #[test]
     fn compact_layout_array_strides_by_compact_element_size() {
         let pool = TypeInternPool::new();
-        pool.set_compact_layout(true);
         let array_ty = pool.try_intern_array(Type::I32, 3).unwrap();
         let frozen = pool.freeze();
         let layout = frozen.layout(array_ty);
@@ -4751,7 +4400,6 @@ mod tests {
         // (the i64), so payload_offset 8. Largest payload packs i32@0,i64@8 =>
         // 16 bytes; size = align_up(8 + 16, 8) = 24.
         let pool = TypeInternPool::new();
-        pool.set_compact_layout(true);
         let interner = ThreadedRodeo::default();
         let def = EnumDef {
             name: "Shape".to_string(),
@@ -4777,22 +4425,6 @@ mod tests {
                 assert_eq!(variants, vec![vec![8, 16], vec![8]]);
             }
             other => panic!("expected enum layout, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn compact_layout_off_is_byte_for_byte_the_slot_model() {
-        // The default pool (flag off) must report exactly the slot values.
-        let pool = TypeInternPool::new();
-        let frozen = pool.freeze();
-        for (ty, size) in [
-            (Type::I8, SLOT_BYTES),
-            (Type::I32, SLOT_BYTES),
-            (Type::U64, SLOT_BYTES),
-        ] {
-            let layout = frozen.layout(ty);
-            assert_eq!(layout.size, size);
-            assert_eq!(layout.alignment, SLOT_BYTES);
         }
     }
 }

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -782,13 +782,6 @@ impl<'a> Sema<'a> {
         } = metadata;
         let type_pool = TypeInternPool::new();
         type_pool.set_symbol_paths(logical_paths.clone());
-        // Select the physical layout model for the whole compilation (ADR-0052).
-        // The choice is a pure function of the enabled preview features, which
-        // already key every compilation cache identity, so the layout authority
-        // reports one consistent model without a separate cache dimension.
-        type_pool.set_compact_layout(
-            preview_features.contains(&rue_error::PreviewFeature::AggregateLayout),
-        );
         Self {
             declarations: MutableDeclarations(DeclarationNamespace::new()),
             rir,

--- a/crates/rue-cli-tests/cases/aggregate_abi_matrix.toml
+++ b/crates/rue-cli-tests/cases/aggregate_abi_matrix.toml
@@ -30,6 +30,15 @@
 #
 # Runs on BOTH backends; the aarch64 runtime path is only exercised in CI, so a
 # backend that forgets a slot-routing gate for one type shape fails here.
+#
+# The `@ptr_read / @ptr_write` cells allocate their backing block on the HEAP
+# (`@alloc`), whose storage is the compact image, so the value round-trips
+# through a single whole-aggregate `@ptr_write`/`@ptr_read`. Taking a raw pointer
+# into a frame-resident non-slot-identical aggregate is refused under the default
+# compact layout (RUE-987 / RUE-1035 M2, frames stay slot-shaped for now); that
+# refusal is pinned in `aggregate_layout.toml`. A bare fixed array cannot be an
+# `@alloc` pointee directly, so the ARR/AOS cells round-trip it as a one-field
+# struct wrapper — the array value still crosses the pointer boundary whole.
 
 [section]
 id = "cli.aggregate_abi_matrix"
@@ -79,13 +88,12 @@ name = "s1_ptr_rw"
 files = [{ path = "main.rue", source = """
 struct S1 { a: i32 }
 fn main() -> i32 {
-    let mut arr: [S1; 1] = [S1 { a: 0 }];
     checked {
-        let wp: ptr mut S1 = @raw_mut(arr[0]);
+        let wp: ptr mut S1 = @alloc(1);
         @ptr_write(wp, S1 { a: 55 });
-        let rp: ptr const S1 = @raw(arr[0]);
-        let v = @ptr_read(rp);
+        let v = @ptr_read(wp);
         @dbg(v.a);
+        @free(wp, 1);
     };
     0
 }
@@ -191,13 +199,12 @@ name = "s2_ptr_rw"
 files = [{ path = "main.rue", source = """
 struct S2 { a: i32, b: i32 }
 fn main() -> i32 {
-    let mut arr: [S2; 1] = [S2 { a: 0, b: 0 }];
     checked {
-        let wp: ptr mut S2 = @raw_mut(arr[0]);
+        let wp: ptr mut S2 = @alloc(1);
         @ptr_write(wp, S2 { a: 7, b: 8 });
-        let rp: ptr const S2 = @raw(arr[0]);
-        let v = @ptr_read(rp);
+        let v = @ptr_read(wp);
         @dbg(v.a); @dbg(v.b);
+        @free(wp, 1);
     };
     0
 }
@@ -231,13 +238,12 @@ name = "s3_ptr_rw"
 files = [{ path = "main.rue", source = """
 struct S3 { a: i32, b: i32, c: i32 }
 fn main() -> i32 {
-    let mut arr: [S3; 1] = [S3 { a: 0, b: 0, c: 0 }];
     checked {
-        let wp: ptr mut S3 = @raw_mut(arr[0]);
+        let wp: ptr mut S3 = @alloc(1);
         @ptr_write(wp, S3 { a: 3, b: 6, c: 9 });
-        let rp: ptr const S3 = @raw(arr[0]);
-        let v = @ptr_read(rp);
+        let v = @ptr_read(wp);
         @dbg(v.a); @dbg(v.b); @dbg(v.c);
+        @free(wp, 1);
     };
     0
 }
@@ -288,13 +294,12 @@ name = "s8_ptr_rw"
 files = [{ path = "main.rue", source = """
 struct S8 { a: i32, b: i32, c: i32, d: i32, e: i32, f: i32, g: i32, h: i32 }
 fn main() -> i32 {
-    let mut arr: [S8; 1] = [S8 { a: 0, b: 0, c: 0, d: 0, e: 0, f: 0, g: 0, h: 0 }];
     checked {
-        let wp: ptr mut S8 = @raw_mut(arr[0]);
+        let wp: ptr mut S8 = @alloc(1);
         @ptr_write(wp, S8 { a: 11, b: 22, c: 33, d: 44, e: 55, f: 66, g: 77, h: 88 });
-        let rp: ptr const S8 = @raw(arr[0]);
-        let v = @ptr_read(rp);
+        let v = @ptr_read(wp);
         @dbg(v.a); @dbg(v.e); @dbg(v.h);
+        @free(wp, 1);
     };
     0
 }
@@ -360,13 +365,12 @@ files = [{ path = "main.rue", source = """
 struct Inner { a: i32, b: i32 }
 struct Outer { p: Inner, q: i32 }
 fn main() -> i32 {
-    let mut arr: [Outer; 1] = [Outer { p: Inner { a: 0, b: 0 }, q: 0 }];
     checked {
-        let wp: ptr mut Outer = @raw_mut(arr[0]);
+        let wp: ptr mut Outer = @alloc(1);
         @ptr_write(wp, Outer { p: Inner { a: 1, b: 2 }, q: 3 });
-        let rp: ptr const Outer = @raw(arr[0]);
-        let v = @ptr_read(rp);
+        let v = @ptr_read(wp);
         @dbg(v.p.a); @dbg(v.p.b); @dbg(v.q);
+        @free(wp, 1);
     };
     0
 }
@@ -423,14 +427,14 @@ stdout = "7\n9\n"
 [[case]]
 name = "arr_ptr_rw"
 files = [{ path = "main.rue", source = """
+struct ArrBox { a: [i32; 4] }
 fn main() -> i32 {
-    let mut a: [i32; 4] = [0, 0, 0, 0];
     checked {
-        let wp: ptr mut [i32; 4] = @raw_mut(a);
-        @ptr_write(wp, [1, 2, 3, 4]);
-        let rp: ptr const [i32; 4] = @raw(a);
-        let v = @ptr_read(rp);
-        @dbg(v[0]); @dbg(v[3]);
+        let wp: ptr mut ArrBox = @alloc(1);
+        @ptr_write(wp, ArrBox { a: [1, 2, 3, 4] });
+        let v = @ptr_read(wp);
+        @dbg(v.a[0]); @dbg(v.a[3]);
+        @free(wp, 1);
     };
     0
 }
@@ -474,14 +478,14 @@ stdout = "5\n6\n"
 name = "aos_ptr_rw"
 files = [{ path = "main.rue", source = """
 struct P { x: i32, y: i32 }
+struct AosBox { a: [P; 2] }
 fn main() -> i32 {
-    let mut a: [P; 2] = [P { x: 0, y: 0 }, P { x: 0, y: 0 }];
     checked {
-        let wp: ptr mut [P; 2] = @raw_mut(a);
-        @ptr_write(wp, [P { x: 1, y: 2 }, P { x: 3, y: 4 }]);
-        let rp: ptr const [P; 2] = @raw(a);
-        let v = @ptr_read(rp);
-        @dbg(v[0].x); @dbg(v[1].y);
+        let wp: ptr mut AosBox = @alloc(1);
+        @ptr_write(wp, AosBox { a: [P { x: 1, y: 2 }, P { x: 3, y: 4 }] });
+        let v = @ptr_read(wp);
+        @dbg(v.a[0].x); @dbg(v.a[1].y);
+        @free(wp, 1);
     };
     0
 }
@@ -612,13 +616,12 @@ files = [{ path = "main.rue", source = """
 enum E { V(i32, i32), Empty }
 fn sum(e: E) -> i32 { match e { E.V(x, y) => x + y, E.Empty => 0 } }
 fn main() -> i32 {
-    let mut arr: [E; 1] = [E.Empty];
     checked {
-        let wp: ptr mut E = @raw_mut(arr[0]);
+        let wp: ptr mut E = @alloc(1);
         @ptr_write(wp, E.V(9, 8));
-        let rp: ptr const E = @raw(arr[0]);
-        let v = @ptr_read(rp);
+        let v = @ptr_read(wp);
         @dbg(sum(v));
+        @free(wp, 1);
     };
     0
 }

--- a/crates/rue-cli-tests/cases/aggregate_ascending_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_ascending_layout.toml
@@ -3,12 +3,20 @@
 # Every aggregate (struct/array/StrBuf) is laid out ascending-in-address:
 # field 0 / element 0 at the LOWEST address, slot k at base + k*8. `@raw`
 # returns the low end and `@ptr_read`/`@ptr_write`/`@ptr_offset` walk slots
-# UPWARD from it, so a raw pointer behaves identically whether it points into a
-# stack local or an `@alloc`'d heap block. Before the fix, multi-slot aggregates
-# were written descending through a raw pointer (slot i at ptr - i*8), which on
-# the ascending heap underflowed into the PRECEDING allocation — silent memory
-# corruption with zero test coverage. These cases pin the fixed behavior via
-# exact stdout (drops printed for ordering), not just exit codes.
+# UPWARD from it. On the HEAP (`@alloc`), whose storage is the compact image, a
+# raw pointer round-trips a multi-slot aggregate correctly. Before the fix,
+# multi-slot aggregates were written descending through a raw pointer (slot i at
+# ptr - i*8), which on the ascending heap underflowed into the PRECEDING
+# allocation — silent memory corruption with zero test coverage. These cases pin
+# the fixed behavior via exact stdout (drops printed for ordering), not just exit
+# codes.
+#
+# The stack/heap raw-pointer equivalence is SUSPENDED under the default compact
+# layout: a stack frame stays slot-shaped (one eight-byte slot per leaf) while a
+# raw pointer addresses memory by the packed compact image, so taking `@raw` of a
+# frame-resident non-slot-identical aggregate is refused loudly rather than
+# silently mixing representations (RUE-987 / RUE-1035 M2). `stack_raw_ptr_refused`
+# pins that refusal; the heap remains the working round-trip path above.
 
 [section]
 id = "cli.aggregate_ascending_layout"
@@ -46,24 +54,27 @@ fn main() -> i32 {
 """ }]
 stdout = "11\n22\n33\n44\n999\n999\n"
 
-# --- @raw of a stack struct + @ptr round-trip (low-end ascending) -----------
+# --- @raw of a stack struct is refused under the compact layout (M2) ---------
+# Under the default compact layout a stack frame stays slot-shaped, so a raw
+# pointer into a frame-resident non-slot-identical struct would mix the slot
+# frame with the compact image `@ptr_read`/`@ptr_write` assume. It is refused
+# loudly and points at the working heap alternative (RUE-987 / RUE-1035 M2).
 [[case]]
-name = "stack_raw_ptr_roundtrip"
+name = "stack_raw_ptr_refused"
 files = [{ path = "main.rue", source = """
 struct P { x: i32, y: i32, z: i32 }
 fn main() -> i32 {
     let mut v: P = P { x: 5, y: 7, z: 9 };
     checked {
         let p: ptr mut P = @raw_mut(v);
-        let r = @ptr_read(p);
-        @dbg(r.x); @dbg(r.y); @dbg(r.z);
         @ptr_write(p, P { x: 40, y: 50, z: 60 });
     };
     @dbg(v.x); @dbg(v.y); @dbg(v.z);
     0
 }
 """ }]
-stdout = "5\n7\n9\n40\n50\n60\n"
+compile_fail = true
+error_contains = ["raw pointer", "frame-resident aggregate", "@alloc"]
 
 # --- Array-of-struct: whole-element and field write/read --------------------
 [[case]]

--- a/crates/rue-cli-tests/cases/aggregate_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout.toml
@@ -1,29 +1,27 @@
-# Compact native physical layout through the real driver (ADR-0052, RUE-974 +
-# RUE-989). With `--preview aggregate_layout` the canonical layout authority
-# reports the ratified compact representation: natural scalar widths and
-# alignments, declaration-order struct fields with interior/tail padding,
-# ascending array stride, a smallest-sufficient enum tag, and the uniform
-# zero-sized-type rule. The compile-time layout queries (@size_of / @align_of /
-# @offset_of) observe those values; slot-identical aggregates (all eight-byte
-# leaves) marshal correctly through memory; and RUE-989 lowers narrow
-# (one/two/four-byte) scalar access through typed pointers with the correct
-# zero/sign extension, so narrow heap round-trips, compact struct field access,
-# and heap arrays of narrow scalars compile and execute. A program that would
-# still need unimplemented whole-aggregate marshalling through a pointer or
-# across a call (or compact enum memory) fails loudly rather than emitting
-# slot-shaped access against a compact layout. Without the flag every case below
-# observes today's eight-byte slot model unchanged.
+# Compact native physical layout through the real driver (ADR-0052, RUE-987
+# stabilization). The canonical layout authority reports the ratified compact
+# representation by default: natural scalar widths and alignments,
+# declaration-order struct fields with interior/tail padding, ascending array
+# stride, a smallest-sufficient enum tag, and the uniform zero-sized-type rule.
+# The compile-time layout queries (@size_of / @align_of / @offset_of) observe
+# those values; slot-identical aggregates (all eight-byte leaves) marshal
+# correctly through memory; and narrow (one/two/four-byte) scalar access through
+# typed pointers extends with the correct zero/sign extension, so narrow heap
+# round-trips, compact struct field access, and heap arrays of narrow scalars
+# compile and execute. The one construct without a single physical memory image
+# — an enum whose per-variant payloads overlap (an overlapping variant union),
+# or an aggregate containing one — is refused loudly rather than miscompiled.
 
 [section]
 id = "cli.aggregate_layout"
-name = "Compact native layout (ADR-0052 phase 3)"
-description = "The aggregate_layout preview reports the compact physical layout in @size_of / @align_of / @offset_of; slot-identical aggregates still execute, and narrow physical access fails loudly."
+name = "Compact native layout (ADR-0052)"
+description = "The compiler reports the compact physical layout in @size_of / @align_of / @offset_of by default; slot-identical aggregates still execute, and an imageless overlapping-union enum fails loudly."
 
 # Scalars take their natural LP64 width and alignment under the compact layout.
 [[case]]
 name = "compact_scalar_sizes_and_alignments"
-description = "Natural scalar widths/alignments (u8=1, i16=2, i32=4, i64=8, bool=1) under --preview aggregate_layout."
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+description = "Natural scalar widths/alignments (u8=1, i16=2, i32=4, i64=8, bool=1) by default."
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     @dbg(@size_of(u8) == 1);
@@ -44,7 +42,7 @@ exit_code = 0
 [[case]]
 name = "compact_struct_padding_and_offsets"
 description = "Padded { a: u8, b: i32, c: u8 } -> a@0, b@4, c@8, size 12, align 4."
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Padded { a: u8, b: i32, c: u8 }
 fn main() -> i32 {
@@ -63,7 +61,7 @@ exit_code = 0
 [[case]]
 name = "compact_array_stride"
 description = "[i32; 3] has size 12; [u8; 4] has size 4 under the compact layout."
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     @dbg(@size_of([i32; 3]) == 12);
@@ -80,7 +78,7 @@ exit_code = 0
 [[case]]
 name = "compact_zero_sized_rules"
 description = "unit and [i32; 0] are size 0 with alignment 1."
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     @dbg(@size_of(()) == 0);
@@ -98,9 +96,9 @@ exit_code = 0
 # correctly under the compact layout.
 [[case]]
 name = "compact_slot_identical_field_ptr_roundtrip"
-description = "An all-i64 struct writes and reads a field through a pointer under --preview aggregate_layout."
+description = "An all-i64 struct writes and reads a field through a pointer by default."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Cell { first: i64, second: i64 }
 fn main() -> i32 {
@@ -123,7 +121,7 @@ exit_code = 100
 [[case]]
 name = "compact_slot_identical_offsets_match_slot_model"
 description = "An all-i64 struct has offsets 0/8 and size 16 under the compact layout."
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Cell { first: i64, second: i64 }
 fn main() -> i32 {
@@ -142,9 +140,9 @@ exit_code = 0
 # store hits its low bytes (little-endian), so the round-trip is correct.
 [[case]]
 name = "compact_struct_field_narrow_roundtrip"
-description = "Writing a narrow i32 field through a pointer round-trips under --preview aggregate_layout (RUE-989)."
+description = "Writing a narrow i32 field through a pointer round-trips (RUE-989)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Pair { a: i32, b: i32 }
 fn main() -> i32 {
@@ -160,33 +158,15 @@ fn main() -> i32 {
 stdout = "7\n"
 exit_code = 100
 
-# The same narrow-field program also compiles and runs under the default slot
-# model when the preview is off (byte-identical gate-off behavior).
-[[case]]
-name = "narrow_program_unchanged_without_the_preview"
-description = "The narrow-field program compiles and runs under the default slot model when the preview is off."
-files = [{ path = "main.rue", source = """
-struct Pair { a: i32, b: i32 }
-fn main() -> i32 {
-    let mut p = Pair { a: 7, b: 9 };
-    checked {
-        let fp: ptr mut i32 = @field_ptr(p.b);
-        @ptr_write(fp, 100);
-    };
-    p.b
-}
-""" }]
-exit_code = 100
-
 # RUE-989: narrow scalar heap round-trips through @alloc/@ptr_write/@ptr_read
 # for i32, i16 (signed, storing -1 and reading it back), u16 (zero-extended),
 # and u8. The load extends the narrow physical value into its slot per the
 # scalar's signedness.
 [[case]]
 name = "narrow_heap_roundtrip_scalars"
-description = "i32/i16/u16/u8 heap round-trips with correct sign/zero extension under --preview aggregate_layout (RUE-989)."
+description = "i32/i16/u16/u8 heap round-trips with correct sign/zero extension (RUE-989)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     checked {
@@ -220,9 +200,9 @@ exit_code = 0
 # stride (u8 stride 1, i16 stride 2, i32 stride 4), covering signed negatives.
 [[case]]
 name = "narrow_heap_array_walk"
-description = "Walk heap [u8;4], [i16;3] (with negatives), [i32;3] at compact stride under --preview aggregate_layout (RUE-989)."
+description = "Walk heap [u8;4], [i16;3] (with negatives), [i32;3] at compact stride (RUE-989)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     checked {
@@ -262,7 +242,7 @@ exit_code = 0
 name = "mixed_struct_field_roundtrip"
 description = "Round-trip every field of { a: u8, b: i32, c: u8 } through narrow field pointers (RUE-989)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Mixed { a: u8, b: i32, c: u8 }
 fn main() -> i32 {
@@ -296,7 +276,7 @@ exit_code = 0
 [[case]]
 name = "compact_struct_through_pointer_roundtrip"
 description = "A whole compact struct round-trips through a typed heap pointer via its compact memory image (RUE-987)."
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Padded { a: u8, b: i32, c: u8 }
 fn main() -> i32 {
@@ -327,7 +307,7 @@ exit_code = 0
 name = "array_bearing_struct_through_pointer_roundtrip"
 description = "A struct containing a fixed array marshals whole through a pointer: the array field flattens into the compact image at the compact element stride (RUE-1014)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct HasArr { xs: [i32; 2] }
 fn main() -> i32 {
@@ -351,8 +331,8 @@ exit_code = 0
 # so @size_of reflects the u8 tag (1) rather than the eight-byte slot.
 [[case]]
 name = "compact_enum_tag_narrows_size"
-description = "A discriminant-only enum is one byte (u8 tag) under --preview aggregate_layout; a payload enum sizes tag + max-aligned payload."
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+description = "A discriminant-only enum is one byte (u8 tag); a payload enum sizes tag + max-aligned payload."
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Flag { Off, On }
 enum Opt { Some(i32), None }
@@ -374,8 +354,8 @@ exit_code = 0
 # compiles and runs under the preview (RUE-989 refused every enum value).
 [[case]]
 name = "compact_enum_frame_match_allowed"
-description = "A frame-only enum construct-and-match compiles and runs under --preview aggregate_layout (RUE-1000)."
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+description = "A frame-only enum construct-and-match compiles and runs (RUE-1000)."
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Color { Red, Green, Blue }
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
@@ -394,9 +374,9 @@ exit_code = 9
 # at the compact payload offset. Some(42) reads back 42; None matches None.
 [[case]]
 name = "compact_enum_option_heap_roundtrip"
-description = "An Option-like enum write/read/match round-trips through heap memory under --preview aggregate_layout (RUE-1000)."
+description = "An Option-like enum write/read/match round-trips through heap memory (RUE-1000)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Opt { Some(i32), None }
 fn main() -> i32 {
@@ -422,9 +402,9 @@ exit_code = 0
 # the narrower values are clean in their slot, so each variant round-trips.
 [[case]]
 name = "compact_enum_mixed_payload_widths"
-description = "An enum with u8/i32/i64 payload variants round-trips each through heap memory under --preview aggregate_layout (RUE-1000)."
+description = "An enum with u8/i32/i64 payload variants round-trips each through heap memory (RUE-1000)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Num { B(u8), W(i32), Big(i64) }
 fn main() -> i32 {
@@ -452,9 +432,9 @@ exit_code = 0
 # distinct, non-overlapping compact positions (payload_offset and +4).
 [[case]]
 name = "compact_enum_uniform_multifield_heap"
-description = "A multi-field payload enum (Rect(i32,i32)) round-trips through heap memory under --preview aggregate_layout (RUE-1000)."
+description = "A multi-field payload enum (Rect(i32,i32)) round-trips through heap memory (RUE-1000)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn main() -> i32 {
@@ -485,7 +465,7 @@ exit_code = 0
 name = "compact_enum_padding_is_deterministically_zeroed"
 description = "An enum heap image zeros its tag-to-payload and inter-field padding on @ptr_write, with no residue across an overwrite (RUE-1007)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Wide { A(u8, i32), B }
 fn main() -> i32 {
@@ -544,7 +524,7 @@ exit_code = 0
 name = "compact_enum_overlapping_union_roundtrip"
 description = "A heterogeneous enum (i64 vs two i32, overlapping union positions) round-trips through a heap pointer via per-variant tag dispatch (RUE-1037)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Bad { A(i64), B(i32, i32) }
 fn first(v: Bad) -> i64 {
@@ -574,7 +554,7 @@ exit_code = 0
 name = "compact_enum_struct_payload_roundtrip"
 description = "An enum with a struct payload marshals whole through a pointer: the struct payload flattens to a variant-independent image (RUE-1014)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Res { id: i32 }
 enum Holder { Full(Res), Nothing }
@@ -605,7 +585,7 @@ exit_code = 0
 name = "compact_heterogeneous_enum_crossing_call_by_value"
 description = "A heterogeneous compact enum (i64 vs two i32) passed by value across a call marshals through its tag-dispatched image (RUE-1037)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Bad { A(i64), B(i32, i32) }
 fn first(v: Bad) -> i64 {
@@ -637,9 +617,9 @@ exit_code = 0
 # reads that image back, extending each field into its slot-shaped vreg.
 [[case]]
 name = "compact_struct_return_sret_roundtrip"
-description = "A padded struct returned by value round-trips its fields through the compact sret image under --preview aggregate_layout (RUE-1004)."
+description = "A padded struct returned by value round-trips its fields through the compact sret image (RUE-1004)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Padded { a: u8, b: i32, c: u8 }
 fn make(x: i32) -> Padded { Padded { a: 7, b: x, c: 9 } }
@@ -659,9 +639,9 @@ exit_code = 0
 # round-trip and match correctly in the caller.
 [[case]]
 name = "compact_enum_return_sret_roundtrip"
-description = "An Option-like enum returned by value round-trips through the compact sret image under --preview aggregate_layout (RUE-1004)."
+description = "An Option-like enum returned by value round-trips through the compact sret image (RUE-1004)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Opt { Some(i32), None }
 fn wrap(x: i32) -> Opt { Opt.Some(x) }
@@ -684,9 +664,9 @@ exit_code = 0
 # transport. The callee's mutation is observed by the caller.
 [[case]]
 name = "compact_struct_inout_mutation"
-description = "An inout compact struct mutated by the callee is observed by the caller under --preview aggregate_layout (RUE-1004)."
+description = "An inout compact struct mutated by the callee is observed by the caller (RUE-1004)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Padded { a: u8, b: i32, c: u8 }
 fn bump(inout p: Padded) {
@@ -709,9 +689,9 @@ exit_code = 0
 # its fields through the pointer without mutating the caller's value.
 [[case]]
 name = "compact_struct_borrow_read"
-description = "A borrow compact struct read field-by-field in the callee under --preview aggregate_layout (RUE-1004)."
+description = "A borrow compact struct read field-by-field in the callee (RUE-1004)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Padded { a: u8, b: i32, c: u8 }
 fn total(borrow p: Padded) -> i32 { p.b }
@@ -731,9 +711,9 @@ exit_code = 0
 # reads back correctly. Gate-off passes slot-shaped registers identically.
 [[case]]
 name = "compact_struct_by_value_read_fields"
-description = "A compact struct passed by value has all fields read in the callee via the caller-written compact image and homed pointer under --preview aggregate_layout (RUE-1005)."
+description = "A compact struct passed by value has all fields read in the callee via the caller-written compact image and homed pointer (RUE-1005)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Padded { a: u8, b: i32, c: u8 }
 fn sum(p: Padded) -> i32 {
@@ -756,9 +736,9 @@ exit_code = 0
 # both variants correctly.
 [[case]]
 name = "compact_enum_by_value_match"
-description = "An Option-like enum passed by value is matched in the callee through the compact image and homed pointer under --preview aggregate_layout (RUE-1005)."
+description = "An Option-like enum passed by value is matched in the callee through the compact image and homed pointer (RUE-1005)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Opt { Some(i32), None }
 fn unwrap_or(o: Opt, d: i32) -> i32 {
@@ -778,9 +758,9 @@ exit_code = 0
 # for the next call, and the deepest callee reads every field.
 [[case]]
 name = "compact_struct_by_value_two_level_chain"
-description = "A compact struct passed by value through a two-level call chain (caller -> f -> g) reads correctly at the bottom under --preview aggregate_layout (RUE-1005)."
+description = "A compact struct passed by value through a two-level call chain (caller -> f -> g) reads correctly at the bottom (RUE-1005)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Padded { a: u8, b: i32, c: u8 }
 fn g(p: Padded) -> i32 { @intCast(p.a) + p.b + @intCast(p.c) }
@@ -800,9 +780,9 @@ exit_code = 0
 # preserved convention.
 [[case]]
 name = "compact_mixed_signature_by_value"
-description = "A call mixing i64, a by-value compact struct, and bool passes the struct indirectly while scalars stay direct under --preview aggregate_layout (RUE-1005)."
+description = "A call mixing i64, a by-value compact struct, and bool passes the struct indirectly while scalars stay direct (RUE-1005)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Padded { a: u8, b: i32, c: u8 }
 fn mix(x: i64, p: Padded, flag: bool) -> i64 {
@@ -826,9 +806,9 @@ exit_code = 0
 # read-back reads its buffer.
 [[case]]
 name = "compact_struct_takes_and_returns_by_value"
-description = "A call that both takes and returns a compact aggregate by value round-trips under --preview aggregate_layout (RUE-1005)."
+description = "A call that both takes and returns a compact aggregate by value round-trips (RUE-1005)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Padded { a: u8, b: i32, c: u8 }
 fn bump(p: Padded) -> Padded { Padded { a: p.a, b: p.b + 1, c: p.c } }
@@ -851,7 +831,7 @@ exit_code = 0
 name = "compact_array_by_value_arg_roundtrip"
 description = "A by-value fixed array crossing a call marshals through its compact image (compact element stride) and is indexed in the callee at the slot stride (RUE-1014)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn sum(a: [i32; 3]) -> i32 { a[0] + a[1] + a[2] }
 fn main() -> i32 {
@@ -863,8 +843,8 @@ fn main() -> i32 {
 stdout = "60\n"
 exit_code = 0
 
-# RUE-1004 prize: a std-like generic `ArrayBuf(i32)` compiles and runs under
-# --preview aggregate_layout. `ArrayBuf(T)` is `{ buf: ptr mut T, len: u64,
+# RUE-1004 prize: a std-like generic `ArrayBuf(i32)` compiles and runs under the
+# default compact layout. `ArrayBuf(T)` is `{ buf: ptr mut T, len: u64,
 # cap: u64 }` — all eight-byte leaves, so it is slot-identical and crosses its
 # `borrow self` / `inout self` method calls unchanged; the i32 heap elements use
 # RUE-989 narrow access; and `get`/`pop` return `Option(i32)` BY VALUE, which is
@@ -873,9 +853,9 @@ exit_code = 0
 # to compile and execute under the compact-layout gate.
 [[case]]
 name = "compact_arraybuf_option_return_dogfood"
-description = "A generic ArrayBuf(i32) push/get/pop dogfood compiles and runs under --preview aggregate_layout; Option(i32) returns cross via the compact sret image (RUE-1004)."
+description = "A generic ArrayBuf(i32) push/get/pop dogfood compiles and runs; Option(i32) returns cross via the compact sret image (RUE-1004)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [
   { path = "main.rue", source = """const arraybuf = @import("arraybuf.rue");
 
@@ -988,9 +968,9 @@ exit_code = 0
 # behavior across all opt levels; the output matches the gate-off run.
 [[case]]
 name = "compact_arraybuf_struct_element_dogfood"
-description = "A generic ArrayBuf(Point) with a compact struct element: push/get/set/pop_or round-trip the whole struct through heap pointers and sret returns under --preview aggregate_layout (RUE-987)."
+description = "A generic ArrayBuf(Point) with a compact struct element: push/get/set/pop_or round-trip the whole struct through heap pointers and sret returns (RUE-987)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [
   { path = "main.rue", source = """const arraybuf = @import("arraybuf.rue");
 
@@ -1092,7 +1072,7 @@ exit_code = 0
 name = "variant_dependent_enum_struct_payload_sret"
 description = "An Option(struct) enum returned by value marshals through the compact sret image and matches on both variants (RUE-1014)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Point { x: i32, y: i32 }
 enum Opt { Some(Point), None }
@@ -1116,7 +1096,7 @@ exit_code = 0
 name = "compact_enum_variant_overwrite_leaves_no_residue"
 description = "Overwriting a heap enum with a shorter variant leaves no residue from the wider variant's payload (RUE-1014 / RUE-1007 ruling 5)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum E { Big(i64, i64), Small(u8) }
 fn main() -> i32 {
@@ -1138,9 +1118,10 @@ stdout = "0\n"
 exit_code = 0
 
 # --- RUE-1035: single-slot by-value, array drop glue, and frame @raw ---------
-# Three compact-codegen miscompiles reachable under --preview aggregate_layout,
-# each reproduced then fixed. M1/M3 now execute correctly across optimization
-# levels; M2 converts a silent miscompile into a loud construct-level refusal.
+# Three compact-codegen miscompiles that the flip to the default compact layout
+# exposed, each reproduced then fixed (RUE-1035). M1/M3 now execute correctly
+# across optimization levels; M2 converts a silent miscompile into a loud
+# construct-level refusal that is now the default behavior (RUE-987).
 
 # M1: a single-narrow-field struct passed BY VALUE. The classifier used to force
 # ANY non-slot-identical aggregate indirect; a one-slot struct went through the
@@ -1151,7 +1132,7 @@ exit_code = 0
 name = "compact_single_field_struct_by_value"
 description = "A single-i32-field struct passed by value returns its field, not garbage (RUE-1035 M1)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct D { v: i32 }
 fn c(d: D) -> i32 { d.v }
@@ -1170,7 +1151,7 @@ exit_code = 0
 name = "compact_single_field_struct_returned"
 description = "A single-i32-field struct returned by value round-trips (RUE-1035 M1, return side)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct D { v: i32 }
 fn mk() -> D { D { v: 7 } }
@@ -1192,7 +1173,7 @@ exit_code = 0
 name = "compact_array_element_drop_glue"
 description = "Array-element drop glue over a struct with a destructor drops each element in order (RUE-1035 M3)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct D { a: i32, b: i32 }
 drop fn D(self) { @dbg(self.a); @dbg(self.b); }
@@ -1211,7 +1192,7 @@ exit_code = 0
 [[case]]
 name = "compact_frame_raw_whole_struct_refused"
 description = "@raw_mut of a non-slot-identical frame struct is refused with a construct-level error (RUE-1035 M2)."
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct P { x: i32, y: i32, z: i32 }
 fn main() -> i32 {
@@ -1233,7 +1214,7 @@ error_contains = ["raw pointer", "frame-resident aggregate", "@alloc"]
 [[case]]
 name = "compact_frame_raw_array_element_refused"
 description = "@raw of a frame array element (a non-slot-identical array) is refused (RUE-1035 M2)."
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let mut arr: [i32; 3] = [10, 20, 30];
@@ -1261,7 +1242,7 @@ error_contains = ["raw pointer", "frame-resident aggregate"]
 name = "compact_heterogeneous_enum_construct_return_match"
 description = "A heterogeneous enum { Ok(struct{i32,i32,i32}), Err(i64) } is constructed, sret-returned, passed by value, and matched on both variants (RUE-1037)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum R { Ok(Point), Err(i64) }
 struct Point { x: i32, y: i32, z: i32 }
@@ -1292,7 +1273,7 @@ exit_code = 0
 name = "compact_heterogeneous_enum_heap_overwrite_no_residue"
 description = "Overwriting a heap heterogeneous enum with a shorter variant zeroes the wider variant's payload bytes; the round-tripped value classifies correctly (RUE-1037 / RUE-1007)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum R { Ok(Point), Err(i64) }
 struct Point { x: i32, y: i32, z: i32 }
@@ -1328,7 +1309,7 @@ exit_code = 0
 name = "compact_heterogeneous_enum_in_struct_across_call"
 description = "A struct containing a heterogeneous enum crosses a call boundary in both directions, marshalled via a nested tag dispatch (RUE-1037)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum R { Ok(Point), Err(i64) }
 struct Point { x: i32, y: i32, z: i32 }

--- a/crates/rue-cli-tests/cases/aggregate_layout_std_sweep.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout_std_sweep.toml
@@ -1,17 +1,16 @@
-# std-under-aggregate_layout sweep (ADR-0052, RUE-987 / RUE-1014).
+# std-under-compact-layout sweep (ADR-0052, RUE-987 / RUE-1014).
 #
-# The compact physical layout (`--preview aggregate_layout`) is only useful if the
-# standard library's data-structure PATTERNS compile and run correctly under it.
-# This suite is the permanent CI home for that sweep: each case exercises a real
-# std shape — heap-backed containers, byte buffers, nested records, struct
-# elements, and now variant-dependent enum images and compact arrays — through the
-# compact-layout machinery (narrow scalar access RUE-989, compact enum memory
-# RUE-1000, call-boundary marshalling RUE-1004/1005, zero-padding RUE-1007, whole
+# The compact physical layout is only useful if the standard library's
+# data-structure PATTERNS compile and run correctly under it. This suite is the
+# permanent CI home for that sweep: each case exercises a real std shape —
+# heap-backed containers, byte buffers, nested records, struct elements, and
+# variant-dependent enum images and compact arrays — through the compact-layout
+# machinery (narrow scalar access RUE-989, compact enum memory RUE-1000,
+# call-boundary marshalling RUE-1004/1005, zero-padding RUE-1007, whole
 # compact-struct marshalling through typed pointers RUE-987, and variant-dependent
 # enum images plus compact arrays through pointers and across calls RUE-1014).
-# Every `stdout`/`exit_code` here is the gate-OFF oracle: the compact-layout run
-# must be byte-identical, so a miscompile changes the pinned output and fails.
-# `differential_opt` additionally pins identical behavior across every
+# Every `stdout`/`exit_code` here is pinned oracle output that a miscompile would
+# change. `differential_opt` additionally pins identical behavior across every
 # optimization level.
 #
 # Most programs are self-contained mirrors of the std container/string/record
@@ -26,7 +25,7 @@
 [section]
 id = "cli.aggregate_layout_std_sweep"
 name = "std patterns under the compact layout"
-description = "Self-contained programs mirroring std container/string/record patterns compile and run byte-identically under --preview aggregate_layout (RUE-987)."
+description = "Self-contained programs mirroring std container/string/record patterns compile and run byte-identically (RUE-987)."
 
 # A heap array of compact records walked with @ptr_offset at the compact stride:
 # each record { id: u8, val: i32, tag: u16 } is written whole through the typed
@@ -36,7 +35,7 @@ description = "Self-contained programs mirroring std container/string/record pat
 name = "heap_struct_array_walk"
 description = "A heap array of compact { u8, i32, u16 } records walked with @ptr_offset; whole-struct @ptr_write/@ptr_read at the compact stride."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Rec { id: u8, val: i32, tag: u16 }
 fn main() -> i32 {
@@ -74,7 +73,7 @@ exit_code = 0
 name = "nested_compact_struct_through_pointer"
 description = "A nested compact record round-trips whole through a typed pointer; the inner struct's leaves flatten into the outer compact image (RUE-987)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Inner { a: u8, b: i32 }
 struct Outer { x: u16, inner: Inner, y: u8 }
@@ -105,7 +104,7 @@ exit_code = 0
 name = "narrow_byte_buffer_roundtrip"
 description = "A heap u8 buffer written/read at compact stride 1 with narrow access — the StrBuf/ArrayBuf(u8) storage pattern."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let sum = checked {
@@ -134,7 +133,7 @@ exit_code = 0
 name = "arraybuf_compact_struct_element"
 description = "A generic @import ArrayBuf(Point) with a compact struct element: push/get/set/pop_or round-trip whole structs under the gate (RUE-987)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [
   { path = "main.rue", source = """const arraybuf = @import("arraybuf.rue");
 struct Point { x: i32, y: i32 }
@@ -214,7 +213,7 @@ exit_code = 0
 name = "option_struct_return_roundtrip"
 description = "Returning an enum with a struct payload (Option(struct)) by value round-trips under the gate: the struct payload flattens to a variant-independent image (RUE-1014)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct P { x: i32, y: i32 }
 enum Opt { Some(P), None }
@@ -237,7 +236,7 @@ exit_code = 0
 name = "array_crossing_call_roundtrip"
 description = "A fixed array returned by value across a call marshals through its compact image and is then indexed as a frame value (RUE-1014)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn make() -> [u8; 4] { [1, 2, 3, 4] }
 fn main() -> i32 {
@@ -258,10 +257,10 @@ exit_code = 0
 # construct RUE-987 recorded as the last blocker; classifying the parsed value
 # pins the top-level variant (an array -> 5).
 [[case]]
-name = "std_json_parse_variant_under_gate"
-description = "The real std.json parser compiles and runs under the gate: Json's variant-dependent aggregate payloads marshal through one variant-independent image (RUE-1014)."
+name = "std_json_parse_variant"
+description = "The real std.json parser compiles and runs by default: Json's variant-dependent aggregate payloads marshal through one variant-independent image (RUE-1014)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -299,10 +298,10 @@ exit_code = 0
 # dependent enum image (RUE-1014) — across the sret boundary. A four-element
 # min-heap pops in ascending priority order, pinning the whole pipeline.
 [[case]]
-name = "std_priority_queue_option_pair_under_gate"
-description = "The real std PriorityQueue(i32,i32) runs under the gate: ArrayBuf(Pair) struct elements plus Option(Pair) variant-dependent enum returns (RUE-1014)."
+name = "std_priority_queue_option_pair"
+description = "The real std PriorityQueue(i32,i32) runs by default: ArrayBuf(Pair) struct elements plus Option(Pair) variant-dependent enum returns (RUE-1014)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -341,7 +340,7 @@ exit_code = 0
 name = "overlapping_union_enum_roundtrips_via_dispatch"
 description = "An enum with overlapping narrow payload positions (u16,u16 vs u32) round-trips through a heap pointer via per-variant tag dispatch (RUE-1037)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Ov { A(u16, u16), B(u32) }
 fn make(v: bool) -> Ov { if v { Ov.A(1, 2) } else { Ov.B(3) } }
@@ -364,18 +363,18 @@ fn main() -> i32 {
 stdout = "33\n"
 exit_code = 0
 
-# RUE-1037 SUCCESS GATE: a faithful mirror of std.net's Result(SockAddr,
-# NetworkError) return surface (TcpListener.local_addr) — the exact heterogeneous
-# shape that blocked the compact-layout default. Ok(SockAddr{ IpAddr enum, u16 })
-# and Err(NetworkError enum with an Other(i64) payload) have DISAGREEING payload
+# RUE-1037: a faithful mirror of std.net's Result(SockAddr, NetworkError) return
+# surface (TcpListener.local_addr) — the exact heterogeneous shape that blocked
+# the compact-layout default. Ok(SockAddr{ IpAddr enum, u16 }) and
+# Err(NetworkError enum with an Other(i64) payload) have DISAGREEING payload
 # layouts, so the enum is marshalled by per-variant tag dispatch. Exercised as an
 # sret return, a by-value argument, a heap @ptr_write/@ptr_read round-trip, and a
 # nested-match on both variants. 8208 (Ok) + 111 (Err) + 8208 (heap Ok) = 16527.
 [[case]]
-name = "std_net_result_sockaddr_networkerror_mirror_under_gate"
-description = "A faithful mirror of std.net Result(SockAddr, NetworkError) — the heterogeneous enum blocking the compact default — round-trips by value, by argument, and through the heap under the gate via per-variant tag dispatch (RUE-1037)."
+name = "std_net_result_sockaddr_networkerror_mirror"
+description = "A faithful mirror of std.net Result(SockAddr, NetworkError) — the heterogeneous enum blocking the compact default — round-trips by value, by argument, and through the heap via per-variant tag dispatch (RUE-1037)."
 differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Ipv4Addr { a: u8, b: u8, c: u8, d: u8 }
 enum IpAddr { V4(Ipv4Addr) }

--- a/crates/rue-cli-tests/cases/comptime_type_var_composite.toml
+++ b/crates/rue-cli-tests/cases/comptime_type_var_composite.toml
@@ -59,8 +59,12 @@ stdout = "7\n"
 [[case]]
 name = "pointer_to_comptime_type_var"
 description = "`ptr const P` where P is a local comptime type value resolves as a pointee type (RUE-263)."
+# Slot-identical field type (i64) so a raw pointer into the frame-resident
+# struct is supported; a non-slot-identical frame struct (e.g. i32 fields) is
+# refused under the default compact layout (RUE-987 / RUE-1035 M2). The
+# pointer-to-comptime-type resolution under test is field-width-independent.
 files = [{ path = "main.rue", source = """
-fn Point() -> type { struct { x: i32, y: i32 } }
+fn Point() -> type { struct { x: i64, y: i64 } }
 fn main() -> i32 {
     let P = Point();
     let p: P = P { x: 10, y: 20 };

--- a/crates/rue-cli-tests/cases/nested_intrinsic_argument.toml
+++ b/crates/rue-cli-tests/cases/nested_intrinsic_argument.toml
@@ -10,9 +10,8 @@
 #
 # NOTE: what these cases pin is PARSING (RUE-343), not any intrinsic's value.
 # Value assertions here use @offset_of, which yields correct, field-distinct
-# offsets (x=0, y=8). @size_of currently reports 8 for every width — a separate,
-# unrelated codegen bug — so the pure-@size_of repro below only checks that it
-# parses and runs, not that 8 is the right size of an i32.
+# offsets (x=0, y=8, since the i64 `y` sits at its eight-byte alignment).
+# @size_of reports each type's natural compact width (i32 is 4).
 
 [section]
 id = "cli.nested_intrinsic_argument"
@@ -20,8 +19,8 @@ name = "Nested intrinsic-call arguments"
 description = "An intrinsic call is a full expression and composes as a direct argument to another intrinsic (RUE-343)."
 
 # The exact RUE-343 repro: a bare @size_of(i32) call passed directly as the
-# argument to @dbg. The point is that it PARSES and runs; the printed value
-# reflects @size_of's current (buggy) behavior, tracked separately.
+# argument to @dbg. The point is that it PARSES and runs; the printed value is
+# i32's natural compact width, 4.
 [[case]]
 name = "dbg_of_size_of"
 description = "@dbg(@size_of(i32)) parses and runs (exact RUE-343 repro)."
@@ -31,7 +30,7 @@ fn main() -> i32 {
     0
 }
 """ }]
-stdout = "8\n"
+stdout = "4\n"
 exit_code = 0
 
 # A second intrinsic (@offset_of) whose own first argument is a TYPE, nested as

--- a/crates/rue-cli-tests/cases/offset_of_field_ptr.toml
+++ b/crates/rue-cli-tests/cases/offset_of_field_ptr.toml
@@ -14,8 +14,9 @@ id = "cli.offset_of_field_ptr"
 name = "@offset_of / @field_ptr"
 description = "Compiler-mediated field offsets and field pointers via the CLI driver."
 
-# @offset_of returns the byte offset of each field under the current 8-byte
-# slot layout. i32 `a` occupies one slot, so `b` is at byte 8 and `c` at 16.
+# @offset_of returns the compact byte offset of each field. `a` is an i32 at 0;
+# `b` is an i64, so it is placed at its natural eight-byte alignment (byte 8);
+# `c` (bool) follows the i64 at byte 16.
 [[case]]
 name = "offset_of_mixed_scalars"
 files = [{ path = "main.rue", source = """
@@ -33,8 +34,10 @@ fn main() -> i32 {
 stdout = "0\n8\n16\n"
 exit_code = 0
 
-# Multi-slot preceding fields (an array and a nested struct) shift later
-# offsets by their full slot count.
+# Preceding fields (a bool, an array, and a nested struct) shift later offsets
+# by their compact size at their natural alignment. flag@0 (bool), arr@4
+# ([i32;3], align 4, size 12), inner@16 (Inner{i32,i32}, align 4, size 8),
+# last@24 (i64 at its eight-byte alignment).
 [[case]]
 name = "offset_of_array_and_nested"
 files = [{ path = "main.rue", source = """
@@ -42,9 +45,9 @@ struct Inner { x: i32, y: i32 }
 struct Outer { flag: bool, arr: [i32; 3], inner: Inner, last: i64 }
 fn main() -> i32 {
     @dbg(@offset_of(Outer, flag) == 0);
-    @dbg(@offset_of(Outer, arr) == 8);
-    @dbg(@offset_of(Outer, inner) == 32);
-    @dbg(@offset_of(Outer, last) == 48);
+    @dbg(@offset_of(Outer, arr) == 4);
+    @dbg(@offset_of(Outer, inner) == 16);
+    @dbg(@offset_of(Outer, last) == 24);
     0
 }
 """ }]

--- a/crates/rue-cli-tests/cases/pointers.toml
+++ b/crates/rue-cli-tests/cases/pointers.toml
@@ -91,16 +91,20 @@ stdout = "99\n"
 # wrong-direction scale) reads 10 or garbage instead.
 [[case]]
 name = "ptr_offset_reads_offset_element"
+# Uses a slot-identical element type (i64) so a raw pointer into the frame
+# array is supported; a non-slot-identical frame array (e.g. [i32; 3]) is
+# refused under the default compact layout (RUE-987 / RUE-1035 M2). The
+# @ptr_offset arithmetic under test is element-width-independent.
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let arr: [i32; 3] = [10, 20, 30];
-    let v: i32 = checked {
-        let base: ptr const i32 = @raw(arr[0]);
+    let arr: [i64; 3] = [10, 20, 30];
+    let v: i64 = checked {
+        let base: ptr const i64 = @raw(arr[0]);
         @ptr_read(@ptr_offset(base, 1))
     };
     @dbg(v);
-    let w: i32 = checked {
-        let base: ptr const i32 = @raw(arr[0]);
+    let w: i64 = checked {
+        let base: ptr const i64 = @raw(arr[0]);
         @ptr_read(@ptr_offset(base, 2))
     };
     @dbg(w);
@@ -115,11 +119,15 @@ stdout = "20\n30\n"
 # as ~4 billion and the address is corrupted (RUE-213).
 [[case]]
 name = "ptr_offset_negative_walks_backward"
+# Slot-identical i64 elements (see ptr_offset_reads_offset_element): a raw
+# pointer into a non-slot-identical frame array is refused under the compact
+# layout (M2). The narrow (i32) index -1 whose sign-extension this guards is
+# unchanged.
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let arr: [i32; 3] = [10, 20, 30];
-    let v: i32 = checked {
-        let base: ptr const i32 = @raw(arr[2]);
+    let arr: [i64; 3] = [10, 20, 30];
+    let v: i64 = checked {
+        let base: ptr const i64 = @raw(arr[2]);
         @ptr_read(@ptr_offset(base, -1))
     };
     @dbg(v);
@@ -133,11 +141,14 @@ stdout = "20\n"
 # arr[2].
 [[case]]
 name = "ptr_offset_write_hits_offset_element"
+# Slot-identical i64 elements (see ptr_offset_reads_offset_element): a raw
+# pointer into a non-slot-identical frame array is refused under the compact
+# layout (M2).
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut arr: [i32; 3] = [10, 20, 30];
+    let mut arr: [i64; 3] = [10, 20, 30];
     checked {
-        let base: ptr mut i32 = @raw_mut(arr[0]);
+        let base: ptr mut i64 = @raw_mut(arr[0]);
         @ptr_write(@ptr_offset(base, 2), 99);
     };
     @dbg(arr[0]);
@@ -152,9 +163,10 @@ stdout = "10\n99\n"
 # This walks a fresh mmap region (NOT a local array): @ptr_offset(base, 1)
 # must land one element FORWARD (higher address), so writing 100/200/300 at
 # offsets 0/1/2 and reading them back returns them in order, and the address
-# delta base->base+1 is exactly sizeof(pointee) (8, one slot). Before RUE-243
-# @ptr_offset subtracted, so it walked mmap pointers BACKWARD and this read
-# garbage. mmap uses the x86-64 Linux syscall ABI, so scope to that host.
+# delta base->base+1 is exactly sizeof(pointee) (4 = size_of(i32) under the
+# compact layout). Before RUE-243 @ptr_offset subtracted, so it walked mmap
+# pointers BACKWARD and this read garbage. mmap uses the x86-64 Linux syscall
+# ABI, so scope to that host.
 [[case]]
 name = "ptr_offset_forward_on_mmap_pointer"
 only_on = ["x86-64-linux"]
@@ -182,7 +194,7 @@ fn main() -> i32 {
     0
 }
 """ }]
-stdout = "8\n100\n200\n300\n"
+stdout = "4\n100\n200\n300\n"
 
 # Array indexing and @ptr_offset AGREE by construction (ADR-0040 / RUE-243):
 # both compute base + i*size (ascending). Write element 2 through the index
@@ -192,11 +204,14 @@ stdout = "8\n100\n200\n300\n"
 # through the index path.
 [[case]]
 name = "array_index_and_ptr_offset_agree"
+# Slot-identical i64 elements so a raw pointer into the frame array is
+# supported (a non-slot-identical frame array is refused under the compact
+# layout, M2); the index/@ptr_offset agreement under test is width-independent.
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut a: [i32; 4] = [0, 0, 0, 0];
+    let mut a: [i64; 4] = [0, 0, 0, 0];
     a[2] = 77;
-    let via_ptr: i32 = checked { @ptr_read(@ptr_offset(@raw(a[0]), 2)) };
+    let via_ptr: i64 = checked { @ptr_read(@ptr_offset(@raw(a[0]), 2)) };
     @dbg(via_ptr);
     checked {
         @ptr_write(@ptr_offset(@raw_mut(a[0]), 3), 88);
@@ -209,7 +224,8 @@ stdout = "77\n88\n"
 
 # @ptr_offset moves toward HIGHER addresses for a positive index and LOWER
 # for a negative one, on an ordinary (non-array-origin) local pointer
-# (ADR-0040 / RUE-243). The forward delta is exactly sizeof(pointee) = 8.
+# (ADR-0040 / RUE-243). The forward delta is exactly sizeof(pointee) = 4
+# (size_of(i32) under the compact layout).
 [[case]]
 name = "ptr_offset_forward_is_higher_address"
 files = [{ path = "main.rue", source = """
@@ -223,7 +239,7 @@ fn main() -> i32 {
     0
 }
 """ }]
-stdout = "8\n"
+stdout = "4\n"
 
 # Enforcement: a pointer operation outside a `checked` block is rejected
 # with E1300, not silently accepted (spec 9.1:12).

--- a/crates/rue-cli-tests/cases/ptr_read_write_aggregate.toml
+++ b/crates/rue-cli-tests/cases/ptr_read_write_aggregate.toml
@@ -11,6 +11,12 @@
 # type annotation (inference modeled it as an unconstrained fresh variable), so
 # an i64 pointee flowed into an i32 binding with no E0206 and a silent runtime
 # truncation. The pointee type now participates in ordinary type-checking.
+#
+# The multi-slot aggregate round-trips allocate their backing block on the HEAP
+# (@alloc), whose storage is the compact image, so the whole aggregate transfers
+# through @ptr_write/@ptr_read. A raw pointer into a frame-resident
+# non-slot-identical aggregate is refused under the default compact layout
+# (RUE-987 / RUE-1035 M2, frames stay slot-shaped for now).
 
 [section]
 id = "cli.ptr_read_write_aggregate"
@@ -23,12 +29,13 @@ name = "ptr_read_two_field_struct"
 files = [{ path = "main.rue", source = """
 struct P { x: i32, y: i32 }
 fn main() -> i32 {
-    let arr: [P; 1] = [P { x: 1, y: 2 }];
     checked {
-        let p: ptr const P = @raw(arr[0]);
+        let p: ptr mut P = @alloc(1);
+        @ptr_write(p, P { x: 1, y: 2 });
         let v = @ptr_read(p);
         @dbg(v.x);
         @dbg(v.y);
+        @free(p, 1);
     };
     0
 }
@@ -41,13 +48,14 @@ name = "ptr_write_two_field_struct"
 files = [{ path = "main.rue", source = """
 struct P { x: i32, y: i32 }
 fn main() -> i32 {
-    let mut arr: [P; 1] = [P { x: 0, y: 0 }];
     checked {
-        let p: ptr mut P = @raw_mut(arr[0]);
+        let p: ptr mut P = @alloc(1);
         @ptr_write(p, P { x: 7, y: 9 });
+        let v = @ptr_read(p);
+        @dbg(v.x);
+        @dbg(v.y);
+        @free(p, 1);
     };
-    @dbg(arr[0].x);
-    @dbg(arr[0].y);
     0
 }
 """ }]
@@ -60,19 +68,20 @@ files = [{ path = "main.rue", source = """
 struct Inner { a: i32, b: i32 }
 struct Outer { p: Inner, q: i32 }
 fn main() -> i32 {
-    let mut arr: [Outer; 1] = [Outer { p: Inner { a: 10, b: 20 }, q: 30 }];
     checked {
-        let rp: ptr const Outer = @raw(arr[0]);
-        let v = @ptr_read(rp);
+        let wp: ptr mut Outer = @alloc(1);
+        @ptr_write(wp, Outer { p: Inner { a: 10, b: 20 }, q: 30 });
+        let v = @ptr_read(wp);
         @dbg(v.p.a);
         @dbg(v.p.b);
         @dbg(v.q);
-        let wp: ptr mut Outer = @raw_mut(arr[0]);
         @ptr_write(wp, Outer { p: Inner { a: 1, b: 2 }, q: 3 });
+        let v2 = @ptr_read(wp);
+        @dbg(v2.p.a);
+        @dbg(v2.p.b);
+        @dbg(v2.q);
+        @free(wp, 1);
     };
-    @dbg(arr[0].p.a);
-    @dbg(arr[0].p.b);
-    @dbg(arr[0].q);
     0
 }
 """ }]

--- a/crates/rue-cli-tests/cases/raw_bytes_degate_readiness.toml
+++ b/crates/rue-cli-tests/cases/raw_bytes_degate_readiness.toml
@@ -1,42 +1,31 @@
-# De-gate differential: plain (no preview) vs aggregate_layout (RUE-978,
-# evidence gathered for the RUE-937 gate-removal decision; retained after
-# stabilization as a standing behavior-preservation check).
+# Raw-byte surface behavior check (RUE-978 fold-in; originally the RUE-937
+# de-gate differential, retained after the RUE-987 layout flip as a standing
+# behavior-preservation check).
 #
-# The raw-byte access family is now ungated (ADR-0059 Phase 6, RUE-937). ADR-0059
-# folds that family into the ordinary typed `ptr u8` path under `aggregate_layout`
-# (phase 7): `@byte_read`/`@byte_write` lower through the same one-byte narrow
-# scalar access a typed `ptr u8` takes, and the byte allocators share the general
-# allocator helper. The question these cases pin down is whether that fold-in
-# changes the OBSERVABLE behavior of the byte surface — i.e. does turning
-# `aggregate_layout` on alter what a byte-intrinsic program computes?
-#
-# It must not. The byte family is byte-granular in BOTH layout states (a
+# The raw-byte access family is ungated (ADR-0059 Phase 6, RUE-937) and, under
+# the compact layout that is now the default (ADR-0052, RUE-987), folds into the
+# ordinary typed `ptr u8` path (phase 7): `@byte_read`/`@byte_write` lower
+# through the same one-byte narrow scalar access a typed `ptr u8` takes, and the
+# byte allocators share the general allocator helper. These cases pin that the
+# fold-in is behavior-preserving: the byte family is byte-granular (a
 # `@byte_read` reads one physical byte, `@alloc_bytes(n, a)` reserves n physical
-# bytes, offsets are never scaled by the slot size), so the fold-in only changes
-# which instruction carries the access, never its result. Each program below
-# therefore appears TWICE — once plain (default slot layout, bespoke packed
-# lowering), once under `aggregate_layout` (folded into the narrow typed path) —
-# pinned to the SAME `stdout`/`exit_code`. A divergence (a fold-in that shifted a
-# byte, a stride that leaked into the byte surface) flips one half of a pair and
-# fails.
+# bytes, offsets are never scaled by the slot size), so the result never moves.
 #
 # Note: the byte surface deliberately avoids `@ptr_offset` for byte addressing
-# (it strides by the slot size, which is 8 under the default layout and 1 under
-# aggregate_layout — the one element that is NOT byte-identical across the layout),
-# addressing sub-ranges through `@ptr_to_int`/`@int_to_ptr` exactly as
-# `std/strbuf.rue` does. That is why these programs are byte-identical and a naive
-# `@ptr_offset`-based one would not be.
+# (it strides by the pointee width, so it is not byte-granular), addressing
+# sub-ranges through `@ptr_to_int`/`@int_to_ptr` exactly as `std/strbuf.rue`
+# does.
 
 [section]
 id = "cli.raw_bytes_degate_readiness"
-name = "raw-byte surface behaves identically with and without aggregate_layout"
-description = "Byte-intrinsic programs produce identical output plain (default slot layout) and under `aggregate_layout`, evidencing that the RUE-978 fold-in is behavior-preserving (RUE-937 de-gate readiness)."
+name = "raw-byte surface behaves identically under the compact layout"
+description = "Byte-intrinsic programs compute the byte-granular result the byte surface guarantees, evidencing that the RUE-978 fold-in into the narrow typed path is behavior-preserving."
 
 # The whole byte family — @alloc_bytes/@byte_set/@byte_write/@realloc_bytes/
-# @byte_copy/@byte_read/@free_bytes — in one round-trip. Baseline: plain, no preview.
+# @byte_copy/@byte_read/@free_bytes — in one round-trip.
 [[case]]
 name = "byte_family_roundtrip_plain"
-description = "Full byte-family round-trip plain, no preview (default slot layout, bespoke packed lowering)."
+description = "Full byte-family round-trip through the byte surface."
 differential_opt = true
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
@@ -64,40 +53,8 @@ fn main() -> i32 {
 stdout = "100\n"
 exit_code = 0
 
-# The identical program under aggregate_layout. The fold-in routes
-# @byte_read/@byte_write through the narrow typed path; the output must not move.
-[[case]]
-name = "byte_family_roundtrip_aggregate_layout"
-description = "The same byte-family round-trip under aggregate_layout (folded into the narrow typed path); output must be byte-identical."
-differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
-files = [{ path = "main.rue", source = """
-fn main() -> i32 {
-    checked {
-        let p: ptr mut u8 = @alloc_bytes(6, 1);
-        @byte_set(p, 0, 6);
-        @byte_write(p, 0, 10);
-        @byte_write(p, 1, 20);
-        @byte_write(p, 2, 30);
-        let q: ptr mut u8 = @realloc_bytes(p, 6, 1, 8);
-        @byte_write(q, 3, 40);
-        let dst: ptr mut u8 = @alloc_bytes(8, 1);
-        @byte_copy(dst, q, 8);
-        let sum: i32 = @intCast(@byte_read(dst, 0)) + @intCast(@byte_read(dst, 1))
-            + @intCast(@byte_read(dst, 2)) + @intCast(@byte_read(dst, 3))
-            + @intCast(@byte_read(dst, 4));
-        @dbg(sum);
-        @free_bytes(q, 8, 1);
-        @free_bytes(dst, 8, 1);
-    };
-    0
-}
-""" }]
-stdout = "100\n"
-exit_code = 0
-
 # StrBuf's packed sub-range copy idiom: byte offsets folded into the address via
-# @ptr_to_int/@int_to_ptr (never @ptr_offset), then @byte_copy. Baseline.
+# @ptr_to_int/@int_to_ptr (never @ptr_offset), then @byte_copy.
 [[case]]
 name = "packed_subrange_copy_plain"
 description = "StrBuf-style packed sub-range @byte_copy addressed through @ptr_to_int/@int_to_ptr, plain (no preview)."
@@ -133,37 +90,3 @@ fn main() -> i32 {
 stdout = "9\n"
 exit_code = 0
 
-[[case]]
-name = "packed_subrange_copy_aggregate_layout"
-description = "The same packed sub-range copy under aggregate_layout; output must be byte-identical."
-differential_opt = true
-args = ["main.rue", "--preview", "aggregate_layout", "-o", "prog"]
-files = [{ path = "main.rue", source = """
-fn main() -> i32 {
-    checked {
-        let src: ptr mut u8 = @alloc_bytes(5, 1);
-        let mut i: u64 = 0;
-        while i < 5 {
-            @byte_write(src, i, @intCast(i + 1));
-            i = i + 1;
-        }
-        let dst: ptr mut u8 = @alloc_bytes(5, 1);
-        @byte_set(dst, 0, 5);
-        let sp: ptr mut u8 = @int_to_ptr(@ptr_to_int(src) + 1);
-        let dp: ptr mut u8 = @int_to_ptr(@ptr_to_int(dst) + 2);
-        @byte_copy(dp, sp, 3);
-        let mut sum: i32 = 0;
-        let mut j: u64 = 0;
-        while j < 5 {
-            sum = sum + @intCast(@byte_read(dst, j));
-            j = j + 1;
-        }
-        @dbg(sum);
-        @free_bytes(src, 5, 1);
-        @free_bytes(dst, 5, 1);
-    };
-    0
-}
-""" }]
-stdout = "9\n"
-exit_code = 0

--- a/crates/rue-cli-tests/cases/slices_mvp.toml
+++ b/crates/rue-cli-tests/cases/slices_mvp.toml
@@ -11,6 +11,17 @@
 # Deferred to later phases (still reported cleanly, not runnable here):
 # `inout [T]` write-slices, range slicing `x[a..b]`, ArrayBuf/Vec slices, and
 # returning/storing a slice (E0487-E0489 second-class enforcement).
+#
+# Under the default compact layout these cases view a slot-identical backing
+# element type (i64: one eight-byte slot per element). The view is materialized
+# as `{ptr: @raw(arr[0]), len: N}` and indexed by `@ptr_offset(ptr, i)`, which
+# strides by `size_of(T)`; for a slot-identical element that stride equals the
+# frame's slot stride, so a frame-array view is exact. A slice over a frame array
+# of a NON-slot-identical element (e.g. `[i32]`/`[u8]`, whose compact stride is
+# narrower than the 8-byte frame slot) would stride across mismatched storage and
+# is refused loudly (RUE-987 / RUE-1035 M2); `slice_param_narrow_frame_refused`
+# pins that. The slice runtime itself (len, bounds-checked indexing, forwarding,
+# methods) is element-width-independent and is exercised here on i64.
 
 [section]
 id = "cli.slices"
@@ -22,17 +33,17 @@ description = "borrow-a-whole-array slice parameter: len() and bounds-checked re
 [[case]]
 name = "slice_param_sum_len_index"
 files = [{ path = "main.rue", source = """
-fn sum(borrow s: [i32]) -> i32 {
-    let mut t = 0;
+fn sum(borrow s: [i64]) -> i32 {
+    let mut t: i64 = 0;
     let mut i: u64 = 0;
     while i < s.len() {
         t = t + s[i];
         i = i + 1;
     }
-    t
+    @intCast(t)
 }
 fn main() -> i32 {
-    let a: [i32; 3] = [10, 20, 30];
+    let a: [i64; 3] = [10, 20, 30];
     sum(borrow a)
 }
 """ }]
@@ -44,11 +55,11 @@ exit_code = 60
 [[case]]
 name = "slice_param_index_out_of_bounds_traps"
 files = [{ path = "main.rue", source = """
-fn get(borrow s: [i32], i: u64) -> i32 {
-    s[i]
+fn get(borrow s: [i64], i: u64) -> i32 {
+    @intCast(s[i])
 }
 fn main() -> i32 {
-    let a: [i32; 3] = [10, 20, 30];
+    let a: [i64; 3] = [10, 20, 30];
     get(borrow a, 5)
 }
 """ }]
@@ -61,11 +72,11 @@ exit_code = 101
 [[case]]
 name = "slice_param_negative_signed_index_traps"
 files = [{ path = "main.rue", source = """
-fn get(borrow s: [i32], i: i32) -> i32 {
-    s[i]
+fn get(borrow s: [i64], i: i32) -> i32 {
+    @intCast(s[i])
 }
 fn main() -> i32 {
-    let a: [i32; 3] = [10, 20, 30];
+    let a: [i64; 3] = [10, 20, 30];
     get(borrow a, -1)
 }
 """ }]
@@ -77,11 +88,11 @@ exit_code = 101
 [[case]]
 name = "slice_param_constant_index"
 files = [{ path = "main.rue", source = """
-fn second(borrow s: [i32]) -> i32 {
-    s[1]
+fn second(borrow s: [i64]) -> i32 {
+    @intCast(s[1])
 }
 fn main() -> i32 {
-    let a: [i32; 4] = [3, 5, 7, 9];
+    let a: [i64; 4] = [3, 5, 7, 9];
     second(borrow a)
 }
 """ }]
@@ -92,22 +103,25 @@ exit_code = 5
 [[case]]
 name = "slice_param_len"
 files = [{ path = "main.rue", source = """
-fn ln(borrow s: [i32]) -> i32 {
+fn ln(borrow s: [i64]) -> i32 {
     @intCast(s.len())
 }
 fn main() -> i32 {
-    let a: [i32; 6] = [9, 9, 9, 9, 9, 9];
+    let a: [i64; 6] = [9, 9, 9, 9, 9, 9];
     ln(borrow a)
 }
 """ }]
 args = ["main.rue", "--preview", "slices", "-o", "prog"]
 exit_code = 6
 
-# A `[u8]` slice exercises a different element type: the pointer field is
-# `ptr const u8` and `@ptr_offset` stride must still land on each element
-# (sum 1+2+3+4 = 10).
+# A `[u8]` view over a frame array is refused under the compact layout: the
+# slice would stride `@ptr_offset` by the compact element size (1) while the
+# frame stores each `u8` element in an 8-byte slot, so the pointer walk crosses
+# mismatched storage. The refusal is loud (RUE-987 / RUE-1035 M2) and names the
+# frame aggregate. A slot-identical element (see the i64 cases above) is exact;
+# a heap-backed narrow slice awaits compact frames (RUE-975) / a heap slice API.
 [[case]]
-name = "slice_param_u8_element"
+name = "slice_param_narrow_frame_refused"
 files = [{ path = "main.rue", source = """
 fn sum(borrow s: [u8]) -> i32 {
     let mut t: i32 = 0;
@@ -124,7 +138,8 @@ fn main() -> i32 {
 }
 """ }]
 args = ["main.rue", "--preview", "slices", "-o", "prog"]
-exit_code = 10
+compile_fail = true
+error_contains = ["raw pointer", "frame-resident aggregate"]
 
 # Borrowing a zero-length fixed array still produces a valid zero-length slice:
 # the pointer word is never dereferenced because `len()` is 0. This used to ICE
@@ -155,20 +170,20 @@ exit_code = 0
 [[case]]
 name = "slice_param_forwarding"
 files = [{ path = "main.rue", source = """
-fn sum(borrow s: [i32]) -> i32 {
-    let mut t = 0;
+fn sum(borrow s: [i64]) -> i32 {
+    let mut t: i64 = 0;
     let mut i: u64 = 0;
     while i < s.len() {
         t = t + s[i];
         i = i + 1;
     }
-    t
+    @intCast(t)
 }
-fn outer(borrow s: [i32]) -> i32 {
+fn outer(borrow s: [i64]) -> i32 {
     sum(borrow s)
 }
 fn main() -> i32 {
-    let a: [i32; 3] = [10, 20, 30];
+    let a: [i64; 3] = [10, 20, 30];
     outer(borrow a)
 }
 """ }]
@@ -184,17 +199,17 @@ files = [{ path = "main.rue", source = """
 struct Sum {
     bias: i32,
 
-    fn method(borrow self, borrow s: [i32]) -> i32 {
-        self.bias + s[0] + s[1]
+    fn method(borrow self, borrow s: [i64]) -> i32 {
+        self.bias + @intCast(s[0] + s[1])
     }
 
-    fn assoc(borrow s: [i32]) -> i32 {
-        s[0] + s[1]
+    fn assoc(borrow s: [i64]) -> i32 {
+        @intCast(s[0] + s[1])
     }
 }
 
 fn main() -> i32 {
-    let values: [i32; 2] = [5, 7];
+    let values: [i64; 2] = [5, 7];
     let sum = Sum { bias: 18 };
     sum.method(borrow values) + Sum.assoc(borrow values)
 }
@@ -211,22 +226,22 @@ files = [{ path = "main.rue", source = """
 struct Sum {
     bias: i32,
 
-    fn method(borrow self, borrow s: [i32]) -> i32 {
-        self.bias + s[0] + s[1]
+    fn method(borrow self, borrow s: [i64]) -> i32 {
+        self.bias + @intCast(s[0] + s[1])
     }
 
-    fn assoc(borrow s: [i32]) -> i32 {
-        s[0] + s[1]
+    fn assoc(borrow s: [i64]) -> i32 {
+        @intCast(s[0] + s[1])
     }
 }
 
-fn forward(borrow s: [i32]) -> i32 {
+fn forward(borrow s: [i64]) -> i32 {
     let sum = Sum { bias: 18 };
     sum.method(borrow s) + Sum.assoc(borrow s)
 }
 
 fn main() -> i32 {
-    let values: [i32; 2] = [5, 7];
+    let values: [i64; 2] = [5, 7];
     forward(borrow values)
 }
 """ }]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1750,16 +1750,11 @@ impl<'a> CfgLower<'a> {
                     src2: Operand::Virtual(plan.args[1].primary),
                 });
                 let dst = self.mir.alloc_vreg();
-                if let Some(narrow) = plan.narrow_access {
-                    // Gate-on: fold into the typed `ptr u8` narrow load (RUE-978).
-                    self.emit_narrow_load_through_ptr(dst, addr, 0, narrow);
-                } else {
-                    // Gate-off: the bespoke packed byte load, byte-for-byte.
-                    self.mir.push(Aarch64Inst::LdrbIndexed {
-                        dst: Operand::Virtual(dst),
-                        base: addr,
-                    });
-                }
+                let narrow = plan
+                    .narrow_access
+                    .expect("byte access always has a one-byte narrow descriptor");
+                // Fold into the typed `ptr u8` narrow load (ADR-0052, RUE-978).
+                self.emit_narrow_load_through_ptr(dst, addr, 0, narrow);
                 dst
             }
             crate::value_plan::IntrinsicOperation::ByteWrite => {
@@ -1769,16 +1764,11 @@ impl<'a> CfgLower<'a> {
                     src1: Operand::Virtual(plan.args[0].primary),
                     src2: Operand::Virtual(plan.args[1].primary),
                 });
-                if let Some(narrow) = plan.narrow_access {
-                    // Gate-on: fold into the typed `ptr u8` narrow store (RUE-978).
-                    self.emit_narrow_store_through_ptr(plan.args[2].primary, addr, 0, narrow);
-                } else {
-                    // Gate-off: the bespoke packed byte store, byte-for-byte.
-                    self.mir.push(Aarch64Inst::StrbIndexed {
-                        src: Operand::Virtual(plan.args[2].primary),
-                        base: addr,
-                    });
-                }
+                let narrow = plan
+                    .narrow_access
+                    .expect("byte access always has a one-byte narrow descriptor");
+                // Fold into the typed `ptr u8` narrow store (ADR-0052, RUE-978).
+                self.emit_narrow_store_through_ptr(plan.args[2].primary, addr, 0, narrow);
                 let dst = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::MovImm {
                     dst: Operand::Virtual(dst),
@@ -3280,7 +3270,7 @@ mod tests {
     use super::*;
     use rue_air::Sema;
     use rue_cfg::CfgBuilder;
-    use rue_error::{PreviewFeature, PreviewFeatures};
+    use rue_error::PreviewFeatures;
     use rue_lexer::Lexer;
     use rue_parser::Parser;
     use rue_rir::AstGen;
@@ -3386,32 +3376,27 @@ mod tests {
         .lower()
     }
 
-    /// RUE-1014: under `aggregate_layout`, a non-slot-identical **array** frame
-    /// value now lowers on AArch64 too, in lockstep with x86-64: array `[]`
+    /// RUE-1014: under the default compact layout, a non-slot-identical **array**
+    /// frame value lowers on AArch64 in lockstep with x86-64: array `[]`
     /// indexing strides by the *slot* stride (`abi_slot_count(element) *
     /// SLOT_BYTES`) against the slot-shaped frame storage (RUE-975).
     #[test]
     fn aggregate_layout_allows_frame_array_slot_stride_indexing() {
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
         try_lower_first_fn(
             "fn main() -> i32 { let a: [i32; 3] = [1, 2, 3]; let i: u64 = 1; a[i] }",
-            preview,
+            PreviewFeatures::new(),
         )
         .expect("a frame array indexed at the slot stride must lower under compact layout");
     }
 
-    /// RUE-989: under `aggregate_layout`, narrow scalar access through a typed
-    /// pointer lowers on AArch64 in lockstep with x86-64, emitting the narrow
-    /// pseudos (`ldrsw`/`str w`) instead of the eight-byte `Ldr`/`Str`. Gate-off,
-    /// the same program keeps the eight-byte indexed access.
+    /// RUE-989: under the default compact layout, narrow scalar access through a
+    /// typed pointer lowers on AArch64 in lockstep with x86-64, emitting the
+    /// narrow pseudos (`ldrsw`/`str w`) instead of the eight-byte `Ldr`/`Str`.
     #[test]
     fn aggregate_layout_allows_narrow_scalar_physical_access() {
         let source = "fn main() -> i32 { checked { let p: ptr mut i32 = @alloc(1); \
                       @ptr_write(p, 5); @dbg(@ptr_read(p)); @free(p, 1); }; 0 }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_first_fn(source, preview)
+        let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a narrow scalar through a typed pointer must lower under compact layout");
         assert!(
             mir.instructions()
@@ -3430,22 +3415,11 @@ mod tests {
             )),
             "a narrow i32 @ptr_read must emit a sign-extending 4-byte narrow load"
         );
-
-        let off = try_lower_first_fn(source, PreviewFeatures::new())
-            .expect("the same program lowers under the default slot model");
-        assert!(
-            off.instructions().iter().all(|inst| !matches!(
-                inst,
-                Aarch64Inst::NarrowStoreIndexed { .. } | Aarch64Inst::NarrowLoadIndexed { .. }
-            )),
-            "gate-off must not emit any narrow access"
-        );
     }
 
     /// RUE-1000: a compact enum with a variant-independent memory image
     /// round-trips through a typed pointer on AArch64, marshalling the narrow
-    /// tag at offset 0 and the payload at its compact offset. Gate-off keeps the
-    /// eight-byte slot access.
+    /// tag at offset 0 and the payload at its compact offset.
     #[test]
     fn aggregate_layout_allows_compact_enum_memory() {
         let source = "enum Opt { Some(i32), None } \
@@ -3453,9 +3427,7 @@ mod tests {
                       @ptr_write(p, Opt.Some(42)); let e = @ptr_read(p); \
                       match e { Opt.Some(x) => @dbg(x), Opt.None => @dbg(0), }; \
                       @free(p, 1); }; 0 }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_first_fn(source, preview)
+        let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a compact enum with a variant-independent image must lower");
         assert!(
             mir.instructions()
@@ -3474,32 +3446,18 @@ mod tests {
             )),
             "the enum read must load the u8 tag zero-extended"
         );
-
-        let off = try_lower_first_fn(source, PreviewFeatures::new())
-            .expect("the same program lowers under the default slot model");
-        assert!(
-            off.instructions().iter().all(|inst| !matches!(
-                inst,
-                Aarch64Inst::NarrowStoreIndexed { .. } | Aarch64Inst::NarrowLoadIndexed { .. }
-            )),
-            "gate-off must not emit any narrow access"
-        );
     }
 
     /// RUE-1037: on AArch64, a HETEROGENEOUS enum (variants whose payload layouts
     /// disagree) is marshalled through a pointer by dispatching on the runtime tag
     /// — the store emits a tag compare per variant plus narrow field stores.
-    /// Gate-off the same `@ptr_write` stores eight-byte slots with no tag dispatch
-    /// and no narrow store.
     #[test]
     fn aggregate_layout_heterogeneous_enum_ptr_write_tag_dispatches() {
         let source = "enum R { Ok(Point), Err(i64) } \
                       struct Point { x: i32, y: i32, z: i32 } \
                       fn store_it(p: ptr mut R) { checked { @ptr_write(p, R.Ok(Point { x: 1, y: 2, z: 3 })); }; } \
                       fn main() -> i32 { checked { let p: ptr mut R = @alloc(1); store_it(p); @free(p, 1); }; 0 }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_named_fn(source, preview, Some("store_it"))
+        let mir = try_lower_named_fn(source, PreviewFeatures::new(), Some("store_it"))
             .expect("a heterogeneous enum @ptr_write must lower via tag dispatch");
         assert!(
             mir.instructions()
@@ -3513,31 +3471,18 @@ mod tests {
                 .any(|inst| matches!(inst, Aarch64Inst::NarrowStoreIndexed { .. })),
             "the active variant's narrow leaves must be stored narrow"
         );
-
-        let off = try_lower_named_fn(source, PreviewFeatures::new(), Some("store_it"))
-            .expect("the same program lowers under the default slot model");
-        assert!(
-            off.instructions().iter().all(|inst| !matches!(
-                inst,
-                Aarch64Inst::CmpImm { .. } | Aarch64Inst::NarrowStoreIndexed { .. }
-            )),
-            "gate-off must store eight-byte slots with no tag dispatch and no narrow store"
-        );
     }
 
     /// RUE-987: a whole compact struct round-trips through a typed pointer on
     /// AArch64, reusing the enum-image slot machinery — `@ptr_write` stores each
-    /// field narrow at its compact offset and `@ptr_read` reloads it. Gate-off
-    /// keeps the eight-byte slot access.
+    /// field narrow at its compact offset and `@ptr_read` reloads it.
     #[test]
     fn aggregate_layout_allows_compact_struct_memory() {
         let source = "struct Padded { a: u8, b: i32, c: u8 } \
                       fn main() -> i32 { checked { let p: ptr mut Padded = @alloc(1); \
                       @ptr_write(p, Padded { a: 7, b: 1000, c: 9 }); let s = @ptr_read(p); \
                       @dbg(s.b); @free(p, 1); }; 0 }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_first_fn(source, preview).expect(
+        let mir = try_lower_first_fn(source, PreviewFeatures::new()).expect(
             "a whole compact struct through a typed pointer must lower under compact layout",
         );
         assert!(
@@ -3552,46 +3497,24 @@ mod tests {
                 .any(|inst| matches!(inst, Aarch64Inst::NarrowLoadIndexed { width: 4, .. })),
             "the struct read must reload the i32 field narrow from its compact offset"
         );
-
-        let off = try_lower_first_fn(source, PreviewFeatures::new())
-            .expect("the same program lowers under the default slot model");
-        assert!(
-            off.instructions().iter().all(|inst| !matches!(
-                inst,
-                Aarch64Inst::NarrowStoreIndexed { .. } | Aarch64Inst::NarrowLoadIndexed { .. }
-            )),
-            "gate-off must not emit any narrow access"
-        );
     }
 
     /// RUE-1014: a struct containing a fixed array now HAS a variant-independent
     /// compact image — the array flattens to its elements at the compact stride —
-    /// so it marshals whole through a pointer on AArch64. Gate-off emits no narrow
-    /// access.
+    /// so it marshals whole through a pointer on AArch64.
     #[test]
     fn aggregate_layout_allows_array_bearing_struct_memory() {
         let source = "struct HasArr { tag: u8, xs: [i32; 2] } \
                       fn main() -> i32 { let r = checked { let p: ptr mut HasArr = @alloc(1); \
                       @ptr_write(p, HasArr { tag: 5, xs: [10, 20] }); let v = @ptr_read(p); \
                       @free(p, 1); v.xs[0] + v.xs[1] }; @dbg(r); 0 }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_first_fn(source, preview)
+        let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a struct with a compact array image must lower under compact layout");
         assert!(
             mir.instructions()
                 .iter()
                 .any(|inst| matches!(inst, Aarch64Inst::NarrowStoreIndexed { width: 4, .. })),
             "the array elements must store narrow (4-byte i32) at their compact stride"
-        );
-        let off = try_lower_first_fn(source, PreviewFeatures::new())
-            .expect("the same program lowers under the default slot model");
-        assert!(
-            off.instructions().iter().all(|inst| !matches!(
-                inst,
-                Aarch64Inst::NarrowStoreIndexed { .. } | Aarch64Inst::NarrowLoadIndexed { .. }
-            )),
-            "gate-off must not emit any narrow access"
         );
     }
 
@@ -3605,9 +3528,7 @@ mod tests {
                       @ptr_write(p, Opt.Some(Point { x: 40, y: 2 })); let v = @ptr_read(p); \
                       @free(p, 1); match v { Opt.Some(pt) => pt.x + pt.y, Opt.None => 0 - 1 } }; \
                       @dbg(r); 0 }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_first_fn(source, preview)
+        let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("an enum with a variant-independent struct-payload image must lower");
         assert!(
             mir.instructions()
@@ -3626,9 +3547,7 @@ mod tests {
         let source = "enum Bad { A(i64), B(i32, i32) } struct HasBad { b: Bad } \
                       fn main() -> i32 { checked { let p: ptr mut HasBad = @alloc(1); \
                       @ptr_write(p, HasBad { b: Bad.A(5) }); @free(p, 1); }; 0 }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_first_fn(source, preview)
+        let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a struct embedding a heterogeneous enum must lower via nested tag dispatch");
         assert!(
             mir.instructions()
@@ -3641,30 +3560,19 @@ mod tests {
     /// RUE-1004: on AArch64, a non-slot-identical struct returned by value is
     /// forced indirect (sret); the caller reads the callee-written compact image
     /// back from the sret buffer with narrow loads at the compact offsets (`main`
-    /// is the caller here). Gate-off reads eight-byte slots, no narrow access.
+    /// is the caller here).
     #[test]
     fn aggregate_layout_allows_compact_struct_sret_return() {
         let source = "struct Padded { a: u8, b: i32, c: u8 } \
                       fn make() -> Padded { Padded { a: 7, b: 1000, c: 9 } } \
                       fn main() -> i32 { let p = make(); @dbg(p.b); 0 }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir =
-            try_lower_first_fn(source, preview).expect("a compact struct sret return must lower");
+        let mir = try_lower_first_fn(source, PreviewFeatures::new())
+            .expect("a compact struct sret return must lower");
         assert!(
             mir.instructions()
                 .iter()
                 .any(|inst| matches!(inst, Aarch64Inst::NarrowLoadIndexed { width: 1, .. })),
             "the caller must read the u8 fields narrow from the compact sret image"
-        );
-
-        let off = try_lower_first_fn(source, PreviewFeatures::new())
-            .expect("the same program lowers under the default slot model");
-        assert!(
-            off.instructions()
-                .iter()
-                .all(|inst| !matches!(inst, Aarch64Inst::NarrowLoadIndexed { .. })),
-            "gate-off must not emit any narrow sret read-back"
         );
     }
 
@@ -3672,29 +3580,24 @@ mod tests {
     /// accepted (slot-shaped by-ref transport to the caller's frame storage).
     #[test]
     fn aggregate_layout_allows_inout_compact_struct_param() {
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
         try_lower_first_fn(
             "struct Padded { a: u8, b: i32, c: u8 } \
              fn bump(inout p: Padded) { p.b = p.b + 1; } \
              fn main() -> i32 { let mut s = Padded { a: 1, b: 2, c: 3 }; bump(inout s); s.b }",
-            preview,
+            PreviewFeatures::new(),
         )
         .expect("an inout compact struct argument must lower");
     }
 
     /// RUE-1005: on AArch64, a non-slot-identical struct passed BY VALUE across a
     /// call now lowers. The caller (`main`, first here) writes the compact image
-    /// into a caller-owned buffer with narrow stores and passes one pointer;
-    /// gate-off it passes slot-shaped registers with no narrow store.
+    /// into a caller-owned buffer with narrow stores and passes one pointer.
     #[test]
     fn aggregate_layout_allows_by_value_compact_struct_arg_caller() {
         let source = "struct Padded { a: u8, b: i32, c: u8 } \
                       fn main() -> i32 { sum(Padded { a: 1, b: 5, c: 3 }) } \
                       fn sum(p: Padded) -> i32 { p.b }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_first_fn(source, preview)
+        let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a by-value compact struct argument must lower");
         assert!(
             mir.instructions()
@@ -3702,43 +3605,23 @@ mod tests {
                 .any(|inst| matches!(inst, Aarch64Inst::NarrowStoreIndexed { width: 1, .. })),
             "the caller must write the u8 fields narrow into the compact argument buffer"
         );
-
-        let off = try_lower_first_fn(source, PreviewFeatures::new())
-            .expect("the same program lowers under the default slot model");
-        assert!(
-            off.instructions()
-                .iter()
-                .all(|inst| !matches!(inst, Aarch64Inst::NarrowStoreIndexed { .. })),
-            "gate-off must not emit any narrow argument-buffer store"
-        );
     }
 
     /// RUE-1005 callee side on AArch64: the receiving function unmarshals the
     /// compact image (narrow loads) from the homed pointer into its frame slots
-    /// at entry; gate-off it reads slot-shaped registers with no narrow load.
+    /// at entry.
     #[test]
     fn aggregate_layout_allows_by_value_compact_struct_arg_callee() {
         let source = "struct Padded { a: u8, b: i32, c: u8 } \
                       fn sum(p: Padded) -> i32 { p.b } \
                       fn main() -> i32 { sum(Padded { a: 1, b: 5, c: 3 }) }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_named_fn(source, preview, Some("sum"))
+        let mir = try_lower_named_fn(source, PreviewFeatures::new(), Some("sum"))
             .expect("the callee of a by-value compact struct argument must lower");
         assert!(
             mir.instructions()
                 .iter()
                 .any(|inst| matches!(inst, Aarch64Inst::NarrowLoadIndexed { width: 1, .. })),
             "the callee must unmarshal the u8 fields narrow from the homed pointer"
-        );
-
-        let off = try_lower_named_fn(source, PreviewFeatures::new(), Some("sum"))
-            .expect("the same program lowers under the default slot model");
-        assert!(
-            off.instructions()
-                .iter()
-                .all(|inst| !matches!(inst, Aarch64Inst::NarrowLoadIndexed { .. })),
-            "gate-off must not emit any narrow parameter unmarshalling"
         );
     }
 
@@ -3747,13 +3630,11 @@ mod tests {
     /// pointer on AArch64 via per-variant tag dispatch rather than being refused.
     #[test]
     fn aggregate_layout_marshals_variant_dependent_enum_memory() {
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
         let mir = try_lower_first_fn(
             "enum Bad { A(i64), B(i32, i32) } \
              fn main() -> i32 { checked { let p: ptr mut Bad = @alloc(1); \
              @ptr_write(p, Bad.A(5)); @free(p, 1); }; 0 }",
-            preview,
+            PreviewFeatures::new(),
         )
         .expect("a variant-dependent enum memory image must lower via tag dispatch");
         assert!(
@@ -3768,11 +3649,9 @@ mod tests {
     /// under compact layout on AArch64 and is accepted.
     #[test]
     fn aggregate_layout_allows_slot_identical_physical_layout_codegen() {
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
         try_lower_first_fn(
             "struct Cell { a: i64, b: i64 } fn main() -> i32 { let c = Cell { a: 7, b: 9 }; @intCast(c.a) }",
-            preview,
+            PreviewFeatures::new(),
         )
         .expect("a slot-identical aggregate must lower under compact layout");
     }
@@ -3935,12 +3814,12 @@ mod tests {
         assert!(
             mir.instructions()
                 .iter()
-                .any(|inst| matches!(inst, Aarch64Inst::StrbIndexed { .. }))
+                .any(|inst| matches!(inst, Aarch64Inst::NarrowStoreIndexed { width: 1, .. }))
         );
         assert!(
             mir.instructions()
                 .iter()
-                .any(|inst| matches!(inst, Aarch64Inst::LdrbIndexed { .. }))
+                .any(|inst| matches!(inst, Aarch64Inst::NarrowLoadIndexed { width: 1, .. }))
         );
 
         let alloc = runtime_call_index(&mir, rue_runtime_abi::RuntimeHelperId::Alloc);
@@ -3957,27 +3836,24 @@ mod tests {
         assert_eq!(immediate_call_arg(&mir, free, Reg::X2), Some(1));
     }
 
-    /// RUE-978: under the compact layout the raw-byte access family folds into
-    /// the ordinary typed `ptr u8` narrow path — `@byte_read`/`@byte_write`
+    /// RUE-978: under the default compact layout the raw-byte access family folds
+    /// into the ordinary typed `ptr u8` narrow path — `@byte_read`/`@byte_write`
     /// emit the same one-byte `NarrowLoadIndexed`/`NarrowStoreIndexed` a typed
-    /// `@ptr_read`/`@ptr_write` of a `u8` pointee does, not the bespoke
-    /// `Ldrb`/`Strb`. Gate-off keeps the bespoke path.
+    /// `@ptr_read`/`@ptr_write` of a `u8` pointee does.
     #[test]
     fn aggregate_layout_folds_byte_access_into_narrow_typed_path() {
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
         let mir = lower_function_to_mir_with_preview(
             "fn main() -> i32 { checked { let p = @alloc_bytes(2, 1); \
              @byte_write(p, 0, 65); let b = @byte_read(p, 1); \
              @free_bytes(p, 2, 1); @intCast(b) } }",
             "main",
-            preview,
+            PreviewFeatures::new(),
         );
         assert!(
             mir.instructions()
                 .iter()
                 .any(|inst| matches!(inst, Aarch64Inst::NarrowStoreIndexed { width: 1, .. })),
-            "gated @byte_write must fold into the one-byte narrow store"
+            "@byte_write must fold into the one-byte narrow store"
         );
         assert!(
             mir.instructions().iter().any(|inst| matches!(
@@ -3988,14 +3864,7 @@ mod tests {
                     ..
                 }
             )),
-            "gated @byte_read must fold into the one-byte zero-extended narrow load"
-        );
-        assert!(
-            mir.instructions().iter().all(|inst| !matches!(
-                inst,
-                Aarch64Inst::LdrbIndexed { .. } | Aarch64Inst::StrbIndexed { .. }
-            )),
-            "the bespoke packed byte load/store must not survive the fold-in"
+            "@byte_read must fold into the one-byte zero-extended narrow load"
         );
     }
 }

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -514,8 +514,6 @@ impl<'a> Emitter<'a> {
                 inst,
                 Aarch64Inst::LdrIndexed { .. }
                     | Aarch64Inst::StrIndexed { .. }
-                    | Aarch64Inst::LdrbIndexed { .. }
-                    | Aarch64Inst::StrbIndexed { .. }
                     | Aarch64Inst::LdrIndexedOffset { .. }
                     | Aarch64Inst::StrIndexedOffset { .. }
                     | Aarch64Inst::NarrowLoadIndexed { .. }
@@ -710,22 +708,6 @@ impl<'a> Emitter<'a> {
                 self.begin_inst();
                 self.emit_str(rs, *base, adjusted_offset);
                 end_inst!(self, "str {}, [{}, #{}]", rs, base, adjusted_offset);
-            }
-
-            Aarch64Inst::Ldrb { dst, base, offset } => {
-                let rd = dst.as_physical();
-                let adjusted_offset = self.adjust_fp_offset(*base, *offset);
-                self.begin_inst();
-                self.emit_ldrb(rd, *base, adjusted_offset);
-                end_inst!(self, "ldrb {}, [{}, #{}]", rd.as_w(), base, adjusted_offset);
-            }
-
-            Aarch64Inst::Strb { src, base, offset } => {
-                let rs = src.as_physical();
-                let adjusted_offset = self.adjust_fp_offset(*base, *offset);
-                self.begin_inst();
-                self.emit_strb(rs, *base, adjusted_offset);
-                end_inst!(self, "strb {}, [{}, #{}]", rs.as_w(), base, adjusted_offset);
             }
 
             Aarch64Inst::NarrowLoad {
@@ -1298,8 +1280,6 @@ impl<'a> Emitter<'a> {
             // These instructions should be caught by the verification at the start of emit()
             Aarch64Inst::LdrIndexed { .. }
             | Aarch64Inst::StrIndexed { .. }
-            | Aarch64Inst::LdrbIndexed { .. }
-            | Aarch64Inst::StrbIndexed { .. }
             | Aarch64Inst::LdrIndexedOffset { .. }
             | Aarch64Inst::StrIndexedOffset { .. }
             | Aarch64Inst::NarrowLoadIndexed { .. }
@@ -1717,24 +1697,6 @@ impl<'a> Emitter<'a> {
             let inst = OPCODE_STR_UOFF | (Reg::X15.encoding() as u32) << 5 | rs.encoding() as u32;
             self.emit_u32(inst);
         }
-    }
-
-    fn emit_ldrb(&mut self, rd: Reg, base: Reg, offset: i32) {
-        assert!((0..=4095).contains(&offset));
-        let inst = 0x3940_0000
-            | ((offset as u32) << 10)
-            | ((base.encoding() as u32) << 5)
-            | rd.encoding() as u32;
-        self.emit_u32(inst);
-    }
-
-    fn emit_strb(&mut self, rs: Reg, base: Reg, offset: i32) {
-        assert!((0..=4095).contains(&offset));
-        let inst = 0x3900_0000
-            | ((offset as u32) << 10)
-            | ((base.encoding() as u32) << 5)
-            | rs.encoding() as u32;
-        self.emit_u32(inst);
     }
 
     /// Emit a narrow (1/2/4-byte) load of `[base]` extended into the 64-bit `rd`
@@ -2644,26 +2606,6 @@ mod tests {
         assert_eq!(inst & 0x1F, 0, "Rd should be X0");
         assert_eq!((inst >> 5) & 0x1F, 1, "Rn should be X1");
         assert_eq!((inst >> 10) & 0xFFF, 16, "Immediate should be 16");
-    }
-
-    #[test]
-    fn test_physical_byte_load_and_store_encoding() {
-        assert_eq!(
-            emit_single(Aarch64Inst::Ldrb {
-                dst: Operand::Physical(Reg::X0),
-                base: Reg::X1,
-                offset: 0,
-            }),
-            vec![0x20, 0x00, 0x40, 0x39]
-        );
-        assert_eq!(
-            emit_single(Aarch64Inst::Strb {
-                src: Operand::Physical(Reg::X2),
-                base: Reg::X3,
-                offset: 0,
-            }),
-            vec![0x62, 0x00, 0x00, 0x39]
-        );
     }
 
     /// RUE-989: the narrow physical load through a pointer selects

--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -131,12 +131,10 @@ fn uses(inst: &Aarch64Inst) -> Vec<VReg> {
         Aarch64Inst::MovRR { src, .. } => {
             add_if_virtual(src, &mut result);
         }
-        Aarch64Inst::Ldr { .. } | Aarch64Inst::Ldrb { .. } | Aarch64Inst::NarrowLoad { .. } => {
+        Aarch64Inst::Ldr { .. } | Aarch64Inst::NarrowLoad { .. } => {
             // Reads from memory via base (physical register)
         }
-        Aarch64Inst::Str { src, .. }
-        | Aarch64Inst::Strb { src, .. }
-        | Aarch64Inst::NarrowStore { src, .. } => {
+        Aarch64Inst::Str { src, .. } | Aarch64Inst::NarrowStore { src, .. } => {
             add_if_virtual(src, &mut result);
         }
         Aarch64Inst::AddRR { src1, src2, .. }
@@ -222,14 +220,11 @@ fn uses(inst: &Aarch64Inst) -> Vec<VReg> {
         Aarch64Inst::LdpPost { .. } => {
             // Only defines
         }
-        Aarch64Inst::LdrIndexed { base, .. }
-        | Aarch64Inst::LdrbIndexed { base, .. }
-        | Aarch64Inst::NarrowLoadIndexed { base, .. } => {
+        Aarch64Inst::LdrIndexed { base, .. } | Aarch64Inst::NarrowLoadIndexed { base, .. } => {
             // base is a VReg directly, not an Operand
             result.push(*base);
         }
         Aarch64Inst::StrIndexed { src, base }
-        | Aarch64Inst::StrbIndexed { src, base }
         | Aarch64Inst::NarrowStoreIndexed { src, base, .. } => {
             add_if_virtual(src, &mut result);
             result.push(*base);
@@ -286,12 +281,10 @@ fn defs(inst: &Aarch64Inst) -> Vec<VReg> {
         Aarch64Inst::MovRR { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
-        Aarch64Inst::Ldr { dst, .. }
-        | Aarch64Inst::Ldrb { dst, .. }
-        | Aarch64Inst::NarrowLoad { dst, .. } => {
+        Aarch64Inst::Ldr { dst, .. } | Aarch64Inst::NarrowLoad { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
-        Aarch64Inst::Str { .. } | Aarch64Inst::Strb { .. } | Aarch64Inst::NarrowStore { .. } => {
+        Aarch64Inst::Str { .. } | Aarch64Inst::NarrowStore { .. } => {
             // Writes to memory
         }
         Aarch64Inst::AddRR { dst, .. }
@@ -358,14 +351,10 @@ fn defs(inst: &Aarch64Inst) -> Vec<VReg> {
             add_if_virtual(dst1, &mut result);
             add_if_virtual(dst2, &mut result);
         }
-        Aarch64Inst::LdrIndexed { dst, .. }
-        | Aarch64Inst::LdrbIndexed { dst, .. }
-        | Aarch64Inst::NarrowLoadIndexed { dst, .. } => {
+        Aarch64Inst::LdrIndexed { dst, .. } | Aarch64Inst::NarrowLoadIndexed { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
-        Aarch64Inst::StrIndexed { .. }
-        | Aarch64Inst::StrbIndexed { .. }
-        | Aarch64Inst::NarrowStoreIndexed { .. } => {
+        Aarch64Inst::StrIndexed { .. } | Aarch64Inst::NarrowStoreIndexed { .. } => {
             // Writes to memory
         }
         Aarch64Inst::LdrIndexedOffset { dst, .. } => {

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -400,16 +400,10 @@ impl fmt::Display for Cond {
 pub enum Aarch64Inst {
     // === Move instructions ===
     /// `mov dst, #imm` - Move immediate to register (MOVZ/MOVN/MOVK sequence).
-    MovImm {
-        dst: Operand,
-        imm: i64,
-    },
+    MovImm { dst: Operand, imm: i64 },
 
     /// `mov dst, src` - Move register to register.
-    MovRR {
-        dst: Operand,
-        src: Operand,
-    },
+    MovRR { dst: Operand, src: Operand },
 
     /// `ldr dst, [base, #offset]` - Load from memory.
     Ldr {
@@ -425,41 +419,11 @@ pub enum Aarch64Inst {
         offset: i32,
     },
 
-    /// `ldrb dst, [base, #offset]` - Load one physical byte, zero-extended.
-    Ldrb {
-        dst: Operand,
-        base: Reg,
-        offset: i32,
-    },
-
-    /// `strb src, [base, #offset]` - Store one physical byte.
-    Strb {
-        src: Operand,
-        base: Reg,
-        offset: i32,
-    },
-
     /// `ldr dst, [base]` - Load from memory via register (indexed).
-    LdrIndexed {
-        dst: Operand,
-        base: VReg,
-    },
+    LdrIndexed { dst: Operand, base: VReg },
 
     /// `str src, [base]` - Store to memory via register (indexed).
-    StrIndexed {
-        src: Operand,
-        base: VReg,
-    },
-
-    /// Pre-register-allocation byte load/store through a virtual address.
-    LdrbIndexed {
-        dst: Operand,
-        base: VReg,
-    },
-    StrbIndexed {
-        src: Operand,
-        base: VReg,
-    },
+    StrIndexed { src: Operand, base: VReg },
 
     /// Pre-register-allocation narrow (1/2/4-byte) load through a virtual
     /// address, extended into the 64-bit `dst` (ADR-0052, RUE-989). `signed`
@@ -476,11 +440,7 @@ pub enum Aarch64Inst {
     /// Pre-register-allocation narrow (1/2/4-byte) store of the low `width` bytes
     /// of `src` through a virtual address (`strb`/`strh`/`str w`). Register
     /// allocation lowers this to [`Aarch64Inst::NarrowStore`].
-    NarrowStoreIndexed {
-        src: Operand,
-        base: VReg,
-        width: u8,
-    },
+    NarrowStoreIndexed { src: Operand, base: VReg, width: u8 },
 
     /// Narrow (1/2/4-byte) load of `[base]` extended into the 64-bit `dst`, the
     /// physical-base form of [`Aarch64Inst::NarrowLoadIndexed`].
@@ -493,11 +453,7 @@ pub enum Aarch64Inst {
 
     /// Narrow (1/2/4-byte) store of the low `width` bytes of `src` to `[base]`,
     /// the physical-base form of [`Aarch64Inst::NarrowStoreIndexed`].
-    NarrowStore {
-        src: Operand,
-        base: Reg,
-        width: u8,
-    },
+    NarrowStore { src: Operand, base: Reg, width: u8 },
 
     /// `ldr dst, [base, #offset]` - Load from memory via register with offset.
     LdrIndexedOffset {
@@ -514,32 +470,16 @@ pub enum Aarch64Inst {
     },
 
     /// `lsl dst, src, #imm` - Logical shift left by immediate (64-bit).
-    LslImm {
-        dst: Operand,
-        src: Operand,
-        imm: u8,
-    },
+    LslImm { dst: Operand, src: Operand, imm: u8 },
 
     /// `lsl dst, src, #imm` - Logical shift left by immediate (32-bit).
-    Lsl32Imm {
-        dst: Operand,
-        src: Operand,
-        imm: u8,
-    },
+    Lsl32Imm { dst: Operand, src: Operand, imm: u8 },
 
     /// `lsr dst, src, #imm` - Logical shift right by immediate (32-bit).
-    Lsr32Imm {
-        dst: Operand,
-        src: Operand,
-        imm: u8,
-    },
+    Lsr32Imm { dst: Operand, src: Operand, imm: u8 },
 
     /// `asr dst, src, #imm` - Arithmetic shift right by immediate (32-bit).
-    Asr32Imm {
-        dst: Operand,
-        src: Operand,
-        imm: u8,
-    },
+    Asr32Imm { dst: Operand, src: Operand, imm: u8 },
 
     // === Arithmetic instructions ===
     /// `add dst, src1, src2` - Add two registers.
@@ -634,18 +574,10 @@ pub enum Aarch64Inst {
     },
 
     /// `lsr dst, src, #imm` - Logical shift right by immediate (64-bit).
-    Lsr64Imm {
-        dst: Operand,
-        src: Operand,
-        imm: u8,
-    },
+    Lsr64Imm { dst: Operand, src: Operand, imm: u8 },
 
     /// `asr dst, src, #imm` - Arithmetic shift right by immediate (64-bit).
-    Asr64Imm {
-        dst: Operand,
-        src: Operand,
-        imm: u8,
-    },
+    Asr64Imm { dst: Operand, src: Operand, imm: u8 },
 
     /// `sdiv dst, src1, src2` - Signed divide (32-bit, W registers).
     SdivRR {
@@ -693,22 +625,13 @@ pub enum Aarch64Inst {
     },
 
     /// `neg dst, src` - Negate (sub from zero).
-    Neg {
-        dst: Operand,
-        src: Operand,
-    },
+    Neg { dst: Operand, src: Operand },
 
     /// `negs dst, src` - Negate and set flags (64-bit, for i64/u64 overflow detection).
-    Negs {
-        dst: Operand,
-        src: Operand,
-    },
+    Negs { dst: Operand, src: Operand },
 
     /// `negs dst, src` - Negate and set flags (32-bit, for i32/u32 overflow detection).
-    Negs32 {
-        dst: Operand,
-        src: Operand,
-    },
+    Negs32 { dst: Operand, src: Operand },
 
     // === Logical instructions ===
     /// `and dst, src1, src2` - Bitwise AND.
@@ -740,20 +663,14 @@ pub enum Aarch64Inst {
     },
 
     /// `mvn dst, src` - Bitwise NOT, 64-bit.
-    MvnRR {
-        dst: Operand,
-        src: Operand,
-    },
+    MvnRR { dst: Operand, src: Operand },
 
     /// `mvn wd, wm` - Bitwise NOT, 32-bit.
     ///
     /// Used for sub-64-bit BitNot: the w-form zeroes the upper 32 bits,
     /// matching the invariant (shared with the x86-64 backend) that
     /// sub-64-bit results don't leak set bits above their width (RUE-59).
-    Mvn32RR {
-        dst: Operand,
-        src: Operand,
-    },
+    Mvn32RR { dst: Operand, src: Operand },
 
     /// `lsl dst, src1, src2` - Logical shift left 64-bit by register.
     LslRR {
@@ -799,113 +716,64 @@ pub enum Aarch64Inst {
 
     // === Comparison instructions ===
     /// `cmp src1, src2` - Compare (subtract and set flags, discard result). Uses 32-bit form.
-    CmpRR {
-        src1: Operand,
-        src2: Operand,
-    },
+    CmpRR { src1: Operand, src2: Operand },
 
     /// `cmp src1, src2` - Compare using 64-bit form (for 64-bit values like SMULL result).
-    Cmp64RR {
-        src1: Operand,
-        src2: Operand,
-    },
+    Cmp64RR { src1: Operand, src2: Operand },
 
     /// `cmp src, #imm` - Compare with immediate.
-    CmpImm {
-        src: Operand,
-        imm: i32,
-    },
+    CmpImm { src: Operand, imm: i32 },
 
     /// `cbz src, label` - Compare and branch if zero.
-    Cbz {
-        src: Operand,
-        label: LabelId,
-    },
+    Cbz { src: Operand, label: LabelId },
 
     /// `cbnz src, label` - Compare and branch if not zero.
-    Cbnz {
-        src: Operand,
-        label: LabelId,
-    },
+    Cbnz { src: Operand, label: LabelId },
 
     /// `cset dst, cond` - Conditional set: dst = 1 if cond, else 0.
-    Cset {
-        dst: Operand,
-        cond: Cond,
-    },
+    Cset { dst: Operand, cond: Cond },
 
     /// `tst src1, src2` - Test bits (AND and set flags).
-    TstRR {
-        src1: Operand,
-        src2: Operand,
-    },
+    TstRR { src1: Operand, src2: Operand },
 
     // === Sign/zero extension ===
     /// `sxtb dst, src` - Sign-extend byte to 64-bit.
-    Sxtb {
-        dst: Operand,
-        src: Operand,
-    },
+    Sxtb { dst: Operand, src: Operand },
 
     /// `sxth dst, src` - Sign-extend halfword to 64-bit.
-    Sxth {
-        dst: Operand,
-        src: Operand,
-    },
+    Sxth { dst: Operand, src: Operand },
 
     /// `sxtw dst, src` - Sign-extend word to 64-bit.
-    Sxtw {
-        dst: Operand,
-        src: Operand,
-    },
+    Sxtw { dst: Operand, src: Operand },
 
     /// `uxtb dst, src` - Zero-extend byte to 64-bit.
-    Uxtb {
-        dst: Operand,
-        src: Operand,
-    },
+    Uxtb { dst: Operand, src: Operand },
 
     /// `uxth dst, src` - Zero-extend halfword to 64-bit.
-    Uxth {
-        dst: Operand,
-        src: Operand,
-    },
+    Uxth { dst: Operand, src: Operand },
 
     // Note: UXTW is implicit in W-register operations; no separate instruction needed.
 
     // === Control flow ===
     /// `b label` - Unconditional branch.
-    B {
-        label: LabelId,
-    },
+    B { label: LabelId },
 
     /// `b.cond label` - Conditional branch.
-    BCond {
-        cond: Cond,
-        label: LabelId,
-    },
+    BCond { cond: Cond, label: LabelId },
 
     /// `b.vs label` - Branch if overflow set.
-    Bvs {
-        label: LabelId,
-    },
+    Bvs { label: LabelId },
 
     /// `b.vc label` - Branch if overflow clear.
-    Bvc {
-        label: LabelId,
-    },
+    Bvc { label: LabelId },
 
     /// Label marker (not a real instruction).
-    Label {
-        id: LabelId,
-    },
+    Label { id: LabelId },
 
     /// `bl symbol` - Branch with link (call).
     ///
     /// The `symbol_id` is an index into the symbol table stored in `Aarch64Mir`.
-    Bl {
-        symbol_id: u32,
-    },
+    Bl { symbol_id: u32 },
 
     /// `ret` - Return (branch to LR).
     Ret,
@@ -922,9 +790,7 @@ pub enum Aarch64Inst {
     /// On macOS, syscalls use `svc #0x80` with syscall number in X16.
     /// On Linux, syscalls use `svc #0` with syscall number in X8.
     /// This instruction takes an immediate that specifies the system call type.
-    Svc {
-        imm: u16,
-    },
+    Svc { imm: u16 },
 
     // === Stack operations ===
     /// `stp x1, x2, [sp, #offset]!` - Store pair with pre-index (push).
@@ -942,23 +808,14 @@ pub enum Aarch64Inst {
     },
 
     /// Load pointer to string constant (pseudo-instruction resolved during emission)
-    StringConstPtr {
-        dst: Operand,
-        string_id: u32,
-    },
+    StringConstPtr { dst: Operand, string_id: u32 },
 
     /// Load string length (pseudo-instruction resolved during emission)
-    StringConstLen {
-        dst: Operand,
-        string_id: u32,
-    },
+    StringConstLen { dst: Operand, string_id: u32 },
 
     /// Load string capacity (pseudo-instruction resolved during emission)
     /// For string literals, this is always 0 (indicating rodata, not heap)
-    StringConstCap {
-        dst: Operand,
-        string_id: u32,
-    },
+    StringConstCap { dst: Operand, string_id: u32 },
 }
 
 impl Aarch64Inst {
@@ -1044,16 +901,8 @@ impl fmt::Display for Aarch64Inst {
                     write!(f, "str {}, [{}, #{}]", src, base, offset)
                 }
             }
-            Aarch64Inst::Ldrb { dst, base, offset } => {
-                write!(f, "ldrb {}, [{}, #{}]", dst, base, offset)
-            }
-            Aarch64Inst::Strb { src, base, offset } => {
-                write!(f, "strb {}, [{}, #{}]", src, base, offset)
-            }
             Aarch64Inst::LdrIndexed { dst, base } => write!(f, "ldr {}, [{}]", dst, base),
             Aarch64Inst::StrIndexed { src, base } => write!(f, "str {}, [{}]", src, base),
-            Aarch64Inst::LdrbIndexed { dst, base } => write!(f, "ldrb {}, [{}]", dst, base),
-            Aarch64Inst::StrbIndexed { src, base } => write!(f, "strb {}, [{}]", src, base),
             Aarch64Inst::NarrowLoadIndexed {
                 dst,
                 base,

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -161,30 +161,6 @@ impl RegAlloc {
                 });
             }
 
-            Aarch64Inst::Ldrb { dst, base, offset } => {
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::X9 =>
-                    emit |dst_op| {
-                        mir.push(Aarch64Inst::Ldrb { dst: dst_op, base, offset });
-                    },
-                    store |spill_offset| {
-                        mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X9),
-                            base: Reg::Fp,
-                            offset: spill_offset,
-                        });
-                    },
-                );
-            }
-
-            Aarch64Inst::Strb { src, base, offset } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::X9)?;
-                mir.push(Aarch64Inst::Strb {
-                    src: src_op,
-                    base,
-                    offset,
-                });
-            }
-
             Aarch64Inst::AddRR { dst, src1, src2 } => {
                 Self::emit_ternop(context, mir, dst, src1, src2, |d, s1, s2| {
                     Aarch64Inst::AddRR {
@@ -762,48 +738,6 @@ impl RegAlloc {
                 mir.push(Aarch64Inst::Str {
                     src: src_op,
                     base: base_phys,
-                    offset: 0,
-                });
-            }
-
-            Aarch64Inst::LdrbIndexed { dst, base } => {
-                let base_reg = Self::load_operand(context, mir, Operand::Virtual(base), Reg::X9)?;
-                let base_phys = base_reg.as_physical();
-                match Self::get_allocation(context, dst) {
-                    Some(Allocation::Register(reg)) => mir.push(Aarch64Inst::Ldrb {
-                        dst: Operand::Physical(reg),
-                        base: base_phys,
-                        offset: 0,
-                    }),
-                    Some(Allocation::Spill(offset)) => {
-                        mir.push(Aarch64Inst::Ldrb {
-                            dst: Operand::Physical(Reg::X10),
-                            base: base_phys,
-                            offset: 0,
-                        });
-                        mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X10),
-                            base: Reg::Fp,
-                            offset,
-                        });
-                    }
-                    Some(Allocation::Rematerialize(_)) => {
-                        unreachable!("destination cannot be rematerializable")
-                    }
-                    None => mir.push(Aarch64Inst::Ldrb {
-                        dst,
-                        base: base_phys,
-                        offset: 0,
-                    }),
-                }
-            }
-
-            Aarch64Inst::StrbIndexed { src, base } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::X9)?;
-                let base_reg = Self::load_operand(context, mir, Operand::Virtual(base), Reg::X10)?;
-                mir.push(Aarch64Inst::Strb {
-                    src: src_op,
-                    base: base_reg.as_physical(),
                     offset: 0,
                 });
             }

--- a/crates/rue-codegen/src/aarch64/schedule.rs
+++ b/crates/rue-codegen/src/aarch64/schedule.rs
@@ -81,9 +81,7 @@ fn get_latency(inst: &Aarch64Inst) -> u32 {
 
         // Memory loads: 4 cycles (L1 cache hit)
         Aarch64Inst::Ldr { .. }
-        | Aarch64Inst::Ldrb { .. }
         | Aarch64Inst::LdrIndexed { .. }
-        | Aarch64Inst::LdrbIndexed { .. }
         | Aarch64Inst::LdrIndexedOffset { .. }
         | Aarch64Inst::NarrowLoad { .. }
         | Aarch64Inst::NarrowLoadIndexed { .. }
@@ -91,9 +89,7 @@ fn get_latency(inst: &Aarch64Inst) -> u32 {
 
         // Memory stores: 1 cycle to retire (store buffer)
         Aarch64Inst::Str { .. }
-        | Aarch64Inst::Strb { .. }
         | Aarch64Inst::StrIndexed { .. }
-        | Aarch64Inst::StrbIndexed { .. }
         | Aarch64Inst::StrIndexedOffset { .. }
         | Aarch64Inst::NarrowStore { .. }
         | Aarch64Inst::NarrowStoreIndexed { .. }
@@ -231,10 +227,6 @@ fn accesses_memory(inst: &Aarch64Inst) -> bool {
             | Aarch64Inst::StrIndexedOffset { .. }
             | Aarch64Inst::StpPre { .. }
             | Aarch64Inst::LdpPost { .. }
-            | Aarch64Inst::Ldrb { .. }
-            | Aarch64Inst::Strb { .. }
-            | Aarch64Inst::LdrbIndexed { .. }
-            | Aarch64Inst::StrbIndexed { .. }
             | Aarch64Inst::NarrowLoad { .. }
             | Aarch64Inst::NarrowStore { .. }
             | Aarch64Inst::NarrowLoadIndexed { .. }
@@ -255,12 +247,8 @@ fn regs_read(inst: &Aarch64Inst) -> Vec<Reg> {
     match inst {
         Aarch64Inst::MovImm { .. } => {}
         Aarch64Inst::MovRR { src, .. } => add_if_phys(src, &mut result),
-        Aarch64Inst::Ldr { base, .. }
-        | Aarch64Inst::Ldrb { base, .. }
-        | Aarch64Inst::NarrowLoad { base, .. } => result.push(*base),
-        Aarch64Inst::Str { src, base, .. }
-        | Aarch64Inst::Strb { src, base, .. }
-        | Aarch64Inst::NarrowStore { src, base, .. } => {
+        Aarch64Inst::Ldr { base, .. } | Aarch64Inst::NarrowLoad { base, .. } => result.push(*base),
+        Aarch64Inst::Str { src, base, .. } | Aarch64Inst::NarrowStore { src, base, .. } => {
             add_if_phys(src, &mut result);
             result.push(*base);
         }
@@ -343,7 +331,6 @@ fn regs_read(inst: &Aarch64Inst) -> Vec<Reg> {
             result.push(Reg::Sp); // Post-indexed LDP reads SP before writing
         }
         Aarch64Inst::LdrIndexed { .. }
-        | Aarch64Inst::LdrbIndexed { .. }
         | Aarch64Inst::LdrIndexedOffset { .. }
         | Aarch64Inst::NarrowLoadIndexed { .. } => {
             // Pre-regalloc indexed load. The scheduler runs after regalloc,
@@ -351,7 +338,6 @@ fn regs_read(inst: &Aarch64Inst) -> Vec<Reg> {
             // register to record here.
         }
         Aarch64Inst::StrIndexed { src, .. }
-        | Aarch64Inst::StrbIndexed { src, .. }
         | Aarch64Inst::StrIndexedOffset { src, .. }
         | Aarch64Inst::NarrowStoreIndexed { src, .. } => {
             // Pre-regalloc indexed store. The scheduler runs after regalloc,
@@ -391,7 +377,6 @@ fn regs_written(inst: &Aarch64Inst) -> Vec<Reg> {
         Aarch64Inst::MovImm { dst, .. }
         | Aarch64Inst::MovRR { dst, .. }
         | Aarch64Inst::Ldr { dst, .. }
-        | Aarch64Inst::Ldrb { dst, .. }
         | Aarch64Inst::AddRR { dst, .. }
         | Aarch64Inst::AddsRR { dst, .. }
         | Aarch64Inst::AddsRR64 { dst, .. }
@@ -439,7 +424,6 @@ fn regs_written(inst: &Aarch64Inst) -> Vec<Reg> {
         | Aarch64Inst::Uxtb { dst, .. }
         | Aarch64Inst::Uxth { dst, .. }
         | Aarch64Inst::LdrIndexed { dst, .. }
-        | Aarch64Inst::LdrbIndexed { dst, .. }
         | Aarch64Inst::LdrIndexedOffset { dst, .. }
         | Aarch64Inst::NarrowLoad { dst, .. }
         | Aarch64Inst::NarrowLoadIndexed { dst, .. }
@@ -454,9 +438,7 @@ fn regs_written(inst: &Aarch64Inst) -> Vec<Reg> {
             result.push(Reg::Sp); // Post-indexed LDP writes SP
         }
         Aarch64Inst::Str { .. }
-        | Aarch64Inst::Strb { .. }
         | Aarch64Inst::StrIndexed { .. }
-        | Aarch64Inst::StrbIndexed { .. }
         | Aarch64Inst::StrIndexedOffset { .. }
         | Aarch64Inst::NarrowStore { .. }
         | Aarch64Inst::NarrowStoreIndexed { .. } => {

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -360,7 +360,6 @@ mod tests {
                 let i: u64 = 1;
                 let j: u64 = 0;
                 grid.cells[i][j] = grid.cells[i][j] + 1;
-                let _address: ptr const i32 = checked { @raw(grid.cells[i][j]) };
                 grid.cells[i][j]
             }
         "#;
@@ -408,31 +407,33 @@ mod tests {
         .lower()
         .expect("AArch64 fixture should lower");
 
-        // RHS read, write destination, @raw's argument read/address pair, and
-        // final read each walk both indices. Only the write emits an indexed
-        // store; the three ordinary reads emit indexed loads. These counts
-        // make projection traversal regressions visible without snapshotting
-        // unrelated prologue/ABI details.
+        // RHS read, write destination, and final read each walk both indices.
+        // Only the write emits an indexed store; the two ordinary reads emit
+        // indexed loads. (Taking a raw pointer into the frame-resident nested
+        // array is refused by the compact-layout M2 contract and is covered by
+        // `raw_pointer_into_frame_nested_array_is_refused_on_both_backends`.)
+        // These counts make projection traversal regressions visible without
+        // snapshotting unrelated prologue/ABI details.
         assert_eq!(
             x86.instructions()
                 .iter()
                 .filter(|inst| matches!(inst, X86Inst::ImulRR64 { .. }))
                 .count(),
-            5
+            3
         );
         assert_eq!(
             x86.instructions()
                 .iter()
                 .filter(|inst| matches!(inst, X86Inst::Shl { .. }))
                 .count(),
-            5
+            3
         );
         assert_eq!(
             x86.instructions()
                 .iter()
                 .filter(|inst| matches!(inst, X86Inst::MovRMIndexed { .. }))
                 .count(),
-            3
+            2
         );
         assert_eq!(
             x86.instructions()
@@ -447,21 +448,21 @@ mod tests {
                 .iter()
                 .filter(|inst| matches!(inst, Aarch64Inst::MulRR { .. }))
                 .count(),
-            5
+            3
         );
         assert_eq!(
             arm.instructions()
                 .iter()
                 .filter(|inst| matches!(inst, Aarch64Inst::LslImm { .. }))
                 .count(),
-            5
+            3
         );
         assert_eq!(
             arm.instructions()
                 .iter()
                 .filter(|inst| matches!(inst, Aarch64Inst::LdrIndexed { .. }))
                 .count(),
-            3
+            2
         );
         assert_eq!(
             arm.instructions()
@@ -698,5 +699,73 @@ mod tests {
         assert!(unit_write_arm.instructions().iter().any(|inst| {
             matches!(inst, Aarch64Inst::Bl { symbol_id } if unit_write_arm.get_symbol(*symbol_id) == "__rue_bounds_check")
         }));
+    }
+
+    /// Taking a raw pointer into an element of a frame-resident non-slot-identical
+    /// array (`@raw(grid.cells[i][j])`) is refused loudly on both backends: the
+    /// frame stores the array slot-shaped while the raw pointer addresses memory
+    /// by its packed compact image, so an `@ptr_offset` walk would stride across
+    /// mismatched layouts (the compact-layout M2b contract, RUE-1035 / RUE-987).
+    /// The sibling read/write projection test covers the paths that still lower.
+    #[test]
+    fn raw_pointer_into_frame_nested_array_is_refused_on_both_backends() {
+        let source = r#"
+            struct Grid { pad: i32, cells: [[i32; 2]; 2] }
+            fn main() -> i32 {
+                let mut grid = Grid { pad: 9, cells: [[10, 20], [30, 40]] };
+                let i: u64 = 1;
+                let j: u64 = 0;
+                let _address: ptr const i32 = checked { @raw(grid.cells[i][j]) };
+                grid.cells[i][j]
+            }
+        "#;
+
+        let lexer = Lexer::new(source);
+        let (tokens, interner) = lexer.tokenize().expect("fixture should lex");
+        let parser = Parser::new(tokens, interner);
+        let (ast, mut interner) = parser.parse().expect("fixture should parse");
+        let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
+        astgen.append_items(&ast.items);
+        let rir = astgen.finish();
+        let output = Sema::new_synthetic(&rir, &mut interner, PreviewFeatures::new())
+            .analyze_all()
+            .expect("fixture should analyze");
+        let function = output
+            .functions
+            .iter()
+            .find(|function| function.name == "main")
+            .expect("fixture function should exist");
+        let cfg = CfgBuilder::build(
+            &function.air,
+            function.num_locals,
+            function.num_param_slots,
+            &function.name,
+            &output.type_pool,
+            function.param_modes.clone(),
+            &interner,
+            function.allow_unreachable_code,
+        )
+        .cfg
+        .unwrap();
+
+        let x86_err = X86CfgLower::new_unchecked(&cfg, &output.type_pool, &interner)
+            .lower()
+            .expect_err("x86 must refuse a raw pointer into a frame nested array");
+        assert!(
+            format!("{x86_err:?}").contains("frame-resident aggregate"),
+            "unexpected x86 diagnostic: {x86_err:?}"
+        );
+        let arm_err = Aarch64CfgLower::new_unchecked(
+            &cfg,
+            &output.type_pool,
+            &interner,
+            Target::Aarch64Linux,
+        )
+        .lower()
+        .expect_err("AArch64 must refuse a raw pointer into a frame nested array");
+        assert!(
+            format!("{arm_err:?}").contains("frame-resident aggregate"),
+            "unexpected AArch64 diagnostic: {arm_err:?}"
+        );
     }
 }

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -280,10 +280,8 @@ pub struct NarrowScalar {
 }
 
 /// The narrow-access description for a scalar accessed through a pointer, or
-/// `None` when the value occupies a full eight-byte slot (`i64`/`u64`/pointers)
-/// or the compact layout is inactive. When `None`, the existing eight-byte
-/// slot-shaped load/store is byte-for-byte correct, so gate-off behavior is
-/// unchanged.
+/// `None` when the value occupies a full eight-byte slot (`i64`/`u64`/pointers).
+/// When `None`, the eight-byte slot-shaped load/store is byte-for-byte correct.
 ///
 /// Only scalar leaves narrow: aggregates crossing the pointer boundary as whole
 /// values remain refused by [`compact_physical_access_unsupported`].
@@ -291,9 +289,6 @@ pub(crate) fn narrow_scalar_access(
     type_pool: &FrozenTypeInternPool,
     ty: Type,
 ) -> Option<NarrowScalar> {
-    if !type_pool.compact_layout() {
-        return None;
-    }
     let (width, signed) = match ty.kind() {
         TypeKind::I8 => (1, true),
         TypeKind::U8 | TypeKind::Bool => (1, false),
@@ -375,9 +370,6 @@ pub(crate) fn enum_physical_slot_map(
 ) -> Option<Vec<PhysicalEnumSlot>> {
     use rue_air::layout::LayoutKind;
 
-    if !type_pool.compact_layout() {
-        return None;
-    }
     let enum_id = ty.as_enum()?;
     let layout = type_pool.layout(ty);
     let (tag_size, payload_offset, variant_offsets) = match &layout.kind {
@@ -516,14 +508,11 @@ pub(crate) fn enum_physical_slot_map(
 /// Returns `None` (stay refused) for any aggregate containing a construct without
 /// a variant-independent image (an array, or an enum [`enum_physical_slot_map`]
 /// rejects), and asserts the flattened slot count equals the type's
-/// [`type_slot_count`]. Always `None` with the gate off.
+/// [`type_slot_count`].
 pub(crate) fn aggregate_physical_slot_map(
     type_pool: &FrozenTypeInternPool,
     ty: Type,
 ) -> Option<Vec<PhysicalEnumSlot>> {
-    if !type_pool.compact_layout() {
-        return None;
-    }
     let mut slots = Vec::new();
     push_physical_slots(type_pool, ty, 0, &mut slots)?;
     if slots.len() != type_pool.abi_slot_count(ty) as usize {
@@ -683,7 +672,7 @@ pub struct DispatchImage {
 /// when `ty` needs no dispatch — a slot-identical aggregate, or one whose compact
 /// image is already variant-independent (`aggregate_physical_slot_map` is
 /// `Some`), both of which use their existing single-map / full-slot paths
-/// unchanged. Also `None` with the gate off.
+/// unchanged.
 ///
 /// Returns `Some` only when the aggregate genuinely requires a per-variant tag
 /// dispatch, i.e. it contains at least one heterogeneous enum whose per-variant
@@ -694,9 +683,6 @@ pub(crate) fn aggregate_dispatch_image(
     type_pool: &FrozenTypeInternPool,
     ty: Type,
 ) -> Option<DispatchImage> {
-    if !type_pool.compact_layout() {
-        return None;
-    }
     // A variant-independent image (or a slot-identical aggregate) needs no
     // dispatch; those keep their existing single-map / full-slot paths.
     if aggregate_physical_slot_map(type_pool, ty).is_some() {
@@ -920,10 +906,6 @@ pub(crate) fn compact_physical_access_unsupported(
     type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
 ) -> Option<Type> {
-    if !type_pool.compact_layout() {
-        return None;
-    }
-
     // A non-slot-identical aggregate (struct/array/enum) whose whole-value
     // marshalling across a CALL boundary is still unimplemented (RUE-976's
     // transitional indirect rule; call marshalling is the next phase). Narrow
@@ -1071,7 +1053,7 @@ pub(crate) fn compact_physical_access_unsupported(
     None
 }
 
-/// Under the compact layout, an `@raw`/`@raw_mut`/`@field_ptr` pointer into a
+/// An `@raw`/`@raw_mut`/`@field_ptr` pointer into a
 /// **frame** aggregate that would then be accessed as a whole non-slot-identical
 /// aggregate, or strided across a non-slot-identical array, is unsupported and
 /// must be refused loudly (RUE-1035 M2).
@@ -1104,10 +1086,6 @@ fn frame_raw_aggregate_pointer_unsupported(
     type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
 ) -> Option<Type> {
-    if !type_pool.compact_layout() {
-        return None;
-    }
-
     let non_slot_identical_aggregate = |ty: Type| -> bool {
         matches!(
             ty.kind(),
@@ -1155,11 +1133,11 @@ fn frame_raw_aggregate_pointer_unsupported(
     None
 }
 
-/// Refuse code generation with a clear diagnostic when the compact physical
-/// layout is active but the function needs narrow physical memory access that is
-/// not yet implemented (see [`compact_physical_access_unsupported`]). Both
-/// backends call this at the top of lowering so the feature fails loudly rather
-/// than silently emitting slot-shaped access against a compact layout.
+/// Refuse code generation with a clear diagnostic when the function marshals a
+/// compact aggregate that has no single physical memory image (see
+/// [`compact_physical_access_unsupported`]). Both backends call this at the top
+/// of lowering so an unsupported construct fails loudly rather than being
+/// silently miscompiled.
 pub(crate) fn ensure_compact_layout_codegen_supported(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,
@@ -1188,16 +1166,17 @@ pub(crate) fn ensure_compact_layout_codegen_supported(
         let name = type_name(ty, type_pool);
         return Err(rue_error::CompileError::without_span(
             rue_error::ErrorKind::InternalCodegenError(format!(
-                "aggregate_layout: physical-layout code generation for type `{name}` (in function \
-                 `{}`) is not yet implemented. Narrow scalar access through typed pointers \
-                 (RUE-989), compact enum memory (RUE-1000), call-boundary marshalling of a compact \
-                 aggregate through its memory image — sret returns and `inout`/`borrow` parameters \
-                 (RUE-1004), by-value arguments (RUE-1005) — whole compact-struct marshalling \
-                 through typed pointers (RUE-987), variant-dependent enum images plus compact \
-                 arrays through pointers and across calls (RUE-1014), and heterogeneous enums whose \
-                 per-variant payload layouts disagree via per-variant tag dispatch (RUE-1037) are \
-                 lowered, but this aggregate has neither a variant-independent compact image nor a \
-                 tag-dispatched one, so it is refused.",
+                "the aggregate `{name}` (in function `{}`) has no compact memory image, so it \
+                 cannot be marshalled through a pointer or across a call boundary. Narrow scalar \
+                 access through typed pointers (RUE-989), compact enum memory (RUE-1000), \
+                 call-boundary marshalling of a compact aggregate through its memory image — sret \
+                 returns and `inout`/`borrow` parameters (RUE-1004), by-value arguments (RUE-1005) \
+                 — whole compact-struct marshalling through typed pointers (RUE-987), \
+                 variant-dependent enum images plus compact arrays through pointers and across \
+                 calls (RUE-1014), and heterogeneous enums whose per-variant payload layouts \
+                 disagree via per-variant tag dispatch (RUE-1037) all marshal, but this aggregate \
+                 reduces to neither a variant-independent compact image nor a tag-dispatched one, \
+                 so it is refused.",
                 cfg.fn_name()
             )),
         ));
@@ -1379,7 +1358,7 @@ pub fn collect_struct_scalar_vregs(
 #[cfg(test)]
 mod layout_authority_tests {
     use rue_air::Sema;
-    use rue_air::layout::{LayoutKind, SLOT_BYTES};
+    use rue_air::layout::LayoutKind;
     use rue_error::PreviewFeatures;
     use rue_lexer::Lexer;
     use rue_parser::Parser;
@@ -1387,10 +1366,14 @@ mod layout_authority_tests {
 
     use super::{struct_field_slot_offset, type_size_bytes, type_slot_count};
 
-    /// The layout authority, the slot decomposition, and code generation's
-    /// field/size helpers agree across every type in a real compiled program.
+    /// The compact layout authority and code generation's size helper agree, and
+    /// the physical field offsets and the internal slot decomposition are each
+    /// self-consistent (ascending, in bounds) across every type in a real
+    /// compiled program. The physical byte offsets and the slot indices are
+    /// deliberately distinct representations (ADR-0052), so they are checked for
+    /// their own invariants rather than for equality.
     #[test]
-    fn layout_agrees_with_slot_model_over_a_compiled_fixture() {
+    fn layout_agrees_with_codegen_helpers_over_a_compiled_fixture() {
         let source = r#"
             struct Point { x: i32, y: i64 }
             struct Outer { tag: bool, points: [Point; 3] }
@@ -1421,24 +1404,27 @@ mod layout_authority_tests {
 
         for ty in pool.all_types() {
             let layout = pool.layout(ty);
-            assert_eq!(
-                layout.size,
-                u64::from(pool.abi_slot_count(ty)) * SLOT_BYTES,
-                "layout size disagrees with slot count for {ty:?}"
-            );
+            // Code generation's size helper reads the same authority.
             assert_eq!(type_size_bytes(pool, ty), layout.size);
             assert_eq!(layout.stride, layout.size);
 
-            // Struct field addressing and the layout's field offsets are one
-            // computation.
+            // The physical field byte offsets (compact) and the internal slot
+            // offsets (value decomposition) are each ascending and in bounds,
+            // but are distinct representations and need not coincide.
             if let (Some(struct_id), LayoutKind::Struct { field_offsets, .. }) =
                 (ty.as_struct(), &layout.kind)
             {
+                let mut prev_offset = 0u64;
+                let mut prev_slot = 0u32;
                 for (index, &offset) in field_offsets.iter().enumerate() {
+                    assert!(offset <= layout.size, "field offset within {ty:?}");
+                    assert!(offset >= prev_offset, "field offsets ascend in {ty:?}");
+                    prev_offset = offset;
                     let slot_offset = struct_field_slot_offset(pool, struct_id, index as u32);
-                    assert_eq!(u64::from(slot_offset) * SLOT_BYTES, offset);
+                    assert!(slot_offset >= prev_slot, "slot offsets ascend in {ty:?}");
+                    prev_slot = slot_offset;
                 }
-                let _ = type_slot_count(pool, ty);
+                assert!(type_slot_count(pool, ty) >= field_offsets.len() as u32);
             }
         }
     }

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -1095,7 +1095,9 @@ fn residual_plan<A: ValueLowerAdapter>(
                 })
                 .collect(),
             total_slots: ctx.type_slot_count(ctx.cfg.get_inst(value).ty),
-            zero_unused_payload: ctx.type_pool.compact_layout(),
+            // ADR-0052 ruling 5: the compact image zeroes padding and unused
+            // payload bytes deterministically on construction.
+            zero_unused_payload: true,
         },
         ResidualInput::EnumPayloadGet {
             base,
@@ -1650,14 +1652,12 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                         ctx.type_pool,
                         ctx.cfg.get_inst(args[1]).ty,
                     ),
-                    // Under the compact layout (`aggregate_layout`) the raw-byte
-                    // family folds into the ordinary typed `ptr u8` path: a byte
-                    // access is exactly the one-byte narrow scalar access
-                    // (RUE-989) that `@ptr_read`/`@ptr_write` of a `u8` pointee
-                    // take, so `@byte_read`/`@byte_write` reuse that single
-                    // emission path (ADR-0052 phase 7, RUE-978). Keying on
-                    // `Type::U8` makes the gate the sole switch: gate-off this is
-                    // `None`, preserving the bespoke byte load/store byte-for-byte.
+                    // Under the compact layout the raw-byte family folds into the
+                    // ordinary typed `ptr u8` path: a byte access is exactly the
+                    // one-byte narrow scalar access (RUE-989) that
+                    // `@ptr_read`/`@ptr_write` of a `u8` pointee take, so
+                    // `@byte_read`/`@byte_write` reuse that single emission path
+                    // (ADR-0052 phase 7, RUE-978).
                     IntrinsicOperation::ByteRead | IntrinsicOperation::ByteWrite => {
                         crate::types::narrow_scalar_access(ctx.type_pool, Type::U8)
                     }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2009,17 +2009,11 @@ impl<'a> CfgLower<'a> {
                     src: Operand::Virtual(plan.args[1].primary),
                 });
                 let dst = self.mir.alloc_vreg();
-                if let Some(narrow) = plan.narrow_access {
-                    // Gate-on: fold into the typed `ptr u8` narrow load (RUE-978).
-                    self.emit_narrow_load_through_ptr(dst, addr, 0, narrow);
-                } else {
-                    // Gate-off: the bespoke packed byte load, byte-for-byte.
-                    self.mir.push(X86Inst::Movzx8RMIndexed {
-                        dst: Operand::Virtual(dst),
-                        base: addr,
-                        offset: 0,
-                    });
-                }
+                let narrow = plan
+                    .narrow_access
+                    .expect("byte access always has a one-byte narrow descriptor");
+                // Fold into the typed `ptr u8` narrow load (RUE-978).
+                self.emit_narrow_load_through_ptr(dst, addr, 0, narrow);
                 dst
             }
             crate::value_plan::IntrinsicOperation::ByteWrite => {
@@ -2032,17 +2026,11 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(addr),
                     src: Operand::Virtual(plan.args[1].primary),
                 });
-                if let Some(narrow) = plan.narrow_access {
-                    // Gate-on: fold into the typed `ptr u8` narrow store (RUE-978).
-                    self.emit_narrow_store_through_ptr(plan.args[2].primary, addr, 0, narrow);
-                } else {
-                    // Gate-off: the bespoke packed byte store, byte-for-byte.
-                    self.mir.push(X86Inst::MovMR8Indexed {
-                        base: addr,
-                        offset: 0,
-                        src: Operand::Virtual(plan.args[2].primary),
-                    });
-                }
+                let narrow = plan
+                    .narrow_access
+                    .expect("byte access always has a one-byte narrow descriptor");
+                // Fold into the typed `ptr u8` narrow store (RUE-978).
+                self.emit_narrow_store_through_ptr(plan.args[2].primary, addr, 0, narrow);
                 let dst = self.mir.alloc_vreg();
                 self.mir.push(X86Inst::MovRI32 {
                     dst: Operand::Virtual(dst),
@@ -3154,7 +3142,7 @@ mod tests {
     use super::*;
     use rue_air::Sema;
     use rue_cfg::CfgBuilder;
-    use rue_error::{PreviewFeature, PreviewFeatures};
+    use rue_error::PreviewFeatures;
     use rue_lexer::Lexer;
     use rue_parser::Parser;
     use rue_rir::AstGen;
@@ -3247,26 +3235,21 @@ mod tests {
     /// even when the compact element size diverges from the slot stride.
     #[test]
     fn aggregate_layout_allows_frame_array_slot_stride_indexing() {
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
         try_lower_first_fn(
             "fn main() -> i32 { let a: [i32; 3] = [1, 2, 3]; let i: u64 = 1; a[i] }",
-            preview,
+            PreviewFeatures::new(),
         )
         .expect("a frame array indexed at the slot stride must lower under compact layout");
     }
 
-    /// RUE-989: under `aggregate_layout`, narrow scalar access through a typed
-    /// pointer now lowers, emitting the narrow (1/2/4-byte) load/store pseudos
-    /// instead of a full eight-byte slot access. Gate-off, the same program uses
-    /// the eight-byte `MovRMIndexed`/`MovMRIndexed`.
+    /// RUE-989: narrow scalar access through a typed pointer lowers, emitting the
+    /// narrow (1/2/4-byte) load/store pseudos instead of a full eight-byte slot
+    /// access.
     #[test]
     fn aggregate_layout_allows_narrow_scalar_physical_access() {
         let source = "fn main() -> i32 { checked { let p: ptr mut i32 = @alloc(1); \
                       @ptr_write(p, 5); @dbg(@ptr_read(p)); @free(p, 1); }; 0 }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_first_fn(source, preview)
+        let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a narrow scalar through a typed pointer must lower under compact layout");
         assert!(
             mir.instructions()
@@ -3285,23 +3268,11 @@ mod tests {
             )),
             "a narrow i32 @ptr_read must emit a sign-extending 4-byte narrow load"
         );
-
-        // Gate-off, the identical program keeps the eight-byte slot access.
-        let off = try_lower_first_fn(source, PreviewFeatures::new())
-            .expect("the same program lowers under the default slot model");
-        assert!(
-            off.instructions().iter().all(|inst| !matches!(
-                inst,
-                X86Inst::NarrowStoreIndexed { .. } | X86Inst::NarrowLoadIndexed { .. }
-            )),
-            "gate-off must not emit any narrow access"
-        );
     }
 
-    /// RUE-1000: under `aggregate_layout`, a compact enum with a
-    /// variant-independent memory image round-trips through a typed pointer,
-    /// marshalling the narrow tag at offset 0 and the payload at its compact
-    /// offset. Gate-off, the same program uses eight-byte slot access.
+    /// RUE-1000: a compact enum with a variant-independent memory image
+    /// round-trips through a typed pointer, marshalling the narrow tag at offset 0
+    /// and the payload at its compact offset.
     #[test]
     fn aggregate_layout_allows_compact_enum_memory() {
         let source = "enum Opt { Some(i32), None } \
@@ -3309,9 +3280,7 @@ mod tests {
                       @ptr_write(p, Opt.Some(42)); let e = @ptr_read(p); \
                       match e { Opt.Some(x) => @dbg(x), Opt.None => @dbg(0), }; \
                       @free(p, 1); }; 0 }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_first_fn(source, preview)
+        let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a compact enum with a variant-independent image must lower");
         assert!(
             mir.instructions()
@@ -3330,32 +3299,18 @@ mod tests {
             )),
             "the enum read must load the u8 tag zero-extended"
         );
-
-        // Gate-off, the identical program keeps eight-byte slot marshalling.
-        let off = try_lower_first_fn(source, PreviewFeatures::new())
-            .expect("the same program lowers under the default slot model");
-        assert!(
-            off.instructions().iter().all(|inst| !matches!(
-                inst,
-                X86Inst::NarrowStoreIndexed { .. } | X86Inst::NarrowLoadIndexed { .. }
-            )),
-            "gate-off must not emit any narrow access"
-        );
     }
 
     /// RUE-987: a whole compact struct round-trips through a typed pointer on
     /// x86-64, reusing the enum-image slot machinery — `@ptr_write` stores each
-    /// field narrow at its compact offset and `@ptr_read` reloads it. Gate-off
-    /// keeps the eight-byte slot access.
+    /// field narrow at its compact offset and `@ptr_read` reloads it.
     #[test]
     fn aggregate_layout_allows_compact_struct_memory() {
         let source = "struct Padded { a: u8, b: i32, c: u8 } \
                       fn main() -> i32 { checked { let p: ptr mut Padded = @alloc(1); \
                       @ptr_write(p, Padded { a: 7, b: 1000, c: 9 }); let s = @ptr_read(p); \
                       @dbg(s.b); @free(p, 1); }; 0 }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_first_fn(source, preview).expect(
+        let mir = try_lower_first_fn(source, PreviewFeatures::new()).expect(
             "a whole compact struct through a typed pointer must lower under compact layout",
         );
         assert!(
@@ -3370,46 +3325,25 @@ mod tests {
                 .any(|inst| matches!(inst, X86Inst::NarrowLoadIndexed { width: 4, .. })),
             "the struct read must reload the i32 field narrow from its compact offset"
         );
-
-        let off = try_lower_first_fn(source, PreviewFeatures::new())
-            .expect("the same program lowers under the default slot model");
-        assert!(
-            off.instructions().iter().all(|inst| !matches!(
-                inst,
-                X86Inst::NarrowStoreIndexed { .. } | X86Inst::NarrowLoadIndexed { .. }
-            )),
-            "gate-off must not emit any narrow access"
-        );
     }
 
     /// RUE-1014: a struct containing a fixed array now HAS a variant-independent
     /// compact image — the array flattens to its elements at the compact stride —
     /// so it marshals whole through a pointer on x86-64. The narrow element
-    /// stores/loads land at the compact byte offsets; gate-off emits none.
+    /// stores/loads land at the compact byte offsets.
     #[test]
     fn aggregate_layout_allows_array_bearing_struct_memory() {
         let source = "struct HasArr { tag: u8, xs: [i32; 2] } \
                       fn main() -> i32 { let r = checked { let p: ptr mut HasArr = @alloc(1); \
                       @ptr_write(p, HasArr { tag: 5, xs: [10, 20] }); let v = @ptr_read(p); \
                       @free(p, 1); v.xs[0] + v.xs[1] }; @dbg(r); 0 }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_first_fn(source, preview)
+        let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a struct with a compact array image must lower under compact layout");
         assert!(
             mir.instructions()
                 .iter()
                 .any(|inst| matches!(inst, X86Inst::NarrowStoreIndexed { width: 4, .. })),
             "the array elements must store narrow (4-byte i32) at their compact stride"
-        );
-        let off = try_lower_first_fn(source, PreviewFeatures::new())
-            .expect("the same program lowers under the default slot model");
-        assert!(
-            off.instructions().iter().all(|inst| !matches!(
-                inst,
-                X86Inst::NarrowStoreIndexed { .. } | X86Inst::NarrowLoadIndexed { .. }
-            )),
-            "gate-off must not emit any narrow access"
         );
     }
 
@@ -3423,9 +3357,7 @@ mod tests {
                       @ptr_write(p, Opt.Some(Point { x: 40, y: 2 })); let v = @ptr_read(p); \
                       @free(p, 1); match v { Opt.Some(pt) => pt.x + pt.y, Opt.None => 0 - 1 } }; \
                       @dbg(r); 0 }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_first_fn(source, preview)
+        let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("an enum with a variant-independent struct-payload image must lower");
         assert!(
             mir.instructions()
@@ -3444,9 +3376,7 @@ mod tests {
         let source = "enum Bad { A(i64), B(i32, i32) } struct HasBad { b: Bad } \
                       fn main() -> i32 { checked { let p: ptr mut HasBad = @alloc(1); \
                       @ptr_write(p, HasBad { b: Bad.A(5) }); @free(p, 1); }; 0 }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_first_fn(source, preview)
+        let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a struct embedding a heterogeneous enum must lower via nested tag dispatch");
         assert!(
             mir.instructions()
@@ -3456,51 +3386,35 @@ mod tests {
         );
     }
 
-    /// RUE-1004: under `aggregate_layout`, a non-slot-identical struct returned
-    /// by value is forced indirect (sret); the caller reads the callee-written
-    /// compact image back from the sret buffer, extending each narrow field from
-    /// its compact byte offset (`main` here is the caller). Gate-off, the same
-    /// return reads eight-byte slots and emits no narrow access.
+    /// RUE-1004: a non-slot-identical struct returned by value is forced indirect
+    /// (sret); the caller reads the callee-written compact image back from the
+    /// sret buffer, extending each narrow field from its compact byte offset
+    /// (`main` here is the caller).
     #[test]
     fn aggregate_layout_allows_compact_struct_sret_return() {
         let source = "struct Padded { a: u8, b: i32, c: u8 } \
                       fn make() -> Padded { Padded { a: 7, b: 1000, c: 9 } } \
                       fn main() -> i32 { let p = make(); @dbg(p.b); 0 }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir =
-            try_lower_first_fn(source, preview).expect("a compact struct sret return must lower");
+        let mir = try_lower_first_fn(source, PreviewFeatures::new())
+            .expect("a compact struct sret return must lower");
         assert!(
             mir.instructions()
                 .iter()
                 .any(|inst| matches!(inst, X86Inst::NarrowLoadIndexed { width: 1, .. })),
             "the caller must read the u8 fields narrow from the compact sret image"
         );
-
-        let off = try_lower_first_fn(source, PreviewFeatures::new())
-            .expect("the same program lowers under the default slot model");
-        assert!(
-            off.instructions()
-                .iter()
-                .all(|inst| !matches!(inst, X86Inst::NarrowLoadIndexed { .. })),
-            "gate-off must not emit any narrow sret read-back"
-        );
     }
 
-    /// RUE-1037: under `aggregate_layout`, a HETEROGENEOUS enum (variants whose
-    /// payload layouts disagree) is marshalled through a pointer by dispatching on
-    /// the runtime tag — the store emits a tag compare/branch per variant plus
-    /// narrow field stores. Gate-off the same `@ptr_write` stores eight-byte slots
-    /// with no tag dispatch and no narrow store.
+    /// RUE-1037: a HETEROGENEOUS enum (variants whose payload layouts disagree) is
+    /// marshalled through a pointer by dispatching on the runtime tag — the store
+    /// emits a tag compare/branch per variant plus narrow field stores.
     #[test]
     fn aggregate_layout_heterogeneous_enum_ptr_write_tag_dispatches() {
         let source = "enum R { Ok(Point), Err(i64) } \
                       struct Point { x: i32, y: i32, z: i32 } \
                       fn store_it(p: ptr mut R) { checked { @ptr_write(p, R.Ok(Point { x: 1, y: 2, z: 3 })); }; } \
                       fn main() -> i32 { checked { let p: ptr mut R = @alloc(1); store_it(p); @free(p, 1); }; 0 }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_named_fn(source, preview, Some("store_it"))
+        let mir = try_lower_named_fn(source, PreviewFeatures::new(), Some("store_it"))
             .expect("a heterogeneous enum @ptr_write must lower via tag dispatch");
         assert!(
             mir.instructions()
@@ -3514,48 +3428,32 @@ mod tests {
                 .any(|inst| matches!(inst, X86Inst::NarrowStoreIndexed { .. })),
             "the active variant's narrow leaves must be stored narrow"
         );
-
-        let off = try_lower_named_fn(source, PreviewFeatures::new(), Some("store_it"))
-            .expect("the same program lowers under the default slot model");
-        assert!(
-            off.instructions().iter().all(|inst| !matches!(
-                inst,
-                X86Inst::CmpRI { .. } | X86Inst::NarrowStoreIndexed { .. }
-            )),
-            "gate-off must store eight-byte slots with no tag dispatch and no narrow store"
-        );
     }
 
-    /// RUE-1004: under `aggregate_layout`, an `inout` non-slot-identical struct
-    /// argument is accepted — the callee reads/writes the caller's slot-based
-    /// frame storage through the by-reference pointer (slot-shaped transport), so
-    /// the call site lowers rather than being refused.
+    /// RUE-1004: an `inout` non-slot-identical struct argument is accepted — the
+    /// callee reads/writes the caller's slot-based frame storage through the
+    /// by-reference pointer (slot-shaped transport), so the call site lowers
+    /// rather than being refused.
     #[test]
     fn aggregate_layout_allows_inout_compact_struct_param() {
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
         try_lower_first_fn(
             "struct Padded { a: u8, b: i32, c: u8 } \
              fn bump(inout p: Padded) { p.b = p.b + 1; } \
              fn main() -> i32 { let mut s = Padded { a: 1, b: 2, c: 3 }; bump(inout s); s.b }",
-            preview,
+            PreviewFeatures::new(),
         )
         .expect("an inout compact struct argument must lower");
     }
 
-    /// RUE-1005: under `aggregate_layout`, a non-slot-identical struct passed BY
-    /// VALUE across a call now lowers. The caller (`main`, first here) writes the
-    /// aggregate's compact image into a caller-owned buffer with narrow stores
-    /// and passes one pointer. Gate-off, the same call passes slot-shaped
-    /// registers and emits no narrow store.
+    /// RUE-1005: a non-slot-identical struct passed BY VALUE across a call lowers.
+    /// The caller (`main`, first here) writes the aggregate's compact image into a
+    /// caller-owned buffer with narrow stores and passes one pointer.
     #[test]
     fn aggregate_layout_allows_by_value_compact_struct_arg_caller() {
         let source = "struct Padded { a: u8, b: i32, c: u8 } \
                       fn main() -> i32 { sum(Padded { a: 1, b: 5, c: 3 }) } \
                       fn sum(p: Padded) -> i32 { p.b }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_first_fn(source, preview)
+        let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a by-value compact struct argument must lower");
         assert!(
             mir.instructions()
@@ -3563,29 +3461,17 @@ mod tests {
                 .any(|inst| matches!(inst, X86Inst::NarrowStoreIndexed { width: 1, .. })),
             "the caller must write the u8 fields narrow into the compact argument buffer"
         );
-
-        let off = try_lower_first_fn(source, PreviewFeatures::new())
-            .expect("the same program lowers under the default slot model");
-        assert!(
-            off.instructions()
-                .iter()
-                .all(|inst| !matches!(inst, X86Inst::NarrowStoreIndexed { .. })),
-            "gate-off must not emit any narrow argument-buffer store"
-        );
     }
 
     /// RUE-1005 callee side: the function receiving a by-value compact aggregate
     /// unmarshals its compact image (narrow loads) from the homed pointer into
-    /// its frame slots at entry. Gate-off, it reads slot-shaped registers with no
-    /// narrow load.
+    /// its frame slots at entry.
     #[test]
     fn aggregate_layout_allows_by_value_compact_struct_arg_callee() {
         let source = "struct Padded { a: u8, b: i32, c: u8 } \
                       fn sum(p: Padded) -> i32 { p.b } \
                       fn main() -> i32 { sum(Padded { a: 1, b: 5, c: 3 }) }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = try_lower_named_fn(source, preview, Some("sum"))
+        let mir = try_lower_named_fn(source, PreviewFeatures::new(), Some("sum"))
             .expect("the callee of a by-value compact struct argument must lower");
         assert!(
             mir.instructions()
@@ -3593,26 +3479,13 @@ mod tests {
                 .any(|inst| matches!(inst, X86Inst::NarrowLoadIndexed { width: 1, .. })),
             "the callee must unmarshal the u8 fields narrow from the homed pointer"
         );
-
-        let off = try_lower_named_fn(source, PreviewFeatures::new(), Some("sum"))
-            .expect("the same program lowers under the default slot model");
-        assert!(
-            off.instructions()
-                .iter()
-                .all(|inst| !matches!(inst, X86Inst::NarrowLoadIndexed { .. })),
-            "gate-off must not emit any narrow parameter unmarshalling"
-        );
     }
 
-    /// RUE-1005 descriptor plumbing: with the gate off, the per-source-parameter
-    /// prologue homing plan is byte-identical to the historical one-register-per-
-    /// slot loop — a multi-slot direct struct parameter homes exactly one
-    /// incoming register per frame slot, so the flattened register→slot mapping is
-    /// the identity. With the gate on, the same struct parameter crosses as one
+    /// RUE-1005 descriptor plumbing: a compact struct parameter crosses as one
     /// indirect pointer, so its plan entry consumes a single register while still
     /// reserving all three frame slots.
     #[test]
-    fn param_homing_plan_is_inert_gate_off_and_collapses_indirect_gate_on() {
+    fn param_homing_plan_collapses_indirect_compact_aggregate() {
         use rue_cfg::CfgBuilder;
         let source = "struct Padded { a: u8, b: i32, c: u8 } \
                       fn take(p: Padded, q: i32) -> i32 { p.b + q } \
@@ -3647,28 +3520,10 @@ mod tests {
             (plan, cfg.num_params())
         };
 
-        // Gate-off: total incoming registers equals the parameter slot count and
-        // register i homes into frame slot i (identity) — the historical prologue.
-        let (off, num_params) = plan_for(PreviewFeatures::new());
-        assert_eq!(off.iter().map(|h| h.reg_count).sum::<u32>(), num_params);
-        let mut reg = 0u32;
-        for homing in &off {
-            for k in 0..homing.reg_count {
-                assert_eq!(
-                    homing.start_slot + k,
-                    reg,
-                    "gate-off homing must be identity"
-                );
-                reg += 1;
-            }
-        }
-
-        // Gate-on: the compact struct parameter collapses to one incoming pointer
-        // register while its three frame slots stay reserved, so the total
-        // incoming register count drops below the parameter slot count.
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let (on, num_params_on) = plan_for(preview);
+        // The compact struct parameter collapses to one incoming pointer register
+        // while its three frame slots stay reserved, so the total incoming
+        // register count drops below the parameter slot count.
+        let (on, num_params_on) = plan_for(PreviewFeatures::new());
         assert_eq!(num_params_on, 4, "Padded (3 slots) + i32 (1 slot)");
         assert_eq!(
             on.iter().map(|h| h.reg_count).sum::<u32>(),
@@ -3697,13 +3552,11 @@ mod tests {
     /// dispatches on the tag and writes the active variant's leaves.
     #[test]
     fn aggregate_layout_marshals_variant_dependent_enum_memory() {
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
         let mir = try_lower_first_fn(
             "enum Bad { A(i64), B(i32, i32) } \
              fn main() -> i32 { checked { let p: ptr mut Bad = @alloc(1); \
              @ptr_write(p, Bad.A(5)); @free(p, 1); }; 0 }",
-            preview,
+            PreviewFeatures::new(),
         )
         .expect("a variant-dependent enum memory image must lower via tag dispatch");
         assert!(
@@ -3719,11 +3572,9 @@ mod tests {
     /// compact codegen is accepted.
     #[test]
     fn aggregate_layout_allows_slot_identical_physical_layout_codegen() {
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
         try_lower_first_fn(
             "struct Cell { a: i64, b: i64 } fn main() -> i32 { let c = Cell { a: 7, b: 9 }; @intCast(c.a) }",
-            preview,
+            PreviewFeatures::new(),
         )
         .expect("a slot-identical aggregate must lower under compact layout");
     }
@@ -3907,12 +3758,12 @@ mod tests {
         assert!(
             mir.instructions()
                 .iter()
-                .any(|inst| matches!(inst, X86Inst::MovMR8Indexed { .. }))
+                .any(|inst| matches!(inst, X86Inst::NarrowStoreIndexed { width: 1, .. }))
         );
         assert!(
             mir.instructions()
                 .iter()
-                .any(|inst| matches!(inst, X86Inst::Movzx8RMIndexed { .. }))
+                .any(|inst| matches!(inst, X86Inst::NarrowLoadIndexed { width: 1, .. }))
         );
 
         let alloc = runtime_call_index(&mir, rue_runtime_abi::RuntimeHelperId::Alloc);
@@ -3929,25 +3780,21 @@ mod tests {
         assert_eq!(immediate_call_arg(&mir, free, Reg::Rdx), Some(1));
     }
 
-    /// RUE-978: under the compact layout the raw-byte access family folds into
-    /// the ordinary typed `ptr u8` narrow path — `@byte_read`/`@byte_write`
-    /// emit the same one-byte `NarrowLoadIndexed`/`NarrowStoreIndexed` a typed
-    /// `@ptr_read`/`@ptr_write` of a `u8` pointee does, not the bespoke
-    /// `Movzx8RMIndexed`/`MovMR8Indexed`. Gate-off keeps the bespoke path
-    /// (asserted by `raw_bytes_runtime_helper_identity_and_slots_match_shared_plan`).
+    /// RUE-978: the raw-byte access family folds into the ordinary typed
+    /// `ptr u8` narrow path — `@byte_read`/`@byte_write` emit the same one-byte
+    /// `NarrowLoadIndexed`/`NarrowStoreIndexed` a typed `@ptr_read`/`@ptr_write`
+    /// of a `u8` pointee does.
     #[test]
     fn aggregate_layout_folds_byte_access_into_narrow_typed_path() {
         let source = "fn main() -> i32 { checked { let p = @alloc_bytes(2, 1); \
              @byte_write(p, 0, 65); let b = @byte_read(p, 1); \
              @free_bytes(p, 2, 1); @intCast(b) } }";
-        let mut preview = PreviewFeatures::new();
-        preview.insert(PreviewFeature::AggregateLayout);
-        let mir = lower_to_mir_with_preview(source, preview);
+        let mir = lower_to_mir_with_preview(source, PreviewFeatures::new());
         assert!(
             mir.instructions()
                 .iter()
                 .any(|inst| matches!(inst, X86Inst::NarrowStoreIndexed { width: 1, .. })),
-            "gated @byte_write must fold into the one-byte narrow store"
+            "@byte_write must fold into the one-byte narrow store"
         );
         assert!(
             mir.instructions().iter().any(|inst| matches!(
@@ -3958,14 +3805,7 @@ mod tests {
                     ..
                 }
             )),
-            "gated @byte_read must fold into the one-byte zero-extended narrow load"
-        );
-        assert!(
-            mir.instructions().iter().all(|inst| !matches!(
-                inst,
-                X86Inst::Movzx8RMIndexed { .. } | X86Inst::MovMR8Indexed { .. }
-            )),
-            "the bespoke packed byte load/store must not survive the fold-in"
+            "@byte_read must fold into the one-byte zero-extended narrow load"
         );
     }
 }

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -398,8 +398,6 @@ impl<'a> Emitter<'a> {
                 inst,
                 X86Inst::MovRMIndexed { .. }
                     | X86Inst::MovMRIndexed { .. }
-                    | X86Inst::Movzx8RMIndexed { .. }
-                    | X86Inst::MovMR8Indexed { .. }
                     | X86Inst::NarrowLoadIndexed { .. }
                     | X86Inst::NarrowStoreIndexed { .. }
             ) {
@@ -1209,8 +1207,6 @@ impl<'a> Emitter<'a> {
 
             X86Inst::MovRMIndexed { .. }
             | X86Inst::MovMRIndexed { .. }
-            | X86Inst::Movzx8RMIndexed { .. }
-            | X86Inst::MovMR8Indexed { .. }
             | X86Inst::NarrowLoadIndexed { .. }
             | X86Inst::NarrowStoreIndexed { .. } => {
                 // Regalloc lowers these into MovRM/MovMR/NarrowLoadRM/NarrowStoreMR,

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -250,15 +250,11 @@ pub fn uses(inst: &X86Inst) -> Vec<VReg> {
             add_if_virtual(dst, &mut result);
             add_if_virtual(count, &mut result);
         }
-        X86Inst::MovRMIndexed { base, .. }
-        | X86Inst::Movzx8RMIndexed { base, .. }
-        | X86Inst::NarrowLoadIndexed { base, .. } => {
+        X86Inst::MovRMIndexed { base, .. } | X86Inst::NarrowLoadIndexed { base, .. } => {
             // base is a VReg
             result.push(*base);
         }
-        X86Inst::MovMRIndexed { base, src, .. }
-        | X86Inst::MovMR8Indexed { base, src, .. }
-        | X86Inst::NarrowStoreIndexed { base, src, .. } => {
+        X86Inst::MovMRIndexed { base, src, .. } | X86Inst::NarrowStoreIndexed { base, src, .. } => {
             result.push(*base);
             add_if_virtual(src, &mut result);
         }
@@ -413,14 +409,10 @@ pub fn defs(inst: &X86Inst) -> Vec<VReg> {
         X86Inst::Shl { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
-        X86Inst::MovRMIndexed { dst, .. }
-        | X86Inst::Movzx8RMIndexed { dst, .. }
-        | X86Inst::NarrowLoadIndexed { dst, .. } => {
+        X86Inst::MovRMIndexed { dst, .. } | X86Inst::NarrowLoadIndexed { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
-        X86Inst::MovMRIndexed { .. }
-        | X86Inst::MovMR8Indexed { .. }
-        | X86Inst::NarrowStoreIndexed { .. } => {
+        X86Inst::MovMRIndexed { .. } | X86Inst::NarrowStoreIndexed { .. } => {
             // Writes to memory
         }
         X86Inst::MovRMSib { dst, .. } => {

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -485,20 +485,6 @@ pub enum X86Inst {
         src: Operand,
     },
 
-    /// Pre-register-allocation one-byte load through a virtual address.
-    Movzx8RMIndexed {
-        dst: Operand,
-        base: VReg,
-        offset: i32,
-    },
-
-    /// Pre-register-allocation one-byte store through a virtual address.
-    MovMR8Indexed {
-        base: VReg,
-        offset: i32,
-        src: Operand,
-    },
-
     /// Pre-register-allocation narrow (1/2/4-byte) load of `[base]` extended
     /// into the 64-bit `dst` (ADR-0052, RUE-989). `signed` selects `movsx`
     /// (sign-extend) versus `movzx`/`mov r32` (zero-extend). The pointer address
@@ -745,12 +731,6 @@ impl fmt::Display for X86Inst {
                 } else {
                     write!(f, "mov [{}-{}], {}", base, -offset, src)
                 }
-            }
-            X86Inst::Movzx8RMIndexed { dst, base, offset } => {
-                write!(f, "movzx {}, byte [{}+{}]", dst, base, offset)
-            }
-            X86Inst::MovMR8Indexed { base, offset, src } => {
-                write!(f, "mov byte [{}+{}], {}", base, offset, src)
             }
             X86Inst::NarrowLoadIndexed {
                 dst,

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -728,48 +728,6 @@ impl RegAlloc {
                 });
             }
 
-            X86Inst::Movzx8RMIndexed { dst, base, offset } => {
-                let base_reg = Self::load_operand(context, mir, Operand::Virtual(base), Reg::Rax)?;
-                let base_phys = base_reg.as_physical();
-                match Self::get_allocation(context, dst) {
-                    Some(Allocation::Register(reg)) => mir.push(X86Inst::Movzx8RM {
-                        dst: Operand::Physical(reg),
-                        base: base_phys,
-                        offset,
-                    }),
-                    Some(Allocation::Spill(spill_off)) => {
-                        mir.push(X86Inst::Movzx8RM {
-                            dst: Operand::Physical(Reg::Rdx),
-                            base: base_phys,
-                            offset,
-                        });
-                        mir.push_after(X86Inst::MovMR {
-                            base: Reg::Rbp,
-                            offset: spill_off,
-                            src: Operand::Physical(Reg::Rdx),
-                        });
-                    }
-                    Some(Allocation::Rematerialize(_)) => {
-                        unreachable!("destination cannot be rematerializable")
-                    }
-                    None => mir.push(X86Inst::Movzx8RM {
-                        dst,
-                        base: base_phys,
-                        offset,
-                    }),
-                }
-            }
-
-            X86Inst::MovMR8Indexed { base, offset, src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::Rdx)?;
-                let base_reg = Self::load_operand(context, mir, Operand::Virtual(base), Reg::Rax)?;
-                mir.push(X86Inst::MovMR8 {
-                    base: base_reg.as_physical(),
-                    offset,
-                    src: src_op,
-                });
-            }
-
             X86Inst::NarrowLoadIndexed {
                 dst,
                 base,

--- a/crates/rue-codegen/src/x86_64/schedule.rs
+++ b/crates/rue-codegen/src/x86_64/schedule.rs
@@ -85,7 +85,6 @@ fn get_latency(inst: &X86Inst) -> u32 {
         | X86Inst::MovRMIndexed { .. }
         | X86Inst::MovRMSib { .. }
         | X86Inst::Movzx8RM { .. }
-        | X86Inst::Movzx8RMIndexed { .. }
         | X86Inst::NarrowLoadRM { .. }
         | X86Inst::NarrowLoadIndexed { .. } => 4,
 
@@ -94,7 +93,6 @@ fn get_latency(inst: &X86Inst) -> u32 {
         | X86Inst::MovMRIndexed { .. }
         | X86Inst::MovMRSib { .. }
         | X86Inst::MovMR8 { .. }
-        | X86Inst::MovMR8Indexed { .. }
         | X86Inst::NarrowStoreMR { .. }
         | X86Inst::NarrowStoreIndexed { .. } => 1,
 
@@ -249,8 +247,6 @@ fn accesses_memory(inst: &X86Inst) -> bool {
             | X86Inst::MovMRSib { .. }
             | X86Inst::Movzx8RM { .. }
             | X86Inst::MovMR8 { .. }
-            | X86Inst::Movzx8RMIndexed { .. }
-            | X86Inst::MovMR8Indexed { .. }
             | X86Inst::NarrowLoadRM { .. }
             | X86Inst::NarrowStoreMR { .. }
             | X86Inst::NarrowLoadIndexed { .. }
@@ -379,16 +375,12 @@ fn regs_read(inst: &X86Inst) -> Vec<Reg> {
             add_if_phys(dst, &mut result);
             add_if_phys(count, &mut result);
         }
-        X86Inst::MovRMIndexed { .. }
-        | X86Inst::Movzx8RMIndexed { .. }
-        | X86Inst::NarrowLoadIndexed { .. } => {
+        X86Inst::MovRMIndexed { .. } | X86Inst::NarrowLoadIndexed { .. } => {
             // Pre-regalloc indexed load. The scheduler runs after regalloc,
             // which rewrites this variant; the virtual base has no physical
             // register to record here.
         }
-        X86Inst::MovMRIndexed { src, .. }
-        | X86Inst::MovMR8Indexed { src, .. }
-        | X86Inst::NarrowStoreIndexed { src, .. } => {
+        X86Inst::MovMRIndexed { src, .. } | X86Inst::NarrowStoreIndexed { src, .. } => {
             // Pre-regalloc indexed store. The scheduler runs after regalloc,
             // which rewrites this variant; the virtual base has no physical
             // register to record here.
@@ -521,12 +513,10 @@ fn regs_written(inst: &X86Inst) -> Vec<Reg> {
         }
         X86Inst::Lea { dst, .. } => add_if_phys(dst, &mut result),
         X86Inst::Shl { dst, .. } => add_if_phys(dst, &mut result),
-        X86Inst::MovRMIndexed { dst, .. }
-        | X86Inst::Movzx8RMIndexed { dst, .. }
-        | X86Inst::NarrowLoadIndexed { dst, .. } => add_if_phys(dst, &mut result),
-        X86Inst::MovMRIndexed { .. }
-        | X86Inst::MovMR8Indexed { .. }
-        | X86Inst::NarrowStoreIndexed { .. } => {}
+        X86Inst::MovRMIndexed { dst, .. } | X86Inst::NarrowLoadIndexed { dst, .. } => {
+            add_if_phys(dst, &mut result)
+        }
+        X86Inst::MovMRIndexed { .. } | X86Inst::NarrowStoreIndexed { .. } => {}
         X86Inst::MovRMSib { dst, .. } => add_if_phys(dst, &mut result),
         X86Inst::MovMRSib { .. } => {} // Store doesn't write to register (only memory)
         X86Inst::CallRel { .. } | X86Inst::Syscall => {

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -8514,11 +8514,12 @@ mod tests {
     /// semantic store — so the variants force one eviction in every terminal
     /// family under test.
     ///
-    /// With fewer preview features than the bits the mask spans, one target is
-    /// not enough distinct keys (`2^feature_bits < LIMIT + 1`), so the target
-    /// list carries the overflow. Each `feature_bits`-wide block of masks maps
-    /// to one target, and the assertion holds that the mask range spans no more
-    /// blocks than there are targets.
+    /// With `2` preview features the mask spans four subsets, and three targets
+    /// carry them to `4 * 3 = 12` distinct keys, exactly `LIMIT + 1`. The
+    /// assertion guards that the mask range spans no more `feature_bits`-wide
+    /// blocks than there are targets; if a future feature-count drop breaks it,
+    /// `QUERY_TERMINAL_RETENTION_LIMIT` must fall so `LIMIT + 1` still fits the
+    /// available `(preview_features, target)` key space.
     fn retention_variants() -> Vec<CompileOptions> {
         let feature_bits = PreviewFeature::all().len();
         let targets = Target::all();

--- a/crates/rue-compiler/src/typed_query_store.rs
+++ b/crates/rue-compiler/src/typed_query_store.rs
@@ -18,7 +18,14 @@ use crate::session::{AttemptId, QueryStructuralWork};
 /// Records survive source publication changes. Their declared dependency
 /// edges decide whether they remain reusable; the bound prevents old source
 /// and option variants from creating unbounded session-owned history.
-pub(crate) const QUERY_TERMINAL_RETENTION_LIMIT: usize = 16;
+///
+/// `LIMIT + 1` must not exceed the number of distinct
+/// `(preview_features, target)` query keys the eviction tests can enumerate with
+/// two preview features and three targets (`2^2 * 3 = 12`). Stabilizing a
+/// preview feature shrinks that key space, so the retention bound tracks it
+/// (RUE-987 took it from `16` to `10` when `aggregate_layout` retired); see
+/// `session::tests::retention_variants`.
+pub(crate) const QUERY_TERMINAL_RETENTION_LIMIT: usize = 10;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TerminalKind {

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -520,15 +520,6 @@ pub enum PreviewFeature {
     /// collection/string trio. Gated until the fat-pointer ABI lands on both
     /// backends.
     Slices,
-    /// Compact native physical type layout (ADR-0052). Replaces the flattened
-    /// eight-byte ABI-slot physical layout with natural scalar widths and
-    /// alignments, declaration-order struct fields with padding, ascending
-    /// array stride, and tagged-enum representation. Gated while compact-memory
-    /// code generation is staged: RUE-974 lands the layout authority and the
-    /// compile-time layout queries (`@size_of`/`@align_of`/`@offset_of`);
-    /// RUE-975/RUE-976 land the stack-and-value separation and call-ABI
-    /// classifier that compact heap/pointer code generation depends on.
-    AggregateLayout,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -550,7 +541,6 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "test_infra",
             PreviewFeature::Slices => "slices",
-            PreviewFeature::AggregateLayout => "aggregate_layout",
         }
     }
 
@@ -560,17 +550,12 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "ADR-0005",
             PreviewFeature::Slices => "ADR-0043",
-            PreviewFeature::AggregateLayout => "ADR-0052",
         }
     }
 
     /// Get all available preview features.
     pub fn all() -> &'static [PreviewFeature] {
-        &[
-            PreviewFeature::TestInfra,
-            PreviewFeature::Slices,
-            PreviewFeature::AggregateLayout,
-        ]
+        &[PreviewFeature::TestInfra, PreviewFeature::Slices]
     }
 
     /// Get a comma-separated list of all feature names (for help text).
@@ -594,7 +579,6 @@ impl std::str::FromStr for PreviewFeature {
         match s {
             "test_infra" => Ok(PreviewFeature::TestInfra),
             "slices" => Ok(PreviewFeature::Slices),
-            "aggregate_layout" => Ok(PreviewFeature::AggregateLayout),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -2610,7 +2594,7 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(names, "test_infra, slices, aggregate_layout");
+        assert_eq!(names, "test_infra, slices");
     }
 
     #[test]
@@ -2688,8 +2672,9 @@ mod tests {
     #[test]
     fn test_preview_feature_stabilized_are_unknown() {
         // for_loops, method_receivers, enum_payloads, array_repeat,
-        // field_init_shorthand, inline_type_ctor_paths, and raw_bytes were
-        // stabilized (no longer gated) — their names must now be rejected.
+        // field_init_shorthand, inline_type_ctor_paths, raw_bytes, and
+        // aggregate_layout were stabilized (no longer gated) — their names must
+        // now be rejected.
         for name in [
             "for_loops",
             "method_receivers",
@@ -2698,6 +2683,7 @@ mod tests {
             "field_init_shorthand",
             "inline_type_ctor_paths",
             "raw_bytes",
+            "aggregate_layout",
         ] {
             assert!(
                 name.parse::<PreviewFeature>().is_err(),

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -65,15 +65,11 @@ impl Entry {
 ///
 /// Entries are generated from unknown-gap diagnostics emitted by the real
 /// production classifier, then reviewed into this typed list. Dynamic
-/// `Unsupported::detail` text is intentionally absent from the policy key.
-///
-/// Clusters marked `slot-model-default` cover corpus cases that pin the current
-/// default eight-byte slot layout (byte offsets, per-slot sizes, aggregate
-/// widths). The gap *reasons* here are layout-independent (they are unmodeled
-/// raw-pointer / `@field_ptr` intrinsics), but the cases' expected values move
-/// when the ratified compact layout (ADR-0052, `aggregate_layout`) becomes the
-/// default, so the stabilization sweep (RUE-987) greps `slot-model-default` to
-/// enumerate every ledger entry it must re-verify after the flip.
+/// `Unsupported::detail` text is intentionally absent from the policy key. The
+/// gap *reasons* are layout-independent (unmodeled raw-pointer / `@field_ptr`
+/// intrinsics), so the compact layout (ADR-0052, RUE-987) becoming the default
+/// left this inventory's reasons unchanged; only the corpus cases' observed
+/// values moved, which the RUE-987 sweep re-verified.
 const ENTRIES: &[Entry] = &[
     Entry::new(
         "array_literal_string",
@@ -105,69 +101,60 @@ const ENTRIES: &[Entry] = &[
         implementation_defined(ImplementationDefinedKind::StringCapacityValue),
         &[],
     ),
-    // slot-model-default: the aggregate ABI matrix pins per-slot byte layout.
     Entry::new(
         "cli.aggregate_abi_matrix",
         "aos_ptr_rw",
-        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
     ),
     Entry::new(
         "cli.aggregate_abi_matrix",
         "arr_ptr_rw",
-        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
     ),
     Entry::new(
         "cli.aggregate_abi_matrix",
         "enum_ptr_rw",
-        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
     ),
     Entry::new(
         "cli.aggregate_abi_matrix",
         "nest_ptr_rw",
-        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
     ),
     Entry::new(
         "cli.aggregate_abi_matrix",
         "s1_ptr_rw",
-        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
     ),
     Entry::new(
         "cli.aggregate_abi_matrix",
         "s2_ptr_rw",
-        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
     ),
     Entry::new(
         "cli.aggregate_abi_matrix",
         "s3_ptr_rw",
-        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
     ),
     Entry::new(
         "cli.aggregate_abi_matrix",
         "s8_ptr_rw",
-        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
     ),
-    // slot-model-default: ascending-layout cases assert "slot k at base + k*8".
     Entry::new(
         "cli.aggregate_ascending_layout",
         "heap_multislot_roundtrip_no_clobber",
         intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
     ),
-    Entry::new(
-        "cli.aggregate_ascending_layout",
-        "stack_raw_ptr_roundtrip",
-        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
-        &[],
-    ),
-    // slot-model-default: aggregate_slots pins per-slot 8-byte field layout.
     Entry::new(
         "cli.aggregate_slots",
         "dbg_string_from_field",
@@ -510,8 +497,6 @@ const ENTRIES: &[Entry] = &[
         semantic(SemanticGapKind::InoutParameterForwarding),
         &[],
     ),
-    // slot-model-default: offset_of_field_ptr pins @offset_of byte values
-    // (0/8/16/24) and their @field_ptr agreement.
     Entry::new(
         "cli.offset_of_field_ptr",
         "field_ptr_on_param_struct",
@@ -539,17 +524,9 @@ const ENTRIES: &[Entry] = &[
     // ADR-0052 phase 3 (RUE-974): the compact-layout CLI cases reach a field
     // through `@field_ptr`, which the oracle model does not model (same gap as
     // the `offset_of_field_ptr` cases above).
-    // slot-model-default: aggregate_layout contrasts the default slot layout
-    // with the compact preview, so its expected values track the flip.
     Entry::new(
         "cli.aggregate_layout",
         "compact_slot_identical_field_ptr_roundtrip",
-        intrinsic(UnsupportedIntrinsicKind::FieldPointer),
-        &[],
-    ),
-    Entry::new(
-        "cli.aggregate_layout",
-        "narrow_program_unchanged_without_the_preview",
         intrinsic(UnsupportedIntrinsicKind::FieldPointer),
         &[],
     ),
@@ -682,42 +659,30 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "cli.aggregate_layout_std_sweep",
-        "std_net_result_sockaddr_networkerror_mirror_under_gate",
+        "std_net_result_sockaddr_networkerror_mirror",
         intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
     ),
-    // RUE-1014: the real-std json/priority-queue cases under the gate reach memory
-    // through the std allocators (`@alloc_bytes` in StrBuf, `@int_to_ptr` in
-    // ArrayBuf.new()), outside the oracle model.
+    // RUE-1014: the real-std json/priority-queue cases reach memory through the
+    // std allocators (`@alloc_bytes` in StrBuf, `@int_to_ptr` in ArrayBuf.new()),
+    // outside the oracle model.
     Entry::new(
         "cli.aggregate_layout_std_sweep",
-        "std_json_parse_variant_under_gate",
+        "std_json_parse_variant",
         intrinsic(UnsupportedIntrinsicKind::AllocateBytes),
         &[],
     ),
     Entry::new(
         "cli.aggregate_layout_std_sweep",
-        "std_priority_queue_option_pair_under_gate",
+        "std_priority_queue_option_pair",
         intrinsic(UnsupportedIntrinsicKind::IntToPointer),
         &[],
     ),
-    // ADR-0052 phase 7 (RUE-978): the de-gate readiness differential cases
-    // allocate through @alloc_bytes, which the oracle model does not model.
-    Entry::new(
-        "cli.raw_bytes_degate_readiness",
-        "byte_family_roundtrip_aggregate_layout",
-        intrinsic(UnsupportedIntrinsicKind::AllocateBytes),
-        &[],
-    ),
+    // RUE-978: the byte-surface behavior cases allocate through @alloc_bytes,
+    // which the oracle model does not model.
     Entry::new(
         "cli.raw_bytes_degate_readiness",
         "byte_family_roundtrip_plain",
-        intrinsic(UnsupportedIntrinsicKind::AllocateBytes),
-        &[],
-    ),
-    Entry::new(
-        "cli.raw_bytes_degate_readiness",
-        "packed_subrange_copy_aggregate_layout",
         intrinsic(UnsupportedIntrinsicKind::AllocateBytes),
         &[],
     ),
@@ -892,13 +857,13 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.ptr_read_write_aggregate",
         "ptr_read_two_field_struct",
-        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
     ),
     Entry::new(
         "cli.ptr_read_write_aggregate",
         "ptr_read_write_nested_struct",
-        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
     ),
     Entry::new(
@@ -910,7 +875,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.ptr_read_write_aggregate",
         "ptr_write_two_field_struct",
-        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
     ),
     Entry::new(
@@ -1006,12 +971,6 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.slices",
         "slice_param_sum_len_index",
-        intrinsic(UnsupportedIntrinsicKind::RawAddress),
-        &[],
-    ),
-    Entry::new(
-        "cli.slices",
-        "slice_param_u8_element",
         intrinsic(UnsupportedIntrinsicKind::RawAddress),
         &[],
     ),

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -614,7 +614,7 @@ enum Value {
     /// it were a growable string. Every width here is the compiler's
     /// `abi_slot_count` for the corresponding text type; `string_literal_value`
     /// and `text_struct_slots` derive it from that authority, and the type-free
-    /// constructors below carry the same values (slot-model-default) for the
+    /// constructors below carry the same values for the
     /// sites that have no type in hand.
     Str {
         bytes: Vec<u8>,
@@ -627,7 +627,7 @@ impl Value {
         Self::string_bytes(text.into().into_bytes())
     }
 
-    /// slot-model-default: the owned-`StrBuf` width `abi_slot_count(StrBuf) == 3`
+    /// The owned-`StrBuf` width `abi_slot_count(StrBuf) == 3`
     /// ({ptr, len, cap}). Used by the type-free sites (the `@to_string` result,
     /// which is always a `StrBuf`, and test fixtures); the type-aware paths
     /// derive the same value from the compiler authority.
@@ -643,7 +643,7 @@ impl Value {
         Self::str_view_bytes(text.into().into_bytes())
     }
 
-    /// slot-model-default: the `str`/`Str(N)` view width
+    /// The `str`/`Str(N)` view width
     /// `abi_slot_count(str) == 2` ({ptr, len}). The interpreter's live path
     /// (`string_literal_value`) now derives the width from the compiler
     /// authority, so this explicit two-slot constructor is a test fixture only.
@@ -855,7 +855,7 @@ enum WritebackPlace<'a> {
 
 impl<'a> Interp<'a> {
     fn string_literal_value(&self, text: String, ty: Type) -> Value {
-        // slot-model-default: derive the text value's ABI slot width from the
+        // Derive the text value's ABI slot width from the
         // compiler's `abi_slot_count` authority instead of hardcoding
         // str/Str(N) = 2 and StrBuf = 3. A str/Str(N) view is two slots
         // ({ptr, len}); an owned StrBuf is three ({ptr, len, cap}). The
@@ -897,7 +897,7 @@ impl<'a> Interp<'a> {
     }
 
     fn text_struct_slots(&self, struct_id: rue_air::StructId) -> Option<usize> {
-        // slot-model-default: a str/Str(N) view certifies two ABI slots and an
+        // A str/Str(N) view certifies two ABI slots and an
         // owned StrBuf three. Derive the width from `abi_slot_count` rather than
         // carrying the 2/3 literals independently; the guard keeps this `None`
         // for every non-text struct.

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -28,7 +28,7 @@ fn main() -> i32 {
     @size_of(i32)
 }
 """
-exit_code = 8
+exit_code = 4
 
 [[case]]
 name = "unknown_intrinsic"
@@ -417,7 +417,7 @@ fn main() -> i32 {
     @size_of(i32)
 }
 """
-exit_code = 8
+exit_code = 4
 
 [[case]]
 name = "size_of_returns_i32"
@@ -428,7 +428,7 @@ fn main() -> i32 {
     takes_i32(@size_of(i32))
 }
 """
-exit_code = 8
+exit_code = 4
 
 [[case]]
 name = "size_of_compile_time"
@@ -440,7 +440,7 @@ fn main() -> i32 {
     size
 }
 """
-exit_code = 8
+exit_code = 4
 
 [[case]]
 name = "size_of_struct"
@@ -451,7 +451,7 @@ fn main() -> i32 {
     @size_of(Point)
 }
 """
-exit_code = 16
+exit_code = 8
 
 [[case]]
 name = "size_of_array"
@@ -461,7 +461,7 @@ fn main() -> i32 {
     @size_of([i32; 3])
 }
 """
-exit_code = 24
+exit_code = 12
 
 # =============================================================================
 # @align_of Intrinsic
@@ -475,7 +475,7 @@ fn main() -> i32 {
     @align_of(i32)
 }
 """
-exit_code = 8
+exit_code = 4
 
 [[case]]
 name = "align_of_returns_i32"
@@ -486,7 +486,7 @@ fn main() -> i32 {
     takes_i32(@align_of(i32))
 }
 """
-exit_code = 8
+exit_code = 4
 
 [[case]]
 name = "align_of_compile_time"
@@ -498,22 +498,21 @@ fn main() -> i32 {
     align
 }
 """
-exit_code = 8
+exit_code = 4
 
-# slot-model-default: observes 8-byte alignment under the current default
-# layout (4.13:22, now observe-only). RUE-987 re-golds these values when the
-# compact layout (ADR-0052) becomes the default.
+# Each type observes its natural compact alignment (4.13:22): i8 and bool are
+# one byte, i64 is eight, and a struct's alignment is its widest field's (Point
+# is four, from its i32 fields).
 [[case]]
-name = "align_of_all_types_8"
+name = "align_of_natural_alignments"
 spec = ["4.13:22"]
 source = """
 struct Point { x: i32, y: i32 }
 fn main() -> i32 {
-    // All types currently observe 8-byte alignment under the default layout.
-    if @align_of(i8) != 8 { return 1; }
+    if @align_of(i8) != 1 { return 1; }
     if @align_of(i64) != 8 { return 2; }
-    if @align_of(bool) != 8 { return 3; }
-    if @align_of(Point) != 8 { return 4; }
+    if @align_of(bool) != 1 { return 3; }
+    if @align_of(Point) != 4 { return 4; }
     0
 }
 """
@@ -545,7 +544,7 @@ fn main() -> i32 {
     @intCast(off)
 }
 """
-exit_code = 8
+exit_code = 4
 
 [[case]]
 name = "offset_of_returns_u64"
@@ -558,7 +557,7 @@ fn main() -> i32 {
     @intCast(off)
 }
 """
-exit_code = 8
+exit_code = 4
 
 [[case]]
 name = "offset_of_accounts_for_multislot_fields"
@@ -567,13 +566,13 @@ source = """
 struct Inner { x: i32, y: i32 }
 struct Outer { flag: bool, arr: [i32; 3], inner: Inner, last: i64 }
 fn main() -> i32 {
-    // flag: 1 slot -> arr at slot 1 (byte 8)
-    // arr: 3 slots -> inner at slot 4 (byte 32)
-    // inner: 2 slots -> last at slot 6 (byte 48)
+    // flag: bool@0 -> arr (align 4) at byte 4
+    // arr: [i32;3] size 12 -> inner (align 4) at byte 16
+    // inner: Inner size 8 -> last (i64, align 8) at byte 24
     if @offset_of(Outer, flag) != 0 { return 1; }
-    if @offset_of(Outer, arr) != 8 { return 2; }
-    if @offset_of(Outer, inner) != 32 { return 3; }
-    if @offset_of(Outer, last) != 48 { return 4; }
+    if @offset_of(Outer, arr) != 4 { return 2; }
+    if @offset_of(Outer, inner) != 16 { return 3; }
+    if @offset_of(Outer, last) != 24 { return 4; }
     0
 }
 """
@@ -590,7 +589,7 @@ fn main() -> i32 {
     @intCast(off)
 }
 """
-exit_code = 8
+exit_code = 4
 
 [[case]]
 name = "offset_of_non_struct_type_errors"
@@ -2198,7 +2197,7 @@ fn main() -> i32 {
     @size_of(Pair(i32)) + witness.first - 1
 }
 """
-exit_code = 16
+exit_code = 8
 
 [[case]]
 name = "align_of_pointer_type"
@@ -2224,7 +2223,7 @@ fn main() -> i32 {
     @align_of(Pair(i32)) + witness.first - 1
 }
 """
-exit_code = 8
+exit_code = 4
 
 [[case]]
 name = "offset_of_type_call"

--- a/crates/rue-spec/cases/lexical/builtins.toml
+++ b/crates/rue-spec/cases/lexical/builtins.toml
@@ -27,7 +27,7 @@ fn main() -> i32 {
     @size_of(i32)
 }
 """
-exit_code = 8
+exit_code = 4
 
 [[case]]
 name = "builtin_kinds_directive"

--- a/crates/rue-spec/cases/runtime/pointers.toml
+++ b/crates/rue-spec/cases/runtime/pointers.toml
@@ -28,6 +28,15 @@ exit_code = 42
 
 # =============================================================================
 # @raw with array element (the bug fix this was added for)
+#
+# These use a slot-identical element type (`i64`: one eight-byte slot per
+# element, so the compact image and the slot-shaped frame agree). Under the
+# default compact layout a raw pointer into a frame-resident NON-slot-identical
+# array (e.g. `[i32; 3]`, which packs to 4-byte strides while the frame stores
+# 8-byte slots) is refused loudly rather than silently mixing representations
+# (RUE-987 / RUE-1035 M2); that refusal is pinned in the CLI corpora. The `@raw`
+# and `@ptr_offset` semantics themselves are width-independent, so a
+# slot-identical array demonstrates them faithfully on the frame.
 # =============================================================================
 
 [[case]]
@@ -35,12 +44,12 @@ name = "raw_array_element"
 spec = ["9.2:1"]
 source = """
 fn main() -> i32 {
-    let arr: [i32; 3] = [10, 20, 30];
-    let first: i32 = checked {
-        let p: ptr const i32 = @raw(arr[0]);
+    let arr: [i64; 3] = [10, 20, 30];
+    let first: i64 = checked {
+        let p: ptr const i64 = @raw(arr[0]);
         @ptr_read(p)
     };
-    first
+    @intCast(first)
 }
 """
 exit_code = 10
@@ -50,12 +59,12 @@ name = "raw_array_second_element"
 spec = ["9.2:1"]
 source = """
 fn main() -> i32 {
-    let arr: [i32; 3] = [10, 20, 30];
-    let second: i32 = checked {
-        let p: ptr const i32 = @raw(arr[1]);
+    let arr: [i64; 3] = [10, 20, 30];
+    let second: i64 = checked {
+        let p: ptr const i64 = @raw(arr[1]);
         @ptr_read(p)
     };
-    second
+    @intCast(second)
 }
 """
 exit_code = 20
@@ -65,12 +74,12 @@ name = "raw_array_last_element"
 spec = ["9.2:1"]
 source = """
 fn main() -> i32 {
-    let arr: [i32; 3] = [10, 20, 30];
-    let third: i32 = checked {
-        let p: ptr const i32 = @raw(arr[2]);
+    let arr: [i64; 3] = [10, 20, 30];
+    let third: i64 = checked {
+        let p: ptr const i64 = @raw(arr[2]);
         @ptr_read(p)
     };
-    third
+    @intCast(third)
 }
 """
 exit_code = 30
@@ -118,12 +127,12 @@ name = "ptr_write_array_element"
 spec = ["9.2:1"]
 source = """
 fn main() -> i32 {
-    let mut arr: [i32; 3] = [10, 20, 30];
+    let mut arr: [i64; 3] = [10, 20, 30];
     checked {
-        let p: ptr mut i32 = @raw_mut(arr[1]);
+        let p: ptr mut i64 = @raw_mut(arr[1]);
         @ptr_write(p, 77);
     };
-    arr[1]
+    @intCast(arr[1])
 }
 """
 exit_code = 77
@@ -191,13 +200,14 @@ name = "ptr_offset_add_forward"
 spec = ["9.2:7"]
 source = """
 fn main() -> i32 {
-    let arr: [i32; 3] = [10, 20, 30];
-    checked {
-        let base: ptr const i32 = @raw(arr[0]);
-        let a: i32 = @ptr_read(@ptr_offset(base, 1));
-        let b: i32 = @ptr_read(@ptr_offset(base, 2));
+    let arr: [i64; 3] = [10, 20, 30];
+    let sum: i64 = checked {
+        let base: ptr const i64 = @raw(arr[0]);
+        let a: i64 = @ptr_read(@ptr_offset(base, 1));
+        let b: i64 = @ptr_read(@ptr_offset(base, 2));
         a + b
-    }
+    };
+    @intCast(sum)
 }
 """
 exit_code = 50  # 20 + 30
@@ -209,11 +219,12 @@ name = "ptr_offset_add_backward"
 spec = ["9.2:7"]
 source = """
 fn main() -> i32 {
-    let arr: [i32; 3] = [10, 20, 30];
-    checked {
-        let base: ptr const i32 = @raw(arr[2]);
+    let arr: [i64; 3] = [10, 20, 30];
+    let v: i64 = checked {
+        let base: ptr const i64 = @raw(arr[2]);
         @ptr_read(@ptr_offset(base, -1))
-    }
+    };
+    @intCast(v)
 }
 """
 exit_code = 20

--- a/crates/rue-spec/cases/types/structs.toml
+++ b/crates/rue-spec/cases/types/structs.toml
@@ -87,32 +87,32 @@ exit_code = 42
 # Layout is implementation-defined (3.6:7): @size_of/@align_of report the layout
 # the current implementation chose, they do not guarantee a value. The guarantee
 # tested here is that @size_of/@align_of are well-defined observations (3.6:8);
-# the specific numbers (8-byte slots, declaration order, no padding, 8-byte
-# alignment) are documented observations of the current layout (3.6:9/10/12),
-# not language guarantees.
+# the specific numbers (natural scalar widths, declaration order, natural
+# alignment with padding) are documented observations of the current compact
+# layout (3.6:9/10/12), not language guarantees.
 # =============================================================================
 
-# @size_of is a well-defined observation (3.6:8); the concrete 8-byte slot is
-# this implementation's documented choice (3.6:9).
+# @size_of is a well-defined observation (3.6:8); the concrete natural scalar
+# width is this implementation's documented choice (3.6:9).
 [[case]]
-name = "scalar_size_8_bytes"
+name = "scalar_size_i32"
 spec = ["3.6:8", "3.6:9"]
 source = """
 fn main() -> i32 {
     @size_of(i32)
 }
 """
-exit_code = 8
+exit_code = 4
 
 [[case]]
-name = "bool_size_8_bytes"
+name = "bool_size_one_byte"
 spec = ["3.6:8", "3.6:9"]
 source = """
 fn main() -> i32 {
     @size_of(bool)
 }
 """
-exit_code = 8
+exit_code = 1
 
 [[case]]
 name = "unit_size_zero"
@@ -124,7 +124,7 @@ fn main() -> i32 {
 """
 exit_code = 0
 
-# Declaration-order, 8-byte-slot layout is this implementation's documented
+# Declaration-order compact layout is this implementation's documented
 # observation (3.6:9), not a language guarantee.
 [[case]]
 name = "struct_fields_declaration_order"
@@ -132,25 +132,25 @@ spec = ["3.6:9"]
 source = """
 struct Point { x: i32, y: i32 }
 fn main() -> i32 {
-    // Current implementation: two fields, each in one 8-byte slot = 16 bytes.
+    // Current implementation: two i32 fields at their natural width = 8 bytes.
     @size_of(Point)
 }
 """
-exit_code = 16
+exit_code = 8
 
-# Size = sum of field sizes with no padding is a documented observation of the
-# current layout (3.6:10), not guaranteed.
+# Size packs fields at their natural alignment (here all i32, so no padding) is a
+# documented observation of the current layout (3.6:10), not guaranteed.
 [[case]]
 name = "struct_size_sum_of_fields"
 spec = ["3.6:10"]
 source = """
 struct Triple { a: i32, b: i32, c: i32 }
 fn main() -> i32 {
-    // Current implementation: three 8-byte slots = 24 bytes.
+    // Current implementation: three i32 fields = 12 bytes.
     @size_of(Triple)
 }
 """
-exit_code = 24
+exit_code = 12
 
 [[case]]
 name = "nested_struct_size"
@@ -159,16 +159,16 @@ source = """
 struct Point { x: i32, y: i32 }
 struct Line { start: Point, end: Point }
 fn main() -> i32 {
-    // Current implementation: two Points, each 16 bytes = 32 bytes.
+    // Current implementation: two Points, each 8 bytes = 16 bytes.
     @size_of(Line)
 }
 """
-exit_code = 32
+exit_code = 16
 
-# @align_of is a well-defined observation (3.6:8); the concrete 8-byte alignment
-# is this implementation's documented choice (3.6:12).
+# @align_of is a well-defined observation (3.6:8); a struct's concrete alignment
+# is its widest field's, this implementation's documented choice (3.6:12).
 [[case]]
-name = "struct_alignment_8_bytes"
+name = "struct_alignment_natural"
 spec = ["3.6:8", "3.6:12"]
 source = """
 struct Point { x: i32, y: i32 }
@@ -176,7 +176,7 @@ fn main() -> i32 {
     @align_of(Point)
 }
 """
-exit_code = 8
+exit_code = 4
 
 [[case]]
 name = "scalar_alignment_8_bytes"
@@ -259,11 +259,11 @@ source = """
 struct Empty {}
 struct Container { value: i32, marker: Empty }
 fn main() -> i32 {
-    // Empty field contributes 0 bytes, so size is just value's 8 bytes
+    // Empty field contributes 0 bytes, so size is just value's 4 bytes
     @size_of(Container)
 }
 """
-exit_code = 8
+exit_code = 4
 
 [[case]]
 name = "nested_empty_structs"

--- a/crates/rue-ui-tests/cases/diagnostics/directives.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/directives.toml
@@ -167,7 +167,7 @@ fn main() -> i32 {
     @size_of(i32)
 }
 """
-exit_code = 8
+exit_code = 4
 
 [[case]]
 name = "duplicate_comptime_modifier_rejected"

--- a/crates/rue-ui-tests/cases/diagnostics/type_too_large.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/type_too_large.toml
@@ -42,7 +42,7 @@ error_contains = ["[E0906]"]
 name = "large_but_legal_array_size_of_ok"
 source = """
 fn main() -> i32 {
-    if @size_of([i32; 1000]) == 8000 { 0 } else { 1 }
+    if @size_of([i32; 1000]) == 4000 { 0 } else { 1 }
 }
 """
 exit_code = 0

--- a/docs/notes/compact-layout-default.md
+++ b/docs/notes/compact-layout-default.md
@@ -1,0 +1,112 @@
+# Compact physical layout is now the default (ADR-0052)
+
+*2026-07-19. RUE-987. The compact native physical layout ratified in ADR-0052
+stops being a `--preview aggregate_layout` opt-in and becomes Rue's one and only
+memory representation. This is an observable change: `@size_of`, `@align_of`, and
+`@offset_of` now report smaller, natural values, and code that hardcoded the old
+eight-byte-slot layout breaks.*
+
+## What changed, observably
+
+Until now every materialized value used a flattened **eight-byte ABI slot**
+layout: every scalar occupied 8 bytes at 8-byte alignment, structs were packed
+one field per slot with no padding, arrays strode by 8 bytes per element, and
+every enum tag was a full 8-byte slot. That was always a placeholder. ADR-0052
+ratified the **compact native layout**, and RUE-987 makes it the default:
+
+- **Scalars take their natural LP64 width and alignment.** `@size_of(u8)` is now
+  `1` (was `8`); `@size_of(i16)` is `2`, `i32` is `4`, `i64`/`u64`/pointers stay
+  `8`. `@align_of` follows: `@align_of(i8)` is `1`, `@align_of(i32)` is `4`.
+- **Structs are laid out in declaration order at natural alignment, with
+  interior and tail padding.** `struct Padded { a: u8, b: i32, c: u8 }` is now
+  `12` bytes (was `24`): `a@0`, padding `[1,4)`, `b@4`, `c@8`, tail padding
+  `[9,12)`, alignment `4`. A struct's alignment is its widest field's.
+- **Arrays stride by the compact element size.** `[i32; 3]` is `12` bytes (was
+  `24`); `[u8; 4]` is `4` (was `32`).
+- **Enum tags narrow to the smallest sufficient unsigned integer** (`u8` for up
+  to 256 variants, then `u16`, then `u32`) and the payload is placed at the
+  maximum variant alignment. A discriminant-only enum is one byte.
+- **Zero-sized types** keep size `0`, alignment `1`, stride `0`.
+
+Padding bytes are deterministically zeroed on construction (ADR-0052 ruling 5),
+so a freshly built aggregate has no indeterminate bytes in its physical image.
+
+## The `@ptr_offset` u8 stride change
+
+A raw pointer to a narrow scalar now strides by that scalar's compact size.
+`@ptr_offset(p, 1)` on a `ptr mut u8` advances **one** byte, not eight; on a
+`ptr mut i16` it advances two, on a `ptr mut i32` four. Walking a heap
+`[u8; N]`/`[i16; N]`/`[i32; N]` buffer now uses the compact stride, and narrow
+loads/stores extend with the correct sign (signed integers sign-extend, `u8`,
+`bool`, and unsigned integers zero-extend). This is the same authority the
+compile-time queries report, so `@offset_of` + `@ptr_offset` navigation and a
+direct field access still agree.
+
+Note that this is the *physical* memory model. Rue's internal
+value-decomposition — the slot-shaped model that frames, vregs, and the call ABI
+use (ADR-0052 representation 2) — is unchanged; `@ptr_offset` over a pointer to a
+whole aggregate still strides by that aggregate's slot-shaped storage size, not
+its packed compact size.
+
+## What breaks
+
+**Any code that assumed the eight-byte-slot layout breaks.** Concretely:
+
+- Hardcoded byte offsets or sizes (`8`, `16`, `24`, …) computed by hand for
+  struct fields, array elements, or enum payloads are now wrong. Use
+  `@offset_of` / `@size_of` instead of literals.
+- Raw-pointer walks that advanced by a hardcoded 8 bytes per element now
+  over-stride narrow buffers. Use `@ptr_offset`, which strides correctly.
+- `@size_of` / `@align_of` / `@offset_of` return smaller values; any comparison
+  or arithmetic pinned to the old numbers must be re-golded.
+
+Programs that only used `@size_of` / `@offset_of` for navigation — never
+hardcoding the slot numbers — keep working unchanged; that was the point of
+exposing those intrinsics (RUE-288 / RUE-301). `StrBuf`, `str`/`Str(N)` views,
+and any aggregate built entirely from eight-byte leaves are *slot-identical*:
+their compact and slot layouts coincide, so they are byte-for-byte unaffected.
+
+## The `--preview aggregate_layout` flag is gone
+
+The preview feature is retired. `--preview aggregate_layout` is now a plain
+unknown-preview error listing the remaining features (`test_infra`, `slices`).
+There is nothing to opt into: the compact layout is simply how Rue lays out
+memory.
+
+## What did *not* change
+
+The layout *guarantees* are exactly as before (specification 3.6/4.13/9.2): a
+type's memory layout remains **implementation-defined**. `@size_of`,
+`@align_of`, and `@offset_of` are well-defined observations of the layout the
+implementation chose; the concrete numbers they report are documented
+observations, not language guarantees. RUE-987 changes those observed numbers
+from the slot values to the compact values; it does not add or remove any
+guarantee.
+
+## Heterogeneous enums marshal too
+
+An enum whose per-variant payloads disagree in layout — placing fields at
+conflicting byte offsets or widths, e.g. `Result(SockAddr, NetworkError)` — has
+no single variant-independent physical image, but it is **not** refused. Such an
+enum (and any array of, struct containing, or enum nesting one) marshals through
+a pointer and across a call by dispatching on its runtime tag and running the
+active variant's own slot→byte map (RUE-1037). A store zeroes the full image
+extent first, so bytes outside the active variant are deterministic with no
+residue after a variant overwrite. This is the shape that `std.net`'s
+`Result`-returning surface (`TcpListener.local_addr`) uses, and it now compiles
+and runs under the default layout.
+
+## The one remaining refusal: raw pointers into frame aggregates
+
+One construct is refused rather than laid out. Taking a raw pointer with
+`@raw` / `@raw_mut` / `@field_ptr` into a **frame-resident** non-slot-identical
+aggregate — or indexing such a frame array through a place — is refused with a
+construct-level diagnostic. The stack frame stores an aggregate slot-shaped (one
+eight-byte slot per leaf, the unchanged value-decomposition model, RUE-975),
+while `@ptr_read` / `@ptr_write` / `@ptr_offset` address memory by its packed
+compact image, so a raw pointer into a frame aggregate would stride across
+mismatched field and element layouts. Allocate the aggregate on the heap with
+`@alloc`, whose storage *is* the compact image, to round-trip it through a raw
+pointer. That refusal is about the construct, not about any preview flag; a
+slot-identical aggregate (all eight-byte leaves) is unaffected because its frame
+and compact images coincide.

--- a/docs/spec/src/03-types/06-struct-types.md
+++ b/docs/spec/src/03-types/06-struct-types.md
@@ -61,44 +61,33 @@ Whatever layout the implementation chooses, every value of a struct type satisfi
 - `@size_of(T)` and `@align_of(T)` are well-defined for every sized type `T` and report the size and alignment the implementation has chosen for `T`.
 - The size of a type is a multiple of its alignment.
 
-These are the only layout properties a portable program may rely on; the specific offsets, slot sizes, and paddings the current implementation happens to use (3.6:9, 3.6:10, 3.6:12) are documented observations, not part of this set.
+These are the only layout properties a portable program may rely on; the specific offsets, sizes, alignments, and paddings the current implementation happens to use (3.6:9, 3.6:10, 3.6:12) are documented observations, not part of this set.
 
 {{ rule(id="3.6:9", cat="informative") }}
 
-Under the current implementation, every non-zero-sized value occupies one or more 8-byte slots: each scalar type (`i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `bool`) occupies a single slot, and a struct's fields are placed in declaration order, each in the slots determined by its type, with no padding between or after them. This is a documented property of the current implementation (1.3:6), not a language guarantee.
+Under the current implementation, each scalar type uses its natural byte width and alignment (`i8`, `u8`, and `bool` are one byte; `i16`/`u16` two; `i32`/`u32` four; `i64`/`u64` and raw pointers eight), and a struct's fields are placed in declaration order, each at the lowest offset satisfying its alignment, with interior padding inserted where a field's alignment requires it. This is a documented property of the current implementation (1.3:6), not a language guarantee.
 
 {{ rule(id="3.6:10", cat="informative") }}
 
-It follows that, under the current implementation, the size of a struct is the sum of the sizes of all its fields, with no padding between fields or at the end (a zero-sized field contributes nothing). A future version that packed scalars or reordered fields would change this observation.
+It follows that, under the current implementation, a struct's size packs its fields at their natural alignment and is rounded up to the struct's own alignment, so it includes any interior and tail padding (a zero-sized field contributes nothing). A future version that reordered fields or chose a different packing would change this observation.
 
 {{ rule(id="3.6:10a", cat="informative") }}
 
-The ratified direction (ADR-0052) replaces the eight-byte slot model with a
-*compact* native layout, already selectable behind the `aggregate_layout`
-preview feature. Under it each scalar uses its natural byte width and alignment
-(for example `i32` is four bytes, four-aligned; `bool` is one byte), struct
-fields are placed in declaration order at offsets satisfying their alignment
-with explicit interior and tail padding, a type's size includes that tail
-padding and equals its array element stride (`stride == size`), enums use the
-smallest sufficient unsigned tag, and a zero-sized type has size `0`, alignment
-`1`, and stride `0`. This too is a documented observation, not a guarantee:
-whichever layout is in effect, only the properties of 3.6:8 are portable, and
-`@size_of`, `@align_of`, `@offset_of`, and `@field_ptr` continue to report the
-chosen layout so compiler-mediated code stays correct across the change.
+This is the *compact* native layout ratified by ADR-0052, the compiler's default. Under it a type's size includes tail padding and equals its array element stride (`stride == size`), enums use the smallest sufficient unsigned tag placed before a payload at the maximum variant alignment, and a zero-sized type has size `0`, alignment `1`, and stride `0`. This too is a documented observation, not a guarantee: only the properties of 3.6:8 are portable, and `@size_of`, `@align_of`, `@offset_of`, and `@field_ptr` continue to report the chosen layout so compiler-mediated code stays correct even if it changes again.
 
 {{ rule(id="3.6:11") }}
 
 ```rue
-// Under the current implementation, two i32 fields occupy 2 slots (16 bytes).
+// Under the current implementation, two i32 fields pack to 8 bytes.
 struct Point { x: i32, y: i32 }
 
-// A nested struct occupies the sum of all nested field slots: 4 slots (32 bytes).
+// A nested struct is the sum of its nested fields: two Points = 16 bytes.
 struct Line { start: Point, end: Point }
 ```
 
 {{ rule(id="3.6:12", cat="informative") }}
 
-Under the current implementation, a struct with one or more fields has 8-byte alignment, and an empty struct (a zero-sized type) has 1-byte alignment; `@align_of` observes these values. Like the sizes above, these are documented observations of the current layout, not language guarantees.
+Under the current implementation, a struct's alignment is that of its most-aligned field (a struct of `i32` fields is four-aligned), and an empty struct (a zero-sized type) has 1-byte alignment; `@align_of` observes these values. Like the sizes above, these are documented observations of the current layout, not language guarantees.
 
 {{ rule(id="3.6:13", cat="normative") }}
 

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -214,7 +214,7 @@ The value returned by `@size_of` is determined at compile time.
 
 ```rue
 fn main() -> i32 {
-    @size_of(i32)     // 8 (one 8-byte slot, observed under the current default layout)
+    @size_of(i32)     // 4 (i32's natural byte width, observed under the compact layout)
 }
 ```
 
@@ -224,9 +224,8 @@ fn main() -> i32 {
 struct Point { x: i32, y: i32 }
 
 fn main() -> i32 {
-    // 16 under the current default layout (two 8-byte slots); the ratified
-    // compact layout (ADR-0052) would observe 8 (two 4-byte i32 fields).
-    @size_of(Point)   // 16
+    // 8 under the compact layout (ADR-0052): two four-byte i32 fields, no padding.
+    @size_of(Point)   // 8
 }
 ```
 
@@ -252,19 +251,18 @@ The value returned by `@align_of` is determined at compile time.
 
 `@align_of(T)` reports the alignment the implementation has chosen for `T`
 under the layout in effect for the compilation (1.3:6, 3.6:12); it *observes*
-that choice and does not guarantee a particular value. Under the current
-default layout every type observes 8-byte alignment. The ratified compact
-layout (ADR-0052, previewed by the `aggregate_layout` feature) instead gives
-each scalar its natural alignment — `@align_of(i32)` would then observe `4` and
-`@align_of(bool)` `1` — so a portable program must not assume the value `8`.
-Whichever layout is in effect, the size of a type is always a multiple of its
-alignment (3.6:8).
+that choice and does not guarantee a particular value. Under the compact layout
+(ADR-0052) each scalar has its natural alignment — `@align_of(i32)` observes
+`4`, `@align_of(bool)` observes `1`, `@align_of(i64)` observes `8` — and a
+struct's alignment is that of its most-aligned field, so a portable program must
+not assume a particular value such as `8`. Whichever layout is in effect, the
+size of a type is always a multiple of its alignment (3.6:8).
 
 {{ rule(id="4.13:23") }}
 
 ```rue
 fn main() -> i32 {
-    @align_of(i32)    // 8 (observed under the current default layout)
+    @align_of(i32)    // 4 (i32's natural alignment, observed under the compact layout)
 }
 ```
 
@@ -290,8 +288,9 @@ The value returned by `@offset_of` is the offset the compiler assigns to the
 field under the layout it chooses for the struct, determined at compile time.
 Because the value comes from the compiler's own layout rather than a
 hand-computed constant, `@offset_of` remains correct even if the struct layout
-is implementation-defined. The offset of a field is the sum of the sizes of all
-preceding fields under the current layout (§3.6).
+is implementation-defined. Under the compact layout each field is placed at the
+lowest offset satisfying its alignment after the preceding fields, so an offset
+accounts for both the preceding fields' sizes and any alignment padding (§3.6).
 
 {{ rule(id="4.13:95", cat="legality-rule") }}
 
@@ -305,8 +304,8 @@ struct Mixed { a: i32, b: i64, c: bool }
 
 fn main() -> i32 {
     let off_a: u64 = @offset_of(Mixed, a);   // 0
-    let off_b: u64 = @offset_of(Mixed, b);   // 8  (observed under the current default layout)
-    let off_c: u64 = @offset_of(Mixed, c);   // 16 (observed under the current default layout)
+    let off_b: u64 = @offset_of(Mixed, b);   // 8  (i64 field at its eight-byte alignment)
+    let off_c: u64 = @offset_of(Mixed, c);   // 16 (bool after the i64)
     let sum: u64 = off_a + off_b + off_c;    // 24
     @intCast(sum)
 }

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -41,16 +41,23 @@ Syscall numbers and conventions differ between operating systems. Linux x86-64 s
 
 ```rue
 fn main() -> i32 {
-    let msg: [u8; 3] = [72, 73, 10]; // "HI\n"
     let write_num: u64 = 1;          // Linux x86-64: write
     let fd: u64 = 1;                 // stdout
     let exit_num: u64 = 231;         // Linux x86-64: exit_group
     let code: u64 = 0;
     checked {
+        // A syscall buffer must be a contiguous byte image; allocate it on the
+        // heap (@alloc storage is the compact image) rather than an @raw of a
+        // frame-resident byte array, whose storage is slot-shaped (§3.6, ADR-0040).
+        let msg: ptr mut u8 = @alloc(3); // "HI\n"
+        @ptr_write(msg, 72);
+        @ptr_write(@ptr_offset(msg, 1), 73);
+        @ptr_write(@ptr_offset(msg, 2), 10);
         // write(fd=1, buf, len)
-        let msg_ptr: u64 = @ptr_to_int(@raw(msg[0]));
+        let msg_ptr: u64 = @ptr_to_int(msg);
         let msg_len: u64 = 3;
         let result = @syscall(write_num, fd, msg_ptr, msg_len);
+        @free(msg, 3);
 
         // exit_group(code)
         @syscall(exit_num, code);
@@ -78,12 +85,16 @@ bounds of the pointed-to allocation is undefined behavior (see ADR-0028).
 
 ```rue
 fn main() -> i32 {
-    let arr: [i32; 3] = [10, 20, 30];
-    checked {
-        let base: ptr const i32 = @raw(arr[0]);
+    // A slot-identical element type (i64: one eight-byte slot per element) so a
+    // raw pointer into the frame-resident array is supported; a non-slot-identical
+    // frame array (e.g. [i32; 3]) is refused under the compact layout (§3.6, M2).
+    let arr: [i64; 3] = [10, 20, 30];
+    let v: i64 = checked {
+        let base: ptr const i64 = @raw(arr[0]);
         // base points at element 0; +1 advances to element 1 (value 20).
         @ptr_read(@ptr_offset(base, 1))
-    }
+    };
+    @intCast(v)
 }
 ```
 


### PR DESCRIPTION
## Summary

**The flip.** The ratified compact physical layout (ADR-0052) becomes Rue's default and the slot model is deleted. `@size_of(u8)` is 1; structs place declaration-order fields at naturally aligned offsets with interior/tail padding (stride == size); arrays stride at compact element size; enum tags take the smallest sufficient width; ZSTs are 0/1/0; `u8` pointers stride 1; padding is deterministically zeroed on construction. The internal value decomposition and slot-based frames are unchanged (the three-representation split survives); the preserved call convention marshals compact images indirectly where needed, including per-variant tag dispatch for heterogeneous enums.

- **Retired**: the `aggregate_layout` preview end-to-end — registry, gate plumbing, `compact_layout()` and every slot-model branch it guarded, dead bespoke byte instructions on both backends.
- **One intentional new contract**: `@raw`/`@raw_mut` of a non-slot-identical *frame* aggregate refuses with a construct-naming error pointing at `@alloc` — a silent representation mix becomes a loud error until frames go compact.
- **Sweep**: every `slot-model-default`-marked expectation re-golded to authority-derived compact values; `@raw`-frame slot cases converted to heap/slot-identical forms judged by what each still proves; obsolete refusal sentinels replaced by executing round-trips. Release note: `docs/notes/compact-layout-default.md`.

**Three-pass landing**: attempt one surfaced three latent miscompiles (fixed, RUE-1035 / #1834); attempt two surfaced the heterogeneous-enum gap (fixed, RUE-1037 / #1840); attempt three is fully green with no xfails and no std edits.

## Verification

cli 1644 (incl. `std_net_tcp`); spec 2153 with traceability 100%; ui 195; codegen 594; air 494; both oracle-diff audits at 0 disagreements; reproducibility and fmt gates green; full `test.sh` clean except the four known uid-0 environmental failures, both harness formats checked. Re-verified by execution at integration with **no flags**: layout values 1/12/4/8, the RUE-1035 repros (M1 deterministic ×5, M3 six drop values), the heterogeneous `Result` (42/−7), the byte family (42), and the ArrayBuf dogfood (3/20/30/2).

Fixes RUE-987

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_