### PR TITLE
RUE-1042: add byte literals (b'a') for readable u8 bytes

### DIFF
--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -90,6 +90,7 @@ impl ErrorCode {
     pub const UPPERCASE_BASE_PREFIX: Self = Self(6);
     pub const EMPTY_BASED_LITERAL: Self = Self(7);
     pub const INVALID_DIGIT_FOR_BASE: Self = Self(8);
+    pub const MALFORMED_BYTE_LITERAL: Self = Self(9);
 
     // ========================================================================
     // Parser errors (E0100-E0199)
@@ -1052,6 +1053,12 @@ pub enum ErrorKind {
     /// `0xG`). (RUE-177)
     #[error("invalid digit `{digit}` in {base} integer literal")]
     InvalidDigitForBase { digit: char, base: &'static str },
+    /// A malformed byte literal (`b'ab'`, `b''`, `b'\q'`, `b'é'`, an
+    /// unterminated `b'a`). Carries a specific, already-rendered reason built
+    /// by the lexer. Byte literals (`b'a'`) are readable `u8` spellings of a
+    /// single ASCII byte (RUE-1042).
+    #[error("{0}")]
+    MalformedByteLiteral(String),
 
     // Parser errors
     #[error("expected {expected}, found {found}")]
@@ -1622,6 +1629,7 @@ impl ErrorKind {
             ErrorKind::UnterminatedString => ErrorCode::UNTERMINATED_STRING,
             ErrorKind::UppercaseBasePrefix(_) => ErrorCode::UPPERCASE_BASE_PREFIX,
             ErrorKind::EmptyBasedLiteral { .. } => ErrorCode::EMPTY_BASED_LITERAL,
+            ErrorKind::MalformedByteLiteral(_) => ErrorCode::MALFORMED_BYTE_LITERAL,
             ErrorKind::InvalidDigitForBase { .. } => ErrorCode::INVALID_DIGIT_FOR_BASE,
 
             // Parser errors (E0100-E0199)

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -47,6 +47,9 @@ pub enum LexError {
         base: &'static str,
         offset: u32,
     },
+    /// A malformed byte literal (`b'ab'`, `b''`, `b'\q'`, non-ASCII `b'é'`, or
+    /// an unterminated `b'a`). Carries an already-rendered reason. (RUE-1042)
+    MalformedByteLiteral(String),
 }
 
 /// Process a string literal starting from an opening quote.
@@ -246,6 +249,116 @@ fn parse_based_literal(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Result<u64
     Ok(value)
 }
 
+/// Callback for byte literals `b'a'` (RUE-1042), triggered on the `b'` prefix.
+///
+/// A byte literal is a readable `u8` spelling of a single ASCII byte: `b'a'`
+/// lexes to exactly the integer literal `97`, so it flows through the parser
+/// and contextual integer typing like any other integer literal (it becomes a
+/// `u8` in a `u8` comparison, an `i64` where one is expected, etc.). This keeps
+/// the feature lexer-only: no new token, type, or inference rule.
+///
+/// The content is one of: a single printable ASCII character, or an escape
+/// from the same set the string lexer accepts (`\\ \" \n \t \r \0`) plus `\'`.
+/// Non-ASCII characters, an empty literal, more than one byte, an unknown
+/// escape, or a missing closing quote are rejected. On any error the token is
+/// bumped to cover the offending text (to the closing quote, or to
+/// end-of-line) so the lexer resyncs cleanly, mirroring the string path.
+fn process_byte_literal(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Result<u64, LexError> {
+    let rest = lex.remainder();
+    let mut chars = rest.char_indices();
+
+    // Parse the byte content, tracking how many bytes of `rest` it spans.
+    let (value, content_len) = match chars.next() {
+        None => {
+            return Err(LexError::MalformedByteLiteral(
+                "unterminated byte literal: expected a byte then a closing `'`".to_string(),
+            ));
+        }
+        Some((_, '\'')) => {
+            lex.bump(1);
+            return Err(LexError::MalformedByteLiteral(
+                "empty byte literal `b''`: a byte literal must contain exactly one byte"
+                    .to_string(),
+            ));
+        }
+        Some((_, '\n')) | Some((_, '\r')) => {
+            return Err(LexError::MalformedByteLiteral(
+                "unterminated byte literal (line ended before the closing `'`)".to_string(),
+            ));
+        }
+        Some((_, '\\')) => match chars.next() {
+            None => {
+                lex.bump(1);
+                return Err(LexError::MalformedByteLiteral(
+                    "unterminated escape in byte literal".to_string(),
+                ));
+            }
+            Some((_, escape)) => {
+                let byte = match escape {
+                    '\\' => b'\\',
+                    '\'' => b'\'',
+                    '"' => b'"',
+                    'n' => b'\n',
+                    't' => b'\t',
+                    'r' => b'\r',
+                    '0' => 0,
+                    other => {
+                        lex.bump(1 + other.len_utf8());
+                        return Err(LexError::MalformedByteLiteral(format!(
+                            "unknown escape `\\{}` in byte literal",
+                            other.escape_debug()
+                        )));
+                    }
+                };
+                (u64::from(byte), 1 + escape.len_utf8())
+            }
+        },
+        Some((_, c)) => {
+            if !c.is_ascii() {
+                lex.bump(c.len_utf8());
+                return Err(LexError::MalformedByteLiteral(format!(
+                    "byte literal must be a single ASCII byte, found `{}`",
+                    c.escape_debug()
+                )));
+            }
+            (u64::from(c as u8), 1)
+        }
+    };
+
+    // Expect the closing quote immediately after the single byte's content.
+    match rest[content_len..].chars().next() {
+        Some('\'') => {
+            lex.bump(content_len + 1);
+            Ok(value)
+        }
+        Some(_) => {
+            // More than one byte before the quote (`b'ab'`). Resync to the
+            // closing quote if there is one on this line, else to line end.
+            let tail = &rest[content_len..];
+            let stop = tail
+                .find(['\'', '\n', '\r'])
+                .map(|i| {
+                    if tail.as_bytes()[i] == b'\'' {
+                        i + 1
+                    } else {
+                        i
+                    }
+                })
+                .unwrap_or(tail.len());
+            lex.bump(content_len + stop);
+            Err(LexError::MalformedByteLiteral(
+                "a byte literal must contain exactly one byte".to_string(),
+            ))
+        }
+        None => {
+            lex.bump(content_len);
+            Err(LexError::MalformedByteLiteral(
+                "unterminated byte literal (missing closing `'`)".to_string(),
+            ))
+        }
+    }
+}
+
 /// Token kinds in the Rue language, using logos derive macro.
 #[derive(Logos, Debug, Clone, PartialEq, Eq)]
 #[logos(error = LexError)]
@@ -366,6 +479,9 @@ pub enum LogosTokenKind {
     // (RUE-133, RUE-177)
     #[regex(r"[0-9][0-9_]*", parse_decimal_literal)]
     #[regex(r"0[xXbBoO][0-9a-zA-Z_]*", parse_based_literal)]
+    // Byte literals `b'a'` are `u8` spellings of a single ASCII byte and lex to
+    // the same untyped integer literal as the byte's decimal code (RUE-1042).
+    #[token("b'", process_byte_literal)]
     Int(u64),
 
     // String literals - match opening quote and process content manually
@@ -688,6 +804,14 @@ impl<'a> LogosLexer<'a> {
                                 ),
                                 LexError::EmptyBasedLiteral { base } => (
                                     ErrorKind::EmptyBasedLiteral { base },
+                                    Span::with_file(
+                                        self.file_id,
+                                        span.start as u32,
+                                        span.end as u32,
+                                    ),
+                                ),
+                                LexError::MalformedByteLiteral(message) => (
+                                    ErrorKind::MalformedByteLiteral(message),
                                     Span::with_file(
                                         self.file_id,
                                         span.start as u32,
@@ -1169,6 +1293,58 @@ mod tests {
         // `_1` is an identifier, not an integer literal (RUE-177).
         let (tokens, interner) = LogosLexer::new("_1").tokenize().unwrap();
         assert_eq!(get_ident_str(&tokens[0].kind, &interner), Some("_1"));
+    }
+
+    #[test]
+    fn test_byte_literal_values() {
+        // RUE-1042: `b'a'` lexes to the same integer literal as the byte's
+        // decimal code — a readable u8 spelling.
+        assert_eq!(lex_int("b'a'"), 97);
+        assert_eq!(lex_int("b'A'"), 65);
+        assert_eq!(lex_int("b'0'"), 48);
+        assert_eq!(lex_int("b' '"), 32);
+        assert_eq!(lex_int("b'~'"), 126);
+        // A double-quote needs no escape inside a byte literal.
+        assert_eq!(lex_int("b'\"'"), 34);
+        // Escapes: same set as strings, plus `\'`.
+        assert_eq!(lex_int(r"b'\n'"), 10);
+        assert_eq!(lex_int(r"b'\t'"), 9);
+        assert_eq!(lex_int(r"b'\r'"), 13);
+        assert_eq!(lex_int(r"b'\0'"), 0);
+        assert_eq!(lex_int(r"b'\\'"), 92);
+        assert_eq!(lex_int(r"b'\''"), 39);
+    }
+
+    #[test]
+    fn test_byte_literal_bare_b_is_still_an_identifier() {
+        // The `b'` rule must not steal a bare `b` identifier or a `b`-prefixed
+        // name — only `b` immediately followed by `'` is a byte literal.
+        let (tokens, interner) = LogosLexer::new("b").tokenize().unwrap();
+        assert_eq!(get_ident_str(&tokens[0].kind, &interner), Some("b"));
+        let (tokens, interner) = LogosLexer::new("byte").tokenize().unwrap();
+        assert_eq!(get_ident_str(&tokens[0].kind, &interner), Some("byte"));
+        // `b + 1`: identifier, operator, integer — not a byte literal.
+        let (tokens, _) = LogosLexer::new("b + 1").tokenize().unwrap();
+        assert!(matches!(tokens[0].kind, TokenKind::Ident(_)));
+        assert!(matches!(tokens[2].kind, TokenKind::Int(1)));
+    }
+
+    #[test]
+    fn test_byte_literal_errors() {
+        for src in [
+            "b''",    // empty
+            "b'ab'",  // more than one byte
+            "b'a",    // unterminated (missing close)
+            r"b'\q'", // unknown escape
+            "b'é'",   // non-ASCII
+        ] {
+            let err = LogosLexer::new(src).tokenize().unwrap_err();
+            assert!(
+                matches!(err.kind, ErrorKind::MalformedByteLiteral(_)),
+                "expected MalformedByteLiteral for {src:?}, got {:?}",
+                err.kind
+            );
+        }
     }
 
     #[test]

--- a/crates/rue-spec/cases/lexical/tokens.toml
+++ b/crates/rue-spec/cases/lexical/tokens.toml
@@ -167,6 +167,56 @@ source = "fn main() -> i32 { 0B101 }"
 compile_fail = true
 error_contains = "base prefixes are lowercase"
 
+# Byte literals (RUE-1042): `b'a'` is a readable u8 spelling of an ASCII byte
+# and lexes to the same integer literal as the byte's decimal code.
+[[case]]
+name = "byte_literal_ascii_value"
+spec = ["2.1:26"]
+source = "fn main() -> i32 { b'*' }"
+exit_code = 42
+
+[[case]]
+name = "byte_literal_types_as_u8_in_context"
+spec = ["2.1:26", "2.1:4"]
+source = """
+fn is_digit(c: u8) -> bool { c >= b'0' && c <= b'9' }
+fn main() -> i32 { if is_digit(b'7') { 0 } else { 1 } }
+"""
+exit_code = 0
+
+[[case]]
+name = "byte_literal_newline_escape"
+spec = ["2.1:26"]
+source = "fn main() -> i32 { let n: u8 = b'\\n'; @dbg(n); 0 }"
+exit_code = 0
+
+[[case]]
+name = "byte_literal_quote_escape"
+spec = ["2.1:26"]
+source = "fn main() -> i32 { b'\\'' }"
+exit_code = 39
+
+[[case]]
+name = "byte_literal_empty_error"
+spec = ["2.1:27"]
+source = "fn main() -> i32 { b'' }"
+compile_fail = true
+error_contains = "a byte literal must contain exactly one byte"
+
+[[case]]
+name = "byte_literal_multiple_bytes_error"
+spec = ["2.1:27"]
+source = "fn main() -> i32 { b'ab' }"
+compile_fail = true
+error_contains = "a byte literal must contain exactly one byte"
+
+[[case]]
+name = "byte_literal_unknown_escape_error"
+spec = ["2.1:27"]
+source = "fn main() -> i32 { b'\\q' }"
+compile_fail = true
+error_contains = "unknown escape"
+
 # =============================================================================
 # StrBuf Literals (syntax and legality)
 # =============================================================================

--- a/docs/spec/src/02-lexical-structure/01-tokens.md
+++ b/docs/spec/src/02-lexical-structure/01-tokens.md
@@ -21,6 +21,7 @@ Rue tokens fall into the following categories:
 | Keywords | `fn`, `let`, `mut`, `if`, `else`, `while`, `match`, `return`, `break`, `continue`, `true`, `false` |
 | Identifiers | `main`, `x`, `my_var`, `_unused` |
 | Integer literals | `0`, `42`, `1_000_000`, `0xFF`, `0o17`, `0b1010` |
+| Byte literals | `b'a'`, `b'0'`, `b'\n'`, `b'\''` |
 | String literals | `"hello"`, `"world"`, `"with \"escapes\""` |
 | Operators | `+`, `-`, `*`, `/`, `%`, `==`, `!=`, `<`, `>`, `<=`, `>=`, `&&`, `\|\|`, `!`, `&`, `\|`, `^`, `~`, `<<`, `>>` |
 | Delimiters | `(`, `)`, `{`, `}`, `[`, `]`, `,`, `;`, `:`, `->`, `=>` |
@@ -75,6 +76,35 @@ fn main() -> i32 {
     0x_FF_       // underscores legal after the prefix and trailing
     0o17         // octal, value 15
     0b1010       // binary, value 10
+}
+```
+
+## Byte Literals
+
+{{ rule(id="2.1:26", cat="normative") }}
+
+A byte literal is written `b'c'`, where `c` is a single ASCII character (other than `'` or `\`) or an escape sequence, and denotes the integer value of that byte (0–255). A byte literal *is* an integer literal: the integer-literal typing and representability rules (2.1:4) apply, so `b'a'` and `97` are interchangeable and a byte literal is typically written where a `u8` is expected. Byte literals accept the string-literal escape sequences (2.1:7) and additionally `\'` (a single quote).
+
+```ebnf
+byte_literal = "b'" ( byte_char | escape_sequence | "\'" ) "'" ;
+byte_char = ? any ASCII character except "'" or "\" ? ;
+```
+
+{{ rule(id="2.1:27", cat="legality-rule") }}
+
+A byte literal that is empty (`b''`), contains more than one byte, contains a non-ASCII character, uses an unknown escape sequence, or is unterminated (reaching end-of-file or end-of-line before the closing `'`) is a compile-time error.
+
+{{ rule(id="2.1:28") }}
+
+```rue
+fn is_digit(c: u8) -> bool {
+    c >= b'0' && c <= b'9'   // b'0' is 48, b'9' is 57
+}
+
+fn main() -> i32 {
+    let newline: u8 = b'\n';   // 10
+    let quote: u8 = b'\'';     // 39
+    0
 }
 ```
 


### PR DESCRIPTION
## Summary

Rue lexers/parsers (`examples/rill`, `ruelex`, `calculator`) are walls of raw
ASCII decimal codes — `b == 34` for a quote, `push(10)` for a newline — because
there was no character/byte literal syntax (RUE-1042). This is the same
Rust-parity "pothole, not a highway" class as the accepted RUE-177 (hex/octal/
binary integer literals).

## Approach — lexer-only

Add **byte literals** `b'a'`: a readable `u8` spelling of a single ASCII byte.
The key design choice keeps this tiny: **`b'a'` lexes to exactly the integer
literal `97`**, so it flows through the parser and contextual integer typing
like any other integer literal — it becomes `u8` in a `u8` comparison, `i64`
where one is expected, etc. No new token kind, no new type, no new inference
rule; the entire change is in the lexer plus one error kind.

Content is one ASCII character or an escape from the string set
(`\\ \" \n \t \r \0`) plus `\'`. Empty (`b''`), multi-byte (`b'ab'`), non-ASCII
(`b'é'`), unknown-escape (`b'\q'`), and unterminated (`b'a`) literals are
rejected with a new `E0009` diagnostic. `b` followed by anything other than `'`
is still an ordinary identifier.

### Deliberately out of scope
- A **`char` literal** (`'a'` without the `b`) — that needs a `char` type, which
  is a design decision. `b'a'` alone removes the bulk of the friction since Rue
  string bytes are already `u8`.
- **`\xNN`** byte escapes — a clean follow-up; the printable-ASCII + control
  escapes here cover the readability cases.

Consistent with RUE-177, no preview gate (a complete lexical addition).

## Testing

- Lexer unit tests: values, all escapes, `b`/`byte`/`b + 1` stay identifiers,
  and the five error cases.
- Spec §2.1 gains a "Byte Literals" section (rules 2.1:23–25) with citing spec
  cases; full spec suite green (2145 passed) including traceability.
- `rue-error` (103) and `rue-lexer` (51) suites green.
- End-to-end: a `fn is_digit(c: u8) -> bool { c >= b'0' && c <= b'9' }`
  classifier compiles and runs; `b'\n'` prints `10`; `b'ab'` errors with
  `E0009: a byte literal must contain exactly one byte`.

Fixes RUE-1042


---
_Generated by [Claude Code](https://claude.ai/code/session_016y4YDUmk7Gcbo1nKaXiXFR)_