### PR TITLE
test-runner/spec: skip permission-bit tests when mode bits are not enforced

### DIFF
--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -894,6 +894,13 @@ params = [{ kind = "expanded", spec_extra = ["1.1:2"] }]
         let spec = spec_dir.path().join("unreadable.md");
         fs::write(&spec, "{{ rule(id=\"1.1:1\") }}\nRule.").unwrap();
         fs::set_permissions(&spec, fs::Permissions::from_mode(0o000)).unwrap();
+        if fs::read(&spec).is_ok() {
+            // Mode bits are not enforced for this user (root / CAP_DAC_OVERRIDE),
+            // so the unreadable-file premise is vacuous here. Skip, don't fail.
+            fs::set_permissions(&spec, fs::Permissions::from_mode(0o600)).unwrap();
+            eprintln!("skipped: permission bits not enforced for this user");
+            return;
+        }
         let cases_dir = tempfile::tempdir().unwrap();
         let result = generate_report(spec_dir.path(), cases_dir.path());
         fs::set_permissions(&spec, fs::Permissions::from_mode(0o600)).unwrap();

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -2584,6 +2584,13 @@ exit_code = 0
         let root = directory.path().join("root");
         fs::create_dir(&root).unwrap();
         fs::set_permissions(&root, fs::Permissions::from_mode(0o000)).unwrap();
+        if fs::read_dir(&root).is_ok() {
+            // Mode bits are not enforced for this user (root / CAP_DAC_OVERRIDE),
+            // so the unreadable-directory premise is vacuous here. Skip, don't fail.
+            fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
+            eprintln!("skipped: permission bits not enforced for this user");
+            return;
+        }
         let result = discover_files(&root, "toml");
         fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
         assert!(result.is_err());
@@ -2610,6 +2617,13 @@ exit_code = 0
         fs::create_dir(&unreadable).unwrap();
         fs::write(unreadable.join("hidden.toml"), VALID_TEST_FILE).unwrap();
         fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
+        if fs::read_dir(&unreadable).is_ok() {
+            // Mode bits are not enforced for this user (root / CAP_DAC_OVERRIDE),
+            // so the unreadable-subdirectory premise is vacuous here. Skip.
+            fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o700)).unwrap();
+            eprintln!("skipped: permission bits not enforced for this user");
+            return;
+        }
         let result = discover_files(directory.path(), "toml");
         fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o700)).unwrap();
         assert!(result.is_err());
@@ -2624,6 +2638,13 @@ exit_code = 0
         let unreadable = directory.path().join("unreadable.toml");
         fs::write(&unreadable, VALID_TEST_FILE).unwrap();
         fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
+        if fs::read(&unreadable).is_ok() {
+            // Mode bits are not enforced for this user (root / CAP_DAC_OVERRIDE),
+            // so the unreadable-file premise is vacuous here. Skip, don't fail.
+            fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o600)).unwrap();
+            eprintln!("skipped: permission bits not enforced for this user");
+            return;
+        }
         let result = load_test_files(directory.path());
         fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o600)).unwrap();
         assert!(result.is_err());


### PR DESCRIPTION
## Summary

The four `unreadable_*` tests chmod a fixture to `0o000` and assert access fails — vacuous for root/CAP_DAC_OVERRIDE, so privileged containers saw four false failures in every otherwise-green run, training agents and humans alike to read "exit 32" as "probably fine" (which hid one real failure during the layout campaign).

Each test now **probes whether the chmod actually denies access** and skips with a message when it doesn't, restoring permissions on the way out. Assertions are unchanged wherever mode bits are enforced — normal development and CI keep the full guarantee. A capability probe rather than a `geteuid()` check, so fakeroot and capability-granted environments are handled correctly too.

## Verification

As root: both crates pass (`rue-test-runner` 91, `rue-spec` traceability 16) — previously the only failures in green runs. The denial path remains exercised for unprivileged users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_