### PR TITLE
ADR-0064: C FFI — proposal

### DIFF
--- a/docs/designs/0064-c-ffi.md
+++ b/docs/designs/0064-c-ffi.md
@@ -1,0 +1,426 @@
+---
+id: 0064
+title: "C FFI: a guaranteed target-C boundary for imports and exports"
+status: proposal
+tags: [ffi, abi, codegen, linker, types, semantics, unsafe, interop]
+feature-flag: c_ffi
+created: 2026-07-19
+accepted:
+implemented:
+spec-sections: []
+superseded-by:
+relates: ["RUE-742", "RUE-745", "RUE-714", "RUE-738", "RUE-987", "ADR-0052", "ADR-0028", "ADR-0038", "ADR-0005", "ADR-0035", "ADR-0043", "ADR-0055"]
+---
+
+# ADR-0064: C FFI — a guaranteed target-C boundary
+
+## Status
+
+Proposed. This record operationalizes the RUE-738 conformance audit
+(`docs/notes/ffi-abi-conformance-audit.md`) and the "guaranteed target C layout
+and C ABI" future-work item ADR-0052 reserves to RUE-742 / RUE-745. It supersedes
+nothing; it fills the `CallAbi` seam ADR-0052 built and left with a single
+`Native` variant.
+
+The maintainer accepts or amends. The three rulings in
+[Open questions for acceptance](#open-questions-for-acceptance) each carry a
+recommendation; none is settled until ratified. Do not begin phase work past P0
+before then — this is an ADR-gated design under AGENTS.md and ADR-0005.
+
+## Summary
+
+Rue will grow a **guaranteed target-C calling convention and a foreign-declaration
+surface** so Rue code can call C functions and expose Rue functions to C callers,
+starting with the smallest end-to-end path: a header-less `extern fn`
+declaration, a `CallAbi::TargetC` classifier that implements SysV AMD64 and
+AAPCS64 for scalars and pointers, and **static-archive linking**, which the
+internal linker's existing undefined-symbol resolution already supports. The v0
+surface is deliberately narrow: **integer and pointer scalars and C-classifiable
+structs cross; enums, floats, and variadics do not.** Foreign calls are
+**unchecked-context-only**, and a Rue export that would trap **aborts at the
+boundary rather than unwinding into C**. Floating-point interop is sequenced
+behind RUE-714 (which the type system does not yet have) as a distinct later
+phase, so the integer/pointer core can land first. The whole surface lives behind
+the `c_ffi` preview gate until every phase is proven and a single stabilization
+checklist (a RUE-987-style tracker) is filed at acceptance.
+
+## Context
+
+### Physical layout already matches C; the *call* surface does not
+
+Compact layout is Rue's sole memory representation (ADR-0052 / RUE-987,
+`docs/notes/compact-layout-default.md`). A struct of scalar and pointer fields is
+laid out in declaration order at natural alignment with interior and tail padding
+— byte-for-byte the SysV/AAPCS aggregate rule — so `@size_of` / `@offset_of`
+already equal a C compiler's for those types, arrays stride by the C element
+size, and pointers are 8-byte LP64. **Physical-layout parity is necessary but not
+sufficient.** The conformance note is emphatic that native values are still not a
+C *call* surface: the native call planner flattens a value into logical 8-byte
+slots and **reverses a multi-slot value's slots** before assigning locations, so
+"even an aggregate small enough to remain in registers is not passed like the
+corresponding C struct." A worker must not read "struct layout now matches C" as
+"P3 is free."
+
+### The `CallAbi` seam exists and is unfilled
+
+`crates/rue-air/src/call_abi.rs` is the ADR-0052 extensibility seam; its doc
+comment reserves it for "the guaranteed target C ABI (RUE-742 / RUE-745, SysV /
+AAPCS)," and `enum CallAbi { Native }` is the only variant today. The native
+classifier decides register-vs-sret purely by *flattened slot count vs
+return-register budget* (`return_uses_sret`: `slot_count > ret_reg_budget`). It
+has **one register file and no INTEGER/SSE distinction**, no eightbyte
+classification, no byval stack args, no `rax`/`x8` sret echo, and only an ad-hoc
+i8/u8 extension for debug helpers. A target-C classifier is the *content* of this
+ADR's middle phases, not a blocker to be closed before them. RUE-742/745 are
+those phases; **RUE-714 (floats) is the one genuine external hard dependency.**
+
+### Floats are absent from the type system entirely
+
+`TypeKind` has no `F32`/`F64` (`crates/rue-air/src/types.rs`), no XMM/SSE on
+x86-64 and no V-registers on AArch64 anywhere in codegen; the conformance note
+confirms "Vector registers are currently unused." Any C signature using
+`float`/`double` is unreachable until RUE-714 lands the type, its IEEE-754
+codegen, and the FP register class. This is the single largest structural gap and
+the primary scoping lever.
+
+### No `extern`, but the linker already pulls from archives
+
+Grepping `crates/rue-lexer` and `crates/rue-parser` for `extern` returns nothing:
+there is no keyword, token, or parse path. The declaration surface must be built
+lexer→parser→RIR→sema→AIR from scratch; the `@`-intrinsic pattern (`@syscall`,
+`@ptr_read`, analyzed in `crates/rue-air/src/sema/analysis/pointers.rs`) is the
+idiom template. But the *linking* half is substantially present: the internal
+linker resolves undefined symbols from `ar` archives with an iterative rescan
+("pulling one member can expose new undefined symbols",
+`crates/rue-linker/src/linker.rs:823-921`) and already applies the relocations a C
+call needs — `R_X86_64_PLT32` (treated as PC32 for static linking), `GOTPCREL`,
+`PC32`, `ABS64`, and the AArch64 `CALL26`/`ADRP`/`ADD_LO12`/`LDST*_LO12` family
+(`crates/rue-linker/src/elf.rs`). The runtime itself is linked as an archive
+through this path on every build. **Emitting a call to an undefined external
+symbol and resolving it from a `.a` already works end-to-end**; what is missing is
+a *declaration to emit the undefined reference from*. The linker emits a
+statically-linked `ET_EXEC` only — `ET_DYN` is a defined constant that is never
+emitted, and there is no `PT_INTERP`, `PT_DYNAMIC`, dynamic symbol table, or
+PLT/GOT synthesis. Dynamic linking is therefore a separable, larger workstream.
+
+### `@syscall` is a zero-cost interim proof on Linux
+
+`@syscall(num, a0..a5) -> i64` is implemented and analyzed
+(`pointers.rs:1058`), and the runtime uses raw syscalls on all three targets. On
+Linux, `write`/`getpid` are already reachable with no FFI at all. This is the
+free smoke test that de-risks P1 before the archive path exists, and the honest
+interim answer for "I just need one syscall." (macOS uses a non-1:1 syscall path;
+libc is the macOS story.)
+
+## Goals
+
+- A header-less `extern fn` import declaration resolving to an undefined linker
+  symbol, satisfied from a static archive.
+- A `CallAbi::TargetC` classifier implementing SysV AMD64 and AAPCS64 for the
+  supported representations, sharing the existing seam rather than embedding a
+  peer FFI calculator in a backend.
+- Rue-to-C **export thunks** so a separately compiled C caller can invoke an
+  exported Rue function.
+- Execution-verified conformance per the layout-campaign standard: every phase
+  produces a compiled, independently linked, run probe checked for exact output,
+  extending the `cli.abi_conformance` harness with C-caller and C-callee probes.
+- A written safety, panic/trap, and provenance contract for the boundary.
+
+## Non-goals (v0)
+
+- **Floats/vectors** until RUE-714 (own phase, P5).
+- **Rue tagged enums as an FFI type** (see ruling 2); a `cenum`/`repr(C)`
+  attribute is future work.
+- **Variadic C calls**: rejected with a diagnostic in v0 (P6), not implemented.
+- **Dynamic linking** against `libc.so`: a stretch (P7) with its own future ADR.
+- **Header/bindgen ingestion**: declarations are manual in v0.
+- **Automatic string marshaling / lifetime tracking** across the boundary:
+  `StrBuf`↔`char*` is an explicit manual contract, not an automatic conversion.
+
+## Design
+
+### The `extern` declaration surface
+
+The minimal viable import is a **header-less manual declaration** naming a C
+symbol and a target-C signature, lowered to an undefined linker symbol. Two
+spellings were considered.
+
+**Chosen — `extern` block with an ABI string**, following Rue's existing
+declaration idioms and Rust/Zig precedent:
+
+```rue
+extern "C" {
+    fn getpid() -> i32;
+    fn write(fd: i32, buf: ptr const u8, count: u64) -> i64;
+}
+```
+
+The ABI string is a first-class part of the grammar (`"C"` is the only accepted
+value in v0; the slot reserves room for later `"C-unwind"` or platform variants
+without a re-spelling). A block groups declarations that share an ABI and a
+future `link_name`/library attribute, and it reads as a boundary — everything
+inside is foreign. A symbol-rename escape (`fn puts(...) = "c_puts";` shape, exact
+syntax deferred to P1) covers the case where the Rue identifier and the C symbol
+differ.
+
+**Alternative considered — per-function attribute** (`@extern("C", "getpid") fn
+getpid(...) -> i32;`). This is closer to the existing `@`-intrinsic surface and
+would be the fastest thing to bolt on, but it puts the ABI on every declaration
+rather than on the boundary, has no natural home for a shared library/link
+attribute, and does not scale to a block of related imports. It remains a
+reasonable P1-only bootstrap if the block grammar proves too large for the first
+landable slice; the AIR representation is identical either way, so this is a
+front-end-only choice that does not fork the seam.
+
+Both lower to the same AIR: a foreign function entity with a C symbol name, a
+target-C signature, a body that is *undefined* (no CFG), and codegen that emits an
+undefined external symbol reference for the linker to resolve. The feature is
+gated by `require_preview(PreviewFeature::CFfi)` in sema (AGENTS.md language-change
+layering: spec/grammar, lexer/parser, RIR, sema/AIR with `require_preview`,
+codegen, then spec/UI/CLI coverage).
+
+**Safety.** Foreign calls are **unchecked-only**, permitted only inside a
+`checked {}` block, exactly as `@syscall` "Requires a checked block" today
+(ADR-0028). No borrow, exclusivity, or lifetime guarantee crosses the boundary;
+pointer provenance at the boundary is documented as unchecked (ruling 3).
+
+### `CallAbi::TargetC` — extending the seam
+
+Add a `TargetC` variant to `CallAbi` and a `TargetCCallAbi` classifier beside
+`NativeCallAbi`, sharing `ReturnClass`/`ArgClass`/`ArgConvention`. It implements
+what Native structurally cannot:
+
+- **SysV eightbyte classification.** Recursively classify each eightbyte of an
+  aggregate as INTEGER vs SSE; INTEGER→GP registers, SSE→XMM. In the integer-only
+  core every eightbyte is INTEGER, but the classifier is written eightbyte-wise
+  from the start so P5 extends it rather than rewrites it.
+- **Small-aggregate register packing by eightbyte.** C packs two scalar fields
+  into one eightbyte register; the native slot model passes one slot per leaf and
+  *reverses* them. `TargetC` must pack in C order — the two models disagree even
+  for a 2-field struct, so this cannot reuse the native path.
+- **byval memory arguments.** C stack args (marked "Not implemented" in the note's
+  matrix) including Apple's packed stack-area amendment, once register budget is
+  exhausted.
+- **sret register + echo.** SysV passes the hidden sret pointer in `rdi` and
+  **requires the callee to echo it in `rax`**; AAPCS64 uses the dedicated `x8`.
+  Native promises neither. `TargetC` implements both echoes.
+- **General narrow-integer extension.** SysV/Apple require sub-32-bit args
+  extended (signed→sign-extend, `bool`/unsigned→zero-extend) at *every* import and
+  export boundary — a general rule replacing the ad-hoc debug-helper extension.
+- **`_Bool` 1-byte boundary.** The runtime ABI's canonical boolean is a 64-bit
+  word (`AbiType::BoolWordI64`), but C `_Bool` is one byte with a 0/1 contract;
+  the boundary narrows/extends explicitly (see ruling secondary A).
+
+Preserved machine state already conforms on both backends (16-byte call
+alignment, all used callee-saved registers saved, no red zone, AArch64 platform
+`x18` and veneer `x16`/`x17` avoided) — the one B-item that is already C-correct,
+so no work there.
+
+### Linking: static archive first
+
+The recommended first target is a **static archive** (`libc.a`, a Rust
+`staticlib` `.a`, or a hand-written `.a`). The linker's undefined-symbol rescan
+already handles member pull-in and the required relocations, so the only new work
+is emitting the undefined reference from the P1 declaration plus narrow-arg
+extension. `@syscall` is the zero-cost interim proof point that predates even that.
+**Dynamic linking** (`PT_INTERP`, dynamic symtab, PLT/GOT synthesis) is a large,
+separable linker workstream (P7) deferred to its own future ADR and pursued only
+if static archives prove insufficient.
+
+### Rue-to-C export thunks
+
+Exporting an arbitrary Rue function to C needs a **C-ABI callee thunk**: a
+prologue that accepts C-classified arguments and adapts them to the internal slot
+form, and an epilogue that produces a C-classified return including the
+`rax`/`x8` sret echo. The runtime's zero-argument entry into Rue `main` is *not*
+evidence this works for an arbitrary function (conformance note); the thunk is new
+codegen (P4), verified by a separately compiled C `main` calling an exported Rue
+function.
+
+### StrBuf ↔ char* interop
+
+`StrBuf` is slot-identical and already crosses the runtime boundary via sret
+(ADR-0035/0043). C `char*` is `ptr const u8` / `ptr mut u8`. Minimal interop
+exposes a `StrBuf`'s data pointer as `ptr const u8` for a `char*` parameter; **NUL
+termination and ownership are an explicit manual contract**, not an automatic
+conversion. Helper ergonomics land in P6 alongside the variadic decision.
+
+### Variadics
+
+Not implemented in v0. A C variadic signature in an `extern` block is **rejected
+with a diagnostic** (the note requires "variadic calls, or an explicit diagnostic
+rejecting them"). Full variadic support is a later design decision, not a worker
+task.
+
+## Staged migration plan
+
+Each phase is independently landable and **verified by execution** — a compiled,
+independently linked, run probe producing exact output, matching
+`cli.abi_conformance`'s per-target harness (x86-64 Linux, AArch64 Linux, AArch64
+macOS). All land behind `c_ffi` until the whole surface is proven.
+
+**Dependency spine:** `P0 → P1 → P2 → {P3 → P4, P6}; RUE-714 + P3 → P5; P1 → P7`.
+
+| Phase | Scope | Depends | Verification proof program |
+| --- | --- | --- | --- |
+| **P0** | ADR ruling: settle the three open questions, name the `c_ffi` gate, fix the `extern` surface and the checked-only contract. *Design — maintainer.* | — | ADR ratified; no code. |
+| **P1** | `extern fn` decl (lexer/parser/RIR/sema/AIR) + undefined-symbol emission; linker resolves it from a supplied `.a`. Narrow-arg extension enters here. | P0 | Call a static-archive C function returning an `int` (e.g. `getpid`) and print it; `@syscall` `write` as the zero-cost pre-check. |
+| **P2** | `CallAbi::TargetC` classifier, scalars + pointers, register-only: GP-reg int/ptr args, scalar returns, general narrow-int extension, `_Bool` 1-byte boundary, single-aggregate `rax`/`x8` sret echo. No stack args, no floats. | P1 | Rue↔C scalar/pointer round-trip probe, both backends, exact output. |
+| **P3** | C aggregate classification + byval stack args: SysV eightbyte INTEGER classification + register packing, AAPCS64 composite rules, byval memory args incl. Apple packed-stack amendment, direct + indirect C aggregate returns. Largest integer-side phase. | P2 | Struct-by-value C↔Rue probe (multi-field struct passed and returned). |
+| **P4** | Rue-to-C export thunks: C-ABI callee prologue/epilogue so a C caller invokes an exported Rue fn. | P2 (P3 for aggregate params) | A separately compiled C `main` calls an exported Rue function and checks its result. |
+| **P5** | Floats + FP calling convention: after RUE-714 delivers `f32`/`f64`, IEEE-754 codegen, and the XMM (SSE) / V-register files, extend the P2/P3 classifier to FP args/results and HFA/HVA. | **RUE-714** + P3 | A `double`-taking libm probe (e.g. `pow`) called from Rue with exact result. |
+| **P6** | Variadic rejecting diagnostic (or full support as a separate decision) + `StrBuf`↔`char*` helpers with an explicit NUL/ownership contract. | P2 | A variadic `extern` decl emits the rejecting diagnostic (UI test); a `StrBuf` passed to a C `strlen`-shape function. |
+| **P7** | Dynamic linking against `libc.so` (stretch): `PT_INTERP`, dynamic symtab, PLT/GOT synthesis. Likely its own ADR. | P1 | A dynamically linked executable calls a `libc.so` symbol at runtime. |
+
+## Open questions for acceptance
+
+Three rulings gate P1. Each carries a recommendation; none is settled until the
+maintainer ratifies.
+
+### 1. Float scope and sequencing — *recommend: integer-first*
+
+Floats are absent from the type system entirely. Either **hard-block the FFI arc
+on RUE-714**, or **ship an integer/pointer-only C ABI first (P1–P4)** and diagnose
+float signatures as unsupported until P5.
+
+**Recommendation: integer-first.** This is the single largest scoping lever. The
+integer/pointer core is the majority of real C surface (`write`, `getpid`,
+`malloc`, most syscalls and libc string/memory functions) and depends on nothing
+RUE-714 owns; blocking the entire arc on a separately owned type-system epic
+strands landable, verifiable value for no design benefit. A `float`/`double` in an
+`extern` signature gets a clear "floating-point FFI is not yet supported (RUE-714)"
+diagnostic in v0. **P5 blocks on RUE-714 either way** — the only question is
+whether P1–P4 wait with it, and they should not.
+
+### 2. Enum representation at the C boundary — *recommend: enums are not FFI-safe in v0*
+
+Rue enums are *tagged* sum types (narrow `u8`/`u16`/`u32` tag, payload at max
+variant alignment); a C `enum` is an `int`. There is no natural correspondence: a
+Rue enum cannot be handed to a C function as a C enum, and a C enum maps to a Rue
+*integer*, not a Rue enum.
+
+**Recommendation: enums are not FFI-safe types in v0.** Only scalars, pointers,
+and C-classifiable structs cross the boundary; a Rue enum in an `extern` signature
+is rejected with a diagnostic. A C `enum` parameter is declared on the Rue side as
+the corresponding integer type (`i32` by default). A future opt-in
+`cenum`/`repr(C)`-style attribute that gives an enum a guaranteed C-integer
+representation is **explicitly out of scope** and left to a later design — it is
+additive and does not constrain the v0 surface.
+
+### 3. Error / panic / provenance boundary policy — *recommend: unchecked-only, abort-not-unwind, provenance unchecked*
+
+Rue traps (arithmetic overflow, bounds) and models recoverable failure with
+Result sum types (ADR-0038); C has neither. The conformance note defers "pointer
+provenance, mutability, and lifetime rules" to an explicit contract this ADR must
+write.
+
+**Recommendation:**
+- **Foreign calls are unchecked-context-only in v0** — permitted solely inside a
+  `checked {}` block (ADR-0028), matching `@syscall`.
+- **A trap must not unwind into C.** When an exported Rue function would trap under
+  a C caller (overflow, bounds, failed checked assertion), the boundary **aborts
+  the process** (a defined trap: the same illegal-instruction/abort path Rue's trap
+  machinery already uses), never propagating a Rust-style unwind or a Rue trap
+  across the C frame. Rue does not have unwinding; the contract is defined as
+  abort-at-boundary so no C frame is ever unwound through. Reserving a future
+  `"C-unwind"` ABI string keeps room for a richer policy without re-spelling `"C"`.
+- **Pointer provenance at the boundary is documented as unchecked.** A pointer
+  handed to or received from C carries no Rue exclusivity, aliasing, or lifetime
+  guarantee; the caller is responsible in the same way `@ptr_read`/`@ptr_write`
+  place the obligation on unchecked code. Result values are ordinary Rue
+  aggregates and are not automatically translated to a C error convention (errno,
+  sentinel return) — that is a manual contract in v0.
+
+### Secondary rulings (ADR-worthy, recommendations attached)
+
+- **A. `bool` boundary width.** The runtime ABI's canonical boolean is a 64-bit
+  word (`BoolWordI64`) and native classification treats `Bool` as a narrow,
+  non-slot-identical scalar, but C `_Bool` is one byte with a 0/1 validity rule.
+  *Recommend:* the `TargetC` boundary uses a **1-byte `_Bool` with a 0/1
+  contract**, zero-extending on the way in and materializing exactly 0/1 on the
+  way out, independent of the internal 64-bit representation.
+- **B. Variadics.** *Recommend:* **reject with a diagnostic** in v0 (P6); full
+  support is a later, separate decision.
+
+## Preview gating and stabilization
+
+The feature is added to `PreviewFeature` in `crates/rue-error/src/lib.rs` as
+`CFfi` (CLI name `c_ffi`, `adr()` → `"ADR-0064"`), following `test_infra` and
+`slices`. Every phase's language surface is gated by `require_preview` in sema; the
+gate is removed once, at the end, by the ADR-0005 stabilization procedure (drop
+`preview =` from spec tests, remove the `require_preview()` sites, remove the
+`PreviewFeature::CFfi` variant, set this ADR `implemented`). Per the
+layout-campaign standard, no partial early stabilization.
+
+**Stabilization tracker.** At acceptance, file a single checklist tracking issue in
+the RUE-987 style (the compact-layout-default epic that carried ADR-0052's
+migration to stabilization) — one issue enumerating P0–P7 as checkboxes with their
+per-phase verification bars, the two backend implementations each phase requires
+(AGENTS.md multi-backend rule), and the final de-gate step. Child issues (RUE-742
+import/classifier, RUE-745 exports, and RUE-714 as an external `blockedBy` for P5)
+hang off it. This ADR does not create the tracker; it defines its shape for the
+acceptance step.
+
+## Consequences
+
+### Positive
+
+- Rue gains a real, execution-verified C boundary reusing the `CallAbi` seam and
+  the archive-linking path that already run on every build — no peer FFI calculator
+  in a backend, no new linker for the first target.
+- The integer-first cut lands most real C surface without waiting on the RUE-714
+  float epic.
+- The narrow v0 type set (no enums, no floats, no variadics) keeps every crossing
+  representation one the classifier can implement correctly and prove, avoiding the
+  "layout parity implies call-ABI parity" trap the conformance note warns against.
+- The trap-aborts-at-boundary rule makes the panic contract defined rather than
+  latent undefined behavior.
+
+### Negative
+
+- Two backends each need matching target-C classification, packing, stack-arg, and
+  sret-echo work (P2–P4); this is the largest integer-side codegen effort since the
+  layout migration.
+- Floats, enums, variadics, dynamic linking, and header ingestion are all deferred,
+  so v0 cannot bind an arbitrary C library unchanged.
+- The reversed-slot native convention and the C packing convention must coexist as
+  two distinct classifiers, a permanent two-model cost the seam accepts by design.
+
+### Neutral
+
+- `@syscall` remains the honest interim answer for single-syscall Linux needs and
+  the zero-cost P1 pre-check; it is not superseded by the archive path.
+- String and error marshaling stay source-defined and manual, matching how Rue
+  keeps policy out of primitive surfaces (ADR-0059 precedent).
+
+## Future work
+
+- **Floating-point/vector FFI** — P5, gated on RUE-714.
+- **`cenum` / `repr(C)` enum representation** — a C-integer opt-in for enums.
+- **Variadic C calls** — beyond the v0 rejecting diagnostic.
+- **Dynamic linking** against shared objects (`PT_INTERP`, PLT/GOT) — its own ADR.
+- **Header/bindgen ingestion** — deriving `extern` blocks from C headers.
+- **`"C-unwind"` ABI** — a richer cross-boundary panic policy than abort.
+- **Automatic string/lifetime marshaling** — typed `char*`↔`StrBuf` conversions
+  with an ownership model.
+
+## References
+
+- RUE-742 / RUE-745 — target C layout and FFI implementation (the import
+  classifier and export phases of this ADR).
+- RUE-714 — floating-point types and codegen (external hard dependency for P5).
+- RUE-738 / `docs/notes/ffi-abi-conformance-audit.md` — the conformance audit this
+  ADR operationalizes; its "Requirements for future FFI work" list is the phase
+  acceptance bar.
+- ADR-0052 / RUE-987 — canonical physical type layout; built the `CallAbi` seam
+  and reserved the target-C representation.
+- ADR-0028 — unchecked code and raw pointers (the `checked {}` boundary gate).
+- ADR-0038 — error handling via Result sum types (the C-side translation contract).
+- ADR-0035 / ADR-0043 — byte-string model and the collection/string trio
+  (`StrBuf`↔`char*`).
+- ADR-0055 — typed runtime ABI manifest (the existing `TargetC` runtime subset the
+  classifier generalizes).
+- ADR-0005 — preview-feature gating and stabilization procedure.
+- `crates/rue-air/src/call_abi.rs` — the seam. `crates/rue-linker/src/linker.rs`,
+  `elf.rs` — archive resolution and relocations. `crates/rue-air/src/sema/analysis/pointers.rs`
+  — the `@syscall` / intrinsic idiom.

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -226,4 +226,5 @@ The table is generated from ADR frontmatter. Run
 | [0061](0061-supported-compiler-facade.md) | Supported compiler facade and immutable artifact views | Accepted | architecture, compiler, tooling, api, incremental |
 | [0062](0062-place-returning-borrow-accessors.md) | Place-returning borrow accessors: projection reads of owned elements | Accepted | ownership, borrows, collections, accessors, stdlib, formal-semantics |
 | [0063](0063-parallel-demand-driven-incremental-compilation.md) | Parallel demand-driven incremental compilation | Accepted | architecture, compiler, incremental, parallelism, codegen, linker, performance |
+| [0064](0064-c-ffi.md) | C FFI: a guaranteed target-C boundary for imports and exports | Proposal | ffi, abi, codegen, linker, types, semantics, unsafe, interop |
 <!-- ADR-INDEX:END -->


### PR DESCRIPTION
## Summary

The C FFI proposal, operationalizing the RUE-738 ABI conformance audit now that compact layout is default. **Status: proposal — this PR merges the *draft* for review; acceptance is a separate ratification step** (same flow as ADR-0052/0059).

- `extern` declaration surface (lexer→AIR), `CallAbi::TargetC` extending the existing classifier authority (SysV eightbytes + AAPCS64, byval, sret echo, narrow-int extension), **static-archive linking first** (the internal linker already resolves undefined symbols from archives), Rue→C export thunks, `StrBuf`↔`char*`, variadics rejected with a diagnostic, dynamic linking deferred to its own ADR. Gate: `c_ffi`.
- **Open questions carried for acceptance, each with a recommendation**: integer-first float sequencing (P5 blocks on RUE-714 either way); enums are not FFI-safe in v0 (C enums map to Rue integers); foreign calls unchecked-only with defined abort-at-boundary trap semantics.
- Phases P0–P7, each with an execution-verified proof program (P1: call static-archive C `getpid`; P4: a C `main` calls an exported Rue fn), spine P0→P1→P2→{P3→P4, P6}, floats after RUE-714+P3.

## Verification

`scripts/validate-adrs.py` green (65 records, README index regenerated); docs-only change, fmt clean. Grounded in the cited FFI audit (gaps verified at file:line against current trunk, including the two corrections to prior framing: physical-layout parity ≠ call-ABI parity, and RUE-742/745 are the classifier phases' content rather than blockers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_