### PR TITLE
std.fs v1: seek, stat, rename/remove, directories (ADR-0057 follow-ups)

### DIFF
--- a/crates/rue-cli-tests/cases/fs_file_io.toml
+++ b/crates/rue-cli-tests/cases/fs_file_io.toml
@@ -1,3 +1,12 @@
+# V1 FOLLOW-UPS (ADR-0057 "Future Work"): the cases whose names begin `fs_seek_`,
+# `fs_stat_`/`fs_metadata_`, `fs_rename_`, `fs_remove_`, and `fs_mkdir_` exercise
+# seek/tell, fstat/newfstatat metadata, rename, unlink, and directory
+# create/remove. They are `only_on` the two Linux targets: this repo's CI host is
+# Linux, and the macOS `struct stat` layout plus the Darwin *at/stat syscall
+# numbers are the DOCUMENTED, not-yet-device-verified follow-up (see std/fs.rue).
+# Seek offsets are bound to an `i64` value before the call to dodge a caller-side
+# literal-typing limitation for imported functions (see File.seek's doc comment).
+#
 # std.fs File IO v0 (RUE-712, ADR-0057) driven end-to-end as a user would: the
 # real std.fs (via RUE_STD_PATH) compiled to a real binary that opens, writes,
 # reads, and closes real files in the harness's per-case temp directory (the
@@ -419,6 +428,297 @@ fn main() -> i32 {
     };
     match g.close() { CR.Ok(_u) => {}, CR.Err(_e) => {} };
     outcome
+}
+""" }]
+exit_code = 0
+
+# ---------------------------------------------------------------------------
+# v1 follow-ups (ADR-0057 "Future Work"). Linux-scoped; see the header note.
+# ---------------------------------------------------------------------------
+
+# seek-then-read-back: write "0123456789", reopen, seek to offset 4 (SEEK_SET),
+# read the remaining bytes, and assert they are "456789" (6 bytes) starting at
+# '4'. Also asserts seek returns the new absolute offset (4) and tell() reports
+# it. Exit code is the read count (6).
+[[case]]
+name = "fs_seek_set_read_back"
+only_on = ["x86-64-linux", "aarch64-linux"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let WR = std.result.Result(u64, FE);
+    let CR = std.result.Result((), FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+    let W = std.fs.Whence;
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("seekset.dat");
+
+    let mut out = Buf.new();
+    let mut k: u64 = 0;
+    while k < 10 { out.push(48 + @intCast(k)); k = k + 1; } // "0123456789"
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 81; } };
+    match f.write_all(borrow out) { CR.Ok(_u) => {}, CR.Err(_e) => { return 82; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 83; } };
+
+    let mut g = match F.open(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 84; } };
+    let four: i64 = 4;
+    let pos = match g.seek(four, W.Set) { WR.Ok(p) => p, WR.Err(_e) => { return 85; } };
+    if pos != 4 { return 70; }
+    let t = match g.tell() { WR.Ok(p) => p, WR.Err(_e) => { return 86; } };
+    if t != 4 { return 71; }
+    let mut inb = Buf.with_capacity(32);
+    let nr = match g.read(inout inb) { WR.Ok(n) => n, WR.Err(_e) => { return 87; } };
+    match g.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 88; } };
+
+    if nr != 6 { return 72; }
+    if inb.get_or(0, 0) != 52 { return 73; } // '4'
+    if inb.get_or(5, 0) != 57 { return 74; } // '9'
+    @intCast(nr)
+}
+""" }]
+exit_code = 6
+
+# relative seeks: after reading to EOF the offset is at end; seek CUR by -2 lands
+# at 8, then seek END by -3 lands at 7. Negative offsets are bound to an i64
+# value first (caller literal-typing limitation). Exit code is the final offset (7).
+[[case]]
+name = "fs_seek_cur_end_relative"
+only_on = ["x86-64-linux", "aarch64-linux"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let WR = std.result.Result(u64, FE);
+    let CR = std.result.Result((), FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+    let W = std.fs.Whence;
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("seekrel.dat");
+
+    let mut out = Buf.new();
+    let mut k: u64 = 0;
+    while k < 10 { out.push(65); k = k + 1; } // 10 'A' bytes
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 61; } };
+    match f.write_all(borrow out) { CR.Ok(_u) => {}, CR.Err(_e) => { return 62; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 63; } };
+
+    let mut g = match F.open(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 64; } };
+    // read all 10 -> offset now at 10 (EOF)
+    let mut inb = Buf.with_capacity(16);
+    let nr = match g.read(inout inb) { WR.Ok(n) => n, WR.Err(_e) => { return 65; } };
+    if nr != 10 { return 51; }
+
+    let back2: i64 = 0 - 2;
+    let p1 = match g.seek(back2, W.Cur) { WR.Ok(p) => p, WR.Err(_e) => { return 66; } };
+    if p1 != 8 { return 52; }
+
+    let back3: i64 = 0 - 3;
+    let p2 = match g.seek(back3, W.End) { WR.Ok(p) => p, WR.Err(_e) => { return 67; } };
+    if p2 != 7 { return 53; }
+    match g.close() { CR.Ok(_u) => {}, CR.Err(_e) => {} };
+    @intCast(p2)
+}
+""" }]
+exit_code = 7
+
+# stat size after write: write 13 bytes, then File.metadata (fstat) reports
+# size==13, is_file()==true, is_dir()==false. Exit code is the reported size (13).
+[[case]]
+name = "fs_stat_size_and_is_file"
+only_on = ["x86-64-linux", "aarch64-linux"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let CR = std.result.Result((), FE);
+    let MR = std.result.Result(std.fs.Metadata, FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("statsize.dat");
+
+    let mut out = Buf.new();
+    let mut k: u64 = 0;
+    while k < 13 { out.push(88); k = k + 1; } // 13 'X' bytes
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 41; } };
+    match f.write_all(borrow out) { CR.Ok(_u) => {}, CR.Err(_e) => { return 42; } };
+
+    let md = match f.metadata() { MR.Ok(m) => m, MR.Err(_e) => { return 43; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 44; } };
+
+    if md.size() != 13 { return 31; }
+    if !md.is_file() { return 32; }
+    if md.is_dir() { return 33; }
+    @intCast(md.size())
+}
+""" }]
+exit_code = 13
+
+# metadata by path (newfstatat): create a 9-byte file, close, then stat it by
+# path — size==9 and is_file. Exit code is the size (9).
+[[case]]
+name = "fs_metadata_by_path_size"
+only_on = ["x86-64-linux", "aarch64-linux"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let CR = std.result.Result((), FE);
+    let MR = std.result.Result(std.fs.Metadata, FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("pathstat.dat");
+
+    let mut out = Buf.new();
+    let mut k: u64 = 0;
+    while k < 9 { out.push(89); k = k + 1; } // 9 'Y' bytes
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 21; } };
+    match f.write_all(borrow out) { CR.Ok(_u) => {}, CR.Err(_e) => { return 22; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 23; } };
+
+    let md = match std.fs.metadata(borrow path) { MR.Ok(m) => m, MR.Err(_e) => { return 24; } };
+    if md.size() != 9 { return 11; }
+    if !md.is_file() { return 12; }
+    @intCast(md.size())
+}
+""" }]
+exit_code = 9
+
+# rename: create a file at the old path, rename it, then opening the OLD path
+# fails with NotFound while opening the NEW path succeeds and reads the content
+# back. Exit code 0 on the full success path.
+[[case]]
+name = "fs_rename_old_gone_new_present"
+only_on = ["x86-64-linux", "aarch64-linux"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let WR = std.result.Result(u64, FE);
+    let CR = std.result.Result((), FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+
+    let mut oldp = std.strbuf.StrBuf.new();
+    oldp.push_str("rename_old.dat");
+    let mut newp = std.strbuf.StrBuf.new();
+    newp.push_str("rename_new.dat");
+
+    let mut payload = Buf.new();
+    payload.push(77); payload.push(78); // "MN"
+    let mut f = match F.create(borrow oldp) { R.Ok(x) => x, R.Err(_e) => { return 91; } };
+    match f.write_all(borrow payload) { CR.Ok(_u) => {}, CR.Err(_e) => { return 92; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 93; } };
+
+    match std.fs.rename(borrow oldp, borrow newp) { CR.Ok(_u) => {}, CR.Err(_e) => { return 94; } };
+
+    // old path must be gone
+    match F.open(borrow oldp) {
+        R.Ok(_x) => { return 95; },
+        R.Err(e) => match e { FE.NotFound => {}, _ => { return 96; } },
+    };
+
+    // new path opens and reads "MN"
+    let mut g = match F.open(borrow newp) { R.Ok(x) => x, R.Err(_e) => { return 97; } };
+    let mut inb = Buf.with_capacity(8);
+    let nr = match g.read(inout inb) { WR.Ok(n) => n, WR.Err(_e) => { return 98; } };
+    match g.close() { CR.Ok(_u) => {}, CR.Err(_e) => {} };
+    if nr != 2 { return 31; }
+    if inb.get_or(0, 0) != 77 { return 32; }
+    if inb.get_or(1, 0) != 78 { return 33; }
+    0
+}
+""" }]
+exit_code = 0
+
+# remove (unlink): create a file, remove it, then opening it fails with
+# NotFound. Exit code 0 on the full success path.
+[[case]]
+name = "fs_remove_file_then_open_notfound"
+only_on = ["x86-64-linux", "aarch64-linux"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let CR = std.result.Result((), FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("to_remove.dat");
+
+    let mut payload = Buf.new();
+    payload.push(81); // "Q"
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 71; } };
+    match f.write_all(borrow payload) { CR.Ok(_u) => {}, CR.Err(_e) => { return 72; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 73; } };
+
+    match std.fs.remove(borrow path) { CR.Ok(_u) => {}, CR.Err(_e) => { return 74; } };
+
+    match F.open(borrow path) {
+        R.Ok(_x) => 1,
+        R.Err(e) => match e { FE.NotFound => 0, _ => 2 },
+    }
+}
+""" }]
+exit_code = 0
+
+# directory create/stat/remove: create_dir, then stat the path — is_dir()==true,
+# is_file()==false — remove_dir, then stat fails with NotFound. Exit code 0 on
+# the full success path.
+[[case]]
+name = "fs_mkdir_stat_is_dir_then_rmdir"
+only_on = ["x86-64-linux", "aarch64-linux"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let FE = std.fs.FileError;
+    let CR = std.result.Result((), FE);
+    let MR = std.result.Result(std.fs.Metadata, FE);
+
+    let mut dir = std.strbuf.StrBuf.new();
+    dir.push_str("rue_v1_dir");
+
+    match std.fs.create_dir(borrow dir) { CR.Ok(_u) => {}, CR.Err(_e) => { return 61; } };
+
+    let md = match std.fs.metadata(borrow dir) { MR.Ok(m) => m, MR.Err(_e) => { return 62; } };
+    if !md.is_dir() { return 51; }
+    if md.is_file() { return 52; }
+
+    match std.fs.remove_dir(borrow dir) { CR.Ok(_u) => {}, CR.Err(_e) => { return 63; } };
+
+    match std.fs.metadata(borrow dir) {
+        MR.Ok(_m) => 1,
+        MR.Err(e) => match e { FE.NotFound => 0, _ => 2 },
+    }
 }
 """ }]
 exit_code = 0

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -425,6 +425,54 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::IntToPointer),
         &[],
     ),
+    // std.fs v1 follow-ups (ADR-0057 "Future Work"): seek/tell, fstat/newfstatat
+    // metadata, rename, unlink, and directory create/remove. Same raw-pointer
+    // substrate as v0 (StrBuf/ArrayBuf `@int_to_ptr` prologue), so the oracle
+    // model stops at the same IntToPointer gap. These cases are `only_on` the two
+    // Linux targets (macOS stat layout + Darwin *at syscall numbers are a
+    // documented, unverified follow-up), so their scope is Linux-only to match.
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_seek_set_read_back",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &["aarch64-linux", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_seek_cur_end_relative",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &["aarch64-linux", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_stat_size_and_is_file",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &["aarch64-linux", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_metadata_by_path_size",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &["aarch64-linux", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_rename_old_gone_new_present",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &["aarch64-linux", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_remove_file_then_open_notfound",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &["aarch64-linux", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_mkdir_stat_is_dir_then_rmdir",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &["aarch64-linux", "x86-64-linux"],
+    ),
     Entry::new(
         "cli.heap_intrinsics",
         "alloc_count_size_overflow_traps",

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -16,7 +16,8 @@
 //   ArrayBuf(u8) (`from_str`, `from_bytes`, `to_bytes`, and append variants)
 // - std.arraybuf.ArrayBuf: Growable heap-backed collections; ArrayBuf(u8) can
 //   copy from str with `from_str` / `extend_str`
-// - std.fs.File: File IO v0 (open/create/append/read/write/close over @syscall)
+// - std.fs.File: File IO (open/create/append/read/write/seek/tell/metadata/close
+//   over @syscall) plus fs.rename/remove/create_dir/remove_dir/metadata
 // - std.binary: endianness-explicit integer<->byte conversions
 // - std.net: network IO v1 address model + Linux sockaddr marshalling
 
@@ -31,7 +32,8 @@ pub const result = @import("result.rue");
 pub const strbuf = @import("strbuf.rue");
 pub const arraybuf = @import("arraybuf.rue");
 
-// File IO v0 (RUE-712, ADR-0057): pure-Rue std.fs over @syscall.
+// File IO (RUE-712, ADR-0057): pure-Rue std.fs over @syscall. v0 open/read/
+// write/close plus the v1 follow-ups seek/stat/rename/remove/directories.
 pub const fs = @import("fs.rue");
 
 // Endianness-explicit integer<->byte conversions (RUE-970, ADR-0059/0060).

--- a/std/fs.rue
+++ b/std/fs.rue
@@ -9,8 +9,24 @@
 //
 // v0 surface: `File.open` (read-only), `File.create` (truncate+write),
 // `File.append`, `read`, `write`/`write_all`, and a consuming `close`. Files
-// close themselves via a `drop fn` at scope exit. No seek, stat, directories,
-// rename, or buffering (ADR-0057 defers all of it).
+// close themselves via a `drop fn` at scope exit.
+//
+// v1 follow-ups (this change, the ADR-0057 "Future Work" items): `File.seek`
+// (lseek with a `Whence` enum) and `File.tell`; `File.metadata`/`fs.metadata`
+// (fstat/newfstatat -> `Metadata` with size + is_file/is_dir); `fs.rename`,
+// `fs.remove` (unlinkat); and directory create/remove (`fs.create_dir`,
+// `fs.remove_dir` via mkdirat/unlinkat+AT_REMOVEDIR). Reading directory
+// entries (getdents64) remains DEFERRED — the largest remaining chunk — as
+// does buffering and stdin/stdout unification (still out of ADR-0057 scope).
+//
+// PER-TARGET STAT LAYOUT: `stat` is the fiddliest v1 piece because the kernel's
+// `struct stat` byte layout differs per OS AND per arch. This module decodes
+// only two fields (st_mode, st_size) at documented offsets (see the stat
+// section below). x86-64-linux and aarch64-linux offsets are exercised by CI
+// here; the macOS 64-bit-inode offsets and Darwin stat/at-syscall numbers are
+// the DOCUMENTED, NOT-YET-CI-VERIFIED follow-up (this host is Linux). New v1
+// CLI cases are therefore `only_on` the two Linux targets, mirroring how v0's
+// error-detection cases were Linux-scoped until a macOS device could confirm.
 //
 // PATHS are byte-string `StrBuf`s; the syscall boundary copies the bytes into a
 // NUL-terminated buffer and never exposes that terminator to the caller.
@@ -35,6 +51,7 @@ const result = @import("result.rue");
 const option = @import("option.rue");
 const strbuf = @import("strbuf.rue");
 const arraybuf = @import("arraybuf.rue");
+const binary = @import("binary.rue");
 
 // A normalized, target-independent file error. Decoded from the per-OS errno
 // tables below so that a program matching on `FileError` means the same thing
@@ -48,6 +65,47 @@ pub enum FileError {
     WouldBlock,         // EAGAIN / EWOULDBLOCK
     InvalidInput,       // EINVAL, EBADF
     Other(i64),         // any other raw errno
+}
+
+// Where a `seek` offset is measured from (the lseek `whence` argument). The
+// three constants agree across Linux and macOS: SEEK_SET=0, SEEK_CUR=1,
+// SEEK_END=2, so `Whence` maps to a plain integer with no per-OS table.
+pub enum Whence {
+    Set,   // SEEK_SET: from the start of the file
+    Cur,   // SEEK_CUR: from the current position (offset may be negative)
+    End,   // SEEK_END: from end-of-file (offset may be negative)
+}
+
+// Size + type metadata for a file, decoded from `struct stat` (ADR-0057 v1
+// follow-up). v1 exposes only the two portable fields programs branch on most:
+// the byte size and whether the entry is a regular file or a directory. The
+// S_IF* type constants are POSIX and identical on Linux and macOS even though
+// the byte OFFSET of st_mode within `struct stat` is per-OS/per-arch.
+pub struct Metadata {
+    // The low 16 bits of st_mode: the file-type bits (S_IFMT) plus permission
+    // bits. Reading 2 bytes suffices on every target — the type bits live in
+    // the low 16 bits of st_mode whether st_mode is a 32-bit (Linux) or 16-bit
+    // (macOS) field, and the buffer is little-endian on all supported targets.
+    mode: u16,
+    // The file size in bytes (st_size), read as a little-endian 64-bit field.
+    size_bytes: u64,
+
+    // The file size in bytes.
+    fn size(borrow self) -> u64 {
+        self.size_bytes
+    }
+
+    // True if this is a regular file: (st_mode & S_IFMT) == S_IFREG.
+    // S_IFMT=0o170000=61440, S_IFREG=0o100000=32768.
+    fn is_file(borrow self) -> bool {
+        (self.mode & 61440) == 32768
+    }
+
+    // True if this is a directory: (st_mode & S_IFMT) == S_IFDIR.
+    // S_IFMT=0o170000=61440, S_IFDIR=0o040000=16384.
+    fn is_dir(borrow self) -> bool {
+        (self.mode & 61440) == 16384
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -125,6 +183,126 @@ fn _sys_write() -> u64 {
     }
 }
 
+// lseek(2) — reposition the file offset. Linux: 8 (x86-64), 62 (aarch64,
+// asm-generic). macOS raw BSD trap 199 (DOCUMENTED, not CI-verified here).
+fn _sys_lseek() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 8,
+                Os.Macos => 199,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 62,
+                Os.Macos => 199,
+            }
+        },
+    }
+}
+
+// fstat(2) — stat an open fd. Linux: 5 (x86-64), 80 (aarch64). macOS raw BSD
+// fstat64 trap 339 (DOCUMENTED, not CI-verified — see the stat-layout note).
+fn _sys_fstat() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 5,
+                Os.Macos => 339,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 80,
+                Os.Macos => 339,
+            }
+        },
+    }
+}
+
+// newfstatat(2)/fstatat — stat a path relative to a dirfd. Used uniformly with
+// AT_FDCWD for path-based stat (aarch64 Linux has no bare `stat`, exactly like
+// openat). Linux: 262 (x86-64), 79 (aarch64). macOS raw BSD fstatat trap 469
+// (DOCUMENTED, not CI-verified).
+fn _sys_newfstatat() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 262,
+                Os.Macos => 469,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 79,
+                Os.Macos => 469,
+            }
+        },
+    }
+}
+
+// renameat(2) — rename oldpath to newpath, both relative to a dirfd. Used with
+// AT_FDCWD for both ends. Linux: 264 (x86-64), 38 (aarch64). macOS raw BSD
+// renameat trap 465 (DOCUMENTED, not CI-verified).
+fn _sys_renameat() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 264,
+                Os.Macos => 465,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 38,
+                Os.Macos => 465,
+            }
+        },
+    }
+}
+
+// unlinkat(2) — remove a path relative to a dirfd; with AT_REMOVEDIR it removes
+// a directory instead of a file. Used with AT_FDCWD for both `remove` and
+// `remove_dir`. Linux: 263 (x86-64), 35 (aarch64). macOS raw BSD unlinkat trap
+// 472 (DOCUMENTED, not CI-verified).
+fn _sys_unlinkat() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 263,
+                Os.Macos => 472,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 35,
+                Os.Macos => 472,
+            }
+        },
+    }
+}
+
+// mkdirat(2) — create a directory relative to a dirfd. Used with AT_FDCWD.
+// Linux: 258 (x86-64), 34 (aarch64). macOS raw BSD mkdirat trap 475
+// (DOCUMENTED, not CI-verified).
+fn _sys_mkdirat() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 258,
+                Os.Macos => 475,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 34,
+                Os.Macos => 475,
+            }
+        },
+    }
+}
+
 // AT_FDCWD as a u64 bit pattern. Linux uses -100, macOS uses -2, so this is
 // per-OS data, not a shared constant.
 fn _at_fdcwd() -> u64 {
@@ -166,6 +344,117 @@ fn _o_append() -> u64 {
 
 // Default mode for newly created files: 0o644.
 fn _create_mode() -> u64 { 420 }
+
+// Default mode for newly created directories: 0o755.
+fn _dir_mode() -> u64 { 493 }
+
+// AT_REMOVEDIR: the unlinkat flag that makes it remove a directory (like rmdir)
+// instead of a file. Linux 0x200=512 (asm-generic, both arches); macOS 0x80=128
+// (DOCUMENTED, not CI-verified).
+fn _at_removedir() -> u64 {
+    match @target_os() {
+        Os.Linux => 512,
+        Os.Macos => 128,
+    }
+}
+
+// Reinterpret an i64 as its raw u64 two's-complement bit pattern, for passing a
+// possibly-negative argument (a seek offset) to `@syscall`, whose arguments are
+// u64. `@intCast` PANICS on a negative source (the value is not representable in
+// u64), so it cannot be used for the bit reinterpretation; the low path rebuilds
+// 2^64 + x from the magnitude with non-trapping unsigned arithmetic. (An offset
+// of i64::MIN is not supported — its negation overflows i64 — but no real seek
+// uses it.)
+fn _i64_bits(x: i64) -> u64 {
+    if x >= 0 {
+        @intCast(x)
+    } else {
+        // Two's complement of a negative x: 2^64 - |x| == ~(|x| - 1) computed in
+        // u64. `~` is a bitwise op (never traps), and |x| - 1 >= 0 for x < 0, so
+        // it @intCasts cleanly. This avoids a 2^64-scale decimal literal.
+        let mag_minus_1: u64 = @intCast((0 - x) - 1);
+        ~mag_minus_1
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-target `struct stat` field offsets. v1 decodes only st_mode and st_size.
+// The kernel layout is per-OS AND per-arch, so the offsets are a small table
+// (ADR-0057 v1). Verified against the kernel headers cited below.
+//
+//   Linux x86-64 (arch/x86 `struct stat`, asm/stat.h):
+//     st_mode  unsigned int  @ 24     st_size  long  @ 48
+//   Linux aarch64 (asm-generic `struct stat`, uapi/asm-generic/stat.h):
+//     st_mode  unsigned int  @ 16     st_size  long  @ 48
+//   macOS (Darwin `struct stat`, _DARWIN_FEATURE_64_BIT_INODE, sys/stat.h):
+//     st_mode  __uint16_t    @ 4      st_size  __int64_t  @ 96
+//     (DOCUMENTED, not CI-verified on this Linux host.)
+//
+// st_mode is read as a little-endian u16 (the file-type bits fit the low 16
+// bits on every target); st_size is read as a little-endian u64.
+// ---------------------------------------------------------------------------
+
+fn _stat_mode_offset() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 24,
+                Os.Macos => 4,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 16,
+                Os.Macos => 4,
+            }
+        },
+    }
+}
+
+fn _stat_size_offset() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 48,
+                Os.Macos => 96,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 48,
+                Os.Macos => 96,
+            }
+        },
+    }
+}
+
+// Bytes to allocate for a kernel `struct stat`. 256 comfortably exceeds every
+// supported layout (Linux x86-64 is 144, aarch64 128, macOS ~144), so the
+// documented field offsets are always in bounds.
+fn _stat_buf_size() -> u64 { 256 }
+
+// Decode the two v1 fields from a kernel-filled `struct stat` buffer at the
+// per-target offsets above. Reads bytes through `@byte_read` and reassembles
+// them little-endian, so nothing depends on Rue struct layout.
+fn _decode_stat(buf: ptr mut u8) -> Metadata {
+    let mo = _stat_mode_offset();
+    let m0 = checked { @byte_read(buf, mo) };
+    let m1 = checked { @byte_read(buf, mo + 1) };
+    let mode = binary.u16_from_le_bytes([m0, m1]);
+
+    let so = _stat_size_offset();
+    let s0 = checked { @byte_read(buf, so) };
+    let s1 = checked { @byte_read(buf, so + 1) };
+    let s2 = checked { @byte_read(buf, so + 2) };
+    let s3 = checked { @byte_read(buf, so + 3) };
+    let s4 = checked { @byte_read(buf, so + 4) };
+    let s5 = checked { @byte_read(buf, so + 5) };
+    let s6 = checked { @byte_read(buf, so + 6) };
+    let s7 = checked { @byte_read(buf, so + 7) };
+    let size = binary.u64_from_le_bytes([s0, s1, s2, s3, s4, s5, s6, s7]);
+
+    Metadata { mode: mode, size_bytes: size }
+}
 
 // ---------------------------------------------------------------------------
 // Errno normalization. `errno` is the POSITIVE OS error number. The tables are
@@ -414,6 +703,64 @@ pub struct File {
         R.Ok(())
     }
 
+    // Reposition the file offset. `offset` is measured from `whence`
+    // (SEEK_SET/CUR/END) and may be negative for `Cur`/`End`. Returns the new
+    // absolute offset from the start of the file (lseek's own return), or the
+    // normalized error. Seeking before the start is `Err(FileError.InvalidInput)`
+    // (EINVAL); seeking past end-of-file is allowed (a later write leaves a hole).
+    //
+    // CALLER NOTE: pass `offset` as an `i64` VALUE, not a bare integer literal:
+    //
+    //     let off: i64 = 0 - 2;          // bind first
+    //     f.seek(off, Whence.Cur)?;      // then seek two bytes back
+    //
+    // A bare literal argument (`f.seek(0 - 2, ...)`) is currently mis-typed as
+    // `i32` by the caller's inference for imported functions, which sign-loses a
+    // negative offset and rejects any magnitude above 2^31. Binding to an `i64`
+    // first is the reliable form until that frontend limitation is fixed.
+    fn seek(inout self, offset: i64, whence: Whence) -> result.Result(u64, FileError) {
+        let R = result.Result(u64, FileError);
+        let w: u64 = match whence {
+            Whence.Set => 0,
+            Whence.Cur => 1,
+            Whence.End => 2,
+        };
+        let fd_u: u64 = @intCast(self.fd);
+        let off_u: u64 = _i64_bits(offset);
+        let ret: i64 = checked { @syscall(_sys_lseek(), fd_u, off_u, w) };
+        if ret < 0 {
+            R.Err(_normalize_errno(0 - ret))
+        } else {
+            R.Ok(@intCast(ret))
+        }
+    }
+
+    // The current file offset, in bytes from the start: lseek(0, SEEK_CUR).
+    fn tell(inout self) -> result.Result(u64, FileError) {
+        self.seek(0, Whence.Cur)
+    }
+
+    // Size + type metadata for this open file, via fstat on the fd (no path
+    // lookup). See `Metadata` for the exposed fields.
+    fn metadata(inout self) -> result.Result(Metadata, FileError) {
+        let R = result.Result(Metadata, FileError);
+        let sz = _stat_buf_size();
+        let buf: ptr mut u8 = checked { @alloc_bytes(sz, 8) };
+        if checked { @ptr_to_int(buf) } == 0 {
+            @panic("out of memory");
+        }
+        let addr: u64 = checked { @ptr_to_int(buf) };
+        let fd_u: u64 = @intCast(self.fd);
+        let ret: i64 = checked { @syscall(_sys_fstat(), fd_u, addr) };
+        if ret < 0 {
+            checked { @free_bytes(buf, sz, 8); };
+            return R.Err(_normalize_errno(0 - ret));
+        }
+        let md = _decode_stat(buf);
+        checked { @free_bytes(buf, sz, 8); };
+        R.Ok(md)
+    }
+
     // Consuming close: closes the fd and returns the close error. Moving `self`
     // out of the caller's binding means the caller's scope-exit drop does not
     // fire; the sentinel (`fd = -1`) makes THIS value's own scope-exit drop a
@@ -442,5 +789,109 @@ drop fn File(self) {
     if self.fd >= 0 {
         let fd_u: u64 = @intCast(self.fd);
         checked { @syscall(_sys_close(), fd_u); };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Path-based operations (ADR-0057 v1 follow-ups). Each marshals its path(s)
+// through the same NUL-appended `_path_to_cbuf` the constructors use, issues an
+// *at syscall relative to AT_FDCWD (uniform with `openat`), and normalizes the
+// errno through the shared per-OS tables. No new errno class appears, so the
+// tables are unchanged.
+// ---------------------------------------------------------------------------
+
+// Size + type metadata for a path, via newfstatat(AT_FDCWD, path, .., 0). This
+// follows symlinks (flags 0). See `Metadata` for the exposed fields.
+pub fn metadata(borrow path: strbuf.StrBuf) -> result.Result(Metadata, FileError) {
+    let R = result.Result(Metadata, FileError);
+    let cbuf = _path_to_cbuf(borrow path);
+    let paddr: u64 = checked { @ptr_to_int(cbuf) };
+    let free_len = path.len() + 1;
+
+    let sz = _stat_buf_size();
+    let sbuf: ptr mut u8 = checked { @alloc_bytes(sz, 8) };
+    if checked { @ptr_to_int(sbuf) } == 0 {
+        @panic("out of memory");
+    }
+    let saddr: u64 = checked { @ptr_to_int(sbuf) };
+    let no_flags: u64 = 0; // follow symlinks (AT_SYMLINK_NOFOLLOW unset)
+    let ret: i64 = checked { @syscall(_sys_newfstatat(), _at_fdcwd(), paddr, saddr, no_flags) };
+    checked { @free_bytes(cbuf, free_len, 1); };
+    if ret < 0 {
+        checked { @free_bytes(sbuf, sz, 8); };
+        return R.Err(_normalize_errno(0 - ret));
+    }
+    let md = _decode_stat(sbuf);
+    checked { @free_bytes(sbuf, sz, 8); };
+    R.Ok(md)
+}
+
+// Rename (move) `from` to `to`: renameat(AT_FDCWD, from, AT_FDCWD, to). An
+// existing `to` is atomically replaced (POSIX rename semantics).
+pub fn rename(borrow from: strbuf.StrBuf, borrow to: strbuf.StrBuf) -> result.Result((), FileError) {
+    let R = result.Result((), FileError);
+    let fbuf = _path_to_cbuf(borrow from);
+    let faddr: u64 = checked { @ptr_to_int(fbuf) };
+    let flen = from.len() + 1;
+    let tbuf = _path_to_cbuf(borrow to);
+    let taddr: u64 = checked { @ptr_to_int(tbuf) };
+    let tlen = to.len() + 1;
+    let ret: i64 = checked { @syscall(_sys_renameat(), _at_fdcwd(), faddr, _at_fdcwd(), taddr) };
+    checked { @free_bytes(fbuf, flen, 1); };
+    checked { @free_bytes(tbuf, tlen, 1); };
+    if ret < 0 {
+        R.Err(_normalize_errno(0 - ret))
+    } else {
+        R.Ok(())
+    }
+}
+
+// Remove a file (not a directory): unlinkat(AT_FDCWD, path, 0). Removing a
+// directory path fails (EISDIR/EPERM -> the normalized error); use `remove_dir`.
+pub fn remove(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
+    let R = result.Result((), FileError);
+    let cbuf = _path_to_cbuf(borrow path);
+    let addr: u64 = checked { @ptr_to_int(cbuf) };
+    let free_len = path.len() + 1;
+    let no_flags: u64 = 0; // no AT_REMOVEDIR: unlink a file, not a directory
+    let ret: i64 = checked { @syscall(_sys_unlinkat(), _at_fdcwd(), addr, no_flags) };
+    checked { @free_bytes(cbuf, free_len, 1); };
+    if ret < 0 {
+        R.Err(_normalize_errno(0 - ret))
+    } else {
+        R.Ok(())
+    }
+}
+
+// Create a directory with mode 0o755: mkdirat(AT_FDCWD, path, 0o755). Only the
+// final component is created; a missing parent is `Err(FileError.NotFound)`, an
+// existing path is `Err(FileError.AlreadyExists)`.
+pub fn create_dir(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
+    let R = result.Result((), FileError);
+    let cbuf = _path_to_cbuf(borrow path);
+    let addr: u64 = checked { @ptr_to_int(cbuf) };
+    let free_len = path.len() + 1;
+    let ret: i64 = checked { @syscall(_sys_mkdirat(), _at_fdcwd(), addr, _dir_mode()) };
+    checked { @free_bytes(cbuf, free_len, 1); };
+    if ret < 0 {
+        R.Err(_normalize_errno(0 - ret))
+    } else {
+        R.Ok(())
+    }
+}
+
+// Remove an empty directory: unlinkat(AT_FDCWD, path, AT_REMOVEDIR). A
+// non-empty directory is `Err` (ENOTEMPTY -> `Other`, or the normalized case).
+pub fn remove_dir(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
+    let R = result.Result((), FileError);
+    let cbuf = _path_to_cbuf(borrow path);
+    let addr: u64 = checked { @ptr_to_int(cbuf) };
+    let free_len = path.len() + 1;
+    let ret: i64 = checked { @syscall(_sys_unlinkat(), _at_fdcwd(), addr, _at_removedir()) };
+    checked { @free_bytes(cbuf, free_len, 1); };
+    if ret < 0 {
+        R.Err(_normalize_errno(0 - ret))
+    } else {
+        R.Ok(())
     }
 }


### PR DESCRIPTION
## Summary

The staged follow-ups ADR-0057 (File IO v0, accepted) named as next, matching v0's error model, `File` shape, and per-target `@syscall` dispatch throughout — no redesign:

- **seek/tell**: `File.seek(offset, Whence{Set,Cur,End})` via lseek, `tell()` as `seek(0, Cur)`; negative offsets pass their two's-complement pattern bitwise (avoiding `@intCast`'s trap-on-negative).
- **stat/metadata**: `File.metadata()` (fstat) and `fs.metadata(path)` (newfstatat) → size/is_file/is_dir, with per-target `st_mode`/`st_size` offsets verified against kernel headers (x86-64: 24/48; aarch64: 16/48). macOS offsets present but documented not-device-verified; new cases `only_on` Linux targets.
- **rename/remove** (renameat/unlinkat) and **directories** (mkdirat, unlinkat+AT_REMOVEDIR), all through the unchanged v0 FileError tables.
- Deferred, documented: getdents64 directory listing; buffering and stdin/stdout unification remain out of ADR scope.
- **Bug found and filed (RUE-1053)**: integer literals passed to imported functions type as i32, silently zero-extending negatives — pre-existing, documented at the call site.

## Verification

Seven new `fs_file_io` cases (16 total; v0's nine unchanged) with oracle ledger entries; `std_net_tcp` green; both oracle-diff audits green; **full `test.sh` PASSED with zero failures** — the first fully clean suite, with the permission-test skips landed.

Part of RUE-712

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_