### PR TITLE
ADR-0064: accept the C FFI design

### DIFF
--- a/docs/designs/0064-c-ffi.md
+++ b/docs/designs/0064-c-ffi.md
@@ -1,11 +1,11 @@
 ---
 id: 0064
 title: "C FFI: a guaranteed target-C boundary for imports and exports"
-status: proposal
+status: accepted
 tags: [ffi, abi, codegen, linker, types, semantics, unsafe, interop]
 feature-flag: c_ffi
 created: 2026-07-19
-accepted:
+accepted: 2026-07-19
 implemented:
 spec-sections: []
 superseded-by:
@@ -16,16 +16,27 @@ relates: ["RUE-742", "RUE-745", "RUE-714", "RUE-738", "RUE-987", "ADR-0052", "AD
 
 ## Status
 
-Proposed. This record operationalizes the RUE-738 conformance audit
+Accepted 2026-07-19. This record operationalizes the RUE-738 conformance audit
 (`docs/notes/ffi-abi-conformance-audit.md`) and the "guaranteed target C layout
 and C ABI" future-work item ADR-0052 reserves to RUE-742 / RUE-745. It supersedes
 nothing; it fills the `CallAbi` seam ADR-0052 built and left with a single
 `Native` variant.
 
-The maintainer accepts or amends. The three rulings in
-[Open questions for acceptance](#open-questions-for-acceptance) each carry a
-recommendation; none is settled until ratified. Do not begin phase work past P0
-before then — this is an ADR-gated design under AGENTS.md and ADR-0005.
+Resolved at acceptance — the maintainer ratified every ruling in
+[Open questions for acceptance](#open-questions-for-acceptance) as recommended:
+
+1. **Integer-first float sequencing**: P1–P4 ship without floats; a float in an
+   `extern` signature diagnoses as unsupported (RUE-714); P5 blocks on RUE-714.
+2. **Enums are not FFI-safe in v0**: only scalars, pointers, and C-classifiable
+   structs cross; a C `enum` maps to a Rue integer; a `cenum`/repr attribute is
+   a later, additive design.
+3. **Unchecked-only, abort-not-unwind, provenance unchecked**: foreign calls are
+   permitted solely in `checked {}` blocks; a trap under a C caller aborts at
+   the boundary and never unwinds a C frame (`"C-unwind"` reserved); boundary
+   pointers carry no Rue exclusivity/lifetime guarantee.
+
+The secondary rulings (1-byte `_Bool` with 0/1 contract; variadics rejected with
+a diagnostic) are likewise ratified as recommended. Phase work past P0 may begin.
 
 ## Summary
 

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -226,5 +226,5 @@ The table is generated from ADR frontmatter. Run
 | [0061](0061-supported-compiler-facade.md) | Supported compiler facade and immutable artifact views | Accepted | architecture, compiler, tooling, api, incremental |
 | [0062](0062-place-returning-borrow-accessors.md) | Place-returning borrow accessors: projection reads of owned elements | Accepted | ownership, borrows, collections, accessors, stdlib, formal-semantics |
 | [0063](0063-parallel-demand-driven-incremental-compilation.md) | Parallel demand-driven incremental compilation | Accepted | architecture, compiler, incremental, parallelism, codegen, linker, performance |
-| [0064](0064-c-ffi.md) | C FFI: a guaranteed target-C boundary for imports and exports | Proposal | ffi, abi, codegen, linker, types, semantics, unsafe, interop |
+| [0064](0064-c-ffi.md) | C FFI: a guaranteed target-C boundary for imports and exports | Accepted | ffi, abi, codegen, linker, types, semantics, unsafe, interop |
 <!-- ADR-INDEX:END -->


### PR DESCRIPTION
## Summary

Ratify ADR-0064 per the maintainer's explicit acceptance, with every open-question recommendation adopted and recorded in the ADR's Status section:

1. **Integer-first sequencing** — P1–P4 ship without floats; float signatures diagnose as unsupported; P5 blocks on RUE-714.
2. **Enums are not FFI-safe in v0** — C enums map to Rue integers; a repr attribute is a later, additive design.
3. **Boundary policy** — foreign calls unchecked-only; abort-not-unwind at the boundary with `"C-unwind"` reserved; pointer provenance unchecked.

Secondary rulings ratified: 1-byte `_Bool` with the 0/1 contract; variadics rejected with a diagnostic. Phase work past P0 may begin.

Linear structure filed at acceptance per the ADR's convention: epic RUE-1054, phases RUE-1055–1061, stabilization tracker RUE-1062.

## Verification

Docs-only. `scripts/validate-adrs.py` green (65 records; README index regenerated), re-validated after rebase onto current trunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_