### PR TITLE
RUE-1055: extern fn declarations and static-archive linking (ADR-0064 P1)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1514,6 +1514,14 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                     continue;
                 }
 
+                // Skip foreign `extern "C"` declarations (ADR-0064 C FFI): they
+                // have no body and no CFG. A call to one lowers to an undefined
+                // linker symbol resolved from a static archive, so the function
+                // is never analyzed or code-generated here.
+                if fn_info.is_extern {
+                    continue;
+                }
+
                 let fn_name_str = sema.interner.resolve(&fn_name).to_string();
 
                 // Bind the body through the exact free-function declaration that

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -332,6 +332,20 @@ impl<'a> BodySema<'a> {
             .with_help("wrap the call in a `checked { ... }` block"));
         }
 
+        // A foreign `extern "C"` function may only be called inside a `checked`
+        // block (ADR-0064 unchecked-only ruling): the boundary carries no Rue
+        // exclusivity, aliasing, or lifetime guarantee, exactly as `@syscall`
+        // requires a checked context (ADR-0028).
+        if fn_info.is_extern && ctx.checked_depth == 0 {
+            return Err(CompileError::new(
+                ErrorKind::UncheckedOpRequiresChecked {
+                    what: format!("calling foreign function `{fn_name_str}`"),
+                },
+                span,
+            )
+            .with_help("wrap the call in a `checked { ... }` block"));
+        }
+
         // Track this function as referenced (for lazy analysis)
         ctx.referenced_functions.insert(name);
 

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -225,6 +225,8 @@ pub struct SemanticDeclarationShell {
     pub is_generic: bool,
     pub is_public: bool,
     pub is_unchecked: bool,
+    /// Whether this is a foreign `extern "C"` declaration (ADR-0064 C FFI).
+    pub is_extern: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -767,6 +769,7 @@ impl<'a> DeclarationShells<'a> {
                                 is_generic: pending.shell.is_generic,
                                 is_pub: pending.shell.is_public,
                                 is_unchecked: pending.shell.is_unchecked,
+                                is_extern: pending.shell.is_extern,
                                 allow_unused_function,
                                 allow_unused_variable,
                                 allow_unreachable_code,
@@ -1467,6 +1470,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                         is_generic: false,
                         is_public: *is_pub,
                         is_unchecked: false,
+                        is_extern: false,
                     },
                     declaration: inst_ref,
                 });
@@ -1480,11 +1484,13 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                 is_generic,
                 is_public,
                 is_unchecked,
+                is_extern,
                 source,
             ) = match &inst.data {
                 InstData::FnDecl {
                     is_pub,
                     is_unchecked,
+                    is_extern,
                     name,
                     params,
                     body,
@@ -1530,6 +1536,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                         comptime.into_iter().any(|value| value),
                         *is_pub,
                         *is_unchecked,
+                        *is_extern,
                         DeclarationPayloadSource::Callable { body: *body },
                     )
                 }
@@ -1556,6 +1563,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     false,
                     *is_pub,
                     false,
+                    false,
                     DeclarationPayloadSource::Const { initializer: *init },
                 ),
                 InstData::DropFnDecl { type_name, body } => (
@@ -1576,6 +1584,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     false,
                     false,
                     false,
+                    false,
                     DeclarationPayloadSource::Destructor { body: *body },
                 ),
                 _ => continue,
@@ -1592,6 +1601,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     is_generic,
                     is_public,
                     is_unchecked,
+                    is_extern,
                 },
                 declaration: inst_ref,
                 source,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -12,7 +12,9 @@
 use std::collections::{HashMap, HashSet};
 
 use lasso::Spur;
-use rue_error::{CompileError, CompileResult, CopyStructNonCopyFieldError, ErrorKind, ice};
+use rue_error::{
+    CompileError, CompileResult, CopyStructNonCopyFieldError, ErrorKind, PreviewFeature, ice,
+};
 use rue_rir::{InstData, InstRef, RirParamMode};
 use rue_span::{FileId, Span};
 
@@ -1055,6 +1057,7 @@ impl<'a> Sema<'a> {
                 InstData::FnDecl {
                     is_pub,
                     is_unchecked,
+                    is_extern,
                     name,
                     params,
                     return_type,
@@ -1098,6 +1101,7 @@ impl<'a> Sema<'a> {
                         inst.span,
                         *is_pub,
                         *is_unchecked,
+                        *is_extern,
                     )?;
                 }
 
@@ -1274,6 +1278,7 @@ impl<'a> Sema<'a> {
     }
 
     /// Collect a function signature for forward reference.
+    #[allow(clippy::too_many_arguments)]
     fn collect_function_signature(
         &mut self,
         declaration: InstRef,
@@ -1283,6 +1288,7 @@ impl<'a> Sema<'a> {
         span: Span,
         is_pub: bool,
         is_unchecked: bool,
+        is_extern: bool,
     ) -> CompileResult<()> {
         // Reject user functions whose name collides with a runtime/codegen helper
         // symbol (e.g. `__rue_str_eq`, `__rue_alloc`, `_start`). Without this, such a
@@ -1416,6 +1422,41 @@ impl<'a> Sema<'a> {
             self.resolve_type(return_type_sym, span)?
         };
 
+        // Foreign `extern "C"` declarations are gated behind the `c_ffi` preview
+        // and restricted to the P1 type set — the types whose native and
+        // target-C representations coincide (ADR-0064 P1): `i64`, `u64`, and
+        // pointers, plus `()` in return position (C `void`). Every other type
+        // (narrow integers, `bool`, aggregates, floats, enums) awaits a later
+        // FFI phase and is rejected here with a clear not-yet diagnostic.
+        if is_extern {
+            self.require_preview(
+                PreviewFeature::CFfi,
+                "an `extern \"C\"` foreign declaration",
+                span,
+            )?;
+            let is_supported_extern_scalar = |ty: Type| {
+                ty == Type::I64 || ty == Type::U64 || ty.is_ptr_const() || ty.is_ptr_mut()
+            };
+            for &param_type in &param_types {
+                if !is_supported_extern_scalar(param_type) {
+                    return Err(CompileError::new(
+                        ErrorKind::ExternSignatureTypeUnsupported {
+                            ty: self.format_type_name(param_type),
+                        },
+                        span,
+                    ));
+                }
+            }
+            if ret_type != Type::UNIT && !is_supported_extern_scalar(ret_type) {
+                return Err(CompileError::new(
+                    ErrorKind::ExternSignatureTypeUnsupported {
+                        ty: self.format_type_name(ret_type),
+                    },
+                    span,
+                ));
+            }
+        }
+
         // Allocate parameter data in the arena
         let params_range = self.param_arena.alloc(
             param_names.into_iter(),
@@ -1441,6 +1482,7 @@ impl<'a> Sema<'a> {
                 is_generic,
                 is_pub,
                 is_unchecked,
+                is_extern,
                 allow_unused_function,
                 allow_unused_variable,
                 allow_unreachable_code,
@@ -2710,19 +2752,27 @@ impl<'a> Sema<'a> {
         let Some(inst_ref) = self.declaration_index.first_free_function(target, file_id) else {
             return Ok(None);
         };
-        let (span, is_pub, return_type, body, is_unchecked) = {
+        let (span, is_pub, return_type, body, is_unchecked, is_extern) = {
             let inst = self.rir.get(inst_ref);
             let InstData::FnDecl {
                 is_pub,
                 return_type,
                 body,
                 is_unchecked,
+                is_extern,
                 ..
             } = &inst.data
             else {
                 unreachable!("free-function index contains only FnDecl instructions");
             };
-            (inst.span, *is_pub, *return_type, *body, *is_unchecked)
+            (
+                inst.span,
+                *is_pub,
+                *return_type,
+                *body,
+                *is_unchecked,
+                *is_extern,
+            )
         };
 
         let internal_target = self.internal_function_name(target, span.file_id);
@@ -2743,6 +2793,7 @@ impl<'a> Sema<'a> {
                 span,
                 is_pub,
                 is_unchecked,
+                is_extern,
             );
             self.fn_signatures_in_flight.remove(&internal_target);
             collected?;

--- a/crates/rue-air/src/sema/info.rs
+++ b/crates/rue-air/src/sema/info.rs
@@ -35,6 +35,11 @@ pub struct FunctionInfo {
     /// Whether this function carries the `unchecked` modifier. Calling it
     /// requires a `checked` block at the call site (spec 9.1:1).
     pub is_unchecked: bool,
+    /// Whether this is a foreign `extern "C"` declaration (ADR-0064 C FFI): a
+    /// body-less import with no CFG. Calling it requires the `c_ffi` preview and
+    /// a `checked` block; codegen emits an undefined linker symbol rather than a
+    /// definition.
+    pub is_extern: bool,
     /// Whether `@allow(unused_function)` was applied to this function.
     pub allow_unused_function: bool,
     /// Whether `@allow(unused_variable)` was applied to this function.

--- a/crates/rue-cli-tests/BUCK
+++ b/crates/rue-cli-tests/BUCK
@@ -6,6 +6,7 @@ load("//crates:defs.bzl", "rue_binary")
 rue_binary(
     name = "rue-cli-tests",
     deps = [
+        "//crates/rue-linker:rue-linker",
         "//crates/rue-target:rue-target",
         "//crates/rue-test-runner:rue-test-runner",
         "//third-party:libtest2-mimic",

--- a/crates/rue-cli-tests/cases/c_ffi.toml
+++ b/crates/rue-cli-tests/cases/c_ffi.toml
@@ -1,0 +1,154 @@
+# C FFI P1 (ADR-0064, RUE-1055): `extern "C"` foreign declarations and
+# static-archive linking, gated behind the `c_ffi` preview.
+#
+# The proof program declares a foreign `answer() -> i64`, calls it inside a
+# `checked {}` block, and prints the result. The archive that defines `answer`
+# is synthesized in-tree by the harness with the compiler's own object machinery
+# (`ffi_answer_archive` -> `rue_linker::ObjectBuilder`), producing pure machine
+# code that returns 42 for each target — no C toolchain is involved, mirroring
+# how the runtime archive is linked in.
+
+[section]
+id = "cli.c_ffi"
+name = "C FFI — extern fn declarations and static-archive linking"
+description = "Foreign `extern \"C\"` calls resolve from a supplied static archive; the preview gate, checked-context, and signature-type diagnostics hold."
+
+# --- Execution-verified proof program (both backends) ----------------------
+# Target-pinned like cli.abi_conformance: every host compiles and links both;
+# the matching native host also executes and checks exact output.
+
+[[case]]
+name = "x86_64_linux_extern_answer_returns_42"
+description = "extern answer() resolved from a static archive prints 42 on x86-64."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 {
+    let result = checked { answer() };
+    @dbg(result);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "x86-64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = "42\n"
+exit_code = 0
+
+[[case]]
+name = "aarch64_linux_extern_answer_returns_42"
+description = "extern answer() resolved from a static archive prints 42 on AArch64."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 {
+    let result = checked { answer() };
+    @dbg(result);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "aarch64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "aarch64-linux"
+execute_if_native = true
+stdout = "42\n"
+exit_code = 0
+
+# --- Diagnostics -----------------------------------------------------------
+
+[[case]]
+name = "extern_declaration_requires_preview"
+description = "An `extern \"C\"` declaration is inert without `--preview c_ffi`."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["c_ffi", "preview"]
+
+[[case]]
+name = "extern_call_requires_checked_block"
+description = "Calling a foreign function outside `checked {}` is rejected (unchecked-only ruling)."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 {
+    let result = answer();
+    @dbg(result);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["foreign function", "checked"]
+
+[[case]]
+name = "extern_unsupported_signature_type_rejected"
+description = "A P1-unsupported type (i32) in an extern signature gets a clear not-yet diagnostic."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn f(x: i32) -> i32;
+}
+
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["i32", "not yet supported", "ADR-0064"]
+
+[[case]]
+name = "extern_unsupported_bool_return_rejected"
+description = "`bool` is not in the P1 extern type set (narrow scalar boundary is a later phase)."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn ready() -> bool;
+}
+
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["bool", "not yet supported"]
+
+[[case]]
+name = "extern_unsupported_abi_rejected"
+description = "Only the \"C\" ABI is accepted in v0."
+files = [{ path = "main.rue", source = """
+extern "Rust" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["unsupported extern ABI", "\"C\""]
+
+[[case]]
+name = "extern_unresolved_symbol_at_link_time"
+description = "A foreign call with no archive defining the symbol fails at link, naming the symbol and searched archives."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn answer() -> i64;
+}
+
+fn main() -> i32 {
+    let result = checked { answer() };
+    @dbg(result);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["undefined symbol", "answer", "searched"]

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -98,6 +98,58 @@ use std::time::Duration;
 
 use libtest2_mimic::{Harness, RunContext, RunError, Trial};
 use rue_target::{Arch, Target};
+
+/// Build a tiny C-free static archive exporting `answer() -> 42` as pure machine
+/// code for `target` (ADR-0064 C FFI P1 proof). The object is produced with the
+/// compiler's own `rue_linker::ObjectBuilder` (which emits a defined global
+/// symbol named `answer`), then wrapped in a GNU `ar` archive — the same static
+/// archive shape the linker already resolves the runtime from.
+fn synthesize_answer_archive(target: Target) -> TestResult<Vec<u8>> {
+    // A leaf function that returns the integer 42 and nothing else.
+    let code: Vec<u8> = match target.arch() {
+        // mov eax, 42 ; ret
+        Arch::X86_64 => vec![0xB8, 0x2A, 0x00, 0x00, 0x00, 0xC3],
+        // movz w0, #42 ; ret
+        Arch::Aarch64 => vec![0x40, 0x05, 0x80, 0x52, 0xC0, 0x03, 0x5F, 0xD6],
+    };
+    let object = rue_linker::ObjectBuilder::new(target, "answer")
+        .code(code)
+        .build();
+    Ok(ar_archive(&[("answer.o", &object)]))
+}
+
+/// Assemble a minimal GNU `ar` archive from named object members. Only the
+/// fields the internal linker's archive reader consumes are populated.
+fn ar_archive(members: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"!<arch>\n");
+    for (name, data) in members {
+        // GNU short-name members terminate the name with `/`.
+        let header_name = format!("{name}/");
+        let mut header = [b' '; 60];
+        let name_bytes = header_name.as_bytes();
+        header[..name_bytes.len()].copy_from_slice(name_bytes);
+        write_ar_field(&mut header, 16, 12, b"0"); // mtime
+        write_ar_field(&mut header, 28, 6, b"0"); // uid
+        write_ar_field(&mut header, 34, 6, b"0"); // gid
+        write_ar_field(&mut header, 40, 8, b"644"); // mode (octal)
+        write_ar_field(&mut header, 48, 10, data.len().to_string().as_bytes()); // size
+        header[58] = b'`';
+        header[59] = b'\n';
+        out.extend_from_slice(&header);
+        out.extend_from_slice(data);
+        if data.len() % 2 == 1 {
+            out.push(b'\n');
+        }
+    }
+    out
+}
+
+/// Left-justify `value` into a fixed-width `ar` header field.
+fn write_ar_field(header: &mut [u8; 60], offset: usize, width: usize, value: &[u8]) {
+    let len = value.len().min(width);
+    header[offset..offset + len].copy_from_slice(&value[..len]);
+}
 use rue_test_runner::{
     DEFAULT_TIMEOUT_MS, ExpectedFailureOutcome, KNOWN_TARGETS, TestFailure, TestResult,
     classify_expected_failure, compiler_command, find_dir, find_rue_binary, ice_message,
@@ -465,6 +517,14 @@ struct Case {
     /// Compiler arguments, relative to the temp dir (default: first file + `-o prog`).
     #[serde(default)]
     args: Option<Vec<String>>,
+    /// Synthesize a tiny C-free static archive exporting `answer() -> 42` as
+    /// pure machine code for the case's target, and substitute its path for the
+    /// `${FFI_ARCHIVE}` token in `args` (ADR-0064 C FFI P1 proof program). The
+    /// archive is produced with the compiler's own object machinery
+    /// (`rue_linker::ObjectBuilder`), mirroring how the runtime archive is
+    /// linked in — no C toolchain is required.
+    #[serde(default)]
+    ffi_answer_archive: bool,
     /// Name of the executable the compiler is expected to produce.
     #[serde(default)]
     output: Option<String>,
@@ -1091,6 +1151,28 @@ fn run_case(
         for argument in &mut args {
             if argument == "${SOURCE}" {
                 *argument = source_path.clone();
+            }
+        }
+    }
+    // Synthesize the C FFI proof archive (ADR-0064 P1) and substitute its path
+    // for the `${FFI_ARCHIVE}` token. The archive target matches the case's
+    // `executable_target` (default host) so the emitted machine code is valid.
+    if case.ffi_answer_archive {
+        let archive_target = match &case.executable_target {
+            Some(name) => name.parse::<Target>().map_err(|_| {
+                TestFailure::assertion(format!("invalid executable_target `{name}`"))
+            })?,
+            None => Target::host()
+                .ok_or_else(|| TestFailure::assertion("no host target for ffi_answer_archive"))?,
+        };
+        let archive_path = dir.join("libanswer.a");
+        let archive_bytes = synthesize_answer_archive(archive_target)?;
+        std::fs::write(&archive_path, &archive_bytes)
+            .map_err(|e| TestFailure::fatal(format!("failed to write ffi answer archive: {e}")))?;
+        let archive_path = archive_path.display().to_string();
+        for argument in &mut args {
+            if argument == "${FFI_ARCHIVE}" {
+                *argument = archive_path.clone();
             }
         }
     }

--- a/crates/rue-compiler/src/artifact_views.rs
+++ b/crates/rue-compiler/src/artifact_views.rs
@@ -198,6 +198,7 @@ impl TokenView {
             Checked => "CHECKED",
             Unchecked => "UNCHECKED",
             Ptr => "PTR",
+            Extern => "EXTERN",
             I8 => "TYPE(i8)",
             I16 => "TYPE(i16)",
             I32 => "TYPE(i32)",
@@ -1074,6 +1075,22 @@ fn syntax_item_record(
                 expr_record(owner, &drop_fn.body),
             ],
         ),
+        rue_parser::Item::Extern(extern_block) => {
+            let children = extern_block
+                .fns
+                .iter()
+                .map(|foreign| {
+                    syntax_record(
+                        "extern_function",
+                        foreign.span,
+                        Some(resolved_ident(owner, foreign.name)),
+                        None,
+                        Vec::new(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            syntax_record("extern", extern_block.span, None, None, children)
+        }
         rue_parser::Item::Const(constant) => {
             let mut children = directive_records(owner, &constant.directives).collect::<Vec<_>>();
             children.push(modifier_record(

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -2,6 +2,46 @@
 // Backend (code generation and linking)
 // ============================================================================
 
+/// Collect the raw C symbol names of every `extern "C"` foreign declaration in
+/// the lowered program (ADR-0064 C FFI). These are the undefined symbols a call
+/// site references and the linker resolves from a supplied static archive.
+pub(crate) fn collect_foreign_symbols(rir: &rue_rir::Rir, interner: &ThreadedRodeo) -> Vec<String> {
+    rir.iter()
+        .filter_map(|(_, inst)| match &inst.data {
+            rue_rir::InstData::FnDecl {
+                is_extern: true,
+                name,
+                ..
+            } => Some(interner.resolve(name).to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Project live callable legacy names to their machine symbols, plus an
+/// identity mapping for every `extern "C"` foreign declaration.
+///
+/// A foreign symbol maps to itself (no mangling, ADR-0064): a call site resolves
+/// it to the raw C name, the object writer records it as an undefined external,
+/// and the linker satisfies it from a static archive. The identity mapping also
+/// lets `validate_production_call_relocations` recognize the raw name as a
+/// declared foreign call rather than an unresolved glue symbol.
+fn foreign_call_symbol_mappings(
+    functions: &[FunctionWithCfg],
+    foreign_symbols: &[String],
+) -> std::collections::BTreeMap<String, String> {
+    let mut symbol_mappings = functions
+        .iter()
+        .map(|function| (function.legacy_name.clone(), function.machine_name.clone()))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    for name in foreign_symbols {
+        symbol_mappings
+            .entry(name.clone())
+            .or_insert_with(|| name.clone());
+    }
+    symbol_mappings
+}
+
 /// Compile analyzed functions to a binary.
 ///
 /// This backend handles both architectures. It:
@@ -10,6 +50,7 @@
 /// 3. Links them into an executable
 ///
 /// This function is used by the sole one-shot compilation adapter.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn compile_backend(
     functions: &[FunctionWithCfg],
     type_pool: &FrozenTypeInternPool,
@@ -17,6 +58,10 @@ pub(crate) fn compile_backend(
     interner: &ThreadedRodeo,
     options: &CompileOptions,
     warnings: &[CompileWarning],
+    // Names of `extern "C"` foreign declarations (ADR-0064 C FFI). Each is an
+    // undefined symbol a call site references by its raw (unmangled) name and
+    // that the linker resolves from a supplied static archive.
+    foreign_symbols: &[String],
 ) -> MultiErrorResult<CompileOutput> {
     // Check for main function
     let _main_fn = functions
@@ -53,10 +98,22 @@ pub(crate) fn compile_backend(
 
     // Generate object files based on target architecture
     let object_files = match options.target.arch() {
-        Arch::X86_64 => generate_x86_64_objects(functions, type_pool, strings, interner, options)?,
-        Arch::Aarch64 => {
-            generate_aarch64_objects(functions, type_pool, strings, interner, options)?
-        }
+        Arch::X86_64 => generate_x86_64_objects(
+            functions,
+            type_pool,
+            strings,
+            interner,
+            options,
+            foreign_symbols,
+        )?,
+        Arch::Aarch64 => generate_aarch64_objects(
+            functions,
+            type_pool,
+            strings,
+            interner,
+            options,
+            foreign_symbols,
+        )?,
     };
 
     // Link to executable
@@ -69,18 +126,17 @@ pub(crate) fn compile_backend(
 }
 
 /// Generate x86-64 object files for all functions.
+#[allow(clippy::too_many_arguments)]
 fn generate_x86_64_objects(
     functions: &[FunctionWithCfg],
     type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
     options: &CompileOptions,
+    foreign_symbols: &[String],
 ) -> MultiErrorResult<Vec<Vec<u8>>> {
     let _span = info_span!("codegen", arch = "x86_64").entered();
-    let symbol_mappings = functions
-        .iter()
-        .map(|function| (function.legacy_name.clone(), function.machine_name.clone()))
-        .collect::<std::collections::BTreeMap<_, _>>();
+    let symbol_mappings = foreign_call_symbol_mappings(functions, foreign_symbols);
     let symbols = rue_codegen::MachineSymbolResolver::new(&symbol_mappings);
 
     let results: Vec<CompileResult<Vec<u8>>> = functions
@@ -146,18 +202,17 @@ fn generate_x86_64_objects(
 }
 
 /// Generate AArch64 object files for all functions.
+#[allow(clippy::too_many_arguments)]
 fn generate_aarch64_objects(
     functions: &[FunctionWithCfg],
     type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
     options: &CompileOptions,
+    foreign_symbols: &[String],
 ) -> MultiErrorResult<Vec<Vec<u8>>> {
     let _span = info_span!("codegen", arch = "aarch64").entered();
-    let symbol_mappings = functions
-        .iter()
-        .map(|function| (function.legacy_name.clone(), function.machine_name.clone()))
-        .collect::<std::collections::BTreeMap<_, _>>();
+    let symbol_mappings = foreign_call_symbol_mappings(functions, foreign_symbols);
     let symbols = rue_codegen::MachineSymbolResolver::new(&symbol_mappings);
 
     let results: Vec<CompileResult<Vec<u8>>> = functions
@@ -750,6 +805,7 @@ drop fn StrBuf(self) { }
                     semantic.strings(),
                     interner,
                     &options,
+                    &[],
                 ),
                 Arch::Aarch64 => generate_aarch64_objects(
                     semantic.functions(),
@@ -757,6 +813,7 @@ drop fn StrBuf(self) { }
                     semantic.strings(),
                     interner,
                     &options,
+                    &[],
                 ),
             }
             .unwrap();
@@ -790,6 +847,7 @@ drop fn StrBuf(self) { }
                     semantic.strings(),
                     interner,
                     &options,
+                    &[],
                 ),
                 Arch::Aarch64 => generate_aarch64_objects(
                     semantic.functions(),
@@ -797,6 +855,7 @@ drop fn StrBuf(self) { }
                     semantic.strings(),
                     interner,
                     &options,
+                    &[],
                 ),
             }
             .unwrap();
@@ -841,6 +900,7 @@ drop fn StrBuf(self) { }
             semantic.strings(),
             interner,
             &options,
+            &[],
             &[],
         )
         .expect("ordinary source-defined StrBuf program must link without obsolete members");

--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -1029,6 +1029,12 @@ fn definition_input_partition(
         Item::Struct(value) => value.span == binding.declaration_span,
         Item::Enum(value) => value.span == binding.declaration_span,
         Item::DropFn(value) => value.span == binding.declaration_span,
+        // A foreign declaration's binding span is the individual `fn`'s span,
+        // not the enclosing `extern` block's (ADR-0064 C FFI).
+        Item::Extern(block) => block
+            .fns
+            .iter()
+            .any(|foreign| foreign.span == binding.declaration_span),
         Item::Const(value) => value.span == binding.declaration_span,
         Item::Error(_) => false,
     });
@@ -1042,6 +1048,18 @@ fn definition_input_partition(
         Some(Item::Enum(value)) => Ok(BoundDefinitionInputPartition::ExactSignature(
             vec![value.span].into(),
         )),
+        // A foreign `extern "C"` declaration is signature-only: the whole
+        // declaration is its exact-signature partition (there is no body).
+        Some(Item::Extern(block)) => {
+            let foreign = block
+                .fns
+                .iter()
+                .find(|foreign| foreign.span == binding.declaration_span)
+                .ok_or_else(|| invalid("extern binding does not join canonical syntax"))?;
+            Ok(BoundDefinitionInputPartition::ExactSignature(
+                vec![foreign.span].into(),
+            ))
+        }
         Some(Item::Error(_)) | None => Err(invalid(
             "semantic binding does not join an authoritative canonical syntax item",
         )),

--- a/crates/rue-compiler/src/definition_snapshot.rs
+++ b/crates/rue-compiler/src/definition_snapshot.rs
@@ -639,9 +639,27 @@ pub(crate) fn definition_parts(item: &Item) -> Option<DefinitionParts> {
             name: constant.name,
             declaration_span: constant.span,
         },
+        // A foreign `extern "C"` block declares several definitions at once, so
+        // it does not fit the one-item/one-definition shape here. The definition
+        // index expands it via `extern_definition_parts` (ADR-0064 C FFI).
+        Item::Extern(_) => return None,
         Item::Error(_) => return None,
     };
     Some(parts)
+}
+
+/// Per-`fn` definition parts for a foreign `extern "C"` block. Each member is an
+/// independent module-item definition keyed by its own declaration span.
+pub(crate) fn extern_definition_parts(
+    block: &rue_parser::ast::ExternBlock,
+) -> impl Iterator<Item = DefinitionParts> + '_ {
+    block.fns.iter().map(|foreign| DefinitionParts {
+        namespace: DefinitionNamespace::ModuleItem,
+        kind: DefinitionKind::Function,
+        visibility: Some(Visibility::Private),
+        name: foreign.name,
+        declaration_span: foreign.span,
+    })
 }
 
 pub(crate) fn validate_span(

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -170,6 +170,23 @@ pub(crate) fn parse_runtime_archive(runtime_bytes: &[u8]) -> Result<Archive, Str
     Ok(archive)
 }
 
+/// Read and parse a user-supplied static archive passed with `--link-archive`
+/// (ADR-0064 C FFI). Its object members satisfy undefined `extern "C"` symbols.
+fn read_user_archive(path: &Path) -> Result<Archive, ErrorKind> {
+    let bytes = std::fs::read(path).map_err(|e| {
+        ErrorKind::LinkError(format!(
+            "failed to read link archive `{}`: {e}",
+            path.display()
+        ))
+    })?;
+    Archive::parse_strict_objects(&bytes).map_err(|e| {
+        ErrorKind::LinkError(format!(
+            "failed to parse link archive `{}`: {e}",
+            path.display()
+        ))
+    })
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RuntimeSymbolKind {
     Function,
@@ -497,6 +514,20 @@ pub(crate) fn link_internal_with_warnings(
     // archive linking only includes objects that define needed symbols.
     linker.require_symbol(entry_point);
 
+    // Add user-supplied static archives (`--link-archive`, ADR-0064 C FFI)
+    // before the runtime so a foreign member that itself depends on a runtime
+    // symbol can still be satisfied. Each archive resolves the undefined
+    // `extern "C"` symbols referenced by the compiled objects.
+    for archive_path in &options.link_archives {
+        let archive = read_user_archive(archive_path)
+            .map_err(CompileError::without_span)
+            .map_err(CompileErrors::from)?;
+        linker
+            .add_archive(archive)
+            .map_err(link_error)
+            .map_err(CompileErrors::from)?;
+    }
+
     // Add the runtime library
     let runtime = validate_runtime_archive(runtime_bytes, options.target)
         .map_err(link_error)
@@ -506,10 +537,25 @@ pub(crate) fn link_internal_with_warnings(
         .map_err(link_error)
         .map_err(CompileErrors::from)?;
 
-    // Link to executable
+    // Link to executable. An undefined symbol at this point is an unresolved
+    // `extern "C"` import (or a runtime gap); name the symbol and the archives
+    // that were searched (ADR-0064 C FFI).
     let executable = linker
         .link(entry_point)
-        .map_err(link_error)
+        .map_err(|err| match &err {
+            rue_linker::LinkError::UndefinedSymbol(symbol) => {
+                let mut searched = vec!["the bundled rue-runtime archive".to_string()];
+                for archive_path in &options.link_archives {
+                    searched.push(format!("`{}`", archive_path.display()));
+                }
+                CompileError::without_span(ErrorKind::LinkError(format!(
+                    "undefined symbol `{symbol}`: no supplied archive defines it \
+                     (searched {})",
+                    searched.join(", ")
+                )))
+            }
+            _ => link_error(err),
+        })
         .map_err(CompileErrors::from)?;
     info!(
         object_count = object_files.len(),
@@ -572,6 +618,12 @@ pub(crate) fn link_system_with_warnings(
     // Add object files
     for path in &temp_dir.obj_paths {
         cmd.arg(path);
+    }
+
+    // Add user-supplied static archives (`--link-archive`, ADR-0064 C FFI)
+    // before the runtime so the runtime can satisfy any dependency they pull.
+    for archive_path in &options.link_archives {
+        cmd.arg(archive_path);
     }
 
     // Add the runtime library

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -1083,6 +1083,17 @@ fn collect_imports(
                 }
             }
             Item::DropFn(value) => walk_expr(&value.body, module, resolver, &mut imports)?,
+            Item::Extern(block) => {
+                for foreign in &block.fns {
+                    walk_signature(
+                        &foreign.params,
+                        foreign.return_type.as_ref(),
+                        module,
+                        resolver,
+                        &mut imports,
+                    )?;
+                }
+            }
             Item::Const(value) => {
                 if let Some(ty) = &value.ty {
                     walk_type_expr(ty, module, resolver, &mut imports)?;
@@ -1384,32 +1395,42 @@ fn build_definition_index(
 ) -> CompileResult<ParsedDefinitionIndex> {
     let mut pending = Vec::new();
     for item in &ast.items {
-        let Some(parts) = definition_parts(item) else {
-            let Item::Error(span) = item else {
-                unreachable!()
+        // A foreign `extern "C"` block expands into one module-item definition
+        // per member `fn` (ADR-0064 C FFI); every other item is a single
+        // definition.
+        let item_parts: Vec<_> = if let Item::Extern(block) = item {
+            crate::definition_snapshot::extern_definition_parts(block).collect()
+        } else {
+            let Some(parts) = definition_parts(item) else {
+                let Item::Error(span) = item else {
+                    unreachable!()
+                };
+                return Err(invalid_input(format!(
+                    "parsed module contains recovered error item at {}..{}",
+                    span.start, span.end
+                )));
             };
-            return Err(invalid_input(format!(
-                "parsed module contains recovered error item at {}..{}",
-                span.start, span.end
-            )));
+            vec![parts]
         };
-        validate_span(
-            "definition declaration",
-            parts.declaration_span,
-            file_id,
-            source_text,
-        )?;
-        validate_span("definition name", parts.name.span, file_id, source_text)?;
-        if parts.name.span.start < parts.declaration_span.start
-            || parts.name.span.end > parts.declaration_span.end
-        {
-            return Err(invalid_input(
-                "definition name span is outside its declaration span",
-            ));
+        for parts in item_parts {
+            validate_span(
+                "definition declaration",
+                parts.declaration_span,
+                file_id,
+                source_text,
+            )?;
+            validate_span("definition name", parts.name.span, file_id, source_text)?;
+            if parts.name.span.start < parts.declaration_span.start
+                || parts.name.span.end > parts.declaration_span.end
+            {
+                return Err(invalid_input(
+                    "definition name span is outside its declaration span",
+                ));
+            }
+            let symbol = resolver.symbol(parts.name.name)?;
+            let name: Arc<str> = Arc::from(resolver.resolve(&symbol)?);
+            pending.push((parts, symbol, name));
         }
-        let symbol = resolver.symbol(parts.name.name)?;
-        let name: Arc<str> = Arc::from(resolver.resolve(&symbol)?);
-        pending.push((parts, symbol, name));
     }
     pending.sort_by(|(left, _, left_name), (right, _, right_name)| {
         (

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -71,6 +71,11 @@ pub struct CompileOptions {
     pub opt_level: OptLevel,
     /// Enabled preview features.
     pub preview_features: PreviewFeatures,
+    /// Static archives (`.a`) supplied on the command line with
+    /// `--link-archive` (ADR-0064 C FFI). The linker resolves undefined
+    /// `extern "C"` symbols from these members. Linking-only: this does not
+    /// participate in the semantic or codegen cache identity.
+    pub link_archives: Vec<std::path::PathBuf>,
 }
 
 impl Default for CompileOptions {
@@ -81,6 +86,7 @@ impl Default for CompileOptions {
             linker: LinkerMode::Internal,
             opt_level: OptLevel::default(),
             preview_features: PreviewFeatures::new(),
+            link_archives: Vec::new(),
         }
     }
 }
@@ -854,6 +860,8 @@ pub(crate) fn compile_with_session(
     };
     let semantic = session.canonical_semantic(options)?;
     let session_work = session.work();
+    let foreign_symbols =
+        crate::backend::collect_foreign_symbols(rir.rir(), rir.semantic_symbols().interner());
     let mut output = crate::backend::compile_backend(
         semantic.functions(),
         semantic.type_pool(),
@@ -861,6 +869,7 @@ pub(crate) fn compile_with_session(
         rir.semantic_symbols().interner(),
         options,
         semantic.warnings(),
+        &foreign_symbols,
     )?;
     output.source_stats = SourceStats {
         files: snapshot.len(),

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -379,6 +379,7 @@ impl ErrorCode {
     // Preview feature errors (E1100-E1199)
     // ========================================================================
     pub const PREVIEW_FEATURE_REQUIRED: Self = Self(1100);
+    pub const EXTERN_SIGNATURE_TYPE_UNSUPPORTED: Self = Self(1101);
 
     // ========================================================================
     // Comptime errors (E1200-E1299)
@@ -521,6 +522,10 @@ pub enum PreviewFeature {
     /// collection/string trio. Gated until the fat-pointer ABI lands on both
     /// backends.
     Slices,
+    /// C FFI: `extern "C"` foreign-function declarations and static-archive
+    /// linking (ADR-0064, RUE-1055). Gated until every phase of the guaranteed
+    /// target-C boundary is proven on both backends.
+    CFfi,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -542,6 +547,7 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "test_infra",
             PreviewFeature::Slices => "slices",
+            PreviewFeature::CFfi => "c_ffi",
         }
     }
 
@@ -551,12 +557,17 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "ADR-0005",
             PreviewFeature::Slices => "ADR-0043",
+            PreviewFeature::CFfi => "ADR-0064",
         }
     }
 
     /// Get all available preview features.
     pub fn all() -> &'static [PreviewFeature] {
-        &[PreviewFeature::TestInfra, PreviewFeature::Slices]
+        &[
+            PreviewFeature::TestInfra,
+            PreviewFeature::Slices,
+            PreviewFeature::CFfi,
+        ]
     }
 
     /// Get a comma-separated list of all feature names (for help text).
@@ -580,6 +591,7 @@ impl std::str::FromStr for PreviewFeature {
         match s {
             "test_infra" => Ok(PreviewFeature::TestInfra),
             "slices" => Ok(PreviewFeature::Slices),
+            "c_ffi" => Ok(PreviewFeature::CFfi),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -1557,6 +1569,20 @@ pub enum ErrorKind {
         what: String,
     },
 
+    /// A type appeared in an `extern "C"` signature that the current FFI phase
+    /// cannot yet classify. C FFI P1 (ADR-0064, RUE-1055) supports only the
+    /// types whose native and target-C representations coincide: `i64`, `u64`,
+    /// and raw pointers. Other types (narrow integers, `bool`, aggregates,
+    /// floats, enums) await later phases.
+    #[error(
+        "type `{ty}` is not yet supported in an `extern \"C\"` signature: \
+         C FFI P1 (ADR-0064) supports only `i64`, `u64`, and pointer types"
+    )]
+    ExternSignatureTypeUnsupported {
+        /// The rejected type, as rendered for the user.
+        ty: String,
+    },
+
     /// A slice type / range-slice was used under `--preview slices` but the
     /// fat-pointer runtime is not implemented yet (ADR-0043 Phase 1, RUE-322).
     #[error("slice types are not yet fully implemented (ADR-0043 Phase 1, RUE-322)")]
@@ -1794,6 +1820,9 @@ impl ErrorKind {
 
             // Preview feature errors (E1100-E1199)
             ErrorKind::PreviewFeatureRequired { .. } => ErrorCode::PREVIEW_FEATURE_REQUIRED,
+            ErrorKind::ExternSignatureTypeUnsupported { .. } => {
+                ErrorCode::EXTERN_SIGNATURE_TYPE_UNSUPPORTED
+            }
             ErrorKind::SliceNotYetImplemented => ErrorCode::SLICE_NOT_YET_IMPLEMENTED,
             ErrorKind::SliceReturnNotAllowed => ErrorCode::SLICE_RETURN_NOT_ALLOWED,
             ErrorKind::SliceInAggregateField => ErrorCode::SLICE_IN_AGGREGATE_FIELD,
@@ -2626,7 +2655,7 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(names, "test_infra, slices");
+        assert_eq!(names, "test_infra, slices, c_ffi");
     }
 
     #[test]

--- a/crates/rue-frontend-diff/src/main.rs
+++ b/crates/rue-frontend-diff/src/main.rs
@@ -895,6 +895,29 @@ impl Shapes<'_> {
                 self.expr(&v.init),
                 "_".into(),
             ),
+            Item::Extern(v) => {
+                let members = v.fns.iter().map(|foreign| {
+                    node(
+                        "extern-fn",
+                        "",
+                        foreign
+                            .return_type
+                            .as_ref()
+                            .map_or("_".into(), |t| self.ty(t)),
+                        "_".into(),
+                        "_".into(),
+                        "_".into(),
+                    )
+                });
+                node(
+                    "extern",
+                    &format!(" abi={}", v.abi),
+                    list(members),
+                    "_".into(),
+                    "_".into(),
+                    "_".into(),
+                )
+            }
             Item::Error(_) => leaf("error"),
         }
     }

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -50,6 +50,7 @@ pub enum TokenKind {
     Checked,   // checked { } block for unchecked operations
     Unchecked, // unchecked fn modifier
     Ptr,       // ptr const T / ptr mut T pointer types
+    Extern,    // extern "C" { } foreign declaration block (ADR-0064 C FFI)
 
     // Type keywords
     I8,
@@ -153,6 +154,7 @@ impl TokenKind {
             TokenKind::Checked => "'checked'",
             TokenKind::Unchecked => "'unchecked'",
             TokenKind::Ptr => "'ptr'",
+            TokenKind::Extern => "'extern'",
             TokenKind::I8 => "type 'i8'",
             TokenKind::I16 => "type 'i16'",
             TokenKind::I32 => "type 'i32'",
@@ -258,6 +260,7 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Checked => write!(f, "CHECKED"),
             TokenKind::Unchecked => write!(f, "UNCHECKED"),
             TokenKind::Ptr => write!(f, "PTR"),
+            TokenKind::Extern => write!(f, "EXTERN"),
             TokenKind::I8 => write!(f, "TYPE(i8)"),
             TokenKind::I16 => write!(f, "TYPE(i16)"),
             TokenKind::I32 => write!(f, "TYPE(i32)"),

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -435,6 +435,8 @@ pub enum LogosTokenKind {
     Unchecked,
     #[token("ptr")]
     Ptr,
+    #[token("extern")]
+    Extern,
 
     // Type keywords
     #[token("i8")]
@@ -611,6 +613,7 @@ impl From<LogosTokenKind> for TokenKind {
             LogosTokenKind::Checked => TokenKind::Checked,
             LogosTokenKind::Unchecked => TokenKind::Unchecked,
             LogosTokenKind::Ptr => TokenKind::Ptr,
+            LogosTokenKind::Extern => TokenKind::Extern,
             LogosTokenKind::I8 => TokenKind::I8,
             LogosTokenKind::I16 => TokenKind::I16,
             LogosTokenKind::I32 => TokenKind::I32,

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -82,6 +82,8 @@ pub enum Item {
     Struct(StructDecl),
     Enum(EnumDecl),
     DropFn(DropFn),
+    /// A foreign-declaration block: `extern "C" { fn ...; }` (ADR-0064 C FFI).
+    Extern(ExternBlock),
     /// Constant declaration (e.g., `const math = @import("math");`)
     Const(ConstDecl),
     /// Error node for recovered parse errors at item level.
@@ -270,6 +272,38 @@ pub struct Function {
     /// Function body
     pub body: Expr,
     /// Span covering the entire function
+    pub span: Span,
+}
+
+/// A foreign-declaration block: `extern "C" { fn getpid() -> i32; }`.
+///
+/// Groups body-less foreign function declarations that share an ABI. The ABI
+/// string is a first-class part of the grammar (`"C"` is the only value the
+/// current C FFI phase accepts, ADR-0064). Everything inside the block is a
+/// foreign import lowered to an undefined linker symbol.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternBlock {
+    /// The ABI string as written (e.g. `"C"`).
+    pub abi: String,
+    /// The span of the ABI string literal, for diagnostics.
+    pub abi_span: Span,
+    /// The foreign function declarations in this block.
+    pub fns: Vec<ExternFn>,
+    /// Span covering the entire `extern` block.
+    pub span: Span,
+}
+
+/// A single body-less foreign function declaration inside an [`ExternBlock`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternFn {
+    /// The declared function name; also the undefined C symbol name (no
+    /// mangling is applied to foreign declarations).
+    pub name: Ident,
+    /// Foreign function parameters.
+    pub params: Vec<Param>,
+    /// Return type (None means implicit unit `()`).
+    pub return_type: Option<TypeExpr>,
+    /// Span covering the entire declaration.
     pub span: Span,
 }
 
@@ -1295,6 +1329,20 @@ fn rebind_item(item: &mut Item, file_id: FileId) {
             rebind_expr(&mut drop_fn.body, file_id);
             rebind_span(&mut drop_fn.span, file_id);
         }
+        Item::Extern(extern_block) => {
+            rebind_span(&mut extern_block.abi_span, file_id);
+            for foreign in &mut extern_block.fns {
+                rebind_ident(&mut foreign.name, file_id);
+                for parameter in &mut foreign.params {
+                    rebind_param(parameter, file_id);
+                }
+                if let Some(return_type) = &mut foreign.return_type {
+                    rebind_type(return_type, file_id);
+                }
+                rebind_span(&mut foreign.span, file_id);
+            }
+            rebind_span(&mut extern_block.span, file_id);
+        }
         Item::Const(constant) => {
             rebind_directives(&mut constant.directives, file_id);
             rebind_ident(&mut constant.name, file_id);
@@ -1674,6 +1722,7 @@ impl fmt::Display for Ast {
                 Item::Struct(s) => fmt_struct(f, s, 0)?,
                 Item::Enum(e) => fmt_enum(f, e, 0)?,
                 Item::DropFn(drop_fn) => fmt_drop_fn(f, drop_fn, 0)?,
+                Item::Extern(extern_block) => fmt_extern(f, extern_block, 0)?,
                 Item::Const(c) => fmt_const(f, c, 0)?,
                 Item::Error(span) => writeln!(f, "Error({:?})", span)?,
             }
@@ -1728,6 +1777,16 @@ fn fmt_enum(f: &mut fmt::Formatter<'_>, e: &EnumDecl, level: usize) -> fmt::Resu
                 variant.payload.len()
             )?;
         }
+    }
+    Ok(())
+}
+
+fn fmt_extern(f: &mut fmt::Formatter<'_>, block: &ExternBlock, level: usize) -> fmt::Result {
+    indent(f, level)?;
+    writeln!(f, "Extern \"{}\"", block.abi)?;
+    for foreign in &block.fns {
+        indent(f, level + 1)?;
+        writeln!(f, "ExternFn sym:{}", foreign.name.name.into_usize())?;
     }
     Ok(())
 }

--- a/crates/rue-parser/src/parser/declarations.rs
+++ b/crates/rue-parser/src/parser/declarations.rs
@@ -45,6 +45,9 @@ impl Parser {
             TokenKind::Drop if directives.is_empty() && visibility == Visibility::Private => {
                 self.drop_fn(start).map(Item::DropFn)
             }
+            TokenKind::Extern if directives.is_empty() && visibility == Visibility::Private => {
+                self.extern_block(start).map(Item::Extern)
+            }
             TokenKind::Const => self
                 .const_decl(start, directives, visibility)
                 .map(Item::Const),
@@ -79,6 +82,69 @@ impl Parser {
             params,
             return_type,
             body,
+            span: self.span_from(start),
+        })
+    }
+
+    /// Parse a foreign-declaration block: `extern "C" { fn name(...) -> T; }`.
+    ///
+    /// The ABI string is captured verbatim (validated in semantic analysis so
+    /// the diagnostic can name the unsupported ABI). Each member is a body-less
+    /// function signature terminated by `;`.
+    fn extern_block(&mut self, start: u32) -> PResult<ExternBlock> {
+        self.expect(TokenKind::Extern)?;
+        let (abi, abi_span) = match self.kind() {
+            TokenKind::String(spur) => {
+                let span = self.bump().span;
+                (self.interner.resolve(&spur).to_string(), span)
+            }
+            _ => {
+                self.unexpected("an ABI string such as \"C\"");
+                return Err(());
+            }
+        };
+        // `"C"` is the only ABI the current C FFI phase accepts (ADR-0064). The
+        // slot reserves room for later `"C-unwind"` or platform variants.
+        if abi != "C" {
+            self.error_at(
+                format!(
+                    "unsupported extern ABI \"{abi}\": only \"C\" is supported \
+                     (ADR-0064 C FFI)"
+                ),
+                abi_span,
+            );
+        }
+        self.expect(TokenKind::LBrace)?;
+        let mut fns = Vec::new();
+        while !self.at(TokenKind::RBrace) && !self.at(TokenKind::Eof) {
+            fns.push(self.extern_fn()?);
+        }
+        self.expect(TokenKind::RBrace)?;
+        Ok(ExternBlock {
+            abi,
+            abi_span,
+            fns,
+            span: self.span_from(start),
+        })
+    }
+
+    /// Parse a single body-less foreign function signature inside an `extern`
+    /// block: `fn name(params) -> ret;`.
+    fn extern_fn(&mut self) -> PResult<ExternFn> {
+        let start = self.start();
+        self.expect(TokenKind::Fn)?;
+        let name = self.ident()?;
+        let params = self.params()?;
+        let return_type = if self.eat(TokenKind::Arrow) {
+            Some(self.ty()?)
+        } else {
+            None
+        };
+        self.expect(TokenKind::Semi)?;
+        Ok(ExternFn {
+            name,
+            params,
+            return_type,
             span: self.span_from(start),
         })
     }

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -155,6 +155,7 @@ impl Validator<'_> {
             }
             Item::Enum(_) => {}
             Item::DropFn(d) => self.check_expr(&d.body),
+            Item::Extern(_) => {}
             Item::Const(c) => {
                 self.check_directives(&c.directives, DirectiveSite::Const);
                 self.check_expr(&c.init);

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -7,7 +7,7 @@
 
 use lasso::{Spur, ThreadedRodeo};
 
-use rue_parser::ast::{ConstDecl, DropFn};
+use rue_parser::ast::{ConstDecl, DropFn, ExternBlock, ExternFn};
 use rue_parser::intrinsics::{OFFSET_OF_INTRINSIC, TYPE_INTRINSICS};
 use rue_parser::{
     ArgMode, ArrayLength, AssignTarget, BinaryOp, CallArg, Directive, DirectiveArg, EnumDecl, Expr,
@@ -192,6 +192,9 @@ impl<'a> AstGen<'a> {
             }
             Item::DropFn(drop_fn) => {
                 self.gen_drop_fn(drop_fn);
+            }
+            Item::Extern(extern_block) => {
+                self.gen_extern_block(extern_block);
             }
             Item::Const(const_decl) => {
                 self.gen_const(const_decl);
@@ -570,6 +573,7 @@ impl<'a> AstGen<'a> {
                 &directives,
                 false,
                 false,
+                false,
                 name,
                 &params,
                 return_type,
@@ -675,6 +679,7 @@ impl<'a> AstGen<'a> {
                 &directives,
                 func.visibility == Visibility::Public,
                 func.is_unchecked,
+                false,
                 name,
                 &params,
                 return_type,
@@ -687,6 +692,65 @@ impl<'a> AstGen<'a> {
             .record_failure(&mut self.payload_error);
 
         decl
+    }
+
+    /// Lower an `extern "C" { ... }` block: each member becomes a body-less
+    /// foreign `FnDecl` (`is_extern = true`) with a synthesized unit placeholder
+    /// body. Sema never analyzes and codegen never emits the placeholder; a call
+    /// to the declaration lowers to an undefined linker symbol (ADR-0064).
+    fn gen_extern_block(&mut self, extern_block: &ExternBlock) {
+        for foreign in &extern_block.fns {
+            self.with_producer_root(|this| this.gen_extern_fn(foreign));
+        }
+    }
+
+    fn gen_extern_fn(&mut self, foreign: &ExternFn) -> InstRef {
+        let name = self.symbol(foreign.name.name);
+        let return_type = match &foreign.return_type {
+            Some(ty) => self.intern_type_at(crate::RirStructuralPathSegment::ReturnType, ty),
+            None => self.interner.get_or_intern("()"),
+        };
+        let params: Vec<_> = foreign
+            .params
+            .iter()
+            .enumerate()
+            .map(|(index, p)| RirParam {
+                name: self.symbol(p.name.name),
+                ty: self.intern_type_at(
+                    crate::RirStructuralPathSegment::ParameterType(index as u32),
+                    &p.ty,
+                ),
+                mode: self.convert_param_mode(p.mode),
+                is_comptime: p.mode == ParamMode::Comptime,
+                span: p.name.span,
+            })
+            .collect();
+        // A foreign declaration has no body; synthesize a unit placeholder that
+        // is never analyzed or code-generated (guarded by `is_extern`).
+        let body = self.rir.add_inst(Inst {
+            data: InstData::UnitConst,
+            span: foreign.span,
+        });
+        self.rir
+            .add_fn_decl(
+                &[],
+                // Foreign declarations carry no Rue visibility modifier (treated
+                // as a private free function for resolution) and are not
+                // `unchecked` functions — the checked-context gate is enforced
+                // at the call site instead (ADR-0064 unchecked-only ruling).
+                false,
+                false,
+                true,
+                name,
+                &params,
+                return_type,
+                body,
+                false,
+                RirParamMode::Normal,
+                false,
+                foreign.span,
+            )
+            .record_failure(&mut self.payload_error)
     }
 
     fn gen_expr(&mut self, expr: &Expr) -> InstRef {

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -1187,11 +1187,13 @@ impl RirEditor {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub fn add_fn_decl(
         &mut self,
         directives: &[RirDirective],
         is_pub: bool,
         is_unchecked: bool,
+        is_extern: bool,
         name: Spur,
         params: &[RirParam],
         return_type: Spur,
@@ -1209,6 +1211,7 @@ impl RirEditor {
                     directives,
                     is_pub,
                     is_unchecked,
+                    is_extern,
                     name,
                     params,
                     return_type,
@@ -1651,6 +1654,7 @@ impl RirEditor {
                         directives,
                         is_pub,
                         is_unchecked,
+                        is_extern,
                         name,
                         params,
                         return_type,
@@ -1675,6 +1679,7 @@ impl RirEditor {
                             &directives,
                             *is_pub,
                             *is_unchecked,
+                            *is_extern,
                             symbol(*name),
                             &params,
                             symbol(*return_type),
@@ -4176,6 +4181,11 @@ pub enum InstData {
         is_pub: bool,
         /// Whether this function is marked `unchecked` (can only be called from checked blocks)
         is_unchecked: bool,
+        /// Whether this is a foreign `extern "C"` declaration (ADR-0064 C FFI):
+        /// a body-less import lowered to an undefined linker symbol. When true
+        /// `body` is a synthesized placeholder that is never analyzed or
+        /// code-generated.
+        is_extern: bool,
         name: Spur,
         /// Index into extra data where params start
         params: RirParamsRange,
@@ -4928,6 +4938,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     directives,
                     is_pub,
                     is_unchecked,
+                    is_extern,
                     name,
                     params,
                     return_type,
@@ -4937,7 +4948,13 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     self_is_mut,
                 } => {
                     let pub_str = if *is_pub { "pub " } else { "" };
-                    let unchecked_str = if *is_unchecked { "unchecked " } else { "" };
+                    let unchecked_str = if *is_unchecked {
+                        "unchecked "
+                    } else if *is_extern {
+                        "extern "
+                    } else {
+                        ""
+                    };
                     let name_str = self.interner.resolve(&*name);
                     let ret_str = self.interner.resolve(&*return_type);
                     let self_str = if *has_self {
@@ -5585,6 +5602,7 @@ mod typed_payload_tests {
             .add_fn_decl(
                 &directives,
                 true,
+                false,
                 false,
                 a,
                 &[RirParam {
@@ -6321,6 +6339,7 @@ mod typed_payload_tests {
                 directives: RirDirectivesRange::payload_fallback(),
                 is_pub: false,
                 is_unchecked: false,
+                is_extern: false,
                 name: a,
                 params,
                 return_type: a,

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -196,6 +196,9 @@ struct Options {
     linker: LinkerMode,
     opt_level: OptLevel,
     preview_features: PreviewFeatures,
+    /// Static archives (`.a`) supplied with `--link-archive`, resolved for
+    /// undefined `extern "C"` symbols at link time (ADR-0064 C FFI).
+    link_archives: Vec<std::path::PathBuf>,
     log_level: LogLevel,
     log_format: LogFormat,
     error_format: ErrorFormat,
@@ -238,6 +241,9 @@ Options:
   -o, --output <path>  Set output path
   --source-manifest <path>
                        Restrict source imports to a line-oriented manifest
+  --link-archive <path>
+                       Link a static archive (.a) resolving extern \"C\" symbols
+                       (ADR-0064 C FFI); can be repeated
   --target <target>    Set compilation target (default: host)
                        Valid targets: {targets}
   --linker <linker>    Set linker to use (default: internal)
@@ -366,6 +372,7 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
     let mut jobs: Option<usize> = None;
     let mut source_manifest_path: Option<String> = None;
     let mut output_path: Option<String> = None;
+    let mut link_archives: Vec<std::path::PathBuf> = Vec::new();
     let mut positional = Vec::new();
     let mut args_iter = args.iter().peekable();
 
@@ -497,6 +504,13 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
                     return ParseResult::Error;
                 };
                 source_manifest_path = Some(path.to_string());
+            }
+            "--link-archive" => {
+                let Some(path) = args_iter.next() else {
+                    eprintln!("Error: --link-archive requires a path");
+                    return ParseResult::Error;
+                };
+                link_archives.push(std::path::PathBuf::from(path));
             }
             "--time-passes" => {
                 time_passes = true;
@@ -636,6 +650,7 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
         linker: linker.unwrap_or_default(),
         opt_level: opt_level.unwrap_or_default(),
         preview_features,
+        link_archives,
         log_level: log_level.unwrap_or_default(),
         log_format: log_format.unwrap_or_default(),
         error_format: error_format.unwrap_or_default(),
@@ -1070,6 +1085,7 @@ fn main() {
                     linker: options.linker.clone(),
                     opt_level: options.opt_level,
                     preview_features: options.preview_features.clone(),
+                    link_archives: options.link_archives.clone(),
                 },
                 diagnostics: &diagnostics,
             }) {
@@ -1120,6 +1136,7 @@ fn main() {
         linker: options.linker.clone(),
         opt_level: options.opt_level,
         preview_features: options.preview_features.clone(),
+        link_archives: options.link_archives.clone(),
     };
     #[cfg(rue_benchmark_allocations)]
     if options.benchmark_json {

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -291,8 +291,8 @@ fn print_help() {
 
 /// Result of parsing command-line arguments.
 enum ParseResult {
-    /// Successfully parsed options.
-    Options(Options),
+    /// Successfully parsed options (boxed: Options dwarfs the other variants).
+    Options(Box<Options>),
     /// Parsing failed with an error.
     Error,
     /// User requested help or version (already printed, should exit 0).
@@ -641,7 +641,7 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
         return ParseResult::Error;
     };
 
-    ParseResult::Options(Options {
+    ParseResult::Options(Box::new(Options {
         source_path,
         source_manifest_path,
         output_path: final_output_path,
@@ -657,7 +657,7 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
         time_passes,
         benchmark_json,
         jobs: jobs.unwrap_or(0),
-    })
+    }))
 }
 
 fn parse_args() -> Option<Options> {
@@ -665,7 +665,7 @@ fn parse_args() -> Option<Options> {
     let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
 
     match parse_args_from(&args_refs) {
-        ParseResult::Options(opts) => Some(opts),
+        ParseResult::Options(opts) => Some(*opts),
         ParseResult::Error => None,
         ParseResult::Exit => std::process::exit(0),
     }
@@ -1432,7 +1432,7 @@ mod tests {
     /// Helper to extract Options from ParseResult, panicking if not Options.
     fn unwrap_options(result: ParseResult) -> Options {
         match result {
-            ParseResult::Options(opts) => opts,
+            ParseResult::Options(opts) => *opts,
             ParseResult::Error => panic!("Expected Options, got Error"),
             ParseResult::Exit => panic!("Expected Options, got Exit"),
         }

--- a/docs/spec/src/02-lexical-structure/04-keywords.md
+++ b/docs/spec/src/02-lexical-structure/04-keywords.md
@@ -47,6 +47,7 @@ The following words are keywords and cannot be used as identifiers:
 | `checked` | Checked block (§9.1) |
 | `unchecked` | Unchecked function modifier |
 | `ptr` | Pointer type constructor (`ptr const T` / `ptr mut T`) |
+| `extern` | Foreign declaration block (`extern "C" { … }`, ADR-0064) |
 
 ## Type Names
 


### PR DESCRIPTION
## Summary

C FFI phase P1, behind the new `c_ffi` preview: **Rue programs can declare and call C-ABI functions resolved from static archives.**

- **Surface**: `extern "C" { fn name(params) -> ret; }` — new `extern` keyword, first-class ABI string (only `"C"` in v0), body-less members. Per the accepted ADR-0064 rulings: calls only inside `checked {}`; P1 signatures restricted to i64/u64/pointers with a staging diagnostic for the rest; fully inert without the preview.
- **Mechanism**: raw unmangled symbol → undefined external (Plt32/Call26) → new `--link-archive` flag feeding the linker's existing undefined-symbol rescan ahead of the runtime archives.
- **The proof is executed, not simulated**: the harness synthesizes an in-tree C-free `.a` exporting `answer() → 42` as pure machine code via the compiler's own object builder and a new `ar` writer — no C toolchain — and the gated program calls it and prints 42 (x86-64 natively; AArch64 cross-compiled and structurally validated).
- **Diagnostics tested**: unchecked call, missing preview, unsupported types, unsupported ABI, unresolved symbol naming the searched archives.

## Verification

Eight `c_ffi` CLI cases (two executing proofs, six diagnostics); error/air/compiler/parser units extended; both oracle-diff audits green; `quick` 34; full `test.sh` **PASSED with zero failures**, both harness failure formats checked. Re-verified at integration on trunk containing the oracle-heap and std.fs v1 merges.

Fixes RUE-1055

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_