### PR TITLE
ADR-0064 amendment 1: C representation guarantees (RUE-742 fold-in)

### DIFF
--- a/docs/designs/0064-c-ffi.md
+++ b/docs/designs/0064-c-ffi.md
@@ -9,7 +9,7 @@ accepted: 2026-07-19
 implemented:
 spec-sections: []
 superseded-by:
-relates: ["RUE-742", "RUE-745", "RUE-714", "RUE-738", "RUE-987", "ADR-0052", "ADR-0028", "ADR-0038", "ADR-0005", "ADR-0035", "ADR-0043", "ADR-0055"]
+relates: ["RUE-742", "RUE-745", "RUE-714", "RUE-738", "RUE-987", "RUE-881", "RUE-504", "ADR-0052", "ADR-0028", "ADR-0038", "ADR-0005", "ADR-0035", "ADR-0042", "ADR-0043", "ADR-0055"]
 ---
 
 # ADR-0064: C FFI — a guaranteed target-C boundary
@@ -37,6 +37,12 @@ Resolved at acceptance — the maintainer ratified every ruling in
 
 The secondary rulings (1-byte `_Bool` with 0/1 contract; variadics rejected with
 a diagnostic) are likewise ratified as recommended. Phase work past P0 may begin.
+
+**Amendment 1 (2026-07-19)** folds in the RUE-742 representation-guarantee ruling
+the original draft skipped: the `@repr(c)` marker, the three FFI-safety predicates,
+the `std.c` transparent scalar aliases, and the target data-model descriptor. It is
+additive — the accepted v0 surface above is unchanged in substance — and is
+recorded in [Amendment 1: C representation guarantees (RUE-742)](#amendment-1-2026-07-19-c-representation-guarantees-rue-742).
 
 ## Summary
 
@@ -270,18 +276,154 @@ independently linked, run probe producing exact output, matching
 `cli.abi_conformance`'s per-target harness (x86-64 Linux, AArch64 Linux, AArch64
 macOS). All land behind `c_ffi` until the whole surface is proven.
 
-**Dependency spine:** `P0 → P1 → P2 → {P3 → P4, P6}; RUE-714 + P3 → P5; P1 → P7`.
+**Dependency spine:** `P0 → P1 → P1.5 → P2 → {P3 → P4, P6}; RUE-714 + P3 → P5; P1 → P7`
+(P1.5 inserted by [Amendment 1](#amendment-1-2026-07-19-c-representation-guarantees-rue-742)).
 
 | Phase | Scope | Depends | Verification proof program |
 | --- | --- | --- | --- |
 | **P0** | ADR ruling: settle the three open questions, name the `c_ffi` gate, fix the `extern` surface and the checked-only contract. *Design — maintainer.* | — | ADR ratified; no code. |
 | **P1** | `extern fn` decl (lexer/parser/RIR/sema/AIR) + undefined-symbol emission; linker resolves it from a supplied `.a`. Narrow-arg extension enters here. | P0 | Call a static-archive C function returning an `int` (e.g. `getpid`) and print it; `@syscall` `write` as the zero-cost pre-check. |
-| **P2** | `CallAbi::TargetC` classifier, scalars + pointers, register-only: GP-reg int/ptr args, scalar returns, general narrow-int extension, `_Bool` 1-byte boundary, single-aggregate `rax`/`x8` sret echo. No stack args, no floats. | P1 | Rue↔C scalar/pointer round-trip probe, both backends, exact output. |
+| **P1.5** | *(Amendment 1.)* The `@repr(c)` marker + the three FFI-safety predicates (`has_c_layout`, `c_ffi_safe`, `c_passable_by_value` — the last written eightbyte-wise but register-only in scope here) + `std.c` transparent scalar aliases + the target descriptor's new data-model field (ILP32/LP64/LLP64). The extern-signature aggregate rule and the reject-don't-guess subset enter here. Reject-don't-guess staging discipline: anything whose classification would need SSE classes is a hard error until floats (P5). | P1 | A `@repr(c)` struct behind a pointer round-trips through an `extern` call; a program using `std.c.c_int` compiles cross-target to the correct width; a non-`@repr(c)` aggregate in an `extern` signature emits the rejecting diagnostic. |
+| **P2** | `CallAbi::TargetC` classifier, scalars + pointers, register-only: GP-reg int/ptr args, scalar returns, general narrow-int extension, `_Bool` 1-byte boundary, single-aggregate `rax`/`x8` sret echo. No stack args, no floats. | P1.5 | Rue↔C scalar/pointer round-trip probe, both backends, exact output. |
 | **P3** | C aggregate classification + byval stack args: SysV eightbyte INTEGER classification + register packing, AAPCS64 composite rules, byval memory args incl. Apple packed-stack amendment, direct + indirect C aggregate returns. Largest integer-side phase. | P2 | Struct-by-value C↔Rue probe (multi-field struct passed and returned). |
 | **P4** | Rue-to-C export thunks: C-ABI callee prologue/epilogue so a C caller invokes an exported Rue fn. | P2 (P3 for aggregate params) | A separately compiled C `main` calls an exported Rue function and checks its result. |
 | **P5** | Floats + FP calling convention: after RUE-714 delivers `f32`/`f64`, IEEE-754 codegen, and the XMM (SSE) / V-register files, extend the P2/P3 classifier to FP args/results and HFA/HVA. | **RUE-714** + P3 | A `double`-taking libm probe (e.g. `pow`) called from Rue with exact result. |
 | **P6** | Variadic rejecting diagnostic (or full support as a separate decision) + `StrBuf`↔`char*` helpers with an explicit NUL/ownership contract. | P2 | A variadic `extern` decl emits the rejecting diagnostic (UI test); a `StrBuf` passed to a C `strlen`-shape function. |
 | **P7** | Dynamic linking against `libc.so` (stretch): `PT_INTERP`, dynamic symtab, PLT/GOT synthesis. Likely its own ADR. | P1 | A dynamically linked executable calls a `libc.so` symbol at runtime. |
+
+## Amendment 1 (2026-07-19): C representation guarantees (RUE-742)
+
+This section folds the RUE-742 design ruling into the accepted ADR. RUE-742 was
+proposed by Steve on 2026-07-14; Dorian signed off with amendments, which Steve
+incorporated; on 2026-07-19 Steve ruled that the surviving items fold into this
+ADR under a single guarantee marker. The amendment is **additive**: the accepted
+v0 surface above is unchanged in substance. What it adds is the *representation
+guarantee* the original draft skipped, plus the predicate structure that anchors
+FFI-safety. Where it touches accepted text — the extern-signature aggregate rule,
+the enum/`repr(C)` future-work wording, and the phase plan — the reconciliation is
+called out explicitly below.
+
+### The `@repr(c)` marker
+
+- **Spelling.** `@repr(c)`, an `@`-sigil attribute matching `@copy` — one
+  attribute convention, self-delimiting, and parameterized so future
+  `@repr(packed)` / `@repr(align(n))` reuse the form. (Dorian's spelling
+  amendment; it replaces the bare `repr(C)` of the original draft.)
+- **A layout no-op today; a guarantee always.** Post-ADR-0052, compact layout
+  already matches the C aggregate rule for structs of scalar and pointer fields,
+  so `@repr(c)` changes no bytes today. Its meaning is a **guarantee**: it pins the
+  target's default C object representation against future native-layout evolution.
+  RUE-881 field reordering remains a live deferred design for *unmarked* types;
+  `@repr(c)` types opt out of it. The marker also anchors the FFI-safety predicate
+  below.
+- **Normative source and precise scope.** The normative source of the layout is
+  the platform psABI documents — **not** "whatever the system C compiler happens to
+  emit." `c` means the *selected compilation target's* default C data model, so
+  cross-compilation computes the target layout. It is not C++, not a packing
+  extension, and not a cross-target or general ABI-stability claim.
+
+### Three separate predicates (the architectural core)
+
+FFI-safety is deliberately split into three predicates rather than one monolith,
+so pointer-based interop can ship before by-value classification:
+
+1. **`has_c_layout(T, Target)`** — T's size, alignment, field order, field
+   offsets, and tail padding equal the target C aggregate's. `@repr(c)` establishes
+   it (a guarantee today; a real constraint once RUE-881 can reorder unmarked
+   types).
+2. **`c_ffi_safe(T, Target)`** — the structural hard-error policy: linear,
+   destructor-bearing, and ownership-bearing fields are forbidden across the
+   boundary. Violations are a hard error, not a silent guess.
+3. **`c_passable_by_value(T, TargetAbi)`** — the by-value classifier (the
+   eightbyte / register-packing work of P2/P3). It is **canonical and shared by all
+   four crossing sites — calls, returns, exports, and callbacks.**
+
+Keeping them separate is what lets pointer-based interop land before by-value
+classification exists. **Acceptance criterion (ratified):** a conformance test
+asserts the classifier agrees across all four sites for every supported type.
+
+**Design note.** Structure the predicates for eventual exposure through the
+machine-readable compiler interface (RUE-504), so "why is this type not FFI-safe"
+is answerable with the failing predicate and the offending field path.
+
+### Extern-signature aggregate rule
+
+- Any aggregate appearing in an `extern` signature **MUST be `@repr(c)`** — the
+  marker is the guarantee trigger. Scalars and raw pointers need no marker. This
+  refines the accepted surface's "C-classifiable structs cross" into an explicit
+  opt-in gate rather than an implicit classification.
+- An ordinary Rue aggregate nested *by value* inside a `@repr(c)` struct does
+  **not** silently become C-layout: this is a **diagnostic**, not a silent
+  promotion.
+- Pointers to opaque / incomplete foreign types are expressible without the
+  pointee's layout.
+
+### Supported subset and reject-don't-guess list (v0, structs only)
+
+Eligible `@repr(c)` struct fields: C-compatible scalars (including the `std.c`
+aliases below), raw pointers, fixed arrays of eligible elements, and nested
+`@repr(c)` structs.
+
+**Rejected with a diagnostic** — each awaits its own later ruling; this
+deliberately does *not* copy Rust's `repr(C)` zero-size/enum implications:
+
+- empty / zero-sized C structs;
+- unions;
+- enums (fieldless or payload-carrying);
+- bitfields;
+- flexible array members;
+- packed / over-aligned representations;
+- unsupported nested field types.
+
+**Fixed-array boundary rule (Dorian's gap).** Fixed arrays are eligible as struct
+**fields** but are **rejected as direct `extern` parameters or returns** — C decays
+arrays to pointers, and a by-value array parameter does not exist in C.
+
+**Normative scalar table.** The ADR carries a normative scalar table:
+`bool`/`_Bool`, `c_char` signedness per target, and the pointer-width integers. The
+1-byte `_Bool` 0/1 contract of [secondary ruling A](#secondary-rulings-adr-worthy-recommendations-attached)
+is the boolean row of that table.
+
+### `std.c` transparent aliases + target data-model descriptor
+
+- **Transparent aliases, not newtypes.** `std.c` provides scalar aliases (`c_int`,
+  `c_long`, `c_char`, `c_size_t`, `wchar_t`, …) as ordinary Rue source. They are
+  transparent aliases: on LP64, `c_int` **is** `i32` (the ADR-0042/0043 aliasing
+  pattern) — no wrapper, no coercion.
+- **Data-model field.** The target descriptor gains a **data-model field**
+  (ILP32 / LP64 / LLP64). Architecture alone is insufficient — AAPCS64 is the
+  worked example — so this is a named work item.
+- **They move early.** These land before P2's scalar round-trips want them (in
+  P1.5), so users never hand-encode target C widths.
+
+### Phase-plan changes
+
+The staged plan above gains phase **P1.5** (marked *(Amendment 1)*), inserted
+between P1 and P2, carrying the marker, the three predicates, the `std.c` aliases,
+and the data-model descriptor; the dependency spine and P2's `Depends` column are
+updated to route through it. Per-phase proof-program convention is preserved: proof
+for the aliases is a program using `std.c.c_int` cross-target; proof for the marker
+is a `@repr(c)` struct behind a pointer round-tripping through an `extern` call. The
+reject-don't-guess staging discipline is restated in the P1.5 row: anything whose
+classification would need SSE classes is a hard error until floats (P5).
+
+### Reconciliation with accepted text
+
+- **`repr(C)` for structs vs. enums.** [Ruling 2](#2-enum-representation-at-the-c-boundary--recommend-enums-are-not-ffi-safe-in-v0)
+  and the [non-goals](#non-goals-v0) leave a `cenum`/`repr(C)` attribute *for
+  enums* to a later design. That remains true. `@repr(c)` here is a **struct
+  layout-guarantee marker**, a different feature that shares the spelling family;
+  it is now in scope for structs. `@repr(c)` (or `cenum`) giving an enum a
+  guaranteed C-integer representation stays out of scope and future work.
+- **"C-classifiable structs cross."** The Summary and Ruling 2 phrase is refined,
+  not contradicted: a struct crosses only if it is marked `@repr(c)` and satisfies
+  `c_ffi_safe`/`c_passable_by_value`.
+
+### Relationship to RUE-742 / RUE-745
+
+This amendment **supersedes RUE-742 / RUE-745's original `cstruct` scoping**.
+RUE-742's surviving implementation scope is: the `@repr(c)` marker, the three
+predicates, the `std.c` transparent aliases, and the target data-model descriptor.
 
 ## Open questions for acceptance
 
@@ -407,7 +549,9 @@ acceptance step.
 ## Future work
 
 - **Floating-point/vector FFI** — P5, gated on RUE-714.
-- **`cenum` / `repr(C)` enum representation** — a C-integer opt-in for enums.
+- **`cenum` / `@repr(c)`-for-enums representation** — a C-integer opt-in for
+  *enums* (the struct `@repr(c)` marker is in scope via Amendment 1; the enum case
+  is not).
 - **Variadic C calls** — beyond the v0 rejecting diagnostic.
 - **Dynamic linking** against shared objects (`PT_INTERP`, PLT/GOT) — its own ADR.
 - **Header/bindgen ingestion** — deriving `extern` blocks from C headers.
@@ -420,6 +564,10 @@ acceptance step.
 - RUE-742 / RUE-745 — target C layout and FFI implementation (the import
   classifier and export phases of this ADR).
 - RUE-714 — floating-point types and codegen (external hard dependency for P5).
+- RUE-881 — native-layout field reordering for *unmarked* types (a live deferred
+  design that `@repr(c)` opts out of; Amendment 1).
+- RUE-504 — machine-readable compiler interface (the eventual exposure surface for
+  the three FFI-safety predicates; Amendment 1).
 - RUE-738 / `docs/notes/ffi-abi-conformance-audit.md` — the conformance audit this
   ADR operationalizes; its "Requirements for future FFI work" list is the phase
   acceptance bar.


### PR DESCRIPTION
## Summary

Folds the maintainer-ratified RUE-742 design discussion (proposed 07-14, signed off with amendments, ruled today to live in this ADR) into accepted ADR-0064 as an in-body **Amendment 1**, reconciled with the post-ADR-0052 reality that compact layout already matches the C aggregate rule for scalar/pointer fields:

- **`@repr(c)`** (the `@`-sigil spelling per the sign-off): a layout no-op whose meaning is the **guarantee** — pins the target's psABI-normative C representation against future native-layout evolution (RUE-881 stays live for unmarked types) and anchors FFI safety. **Aggregates in extern signatures must carry it**; scalars/pointers need none; nested ordinary aggregates diagnose.
- **Three predicates** (`has_c_layout` / `c_ffi_safe` / `c_passable_by_value`) so pointer-based interop ships before by-value classification; canonical classifier across calls/returns/exports/callbacks with a conformance-test criterion; structured for future RUE-504 exposure.
- **v0 subset + reject-don't-guess list** (unions, enums, bitfields, FAMs, packed/over-aligned, empty structs), including the array-decay rule (fields yes, direct params/returns no) and a normative scalar table.
- **`std.c` transparent aliases + target data-model descriptor (ILP32/LP64/LLP64)** pulled early as new **phase P1.5** (spine now P0→P1→P1.5→P2→…); implementation filed as RUE-1063/RUE-1064 under the RUE-1054 epic.
- One collision reconciled explicitly: struct `@repr(c)` is in scope as the marker; enum C-repr stays deferred.

Follows ADR-0047's in-body amendment precedent. RUE-742/RUE-745's original `cstruct` scoping is superseded; the issue thread is answered with this disposition.

## Verification

Docs-only; `scripts/validate-adrs.py` green (65 records) re-validated after rebase onto current trunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_