### PR TITLE
RUE-1063: @repr(c) guarantee marker and the FFI predicates (ADR-0064 P1.5a)

### DIFF
--- a/crates/rue-air/src/ffi_predicates.rs
+++ b/crates/rue-air/src/ffi_predicates.rs
@@ -1,0 +1,621 @@
+//! The three FFI-safety predicates (ADR-0064 Amendment 1, RUE-1063).
+//!
+//! FFI-safety is deliberately split into three queryable compiler judgments,
+//! sitting beside the [`call_abi`](crate::call_abi) classifier they feed, so
+//! pointer-based interop can ship before by-value classification exists:
+//!
+//! 1. [`has_c_layout`] — T's size, alignment, field order, field offsets, and
+//!    tail padding equal the target C aggregate's. `@repr(c)` establishes it for
+//!    a struct (a guarantee today; a real constraint once RUE-881 can reorder
+//!    unmarked types).
+//! 2. [`c_ffi_safe`] — the structural hard-error policy: linear,
+//!    destructor-bearing, and ownership-bearing fields are forbidden across the
+//!    boundary. Pointee layouts are *not* required, so opaque pointers pass.
+//! 3. [`c_passable_by_value`] — the by-value classifier seam. In P1.5 it
+//!    delegates to the P1 register-only restriction (`i64`/`u64`/pointers); it is
+//!    the seam P2/P3 fill with eightbyte classification and register packing.
+//!
+//! Every failure carries the failing [`FfiPredicate`], the offending field
+//! *path*, and a structured [`FfiRejectReason`] rather than a bare `bool` — the
+//! RUE-504 machine-readable exposure direction, so "why is this type not
+//! FFI-safe" is answerable with the failing predicate and the offending field.
+//!
+//! The predicates are generic over [`FfiTypePool`], implemented by both the
+//! mutable [`TypeInternPool`](crate::intern_pool::TypeInternPool) (used during
+//! semantic analysis, when the marker check and extern-signature enforcement
+//! run) and the [`FrozenTypeInternPool`](crate::FrozenTypeInternPool) (used by
+//! the classifier and codegen), so there is one algebra rather than two.
+
+use crate::{ArrayTypeId, StructId, Type, TypeKind};
+
+/// Which of the three FFI predicates a failure belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FfiPredicate {
+    /// [`has_c_layout`]: the type does not have a guaranteed C object layout.
+    HasCLayout,
+    /// [`c_ffi_safe`]: the type carries an ownership obligation C cannot honor.
+    CFfiSafe,
+    /// [`c_passable_by_value`]: the type is not (yet) passable in registers.
+    CPassableByValue,
+}
+
+impl FfiPredicate {
+    /// The predicate name, for machine-readable exposure (RUE-504).
+    pub const fn name(self) -> &'static str {
+        match self {
+            FfiPredicate::HasCLayout => "has_c_layout",
+            FfiPredicate::CFfiSafe => "c_ffi_safe",
+            FfiPredicate::CPassableByValue => "c_passable_by_value",
+        }
+    }
+}
+
+/// The specific reject-don't-guess reason a predicate failed (ADR-0064
+/// Amendment 1). Each maps to a stable human phrase via [`Self::describe`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FfiRejectReason {
+    /// An empty / zero-sized struct (C has no zero-sized object).
+    EmptyStruct,
+    /// An aggregate nested by value without its own `@repr(c)` marker — not
+    /// silently promoted to C layout.
+    NonReprCAggregate,
+    /// A Rue enum (tagged sum type) — not FFI-safe in v0.
+    Enum,
+    /// A destructor-bearing type — an ownership obligation C cannot honor.
+    HasDestructor,
+    /// A linear type — a must-consume obligation C cannot honor.
+    Linear,
+    /// A type with no C representation at all (unit, never, module, comptime,
+    /// slice-shaped, …).
+    UnsupportedType,
+    /// A type that is not in the register-only by-value set the current phase
+    /// (P1.5) implements — the [`c_passable_by_value`] seam P2/P3 widen.
+    NotRegisterPassable,
+}
+
+impl FfiRejectReason {
+    /// A stable human phrase naming this reject-list entry.
+    pub const fn describe(self) -> &'static str {
+        match self {
+            FfiRejectReason::EmptyStruct => {
+                "empty / zero-sized structs have no C object representation in v0"
+            }
+            FfiRejectReason::NonReprCAggregate => {
+                "a nested aggregate must itself be marked `@repr(c)` — C layout is \
+                 never silently promoted"
+            }
+            FfiRejectReason::Enum => "a Rue enum is not FFI-safe in v0",
+            FfiRejectReason::HasDestructor => {
+                "a destructor-bearing type cannot cross the C boundary (no ownership \
+                 obligation crosses)"
+            }
+            FfiRejectReason::Linear => {
+                "a linear type cannot cross the C boundary (no must-consume obligation \
+                 crosses)"
+            }
+            FfiRejectReason::UnsupportedType => "this type has no C representation in v0",
+            FfiRejectReason::NotRegisterPassable => {
+                "this type is not yet passable by value across a C boundary (only \
+                 `i64`, `u64`, and pointers are, until a later FFI phase)"
+            }
+        }
+    }
+}
+
+/// A structured predicate failure: the failing predicate, the field path to the
+/// offending component, the offending type, and the reject reason.
+///
+/// This is the "diagnostic struct, not just a bool" the RUE-504 exposure
+/// direction asks for. `field_path` is empty when the queried type itself is the
+/// problem; otherwise it names the chain of fields from the queried aggregate
+/// down to the offending field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FfiPredicateFailure {
+    /// Which predicate failed.
+    pub predicate: FfiPredicate,
+    /// Field chain from the queried aggregate to the offending field.
+    pub field_path: Vec<String>,
+    /// The offending type.
+    pub failing_type: Type,
+    /// The reject-list reason.
+    pub reason: FfiRejectReason,
+}
+
+impl FfiPredicateFailure {
+    fn new(
+        predicate: FfiPredicate,
+        field_path: &[String],
+        failing_type: Type,
+        reason: FfiRejectReason,
+    ) -> Self {
+        Self {
+            predicate,
+            field_path: field_path.to_vec(),
+            failing_type,
+            reason,
+        }
+    }
+
+    /// The dotted field path (empty string when the queried type itself failed).
+    pub fn field_path_display(&self) -> String {
+        self.field_path.join(".")
+    }
+}
+
+/// The minimal pool interface the predicates need, implemented by both the
+/// mutable and frozen type-intern pools so the algebra is written once.
+pub trait FfiTypePool {
+    /// Whether the struct carries the `@repr(c)` guarantee marker.
+    fn ffi_struct_is_repr_c(&self, id: StructId) -> bool;
+    /// Whether the struct is a `linear` type.
+    fn ffi_struct_is_linear(&self, id: StructId) -> bool;
+    /// Whether the struct has a user-defined destructor.
+    fn ffi_struct_has_destructor(&self, id: StructId) -> bool;
+    /// The struct's fields as `(name, type)` in declaration order.
+    fn ffi_struct_fields(&self, id: StructId) -> Vec<(String, Type)>;
+    /// The element type of a fixed-size array.
+    fn ffi_array_element(&self, id: ArrayTypeId) -> Type;
+}
+
+/// Whether a scalar type kind is a C-compatible scalar (integer widths, `bool`,
+/// or a raw pointer). The `std.c` transparent aliases resolve to these.
+fn is_c_scalar(kind: TypeKind) -> bool {
+    matches!(
+        kind,
+        TypeKind::I8
+            | TypeKind::I16
+            | TypeKind::I32
+            | TypeKind::I64
+            | TypeKind::U8
+            | TypeKind::U16
+            | TypeKind::U32
+            | TypeKind::U64
+            | TypeKind::Bool
+            | TypeKind::PtrConst(_)
+            | TypeKind::PtrMut(_)
+    )
+}
+
+/// Predicate 1: does `ty` have a guaranteed C object layout?
+///
+/// True for C scalars, raw pointers, fixed arrays of eligible elements, and
+/// nested `@repr(c)` structs (recursively). A pure boolean; use
+/// [`check_c_layout`] when the failing field path is wanted.
+pub fn has_c_layout<P: FfiTypePool>(pool: &P, ty: Type) -> bool {
+    check_c_layout(pool, ty, &mut Vec::new()).is_ok()
+}
+
+/// The diagnostic-producing form of [`has_c_layout`]: `Ok(())` when `ty` has a
+/// guaranteed C layout, otherwise the failing field path and reason.
+pub fn check_c_layout<P: FfiTypePool>(
+    pool: &P,
+    ty: Type,
+    path: &mut Vec<String>,
+) -> Result<(), FfiPredicateFailure> {
+    let kind = ty.kind();
+    if is_c_scalar(kind) {
+        return Ok(());
+    }
+    match kind {
+        // Arrays stride by the C element size; their element must have C layout.
+        TypeKind::Array(id) => check_c_layout(pool, pool.ffi_array_element(id), path),
+        TypeKind::Struct(id) => {
+            if !pool.ffi_struct_is_repr_c(id) {
+                return Err(FfiPredicateFailure::new(
+                    FfiPredicate::HasCLayout,
+                    path,
+                    ty,
+                    FfiRejectReason::NonReprCAggregate,
+                ));
+            }
+            let fields = pool.ffi_struct_fields(id);
+            if fields.is_empty() {
+                return Err(FfiPredicateFailure::new(
+                    FfiPredicate::HasCLayout,
+                    path,
+                    ty,
+                    FfiRejectReason::EmptyStruct,
+                ));
+            }
+            for (name, field_ty) in fields {
+                path.push(name);
+                check_c_layout(pool, field_ty, path)?;
+                path.pop();
+            }
+            Ok(())
+        }
+        TypeKind::Enum(_) => Err(FfiPredicateFailure::new(
+            FfiPredicate::HasCLayout,
+            path,
+            ty,
+            FfiRejectReason::Enum,
+        )),
+        _ => Err(FfiPredicateFailure::new(
+            FfiPredicate::HasCLayout,
+            path,
+            ty,
+            FfiRejectReason::UnsupportedType,
+        )),
+    }
+}
+
+/// Predicate 2: is `ty` structurally safe to cross the C boundary?
+///
+/// The hard-error policy: no linear, destructor-bearing, or ownership-bearing
+/// fields (recursively). Pointee layouts are *not* required — an opaque pointer
+/// to an incomplete foreign type is safe, so this does not recurse through
+/// pointers. Enums are rejected as not-FFI-safe in v0.
+pub fn c_ffi_safe<P: FfiTypePool>(pool: &P, ty: Type) -> Result<(), FfiPredicateFailure> {
+    check_c_ffi_safe(pool, ty, &mut Vec::new())
+}
+
+fn check_c_ffi_safe<P: FfiTypePool>(
+    pool: &P,
+    ty: Type,
+    path: &mut Vec<String>,
+) -> Result<(), FfiPredicateFailure> {
+    let kind = ty.kind();
+    // Scalars and pointers are always safe; pointees are opaque and not read.
+    if is_c_scalar(kind) {
+        return Ok(());
+    }
+    match kind {
+        TypeKind::Array(id) => check_c_ffi_safe(pool, pool.ffi_array_element(id), path),
+        TypeKind::Struct(id) => {
+            if pool.ffi_struct_is_linear(id) {
+                return Err(FfiPredicateFailure::new(
+                    FfiPredicate::CFfiSafe,
+                    path,
+                    ty,
+                    FfiRejectReason::Linear,
+                ));
+            }
+            if pool.ffi_struct_has_destructor(id) {
+                return Err(FfiPredicateFailure::new(
+                    FfiPredicate::CFfiSafe,
+                    path,
+                    ty,
+                    FfiRejectReason::HasDestructor,
+                ));
+            }
+            for (name, field_ty) in pool.ffi_struct_fields(id) {
+                path.push(name);
+                check_c_ffi_safe(pool, field_ty, path)?;
+                path.pop();
+            }
+            Ok(())
+        }
+        TypeKind::Enum(_) => Err(FfiPredicateFailure::new(
+            FfiPredicate::CFfiSafe,
+            path,
+            ty,
+            FfiRejectReason::Enum,
+        )),
+        _ => Err(FfiPredicateFailure::new(
+            FfiPredicate::CFfiSafe,
+            path,
+            ty,
+            FfiRejectReason::UnsupportedType,
+        )),
+    }
+}
+
+/// Predicate 3: can `ty` cross a C boundary *by value* in the current phase?
+///
+/// This is the classifier seam. P1.5 delegates to the P1 register-only
+/// restriction — `i64`, `u64`, and raw pointers, the types whose native and
+/// target-C representations coincide in registers. P2 (eightbyte classification,
+/// register packing, `_Bool`/narrow-int extension) and P3 (aggregates, byval
+/// stack args) widen this without touching the other two predicates.
+pub fn c_passable_by_value<P: FfiTypePool>(_pool: &P, ty: Type) -> Result<(), FfiPredicateFailure> {
+    match ty.kind() {
+        TypeKind::I64 | TypeKind::U64 | TypeKind::PtrConst(_) | TypeKind::PtrMut(_) => Ok(()),
+        _ => Err(FfiPredicateFailure::new(
+            FfiPredicate::CPassableByValue,
+            &[],
+            ty,
+            FfiRejectReason::NotRegisterPassable,
+        )),
+    }
+}
+
+/// Whether a `@repr(c)` struct is FFI-eligible under the reject-don't-guess list
+/// (ADR-0064 Amendment 1), enforced *on the marker itself*.
+///
+/// A marked struct must have a guaranteed C layout ([`check_c_layout`]: no empty
+/// body, no enum / non-`@repr(c)` aggregate / unsupported field) *and* be
+/// structurally safe ([`c_ffi_safe`]: no linear / destructor-bearing field). The
+/// C-layout check runs first so the more specific "must be `@repr(c)`" / "empty
+/// struct" / "enum" reasons win over the structural ones. `struct_ty` is the
+/// marked struct's own type, so a failure at the top level reports it directly.
+pub fn repr_c_marker_eligible<P: FfiTypePool>(
+    pool: &P,
+    struct_ty: Type,
+) -> Result<(), FfiPredicateFailure> {
+    check_c_layout(pool, struct_ty, &mut Vec::new())?;
+    c_ffi_safe(pool, struct_ty)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EnumId, PtrConstTypeId, PtrMutTypeId};
+    use std::collections::HashMap;
+
+    /// A tiny hand-built pool so the predicate algebra can be exercised without
+    /// the full type-intern-pool completion protocol. Struct/array IDs are just
+    /// map keys; pointer/enum handles are inert (predicates never dereference a
+    /// pointer's pointee or read an enum body).
+    #[derive(Default)]
+    struct MockPool {
+        structs: HashMap<u32, MockStruct>,
+        arrays: HashMap<u32, Type>,
+    }
+
+    #[derive(Default, Clone)]
+    struct MockStruct {
+        repr_c: bool,
+        linear: bool,
+        has_destructor: bool,
+        fields: Vec<(String, Type)>,
+    }
+
+    impl MockPool {
+        fn add_struct(&mut self, id: u32, s: MockStruct) -> Type {
+            self.structs.insert(id, s);
+            Type::new_struct(StructId::from_pool_index(id))
+        }
+        fn add_array(&mut self, id: u32, element: Type) -> Type {
+            self.arrays.insert(id, element);
+            Type::new_array(ArrayTypeId::from_pool_index(id))
+        }
+    }
+
+    impl FfiTypePool for MockPool {
+        fn ffi_struct_is_repr_c(&self, id: StructId) -> bool {
+            self.structs[&id.0].repr_c
+        }
+        fn ffi_struct_is_linear(&self, id: StructId) -> bool {
+            self.structs[&id.0].linear
+        }
+        fn ffi_struct_has_destructor(&self, id: StructId) -> bool {
+            self.structs[&id.0].has_destructor
+        }
+        fn ffi_struct_fields(&self, id: StructId) -> Vec<(String, Type)> {
+            self.structs[&id.0].fields.clone()
+        }
+        fn ffi_array_element(&self, id: ArrayTypeId) -> Type {
+            self.arrays[&id.0]
+        }
+    }
+
+    fn field(name: &str, ty: Type) -> (String, Type) {
+        (name.to_string(), ty)
+    }
+
+    fn ptr() -> Type {
+        Type::new_ptr_const(PtrConstTypeId::from_pool_index(0))
+    }
+
+    // --- The supported subset is FFI-safe and C-laid-out ------------------
+
+    #[test]
+    fn scalars_and_pointers_have_c_layout_and_are_safe_and_passable() {
+        let pool = MockPool::default();
+        for ty in [Type::I64, Type::U64, Type::I32, Type::U8, Type::BOOL, ptr()] {
+            assert!(has_c_layout(&pool, ty), "{ty:?} should have C layout");
+            assert!(c_ffi_safe(&pool, ty).is_ok(), "{ty:?} should be FFI-safe");
+        }
+        // Only the register-set is passable by value in this phase.
+        assert!(c_passable_by_value(&pool, Type::I64).is_ok());
+        assert!(c_passable_by_value(&pool, Type::U64).is_ok());
+        assert!(c_passable_by_value(&pool, ptr()).is_ok());
+        // Narrow scalars are not yet passable by value (the P2/P3 seam).
+        let fail = c_passable_by_value(&pool, Type::I32).unwrap_err();
+        assert_eq!(fail.predicate, FfiPredicate::CPassableByValue);
+        assert_eq!(fail.reason, FfiRejectReason::NotRegisterPassable);
+    }
+
+    #[test]
+    fn repr_c_struct_of_eligible_fields_is_marker_eligible() {
+        let mut pool = MockPool::default();
+        let inner = pool.add_struct(
+            1,
+            MockStruct {
+                repr_c: true,
+                fields: vec![field("x", Type::I64)],
+                ..Default::default()
+            },
+        );
+        let arr = pool.add_array(0, Type::U8);
+        let outer = pool.add_struct(
+            2,
+            MockStruct {
+                repr_c: true,
+                fields: vec![
+                    field("a", Type::I64),
+                    field("p", ptr()),
+                    field("buf", arr),
+                    field("inner", inner),
+                ],
+                ..Default::default()
+            },
+        );
+        assert!(has_c_layout(&pool, outer));
+        assert!(c_ffi_safe(&pool, outer).is_ok());
+        assert!(repr_c_marker_eligible(&pool, outer).is_ok());
+    }
+
+    // --- Each reject-list entry fails with the right predicate + path ------
+
+    #[test]
+    fn empty_repr_c_struct_fails_has_c_layout() {
+        let mut pool = MockPool::default();
+        let empty = pool.add_struct(
+            1,
+            MockStruct {
+                repr_c: true,
+                ..Default::default()
+            },
+        );
+        let fail = repr_c_marker_eligible(&pool, empty).unwrap_err();
+        assert_eq!(fail.predicate, FfiPredicate::HasCLayout);
+        assert_eq!(fail.reason, FfiRejectReason::EmptyStruct);
+        assert!(fail.field_path.is_empty());
+    }
+
+    #[test]
+    fn enum_field_fails_with_field_path() {
+        let mut pool = MockPool::default();
+        let enum_ty = Type::new_enum(EnumId::from_pool_index(0));
+        let outer = pool.add_struct(
+            1,
+            MockStruct {
+                repr_c: true,
+                fields: vec![field("tag", enum_ty)],
+                ..Default::default()
+            },
+        );
+        let fail = repr_c_marker_eligible(&pool, outer).unwrap_err();
+        assert_eq!(fail.predicate, FfiPredicate::HasCLayout);
+        assert_eq!(fail.reason, FfiRejectReason::Enum);
+        assert_eq!(fail.field_path, vec!["tag".to_string()]);
+        assert_eq!(fail.failing_type, enum_ty);
+    }
+
+    #[test]
+    fn non_repr_c_nested_aggregate_fails_with_field_path() {
+        let mut pool = MockPool::default();
+        let inner = pool.add_struct(
+            1,
+            MockStruct {
+                repr_c: false,
+                fields: vec![field("x", Type::I64)],
+                ..Default::default()
+            },
+        );
+        let outer = pool.add_struct(
+            2,
+            MockStruct {
+                repr_c: true,
+                fields: vec![field("inner", inner)],
+                ..Default::default()
+            },
+        );
+        let fail = repr_c_marker_eligible(&pool, outer).unwrap_err();
+        assert_eq!(fail.predicate, FfiPredicate::HasCLayout);
+        assert_eq!(fail.reason, FfiRejectReason::NonReprCAggregate);
+        assert_eq!(fail.field_path, vec!["inner".to_string()]);
+    }
+
+    #[test]
+    fn deep_field_path_is_reported() {
+        let mut pool = MockPool::default();
+        let enum_ty = Type::new_enum(EnumId::from_pool_index(0));
+        let mid = pool.add_struct(
+            1,
+            MockStruct {
+                repr_c: true,
+                fields: vec![field("tag", enum_ty)],
+                ..Default::default()
+            },
+        );
+        let outer = pool.add_struct(
+            2,
+            MockStruct {
+                repr_c: true,
+                fields: vec![field("mid", mid)],
+                ..Default::default()
+            },
+        );
+        let fail = repr_c_marker_eligible(&pool, outer).unwrap_err();
+        assert_eq!(fail.field_path, vec!["mid".to_string(), "tag".to_string()]);
+        assert_eq!(fail.field_path_display(), "mid.tag");
+    }
+
+    #[test]
+    fn linear_struct_fails_c_ffi_safe() {
+        let mut pool = MockPool::default();
+        let lin = pool.add_struct(
+            1,
+            MockStruct {
+                repr_c: true,
+                linear: true,
+                fields: vec![field("x", Type::I64)],
+                ..Default::default()
+            },
+        );
+        // has_c_layout is satisfied; c_ffi_safe is the failing predicate.
+        assert!(has_c_layout(&pool, lin));
+        let fail = repr_c_marker_eligible(&pool, lin).unwrap_err();
+        assert_eq!(fail.predicate, FfiPredicate::CFfiSafe);
+        assert_eq!(fail.reason, FfiRejectReason::Linear);
+    }
+
+    #[test]
+    fn destructor_bearing_field_fails_c_ffi_safe_with_path() {
+        let mut pool = MockPool::default();
+        let res = pool.add_struct(
+            1,
+            MockStruct {
+                repr_c: true,
+                has_destructor: true,
+                fields: vec![field("x", Type::I64)],
+                ..Default::default()
+            },
+        );
+        let outer = pool.add_struct(
+            2,
+            MockStruct {
+                repr_c: true,
+                fields: vec![field("res", res)],
+                ..Default::default()
+            },
+        );
+        let fail = repr_c_marker_eligible(&pool, outer).unwrap_err();
+        assert_eq!(fail.predicate, FfiPredicate::CFfiSafe);
+        assert_eq!(fail.reason, FfiRejectReason::HasDestructor);
+        assert_eq!(fail.field_path, vec!["res".to_string()]);
+    }
+
+    #[test]
+    fn opaque_pointer_field_does_not_recurse_into_pointee() {
+        // A pointer to a non-`@repr(c)`, destructor-bearing struct is still
+        // FFI-safe and C-laid-out: pointee layouts are not required.
+        let mut pool = MockPool::default();
+        let opaque = pool.add_struct(
+            1,
+            MockStruct {
+                repr_c: false,
+                has_destructor: true,
+                fields: vec![field("x", Type::I64)],
+                ..Default::default()
+            },
+        );
+        // A dangling pointer handle whose pointee we never read.
+        let _ = opaque;
+        let ptr_mut = Type::new_ptr_mut(PtrMutTypeId::from_pool_index(3));
+        let outer = pool.add_struct(
+            2,
+            MockStruct {
+                repr_c: true,
+                fields: vec![field("handle", ptr_mut)],
+                ..Default::default()
+            },
+        );
+        assert!(has_c_layout(&pool, outer));
+        assert!(c_ffi_safe(&pool, outer).is_ok());
+        assert!(repr_c_marker_eligible(&pool, outer).is_ok());
+    }
+
+    #[test]
+    fn array_of_eligible_elements_has_c_layout_but_is_not_passable_by_value() {
+        let mut pool = MockPool::default();
+        let arr = pool.add_array(0, Type::I64);
+        assert!(has_c_layout(&pool, arr));
+        assert!(c_ffi_safe(&pool, arr).is_ok());
+        // Arrays are eligible as fields, never passable directly by value.
+        assert!(c_passable_by_value(&pool, arr).is_err());
+    }
+}

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -346,6 +346,14 @@ struct TypeInternPoolInner {
 
     /// Reverse index enforcing one canonical nominal for each language item.
     lang_item_structs: HashMap<LangItem, StructId>,
+
+    /// Structs carrying the `@repr(c)` guarantee marker (ADR-0064 Amendment 1,
+    /// RUE-1063). A side map, like `struct_lang_items`, so the marker travels
+    /// with the type universe (and into the frozen pool the FFI predicates and
+    /// classifier consult) without widening `StructDef` or its durable form. A
+    /// layout no-op today; the guarantee that pins C representation and anchors
+    /// FFI-safety.
+    repr_c_structs: HashSet<StructId>,
 }
 
 fn checked_pool_index(index: usize) -> Option<u32> {
@@ -1437,6 +1445,7 @@ impl TypeInternPool {
                 symbol_paths: HashMap::new(),
                 struct_lang_items: HashMap::new(),
                 lang_item_structs: HashMap::new(),
+                repr_c_structs: HashSet::new(),
             }),
         }
     }
@@ -2196,6 +2205,20 @@ impl TypeInternPool {
         inner.struct_lang_items.get(&struct_id) == Some(&LangItem::StrBuf)
     }
 
+    /// Record that a struct carries the `@repr(c)` guarantee marker (ADR-0064
+    /// Amendment 1). Set during type-name registration; read by the FFI
+    /// predicates and extern-signature enforcement.
+    pub fn set_struct_repr_c(&self, struct_id: StructId) {
+        let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        inner.repr_c_structs.insert(struct_id);
+    }
+
+    /// Whether a struct carries the `@repr(c)` guarantee marker.
+    pub fn is_struct_repr_c(&self, struct_id: StructId) -> bool {
+        let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+        inner.repr_c_structs.contains(&struct_id)
+    }
+
     /// Get an enum definition by EnumId.
     ///
     /// This method resolves the pool-issued identity and returns a clone of its
@@ -2759,6 +2782,13 @@ impl FrozenTypeInternPool {
         self.struct_lang_item(id) == Some(LangItem::StrBuf)
     }
 
+    /// Whether a struct carries the `@repr(c)` guarantee marker (ADR-0064
+    /// Amendment 1). The marker set during semantic analysis travels into the
+    /// frozen pool for the FFI predicates and the classifier.
+    pub fn is_struct_repr_c(&self, id: StructId) -> bool {
+        self.inner.repr_c_structs.contains(&id)
+    }
+
     pub fn struct_symbol_name(&self, id: StructId) -> String {
         self.inner.struct_symbol_name(id)
     }
@@ -2908,8 +2938,53 @@ impl Clone for TypeInternPool {
                 symbol_paths: inner.symbol_paths.clone(),
                 struct_lang_items: inner.struct_lang_items.clone(),
                 lang_item_structs: inner.lang_item_structs.clone(),
+                repr_c_structs: inner.repr_c_structs.clone(),
             }),
         }
+    }
+}
+
+impl crate::ffi_predicates::FfiTypePool for TypeInternPool {
+    fn ffi_struct_is_repr_c(&self, id: StructId) -> bool {
+        self.is_struct_repr_c(id)
+    }
+    fn ffi_struct_is_linear(&self, id: StructId) -> bool {
+        self.struct_def(id).is_linear
+    }
+    fn ffi_struct_has_destructor(&self, id: StructId) -> bool {
+        self.struct_def(id).destructor.is_some()
+    }
+    fn ffi_struct_fields(&self, id: StructId) -> Vec<(String, Type)> {
+        self.struct_def(id)
+            .fields
+            .iter()
+            .map(|f| (f.name.clone(), f.ty))
+            .collect()
+    }
+    fn ffi_array_element(&self, id: ArrayTypeId) -> Type {
+        self.array_def(id).0
+    }
+}
+
+impl crate::ffi_predicates::FfiTypePool for FrozenTypeInternPool {
+    fn ffi_struct_is_repr_c(&self, id: StructId) -> bool {
+        self.is_struct_repr_c(id)
+    }
+    fn ffi_struct_is_linear(&self, id: StructId) -> bool {
+        self.struct_def(id).is_linear
+    }
+    fn ffi_struct_has_destructor(&self, id: StructId) -> bool {
+        self.struct_def(id).destructor.is_some()
+    }
+    fn ffi_struct_fields(&self, id: StructId) -> Vec<(String, Type)> {
+        self.struct_def(id)
+            .fields
+            .iter()
+            .map(|f| (f.name.clone(), f.ty))
+            .collect()
+    }
+    fn ffi_array_element(&self, id: ArrayTypeId) -> Type {
+        self.array_def(id).0
     }
 }
 

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -15,6 +15,7 @@ mod api_inventory;
 pub mod call_abi;
 mod canonical_imports;
 pub mod drop_glue_names;
+pub mod ffi_predicates;
 mod inference;
 mod inst;
 mod intern_pool;
@@ -38,6 +39,10 @@ pub use call_abi::{
     ArgClass, ArgConvention, CallAbi, NativeCallAbi, ReturnClass, is_slot_identical_layout,
 };
 pub use canonical_imports::CanonicalImportView;
+pub use ffi_predicates::{
+    FfiPredicate, FfiPredicateFailure, FfiRejectReason, FfiTypePool, c_ffi_safe,
+    c_passable_by_value, check_c_layout, has_c_layout, repr_c_marker_eligible,
+};
 pub use inference::{
     Constraint, ConstraintContext, ConstraintGenerator, ExprInfo, FunctionSig, InferType,
     LocalVarInfo, MethodSig, ParamVarInfo, Substitution, TypeVarAllocator, TypeVarId,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -317,6 +317,26 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         false
     }
 
+    /// Check if a directive list carries the `@repr(c)` guarantee marker
+    /// (ADR-0064 Amendment 1). The parser has already validated that a `@repr`
+    /// directive on a struct carries exactly the argument `c`, so presence of a
+    /// `@repr` directive naming `c` is the marker.
+    pub(crate) fn has_repr_c_directive<'r>(
+        &self,
+        directives: impl Iterator<Item = rue_rir::RirDirectiveView<'r>>,
+    ) -> bool {
+        let repr_sym = self.interner.get("repr");
+        let c_sym = self.interner.get("c");
+        for directive in directives {
+            if Some(directive.name) == repr_sym
+                && directive.args.iter().any(|arg| Some(*arg) == c_sym)
+            {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Post-collection check: a value constant's name must not collide with a
     /// function, struct, or enum (spec 10.3:1, 10.5:1, RUE-239).
     ///
@@ -442,6 +462,7 @@ impl<'a> Sema<'a> {
 
                     let directives = self.rir.directives(directives);
                     let is_copy = self.has_copy_directive(directives.iter());
+                    let is_repr_c = self.has_repr_c_directive(directives.iter());
 
                     // Linear types cannot be @copy
                     if *is_linear && is_copy {
@@ -465,6 +486,13 @@ impl<'a> Sema<'a> {
 
                     // Register in type pool and get pool-based StructId
                     let (struct_id, _) = self.type_pool.declare_struct(*name, struct_def);
+                    // Record the `@repr(c)` guarantee marker on the pool as a
+                    // side fact (ADR-0064 Amendment 1). Preview gating and the
+                    // reject-don't-guess eligibility check run in phase 2
+                    // (`validate_repr_c_struct`), once fields are resolved.
+                    if is_repr_c {
+                        self.type_pool.set_struct_repr_c(struct_id);
+                    }
                     if self
                         .trusted_standard_library_files
                         .contains(&inst.span.file_id)
@@ -1117,6 +1145,19 @@ impl<'a> Sema<'a> {
             }
         }
 
+        // Second pass: validate `@repr(c)` structs now that every destructor has
+        // been collected, so the `c_ffi_safe` reject-list sees a
+        // destructor-bearing struct (or field) uniformly regardless of
+        // declaration order.
+        for (_inst_ref, inst) in self.rir.iter() {
+            if let InstData::StructDecl {
+                directives, name, ..
+            } = &inst.data
+            {
+                self.validate_repr_c_struct(directives, *name, inst.span)?;
+            }
+        }
+
         Ok(())
     }
 
@@ -1170,6 +1211,147 @@ impl<'a> Sema<'a> {
             }
         }
         Ok(())
+    }
+
+    /// Enforce one `extern "C"` parameter or return type (ADR-0064 P1 +
+    /// Amendment 1).
+    ///
+    /// ## Diagnostic layering
+    ///
+    /// P1 restricts the by-value type set to `i64`/`u64`/pointers — the types
+    /// whose native and target-C representations coincide in registers — and
+    /// P2/P3 widen it. Amendment 1 adds the marker/array rules *on top*, so the
+    /// gate is already in place when the type set widens. The order below picks
+    /// the most specific, forward-looking diagnostic:
+    ///
+    /// 1. A **fixed array** as a direct parameter/return is the array-decay
+    ///    rejection (`ExternArrayByValue`) — C has no by-value array parameter;
+    ///    arrays are eligible only as struct fields.
+    /// 2. A **struct** without `@repr(c)` names the missing marker
+    ///    (`ExternAggregateNotReprC`). A `@repr(c)` struct is already
+    ///    marker-eligible (checked at declaration), but by-value aggregate
+    ///    passing is not implemented until P2/P3, so it takes the phase
+    ///    diagnostic (`ExternSignatureTypeUnsupported`) — the same "not yet"
+    ///    story as a narrow scalar, now behind a satisfied marker gate.
+    /// 3. Any remaining type that is not register-passable in this phase
+    ///    (narrow integers, `bool`, enums, …) takes the phase diagnostic via the
+    ///    `c_passable_by_value` predicate seam.
+    fn check_extern_signature_type(&self, ty: Type, span: Span) -> CompileResult<()> {
+        match ty.kind() {
+            TypeKind::Array(_) => Err(CompileError::new(
+                ErrorKind::ExternArrayByValue {
+                    ty: self.format_type_name(ty),
+                },
+                span,
+            )),
+            TypeKind::Struct(struct_id) => {
+                if !self.type_pool.is_struct_repr_c(struct_id) {
+                    return Err(CompileError::new(
+                        ErrorKind::ExternAggregateNotReprC {
+                            ty: self.format_type_name(ty),
+                        },
+                        span,
+                    ));
+                }
+                // Marker-eligible, but by-value aggregate passing awaits P2/P3.
+                Err(CompileError::new(
+                    ErrorKind::ExternSignatureTypeUnsupported {
+                        ty: self.format_type_name(ty),
+                    },
+                    span,
+                ))
+            }
+            _ => crate::c_passable_by_value(&self.type_pool, ty).map_err(|_| {
+                CompileError::new(
+                    ErrorKind::ExternSignatureTypeUnsupported {
+                        ty: self.format_type_name(ty),
+                    },
+                    span,
+                )
+            }),
+        }
+    }
+
+    /// Gate and validate a `@repr(c)` struct (ADR-0064 Amendment 1, RUE-1063).
+    ///
+    /// The marker is meaningless without FFI, so it is gated behind the existing
+    /// `c_ffi` preview. When present it must satisfy the reject-don't-guess list
+    /// *on the marker itself*: no empty body, no enum / non-`@repr(c)` aggregate
+    /// / unsupported field, and no linear / destructor-bearing field. Layout is
+    /// otherwise unchanged — compact layout already is the C layout for the
+    /// supported subset, so the marker changes no bytes today; it is a guarantee.
+    fn validate_repr_c_struct(
+        &self,
+        directives: &rue_rir::RirDirectivesRange,
+        name: Spur,
+        span: Span,
+    ) -> CompileResult<()> {
+        let directives = self.rir.directives(directives);
+        if !self.has_repr_c_directive(directives.iter()) {
+            return Ok(());
+        }
+
+        // The marker is inert without the FFI preview: require it explicitly, as
+        // an `extern "C"` declaration does.
+        self.require_preview(
+            rue_error::PreviewFeature::CFfi,
+            "the `@repr(c)` representation marker",
+            span,
+        )?;
+
+        let struct_name = self.interner.resolve(&name).to_string();
+        let struct_id = *self
+            .structs_by_file_name
+            .get(&(span.file_id, name))
+            .ok_or_else(|| {
+                CompileError::new(
+                    ErrorKind::InternalError(
+                        ice!(
+                            "struct not found during @repr(c) validation",
+                            phase: "sema/declarations",
+                            details: { "struct_name" => struct_name.clone() }
+                        )
+                        .to_string(),
+                    ),
+                    span,
+                )
+            })?;
+
+        let struct_ty = Type::new_struct(struct_id);
+        if let Err(failure) = crate::repr_c_marker_eligible(&self.type_pool, struct_ty) {
+            return Err(self.repr_c_ineligible_error(struct_name, &failure, span));
+        }
+        Ok(())
+    }
+
+    /// Render an [`FfiPredicateFailure`](crate::FfiPredicateFailure) from the
+    /// `@repr(c)` eligibility check into a user-facing diagnostic, preserving the
+    /// failing predicate, field path, and reason (the RUE-504 exposure shape).
+    fn repr_c_ineligible_error(
+        &self,
+        struct_name: String,
+        failure: &crate::FfiPredicateFailure,
+        span: Span,
+    ) -> CompileError {
+        let field_path = failure.field_path_display();
+        let failing_type = self.format_type_name(failure.failing_type);
+        let reason = if field_path.is_empty() {
+            failure.reason.describe().to_string()
+        } else {
+            format!(
+                "field `{field_path}` of type `{failing_type}` — {}",
+                failure.reason.describe()
+            )
+        };
+        CompileError::new(
+            ErrorKind::ReprCStructIneligible(Box::new(rue_error::ReprCIneligibleError {
+                struct_name,
+                field_path,
+                failing_type,
+                reason,
+            })),
+            span,
+        )
     }
 
     /// Collect a destructor definition and register it with its struct.
@@ -1424,37 +1606,19 @@ impl<'a> Sema<'a> {
         };
 
         // Foreign `extern "C"` declarations are gated behind the `c_ffi` preview
-        // and restricted to the P1 type set — the types whose native and
-        // target-C representations coincide (ADR-0064 P1): `i64`, `u64`, and
-        // pointers, plus `()` in return position (C `void`). Every other type
-        // (narrow integers, `bool`, aggregates, floats, enums) awaits a later
-        // FFI phase and is rejected here with a clear not-yet diagnostic.
+        // and their signature types enforced (ADR-0064 P1 + Amendment 1). See
+        // `check_extern_signature_type` for the diagnostic layering.
         if is_extern {
             self.require_preview(
                 PreviewFeature::CFfi,
                 "an `extern \"C\"` foreign declaration",
                 span,
             )?;
-            let is_supported_extern_scalar = |ty: Type| {
-                ty == Type::I64 || ty == Type::U64 || ty.is_ptr_const() || ty.is_ptr_mut()
-            };
             for &param_type in &param_types {
-                if !is_supported_extern_scalar(param_type) {
-                    return Err(CompileError::new(
-                        ErrorKind::ExternSignatureTypeUnsupported {
-                            ty: self.format_type_name(param_type),
-                        },
-                        span,
-                    ));
-                }
+                self.check_extern_signature_type(param_type, span)?;
             }
-            if ret_type != Type::UNIT && !is_supported_extern_scalar(ret_type) {
-                return Err(CompileError::new(
-                    ErrorKind::ExternSignatureTypeUnsupported {
-                        ty: self.format_type_name(ret_type),
-                    },
-                    span,
-                ));
+            if ret_type != Type::UNIT {
+                self.check_extern_signature_type(ret_type, span)?;
             }
         }
 

--- a/crates/rue-cli-tests/cases/c_ffi.toml
+++ b/crates/rue-cli-tests/cases/c_ffi.toml
@@ -152,3 +152,177 @@ fn main() -> i32 {
 args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
 compile_fail = true
 error_contains = ["undefined symbol", "answer", "searched"]
+
+# --- @repr(c) guarantee marker and FFI predicates (Amendment 1, RUE-1063) ----
+
+# Layout no-op, execution-verified: a `@repr(c)` struct has byte-identical layout
+# to the same struct unmarked (compact IS the C layout for the supported subset),
+# so `@size_of`/`@offset_of` agree. Prints `1` for each equality.
+[[case]]
+name = "x86_64_linux_repr_c_layout_is_a_no_op"
+description = "A @repr(c) struct has the same @size_of/@offset_of as its unmarked twin."
+files = [{ path = "main.rue", source = """
+@repr(c)
+struct Marked { a: i32, b: i64, c: u8 }
+struct Unmarked { a: i32, b: i64, c: u8 }
+
+fn main() -> i32 {
+    @dbg(@size_of(Marked) == @size_of(Unmarked));
+    @dbg(@offset_of(Marked, b) == @offset_of(Unmarked, b));
+    @dbg(@offset_of(Marked, c) == @offset_of(Unmarked, c));
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--target", "x86-64-linux", "-o", "prog"]
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = "true\ntrue\ntrue\n"
+exit_code = 0
+
+[[case]]
+name = "repr_c_requires_preview"
+description = "The `@repr(c)` marker is inert without `--preview c_ffi` (it is meaningless without FFI)."
+files = [{ path = "main.rue", source = """
+@repr(c)
+struct P { x: i64 }
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["@repr(c)", "c_ffi", "preview"]
+
+# --- reject-don't-guess list, enforced ON THE MARKER -------------------------
+
+[[case]]
+name = "repr_c_empty_struct_rejected"
+description = "An empty / zero-sized @repr(c) struct has no C object representation in v0."
+files = [{ path = "main.rue", source = """
+@repr(c)
+struct Empty {}
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["@repr(c)", "Empty", "empty"]
+
+[[case]]
+name = "repr_c_enum_field_rejected"
+description = "A Rue enum field is not FFI-safe in v0; the diagnostic names the field path."
+files = [{ path = "main.rue", source = """
+enum Color { Red, Green }
+@repr(c)
+struct S { tag: Color }
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["@repr(c)", "tag", "enum is not FFI-safe"]
+
+[[case]]
+name = "repr_c_nested_non_repr_c_aggregate_rejected"
+description = "A by-value aggregate field must itself be @repr(c) — no silent C-layout promotion."
+files = [{ path = "main.rue", source = """
+struct Inner { x: i64 }
+@repr(c)
+struct S { inner: Inner }
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["@repr(c)", "inner", "must itself be marked"]
+
+[[case]]
+name = "repr_c_destructor_rejected"
+description = "A destructor-bearing @repr(c) struct carries an ownership obligation C cannot honor."
+files = [{ path = "main.rue", source = """
+@repr(c)
+struct D { x: i64 }
+drop fn D(self) {}
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["@repr(c)", "destructor-bearing"]
+
+[[case]]
+name = "repr_c_linear_rejected"
+description = "A linear @repr(c) struct carries a must-consume obligation C cannot honor."
+files = [{ path = "main.rue", source = """
+@repr(c)
+linear struct L { x: i64 }
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["@repr(c)", "linear type cannot cross"]
+
+[[case]]
+name = "repr_c_nested_repr_c_and_array_fields_accepted"
+description = "Nested @repr(c) structs and fixed arrays of eligible elements are eligible fields."
+files = [{ path = "main.rue", source = """
+@repr(c)
+struct Inner { x: i64 }
+@repr(c)
+struct S { inner: Inner, buf: [u8; 4], p: ptr const u8 }
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+exit_code = 0
+
+# --- extern-signature enforcement (marker/array layering) --------------------
+
+[[case]]
+name = "extern_aggregate_without_marker_names_the_marker"
+description = "A non-@repr(c) aggregate in an extern signature is rejected naming the marker (Amendment 1)."
+files = [{ path = "main.rue", source = """
+struct Pt { x: i64, y: i64 }
+extern "C" {
+    fn f(p: Pt) -> i64;
+}
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["aggregate type `Pt`", "must be marked", "@repr(c)"]
+
+[[case]]
+name = "extern_repr_c_aggregate_by_value_is_phase_gated"
+description = "A marker-eligible @repr(c) aggregate is still not passable by value until P2/P3: the phase diagnostic."
+files = [{ path = "main.rue", source = """
+@repr(c)
+struct Pt { x: i64, y: i64 }
+extern "C" {
+    fn f(p: Pt) -> i64;
+}
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["Pt", "not yet supported", "ADR-0064"]
+
+[[case]]
+name = "extern_fixed_array_param_decays"
+description = "A fixed array as a direct extern parameter is rejected: C decays arrays to pointers."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn f(a: [i64; 4]) -> i64;
+}
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["fixed-size array", "decays arrays to pointers"]
+
+[[case]]
+name = "extern_pointer_to_repr_c_struct_accepted"
+description = "A pointer to a @repr(c) struct is an accepted extern signature — pointers cross without the pointee's layout."
+files = [{ path = "main.rue", source = """
+@repr(c)
+struct Pt { x: i64, y: i64 }
+extern "C" {
+    fn f(p: ptr const Pt) -> i64;
+}
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+exit_code = 0

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -380,6 +380,9 @@ impl ErrorCode {
     // ========================================================================
     pub const PREVIEW_FEATURE_REQUIRED: Self = Self(1100);
     pub const EXTERN_SIGNATURE_TYPE_UNSUPPORTED: Self = Self(1101);
+    pub const EXTERN_AGGREGATE_NOT_REPR_C: Self = Self(1102);
+    pub const EXTERN_ARRAY_BY_VALUE: Self = Self(1103);
+    pub const REPR_C_STRUCT_INELIGIBLE: Self = Self(1104);
 
     // ========================================================================
     // Comptime errors (E1200-E1299)
@@ -478,6 +481,25 @@ pub struct CopyStructNonCopyFieldError {
     pub struct_name: String,
     pub field_name: String,
     pub field_type: String,
+}
+
+/// Payload for `ErrorKind::ReprCStructIneligible`.
+///
+/// A `@repr(c)` struct failed the reject-don't-guess eligibility check
+/// (ADR-0064 Amendment 1). The structured `field_path` mirrors the failing
+/// predicate's field path (the RUE-504 machine-readable exposure direction);
+/// `reason` is the rendered human explanation naming the reject-list entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReprCIneligibleError {
+    /// The `@repr(c)` struct that is not FFI-eligible.
+    pub struct_name: String,
+    /// Dotted field path to the offending field, empty when the struct body
+    /// itself is the problem (e.g. an empty struct).
+    pub field_path: String,
+    /// The offending type as rendered for the user.
+    pub failing_type: String,
+    /// Human phrase naming the reject-list reason.
+    pub reason: String,
 }
 
 /// Payload for `ErrorKind::LinearFieldDroppedByDestructure`.
@@ -1583,6 +1605,41 @@ pub enum ErrorKind {
         ty: String,
     },
 
+    /// An aggregate type appeared in an `extern "C"` signature without the
+    /// `@repr(c)` guarantee marker (ADR-0064 Amendment 1). The marker is the
+    /// guarantee trigger: any aggregate crossing the C boundary must opt in
+    /// explicitly, never be silently promoted to C layout.
+    #[error(
+        "aggregate type `{ty}` in an `extern \"C\"` signature must be marked \
+         `@repr(c)`: aggregates crossing the C boundary opt in to C layout \
+         explicitly (ADR-0064)"
+    )]
+    ExternAggregateNotReprC {
+        /// The unmarked aggregate type, as rendered for the user.
+        ty: String,
+    },
+
+    /// A fixed-size array appeared directly as an `extern "C"` parameter or
+    /// return type (ADR-0064 Amendment 1). C decays an array argument to a
+    /// pointer and has no by-value array parameter, so a fixed array is only
+    /// eligible as a struct *field*, never as a direct signature type.
+    #[error(
+        "fixed-size array `{ty}` cannot appear directly in an `extern \"C\"` \
+         signature: C decays arrays to pointers — pass a pointer (`ptr const T`) \
+         instead, or wrap the array in a `@repr(c)` struct (ADR-0064)"
+    )]
+    ExternArrayByValue {
+        /// The rejected array type, as rendered for the user.
+        ty: String,
+    },
+
+    /// A `@repr(c)` struct failed the reject-don't-guess eligibility check
+    /// (ADR-0064 Amendment 1): an empty struct, an enum/aggregate field without
+    /// its own `@repr(c)` marker, or a linear / destructor-bearing field. The
+    /// marker is rejected rather than guessing a C representation.
+    #[error("`@repr(c)` struct `{}` is not FFI-eligible: {}", .0.struct_name, .0.reason)]
+    ReprCStructIneligible(Box<ReprCIneligibleError>),
+
     /// A slice type / range-slice was used under `--preview slices` but the
     /// fat-pointer runtime is not implemented yet (ADR-0043 Phase 1, RUE-322).
     #[error("slice types are not yet fully implemented (ADR-0043 Phase 1, RUE-322)")]
@@ -1823,6 +1880,9 @@ impl ErrorKind {
             ErrorKind::ExternSignatureTypeUnsupported { .. } => {
                 ErrorCode::EXTERN_SIGNATURE_TYPE_UNSUPPORTED
             }
+            ErrorKind::ExternAggregateNotReprC { .. } => ErrorCode::EXTERN_AGGREGATE_NOT_REPR_C,
+            ErrorKind::ExternArrayByValue { .. } => ErrorCode::EXTERN_ARRAY_BY_VALUE,
+            ErrorKind::ReprCStructIneligible(_) => ErrorCode::REPR_C_STRUCT_INELIGIBLE,
             ErrorKind::SliceNotYetImplemented => ErrorCode::SLICE_NOT_YET_IMPLEMENTED,
             ErrorKind::SliceReturnNotAllowed => ErrorCode::SLICE_RETURN_NOT_ALLOWED,
             ErrorKind::SliceInAggregateField => ErrorCode::SLICE_IN_AGGREGATE_FIELD,

--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -40,6 +40,7 @@ struct PrimitiveTypeSpurs {
     drop_marker: Spur,
     allow_directive: Spur,
     copy_directive: Spur,
+    repr_directive: Spur,
 }
 
 impl PrimitiveTypeSpurs {
@@ -62,6 +63,7 @@ impl PrimitiveTypeSpurs {
             drop_marker: interner.get_or_intern("__drop"),
             allow_directive: interner.get_or_intern("allow"),
             copy_directive: interner.get_or_intern("copy"),
+            repr_directive: interner.get_or_intern("repr"),
             underscore: interner.get_or_intern("_"),
         }
     }

--- a/crates/rue-parser/src/parser/expressions.rs
+++ b/crates/rue-parser/src/parser/expressions.rs
@@ -544,7 +544,10 @@ impl Parser {
             }
         }
         self.expect(TokenKind::RParen)?;
-        if name.name == self.syms.allow_directive || name.name == self.syms.copy_directive {
+        if name.name == self.syms.allow_directive
+            || name.name == self.syms.copy_directive
+            || name.name == self.syms.repr_directive
+        {
             self.error_at("directive must precede a statement", self.span_from(start));
             return Err(());
         }

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -25,7 +25,17 @@ use rue_error::{CompileError, ErrorKind};
 /// - `allow`  — suppresses lints, e.g. `@allow(unused_variable)` on `let`
 ///   (see `has_allow_directive` in rue-air)
 /// - `copy`   — marks a struct as a copy type (see `has_copy_directive`)
-pub const KNOWN_DIRECTIVES: &[&str] = &["allow", "copy"];
+/// - `repr`   — the C representation guarantee marker `@repr(c)` on a struct
+///   (ADR-0064 Amendment 1; see `has_repr_c_directive` in rue-air)
+pub const KNOWN_DIRECTIVES: &[&str] = &["allow", "copy", "repr"];
+
+/// Representation arguments accepted by `@repr(...)`.
+///
+/// Only `c` is accepted in v0 (ADR-0064 Amendment 1). The parameterized grammar
+/// stays open for future `@repr(packed)` / `@repr(align(n))`; parsing validates
+/// the argument so `@repr(packed)` fails loudly with the accepted set named,
+/// rather than being silently ignored.
+pub const KNOWN_REPR_ARGS: &[&str] = &["c"];
 
 /// Warning names accepted by `@allow(...)`.
 ///
@@ -81,7 +91,7 @@ impl Validator<'_> {
             if !KNOWN_DIRECTIVES.contains(&name) {
                 self.errors.push(CompileError::new(
                     ErrorKind::ParseError(format!(
-                        "unknown directive '@{}'; known directives are @allow and @copy",
+                        "unknown directive '@{}'; known directives are @allow, @copy, and @repr",
                         name
                     )),
                     directive.span,
@@ -106,6 +116,44 @@ impl Validator<'_> {
                             ErrorKind::ParseError("@copy takes no arguments".to_string()),
                             directive.span,
                         ));
+                    }
+                }
+                "repr" => {
+                    // `@repr(c)` is the C representation guarantee marker
+                    // (ADR-0064 Amendment 1). It applies only to structs, and
+                    // is parameterized: exactly one argument, `c` in v0. Unknown
+                    // arguments (e.g. `@repr(packed)`) fail loudly here naming
+                    // the accepted set, leaving the grammar open for future
+                    // packed/align representations.
+                    if !matches!(site, DirectiveSite::Struct) {
+                        self.errors.push(CompileError::new(
+                            ErrorKind::ParseError(format!(
+                                "@repr can only be applied to structs, not {}",
+                                site.description()
+                            )),
+                            directive.span,
+                        ));
+                    } else if directive.args.len() != 1 {
+                        self.errors.push(CompileError::new(
+                            ErrorKind::ParseError(format!(
+                                "@repr takes exactly one representation argument; \
+                                 accepted arguments are {}",
+                                KNOWN_REPR_ARGS.join(", ")
+                            )),
+                            directive.span,
+                        ));
+                    } else {
+                        let crate::ast::DirectiveArg::Ident(ident) = &directive.args[0];
+                        let arg = self.interner.resolve(&ident.name);
+                        if !KNOWN_REPR_ARGS.contains(&arg) {
+                            self.errors.push(CompileError::new(
+                                ErrorKind::ParseError(format!(
+                                    "unknown @repr argument '{arg}'; accepted arguments are {}",
+                                    KNOWN_REPR_ARGS.join(", ")
+                                )),
+                                ident.span,
+                            ));
+                        }
                     }
                 }
                 "allow" => {

--- a/crates/rue-spec/cases/lexical/builtins.toml
+++ b/crates/rue-spec/cases/lexical/builtins.toml
@@ -250,3 +250,67 @@ fn main() -> i32 {
 }
 """
 exit_code = 10
+
+# =============================================================================
+# @repr(c) Directive (ADR-0064 Amendment 1, RUE-1063)
+# =============================================================================
+
+[[case]]
+name = "repr_c_marker_on_struct"
+spec = ["2.5:33"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "@repr(c) marks a struct with the C representation guarantee; it is a layout no-op"
+source = """
+@repr(c)
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { x: 4, y: 3 };
+    p.x + p.y
+}
+"""
+exit_code = 7
+
+[[case]]
+name = "repr_only_accepts_c_argument"
+spec = ["2.5:34"]
+description = "@repr is parameterized and only `c` is accepted; @repr(packed) is a compile-time error"
+source = """
+@repr(packed)
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["unknown @repr argument 'packed'", "accepted arguments are c"]
+
+[[case]]
+name = "repr_c_requires_c_ffi_preview"
+spec = ["2.5:35"]
+description = "@repr(c) is gated behind the c_ffi preview feature"
+source = """
+@repr(c)
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["requires preview feature", "c_ffi"]
+
+[[case]]
+name = "repr_c_rejects_ineligible_field"
+spec = ["2.5:36"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "A @repr(c) struct must be FFI-eligible: an enum field is rejected"
+source = """
+enum Color { Red, Green }
+
+@repr(c)
+struct S { tag: Color }
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["not FFI-eligible", "enum is not FFI-safe"]

--- a/crates/rue-ui-tests/cases/diagnostics/directives.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/directives.toml
@@ -3,7 +3,7 @@
 # Unknown @-directives in item/statement position used to be silently
 # accepted and ignored, so a typo like `@alllow(...)` was a no-op. They are
 # now a compile error naming the directive. The known set lives in
-# rue-parser's `validate::KNOWN_DIRECTIVES` (allow, copy); the cases
+# rue-parser's `validate::KNOWN_DIRECTIVES` (allow, copy, repr); the cases
 # below pin both the rejection and that every known directive still works.
 # (Expression-position intrinsics like @dbg/@intCast and the fused @import
 # token are separate mechanisms and unaffected.)
@@ -23,7 +23,7 @@ source = """
 fn main() -> i32 { 42 }
 """
 compile_fail = true
-error_contains = ["unknown directive '@important'", "@allow and @copy"]
+error_contains = ["unknown directive '@important'", "@allow, @copy, and @repr"]
 
 [[case]]
 name = "unknown_directive_typo_of_allow"
@@ -112,6 +112,57 @@ fn main() -> i32 {
 """
 exit_code = 42
 
+# --- @repr(c) marker grammar (ADR-0064 Amendment 1, RUE-1063) ---------------
+# The `@repr(c)` guarantee marker reuses the parameterized `@name(arg)` directive
+# grammar. Placement (structs only) and argument (`c` in v0) validation happen at
+# parse time, before the `c_ffi` preview gate in sema.
+
+[[case]]
+name = "repr_directive_on_function_rejected"
+description = "@repr is a struct marker; on a function it is a parse error naming the site."
+source = """
+@repr(c)
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["@repr can only be applied to structs"]
+
+[[case]]
+name = "repr_unknown_argument_rejected"
+description = "Only `c` is accepted in v0; @repr(packed) fails loudly naming the accepted set."
+source = """
+@repr(packed)
+struct P { x: i64 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["unknown @repr argument 'packed'", "accepted arguments are c"]
+
+[[case]]
+name = "repr_missing_argument_rejected"
+description = "@repr is parameterized: a bare @repr with no argument is rejected."
+source = """
+@repr
+struct P { x: i64 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["@repr takes exactly one representation argument", "accepted arguments are c"]
+
+[[case]]
+name = "known_directive_repr_c_still_works"
+description = "A well-formed @repr(c) struct compiles under the c_ffi preview (layout no-op)."
+preview = "c_ffi"
+source = """
+@repr(c)
+struct P { x: i32, y: i32 }
+fn main() -> i32 {
+    let p = P { x: 20, y: 22 };
+    p.x + p.y
+}
+"""
+exit_code = 42
+
 [[case]]
 name = "retired_handle_directive_is_unknown"
 description = """
@@ -136,7 +187,7 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = ["unknown directive '@handle'", "@allow and @copy"]
+error_contains = ["unknown directive '@handle'", "@allow, @copy, and @repr"]
 
 [[case]]
 name = "ordinary_handle_method_still_works"

--- a/docs/spec/src/02-lexical-structure/05-builtins.md
+++ b/docs/spec/src/02-lexical-structure/05-builtins.md
@@ -39,7 +39,7 @@ There are two kinds of builtins, distinguished by their syntactic position:
 | Kind | Position | Purpose | Examples |
 |------|----------|---------|----------|
 | Intrinsic | Expression | Produces a value | `@dbg`, `@size_of`, `@align_of` |
-| Directive | Before item/statement | Modifies compiler behavior | `@allow`, `@copy` |
+| Directive | Before item/statement | Modifies compiler behavior | `@allow`, `@copy`, `@repr` |
 
 {{ rule(id="2.5:6", cat="normative") }}
 
@@ -226,3 +226,58 @@ fn main() -> i32 {
 {{ rule(id="2.5:31", cat="informative") }}
 
 See [Move Semantics](@/03-types/08-move-semantics.md#the-copy-directive) for the full semantics of `@copy` structs.
+
+## `@repr`
+
+{{ rule(id="2.5:33", cat="normative") }}
+
+The `@repr` directive is a **representation guarantee marker** for a struct
+type. `@repr(c)` guarantees the struct's object representation follows the
+selected compilation target's default C data model (the platform psABI): its
+size, alignment, field order, field offsets, and tail padding equal the
+corresponding C aggregate's.
+
+{{ rule(id="2.5:34", cat="normative") }}
+
+`@repr` **MUST** appear immediately before a struct definition, and is
+parameterized: it takes exactly one representation argument. Only `c` is
+accepted; any other argument is a compile-time error. The parameterized form
+reserves room for future representations without a re-spelling.
+
+{{ rule(id="2.5:35", cat="normative") }}
+
+`@repr(c)` is gated behind the `c_ffi` preview feature (ADR-0064): the marker is
+meaningful only at a C FFI boundary, so it requires `--preview c_ffi`.
+
+{{ rule(id="2.5:36", cat="normative") }}
+
+A `@repr(c)` struct **MUST** be FFI-eligible: it is not empty, and every field
+is a C-compatible scalar, a raw pointer, a fixed array of eligible elements, or a
+nested `@repr(c)` struct. An empty struct, an enum field, an aggregate field that
+is not itself `@repr(c)`, and a linear or destructor-bearing field are each
+rejected — the representation is never guessed. A pointer field crosses without
+the pointee's layout, so a pointer to an opaque or incomplete type is eligible.
+
+{{ rule(id="2.5:37", cat="informative") }}
+
+Because Rue's sole memory representation (compact layout) already matches the C
+aggregate rule for the supported field subset, `@repr(c)` changes no bytes today:
+it is a layout no-op whose value is the forward guarantee against future
+native-layout evolution, and the anchor of the FFI-safety predicates.
+
+{{ rule(id="2.5:38") }}
+
+```rue
+@repr(c)
+struct Point { x: i32, y: i32 }
+
+extern "C" {
+    fn translate(p: ptr const Point, dx: i32) -> i32;
+}
+```
+
+{{ rule(id="2.5:39", cat="informative") }}
+
+See [ADR-0064](https://github.com/rue-language/rue/blob/trunk/docs/designs/0064-c-ffi.md)
+for the full C FFI boundary contract, the three FFI-safety predicates, and the
+staged migration plan.


### PR DESCRIPTION
Fixes RUE-1063

ADR-0064 Amendment 1, phase P1.5a: the representation-guarantee layer for C FFI.

- **`@repr(c)` marker**: a layout no-op (execution-verified byte-identical to the unmarked twin) that pins a struct's C-compatible representation against future layout evolution (RUE-881). Required on any aggregate named in an `extern "C"` signature — C layout is never silently promoted. Parameterized `@name(arg)` directive grammar validated in the parser: struct-only, only `c` accepted (E0102 otherwise), gated behind `--preview c_ffi` (E1100).
- **`rue-air/ffi_predicates`**: the three Amendment 1 predicates — `has_c_layout`, `c_ffi_safe`, `c_passable_by_value` — over an `FfiTypePool` trait spanning the mutable and frozen pools. Failures carry `{predicate, field_path, failing_type, reason}`.
- **Diagnostic layering** in extern-signature checking: fixed array → C-decay guidance; unmarked aggregate → E1102 naming the marker; marked aggregate → E1101 phase diagnostic (P1's `i64`/`u64`/pointer restriction, widened by P2/P3 without touching the predicates). Eligibility violations (enum field, nested unmarked aggregate, empty struct, destructor-bearing, linear) → E1104 with the failing field path.
- `repr(c)`-ness rides a side-map on the type pool, not the durable type representation.
- 12 new `cli.c_ffi` cases, ui `directives` cases, 10 `ffi_predicates` unit tests, spec builtins updated.

Verification: clean 3-way apply on trunk including #1854; full `./test.sh` green (exit 0, zero failures in both formats); all diagnostics and the layout no-op re-verified by hand-execution on this checkout; fresh cross-mechanism seam tests against P1.5b confirmed `std.c.c_long` is accepted through the alias while `std.c.c_int` is rejected by the P1 restriction, and a `@repr(c)` struct with `std.c` fields passes eligibility.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_