### PR TITLE
RUE-1056: CallAbi::TargetC scalar classifier (ADR-0064 P2)

### DIFF
--- a/crates/rue-air/src/call_abi.rs
+++ b/crates/rue-air/src/call_abi.rs
@@ -35,9 +35,9 @@ use crate::{FrozenTypeInternPool, Type, TypeKind};
 
 /// Which calling convention governs a boundary.
 ///
-/// The seam ADR-0052 requires so the future guaranteed target C classifier
-/// extends this authority instead of adding a peer path. Only the native
-/// convention is implemented today.
+/// The seam ADR-0052 requires so the guaranteed target-C classifier extends this
+/// authority instead of adding a peer path. ADR-0064 P2 (RUE-1056) fills the
+/// second variant with [`TargetCCallAbi`] for scalars and pointers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CallAbi {
     /// The preserved native Rue convention (RUE-106): a by-value aggregate is
@@ -46,6 +46,12 @@ pub enum CallAbi {
     /// `inout` / `borrow` argument is one pointer slot; a by-value argument
     /// occupies one slot per leaf.
     Native,
+    /// The guaranteed target-C convention (ADR-0064): SysV AMD64 or AAPCS64 per
+    /// the target flavor. In P2 it governs scalar and pointer crossings at an
+    /// `extern "C"` boundary — one integer register per scalar, with the psABI's
+    /// narrow-integer extension and the 1-byte `_Bool` 0/1 contract. See
+    /// [`TargetCCallAbi`].
+    TargetC(TargetCAbiFlavor),
 }
 
 /// How a by-value return value crosses the call boundary.
@@ -337,6 +343,208 @@ pub fn is_slot_identical_layout(type_pool: &FrozenTypeInternPool, ty: Type) -> b
     }
 }
 
+// ============================================================================
+// The guaranteed target-C classifier (ADR-0064 P2, RUE-1056)
+// ============================================================================
+
+/// Which platform psABI a [`CallAbi::TargetC`] boundary follows. The flavor is
+/// selected from the compilation target's architecture: x86-64 uses SysV AMD64,
+/// AArch64 uses AAPCS64. The two agree on the scalar operations P2 needs (one
+/// integer register per scalar, narrow values extended to their canonical form),
+/// and differ only in the details documented on the flavor's methods — details
+/// P3/P4 will exercise (byval stack area, sret register + echo).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetCAbiFlavor {
+    /// System V AMD64 psABI (x86-64 Linux/BSD/macOS).
+    SysVAmd64,
+    /// The ARM 64-bit Procedure Call Standard (AArch64 Linux/macOS).
+    Aapcs64,
+}
+
+/// How a narrow scalar is extended to fill its 64-bit integer register at a
+/// target-C boundary (ADR-0064 P2). "Narrow" means any value smaller than the
+/// register: the sub-64-bit integers and `bool`. The extension is the same
+/// operation whether it is applied by the caller before an argument crosses or
+/// by the caller after a return crosses — see [`TargetCCallAbi`] for *who*
+/// applies it under each psABI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScalarAbiExtension {
+    /// The value already fills its 64-bit register (`i64`/`u64`/pointer): no
+    /// extension instruction is emitted.
+    None,
+    /// Sign-extend the low `from_bits` to 64 (a signed narrow integer:
+    /// `i8`/`i16`/`i32`).
+    Signed {
+        /// The declared width of the value, in bits (8, 16, or 32).
+        from_bits: u32,
+    },
+    /// Zero-extend the low `from_bits` to 64 (an unsigned narrow integer
+    /// `u8`/`u16`/`u32`, or `bool` as the 1-byte `_Bool` whose byte is 0/1 by
+    /// contract, `from_bits == 8`).
+    Unsigned {
+        /// The declared width of the value, in bits (8, 16, or 32).
+        from_bits: u32,
+    },
+}
+
+impl ScalarAbiExtension {
+    /// Whether this extension emits no instruction (the value is already
+    /// register-width canonical).
+    pub const fn is_noop(self) -> bool {
+        matches!(self, Self::None)
+    }
+}
+
+/// The guaranteed target-C call-ABI classifier: the [`CallAbi::TargetC`]
+/// implementation for scalars and pointers (ADR-0064 P2, RUE-1056).
+///
+/// This is the single authority both backends' `extern "C"` call lowering and
+/// the oracle consult, so no backend makes a local target-C ABI decision. In P2
+/// its scope is register-only scalar crossings; P3 extends the same authority
+/// with eightbyte aggregate classification and byval stack arguments, and P5
+/// with the SSE/FP register class once RUE-714 lands floats.
+///
+/// ## What P2 fixes, and why scalars need only the return re-extension
+///
+/// Every supported scalar (`c_passable_by_value`: the full integer set, `bool`,
+/// pointers) occupies exactly one general-purpose integer register — the first
+/// six on SysV (`rdi, rsi, rdx, rcx, r8, r9`), the first eight on AAPCS64
+/// (`x0..x7`) — and P2 stays within that budget (no stack arguments). Rue's
+/// internal scalar invariant already keeps a narrow value canonically extended
+/// in its 64-bit vreg (signed values sign-extended, unsigned/`bool`
+/// zero-extended), which is a *stronger* guarantee than either psABI asks of an
+/// argument, so **argument passing needs no boundary instruction**. The one
+/// direction that does is the **return**: a C callee leaves the bits above the
+/// result's declared width unspecified (SysV) — or extended only to 32 bits
+/// (AAPCS64) — so the caller must re-extend the returned scalar to Rue's
+/// canonical 64-bit form. [`Self::scalar_return_extension`] names that
+/// operation; applying it at the boundary is what preserves the program-wide
+/// scalar invariant across a foreign call.
+///
+/// ## Narrow-integer extension: who extends
+///
+/// - **SysV AMD64.** Arguments narrower than the register have unspecified high
+///   bits; a callee that needs a wider value re-extends. Rue over-satisfies the
+///   argument rule by always passing a canonically extended value. For a return,
+///   the bits above the type width are callee-visible garbage, so the **caller
+///   re-extends** (this classifier's return extension).
+/// - **AAPCS64.** A callee is required to extend a narrow return value to 32
+///   bits, but bits 32..63 stay unspecified, so re-extending from the value's
+///   *own* declared width is still correct (bits already agree up to 32). The
+///   caller therefore applies the same [`ScalarAbiExtension`].
+///
+/// ## `_Bool`
+///
+/// C `_Bool` is one byte whose only valid values are 0 and 1. Passing Rue's
+/// `bool` (a 0/1 word) satisfies that directly; a `_Bool` return is
+/// zero-extended from its low byte, materializing exactly 0/1
+/// ([`ScalarAbiExtension::Unsigned`] `{ from_bits: 8 }`).
+#[derive(Debug, Clone, Copy)]
+pub struct TargetCCallAbi {
+    flavor: TargetCAbiFlavor,
+}
+
+impl TargetCCallAbi {
+    /// Build the classifier for a given psABI flavor.
+    pub const fn new(flavor: TargetCAbiFlavor) -> Self {
+        Self { flavor }
+    }
+
+    /// The SysV AMD64 classifier (x86-64).
+    pub const fn sysv_amd64() -> Self {
+        Self::new(TargetCAbiFlavor::SysVAmd64)
+    }
+
+    /// The AAPCS64 classifier (AArch64).
+    pub const fn aapcs64() -> Self {
+        Self::new(TargetCAbiFlavor::Aapcs64)
+    }
+
+    /// The convention this classifier implements.
+    pub const fn abi(&self) -> CallAbi {
+        CallAbi::TargetC(self.flavor)
+    }
+
+    /// The psABI flavor this classifier follows.
+    pub const fn flavor(&self) -> TargetCAbiFlavor {
+        self.flavor
+    }
+
+    /// The number of general-purpose integer registers used for arguments
+    /// before the byval stack area (P3) begins: 6 on SysV (`rdi..r9`), 8 on
+    /// AAPCS64 (`x0..x7`). P2 stays within this budget.
+    pub const fn int_arg_register_budget(&self) -> u32 {
+        match self.flavor {
+            TargetCAbiFlavor::SysVAmd64 => 6,
+            TargetCAbiFlavor::Aapcs64 => 8,
+        }
+    }
+
+    /// Whether the callee echoes the hidden sret pointer back in the primary
+    /// return register: SysV requires `rax` to hold the sret pointer on return;
+    /// AAPCS64 uses the dedicated indirect-result register `x8`, which is **not**
+    /// echoed. Documented here for the P3/P4 aggregate/export work; scalars in P2
+    /// never take an sret path.
+    pub const fn sret_pointer_echoed_in_result_register(&self) -> bool {
+        match self.flavor {
+            TargetCAbiFlavor::SysVAmd64 => true,
+            TargetCAbiFlavor::Aapcs64 => false,
+        }
+    }
+
+    /// The stack alignment required at a `call` instruction on this psABI: 16
+    /// bytes on both SysV AMD64 and AAPCS64.
+    pub const fn call_stack_alignment(&self) -> u32 {
+        16
+    }
+
+    /// The extension a scalar *return* value needs to become Rue's canonical
+    /// 64-bit form after crossing back from C. `None` for register-width scalars
+    /// (`i64`/`u64`/pointer); a sign/zero extension for a narrow integer; a
+    /// zero-extend-from-8 for `bool`/`_Bool`.
+    ///
+    /// The argument-side extension is the same operation
+    /// ([`Self::scalar_arg_extension`]); the two are separated only so the
+    /// "who extends" documentation can differ per direction.
+    pub fn scalar_return_extension(&self, ty: Type) -> ScalarAbiExtension {
+        Self::canonical_extension(ty)
+    }
+
+    /// The extension a scalar *argument* value must already carry when it
+    /// crosses into C. Identical to [`Self::scalar_return_extension`]; Rue's
+    /// internal scalar invariant already satisfies it, so the caller emits no
+    /// extra instruction for arguments in P2.
+    pub fn scalar_arg_extension(&self, ty: Type) -> ScalarAbiExtension {
+        Self::canonical_extension(ty)
+    }
+
+    /// The canonical 64-bit extension for a supported target-C scalar. Shared by
+    /// both directions; both psABIs agree on the operation.
+    fn canonical_extension(ty: Type) -> ScalarAbiExtension {
+        match ty.kind() {
+            TypeKind::I8 => ScalarAbiExtension::Signed { from_bits: 8 },
+            TypeKind::I16 => ScalarAbiExtension::Signed { from_bits: 16 },
+            TypeKind::I32 => ScalarAbiExtension::Signed { from_bits: 32 },
+            TypeKind::U8 => ScalarAbiExtension::Unsigned { from_bits: 8 },
+            TypeKind::U16 => ScalarAbiExtension::Unsigned { from_bits: 16 },
+            TypeKind::U32 => ScalarAbiExtension::Unsigned { from_bits: 32 },
+            // The 1-byte `_Bool` with the 0/1 contract: zero-extend its byte.
+            TypeKind::Bool => ScalarAbiExtension::Unsigned { from_bits: 8 },
+            // Register-width scalars and pointers already fill the register.
+            TypeKind::I64
+            | TypeKind::U64
+            | TypeKind::PtrConst(_)
+            | TypeKind::PtrMut(_)
+            | TypeKind::Error => ScalarAbiExtension::None,
+            other => panic!(
+                "TargetCCallAbi scalar classification called on non-scalar type {other:?}; \
+                 aggregates (P3) and unsupported types are gated by c_passable_by_value \
+                 before lowering"
+            ),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -344,6 +552,89 @@ mod tests {
     // Behavioral coverage that exercises the classifier against a real type
     // pool lives with the backend ABI/oracle suites (which own program
     // fixtures); these unit checks pin the pure classification algebra.
+
+    #[test]
+    fn target_c_scalar_return_extension_table() {
+        let sysv = TargetCCallAbi::sysv_amd64();
+        assert_eq!(
+            sysv.scalar_return_extension(Type::I8),
+            ScalarAbiExtension::Signed { from_bits: 8 }
+        );
+        assert_eq!(
+            sysv.scalar_return_extension(Type::U8),
+            ScalarAbiExtension::Unsigned { from_bits: 8 }
+        );
+        assert_eq!(
+            sysv.scalar_return_extension(Type::I16),
+            ScalarAbiExtension::Signed { from_bits: 16 }
+        );
+        assert_eq!(
+            sysv.scalar_return_extension(Type::U16),
+            ScalarAbiExtension::Unsigned { from_bits: 16 }
+        );
+        assert_eq!(
+            sysv.scalar_return_extension(Type::I32),
+            ScalarAbiExtension::Signed { from_bits: 32 }
+        );
+        assert_eq!(
+            sysv.scalar_return_extension(Type::U32),
+            ScalarAbiExtension::Unsigned { from_bits: 32 }
+        );
+        // The 1-byte `_Bool` 0/1 contract: zero-extend from its byte.
+        assert_eq!(
+            sysv.scalar_return_extension(Type::BOOL),
+            ScalarAbiExtension::Unsigned { from_bits: 8 }
+        );
+        // Register-width scalars need no extension.
+        assert!(sysv.scalar_return_extension(Type::I64).is_noop());
+        assert!(sysv.scalar_return_extension(Type::U64).is_noop());
+    }
+
+    #[test]
+    fn both_flavors_agree_on_the_scalar_extension_operation() {
+        // The narrow-integer extension is the same operation on both psABIs; the
+        // flavors differ only in documented "who extends" / sret-echo details.
+        let sysv = TargetCCallAbi::sysv_amd64();
+        let aapcs = TargetCCallAbi::aapcs64();
+        for ty in [
+            Type::I8,
+            Type::U8,
+            Type::I16,
+            Type::U16,
+            Type::I32,
+            Type::U32,
+            Type::I64,
+            Type::U64,
+            Type::BOOL,
+        ] {
+            assert_eq!(
+                sysv.scalar_return_extension(ty),
+                aapcs.scalar_return_extension(ty),
+                "flavors must agree on the extension for {ty:?}"
+            );
+            assert_eq!(
+                sysv.scalar_arg_extension(ty),
+                sysv.scalar_return_extension(ty),
+                "arg and return extension are the same operation for {ty:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn flavor_specific_register_and_sret_echo_facts() {
+        let sysv = TargetCCallAbi::sysv_amd64();
+        let aapcs = TargetCCallAbi::aapcs64();
+        assert_eq!(sysv.int_arg_register_budget(), 6);
+        assert_eq!(aapcs.int_arg_register_budget(), 8);
+        // SysV echoes the sret pointer in rax; AAPCS64's x8 is not echoed.
+        assert!(sysv.sret_pointer_echoed_in_result_register());
+        assert!(!aapcs.sret_pointer_echoed_in_result_register());
+        // 16-byte call alignment on both.
+        assert_eq!(sysv.call_stack_alignment(), 16);
+        assert_eq!(aapcs.call_stack_alignment(), 16);
+        assert_eq!(sysv.abi(), CallAbi::TargetC(TargetCAbiFlavor::SysVAmd64));
+        assert_eq!(aapcs.abi(), CallAbi::TargetC(TargetCAbiFlavor::Aapcs64));
+    }
 
     #[test]
     fn return_class_slot_count_and_sret_predicate_agree() {

--- a/crates/rue-air/src/ffi_predicates.rs
+++ b/crates/rue-air/src/ffi_predicates.rs
@@ -68,8 +68,8 @@ pub enum FfiRejectReason {
     /// A type with no C representation at all (unit, never, module, comptime,
     /// slice-shaped, …).
     UnsupportedType,
-    /// A type that is not in the register-only by-value set the current phase
-    /// (P1.5) implements — the [`c_passable_by_value`] seam P2/P3 widen.
+    /// A type that is not in the by-value set the current phase (P2) implements
+    /// — the [`c_passable_by_value`] seam P3 widens to aggregates.
     NotRegisterPassable,
 }
 
@@ -96,7 +96,7 @@ impl FfiRejectReason {
             FfiRejectReason::UnsupportedType => "this type has no C representation in v0",
             FfiRejectReason::NotRegisterPassable => {
                 "this type is not yet passable by value across a C boundary (only \
-                 `i64`, `u64`, and pointers are, until a later FFI phase)"
+                 integer and pointer scalars are; aggregates await a later FFI phase)"
             }
         }
     }
@@ -302,14 +302,32 @@ fn check_c_ffi_safe<P: FfiTypePool>(
 
 /// Predicate 3: can `ty` cross a C boundary *by value* in the current phase?
 ///
-/// This is the classifier seam. P1.5 delegates to the P1 register-only
-/// restriction — `i64`, `u64`, and raw pointers, the types whose native and
-/// target-C representations coincide in registers. P2 (eightbyte classification,
-/// register packing, `_Bool`/narrow-int extension) and P3 (aggregates, byval
-/// stack args) widen this without touching the other two predicates.
+/// This is the classifier seam, kept in lock-step with the
+/// [`TargetCCallAbi`](crate::call_abi::TargetCCallAbi) scalar classifier that
+/// lowers each crossing. P2 (RUE-1056) widens it from the P1 register-only set
+/// (`i64`/`u64`/pointers) to the **full integer scalar set** — every signed and
+/// unsigned integer width (`i8`/`u8`/`i16`/`u16`/`i32`/`u32`/`i64`/`u64`),
+/// `bool` as the 1-byte `_Bool` with the 0/1 contract, and raw pointers. These
+/// are exactly the scalars the target-C classifier assigns to a single integer
+/// register with a defined narrow-integer extension at the boundary
+/// ([`ScalarAbiExtension`](crate::call_abi::ScalarAbiExtension)).
+///
+/// Aggregates (eightbyte classification, register packing, byval stack args)
+/// stay rejected until P3; floating-point scalars are unreachable until RUE-714
+/// adds the type (P5). Neither widening touches the other two predicates.
 pub fn c_passable_by_value<P: FfiTypePool>(_pool: &P, ty: Type) -> Result<(), FfiPredicateFailure> {
     match ty.kind() {
-        TypeKind::I64 | TypeKind::U64 | TypeKind::PtrConst(_) | TypeKind::PtrMut(_) => Ok(()),
+        TypeKind::I8
+        | TypeKind::U8
+        | TypeKind::I16
+        | TypeKind::U16
+        | TypeKind::I32
+        | TypeKind::U32
+        | TypeKind::I64
+        | TypeKind::U64
+        | TypeKind::Bool
+        | TypeKind::PtrConst(_)
+        | TypeKind::PtrMut(_) => Ok(()),
         _ => Err(FfiPredicateFailure::new(
             FfiPredicate::CPassableByValue,
             &[],
@@ -407,12 +425,36 @@ mod tests {
             assert!(has_c_layout(&pool, ty), "{ty:?} should have C layout");
             assert!(c_ffi_safe(&pool, ty).is_ok(), "{ty:?} should be FFI-safe");
         }
-        // Only the register-set is passable by value in this phase.
-        assert!(c_passable_by_value(&pool, Type::I64).is_ok());
-        assert!(c_passable_by_value(&pool, Type::U64).is_ok());
-        assert!(c_passable_by_value(&pool, ptr()).is_ok());
-        // Narrow scalars are not yet passable by value (the P2/P3 seam).
-        let fail = c_passable_by_value(&pool, Type::I32).unwrap_err();
+        // P2 (RUE-1056) widens by-value passing to the full integer scalar set
+        // plus `bool` and pointers.
+        for ty in [
+            Type::I8,
+            Type::U8,
+            Type::I16,
+            Type::U16,
+            Type::I32,
+            Type::U32,
+            Type::I64,
+            Type::U64,
+            Type::BOOL,
+            ptr(),
+        ] {
+            assert!(
+                c_passable_by_value(&pool, ty).is_ok(),
+                "{ty:?} should be passable by value in P2"
+            );
+        }
+        // Aggregates are still not passable by value (the P3 seam).
+        let mut agg_pool = MockPool::default();
+        let agg = agg_pool.add_struct(
+            9,
+            MockStruct {
+                repr_c: true,
+                fields: vec![field("x", Type::I64)],
+                ..Default::default()
+            },
+        );
+        let fail = c_passable_by_value(&agg_pool, agg).unwrap_err();
         assert_eq!(fail.predicate, FfiPredicate::CPassableByValue);
         assert_eq!(fail.reason, FfiRejectReason::NotRegisterPassable);
     }

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -37,7 +37,8 @@ mod type_properties;
 mod types;
 
 pub use call_abi::{
-    ArgClass, ArgConvention, CallAbi, NativeCallAbi, ReturnClass, is_slot_identical_layout,
+    ArgClass, ArgConvention, CallAbi, NativeCallAbi, ReturnClass, ScalarAbiExtension,
+    TargetCAbiFlavor, TargetCCallAbi, is_slot_identical_layout,
 };
 pub use canonical_imports::CanonicalImportView;
 pub use ffi_predicates::{

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1218,11 +1218,11 @@ impl<'a> Sema<'a> {
     ///
     /// ## Diagnostic layering
     ///
-    /// P1 restricts the by-value type set to `i64`/`u64`/pointers — the types
-    /// whose native and target-C representations coincide in registers — and
-    /// P2/P3 widen it. Amendment 1 adds the marker/array rules *on top*, so the
-    /// gate is already in place when the type set widens. The order below picks
-    /// the most specific, forward-looking diagnostic:
+    /// P2 (RUE-1056) widens the by-value scalar set to every integer width plus
+    /// `bool` and pointers via the `c_passable_by_value` predicate; aggregates
+    /// stay phase-gated until P3. Amendment 1 adds the marker/array rules *on
+    /// top*, so the gate is already in place. The order below picks the most
+    /// specific, forward-looking diagnostic:
     ///
     /// 1. A **fixed array** as a direct parameter/return is the array-decay
     ///    rejection (`ExternArrayByValue`) — C has no by-value array parameter;

--- a/crates/rue-cli-tests/cases/c_ffi.toml
+++ b/crates/rue-cli-tests/cases/c_ffi.toml
@@ -94,32 +94,118 @@ compile_fail = true
 error_contains = ["foreign function", "checked"]
 
 [[case]]
-name = "extern_unsupported_signature_type_rejected"
-description = "A P1-unsupported type (i32) in an extern signature gets a clear not-yet diagnostic."
+name = "extern_narrow_scalar_signature_accepted"
+description = "The full integer scalar set + bool are now accepted in extern signatures (P2, RUE-1056)."
 files = [{ path = "main.rue", source = """
 extern "C" {
-    fn f(x: i32) -> i32;
+    fn a(x: i8) -> i8;
+    fn b(x: u8) -> u8;
+    fn c(x: i16) -> i16;
+    fn d(x: u16) -> u16;
+    fn e(x: i32) -> i32;
+    fn f(x: u32) -> u32;
+    fn g(x: bool) -> bool;
+    fn h(x: i64, y: ptr const u8) -> u64;
 }
 
 fn main() -> i32 { 0 }
 """ }]
 args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
-compile_fail = true
-error_contains = ["i32", "not yet supported", "ADR-0064"]
+exit_code = 0
+
+# --- P2 narrow-scalar round-trips, execution-verified (both backends) --------
+# The archive's echo/normalizer members return their argument in the low bits of
+# the result register with the bits above 32 deliberately dirtied, so only a
+# caller that applies the target-C narrow-integer extension reads the value back
+# correctly. Target-pinned like cli.abi_conformance; the native host executes.
 
 [[case]]
-name = "extern_unsupported_bool_return_rejected"
-description = "`bool` is not in the P1 extern type set (narrow scalar boundary is a later phase)."
+name = "x86_64_linux_extern_scalar_roundtrips"
+description = "Narrow-scalar C round-trips (i32 sign, u16/u32 echo, _Bool normalize) on x86-64."
 files = [{ path = "main.rue", source = """
 extern "C" {
-    fn ready() -> bool;
+    fn ffi_i32_echo(x: i32) -> i32;
+    fn ffi_u16_echo(x: u16) -> u16;
+    fn ffi_u32_echo(x: u32) -> u32;
+    fn ffi_bool_norm(x: i32) -> bool;
 }
 
-fn main() -> i32 { 0 }
+fn main() -> i32 {
+    @dbg(checked { ffi_i32_echo(-7) });
+    @dbg(checked { ffi_u16_echo(40000) });
+    @dbg(checked { ffi_u32_echo(4000000000) });
+    @dbg(checked { ffi_bool_norm(0) });
+    @dbg(checked { ffi_bool_norm(5) });
+    0
+}
 """ }]
-args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
-compile_fail = true
-error_contains = ["bool", "not yet supported"]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "x86-64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = "-7\n40000\n4000000000\nfalse\ntrue\n"
+exit_code = 0
+
+[[case]]
+name = "aarch64_linux_extern_scalar_roundtrips"
+description = "Narrow-scalar C round-trips (i32 sign, u16/u32 echo, _Bool normalize) on AArch64."
+files = [{ path = "main.rue", source = """
+extern "C" {
+    fn ffi_i32_echo(x: i32) -> i32;
+    fn ffi_u16_echo(x: u16) -> u16;
+    fn ffi_u32_echo(x: u32) -> u32;
+    fn ffi_bool_norm(x: i32) -> bool;
+}
+
+fn main() -> i32 {
+    @dbg(checked { ffi_i32_echo(-7) });
+    @dbg(checked { ffi_u16_echo(40000) });
+    @dbg(checked { ffi_u32_echo(4000000000) });
+    @dbg(checked { ffi_bool_norm(0) });
+    @dbg(checked { ffi_bool_norm(5) });
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "aarch64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "aarch64-linux"
+execute_if_native = true
+stdout = "-7\n40000\n4000000000\nfalse\ntrue\n"
+exit_code = 0
+
+# --- std.c aliases now pass through the widened scalar set (P2) ---------------
+# c_int (i32), c_short (i16), c_ushort (u16), c_bool (bool) are transparent
+# aliases; once the scalar set widened they are usable directly in an extern
+# signature and round-trip through the same archive members.
+
+[[case]]
+name = "x86_64_linux_extern_std_c_aliases_roundtrip"
+description = "std.c aliases (c_int/c_short/c_ushort/c_bool) pass through an extern signature and round-trip on x86-64."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+extern "C" {
+    fn ffi_i32_echo(x: std.c.c_int) -> std.c.c_int;
+    fn ffi_i16_echo(x: std.c.c_short) -> std.c.c_short;
+    fn ffi_u16_echo(x: std.c.c_ushort) -> std.c.c_ushort;
+    fn ffi_bool_norm(x: std.c.c_int) -> std.c.c_bool;
+}
+
+fn main() -> i32 {
+    @dbg(checked { ffi_i32_echo(-9) });
+    @dbg(checked { ffi_i16_echo(-300) });
+    @dbg(checked { ffi_u16_echo(50000) });
+    @dbg(checked { ffi_bool_norm(0) });
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "x86-64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = "-9\n-300\n50000\nfalse\n"
+exit_code = 0
 
 [[case]]
 name = "extern_unsupported_abi_rejected"

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -99,23 +99,100 @@ use std::time::Duration;
 use libtest2_mimic::{Harness, RunContext, RunError, Trial};
 use rue_target::{Arch, Target};
 
-/// Build a tiny C-free static archive exporting `answer() -> 42` as pure machine
-/// code for `target` (ADR-0064 C FFI P1 proof). The object is produced with the
-/// compiler's own `rue_linker::ObjectBuilder` (which emits a defined global
-/// symbol named `answer`), then wrapped in a GNU `ar` archive — the same static
-/// archive shape the linker already resolves the runtime from.
+/// Build a tiny C-free static archive of pure machine code for `target`
+/// (ADR-0064 C FFI proof). Each function is a leaf object produced with the
+/// compiler's own `rue_linker::ObjectBuilder` (which emits one defined global
+/// symbol), and the objects are wrapped in a GNU `ar` archive — the same static
+/// archive shape the linker already resolves the runtime from. No C toolchain is
+/// involved. The linker pulls only the members a program references, so the
+/// unused members impose nothing on the `answer`-only P1 cases.
+///
+/// Members:
+/// - `answer() -> 42` — the P1 smoke function.
+/// - `ffi_i32_echo`/`ffi_i16_echo`/`ffi_u16_echo`/`ffi_u32_echo` — narrow-scalar
+///   echoes for the P2 round-trips. Each returns its argument in the low bits of
+///   the result register **with the bits above 32 deliberately dirtied**, so the
+///   round-trip is a genuine conformance probe: only a caller that applies the
+///   target-C narrow-integer extension (the `TargetCCallAbi` classifier) reads
+///   the right value back.
+/// - `ffi_bool_norm(int) -> _Bool` — a `_Bool` normalizer returning `x != 0` as a
+///   1-byte 0/1 value, again with dirty high bits; the `false`/dirty case is the
+///   load-bearing check that the boundary materializes exactly 0/1.
 fn synthesize_answer_archive(target: Target) -> TestResult<Vec<u8>> {
-    // A leaf function that returns the integer 42 and nothing else.
-    let code: Vec<u8> = match target.arch() {
+    // A leaf function returning 42 (P1).
+    let answer: Vec<u8> = match target.arch() {
         // mov eax, 42 ; ret
         Arch::X86_64 => vec![0xB8, 0x2A, 0x00, 0x00, 0x00, 0xC3],
         // movz w0, #42 ; ret
         Arch::Aarch64 => vec![0x40, 0x05, 0x80, 0x52, 0xC0, 0x03, 0x5F, 0xD6],
     };
-    let object = rue_linker::ObjectBuilder::new(target, "answer")
-        .code(code)
-        .build();
-    Ok(ar_archive(&[("answer.o", &object)]))
+    // A narrow-scalar echo: copy the low 32 bits of the argument into the result
+    // register, then OR in a fixed dirty pattern in bits 32..63 so the high bits
+    // no C callee is required to define are non-zero. Byte-for-byte from
+    // `llvm-mc` (Intel/AArch64), see the assembly in the P2 cases' comments.
+    let echo: Vec<u8> = match target.arch() {
+        // mov eax, edi ; movabs r10, 0xF0F0F0F000000000 ; or rax, r10 ; ret
+        Arch::X86_64 => vec![
+            0x89, 0xF8, 0x49, 0xBA, 0x00, 0x00, 0x00, 0x00, 0xF0, 0xF0, 0xF0, 0xF0, 0x4C, 0x09,
+            0xD0, 0xC3,
+        ],
+        // mov w0, w0 ; movz x10,#0xF0F0,lsl#48 ; movk x10,#0xF0F0,lsl#32
+        //           ; orr x0,x0,x10 ; ret
+        Arch::Aarch64 => vec![
+            0xE0, 0x03, 0x00, 0x2A, 0x0A, 0x1E, 0xFE, 0xD2, 0x0A, 0x1E, 0xDE, 0xF2, 0x00, 0x00,
+            0x0A, 0xAA, 0xC0, 0x03, 0x5F, 0xD6,
+        ],
+    };
+    // A `_Bool` normalizer: al/w0 = (x != 0), then the same dirty-high pattern.
+    let bool_norm: Vec<u8> = match target.arch() {
+        // xor eax,eax ; test edi,edi ; setne al ; movabs r10,... ; or rax,r10 ; ret
+        Arch::X86_64 => vec![
+            0x31, 0xC0, 0x85, 0xFF, 0x0F, 0x95, 0xC0, 0x49, 0xBA, 0x00, 0x00, 0x00, 0x00, 0xF0,
+            0xF0, 0xF0, 0xF0, 0x4C, 0x09, 0xD0, 0xC3,
+        ],
+        // cmp w0,#0 ; cset w0,ne ; movz x10,... ; movk x10,... ; orr x0,x0,x10 ; ret
+        Arch::Aarch64 => vec![
+            0x1F, 0x00, 0x00, 0x71, 0xE0, 0x07, 0x9F, 0x1A, 0x0A, 0x1E, 0xFE, 0xD2, 0x0A, 0x1E,
+            0xDE, 0xF2, 0x00, 0x00, 0x0A, 0xAA, 0xC0, 0x03, 0x5F, 0xD6,
+        ],
+    };
+
+    // One object (and thus one archive member) per exported symbol; the echo
+    // members share their machine code but differ in symbol name so the P2
+    // programs can declare a distinctly-typed signature for each.
+    let echo_symbols = [
+        "ffi_i32_echo",
+        "ffi_i16_echo",
+        "ffi_u16_echo",
+        "ffi_u32_echo",
+    ];
+    let mut objects: Vec<(String, Vec<u8>)> = Vec::new();
+    objects.push((
+        "answer.o".to_string(),
+        rue_linker::ObjectBuilder::new(target, "answer")
+            .code(answer)
+            .build(),
+    ));
+    for symbol in echo_symbols {
+        objects.push((
+            format!("{symbol}.o"),
+            rue_linker::ObjectBuilder::new(target, symbol)
+                .code(echo.clone())
+                .build(),
+        ));
+    }
+    objects.push((
+        "ffi_bool_norm.o".to_string(),
+        rue_linker::ObjectBuilder::new(target, "ffi_bool_norm")
+            .code(bool_norm)
+            .build(),
+    ));
+
+    let members: Vec<(&str, &[u8])> = objects
+        .iter()
+        .map(|(name, bytes)| (name.as_str(), bytes.as_slice()))
+        .collect();
+    Ok(ar_archive(&members))
 }
 
 /// Assemble a minimal GNU `ar` archive from named object members. Only the

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -902,7 +902,56 @@ impl<'a> CfgLower<'a> {
                 imm: 0,
             });
         }
+        // Target-C boundary (ADR-0064 P2): re-extend a foreign scalar return to
+        // Rue's canonical 64-bit form. A C callee leaves the bits above the
+        // return's declared width unspecified, so the caller extends per the
+        // shared classifier's rule.
+        if let Some(ext) = plan.foreign_return_extension {
+            self.emit_c_return_extension(primary, ext);
+        }
         crate::value_plan::MaterializedValue { primary, slots }
+    }
+
+    /// Extend a foreign scalar return (in `vreg`) to its canonical 64-bit form
+    /// per the target-C classifier (ADR-0064 P2). The narrow value occupies the
+    /// low bits of `x0` with unspecified high bits; this restores the sign/zero
+    /// extension Rue's scalar invariant relies on.
+    fn emit_c_return_extension(&mut self, vreg: VReg, ext: rue_air::ScalarAbiExtension) {
+        use rue_air::ScalarAbiExtension;
+        let dst = Operand::Virtual(vreg);
+        let src = Operand::Virtual(vreg);
+        match ext {
+            ScalarAbiExtension::None => {}
+            ScalarAbiExtension::Signed { from_bits: 8 } => {
+                self.mir.push(Aarch64Inst::Sxtb { dst, src })
+            }
+            ScalarAbiExtension::Signed { from_bits: 16 } => {
+                self.mir.push(Aarch64Inst::Sxth { dst, src })
+            }
+            ScalarAbiExtension::Signed { from_bits: 32 } => {
+                self.mir.push(Aarch64Inst::Sxtw { dst, src })
+            }
+            ScalarAbiExtension::Unsigned { from_bits: 8 } => {
+                self.mir.push(Aarch64Inst::Uxtb { dst, src })
+            }
+            ScalarAbiExtension::Unsigned { from_bits: 16 } => {
+                self.mir.push(Aarch64Inst::Uxth { dst, src })
+            }
+            ScalarAbiExtension::Unsigned { from_bits: 32 } => {
+                // AAPCS64 has no single `uxtw` instruction; a 64-bit left/right
+                // logical-shift pair zero-extends the low 32 bits.
+                self.mir.push(Aarch64Inst::LslImm { dst, src, imm: 32 });
+                self.mir.push(Aarch64Inst::Lsr64Imm {
+                    dst,
+                    src: dst,
+                    imm: 32,
+                });
+            }
+            ScalarAbiExtension::Signed { from_bits }
+            | ScalarAbiExtension::Unsigned { from_bits } => {
+                panic!("unexpected target-C scalar extension width {from_bits}")
+            }
+        }
     }
 
     fn lower_residual_value(
@@ -2887,6 +2936,12 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     }
     fn resolve_named_symbol(&self, symbol: &str) -> String {
         self.symbols.resolve(symbol)
+    }
+    fn is_foreign_symbol(&self, machine_symbol: &str) -> bool {
+        self.symbols.is_foreign(machine_symbol)
+    }
+    fn target_c_flavor(&self) -> rue_air::TargetCAbiFlavor {
+        rue_air::TargetCAbiFlavor::Aapcs64
     }
     fn call_arg_register_budget(&self) -> usize {
         ARG_REGS.len()

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -6,6 +6,8 @@
 //! those slots for their ABI.
 
 use rue_air::{ArgClass, ArgConvention, FrozenTypeInternPool, NativeCallAbi, ReturnClass};
+// `ScalarAbiExtension` is referenced by fully-qualified path in the struct so it
+// stays visible to readers of the field; no direct import is needed.
 use rue_cfg::{Cfg, CfgArgMode, CfgCallArg, Type};
 use rue_runtime_abi::{ReservedExportClass, ReservedExportId};
 
@@ -197,6 +199,14 @@ pub struct CallPlan {
     /// call, before the sret read-back. Zero when no argument crosses
     /// indirectly.
     pub caller_indirect_bytes: u32,
+    /// For a call across an `extern "C"` target-C boundary (ADR-0064 P2), the
+    /// narrow-integer extension the caller must apply to a **scalar** return so
+    /// it becomes Rue's canonical 64-bit form — a C callee leaves the bits above
+    /// the return's declared width unspecified. `None` for a native Rue call, a
+    /// non-scalar return, or a register-width scalar that needs no extension. The
+    /// value is resolved from the shared [`rue_air::TargetCCallAbi`] classifier so
+    /// both backends apply the same rule.
+    pub foreign_return_extension: Option<rue_air::ScalarAbiExtension>,
 }
 
 /// Input metadata for one CFG call argument. This is copied out of the CFG
@@ -549,6 +559,9 @@ impl CallPlan {
             stack_slot_count,
             stack_bytes,
             caller_indirect_bytes,
+            // Set by the caller (the value-plan Call arm) for an `extern "C"`
+            // foreign target with a scalar return; native calls leave it None.
+            foreign_return_extension: None,
         }
     }
 
@@ -572,6 +585,7 @@ impl CallPlan {
             stack_slot_count,
             stack_bytes: align_up((stack_slot_count * 8) as u32, 16),
             caller_indirect_bytes: 0,
+            foreign_return_extension: None,
         }
     }
 }
@@ -731,6 +745,7 @@ mod tests {
             stack_slot_count: 0,
             stack_bytes: 0,
             caller_indirect_bytes: 0,
+            foreign_return_extension: None,
         };
 
         assert!(plan.user_args[0].slots.is_empty());

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -114,15 +114,34 @@ pub struct EmittedRelocation {
 
 /// Borrowed compiler authority for projecting legacy live callable names to
 /// canonical machine symbols. Runtime helpers never pass through this map.
+///
+/// It also carries the set of `extern "C"` foreign symbols (ADR-0064): a call to
+/// one of these resolves to its raw (unmangled) C name and crosses under the
+/// target-C ABI, so the backend must apply the boundary's narrow-integer
+/// extension to a scalar return ([`is_foreign`](Self::is_foreign)).
 #[derive(Clone, Copy, Default)]
 pub struct MachineSymbolResolver<'a> {
     mappings: Option<&'a std::collections::BTreeMap<String, String>>,
+    foreign: Option<&'a std::collections::BTreeSet<String>>,
 }
 
 impl<'a> MachineSymbolResolver<'a> {
     pub fn new(mappings: &'a std::collections::BTreeMap<String, String>) -> Self {
         Self {
             mappings: Some(mappings),
+            foreign: None,
+        }
+    }
+
+    /// Build a resolver that also knows which resolved symbols are `extern "C"`
+    /// foreign declarations (ADR-0064 C FFI). `foreign` holds their raw C names.
+    pub fn new_with_foreign(
+        mappings: &'a std::collections::BTreeMap<String, String>,
+        foreign: &'a std::collections::BTreeSet<String>,
+    ) -> Self {
+        Self {
+            mappings: Some(mappings),
+            foreign: Some(foreign),
         }
     }
 
@@ -131,6 +150,14 @@ impl<'a> MachineSymbolResolver<'a> {
             .and_then(|mappings| mappings.get(legacy_or_canonical))
             .cloned()
             .unwrap_or_else(|| legacy_or_canonical.to_owned())
+    }
+
+    /// Whether `machine_symbol` (already resolved via [`resolve`](Self::resolve))
+    /// names an `extern "C"` foreign function. A foreign symbol maps to itself,
+    /// so the resolved name is its raw C name.
+    pub fn is_foreign(&self, machine_symbol: &str) -> bool {
+        self.foreign
+            .is_some_and(|foreign| foreign.contains(machine_symbol))
     }
 }
 

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -412,6 +412,13 @@ pub trait ValueLowerAdapter:
     fn value_is_lowered(&self, value: CfgValue) -> bool;
     fn reserve_value_result(&mut self) -> VReg;
     fn resolve_symbol(&self, symbol: Spur) -> String;
+    /// Whether `machine_symbol` (already resolved via
+    /// [`resolve_symbol`](Self::resolve_symbol)) names an `extern "C"` foreign
+    /// function, so its call crosses under the target-C ABI (ADR-0064 P2).
+    fn is_foreign_symbol(&self, machine_symbol: &str) -> bool;
+    /// The target-C psABI flavor for this backend: SysV AMD64 on x86-64, AAPCS64
+    /// on AArch64. Names the classifier that governs a foreign-call boundary.
+    fn target_c_flavor(&self) -> rue_air::TargetCAbiFlavor;
     /// Resolve an intrinsic dispatch name without applying callable-machine
     /// aliases. A source callable may legally share an intrinsic's spelling.
     fn resolve_intrinsic_symbol(&self, symbol: Spur) -> String;
@@ -1442,8 +1449,22 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                 adapter.emit_runtime_call(plan)
             } else {
                 let symbol = adapter.resolve_symbol(*name);
+                // An `extern "C"` foreign call crosses under the target-C ABI
+                // (ADR-0064 P2): a scalar return is re-extended to Rue's canonical
+                // 64-bit form because a C callee leaves the bits above the
+                // return's declared width unspecified. The rule comes from the
+                // shared `TargetCCallAbi` classifier, not a backend-local choice.
+                let foreign_return_extension = if adapter.is_foreign_symbol(&symbol)
+                    && matches!(inputs.return_plan, crate::call_plan::ReturnPlan::Scalar)
+                {
+                    let ext = rue_air::TargetCCallAbi::new(adapter.target_c_flavor())
+                        .scalar_return_extension(inst.ty);
+                    (!ext.is_noop()).then_some(ext)
+                } else {
+                    None
+                };
                 let result_vreg = adapter.reserve_value_result();
-                let plan = crate::call_plan::CallPlan::from_inputs_with_result(
+                let mut plan = crate::call_plan::CallPlan::from_inputs_with_result(
                     crate::call_plan::CallTarget::rue(symbol),
                     inputs.return_plan,
                     inputs.compact_return_image.clone(),
@@ -1453,6 +1474,7 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     adapter,
                     Some(result_vreg),
                 );
+                plan.foreign_return_extension = foreign_return_extension;
                 adapter.emit_call(plan)
             };
             cache_result(adapter, value, result);

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1095,7 +1095,53 @@ impl<'a> CfgLower<'a> {
                 imm: 0,
             });
         }
+        // Target-C boundary (ADR-0064 P2): re-extend a foreign scalar return to
+        // Rue's canonical 64-bit form. A C callee leaves the bits above the
+        // return's declared width unspecified, so the caller extends per the
+        // shared classifier's rule.
+        if let Some(ext) = plan.foreign_return_extension {
+            self.emit_c_return_extension(primary, ext);
+        }
         crate::value_plan::MaterializedValue { primary, slots }
+    }
+
+    /// Extend a foreign scalar return (in `vreg`) to its canonical 64-bit form
+    /// per the target-C classifier (ADR-0064 P2). The narrow value occupies the
+    /// low bits of the return register with unspecified high bits; this restores
+    /// the sign/zero extension Rue's scalar invariant relies on.
+    fn emit_c_return_extension(&mut self, vreg: VReg, ext: rue_air::ScalarAbiExtension) {
+        use rue_air::ScalarAbiExtension;
+        let dst = Operand::Virtual(vreg);
+        let src = Operand::Virtual(vreg);
+        match ext {
+            ScalarAbiExtension::None => {}
+            ScalarAbiExtension::Signed { from_bits: 8 } => {
+                self.mir.push(X86Inst::Movsx8To64 { dst, src })
+            }
+            ScalarAbiExtension::Signed { from_bits: 16 } => {
+                self.mir.push(X86Inst::Movsx16To64 { dst, src })
+            }
+            ScalarAbiExtension::Signed { from_bits: 32 } => {
+                self.mir.push(X86Inst::Movsx32To64 { dst, src })
+            }
+            ScalarAbiExtension::Unsigned { from_bits: 8 } => {
+                self.mir.push(X86Inst::Movzx8To64 { dst, src })
+            }
+            ScalarAbiExtension::Unsigned { from_bits: 16 } => {
+                self.mir.push(X86Inst::Movzx16To64 { dst, src })
+            }
+            ScalarAbiExtension::Unsigned { from_bits: 32 } => {
+                // x86-64 has no `movzxd`; a 64-bit `shl`/`shr` pair zero-extends
+                // the low 32 bits (the low half survives, the high half is
+                // cleared by the logical right shift).
+                self.mir.push(X86Inst::ShlRI { dst, imm: 32 });
+                self.mir.push(X86Inst::ShrRI { dst, imm: 32 });
+            }
+            ScalarAbiExtension::Signed { from_bits }
+            | ScalarAbiExtension::Unsigned { from_bits } => {
+                panic!("unexpected target-C scalar extension width {from_bits}")
+            }
+        }
     }
 
     fn lower_residual_value(
@@ -2714,6 +2760,12 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     }
     fn resolve_named_symbol(&self, symbol: &str) -> String {
         self.symbols.resolve(symbol)
+    }
+    fn is_foreign_symbol(&self, machine_symbol: &str) -> bool {
+        self.symbols.is_foreign(machine_symbol)
+    }
+    fn target_c_flavor(&self) -> rue_air::TargetCAbiFlavor {
+        rue_air::TargetCAbiFlavor::SysVAmd64
     }
     fn call_arg_register_budget(&self) -> usize {
         ARG_REGS.len()

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -137,7 +137,9 @@ fn generate_x86_64_objects(
 ) -> MultiErrorResult<Vec<Vec<u8>>> {
     let _span = info_span!("codegen", arch = "x86_64").entered();
     let symbol_mappings = foreign_call_symbol_mappings(functions, foreign_symbols);
-    let symbols = rue_codegen::MachineSymbolResolver::new(&symbol_mappings);
+    let foreign_set: std::collections::BTreeSet<String> = foreign_symbols.iter().cloned().collect();
+    let symbols =
+        rue_codegen::MachineSymbolResolver::new_with_foreign(&symbol_mappings, &foreign_set);
 
     let results: Vec<CompileResult<Vec<u8>>> = functions
         .par_iter()
@@ -213,7 +215,9 @@ fn generate_aarch64_objects(
 ) -> MultiErrorResult<Vec<Vec<u8>>> {
     let _span = info_span!("codegen", arch = "aarch64").entered();
     let symbol_mappings = foreign_call_symbol_mappings(functions, foreign_symbols);
-    let symbols = rue_codegen::MachineSymbolResolver::new(&symbol_mappings);
+    let foreign_set: std::collections::BTreeSet<String> = foreign_symbols.iter().cloned().collect();
+    let symbols =
+        rue_codegen::MachineSymbolResolver::new_with_foreign(&symbol_mappings, &foreign_set);
 
     let results: Vec<CompileResult<Vec<u8>>> = functions
         .par_iter()

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1592,13 +1592,14 @@ pub enum ErrorKind {
     },
 
     /// A type appeared in an `extern "C"` signature that the current FFI phase
-    /// cannot yet classify. C FFI P1 (ADR-0064, RUE-1055) supports only the
-    /// types whose native and target-C representations coincide: `i64`, `u64`,
-    /// and raw pointers. Other types (narrow integers, `bool`, aggregates,
-    /// floats, enums) await later phases.
+    /// cannot yet classify. C FFI P2 (ADR-0064, RUE-1056) supports every integer
+    /// and pointer scalar (`i8`/`u8`/`i16`/`u16`/`i32`/`u32`/`i64`/`u64`, `bool`
+    /// as `_Bool`, and raw pointers). Aggregates await by-value classification
+    /// (P3), floating-point awaits RUE-714 (P5), and enums are not FFI-safe.
     #[error(
         "type `{ty}` is not yet supported in an `extern \"C\"` signature: \
-         C FFI P1 (ADR-0064) supports only `i64`, `u64`, and pointer types"
+         C FFI (ADR-0064) supports integer and pointer scalars — aggregates \
+         await a later phase and floating-point awaits RUE-714"
     )]
     ExternSignatureTypeUnsupported {
         /// The rejected type, as rendered for the user.


### PR DESCRIPTION
Fixes RUE-1056

ADR-0064 phase P2: the target-C classifier authority for scalars.

- **`CallAbi::TargetC(flavor)`** backed by `TargetCCallAbi` — the single authority both backends' extern-call lowering consult (no backend-local ABI decisions). Models SysV AMD64 and AAPCS64 scalar/pointer classification: integer register assignment and budgets (6/8), narrow-integer extension rules, the 1-byte `_Bool` 0/1 contract, 16-byte call-stack alignment, and sret-echo semantics (rax echoed on SysV, x8 not on AAPCS64 — documented for P3/P4; unreachable for register scalars).
- **Key finding**: Rue's internal invariant already keeps narrow scalars canonically extended in their 64-bit vregs, over-satisfying both psABIs' *argument* rule. The one required boundary op is on **returns** — a C callee leaves high bits unspecified — so the caller re-extends the returned scalar per the classifier's `ScalarAbiExtension`, threaded through the P1 foreign-symbol plumbing into both backends.
- **`c_passable_by_value` widens in lock-step** to {i8,u8,i16,u16,i32,u32,i64,u64,bool,ptr}; E1101 now points aggregates at a later phase and floats at RUE-714 (a float signature is unreachable today — `TypeKind` has no float types).
- **Proof by execution**: the in-tree archive machinery (llvm-mc-assembled, both targets) gains narrow-scalar echo and `_Bool`-normalizer members that return *deliberately dirty high bits*; the native x86-64 round-trips print `-7`, `40000`, `4000000000`, `false`, `true` exactly — the `u32` and `_Bool(0)` outputs are only correct because the boundary extension is applied. `std.c` aliases (`c_int`, `c_short`, `c_bool`, …) now pass through extern signatures and round-trip.
- Known debug-path property (pre-existing, unchanged): `--emit asm/mir` views use a default symbol resolver and don't display the extension; the real object path threads the foreign set and is what the executed tests exercise.

Verification: integrated on trunk including RUE-1026 (centralized type resolution — landed after the worker's base; everything re-verified on the new trunk). c_ffi corpus 22/22 with native execution; hand-verified the P1→P2 flip (`std.c.c_int` was E1101-rejected pre-P2, compiles clean now; aggregates still reject). Full `./test.sh` exit 0, zero failures in both formats.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_