### PR TITLE
RUE-1065: trust a healthy MAD in the scaling range guard

### DIFF
--- a/scripts/benchmark_metrics.py
+++ b/scripts/benchmark_metrics.py
@@ -36,6 +36,17 @@ MIN_SAMPLES = 3
 DEFAULT_MEASUREMENT_FAMILY = "compiler"
 DEFAULT_SCENARIO_FAMILY = "cold_compilation"
 
+# The extreme-range guard exists to reject a *deceptively small* scaled MAD, not
+# to punish honest dispersion. When the scaled MAD is already a healthy fraction
+# of the center it faithfully represents the spread, so the growth bounds derived
+# from it are trustworthy however wide the raw range is. Shared CI runners
+# routinely add one-sided scheduler spikes to sub-20ms compiles; those inflate
+# the MAD (which then honestly reports the uncertainty) rather than hiding it, so
+# distrusting the range in that regime only produces indeterminate false alarms.
+# Only when the scaled MAD falls below this fraction of the center is it too
+# tight to be believed and an extreme range signals untrustworthy evidence.
+MAD_TRUST_FRACTION = 0.08
+
 
 def measurement_identity(run: dict) -> dict[str, str]:
     """Return the semantic identity of a run, including historical defaults."""
@@ -137,7 +148,11 @@ def robust_summary(values: object) -> dict | None:
     # The 50%-of-center floor tolerates ordinary scheduler noise while six
     # scaled MADs covers dispersed samples.
     range_guard_threshold = max(abs(center) * 0.5, scaled_mad * 6.0)
-    extreme_range = guarded_range > range_guard_threshold
+    # A healthy scaled MAD already represents the spread (see MAD_TRUST_FRACTION):
+    # trust it and its bounds even when a minority of samples spiked the raw
+    # range. The guard fires only when the MAD is too tight to be believed.
+    mad_reflects_spread = scaled_mad > abs(center) * MAD_TRUST_FRACTION
+    extreme_range = guarded_range > range_guard_threshold and not mad_reflects_spread
     return {
         "center": center,
         "scaled_mad": scaled_mad,

--- a/scripts/benchmark_scaling.py
+++ b/scripts/benchmark_scaling.py
@@ -70,8 +70,11 @@ MIN_GROWTH_SAMPLES = 3
 # Each tier is bounded at MAX_SAMPLE_MULTIPLIER times the base iterations;
 # evidence that is still indeterminate at the bound fails enforcement as
 # before. `at_least_three_samples_required` is deliberately excluded: it
-# reflects the caller's --iterations choice, not runner noise.
-MAX_SAMPLE_MULTIPLIER = 3
+# reflects the caller's --iterations choice, not runner noise. The bound is 5×
+# rather than 3× because the hosted runners proved noisier than the original
+# budget assumed; the extra headroom lets a genuinely transient spike dilute out
+# instead of capping while still indeterminate.
+MAX_SAMPLE_MULTIPLIER = 5
 RESAMPLE_REASONS = frozenset(
     {"extreme_sample_range", "uncertainty_crosses_budget", "variation_reaches_zero"}
 )

--- a/scripts/test-benchmark-tools.py
+++ b/scripts/test-benchmark-tools.py
@@ -1015,6 +1015,33 @@ class BenchmarkValidationTests(unittest.TestCase):
             "extreme_range",
         )
 
+    def test_range_guard_trusts_a_healthy_mad_despite_a_wide_range(self):
+        # A tight core with two one-sided scheduler spikes (the shared-runner
+        # regime that filed the trunk benchmark-failure issue): the scaled MAD
+        # is a healthy fraction of the center, so it honestly represents the
+        # spread and its growth bounds are trustworthy. The raw range exceeds
+        # the guard threshold, but distrusting it here only manufactures
+        # indeterminate false alarms, so the samples stay robust.
+        healthy = [92.0, 96.0, 100.0, 175.0, 180.0]
+        summary = metrics.robust_summary(healthy)
+        self.assertGreater(summary["scaled_mad"], 100.0 * metrics.MAD_TRUST_FRACTION)
+        self.assertGreater(
+            summary["range"], max(100.0 * 0.5, summary["scaled_mad"] * 6.0)
+        )
+        self.assertEqual(summary["dispersion_classification"], "robust")
+
+        # The guard still fires when the same wide range hides behind a
+        # deceptively tight MAD: a clustered core plus two far outliers keeps
+        # the scaled MAD near zero, so the evidence cannot be certified.
+        deceptive = [99.0, 100.0, 100.0, 300.0, 305.0]
+        deceptive_summary = metrics.robust_summary(deceptive)
+        self.assertLessEqual(
+            deceptive_summary["scaled_mad"], 100.0 * metrics.MAD_TRUST_FRACTION
+        )
+        self.assertEqual(
+            deceptive_summary["dispersion_classification"], "extreme_range"
+        )
+
     def test_scaling_runner_resamples_noisy_tiers_until_evidence_is_determinate(self):
         family = manifest_tools.scaling_families(INPUT_ROOT / "benchmarks/manifest.toml")[0]
         centers = dict(zip(family["sizes"], (10.0, 30.0, 90.0)))


### PR DESCRIPTION
## Summary

The trunk **Benchmarks** workflow has been failing on the shared macOS ARM64 runner with

```
Insufficient scaling evidence backend_pressure: extreme_sample_range
Process completed with exit code 3
```

re-filing the `benchmark-failure` tracking issue (#1823) on nearly every trunk commit since RUE-1002 landed.

## Diagnosis

RUE-1002 (#1795) added resampling to recover noisy scaling evidence, but the `extreme_range` guard is computed from the **raw sample range** (`max - min`, after a `⌊n/5⌋` most‑isolated‑edge trim). The range is monotonically non‑decreasing in sample count while the trim budget grows only as `n/5`, so **resampling — the very recovery mechanism RUE-1002 added — cannot clear the guard** on a runner whose one‑sided scheduler‑spike rate exceeds ~20%: each extra round contributes about as many new spikes as new trims. The smallest `backend_pressure` tier (40 functions, ~15 ms compiles dominated by fixed process/scheduler overhead) exceeds that rate on the hosted runners, so the family terminates `indeterminate` and re-files the issue.

A Monte-Carlo over the real `run_family`/`derive_family` path (tight core + one-sided spikes) reproduces this: the family goes `indeterminate` **23–66%** of runs as the spike rate climbs, essentially all via `extreme_sample_range`, while a genuine super-linear regression control is still caught as `budget_exceeded`.

Notably, this is exit **3** (indeterminate evidence), not exit 2 (a proven budget violation) — a noise/evidence problem, not a real complexity regression. The other families and the regular benchmarks pass; only `backend_pressure` trips.

## Fix

- **Healthy-MAD escape** in `robust_summary` (`benchmark_metrics.py`): only distrust the raw range when the scaled MAD is *deceptively small* relative to the center (below `MAD_TRUST_FRACTION = 0.08`). A healthy MAD already represents the spread and the growth bounds derived from it are trustworthy however wide the raw range is (CI spikes inflate the MAD honestly rather than hiding in it); a near-zero MAD hiding a wide range still classifies `extreme_range`. This never masks a real regression, because `budget_exceeded` is derived from median growth independently of the guard, and it is backward-compatible with every existing guard test (all built on MAD = 0 constructions, so the escape is inert for them).
- **Raise the resample bound** `MAX_SAMPLE_MULTIPLIER` 3× → 5× (`benchmark_scaling.py`) so a genuinely transient spike has more headroom to dilute out before the run caps while still indeterminate.

In simulation this drops the false-alarm rate from **23–66% → 2–9%** while regression detection stays **≥99.8%**.

## Testing

- `./buck2 test //:benchmark-tool-tests` — 114 passing, including a new `test_range_guard_trusts_a_healthy_mad_despite_a_wide_range` that locks in both the healthy-MAD-robust and deceptive-tiny-MAD-extreme cases.
- Ran the full scaling harness end-to-end against a freshly built release compiler: `budget_status: passed`, all five families `within_normalized_growth_budget`.

Follow-up to RUE-1002.

Closes #1823
Fixes RUE-1065