### PR TITLE
RUE-1026: make declaration shells query-owned

### DIFF
--- a/crates/rue-air/src/sema/anon_structs.rs
+++ b/crates/rue-air/src/sema/anon_structs.rs
@@ -36,6 +36,16 @@ pub(crate) type IssuedCanonicalArguments =
 pub(crate) type IssuedStableProducerId =
     crate::StableProducerId<crate::SemanticDefinitionToken, crate::SemanticModuleToken>;
 
+/// Type-distinct, epoch-local producer for a const whose initializer has not
+/// yet been classified. It has no stable/durable export conversion.
+pub(crate) struct EpochLocalConstCandidateProducer(super::EpochLocalConstCandidateToken);
+
+impl EpochLocalConstCandidateProducer {
+    pub(crate) fn into_comptime_producer(self) -> IssuedStableProducerId {
+        IssuedStableProducerId::Definition(self.0.0)
+    }
+}
+
 impl<D: DeclarationPhase> Sema<'_, D> {
     pub(crate) fn anonymous_key_cmp(
         left: &IssuedAnonymousNominalKey,
@@ -84,6 +94,18 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         Ok(IssuedStableProducerId::Definition(
             self.stable_definition_token(file.index(), name, owner, kind)?,
         ))
+    }
+
+    pub(crate) fn epoch_local_const_candidate_producer(
+        &self,
+        file: rue_span::FileId,
+        name: &str,
+    ) -> Result<EpochLocalConstCandidateProducer, crate::SemanticBodyExportFailure> {
+        self.const_candidate_tokens
+            .get(&(file.index(), name.to_owned()))
+            .copied()
+            .map(EpochLocalConstCandidateProducer)
+            .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)
     }
 
     pub(crate) fn canonical_type_instance(

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use lasso::Spur;
-use rue_error::{CompileErrors, MultiErrorResult};
+use rue_error::{CompileError, CompileErrors, CompileResult, ErrorKind, MultiErrorResult};
 use rue_rir::{InstData, InstRef, RirParamMode};
 use rue_span::{FileId, Span};
 
@@ -222,11 +222,16 @@ pub struct SemanticDeclarationShell {
     pub parameter_comptime: Arc<[bool]>,
     pub source_order: u32,
     pub has_self: bool,
+    pub receiver_mode: Option<RirParamMode>,
+    pub receiver_is_mut: bool,
     pub is_generic: bool,
     pub is_public: bool,
     pub is_unchecked: bool,
     /// Whether this is a foreign `extern "C"` declaration (ADR-0064 C FFI).
     pub is_extern: bool,
+    /// Parser/token-algebra signature identity. Current positions and payloads
+    /// never participate.
+    pub signature_fingerprint: [u8; 32],
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -341,6 +346,10 @@ impl<'a> DeclarationShells<'a> {
     ) -> Result<Self, crate::SemanticStableResolutionFailure> {
         let expected_definitions = self
             .declaration_shells()
+            // Const shells are presemantic candidates, not stable definition
+            // identities. They receive endpoints only after initializer
+            // evaluation classifies ValueConst versus ModuleBinding.
+            .filter(|shell| shell.identity.kind != StableDefinitionKind::ValueConst)
             .map(|shell| {
                 (
                     shell.declaration_span.file_id.index(),
@@ -358,6 +367,7 @@ impl<'a> DeclarationShells<'a> {
             &expected_definitions,
             &expected_modules,
         )?;
+        install_const_candidate_endpoints(&mut self.sema, &self.pending_payloads)?;
         Ok(self)
     }
 
@@ -834,6 +844,74 @@ impl<'a> DeclarationShells<'a> {
     }
 }
 
+fn install_const_candidate_endpoints<D: super::DeclarationPhase>(
+    sema: &mut super::Sema<'_, D>,
+    pending: &[PendingDeclarationPayload],
+) -> Result<(), crate::SemanticStableResolutionFailure> {
+    let issuer = sema
+        .stable_definition_endpoints
+        .keys()
+        .next()
+        .map(|token| token.issuer())
+        .or_else(|| {
+            sema.stable_module_endpoints
+                .keys()
+                .next()
+                .map(|token| token.issuer())
+        })
+        .ok_or(crate::SemanticStableResolutionFailure::Missing)?;
+    let mut next_slot = sema
+        .stable_definition_endpoints
+        .keys()
+        .map(|token| token.slot())
+        .max()
+        .unwrap_or(0)
+        .checked_add(1)
+        .ok_or(crate::SemanticStableResolutionFailure::Ambiguous)?;
+    let mut tokens = HashMap::new();
+    let mut endpoints = HashMap::new();
+    let mut multiplicity = HashMap::new();
+    for candidate in pending
+        .iter()
+        .filter(|candidate| matches!(candidate.source, DeclarationPayloadSource::Const { .. }))
+    {
+        *multiplicity
+            .entry((
+                candidate.shell.declaration_span.file_id.index(),
+                candidate.shell.identity.name.to_string(),
+            ))
+            .or_insert(0_u32) += 1;
+    }
+    for candidate in pending
+        .iter()
+        .filter(|candidate| matches!(candidate.source, DeclarationPayloadSource::Const { .. }))
+    {
+        let key = (
+            candidate.shell.declaration_span.file_id.index(),
+            candidate.shell.identity.name.to_string(),
+        );
+        if multiplicity.get(&key).copied() != Some(1) {
+            continue;
+        }
+        let token = super::EpochLocalConstCandidateToken(crate::SemanticDefinitionToken::new(
+            issuer, next_slot,
+        ));
+        next_slot = next_slot
+            .checked_add(1)
+            .ok_or(crate::SemanticStableResolutionFailure::Ambiguous)?;
+        let endpoint = super::EpochLocalConstCandidateEndpoint {
+            file: key.0,
+            name: key.1.clone(),
+        };
+        if tokens.insert(key, token).is_some() || endpoints.insert(token, endpoint).is_some() {
+            return Err(crate::SemanticStableResolutionFailure::Ambiguous);
+        }
+    }
+    sema.const_candidate_tokens = tokens;
+    sema.const_candidate_endpoints = endpoints;
+    Ok(())
+}
+
 impl Sema<'_> {
     fn import_export_type(
         &self,
@@ -1055,6 +1133,10 @@ fn install_stable_identity_endpoints<D: super::DeclarationPhase>(
                 crate::SemanticDefinitionToken,
                 crate::SemanticDefinitionEndpoint,
             >,
+            old_const_candidates: &HashMap<
+                super::EpochLocalConstCandidateToken,
+                super::EpochLocalConstCandidateEndpoint,
+            >,
             new_definitions: &HashMap<
                 (u32, String, Option<String>, StableDefinitionKind),
                 crate::SemanticDefinitionToken,
@@ -1067,15 +1149,26 @@ fn install_stable_identity_endpoints<D: super::DeclarationPhase>(
         > {
             key.try_map_identities(
                 &|token| {
-                    let endpoint = old_definitions
-                        .get(token)
+                    if let Some(endpoint) = old_definitions.get(token) {
+                        return new_definitions
+                            .get(&(
+                                endpoint.file,
+                                endpoint.name.to_string(),
+                                endpoint.owner.as_deref().map(str::to_owned),
+                                endpoint.kind,
+                            ))
+                            .copied()
+                            .ok_or(crate::SemanticStableResolutionFailure::Missing);
+                    }
+                    let endpoint = old_const_candidates
+                        .get(&super::EpochLocalConstCandidateToken(*token))
                         .ok_or(crate::SemanticStableResolutionFailure::ForeignIssuer)?;
                     new_definitions
                         .get(&(
                             endpoint.file,
-                            endpoint.name.to_string(),
-                            endpoint.owner.as_deref().map(str::to_owned),
-                            endpoint.kind,
+                            endpoint.name.clone(),
+                            None,
+                            StableDefinitionKind::ValueConst,
                         ))
                         .copied()
                         .ok_or(crate::SemanticStableResolutionFailure::Missing)
@@ -1093,11 +1186,13 @@ fn install_stable_identity_endpoints<D: super::DeclarationPhase>(
         }
 
         let old_definition_endpoints = sema.stable_definition_endpoints.clone();
+        let old_const_candidate_endpoints = sema.const_candidate_endpoints.clone();
         let old_module_endpoints = sema.stable_module_endpoints.clone();
         let remap = |key| {
             remap_key(
                 key,
                 &old_definition_endpoints,
+                &old_const_candidate_endpoints,
                 &definition_tokens,
                 &old_module_endpoints,
                 &module_tokens,
@@ -1138,6 +1233,8 @@ fn install_stable_identity_endpoints<D: super::DeclarationPhase>(
     }
     sema.stable_definition_tokens = definition_tokens;
     sema.stable_definition_endpoints = definition_endpoints;
+    sema.const_candidate_tokens.clear();
+    sema.const_candidate_endpoints.clear();
     sema.stable_module_tokens = module_tokens;
     sema.stable_module_endpoints = module_endpoints;
     Ok(())
@@ -1425,6 +1522,180 @@ impl<'a> BoundSema<'a> {
 }
 
 impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
+    pub(super) fn attach_imported_declaration_shells(
+        &self,
+        imported: &[SemanticDeclarationShell],
+    ) -> CompileResult<(Vec<PendingDeclarationPayload>, Vec<PendingNominalPayload>)> {
+        let mut remaining = HashMap::with_capacity(imported.len());
+        for shell in imported {
+            if remaining.insert(shell.declaration_span, shell).is_some() {
+                return Err(CompileError::new(
+                    ErrorKind::InternalError(
+                        "query-owned declaration shells have an ambiguous current locator".into(),
+                    ),
+                    shell.declaration_span,
+                ));
+            }
+        }
+        let mut pending = Vec::new();
+        let mut nominals = Vec::new();
+        for candidate in self.declaration_index.shell_declarations() {
+            let inst_ref = candidate.declaration;
+            let inst = self.rir.get(inst_ref);
+            let Some(imported_shell) = remaining.remove(&inst.span) else {
+                return Err(CompileError::new(
+                    ErrorKind::InternalError(
+                        "query-owned declaration shell has no current RIR locator".into(),
+                    ),
+                    inst.span,
+                ));
+            };
+            let mut shell = imported_shell.clone();
+            shell.source_order = candidate.source_order;
+            let expected_module = self
+                .get_symbol_path(inst.span.file_id)
+                .map(crate::path_norm::normalize_module_path)
+                .unwrap_or_else(|| format!("file{}", inst.span.file_id.index()));
+            if shell.identity.module_path.as_ref() != expected_module
+                || shell.identity.is_trusted_standard_library
+                    != self
+                        .trusted_standard_library_files
+                        .contains(&inst.span.file_id)
+            {
+                return Err(CompileError::new(
+                    ErrorKind::InternalError(
+                        "query-owned declaration shell has foreign module identity".into(),
+                    ),
+                    inst.span,
+                ));
+            }
+            let source = match &inst.data {
+                InstData::StructDecl { name, is_pub, .. }
+                | InstData::EnumDecl { name, is_pub, .. } => {
+                    let kind = if matches!(inst.data, InstData::StructDecl { .. }) {
+                        StableDefinitionKind::Struct
+                    } else {
+                        StableDefinitionKind::Enum
+                    };
+                    validate_imported_shell(
+                        self,
+                        &shell,
+                        *name,
+                        None,
+                        kind,
+                        *is_pub,
+                        &[],
+                        false,
+                        RirParamMode::Normal,
+                        false,
+                        false,
+                        false,
+                    )?;
+                    nominals.push(PendingNominalPayload {
+                        shell,
+                        declaration: inst_ref,
+                    });
+                    continue;
+                }
+                InstData::FnDecl {
+                    is_pub,
+                    is_unchecked,
+                    is_extern,
+                    name,
+                    params,
+                    body,
+                    has_self,
+                    self_mode,
+                    self_is_mut,
+                    ..
+                } if !self.declaration_index.is_anonymous_method(inst_ref) => {
+                    let owner = candidate.named_method_owner;
+                    let kind = match (owner, *has_self) {
+                        (Some(_), true) => StableDefinitionKind::Method,
+                        (Some(_), false) => StableDefinitionKind::AssociatedFunction,
+                        (None, _) => StableDefinitionKind::Function,
+                    };
+                    let params = self.rir.params(params).to_vec();
+                    validate_imported_shell(
+                        self,
+                        &shell,
+                        *name,
+                        owner,
+                        kind,
+                        *is_pub,
+                        &params,
+                        *has_self,
+                        *self_mode,
+                        *self_is_mut,
+                        *is_unchecked,
+                        *is_extern,
+                    )?;
+                    DeclarationPayloadSource::Callable { body: *body }
+                }
+                InstData::ConstDecl {
+                    is_pub, name, init, ..
+                } => {
+                    validate_imported_shell(
+                        self,
+                        &shell,
+                        *name,
+                        None,
+                        StableDefinitionKind::ValueConst,
+                        *is_pub,
+                        &[],
+                        false,
+                        RirParamMode::Normal,
+                        false,
+                        false,
+                        false,
+                    )?;
+                    DeclarationPayloadSource::Const { initializer: *init }
+                }
+                InstData::DropFnDecl { type_name, body } => {
+                    validate_imported_shell(
+                        self,
+                        &shell,
+                        *type_name,
+                        Some(*type_name),
+                        StableDefinitionKind::Destructor,
+                        false,
+                        &[],
+                        true,
+                        RirParamMode::Normal,
+                        false,
+                        false,
+                        false,
+                    )?;
+                    DeclarationPayloadSource::Destructor { body: *body }
+                }
+                _ => {
+                    return Err(CompileError::new(
+                        ErrorKind::InternalError(
+                            "query-owned shell selected an unsupported RIR declaration".into(),
+                        ),
+                        inst.span,
+                    ));
+                }
+            };
+            pending.push(PendingDeclarationPayload {
+                shell,
+                declaration: inst_ref,
+                source,
+            });
+        }
+        if let Some(unmatched) = remaining.values().next() {
+            return Err(CompileError::new(
+                ErrorKind::InternalError(
+                    "query-owned declaration shell has no indexed RIR declaration".into(),
+                ),
+                unmatched.declaration_span,
+            ));
+        }
+        pending.sort_by(|left, right| left.shell.identity.cmp(&right.shell.identity));
+        nominals.sort_by(|left, right| left.shell.identity.cmp(&right.shell.identity));
+        Ok((pending, nominals))
+    }
+
     pub(super) fn predeclare_callable_value_shells(
         &self,
     ) -> (Vec<PendingDeclarationPayload>, Vec<PendingNominalPayload>) {
@@ -1467,10 +1738,13 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                         parameter_comptime: Arc::from([]),
                         source_order,
                         has_self: false,
+                        receiver_mode: None,
+                        receiver_is_mut: false,
                         is_generic: false,
                         is_public: *is_pub,
                         is_unchecked: false,
                         is_extern: false,
+                        signature_fingerprint: [0; 32],
                     },
                     declaration: inst_ref,
                 });
@@ -1481,6 +1755,8 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                 parameter_modes,
                 parameter_comptime,
                 has_self,
+                receiver_mode,
+                receiver_is_mut,
                 is_generic,
                 is_public,
                 is_unchecked,
@@ -1495,6 +1771,8 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     params,
                     body,
                     has_self,
+                    self_mode,
+                    self_is_mut,
                     ..
                 } if !self.declaration_index.is_anonymous_method(inst_ref) => {
                     let owner = candidate.named_method_owner;
@@ -1533,6 +1811,8 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                         modes,
                         comptime.clone(),
                         *has_self,
+                        has_self.then_some(*self_mode),
+                        *self_is_mut,
                         comptime.into_iter().any(|value| value),
                         *is_pub,
                         *is_unchecked,
@@ -1560,6 +1840,8 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     Vec::new(),
                     Vec::new(),
                     false,
+                    None,
+                    false,
                     false,
                     *is_pub,
                     false,
@@ -1581,6 +1863,8 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     Vec::new(),
                     Vec::new(),
                     true,
+                    Some(RirParamMode::Normal),
+                    false,
                     false,
                     false,
                     false,
@@ -1598,10 +1882,13 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     parameter_comptime: parameter_comptime.into(),
                     source_order,
                     has_self,
+                    receiver_mode,
+                    receiver_is_mut,
                     is_generic,
                     is_public,
                     is_unchecked,
                     is_extern,
+                    signature_fingerprint: [0; 32],
                 },
                 declaration: inst_ref,
                 source,
@@ -1611,7 +1898,57 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
         nominals.sort_by(|left, right| left.shell.identity.cmp(&right.shell.identity));
         (pending, nominals)
     }
+}
 
+fn validate_imported_shell<D: super::DeclarationPhase>(
+    sema: &Sema<'_, D>,
+    shell: &SemanticDeclarationShell,
+    name: Spur,
+    owner: Option<Spur>,
+    kind: StableDefinitionKind,
+    is_public: bool,
+    params: &[rue_rir::RirParam],
+    has_self: bool,
+    receiver_mode: RirParamMode,
+    receiver_is_mut: bool,
+    is_unchecked: bool,
+    is_extern: bool,
+) -> CompileResult<()> {
+    let expected_name = sema.interner.resolve(&name);
+    let expected_owner = owner.map(|owner| sema.interner.resolve(&owner));
+    let expected_generic = params.iter().any(|parameter| parameter.is_comptime);
+    let parameter_shape_matches = shell.parameter_names.len() == params.len()
+        && shell.parameter_modes.len() == params.len()
+        && shell.parameter_comptime.len() == params.len()
+        && params.iter().enumerate().all(|(index, parameter)| {
+            shell.parameter_names[index].as_ref() == sema.interner.resolve(&parameter.name)
+                && shell.parameter_modes[index] == parameter.mode
+                && shell.parameter_comptime[index] == parameter.is_comptime
+        });
+    if shell.identity.namespace != kind.namespace()
+        || shell.identity.kind != kind
+        || shell.identity.name.as_ref() != expected_name
+        || shell.identity.owner.as_deref() != expected_owner
+        || shell.is_public != is_public
+        || shell.has_self != has_self
+        || shell.receiver_mode != has_self.then_some(receiver_mode)
+        || shell.receiver_is_mut != receiver_is_mut
+        || shell.is_generic != expected_generic
+        || shell.is_unchecked != is_unchecked
+        || shell.is_extern != is_extern
+        || !parameter_shape_matches
+    {
+        return Err(CompileError::new(
+            ErrorKind::InternalError(
+                "query-owned declaration shell does not match its current RIR declaration".into(),
+            ),
+            shell.declaration_span,
+        ));
+    }
+    Ok(())
+}
+
+impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
     fn export_type(
         &self,
         ty: Type,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -2168,27 +2168,43 @@ impl<'a> Sema<'a> {
         let mut resolved_types: HashMap<InstRef, Type> = HashMap::new();
         self.infer_const_init_types(init, file_id, declared_ty, &mut resolved_types)?;
 
-        let canonical_identity = self
-            .named_const_dependency_source
-            .as_ref()
-            .map(|(file, name)| {
-                self.canonical_definition_producer(
-                    *file,
-                    name,
-                    None,
-                    crate::StableDefinitionKind::ValueConst,
-                )
-                .map(|producer| (producer, crate::CanonicalArguments::default()))
-                .map_err(|failure| {
-                    CompileError::new(
-                        ErrorKind::InternalError(format!(
-                            "failed to issue canonical const producer: {failure:?}"
-                        )),
-                        span,
-                    )
-                })
-            })
-            .transpose()?;
+        let canonical_identity = match self.named_const_dependency_source.as_ref() {
+            Some((file, name)) => {
+                // Query-owned const shells are candidates until initializer
+                // evaluation classifies ValueConst versus ModuleBinding. Use
+                // that exact candidate channel before consulting the final
+                // stable universe: a same-named function or type is a source
+                // collision, not evidence that the const has the wrong kind.
+                let producer = match self.epoch_local_const_candidate_producer(*file, name) {
+                    Ok(producer) => producer.into_comptime_producer(),
+                    Err(crate::SemanticBodyExportFailure::MissingStableIdentity) => self
+                        .canonical_definition_producer(
+                            *file,
+                            name,
+                            None,
+                            crate::StableDefinitionKind::ValueConst,
+                        )
+                        .map_err(|failure| {
+                            CompileError::new(
+                                ErrorKind::InternalError(format!(
+                                    "failed to issue canonical const producer: {failure:?}"
+                                )),
+                                span,
+                            )
+                        })?,
+                    Err(failure) => {
+                        return Err(CompileError::new(
+                            ErrorKind::InternalError(format!(
+                                "failed to issue epoch-local const candidate producer: {failure:?}"
+                            )),
+                            span,
+                        ));
+                    }
+                };
+                Some((producer, crate::CanonicalArguments::default()))
+            }
+            None => None,
+        };
         let mut env = super::comptime_eval::ComptimeEnv::for_const_init(
             &resolved_types,
             &const_module_members,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -89,6 +89,17 @@ use crate::intern_pool::TypeInternPool;
 use crate::param_arena::ParamArena;
 use crate::types::{EnumId, StructId, Type};
 
+/// Epoch-local authorization for evaluating one parser-owned const candidate.
+/// The wrapper deliberately has no stable-definition export conversion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct EpochLocalConstCandidateToken(crate::SemanticDefinitionToken);
+
+#[derive(Debug, Clone)]
+pub(crate) struct EpochLocalConstCandidateEndpoint {
+    file: u32,
+    name: String,
+}
+
 /// The source declaration namespace while declaration binding is in progress.
 ///
 /// This wrapper is the only namespace state that implements `DerefMut`; after
@@ -223,6 +234,9 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
     pub(crate) interner: &'a ThreadedRodeo,
     /// Request-local declaration candidates for this exact RIR arena.
     declaration_index: declaration_index::RirDeclarationIndex,
+    /// Raw RIR declaration discovery is confined to synthetic component-test
+    /// epochs. Canonical compiler epochs must import query-owned shells.
+    synthetic_declaration_discovery: bool,
     /// Function table: maps internal function name symbols to their info.
     ///
     /// The internal key is normally the source name, but functions with the
@@ -282,6 +296,9 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
     >,
     pub(crate) stable_definition_endpoints:
         HashMap<crate::SemanticDefinitionToken, crate::SemanticDefinitionEndpoint>,
+    pub(crate) const_candidate_tokens: HashMap<(u32, String), EpochLocalConstCandidateToken>,
+    pub(crate) const_candidate_endpoints:
+        HashMap<EpochLocalConstCandidateToken, EpochLocalConstCandidateEndpoint>,
     pub(crate) stable_module_tokens: HashMap<FileId, crate::SemanticModuleToken>,
     pub(crate) stable_module_endpoints:
         HashMap<crate::SemanticModuleToken, crate::SemanticModuleEndpoint>,
@@ -421,6 +438,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             rir,
             interner,
             declaration_index,
+            synthetic_declaration_discovery,
             anonymous_methods,
             named_callable_methods_by_symbol,
             anonymous_callable_methods_by_symbol,
@@ -441,6 +459,8 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             reusable_specialized_bodies,
             stable_definition_tokens,
             stable_definition_endpoints,
+            const_candidate_tokens,
+            const_candidate_endpoints,
             stable_module_tokens,
             stable_module_endpoints,
             body_dependency_observer,
@@ -489,6 +509,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             rir,
             interner,
             declaration_index,
+            synthetic_declaration_discovery,
             anonymous_methods,
             named_callable_methods_by_symbol,
             anonymous_callable_methods_by_symbol,
@@ -509,6 +530,8 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             reusable_specialized_bodies,
             stable_definition_tokens,
             stable_definition_endpoints,
+            const_candidate_tokens,
+            const_candidate_endpoints,
             stable_module_tokens,
             stable_module_endpoints,
             body_dependency_observer,
@@ -921,14 +944,16 @@ impl<'a> Sema<'a> {
         interner: &'a ThreadedRodeo,
         preview_features: PreviewFeatures,
     ) -> Self {
-        Self::new_for_target(
+        let mut sema = Self::new_for_target(
             rir,
             interner,
             preview_features,
             SemaMetadata::synthetic_for_rir(rir),
             Target::host()
                 .expect("Rue cannot choose a default sema target on this unsupported host"),
-        )
+        );
+        sema.synthetic_declaration_discovery = true;
+        sema
     }
 
     /// Create a new semantic analyzer for an explicit compilation target.
@@ -951,6 +976,7 @@ impl<'a> Sema<'a> {
             rir,
             interner,
             declaration_index: declaration_index::RirDeclarationIndex::new(rir),
+            synthetic_declaration_discovery: false,
             anonymous_methods: HashMap::new(),
             named_callable_methods_by_symbol: HashMap::new(),
             anonymous_callable_methods_by_symbol: HashMap::new(),
@@ -971,6 +997,8 @@ impl<'a> Sema<'a> {
             reusable_specialized_bodies: Vec::new(),
             stable_definition_tokens: HashMap::new(),
             stable_definition_endpoints: HashMap::new(),
+            const_candidate_tokens: HashMap::new(),
+            const_candidate_endpoints: HashMap::new(),
             stable_module_tokens: HashMap::new(),
             stable_module_endpoints: HashMap::new(),
             body_dependency_observer: None,
@@ -1047,6 +1075,10 @@ impl<'a> Sema<'a> {
     /// executes both sides of the boundary and therefore preserves historical
     /// ordering and failure behavior.
     pub fn predeclare_declaration_shells(mut self) -> MultiErrorResult<DeclarationShells<'a>> {
+        assert!(
+            self.synthetic_declaration_discovery,
+            "canonical compiler epochs must import query-owned declaration shells"
+        );
         let mut binding_work =
             DeclarationBindingWork::from_inputs(self.rir.len(), self.declaration_index.work());
         // Phase 0: Inject built-in types (String, etc.) before user code.
@@ -1063,6 +1095,34 @@ impl<'a> Sema<'a> {
         // current-revision syntax metadata before resolving semantic payloads.
         // This does not evaluate constants or resolve any signature.
         let (pending_payloads, pending_nominals) = self.predeclare_callable_value_shells();
+        binding_work.callable_value_predeclaration_invocations += 1;
+        binding_work.callable_value_shells_predeclared = pending_payloads.len();
+        binding_work.indexed_declaration_records_visited =
+            pending_payloads.len() + pending_nominals.len();
+        Ok(DeclarationShells {
+            sema: self,
+            binding_work,
+            pending_payloads,
+            pending_nominals,
+        })
+    }
+
+    /// Import query-owned, position-free declaration shells and attach them to
+    /// this epoch's private RIR locators. The importer never rediscovers a
+    /// missing shell and fails closed on every mismatch.
+    pub fn predeclare_imported_declaration_shells(
+        mut self,
+        imported: &[SemanticDeclarationShell],
+    ) -> MultiErrorResult<DeclarationShells<'a>> {
+        let mut binding_work =
+            DeclarationBindingWork::from_inputs(self.rir.len(), self.declaration_index.work());
+        self.inject_builtin_types();
+        binding_work.namespace_setup_invocations += 1;
+        self.register_type_names().map_err(CompileErrors::from)?;
+        binding_work.nominal_type_predeclaration_invocations += 1;
+        let (pending_payloads, pending_nominals) = self
+            .attach_imported_declaration_shells(imported)
+            .map_err(CompileErrors::from)?;
         binding_work.callable_value_predeclaration_invocations += 1;
         binding_work.callable_value_shells_predeclared = pending_payloads.len();
         binding_work.indexed_declaration_records_visited =

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -14,6 +14,10 @@ const PRODUCTION_MODULES: &[(&str, &str)] = &[
     ("canonical_merge", include_str!("canonical_merge.rs")),
     ("canonical_semantic", include_str!("canonical_semantic.rs")),
     (
+        "declaration_candidate",
+        include_str!("declaration_candidate.rs"),
+    ),
+    (
         "definition_snapshot",
         include_str!("definition_snapshot.rs"),
     ),
@@ -1503,6 +1507,157 @@ fn revisioned_parse_family_has_no_peer_legacy_authority() {
     assert!(session.contains(".source_revision(&source, snapshot)"));
     assert!(session.contains("revisioned.select_parse(&attempt)"));
     assert!(runtime.contains("parse: RevisionedFamily<super::session::ParseQuery>"));
+}
+
+#[test]
+fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority() {
+    let before_tests = |source: &'static str| {
+        let marker = "\n#[cfg(test)]\nmod ";
+        source
+            .rmatch_indices(marker)
+            .find_map(|(index, _)| {
+                let declaration = source[index + marker.len()..].lines().next().unwrap();
+                declaration.ends_with('{').then_some(&source[..index])
+            })
+            .unwrap_or(source)
+    };
+    let production = PRODUCTION_MODULES
+        .iter()
+        .map(|(name, source)| (*name, before_tests(source)))
+        .collect::<Vec<_>>();
+    let module = |wanted: &str| {
+        production
+            .iter()
+            .find_map(|(name, source)| (*name == wanted).then_some(*source))
+            .unwrap()
+    };
+    let session = module("session");
+    let canonical = before_tests(include_str!("canonical_semantic.rs"));
+    let parsed = module("parsed_modules");
+    let runtime = module("revisioned_query_database");
+
+    for (name, source) in &production {
+        for retired in [
+            ".predeclare_declaration_shells()",
+            ".bind_declarations()",
+            ".analyze_all()",
+            ".definitions().declarations()",
+            ".candidate.fact()",
+            "legacy_declaration_shell",
+            "fallback_declaration_shell",
+            "declaration_shell_cache",
+            "warm_declaration_shell",
+            "eager_declaration_shell",
+        ] {
+            assert!(
+                !source.contains(retired),
+                "compiler production module {name} bypassed keyed shell authority through {retired}"
+            );
+        }
+        if !matches!(*name, "parsed_modules" | "revisioned_query_database") {
+            for evaluator_only in [
+                ".evaluate_declaration_shell(",
+                ".declaration_capabilities()",
+                "project_semantic_shell(",
+            ] {
+                assert!(
+                    !source.contains(evaluator_only),
+                    "raw declaration evaluator/importer escaped into {name}: {evaluator_only}"
+                );
+            }
+        }
+    }
+    assert!(canonical.contains("predeclare_imported_declaration_shells"));
+    assert!(!canonical.contains("fn analyze_canonical_program("));
+    assert_eq!(runtime.matches(".evaluate_declaration_shell(").count(), 1);
+    assert_eq!(parsed.matches("fn evaluate_declaration_shell(").count(), 1);
+    assert!(!runtime.contains("Vec::remove"));
+
+    let occurrence = runtime
+        .split("struct DeclarationOccurrenceIndex {")
+        .nth(1)
+        .and_then(|tail| tail.split("enum DeclarationOccurrenceIndexValue").next())
+        .unwrap();
+    for forbidden in ["DeclarationShellFact", "CompileErrors", "Span", "FileId"] {
+        assert!(
+            !occurrence.contains(forbidden),
+            "occurrence terminal regained shell/parser payload: {forbidden}"
+        );
+    }
+    let terminal_algebra = runtime
+        .split("enum DeclarationOccurrenceIndexValue")
+        .nth(1)
+        .and_then(|tail| tail.split("struct DeclarationShellQueryKey").next())
+        .unwrap();
+    assert!(!terminal_algebra.contains("CompileErrors"));
+    let shell_terminal = runtime
+        .split("enum DeclarationShellQueryValue")
+        .nth(1)
+        .and_then(|tail| {
+            tail.split("pub(crate) enum DeclarationShellBatchFailure")
+                .next()
+        })
+        .unwrap();
+    for forbidden in [
+        "CompileErrors",
+        "Span",
+        "FileId",
+        "InstRef",
+        "Rir",
+        "SemanticDefinitionToken",
+        "SemanticModuleToken",
+    ] {
+        assert!(
+            !shell_terminal.contains(forbidden),
+            "shell terminal regained positioned/live semantic payload: {forbidden}"
+        );
+    }
+    let failure_algebra = module("declaration_candidate")
+        .split("pub(crate) enum DeclarationOccurrenceFailure")
+        .nth(1)
+        .and_then(|tail| tail.split("impl DeclarationCandidateKey").next())
+        .unwrap();
+    for forbidden in [
+        "CompileErrors",
+        "Span",
+        "FileId",
+        "InstRef",
+        "Rir",
+        "SemanticDefinitionToken",
+        "SemanticModuleToken",
+    ] {
+        assert!(
+            !failure_algebra.contains(forbidden),
+            "declaration failure algebra regained position/live identity: {forbidden}"
+        );
+    }
+    assert_eq!(
+        canonical
+            .matches("predeclare_imported_declaration_shells")
+            .count(),
+        2,
+        "only canonical preparation and durable fallback may import query-owned shells"
+    );
+    for (name, source) in &production {
+        if *name == "canonical_semantic" {
+            continue;
+        }
+        let production_source = if *name == "bound_definitions" {
+            source
+                .split(
+                    "\n#[cfg(test)]\npub(crate) fn compare_canonical_durable_declaration_install",
+                )
+                .next()
+                .unwrap()
+        } else {
+            source
+        };
+        assert!(
+            !production_source.contains("predeclare_imported_declaration_shells"),
+            "compiler production module {name} gained a peer shell importer"
+        );
+    }
+    assert!(!session.contains("DeclarationShellFact"));
 }
 
 #[test]

--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -7,9 +7,11 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
 };
 
+#[cfg(test)]
+use rue_air::DeclarationBindingWork;
 use rue_air::{
-    CanonicalImportView, DeclarationBindingWork, Sema, SemanticBinding,
-    SemanticBindingManifestWork, SemanticDeclarationShell,
+    CanonicalImportView, Sema, SemanticBinding, SemanticBindingManifestWork,
+    SemanticDeclarationShell,
 };
 use rue_error::{CompileError, CompileErrors, CompileResult, ErrorKind, MultiErrorResult};
 use rue_parser::ast::{Item, Visibility};
@@ -303,6 +305,12 @@ fn reject_duplicate_stable_definitions(
 }
 
 impl BoundDefinitionSet {
+    pub(crate) fn projected_for_source_revision(&self, revision: &SourceRevision) -> Self {
+        let mut projected = self.clone();
+        projected.source_revision = revision.clone();
+        projected
+    }
+
     pub(crate) fn structurally_eq(&self, other: &Self) -> bool {
         self.source_revision == other.source_revision
             && self.manifest_work == other.manifest_work
@@ -326,6 +334,7 @@ impl BoundDefinitionSet {
     pub fn definitions(&self) -> &[BoundDefinitionRecord] {
         &self.definitions
     }
+    #[cfg(test)]
     pub fn manifest_work(&self) -> SemanticBindingManifestWork {
         self.manifest_work
     }
@@ -577,8 +586,13 @@ pub(crate) fn bind_canonical_declaration_semantics(
     rue_air::SemanticDeclarationExportWork,
 )> {
     let imports = test_fixture_import_graph(merged)?;
-    let sema = configure_canonical_sema(merged, rir, preview_features, target, &imports)?;
-    let bound = sema.bind_declarations()?;
+    let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
+        merged,
+        rir,
+        preview_features,
+        target,
+        &imports,
+    )?;
     let manifest = bound.binding_manifest();
     let definitions = issue_bound_definitions(
         merged,
@@ -626,9 +640,13 @@ pub(crate) fn compare_canonical_durable_declaration_install(
     target: Target,
 ) -> MultiErrorResult<(crate::DurableSemanticProjectionWork, DeclarationBindingWork)> {
     let imports = test_fixture_import_graph(merged)?;
-    let ordinary =
-        configure_canonical_sema(merged, rir, preview_features.clone(), target, &imports)?
-            .bind_declarations()?;
+    let ordinary = crate::canonical_semantic::bind_query_owned_declarations_for_test(
+        merged,
+        rir,
+        preview_features.clone(),
+        target,
+        &imports,
+    )?;
     let manifest = ordinary.binding_manifest();
     let definitions = issue_bound_definitions(
         merged,
@@ -651,9 +669,23 @@ pub(crate) fn compare_canonical_durable_declaration_install(
                 "ordinary durable semantic conversion failed: {failure:?}"
             )))
         })?;
+    let query_shells =
+        crate::revisioned_query_database::projected_declaration_shells_for_test(merged)?;
     let shells = configure_canonical_sema(merged, rir, preview_features, target, &imports)?
-        .predeclare_declaration_shells()?;
+        .predeclare_imported_declaration_shells(&query_shells)?;
     let shell_records = shells.declaration_shells().cloned().collect::<Vec<_>>();
+    let provisional = issue_shell_definitions(merged, rir.source_revision(), &shell_records)
+        .map_err(CompileErrors::from)?;
+    let shells = shells
+        .install_stable_identity_endpoints(
+            &provisional.semantic_definition_endpoints(),
+            &provisional.semantic_module_endpoints(merged),
+        )
+        .map_err(|failure| {
+            CompileErrors::from(invalid(format!(
+                "comparison stable endpoint install failed: {failure:?}"
+            )))
+        })?;
     let (projected, projection_work) = crate::project_durable_declaration_semantics(
         merged,
         &definitions,
@@ -739,6 +771,7 @@ pub(crate) fn compare_canonical_durable_declaration_install(
     Ok((projection_work, binding_work))
 }
 
+#[cfg(test)]
 pub(crate) fn bind_canonical_definitions_with_work(
     merged: &CanonicalMergedProgram,
     rir: &CanonicalRirOutput,
@@ -746,8 +779,13 @@ pub(crate) fn bind_canonical_definitions_with_work(
     target: Target,
     imports: &crate::CanonicalImportGraph,
 ) -> MultiErrorResult<(BoundDefinitionSet, DeclarationBindingWork)> {
-    let sema = configure_canonical_sema(merged, rir, preview_features, target, imports)?;
-    let bound = sema.bind_declarations()?;
+    let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
+        merged,
+        rir,
+        preview_features,
+        target,
+        imports,
+    )?;
     let binding_work = bound.binding_work();
     let manifest = bound.binding_manifest();
     let definitions = issue_bound_definitions(
@@ -971,6 +1009,10 @@ pub(crate) fn issue_shell_definitions(
 ) -> Result<BoundDefinitionSet, CompileError> {
     let bindings = shells
         .iter()
+        // A syntax shell can only prove that a source `const` is a candidate.
+        // Its final stable kind may be ValueConst or ModuleBinding after
+        // initializer evaluation, so no provisional stable ID is issued.
+        .filter(|shell| shell.identity.kind != StableDefinitionKind::ValueConst)
         .map(|shell| SemanticBinding {
             file_id: shell.declaration_span.file_id,
             declaration_span: shell.declaration_span,
@@ -1281,15 +1323,13 @@ mod tests {
         let rir = lower_canonical_rir(&merged).unwrap();
         let current_definitions = bind(&relocated);
         let imports = test_fixture_import_graph(&merged).unwrap();
-        let shells = configure_canonical_sema(
+        let shells = crate::canonical_semantic::query_owned_declaration_shells_for_test(
             &merged,
             &rir,
             PreviewFeatures::new(),
             Target::default(),
             &imports,
         )
-        .unwrap()
-        .predeclare_declaration_shells()
         .unwrap();
         let shell_records = shells.declaration_shells().cloned().collect::<Vec<_>>();
         let (projected, work) = crate::project_durable_declaration_semantics(
@@ -1331,15 +1371,13 @@ mod tests {
         let merged = merge_parsed_modules(&parsed).unwrap();
         let rir = lower_canonical_rir(&merged).unwrap();
         let imports = test_fixture_import_graph(&merged).unwrap();
-        let shells = configure_canonical_sema(
+        let shells = crate::canonical_semantic::query_owned_declaration_shells_for_test(
             &merged,
             &rir,
             PreviewFeatures::new(),
             Target::default(),
             &imports,
         )
-        .unwrap()
-        .predeclare_declaration_shells()
         .unwrap();
         let shell_records = shells.declaration_shells().cloned().collect::<Vec<_>>();
         let (projected, projection) = crate::project_durable_declaration_semantics(
@@ -1366,15 +1404,13 @@ mod tests {
         let merged = merge_parsed_modules(&parsed).unwrap();
         let rir = lower_canonical_rir(&merged).unwrap();
         let imports = test_fixture_import_graph(&merged).unwrap();
-        let shells = configure_canonical_sema(
+        let shells = crate::canonical_semantic::query_owned_declaration_shells_for_test(
             &merged,
             &rir,
             PreviewFeatures::new(),
             Target::default(),
             &imports,
         )
-        .unwrap()
-        .predeclare_declaration_shells()
         .unwrap();
         let shell_records = shells.declaration_shells().cloned().collect::<Vec<_>>();
         let duplicated = durable
@@ -1431,15 +1467,13 @@ mod tests {
         );
         // The failed candidate was consumed; a fresh ordinary epoch remains valid.
         let imports = test_fixture_import_graph(&merged).unwrap();
-        configure_canonical_sema(
+        crate::canonical_semantic::bind_query_owned_declarations_for_test(
             &merged,
             &rir,
             PreviewFeatures::new(),
             Target::default(),
             &imports,
         )
-        .unwrap()
-        .bind_declarations()
         .unwrap()
         .analyze_all_bodies()
         .unwrap();

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -207,6 +207,7 @@ pub(crate) fn prepare_canonical_declarations<'a>(
     rir: &'a CanonicalRirOutput,
     options: &CompileOptions,
     imports: &CanonicalImportGraph,
+    query_shells: &[rue_air::SemanticDeclarationShell],
 ) -> Result<CanonicalPreparedDeclarations<'a>, CanonicalSemanticFailure> {
     let sema = configure_timed_canonical_sema(merged, rir, options, imports).map_err(|errors| {
         CanonicalSemanticFailure::declaration(errors, CanonicalSemanticWork::default())
@@ -218,20 +219,22 @@ pub(crate) fn prepare_canonical_declarations<'a>(
         shell_predeclaration_epochs: 1,
         ..CanonicalDeclarationReuseWork::default()
     };
-    let shells = sema.predeclare_declaration_shells().map_err(|errors| {
-        CanonicalSemanticFailure::declaration(
-            errors,
-            declaration_stage_work(
-                declaration_index,
-                DeclarationBindingWork::default(),
-                SemanticBindingManifestWork::default(),
-                BodyOwnerTokenWork::default(),
-                BodyAnalysisWork::default(),
-                false,
-                declaration_reuse,
-            ),
-        )
-    })?;
+    let shells = sema
+        .predeclare_imported_declaration_shells(query_shells)
+        .map_err(|errors| {
+            CanonicalSemanticFailure::declaration(
+                errors,
+                declaration_stage_work(
+                    declaration_index,
+                    DeclarationBindingWork::default(),
+                    SemanticBindingManifestWork::default(),
+                    BodyOwnerTokenWork::default(),
+                    BodyAnalysisWork::default(),
+                    false,
+                    declaration_reuse,
+                ),
+            )
+        })?;
     let shell_records = shells.declaration_shells().cloned().collect::<Vec<_>>();
     let definitions = match issue_shell_definitions(merged, rir.source_revision(), &shell_records) {
         Ok(definitions) => definitions,
@@ -277,6 +280,38 @@ impl CanonicalPreparedDeclarations<'_> {
     pub(crate) fn definitions(&self) -> &BoundDefinitionSet {
         &self.definitions
     }
+}
+
+#[cfg(test)]
+pub(crate) fn query_owned_declaration_shells_for_test<'a>(
+    merged: &CanonicalMergedProgram,
+    rir: &'a CanonicalRirOutput,
+    preview_features: rue_error::PreviewFeatures,
+    target: crate::Target,
+    imports: &CanonicalImportGraph,
+) -> MultiErrorResult<rue_air::DeclarationShells<'a>> {
+    let options = CompileOptions {
+        preview_features,
+        target,
+        ..CompileOptions::default()
+    };
+    let query_shells =
+        crate::revisioned_query_database::projected_declaration_shells_for_test(merged)?;
+    let prepared = prepare_canonical_declarations(merged, rir, &options, imports, &query_shells)
+        .map_err(|failure| failure.errors)?;
+    Ok(prepared.shells)
+}
+
+#[cfg(test)]
+pub(crate) fn bind_query_owned_declarations_for_test<'a>(
+    merged: &CanonicalMergedProgram,
+    rir: &'a CanonicalRirOutput,
+    preview_features: rue_error::PreviewFeatures,
+    target: crate::Target,
+    imports: &CanonicalImportGraph,
+) -> MultiErrorResult<rue_air::BoundSema<'a>> {
+    query_owned_declaration_shells_for_test(merged, rir, preview_features, target, imports)?
+        .resolve_declarations()
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -743,7 +778,7 @@ impl CanonicalSemanticOutput {
 /// Bind declarations once, optionally issue stable IDs, then consume the same
 /// transient bound Sema for body analysis and CFG construction.
 #[cfg(test)]
-pub(crate) fn analyze_canonical_program(
+pub(crate) fn analyze_canonical_program_for_test_support(
     merged: &CanonicalMergedProgram,
     rir: &CanonicalRirOutput,
     options: &CompileOptions,
@@ -758,7 +793,9 @@ pub(crate) fn analyze_canonical_program(
         ),
         opt_level: options.opt_level.into(),
     };
-    let prepared = prepare_canonical_declarations(merged, rir, options, imports)
+    let query_shells =
+        crate::revisioned_query_database::projected_declaration_shells_for_test(merged)?;
+    let prepared = prepare_canonical_declarations(merged, rir, options, imports, &query_shells)
         .map_err(|failure| failure.errors)?;
     let CanonicalPreparedDeclarations {
         shells,
@@ -981,8 +1018,9 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
                     reuse.declaration_indexes_built +=
                         fallback.rir_declaration_index_work().build_invocations;
                     reuse.shell_predeclaration_epochs += 1;
-                    let fallback_shells =
-                        fallback.predeclare_declaration_shells().map_err(|errors| {
+                    let fallback_shells = fallback
+                        .predeclare_imported_declaration_shells(&shell_records)
+                        .map_err(|errors| {
                             CanonicalSemanticFailure::declaration(
                                 errors,
                                 declaration_stage_work(
@@ -1990,12 +2028,12 @@ mod tests {
 
     use super::{
         BodyOwnerTokenWork, CanonicalSemanticOutput, CanonicalSemanticWork,
-        analyze_canonical_program,
+        analyze_canonical_program_for_test_support,
     };
     use crate::parsed_modules::parse_source_snapshot_modules;
     use crate::{
-        CanonicalRirOutput, CompileOptions, FunctionWithCfg, SourceMetadata, SourceSnapshot,
-        lower_canonical_rir, merge_parsed_modules,
+        CanonicalRirOutput, CompileOptions, FunctionWithCfg, PreviewFeatures, SourceMetadata,
+        SourceSnapshot, Target, lower_canonical_rir, merge_parsed_modules,
     };
 
     fn snapshot(entries: &[(u32, &str, &str, &str)], root: u32) -> SourceSnapshot {
@@ -2026,21 +2064,19 @@ mod tests {
         let options = CompileOptions::default();
         let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
 
-        let ordinary = match crate::bound_definitions::configure_canonical_sema(
-            &merged,
-            &rir,
+        let ordinary = match rue_air::Sema::new_synthetic(
+            rir.rir(),
+            rir.semantic_symbols().interner(),
             options.preview_features.clone(),
-            options.target,
-            &imports,
         )
-        .unwrap()
         .bind_declarations()
         {
             Err(errors) => errors,
             Ok(_) => panic!("test input must fail ordinary declaration binding"),
         };
         let canonical =
-            analyze_canonical_program(&merged, &rir, &options, &imports, false).unwrap_err();
+            analyze_canonical_program_for_test_support(&merged, &rir, &options, &imports, false)
+                .unwrap_err();
         let messages = |errors: crate::CompileErrors| {
             errors.iter().map(ToString::to_string).collect::<Vec<_>>()
         };
@@ -2051,11 +2087,35 @@ mod tests {
     fn token_preparation_failures_recover_ordinary_binding_diagnostics() {
         for source in [
             "const value: i32 = 1; const value: i32 = 2; fn main() {}",
+            "const X: i32 = 1; fn X() -> i32 { 2 } fn main() -> i32 { 0 }",
+            "enum Color { Red, Green } const Color: i32 = 5; fn main() -> i32 { Color }",
             "struct Value {} drop fn Value(self) {} drop fn Value(self) {} fn main() {}",
             "drop fn Missing(self) {} fn main() {}",
         ] {
             assert_token_preparation_preserves_source_errors(source);
         }
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "canonical compiler epochs must import query-owned declaration shells"
+    )]
+    fn canonical_sema_cannot_invoke_raw_declaration_discovery() {
+        let source = snapshot(&[(1, "/main.rue", "main.rue", "fn main() {}")], 1);
+        let parsed = parse_source_snapshot_modules(&source).unwrap();
+        let merged = merge_parsed_modules(&parsed).unwrap();
+        let rir = lower_canonical_rir(&merged).unwrap();
+        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        crate::bound_definitions::configure_canonical_sema(
+            &merged,
+            &rir,
+            PreviewFeatures::new(),
+            Target::default(),
+            &imports,
+        )
+        .unwrap()
+        .predeclare_declaration_shells()
+        .unwrap();
     }
 
     fn canonical(
@@ -2067,7 +2127,9 @@ mod tests {
         let merged = merge_parsed_modules(&parsed).unwrap();
         let rir = lower_canonical_rir(&merged).unwrap();
         let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
-        let output = analyze_canonical_program(&merged, &rir, options, &imports, ids).unwrap();
+        let output =
+            analyze_canonical_program_for_test_support(&merged, &rir, options, &imports, ids)
+                .unwrap();
         (output, rir)
     }
 

--- a/crates/rue-compiler/src/declaration_candidate.rs
+++ b/crates/rue-compiler/src/declaration_candidate.rs
@@ -1,0 +1,134 @@
+//! Stable, presemantic declaration candidates and position-free shell facts.
+//!
+//! These values are produced once at the parser boundary. They intentionally
+//! cannot represent resolved constant identity: every source `const` remains
+//! a [`DeclarationCandidateCategory::ConstCandidate`] until semantic
+//! evaluation classifies its initializer.
+
+use std::sync::Arc;
+
+use crate::ModuleId;
+
+/// Exhaustive syntax categories that may own a stable source occurrence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum DeclarationCandidateCategory {
+    Function,
+    ExternFunction,
+    Struct,
+    Enum,
+    ConstCandidate,
+    Destructor,
+    Method,
+    AssociatedFunction,
+}
+
+/// Stable owner of a named member candidate.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct DeclarationCandidateOwner {
+    pub(crate) category: DeclarationCandidateCategory,
+    pub(crate) name: Arc<str>,
+}
+
+/// Durable identity of one syntax occurrence within a logical module.
+///
+/// The discriminator is counted only among otherwise equal candidates. It
+/// therefore distinguishes malformed duplicates without coupling unrelated
+/// declarations to global source order.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct DeclarationCandidateKey {
+    pub(crate) module: ModuleId,
+    pub(crate) category: DeclarationCandidateCategory,
+    pub(crate) name: Arc<str>,
+    pub(crate) owner: Option<DeclarationCandidateOwner>,
+    pub(crate) duplicate_discriminator: u32,
+}
+
+/// Position-free proof that one exact candidate key is present in a parsed
+/// module. The occurrence family publishes only this capability metadata; the
+/// parser-owned header remains private until the exact shell evaluator asks
+/// for this key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DeclarationOccurrenceCapability {
+    Exact {
+        key: DeclarationCandidateKey,
+        duplicate_multiplicity: u32,
+    },
+    Ambiguous {
+        key: DeclarationCandidateKey,
+        multiplicity: u32,
+    },
+}
+
+impl DeclarationOccurrenceCapability {
+    pub(crate) fn key(&self) -> &DeclarationCandidateKey {
+        match self {
+            Self::Exact { key, .. } | Self::Ambiguous { key, .. } => key,
+        }
+    }
+}
+
+/// Stable, position-free failure retained by the occurrence query.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DeclarationOccurrenceFailure {
+    ParseRejected { module: ModuleId },
+}
+
+/// Stable, position-free failure retained by the exact shell query.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DeclarationShellFailure {
+    OccurrencesUnavailable(DeclarationOccurrenceFailure),
+    Absent(DeclarationCandidateKey),
+    Ambiguous(DeclarationCandidateKey),
+    ParserCapabilityMismatch(DeclarationCandidateKey),
+}
+
+impl DeclarationCandidateKey {
+    pub(crate) fn stable_identity(&self) -> String {
+        // Length-prefix every user-authored component. Query identities must
+        // remain collision-free even when Rue identifiers contain separators.
+        let owner = self.owner.as_ref().map_or_else(
+            || "-".to_owned(),
+            |owner| format!("{:?}:{}:{}", owner.category, owner.name.len(), owner.name),
+        );
+        format!(
+            "{}:{}:{:?}:{}:{}:{}:{}",
+            self.module.as_str().len(),
+            self.module.as_str(),
+            self.category,
+            self.name.len(),
+            self.name,
+            owner,
+            self.duplicate_discriminator
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum DeclarationParameterMode {
+    Value,
+    Borrow,
+    Inout,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct DeclarationParameterHeader {
+    pub(crate) name: Arc<str>,
+    pub(crate) mode: DeclarationParameterMode,
+    pub(crate) is_comptime: bool,
+}
+
+/// Position-free header fact owned by the keyed declaration-shell family.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct DeclarationShellFact {
+    pub(crate) key: DeclarationCandidateKey,
+    pub(crate) is_public: bool,
+    pub(crate) parameters: Arc<[DeclarationParameterHeader]>,
+    pub(crate) receiver: Option<DeclarationParameterMode>,
+    pub(crate) receiver_is_mut: bool,
+    pub(crate) is_generic: bool,
+    pub(crate) is_unchecked: bool,
+    pub(crate) is_extern: bool,
+    /// Hash of parser-authored signature partitions with whitespace removed.
+    /// Bodies and constant initializers are deliberately excluded.
+    pub(crate) signature_fingerprint: [u8; 32],
+}

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -466,16 +466,13 @@ pub fn project_durable_declaration_semantics(
             key
         } else if shell.identity.kind == StableDefinitionKind::ValueConst {
             // Const shells are deliberately captured before initializer
-            // evaluation. A previous durable module payload may reclassify
-            // only this exact current const declaration; either the current
-            // provisional ValueConst definition or an authoritative
-            // ModuleBinding definition must prove its provenance.
+            // evaluation, and therefore have no provisional stable definition.
+            // A selected compatible durable baseline may reclassify only this
+            // exact current candidate as a module binding. The durable query's
+            // input fingerprints prove initializer compatibility; this adapter
+            // supplies only the current locator and header.
             let mut module_join = join_key.clone();
             module_join.kind = StableDefinitionKind::ModuleBinding;
-            let authoritative = definition_by_join_key.get(&module_join);
-            if exact_definition.is_none() && authoritative.is_none() {
-                return Err(DurableSemanticProjectionFailure::MissingDefinition);
-            }
             let key = durable_by_join_key
                 .get(&module_join)
                 .cloned()

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -39,6 +39,7 @@ mod bound_definitions;
 mod canonical_lower;
 mod canonical_merge;
 mod canonical_semantic;
+mod declaration_candidate;
 mod definition_snapshot;
 mod dependency_envelope;
 mod diagnostic;

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 
 #[cfg(test)]
 use std::cell::Cell;
-#[cfg(test)]
 use std::collections::BTreeMap;
 
 #[cfg(test)]
@@ -21,11 +20,17 @@ use rue_parser::{
     AssignTarget, Ast, Expr, IntrinsicArg, Item, Pattern, Statement, TypeExpr, ast::Visibility,
 };
 use rue_span::{FileId, Span};
+use sha2::{Digest, Sha256};
 
 use crate::definition_snapshot::{definition_parts, validate_span};
 use crate::{
     DefinitionKind, DefinitionNamespace, ImportDirective, ImportDirectives, ModuleId,
     ModuleRevision, SourceId, SourceRevision, SourceSnapshot, SyntaxWork,
+    declaration_candidate::{
+        DeclarationCandidateCategory, DeclarationCandidateKey, DeclarationCandidateOwner,
+        DeclarationOccurrenceCapability, DeclarationParameterHeader, DeclarationParameterMode,
+        DeclarationShellFact, DeclarationShellFailure,
+    },
 };
 
 #[derive(Debug)]
@@ -143,6 +148,9 @@ impl ParsedDefinitionCandidate {
 #[derive(Debug, Clone)]
 pub struct ParsedDefinitionIndex {
     candidates: Arc<[ParsedDefinitionCandidate]>,
+    declarations: Arc<[ParsedDeclarationCandidate]>,
+    declaration_by_key: BTreeMap<DeclarationCandidateKey, usize>,
+    declaration_capabilities: Arc<[DeclarationOccurrenceCapability]>,
     #[cfg(test)]
     by_name: BTreeMap<(DefinitionNamespace, Arc<str>), Arc<[ParsedDefinitionOccurrence]>>,
 }
@@ -150,6 +158,42 @@ pub struct ParsedDefinitionIndex {
 impl ParsedDefinitionIndex {
     pub fn candidates(&self) -> &[ParsedDefinitionCandidate] {
         &self.candidates
+    }
+
+    pub(crate) fn declaration_capabilities(&self) -> &[DeclarationOccurrenceCapability] {
+        &self.declaration_capabilities
+    }
+
+    pub(crate) fn evaluate_declaration_shell(
+        &self,
+        key: &DeclarationCandidateKey,
+    ) -> Result<DeclarationShellFact, DeclarationShellFailure> {
+        let Some(index) = self.declaration_by_key.get(key).copied() else {
+            return Err(DeclarationShellFailure::Absent(key.clone()));
+        };
+        let candidate = self
+            .declarations
+            .get(index)
+            .ok_or_else(|| DeclarationShellFailure::ParserCapabilityMismatch(key.clone()))?;
+        if candidate.fact.key != *key {
+            return Err(DeclarationShellFailure::ParserCapabilityMismatch(
+                key.clone(),
+            ));
+        }
+        Ok(candidate.fact.clone())
+    }
+
+    pub(crate) fn declaration_locator(
+        &self,
+        key: &DeclarationCandidateKey,
+    ) -> Option<ParsedDeclarationLocator> {
+        let index = self.declaration_by_key.get(key).copied()?;
+        let candidate = self.declarations.get(index)?;
+        let source_order = u32::try_from(index).ok()?;
+        (candidate.fact.key == *key).then_some(ParsedDeclarationLocator {
+            declaration_span: candidate.declaration_span,
+            source_order,
+        })
     }
 
     #[cfg(test)]
@@ -164,6 +208,19 @@ impl ParsedDefinitionIndex {
             .flat_map(|occurrences| occurrences.iter())
             .map(|occurrence| &self.candidates[occurrence.index()])
     }
+}
+
+/// One canonical source occurrence paired with its current locator.
+#[derive(Debug, Clone)]
+pub(crate) struct ParsedDeclarationCandidate {
+    fact: DeclarationShellFact,
+    declaration_span: Span,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ParsedDeclarationLocator {
+    pub(crate) declaration_span: Span,
+    pub(crate) source_order: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -945,8 +1002,14 @@ fn build_module_with_resolver(
         source: source.clone(),
     };
     validate_pair(&provenanced_ast, &resolver, &revision)?;
-    let definitions =
-        build_definition_index(file_id, &source_text, &provenanced_ast.ast, &resolver)?;
+    let definitions = build_definition_index(
+        revision.module.clone(),
+        file_id,
+        &source_text,
+        &tokens,
+        &provenanced_ast.ast,
+        &resolver,
+    )?;
     let payload = Arc::new(ParsedSyntaxPayload {
         source,
         source_text,
@@ -1012,6 +1075,19 @@ fn bind_payload(
             })
             .collect::<Vec<_>>()
             .into(),
+        declarations: payload
+            .definitions
+            .declarations
+            .iter()
+            .cloned()
+            .map(|candidate| ParsedDeclarationCandidate {
+                declaration_span: remap_span(candidate.declaration_span),
+                ..candidate
+            })
+            .collect::<Vec<_>>()
+            .into(),
+        declaration_by_key: payload.definitions.declaration_by_key.clone(),
+        declaration_capabilities: payload.definitions.declaration_capabilities.clone(),
         #[cfg(test)]
         by_name: payload.definitions.by_name.clone(),
     };
@@ -1388,12 +1464,41 @@ fn validate_pair(
 }
 
 fn build_definition_index(
+    module: ModuleId,
     file_id: FileId,
     source_text: &str,
+    tokens: &[rue_lexer::Token],
     ast: &Ast,
     resolver: &FrozenSymbolResolver,
 ) -> CompileResult<ParsedDefinitionIndex> {
     let mut pending = Vec::new();
+    let mut pending_declarations = Vec::<(DeclarationShellFact, Span)>::new();
+    let resolve_name = |ident: rue_parser::Ident| -> CompileResult<Arc<str>> {
+        let symbol = resolver.symbol(ident.name)?;
+        Ok(Arc::from(resolver.resolve(&symbol)?))
+    };
+    let parameters =
+        |params: &[rue_parser::Param]| -> CompileResult<Arc<[DeclarationParameterHeader]>> {
+            params
+                .iter()
+                .map(|param| {
+                    let (mode, is_comptime) = candidate_parameter_mode(param.mode);
+                    Ok(DeclarationParameterHeader {
+                        name: resolve_name(param.name)?,
+                        mode,
+                        is_comptime,
+                    })
+                })
+                .collect::<CompileResult<Vec<_>>>()
+                .map(Into::into)
+        };
+    // The semantic declaration layer treats every comptime parameter as a
+    // generic specialization input, not only `comptime T: type` parameters.
+    let is_generic = |params: &[rue_parser::Param]| -> CompileResult<bool> {
+        Ok(params
+            .iter()
+            .any(|parameter| parameter.mode == rue_parser::ast::ParamMode::Comptime))
+    };
     for item in &ast.items {
         // A foreign `extern "C"` block expands into one module-item definition
         // per member `fn` (ADR-0064 C FFI); every other item is a single
@@ -1430,6 +1535,178 @@ fn build_definition_index(
             let symbol = resolver.symbol(parts.name.name)?;
             let name: Arc<str> = Arc::from(resolver.resolve(&symbol)?);
             pending.push((parts, symbol, name));
+        }
+
+        let mut push = |category,
+                        name: Arc<str>,
+                        owner: Option<DeclarationCandidateOwner>,
+                        is_public,
+                        parameters,
+                        receiver,
+                        receiver_is_mut,
+                        is_generic,
+                        is_unchecked,
+                        is_extern,
+                        declaration_span,
+                        signature_spans: Vec<Span>|
+         -> CompileResult<()> {
+            let signature_fingerprint = declaration_signature_fingerprint(
+                file_id,
+                source_text,
+                tokens,
+                resolver,
+                &signature_spans,
+            )?;
+            pending_declarations.push((
+                DeclarationShellFact {
+                    key: DeclarationCandidateKey {
+                        module: module.clone(),
+                        category,
+                        name,
+                        owner,
+                        duplicate_discriminator: 0,
+                    },
+                    is_public,
+                    parameters,
+                    receiver,
+                    receiver_is_mut,
+                    is_generic,
+                    is_unchecked,
+                    is_extern,
+                    signature_fingerprint,
+                },
+                declaration_span,
+            ));
+            Ok(())
+        };
+
+        match item {
+            Item::Function(function) => push(
+                DeclarationCandidateCategory::Function,
+                resolve_name(function.name)?,
+                None,
+                function.visibility == Visibility::Public,
+                parameters(&function.params)?,
+                None,
+                false,
+                is_generic(&function.params)?,
+                function.is_unchecked,
+                false,
+                function.span,
+                vec![signature_prefix(function.span, function.body.span())?],
+            )?,
+            Item::Struct(structure) => {
+                let owner_name = resolve_name(structure.name)?;
+                push(
+                    DeclarationCandidateCategory::Struct,
+                    owner_name.clone(),
+                    None,
+                    structure.visibility == Visibility::Public,
+                    Arc::from([]),
+                    None,
+                    false,
+                    false,
+                    false,
+                    false,
+                    structure.span,
+                    signature_fragments_excluding_method_bodies(structure)?,
+                )?;
+                let owner = DeclarationCandidateOwner {
+                    category: DeclarationCandidateCategory::Struct,
+                    name: owner_name,
+                };
+                for method in &structure.methods {
+                    let receiver = method
+                        .receiver
+                        .as_ref()
+                        .map(|receiver| candidate_parameter_mode(receiver.mode).0);
+                    push(
+                        if receiver.is_some() {
+                            DeclarationCandidateCategory::Method
+                        } else {
+                            DeclarationCandidateCategory::AssociatedFunction
+                        },
+                        resolve_name(method.name)?,
+                        Some(owner.clone()),
+                        false,
+                        parameters(&method.params)?,
+                        receiver,
+                        method
+                            .receiver
+                            .as_ref()
+                            .is_some_and(|receiver| receiver.is_mut),
+                        is_generic(&method.params)?,
+                        false,
+                        false,
+                        method.span,
+                        vec![signature_prefix(method.span, method.body.span())?],
+                    )?;
+                }
+            }
+            Item::Enum(value) => push(
+                DeclarationCandidateCategory::Enum,
+                resolve_name(value.name)?,
+                None,
+                value.visibility == Visibility::Public,
+                Arc::from([]),
+                None,
+                false,
+                false,
+                false,
+                false,
+                value.span,
+                vec![value.span],
+            )?,
+            Item::Const(value) => push(
+                DeclarationCandidateCategory::ConstCandidate,
+                resolve_name(value.name)?,
+                None,
+                value.visibility == Visibility::Public,
+                Arc::from([]),
+                None,
+                false,
+                false,
+                false,
+                false,
+                value.span,
+                vec![signature_prefix(value.span, value.init.span())?],
+            )?,
+            Item::DropFn(value) => push(
+                DeclarationCandidateCategory::Destructor,
+                resolve_name(value.type_name)?,
+                Some(DeclarationCandidateOwner {
+                    category: DeclarationCandidateCategory::Struct,
+                    name: resolve_name(value.type_name)?,
+                }),
+                false,
+                Arc::from([]),
+                Some(DeclarationParameterMode::Value),
+                false,
+                false,
+                false,
+                false,
+                value.span,
+                vec![signature_prefix(value.span, value.body.span())?],
+            )?,
+            Item::Extern(block) => {
+                for function in &block.fns {
+                    push(
+                        DeclarationCandidateCategory::ExternFunction,
+                        resolve_name(function.name)?,
+                        None,
+                        false,
+                        parameters(&function.params)?,
+                        None,
+                        false,
+                        is_generic(&function.params)?,
+                        false,
+                        true,
+                        function.span,
+                        vec![function.span],
+                    )?;
+                }
+            }
+            Item::Error(_) => {}
         }
     }
     pending.sort_by(|(left, _, left_name), (right, _, right_name)| {
@@ -1482,11 +1759,150 @@ fn build_definition_index(
         .into_iter()
         .map(|(key, value)| (key, value.into()))
         .collect();
+    pending_declarations.sort_by(|left, right| {
+        left.1
+            .start
+            .cmp(&right.1.start)
+            .then(left.1.end.cmp(&right.1.end))
+            .then(left.0.key.category.cmp(&right.0.key.category))
+            .then(left.0.key.name.cmp(&right.0.key.name))
+    });
+    let mut duplicate_counts = BTreeMap::new();
+    let declarations = pending_declarations
+        .into_iter()
+        .map(|(mut fact, declaration_span)| {
+            let duplicate = duplicate_counts
+                .entry((
+                    fact.key.category,
+                    fact.key.name.clone(),
+                    fact.key.owner.clone(),
+                ))
+                .or_insert(0_u32);
+            fact.key.duplicate_discriminator = *duplicate;
+            *duplicate = duplicate
+                .checked_add(1)
+                .ok_or_else(|| invalid_input("declaration duplicate discriminator exceeds u32"))?;
+            Ok(ParsedDeclarationCandidate {
+                fact,
+                declaration_span,
+            })
+        })
+        .collect::<CompileResult<Vec<_>>>()?;
+    let mut declaration_by_key = BTreeMap::new();
+    let mut declaration_capabilities = Vec::with_capacity(declarations.len());
+    for (index, candidate) in declarations.iter().enumerate() {
+        let key = candidate.fact.key.clone();
+        let duplicate_multiplicity = *duplicate_counts
+            .get(&(key.category, key.name.clone(), key.owner.clone()))
+            .expect("every declaration contributes to its duplicate count");
+        if declaration_by_key.insert(key.clone(), index).is_some() {
+            declaration_capabilities.push(DeclarationOccurrenceCapability::Ambiguous {
+                key,
+                multiplicity: 2,
+            });
+        } else {
+            declaration_capabilities.push(DeclarationOccurrenceCapability::Exact {
+                key,
+                duplicate_multiplicity,
+            });
+        }
+    }
+    declaration_capabilities.sort_by(|left, right| left.key().cmp(right.key()));
     Ok(ParsedDefinitionIndex {
         candidates: candidates.into(),
+        declarations: declarations.into(),
+        declaration_by_key,
+        declaration_capabilities: declaration_capabilities.into(),
         #[cfg(test)]
         by_name,
     })
+}
+
+fn candidate_parameter_mode(mode: rue_parser::ast::ParamMode) -> (DeclarationParameterMode, bool) {
+    match mode {
+        rue_parser::ast::ParamMode::Normal => (DeclarationParameterMode::Value, false),
+        rue_parser::ast::ParamMode::Borrow => (DeclarationParameterMode::Borrow, false),
+        rue_parser::ast::ParamMode::Inout => (DeclarationParameterMode::Inout, false),
+        rue_parser::ast::ParamMode::Comptime => (DeclarationParameterMode::Value, true),
+    }
+}
+
+fn signature_prefix(declaration: Span, payload: Span) -> CompileResult<Span> {
+    if declaration.file_id != payload.file_id
+        || payload.start < declaration.start
+        || payload.end > declaration.end
+        || payload.start >= payload.end
+    {
+        return Err(invalid_input(
+            "declaration payload is not contained by its declaration",
+        ));
+    }
+    Ok(Span::with_file(
+        declaration.file_id,
+        declaration.start,
+        payload.start,
+    ))
+}
+
+fn signature_fragments_excluding_method_bodies(
+    structure: &rue_parser::ast::StructDecl,
+) -> CompileResult<Vec<Span>> {
+    let mut fragments = Vec::with_capacity(structure.methods.len() + 1);
+    let mut cursor = structure.span.start;
+    for method in &structure.methods {
+        let body = method.body.span();
+        if body.file_id != structure.span.file_id
+            || body.start < cursor
+            || body.end > structure.span.end
+            || body.start >= body.end
+        {
+            return Err(invalid_input(
+                "struct method body is not ordered within its declaration",
+            ));
+        }
+        fragments.push(Span::with_file(structure.span.file_id, cursor, body.start));
+        cursor = body.end;
+    }
+    fragments.push(Span::with_file(
+        structure.span.file_id,
+        cursor,
+        structure.span.end,
+    ));
+    Ok(fragments)
+}
+
+fn declaration_signature_fingerprint(
+    file_id: FileId,
+    source_text: &str,
+    tokens: &[rue_lexer::Token],
+    resolver: &FrozenSymbolResolver,
+    spans: &[Span],
+) -> CompileResult<[u8; 32]> {
+    let mut hasher = Sha256::new();
+    for span in spans {
+        validate_span("declaration signature", *span, file_id, source_text)?;
+        for token in tokens.iter().filter(|token| {
+            token.span.file_id == file_id
+                && token.span.start >= span.start
+                && token.span.end <= span.end
+                && !matches!(token.kind, rue_lexer::TokenKind::Eof)
+        }) {
+            let value = match token.kind {
+                rue_lexer::TokenKind::Ident(spur) => {
+                    format!("ident:{}", resolver.resolver.resolve(&spur))
+                }
+                rue_lexer::TokenKind::String(spur) => {
+                    format!("string:{}", resolver.resolver.resolve(&spur))
+                }
+                rue_lexer::TokenKind::Int(value) => format!("int:{value}"),
+                kind => kind.name().to_owned(),
+            };
+            hasher.update((value.len() as u64).to_le_bytes());
+            hasher.update(value.as_bytes());
+        }
+        hasher.update(0_u64.to_le_bytes());
+    }
+    Ok(hasher.finalize().into())
 }
 
 fn invalid_input(message: impl Into<String>) -> CompileError {
@@ -1504,6 +1920,100 @@ mod tests {
     use crate::{
         ModuleResolutionInput, ModuleResolutionInputs, SemanticInputDescriptor, SourceMetadata,
     };
+
+    fn declaration_facts(source: &str) -> Vec<DeclarationShellFact> {
+        let snapshot = snapshot(&[(1, "/main.rue", "main.rue", source)], 1);
+        let parsed = parse_source_snapshot_modules(&snapshot).unwrap();
+        parsed.modules()[0]
+            .definitions()
+            .declaration_capabilities()
+            .iter()
+            .map(|capability| {
+                parsed.modules()[0]
+                    .definitions()
+                    .evaluate_declaration_shell(capability.key())
+                    .unwrap()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn declaration_candidates_cover_every_named_syntax_family_and_duplicates() {
+        use DeclarationCandidateCategory as C;
+        let facts = declaration_facts(
+            r#"
+pub struct Box {
+    fn get(borrow self, comptime T: type) -> i32 { 0 }
+    fn make() -> Box { Box {} }
+}
+enum Choice { A, B(i32) }
+const selected = 1;
+drop fn Box(self) {}
+unchecked fn run(value: i32) -> i32 { value }
+extern "C" { fn getpid() -> i32; }
+fn duplicate() {}
+fn duplicate() {}
+fn type_factory() -> type { struct { fn hidden(self) {} } }
+"#,
+        );
+        let categories = facts
+            .iter()
+            .map(|fact| fact.key.category)
+            .collect::<Vec<_>>();
+        for expected in [
+            C::Struct,
+            C::Method,
+            C::AssociatedFunction,
+            C::Enum,
+            C::ConstCandidate,
+            C::Destructor,
+            C::Function,
+            C::ExternFunction,
+        ] {
+            assert!(categories.contains(&expected), "missing {expected:?}");
+        }
+        let duplicates = facts
+            .iter()
+            .filter(|fact| fact.key.name.as_ref() == "duplicate")
+            .map(|fact| fact.key.duplicate_discriminator)
+            .collect::<Vec<_>>();
+        assert_eq!(duplicates, vec![0, 1]);
+        assert!(facts.iter().all(|fact| fact.key.name.as_ref() != "hidden"));
+        let method = facts
+            .iter()
+            .find(|fact| fact.key.category == C::Method)
+            .unwrap();
+        assert_eq!(method.key.owner.as_ref().unwrap().name.as_ref(), "Box");
+        assert_eq!(method.parameters.len(), 1);
+        assert!(method.parameters[0].is_comptime);
+        assert_eq!(method.receiver, Some(DeclarationParameterMode::Borrow));
+    }
+
+    #[test]
+    fn declaration_shell_facts_ignore_payloads_whitespace_and_const_classification() {
+        let value = declaration_facts(
+            "struct Box { fn get(self) -> i32 { 1 } } const item = 1; fn main() { }",
+        );
+        let module = declaration_facts(
+            "// leading relocation\n  struct Box { fn // between signature tokens\n get(self) -> i32 { 999 } }\n\n const item = @import(\"x.rue\"); // payload boundary\n fn main() { let x = 2; }",
+        );
+        assert_eq!(value, module);
+
+        let edited = declaration_facts(
+            "struct Box { fn get(borrow self) -> i32 { 1 } } const item = 1; fn main() { }",
+        );
+        assert_ne!(value, edited);
+
+        let mutable = declaration_facts(
+            "struct Box { fn get(mut self) -> i32 { 1 } } const item = 1; fn main() { }",
+        );
+        let method = mutable
+            .iter()
+            .find(|fact| fact.key.category == DeclarationCandidateCategory::Method)
+            .unwrap();
+        assert_eq!(method.receiver, Some(DeclarationParameterMode::Value));
+        assert!(method.receiver_is_mut);
+    }
 
     fn snapshot(entries: &[(u32, &str, &str, &str)], root: u32) -> SourceSnapshot {
         let physical = entries

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -35,6 +35,10 @@ use crate::typed_query_store::{TerminalKind, TypedQueryFamily};
 
 const IMPORT_INPUT_REVISION_RETENTION: usize = 64;
 const MODULE_QUERY_MEMO_RETENTION: usize = 4096;
+// A semantic batch commonly requests hundreds of exact declaration shells.
+// Keep one large batch reusable after its active pins drop; the runtime still
+// bounds global retention deterministically.
+const DECLARATION_SHELL_MEMO_RETENTION: usize = MODULE_QUERY_MEMO_RETENTION;
 const MODULE_INPUT_REVISION_RETENTION: usize = 4096;
 
 #[derive(Debug, Clone)]
@@ -386,6 +390,8 @@ pub(crate) struct RevisionedQueryDatabase {
     module_store: Arc<Mutex<ModuleInputStore>>,
     parse_modules: QueryFamily<ModuleQueryKey, ParseModuleValue>,
     module_indexes: QueryFamily<ModuleQueryKey, ModuleIndexValue>,
+    declaration_occurrence_indexes: QueryFamily<ModuleQueryKey, DeclarationOccurrenceIndexValue>,
+    declaration_shells: QueryFamily<DeclarationShellQueryKey, DeclarationShellQueryValue>,
     module_rirs: QueryFamily<ModuleQueryKey, ModuleRirValue>,
     resolve_imports: QueryFamily<ResolveImportKey, ResolveImportValue>,
     lookup_names: QueryFamily<LookupNameKey, LookupNameValue>,
@@ -437,6 +443,41 @@ pub(crate) struct ProjectedModuleIndex {
 
 #[derive(Debug, Clone)]
 struct ModuleIndexValue(Result<Arc<ModuleIndex>, crate::CompileErrors>);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DeclarationOccurrenceIndex {
+    capabilities: BTreeMap<
+        crate::declaration_candidate::DeclarationCandidateKey,
+        crate::declaration_candidate::DeclarationOccurrenceCapability,
+    >,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DeclarationOccurrenceIndexValue {
+    Available(Arc<DeclarationOccurrenceIndex>),
+    Failure(crate::declaration_candidate::DeclarationOccurrenceFailure),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DeclarationShellQueryKey(crate::declaration_candidate::DeclarationCandidateKey);
+
+impl QueryKey for DeclarationShellQueryKey {
+    fn stable_identity(&self) -> String {
+        self.0.stable_identity()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DeclarationShellQueryValue {
+    Available(crate::declaration_candidate::DeclarationShellFact),
+    Failure(crate::declaration_candidate::DeclarationShellFailure),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DeclarationShellBatchFailure {
+    Query(QueryAbort),
+    Stable(crate::declaration_candidate::DeclarationShellFailure),
+}
 
 #[derive(Debug, Clone)]
 struct ModuleRirValue {
@@ -657,6 +698,13 @@ fn module_index_value_equal(left: &ModuleIndexValue, right: &ModuleIndexValue) -
     }
 }
 
+fn declaration_occurrence_index_value_equal(
+    left: &DeclarationOccurrenceIndexValue,
+    right: &DeclarationOccurrenceIndexValue,
+) -> bool {
+    left == right
+}
+
 fn module_rir_value_equal(left: &ModuleRirValue, right: &ModuleRirValue) -> bool {
     match (&left.result, &right.result) {
         (Ok(left), Ok(right)) => left.revision() == right.revision(),
@@ -680,6 +728,78 @@ fn module_rir_value_from_lowering(
             result: Err(crate::CompileErrors::from(error)),
             work,
         },
+    }
+}
+
+fn project_semantic_shell(
+    fact: &crate::declaration_candidate::DeclarationShellFact,
+    declaration_span: rue_span::Span,
+    source_order: u32,
+) -> rue_air::SemanticDeclarationShell {
+    use crate::declaration_candidate::{
+        DeclarationCandidateCategory as C, DeclarationParameterMode as M,
+    };
+    use rue_air::{StableDefinitionKind as K, StableDefinitionNamespace as N};
+
+    let (namespace, kind) = match fact.key.category {
+        C::Function | C::ExternFunction => (N::Value, K::Function),
+        C::Struct => (N::Type, K::Struct),
+        C::Enum => (N::Type, K::Enum),
+        // This is an epoch-local adapter only. The query fact and key remain
+        // `ConstCandidate`; no stable definition ID is issued from this value.
+        C::ConstCandidate => (N::Value, K::ValueConst),
+        C::Destructor => (N::Destructor, K::Destructor),
+        C::Method => (N::Method, K::Method),
+        C::AssociatedFunction => (N::Method, K::AssociatedFunction),
+    };
+    let parameter_names = fact
+        .parameters
+        .iter()
+        .map(|parameter| parameter.name.clone())
+        .collect::<Vec<_>>()
+        .into();
+    let parameter_modes = fact
+        .parameters
+        .iter()
+        .map(|parameter| match parameter.mode {
+            M::Value => rue_rir::RirParamMode::Normal,
+            M::Borrow => rue_rir::RirParamMode::Borrow,
+            M::Inout => rue_rir::RirParamMode::Inout,
+        })
+        .collect::<Vec<_>>()
+        .into();
+    let parameter_comptime = fact
+        .parameters
+        .iter()
+        .map(|parameter| parameter.is_comptime)
+        .collect::<Vec<_>>()
+        .into();
+    rue_air::SemanticDeclarationShell {
+        identity: rue_air::SemanticDeclarationShellIdentity {
+            module_path: Arc::from(fact.key.module.as_str()),
+            is_trusted_standard_library: fact.key.module.is_trusted_standard_library(),
+            namespace,
+            kind,
+            name: fact.key.name.clone(),
+            owner: fact.key.owner.as_ref().map(|owner| owner.name.clone()),
+        },
+        declaration_span,
+        parameter_names,
+        parameter_modes,
+        parameter_comptime,
+        source_order,
+        has_self: fact.receiver.is_some(),
+        receiver_mode: fact.receiver.map(|mode| match mode {
+            M::Value => rue_rir::RirParamMode::Normal,
+            M::Borrow => rue_rir::RirParamMode::Borrow,
+            M::Inout => rue_rir::RirParamMode::Inout,
+        }),
+        receiver_is_mut: fact.receiver_is_mut,
+        is_generic: fact.is_generic,
+        is_public: fact.is_public,
+        is_unchecked: fact.is_unchecked,
+        is_extern: fact.is_extern,
+        signature_fingerprint: fact.signature_fingerprint,
     }
 }
 
@@ -792,6 +912,121 @@ impl Default for RevisionedQueryDatabase {
                 },
             )
             .expect("the ModuleIndex family has one canonical name");
+        let parse_for_declaration_occurrences = parse_modules.clone();
+        let parse_for_declaration_shells = parse_modules.clone();
+        let declaration_occurrence_indexes = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.declaration-occurrence-index",
+                MODULE_QUERY_MEMO_RETENTION,
+                declaration_occurrence_index_value_equal,
+                move |context, _, key: &ModuleQueryKey| {
+                    let parsed = context
+                        .query_registered(&parse_for_declaration_occurrences, key.clone())?;
+                    let rue_query::QueryOutcome::Success(parsed) = parsed.outcome() else {
+                        unreachable!("ParseModule publishes typed values")
+                    };
+                    let value = match &parsed.result {
+                        Ok(module) => DeclarationOccurrenceIndexValue::Available(Arc::new(
+                            DeclarationOccurrenceIndex {
+                                capabilities: module
+                                    .definitions()
+                                    .declaration_capabilities()
+                                    .iter()
+                                    .cloned()
+                                    .map(|capability| (capability.key().clone(), capability))
+                                    .collect(),
+                            },
+                        )),
+                        Err(_) => DeclarationOccurrenceIndexValue::Failure(
+                            crate::declaration_candidate::DeclarationOccurrenceFailure::ParseRejected {
+                                module: key.0.clone(),
+                            },
+                        ),
+                    };
+                    let kind = if matches!(value, DeclarationOccurrenceIndexValue::Available(_)) {
+                        QueryTerminalKind::Success
+                    } else {
+                        QueryTerminalKind::Failure
+                    };
+                    Ok(QueryOutput::success(value).with_terminal_kind(kind))
+                },
+            )
+            .expect("the DeclarationOccurrenceIndex family has one canonical name");
+        let occurrences_for_shells = declaration_occurrence_indexes.clone();
+        let declaration_shells = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.declaration-shell",
+                DECLARATION_SHELL_MEMO_RETENTION,
+                |left: &DeclarationShellQueryValue, right: &DeclarationShellQueryValue| {
+                    left == right
+                },
+                move |context, _, key: &DeclarationShellQueryKey| {
+                    let indexed = context.query_registered(
+                        &occurrences_for_shells,
+                        ModuleQueryKey(key.0.module.clone()),
+                    )?;
+                    let rue_query::QueryOutcome::Success(indexed) = indexed.outcome() else {
+                        unreachable!("DeclarationOccurrenceIndex publishes typed values")
+                    };
+                    let value = match indexed {
+                        DeclarationOccurrenceIndexValue::Failure(failure) => {
+                            DeclarationShellQueryValue::Failure(
+                                crate::declaration_candidate::DeclarationShellFailure::OccurrencesUnavailable(
+                                    failure.clone(),
+                                ),
+                            )
+                        }
+                        DeclarationOccurrenceIndexValue::Available(index) => {
+                            match index.capabilities.get(&key.0) {
+                                None => DeclarationShellQueryValue::Failure(
+                                    crate::declaration_candidate::DeclarationShellFailure::Absent(
+                                        key.0.clone(),
+                                    ),
+                                ),
+                                Some(crate::declaration_candidate::DeclarationOccurrenceCapability::Ambiguous { .. }) => {
+                                    DeclarationShellQueryValue::Failure(
+                                        crate::declaration_candidate::DeclarationShellFailure::Ambiguous(
+                                            key.0.clone(),
+                                        ),
+                                    )
+                                }
+                                Some(crate::declaration_candidate::DeclarationOccurrenceCapability::Exact { .. }) => {
+                                    let parsed = context.query_registered(
+                                        &parse_for_declaration_shells,
+                                        ModuleQueryKey(key.0.module.clone()),
+                                    )?;
+                                    let rue_query::QueryOutcome::Success(parsed) = parsed.outcome() else {
+                                        unreachable!("ParseModule publishes typed values")
+                                    };
+                                    match &parsed.result {
+                                        Ok(module) => match module
+                                            .definitions()
+                                            .evaluate_declaration_shell(&key.0)
+                                        {
+                                            Ok(fact) => DeclarationShellQueryValue::Available(fact),
+                                            Err(failure) => DeclarationShellQueryValue::Failure(failure),
+                                        },
+                                        Err(_) => DeclarationShellQueryValue::Failure(
+                                            crate::declaration_candidate::DeclarationShellFailure::OccurrencesUnavailable(
+                                                crate::declaration_candidate::DeclarationOccurrenceFailure::ParseRejected {
+                                                    module: key.0.module.clone(),
+                                                },
+                                            ),
+                                        ),
+                                    }
+                                }
+                            }
+                        }
+                    };
+                    let kind = if matches!(value, DeclarationShellQueryValue::Available(_)) {
+                        QueryTerminalKind::Success
+                    } else {
+                        QueryTerminalKind::Failure
+                    };
+                    Ok(QueryOutput::success(value).with_terminal_kind(kind))
+                },
+            )
+            .expect("the DeclarationShell family has one canonical name");
         let index_for_lookup = module_indexes.clone();
         let lookup_names = runtime
             .family_with_evaluator(
@@ -927,6 +1162,8 @@ impl Default for RevisionedQueryDatabase {
             module_store,
             parse_modules,
             module_indexes,
+            declaration_occurrence_indexes,
+            declaration_shells,
             module_rirs,
             resolve_imports,
             lookup_names,
@@ -938,6 +1175,113 @@ impl Default for RevisionedQueryDatabase {
 
 impl RevisionedQueryDatabase {
     pub(crate) const SOURCE_INPUT: &'static str = "selected-source";
+
+    pub(crate) fn current_parse_revision(&self) -> Option<Revision> {
+        let terminal = self.parse.selection.current()?;
+        let rue_query::QueryOutcome::Success(record) = terminal.outcome() else {
+            unreachable!("Parse publishes typed records")
+        };
+        Some(record.runtime_revision())
+    }
+
+    /// Request every query-owned declaration shell for the selected parsed
+    /// program and attach only the current revision's diagnostic locators.
+    pub(crate) fn projected_declaration_shells(
+        &self,
+        revision: Revision,
+        program: &crate::canonical_merge::CanonicalMergedAst,
+        cancellation: CancellationToken,
+    ) -> Result<Vec<rue_air::SemanticDeclarationShell>, DeclarationShellBatchFailure> {
+        let mut shells = Vec::new();
+        let mut index_pins = Vec::new();
+        let mut shell_pins = Vec::new();
+        for module in program.modules() {
+            if cancellation.is_canceled() {
+                return Err(DeclarationShellBatchFailure::Query(QueryAbort::Canceled));
+            }
+            let indexed_attempt = self.runtime.request_registered(
+                &self.declaration_occurrence_indexes,
+                revision,
+                ModuleQueryKey(module.module_id().clone()),
+                cancellation.clone(),
+            );
+            let indexed_terminal = indexed_attempt
+                .into_result()
+                .map_err(DeclarationShellBatchFailure::Query)?;
+            index_pins.push(
+                self.declaration_occurrence_indexes
+                    .pin_terminal(&indexed_terminal)
+                    .expect("occurrence terminal belongs to its family"),
+            );
+            let rue_query::QueryOutcome::Success(indexed) = indexed_terminal.outcome() else {
+                unreachable!("DeclarationOccurrenceIndex publishes typed values")
+            };
+            let index = match indexed {
+                DeclarationOccurrenceIndexValue::Available(index) => index,
+                DeclarationOccurrenceIndexValue::Failure(failure) => {
+                    return Err(DeclarationShellBatchFailure::Stable(
+                        crate::declaration_candidate::DeclarationShellFailure::OccurrencesUnavailable(
+                            failure.clone(),
+                        ),
+                    ));
+                }
+            };
+            for capability in index.capabilities.values() {
+                let key = capability.key();
+                let crate::declaration_candidate::DeclarationOccurrenceCapability::Exact { .. } =
+                    capability
+                else {
+                    return Err(DeclarationShellBatchFailure::Stable(
+                        crate::declaration_candidate::DeclarationShellFailure::Ambiguous(
+                            key.clone(),
+                        ),
+                    ));
+                };
+                if cancellation.is_canceled() {
+                    return Err(DeclarationShellBatchFailure::Query(QueryAbort::Canceled));
+                }
+                let attempt = self.runtime.request_registered(
+                    &self.declaration_shells,
+                    revision,
+                    DeclarationShellQueryKey(key.clone()),
+                    cancellation.clone(),
+                );
+                let terminal = attempt
+                    .into_result()
+                    .map_err(DeclarationShellBatchFailure::Query)?;
+                shell_pins.push(
+                    self.declaration_shells
+                        .pin_terminal(&terminal)
+                        .expect("shell terminal belongs to its family"),
+                );
+                let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+                    unreachable!("DeclarationShell publishes typed values")
+                };
+                let fact = match value {
+                    DeclarationShellQueryValue::Available(fact) => fact,
+                    DeclarationShellQueryValue::Failure(failure) => {
+                        return Err(DeclarationShellBatchFailure::Stable(failure.clone()));
+                    }
+                };
+                let Some(locator) = module.definitions().declaration_locator(&fact.key) else {
+                    return Err(DeclarationShellBatchFailure::Stable(
+                        crate::declaration_candidate::DeclarationShellFailure::ParserCapabilityMismatch(
+                            fact.key.clone(),
+                        ),
+                    ));
+                };
+                shells.push(project_semantic_shell(
+                    fact,
+                    locator.declaration_span,
+                    locator.source_order,
+                ));
+            }
+        }
+        if cancellation.is_canceled() {
+            return Err(DeclarationShellBatchFailure::Query(QueryAbort::Canceled));
+        }
+        Ok(shells)
+    }
 
     pub(crate) fn begin_import_inputs(
         &mut self,
@@ -1609,6 +1953,23 @@ impl RevisionedQueryDatabase {
 }
 
 #[cfg(test)]
+pub(crate) fn projected_declaration_shells_for_test(
+    merged: &crate::canonical_merge::CanonicalMergedProgram,
+) -> Result<Vec<rue_air::SemanticDeclarationShell>, crate::CompileErrors> {
+    let snapshot = merged.definitions().source_snapshot();
+    let mut database = RevisionedQueryDatabase::default();
+    let revision =
+        database.source_revision(&super::session::ExactSourceInput::new(snapshot), snapshot);
+    database
+        .projected_declaration_shells(revision, merged.ast(), CancellationToken::new())
+        .map_err(|failure| {
+            crate::CompileErrors::from(CompileError::without_span(ErrorKind::InternalError(
+                format!("test declaration-shell query failed: {failure:?}"),
+            )))
+        })
+}
+
+#[cfg(test)]
 pub(crate) fn execution(attempt: &QueryRequestAttempt<impl Sized>) -> RequestExecution {
     attempt.execution()
 }
@@ -1641,6 +2002,244 @@ mod tests {
                 .collect(),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn declaration_shell_queries_are_keyed_exact_and_payload_stable() {
+        let first = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "struct Box { fn get(self) -> i32 { 1 } } const item = 1; fn main() {}",
+            )],
+            1,
+        );
+        let edited = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "// shifted file\nstruct Box { fn // comment-only signature trivia\n get(self) -> i32 { 999 } } const item = @import(\"x.rue\"); // shifted again\n fn main() { let x = 2; }",
+            )],
+            1,
+        );
+        let main = ModuleId::from_logical_path("main.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let first_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&first),
+            &first,
+        );
+        let indexed = database.runtime.request_registered(
+            &database.declaration_occurrence_indexes,
+            first_revision,
+            ModuleQueryKey(main.clone()),
+            CancellationToken::new(),
+        );
+        assert_eq!(execution(&indexed), RequestExecution::Computed);
+        assert_eq!(indexed.dependencies().len(), 1);
+        let terminal = indexed.terminal().unwrap();
+        let rue_query::QueryOutcome::Success(indexed_value) = terminal.outcome() else {
+            unreachable!()
+        };
+        let DeclarationOccurrenceIndexValue::Available(indexed_value) = indexed_value else {
+            panic!("expected available occurrence index")
+        };
+        let keys = indexed_value
+            .capabilities
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(keys.len(), 4);
+        let mut shell_stamps = BTreeMap::new();
+        for key in &keys {
+            let first = database.runtime.request_registered(
+                &database.declaration_shells,
+                first_revision,
+                DeclarationShellQueryKey(key.clone()),
+                CancellationToken::new(),
+            );
+            assert_eq!(execution(&first), RequestExecution::Computed);
+            shell_stamps.insert(key.stable_identity(), first.terminal().unwrap().stamp());
+            assert_eq!(
+                first
+                    .dependencies()
+                    .iter()
+                    .map(|dependency| dependency.node.family())
+                    .collect::<Vec<_>>(),
+                vec![
+                    "compiler.declaration-occurrence-index",
+                    "compiler.parse-module"
+                ]
+            );
+            let warm = database.runtime.request_registered(
+                &database.declaration_shells,
+                first_revision,
+                DeclarationShellQueryKey(key.clone()),
+                CancellationToken::new(),
+            );
+            assert_eq!(execution(&warm), RequestExecution::Reused);
+        }
+
+        let edited_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&edited),
+            &edited,
+        );
+        let edited_index = database.runtime.request_registered(
+            &database.declaration_occurrence_indexes,
+            edited_revision,
+            ModuleQueryKey(main),
+            CancellationToken::new(),
+        );
+        let rue_query::QueryOutcome::Success(edited_value) =
+            edited_index.terminal().unwrap().outcome()
+        else {
+            unreachable!()
+        };
+        let DeclarationOccurrenceIndexValue::Available(edited_value) = edited_value else {
+            panic!("expected available edited occurrence index")
+        };
+        assert_eq!(&indexed_value.capabilities, &edited_value.capabilities);
+        for key in &keys {
+            let revalidated = database.runtime.request_registered(
+                &database.declaration_shells,
+                edited_revision,
+                DeclarationShellQueryKey(key.clone()),
+                CancellationToken::new(),
+            );
+            let terminal = revalidated.terminal().unwrap();
+            assert_eq!(
+                terminal.stamp(),
+                shell_stamps[&key.stable_identity()],
+                "payload-only edits must preserve the shell publication stamp"
+            );
+        }
+    }
+
+    #[test]
+    fn canceled_declaration_shell_request_publishes_no_terminal_and_recovers() {
+        let source = source_snapshot(&[(1, "/main.rue", "main.rue", "fn main() {}")], 1);
+        let main = ModuleId::from_logical_path("main.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+        let indexed = database.runtime.request_registered(
+            &database.declaration_occurrence_indexes,
+            revision,
+            ModuleQueryKey(main),
+            CancellationToken::new(),
+        );
+        let rue_query::QueryOutcome::Success(indexed) = indexed.terminal().unwrap().outcome()
+        else {
+            unreachable!()
+        };
+        let DeclarationOccurrenceIndexValue::Available(indexed) = indexed else {
+            panic!("expected available occurrence index")
+        };
+        let key = indexed.capabilities.keys().next().unwrap().clone();
+        let canceled = CancellationToken::new();
+        canceled.cancel();
+        let aborted = database.runtime.request_registered(
+            &database.declaration_shells,
+            revision,
+            DeclarationShellQueryKey(key.clone()),
+            canceled,
+        );
+        assert_eq!(execution(&aborted), RequestExecution::Aborted);
+        assert!(aborted.terminal().is_none());
+        let recovered = database.runtime.request_registered(
+            &database.declaration_shells,
+            revision,
+            DeclarationShellQueryKey(key),
+            CancellationToken::new(),
+        );
+        assert_eq!(execution(&recovered), RequestExecution::Computed);
+        assert!(recovered.terminal().is_some());
+    }
+
+    #[test]
+    fn absent_declaration_shell_is_a_typed_position_free_failure_terminal() {
+        let source = source_snapshot(&[(1, "/main.rue", "main.rue", "fn main() {}")], 1);
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+        let key = crate::declaration_candidate::DeclarationCandidateKey {
+            module,
+            category: crate::declaration_candidate::DeclarationCandidateCategory::Function,
+            name: Arc::from("missing"),
+            owner: None,
+            duplicate_discriminator: 0,
+        };
+        let requested = database.runtime.request_registered(
+            &database.declaration_shells,
+            revision,
+            DeclarationShellQueryKey(key.clone()),
+            CancellationToken::new(),
+        );
+        let terminal = requested.terminal().unwrap();
+        assert_eq!(terminal.kind(), QueryTerminalKind::Failure);
+        assert!(terminal.diagnostics().is_empty());
+        assert!(matches!(
+            terminal.outcome(),
+            rue_query::QueryOutcome::Success(DeclarationShellQueryValue::Failure(
+                crate::declaration_candidate::DeclarationShellFailure::Absent(absent)
+            )) if absent == &key
+        ));
+    }
+
+    #[test]
+    fn declaration_shell_batches_over_64_entries_reuse_without_thrashing() {
+        let source_text = (0..129)
+            .map(|index| format!("fn f{index}() {{}}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let source = source_snapshot(&[(1, "/main.rue", "main.rue", source_text.as_str())], 1);
+        let main = ModuleId::from_logical_path("main.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+        let indexed = database.runtime.request_registered(
+            &database.declaration_occurrence_indexes,
+            revision,
+            ModuleQueryKey(main),
+            CancellationToken::new(),
+        );
+        let rue_query::QueryOutcome::Success(indexed) = indexed.terminal().unwrap().outcome()
+        else {
+            unreachable!()
+        };
+        let DeclarationOccurrenceIndexValue::Available(indexed) = indexed else {
+            panic!("expected available occurrence index")
+        };
+        let keys = indexed.capabilities.keys().cloned().collect::<Vec<_>>();
+        let mut first_stamps = Vec::with_capacity(keys.len());
+        for key in &keys {
+            let requested = database.runtime.request_registered(
+                &database.declaration_shells,
+                revision,
+                DeclarationShellQueryKey(key.clone()),
+                CancellationToken::new(),
+            );
+            assert_eq!(execution(&requested), RequestExecution::Computed);
+            first_stamps.push(requested.terminal().unwrap().stamp());
+        }
+        for (key, first_stamp) in keys.iter().zip(first_stamps) {
+            let warm = database.runtime.request_registered(
+                &database.declaration_shells,
+                revision,
+                DeclarationShellQueryKey(key.clone()),
+                CancellationToken::new(),
+            );
+            assert_eq!(execution(&warm), RequestExecution::Reused);
+            assert_eq!(warm.terminal().unwrap().stamp(), first_stamp);
+        }
     }
 
     #[test]

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -16,11 +16,10 @@ use crate::{
     ErrorKind, ModuleResolutionInputs, ParseInvalidationSummary, ParsedModulesWork,
     SemanticInputDescriptor, SourceRevision, SourceSnapshot, StableDefinitionKey,
     StableDefinitionKind, StableDefinitionNamespace, StableOptLevel, StablePreviewFeatures,
-    bound_definitions::bind_canonical_definitions_with_work,
     canonical_lower::project_module_rirs_with_work,
     canonical_merge::merge_parsed_modules_reusing_indexes,
     canonical_semantic::{
-        analyze_prepared_canonical_program_reusing_declarations,
+        CanonicalSemanticFailure, analyze_prepared_canonical_program_reusing_declarations,
         analyze_prepared_canonical_program_with_durable_export, prepare_canonical_declarations,
     },
     parsed_modules::{ParsedProgram, classify_invalidation},
@@ -1703,7 +1702,9 @@ pub struct CompilerSession {
     #[cfg(test)]
     cancel_merge_before_commit: bool,
     #[cfg(test)]
-    cancel_semantic_after_first_mutation: bool,
+    cancel_semantic_after_dependency: bool,
+    #[cfg(test)]
+    cancel_semantic_before_publication: bool,
     published: Option<Arc<ParsedProgram>>,
     published_snapshot: Option<SourceSnapshot>,
     batch_diagnostic_order: Option<Vec<crate::ModuleId>>,
@@ -1716,6 +1717,18 @@ pub struct CompilerSession {
     last_successful_body_cache: Option<DurableOrdinaryBodyCache>,
     #[cfg(test)]
     last_successful_cfg_cache: Option<Arc<[crate::queries::DurableCfgArtifact]>>,
+}
+
+#[derive(Debug)]
+enum SemanticRequestControl {
+    Compile(CompileErrors),
+    Abort(rue_query::QueryAbort),
+}
+
+impl From<CompileErrors> for SemanticRequestControl {
+    fn from(errors: CompileErrors) -> Self {
+        Self::Compile(errors)
+    }
 }
 
 /// The single typed frontend query database owned by `CompilerSession`.
@@ -1874,6 +1887,12 @@ pub(crate) struct ParseQueryRecord {
     diagnostics: Arc<FrontendDiagnosticSnapshot>,
     work: ParsedModulesWork,
     invalidation: ParseInvalidationSummary,
+}
+
+impl ParseQueryRecord {
+    pub(crate) fn runtime_revision(&self) -> rue_query::Revision {
+        self.runtime_revision
+    }
 }
 
 #[derive(Debug)]
@@ -2552,9 +2571,9 @@ impl ExactSourceInput {
 
 fn compute_stable_definitions(
     merged: &CanonicalMergedProgram,
-    rir: &CanonicalRirOutput,
     options: &CompileOptions,
     imports: &CanonicalImportGraph,
+    semantic: &CanonicalSemanticOutput,
 ) -> DefinitionComputation {
     let provenance = DefinitionQueryKey {
         input: SemanticInputDescriptor::new(
@@ -2564,26 +2583,18 @@ fn compute_stable_definitions(
         ),
         imports: imports.clone(),
     };
-    let query = bind_canonical_definitions_with_work(
-        merged,
-        rir,
-        options.preview_features.clone(),
-        options.target,
-        imports,
-    );
-    let (result, binding, manifest, issuance) = match query {
-        Ok((definitions, binding)) => {
-            let manifest = definitions.manifest_work();
-            let issuance = definitions.work();
-            (Ok(Arc::new(definitions)), binding, manifest, issuance)
-        }
-        Err(errors) => (
-            Err(errors),
-            DeclarationBindingWork::default(),
-            SemanticBindingManifestWork::default(),
-            BoundDefinitionWork::default(),
-        ),
-    };
+    // A semantic terminal normally belongs to this exact source descriptor.
+    // Re-stamp the projection at this query boundary so typed fault injection
+    // remains a detectable stale value rather than publishing an internally
+    // inconsistent definition terminal.
+    let definitions = semantic
+        .body_owner_issuer()
+        .projected_for_source_revision(merged.ast().source_revision());
+    let work = semantic.work();
+    let binding = work.binding;
+    let manifest = work.manifest;
+    let issuance = definitions.work();
+    let result = Ok(Arc::new(definitions));
     DefinitionComputation {
         output: DefinitionQueryOutput { provenance, result },
         binding,
@@ -4756,6 +4767,22 @@ impl CompilerSession {
         &mut self,
         options: &CompileOptions,
     ) -> Result<Arc<CanonicalSemanticOutput>, CompileErrors> {
+        match self
+            .canonical_semantic_with_cancellation(options, rue_query::CancellationToken::new())
+        {
+            Ok(output) => Ok(output),
+            Err(SemanticRequestControl::Compile(errors)) => Err(errors),
+            Err(SemanticRequestControl::Abort(abort)) => {
+                panic!("uncanceled semantic request aborted: {abort:?}")
+            }
+        }
+    }
+
+    fn canonical_semantic_with_cancellation(
+        &mut self,
+        options: &CompileOptions,
+        cancellation: rue_query::CancellationToken,
+    ) -> Result<Arc<CanonicalSemanticOutput>, SemanticRequestControl> {
         let mut guard = self.metrics.begin::<SemanticQuery>();
         let attempt_id = guard.id;
         let mut execution = QueryAttemptExecution::Rejected;
@@ -4764,6 +4791,7 @@ impl CompilerSession {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             self.semantic_attempt(
                 options,
+                &cancellation,
                 attempt_id,
                 &mut guard,
                 &mut execution,
@@ -4775,27 +4803,27 @@ impl CompilerSession {
             Ok(result) => result,
             Err(payload) => self.resume_canceled_query(&mut guard, payload),
         };
+        if matches!(result, Err(SemanticRequestControl::Abort(_))) {
+            guard.request_cancel();
+        }
         let structural = attempt_record
             .clone()
             .map(Box::new)
             .map(QueryStructuralWork::Semantic)
             .unwrap_or(QueryStructuralWork::None);
         if guard.cancel_requested {
-            let key = self
-                .queries
-                .semantic
-                .computing_key()
-                .expect("canceled semantic query retains its computing key");
-            let attempt = self.queries.semantic.record_aborted_attempt(
-                &mut self.queries.graph,
-                key,
-                attempt_id.0,
-                AbortedQueryReason::Canceled,
-                structural.clone(),
-                guard.dependencies.clone(),
-                guard.diagnostics.clone(),
-            );
-            guard.bind(attempt);
+            if let Some(key) = self.queries.semantic.computing_key() {
+                let attempt = self.queries.semantic.record_aborted_attempt(
+                    &mut self.queries.graph,
+                    key,
+                    attempt_id.0,
+                    AbortedQueryReason::Canceled,
+                    structural.clone(),
+                    guard.dependencies.clone(),
+                    guard.diagnostics.clone(),
+                );
+                guard.bind(attempt);
+            }
         }
         guard.finish(execution, origin, &result, structural);
         self.metrics.publish_semantic(self.queries.semantic.len());
@@ -4806,16 +4834,27 @@ impl CompilerSession {
     fn semantic_attempt(
         &mut self,
         options: &CompileOptions,
+        cancellation: &rue_query::CancellationToken,
         attempt_id: AttemptId,
         guard: &mut QueryComputationGuard,
         execution: &mut QueryAttemptExecution,
         origin: &mut Option<AttemptId>,
         attempt_record: &mut Option<SemanticQueryRecord>,
-    ) -> Result<Arc<CanonicalSemanticOutput>, CompileErrors> {
+    ) -> Result<Arc<CanonicalSemanticOutput>, SemanticRequestControl> {
+        if cancellation.is_canceled() {
+            return Err(SemanticRequestControl::Abort(
+                rue_query::QueryAbort::Canceled,
+            ));
+        }
         self.require_successful_import_diagnostics()?;
         let imports = self.accepted_semantic_import_graph()?;
         self.queries.publish_import_graph(imports.clone());
         self.queries.publish_request_inputs(options);
+        if cancellation.is_canceled() {
+            return Err(SemanticRequestControl::Abort(
+                rue_query::QueryAbort::Canceled,
+            ));
+        }
         let source = self
             .published_snapshot
             .clone()
@@ -4856,7 +4895,12 @@ impl CompilerSession {
                 self.durable_declaration_cache = entry.durable_declaration_cache.clone();
             }
             self.reuse_diagnostics(entry.diagnostics.clone());
-            return result;
+            if cancellation.is_canceled() {
+                return Err(SemanticRequestControl::Abort(
+                    rue_query::QueryAbort::Canceled,
+                ));
+            }
+            return result.map_err(SemanticRequestControl::Compile);
         }
         let durable_baseline = self.queries.semantic.last_good_record().cloned();
         let previous_body_cache = durable_baseline
@@ -4885,7 +4929,13 @@ impl CompilerSession {
             .clone()
             .unwrap_or(previous_cfg_cache);
 
-        let rir = match self.canonical_rir() {
+        let rir_result = self.canonical_rir();
+        if cancellation.is_canceled() {
+            return Err(SemanticRequestControl::Abort(
+                rue_query::QueryAbort::Canceled,
+            ));
+        }
+        let rir = match rir_result {
             Ok(rir) => rir,
             Err(errors) => {
                 let record = SemanticQueryRecord {
@@ -4936,7 +4986,7 @@ impl CompilerSession {
                 self.diagnostics.select(handle.as_view());
                 guard.bind(handle.as_view());
                 self.refresh_retention_metrics();
-                return Err(errors);
+                return Err(SemanticRequestControl::Compile(errors));
             }
         };
         let merged = self
@@ -4945,22 +4995,71 @@ impl CompilerSession {
             .selected_record(&self.queries.graph)
             .and_then(|entry| entry.merged.clone())
             .expect("successful RIR terminal retains its exact merge input");
+        #[cfg(test)]
+        if std::mem::take(&mut self.cancel_semantic_after_dependency) {
+            cancellation.cancel();
+        }
+        if cancellation.is_canceled() {
+            return Err(SemanticRequestControl::Abort(
+                rue_query::QueryAbort::Canceled,
+            ));
+        }
         *execution = QueryAttemptExecution::Computed;
         guard.started();
-        let mut prepared = prepare_canonical_declarations(&merged, &rir, options, &imports);
+        let runtime_revision = self
+            .queries
+            .revisioned
+            .current_parse_revision()
+            .expect("semantic preparation observes the selected parse revision");
+        let query_shells = self.queries.revisioned.projected_declaration_shells(
+            runtime_revision,
+            merged.ast(),
+            cancellation.clone(),
+        );
+        let (mut prepared, query_shells) = match query_shells {
+            Ok(query_shells) => (
+                prepare_canonical_declarations(&merged, &rir, options, &imports, &query_shells),
+                Some(query_shells),
+            ),
+            Err(crate::revisioned_query_database::DeclarationShellBatchFailure::Query(abort)) => {
+                return Err(SemanticRequestControl::Abort(abort));
+            }
+            Err(crate::revisioned_query_database::DeclarationShellBatchFailure::Stable(
+                failure,
+            )) => (
+                Err(CanonicalSemanticFailure::declaration(
+                    declaration_shell_failure_diagnostics(merged.ast(), &failure),
+                    CanonicalSemanticWork::default(),
+                )),
+                None,
+            ),
+        };
         let current_fingerprints: Result<Vec<StableDefinitionInputFingerprint>, CompileErrors> =
             match &prepared {
-                Ok(definitions) => definitions
-                    .definitions()
-                    .definitions()
-                    .iter()
-                    .map(|record| {
-                        stable_definition_input_fingerprint(
+                Ok(definitions) => (|| {
+                    let mut fingerprints = definitions
+                        .definitions()
+                        .definitions()
+                        .iter()
+                        .map(|record| {
+                            stable_definition_input_fingerprint(
+                                merged.definitions().source_snapshot(),
+                                record,
+                            )
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    if let (Some(cache), Some(query_shells)) =
+                        (&previous_declaration_cache, query_shells.as_deref())
+                    {
+                        fingerprints.extend(stable_const_candidate_input_fingerprints(
                             merged.definitions().source_snapshot(),
-                            record,
-                        )
-                    })
-                    .collect(),
+                            merged.ast(),
+                            query_shells,
+                            &cache.fingerprints,
+                        )?);
+                    }
+                    Ok(fingerprints)
+                })(),
                 Err(failure) => Err(failure.errors.clone()),
             };
         let mut durable_body_work = crate::DurableBodyWork::default();
@@ -5137,6 +5236,15 @@ impl CompilerSession {
                 })
             }
         });
+        #[cfg(test)]
+        if std::mem::take(&mut self.cancel_semantic_before_publication) {
+            cancellation.cancel();
+        }
+        if cancellation.is_canceled() {
+            return Err(SemanticRequestControl::Abort(
+                rue_query::QueryAbort::Canceled,
+            ));
+        }
         let failure = analysis.as_ref().err().map(|failure| failure.failure);
         let semantic_work = analysis
             .as_ref()
@@ -5156,15 +5264,6 @@ impl CompilerSession {
         let mut published_cfg_cache = None;
         if let Ok(output) = &result {
             published_cfg_cache = Some(output.durable_cfgs().clone());
-            #[cfg(test)]
-            if std::mem::take(&mut self.cancel_semantic_after_first_mutation) {
-                guard.request_cancel();
-                return Err(CompileErrors::from(CompileError::without_span(
-                    ErrorKind::InvalidCompilerInput(
-                        "semantic query canceled after first publication mutation".into(),
-                    ),
-                )));
-            }
             debug_assert_eq!(output.input(), &input);
             debug_assert_eq!(semantic_work.binding.bind_invocations, 1);
             debug_assert_eq!(semantic_work.manifest.build_invocations, 1);
@@ -5176,17 +5275,11 @@ impl CompilerSession {
             // and merely advance its exact provenance below.
             if reuse.ordinary_declaration_resolutions_skipped == 0 {
                 if let Some((definitions, semantics)) = cold_durable {
-                    if let Ok(fingerprints) = definitions
-                        .definitions()
-                        .iter()
-                        .map(|record| {
-                            stable_definition_input_fingerprint(
-                                merged.definitions().source_snapshot(),
-                                record,
-                            )
-                        })
-                        .collect::<Result<Vec<_>, _>>()
-                    {
+                    if let Ok(fingerprints) = stable_definition_input_fingerprints(
+                        merged.definitions().source_snapshot(),
+                        definitions.definitions(),
+                        query_shells.as_deref().unwrap_or(&[]),
+                    ) {
                         published_declaration_cache = Some(DurableDeclarationCache {
                             schema_version: crate::DURABLE_SEMANTIC_SCHEMA_VERSION,
                             root: merged.ast().root().clone(),
@@ -5303,15 +5396,14 @@ impl CompilerSession {
         self.diagnostics.select(handle.as_view());
         guard.bind(handle.as_view());
         self.refresh_retention_metrics();
-        result
+        result.map_err(SemanticRequestControl::Compile)
     }
 
     /// Issue stable definition IDs on demand for the current semantic input.
     ///
-    /// Ordinary analysis consumes `BoundSema` without building its optional
-    /// manifest. Retaining that mutable, RIR-borrowing value would duplicate
-    /// substantial semantic state, so this query performs one explicit second
-    /// declaration bind after reusing a successful ordinary body analysis.
+    /// The authoritative semantic terminal already owns the final,
+    /// post-classification definition universe. This projection never starts a
+    /// peer declaration bind or reconstructs stable IDs from shells.
     pub(crate) fn stable_definitions(
         &mut self,
         options: &CompileOptions,
@@ -5428,91 +5520,66 @@ impl CompilerSession {
             .and_then(|entry| entry.merged.clone())
             .expect("successful RIR terminal retains its exact merge input");
 
-        // Body validity is independent of opt/linker. Reuse any ordinary
-        // semantic result with the same binding inputs before doing ID work.
         let semantic_binding_key = SemanticBindingLookupKey {
             input: input.clone(),
             imports: imports.clone(),
         };
-        let semantic_terminal = self
+        let cached_semantic = self
             .queries
             .semantic
             .get_secondary_with_handle(&semantic_binding_key)
-            .map(|(entry, handle)| (handle, entry.result.clone()));
-        if let Some((handle, validation)) = semantic_terminal
-            && handle.is_valid(&mut self.queries.graph)
-        {
-            if let Err(errors) = validation {
-                let record = DefinitionQueryRecord {
-                    input: input.clone(),
-                    binding: DeclarationBindingWork::default(),
-                    manifest: SemanticBindingManifestWork::default(),
-                    issuance: BoundDefinitionWork::default(),
-                    failed: true,
-                };
-                guard.accrue(QueryStructuralWork::Definition(Box::new(record.clone())));
-                *attempt_record = Some(record);
-                let terminal = self
-                    .queries
-                    .definitions
-                    .publish_selected_attempt(
-                        &mut self.queries.graph,
-                        DefinitionCacheEntry {
-                            key: key.clone(),
-                            output: DefinitionQueryOutput {
-                                provenance: key,
-                                result: Err(errors.clone()),
+            .and_then(|(entry, handle)| {
+                handle
+                    .is_valid(&mut self.queries.graph)
+                    .then(|| entry.result.clone())
+            })
+            .and_then(Result::ok);
+        let semantic = match cached_semantic {
+            Some(semantic) => semantic,
+            None => match self.canonical_semantic(options) {
+                Ok(semantic) => semantic,
+                Err(errors) => {
+                    let dependency = self
+                        .queries
+                        .semantic
+                        .selected_handle(&self.queries.graph)
+                        .expect("definition rejection observes a deterministic semantic failure")
+                        .observed();
+                    let record = DefinitionQueryRecord {
+                        input: input.clone(),
+                        binding: DeclarationBindingWork::default(),
+                        manifest: SemanticBindingManifestWork::default(),
+                        issuance: BoundDefinitionWork::default(),
+                        failed: true,
+                    };
+                    guard.accrue(QueryStructuralWork::Definition(Box::new(record.clone())));
+                    *attempt_record = Some(record);
+                    let handle = self
+                        .queries
+                        .definitions
+                        .publish_selected_attempt(
+                            &mut self.queries.graph,
+                            DefinitionCacheEntry {
+                                key: key.clone(),
+                                output: DefinitionQueryOutput {
+                                    provenance: key,
+                                    result: Err(errors.clone()),
+                                },
                             },
-                        },
-                        [handle.observed()],
-                        guard.structural(),
-                        *execution,
-                    )
-                    .unwrap_or_else(query_control_error);
-                guard.bind(terminal.as_view());
-                self.refresh_retention_metrics();
-                return Err(errors);
-            }
-        } else if let Err(errors) = self.canonical_semantic(options) {
-            let dependency = self
-                .queries
-                .semantic
-                .selected_handle(&self.queries.graph)
-                .expect("definition rejection observes a deterministic semantic failure")
-                .observed();
-            let record = DefinitionQueryRecord {
-                input: input.clone(),
-                binding: DeclarationBindingWork::default(),
-                manifest: SemanticBindingManifestWork::default(),
-                issuance: BoundDefinitionWork::default(),
-                failed: true,
-            };
-            guard.accrue(QueryStructuralWork::Definition(Box::new(record.clone())));
-            *attempt_record = Some(record);
-            let handle = self
-                .queries
-                .definitions
-                .publish_selected_attempt(
-                    &mut self.queries.graph,
-                    DefinitionCacheEntry {
-                        key: key.clone(),
-                        output: DefinitionQueryOutput {
-                            provenance: key,
-                            result: Err(errors.clone()),
-                        },
-                    },
-                    [dependency],
-                    guard.structural(),
-                    *execution,
-                )
-                .unwrap_or_else(query_control_error);
-            guard.bind(handle.as_view());
-            self.refresh_retention_metrics();
-            return Err(errors);
-        }
+                            [dependency],
+                            guard.structural(),
+                            *execution,
+                        )
+                        .unwrap_or_else(query_control_error);
+                    guard.bind(handle.as_view());
+                    self.refresh_retention_metrics();
+                    return Err(errors);
+                }
+            },
+        };
         *execution = QueryAttemptExecution::Computed;
         guard.started();
-        let computation = compute_stable_definitions(&merged, &rir, options, &imports);
+        let computation = compute_stable_definitions(&merged, options, &imports, &semantic);
         let result = computation.output.result.clone();
         let record = DefinitionQueryRecord {
             input,
@@ -6898,9 +6965,49 @@ const DEFINITION_DECLARATION_DOMAIN_V2: &[u8] = b"rue.definition.declaration\0v2
 const DEFINITION_SIGNATURE_DOMAIN_V2: &[u8] = b"rue.definition.signature\0v2\0sha256\0";
 const DEFINITION_BODY_DOMAIN_V2: &[u8] = b"rue.definition.body-or-initializer\0v2\0sha256\0";
 
+fn declaration_shell_failure_diagnostics(
+    program: &crate::canonical_merge::CanonicalMergedAst,
+    failure: &crate::declaration_candidate::DeclarationShellFailure,
+) -> CompileErrors {
+    use crate::declaration_candidate::DeclarationShellFailure as F;
+    let key = match failure {
+        F::Absent(key) | F::Ambiguous(key) | F::ParserCapabilityMismatch(key) => Some(key),
+        F::OccurrencesUnavailable(_) => None,
+    };
+    let span = key.and_then(|key| {
+        program
+            .modules()
+            .iter()
+            .find(|module| module.module_id() == &key.module)
+            .and_then(|module| module.definitions().declaration_locator(key))
+            .map(|locator| locator.declaration_span)
+    });
+    let kind = ErrorKind::InternalError(format!(
+        "query-owned declaration shell failed stable validation: {failure:?}"
+    ));
+    CompileErrors::from(match span {
+        Some(span) => CompileError::new(kind, span),
+        None => CompileError::without_span(kind),
+    })
+}
+
 pub(crate) fn stable_definition_input_fingerprint(
     snapshot: &SourceSnapshot,
     record: &crate::BoundDefinitionRecord,
+) -> Result<StableDefinitionInputFingerprint, CompileErrors> {
+    stable_definition_input_fingerprint_parts(
+        snapshot,
+        record.stable_key(),
+        record.visibility(),
+        record.input_partition(),
+    )
+}
+
+fn stable_definition_input_fingerprint_parts(
+    snapshot: &SourceSnapshot,
+    key: &StableDefinitionKey,
+    visibility: Option<rue_parser::ast::Visibility>,
+    partition: crate::bound_definitions::BoundDefinitionInputPartition,
 ) -> Result<StableDefinitionInputFingerprint, CompileErrors> {
     let source_fragment = |span: Span| -> Result<&str, CompileErrors> {
         let source = snapshot.source_text(span.file_id).ok_or_else(|| {
@@ -6922,13 +7029,13 @@ pub(crate) fn stable_definition_input_fingerprint(
     };
 
     let mut declaration = FramedDefinitionHasher::new(DEFINITION_DECLARATION_DOMAIN_V2);
-    hash_stable_definition_key(&mut declaration, record.stable_key());
-    declaration.frame(&[match record.visibility() {
+    hash_stable_definition_key(&mut declaration, key);
+    declaration.frame(&[match visibility {
         None => 0,
         Some(rue_parser::ast::Visibility::Private) => 1,
         Some(rue_parser::ast::Visibility::Public) => 2,
     }]);
-    let (signature_spans, payload_span, precision) = match record.input_partition() {
+    let (signature_spans, payload_span, precision) = match partition {
         crate::bound_definitions::BoundDefinitionInputPartition::Body { signature, body } => (
             vec![signature],
             Some(body),
@@ -6961,12 +7068,131 @@ pub(crate) fn stable_definition_input_fingerprint(
         .transpose()?;
     Ok(StableDefinitionInputFingerprint {
         schema_version: DEFINITION_FINGERPRINT_SCHEMA_V2,
-        key: record.stable_key().clone(),
+        key: key.clone(),
         declaration: declaration.finish(),
         signature: signature.finish(),
         body_or_initializer,
         precision,
     })
+}
+
+fn stable_const_candidate_input_fingerprints(
+    snapshot: &SourceSnapshot,
+    merged: &crate::canonical_merge::CanonicalMergedAst,
+    shells: &[rue_air::SemanticDeclarationShell],
+    previous: &[StableDefinitionInputFingerprint],
+) -> Result<Vec<StableDefinitionInputFingerprint>, CompileErrors> {
+    type Input<'a> = (&'a rue_air::SemanticDeclarationShell, Span);
+    let mut shell_by_name = BTreeMap::new();
+    for shell in shells.iter().filter(|shell| {
+        shell.identity.kind == StableDefinitionKind::ValueConst && shell.identity.owner.is_none()
+    }) {
+        let key = (
+            shell.identity.module_path.clone(),
+            shell.identity.name.clone(),
+        );
+        if shell_by_name.insert(key.clone(), Some(shell)).is_some() {
+            shell_by_name.insert(key, None);
+        }
+    }
+
+    let mut inputs = BTreeMap::<(crate::ModuleId, Arc<str>), Option<Input<'_>>>::new();
+    for module in merged.modules() {
+        for item in &module.ast().items {
+            let rue_parser::ast::Item::Const(value) = item else {
+                continue;
+            };
+            let name: Arc<str> = Arc::from(module.resolve_raw_symbol(value.name.name));
+            let Some(Some(shell)) =
+                shell_by_name.get(&(Arc::from(module.module_id().as_str()), name.clone()))
+            else {
+                continue;
+            };
+            let key = (module.module_id().clone(), name);
+            let input =
+                (value.span == shell.declaration_span).then_some((*shell, value.init.span()));
+            if inputs.insert(key.clone(), input).is_some() {
+                inputs.insert(key, None);
+            }
+        }
+    }
+
+    let mut fingerprints = Vec::new();
+    for previous in previous
+        .iter()
+        .filter(|fingerprint| fingerprint.key.kind() == StableDefinitionKind::ModuleBinding)
+    {
+        let lookup = (
+            previous.key.module().clone(),
+            Arc::from(previous.key.name()),
+        );
+        let Some(Some((shell, initializer))) = inputs.get(&lookup).copied() else {
+            continue;
+        };
+        let declaration = shell.declaration_span;
+        if initializer.file_id != declaration.file_id
+            || initializer.start < declaration.start
+            || initializer.end > declaration.end
+            || initializer.start >= initializer.end
+        {
+            return Err(invalid_dependency_manifest(
+                "const-candidate fingerprint has an invalid initializer locator",
+            ));
+        }
+        let signature = Span::with_file(declaration.file_id, declaration.start, initializer.start);
+        let mut fingerprint = stable_definition_input_fingerprint_parts(
+            snapshot,
+            &previous.key,
+            Some(if shell.is_public {
+                rue_parser::ast::Visibility::Public
+            } else {
+                rue_parser::ast::Visibility::Private
+            }),
+            crate::bound_definitions::BoundDefinitionInputPartition::Initializer {
+                signature,
+                initializer,
+            },
+        )?;
+        fingerprint.signature = StableDefinitionFingerprint(shell.signature_fingerprint);
+        fingerprints.push(fingerprint);
+    }
+    Ok(fingerprints)
+}
+
+fn stable_definition_input_fingerprints(
+    snapshot: &SourceSnapshot,
+    records: &[crate::BoundDefinitionRecord],
+    shells: &[rue_air::SemanticDeclarationShell],
+) -> Result<Vec<StableDefinitionInputFingerprint>, CompileErrors> {
+    let const_signatures = shells
+        .iter()
+        .filter(|shell| shell.identity.kind == StableDefinitionKind::ValueConst)
+        .map(|shell| {
+            (
+                (
+                    shell.identity.module_path.clone(),
+                    shell.identity.name.clone(),
+                ),
+                shell.signature_fingerprint,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    records
+        .iter()
+        .map(|record| {
+            let mut fingerprint = stable_definition_input_fingerprint(snapshot, record)?;
+            if matches!(
+                record.stable_key().kind(),
+                StableDefinitionKind::ValueConst | StableDefinitionKind::ModuleBinding
+            ) && let Some(signature) = const_signatures.get(&(
+                Arc::from(record.stable_key().module().as_str()),
+                Arc::from(record.stable_key().name()),
+            )) {
+                fingerprint.signature = StableDefinitionFingerprint(*signature);
+            }
+            Ok(fingerprint)
+        })
+        .collect()
 }
 
 fn declaration_surfaces_match(
@@ -8427,9 +8653,13 @@ impl CompilerSession {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
+    };
 
     use rue_span::FileId;
+    use sha2::{Digest, Sha256};
 
     use super::*;
     use crate::{
@@ -8672,6 +8902,41 @@ mod tests {
     }
 
     #[test]
+    fn semantic_cancellation_is_control_flow_before_work_and_after_dependencies() {
+        let source = base();
+        let options = CompileOptions::default();
+
+        let mut prework = CompilerSession::new();
+        prework.update(&source).into_result().unwrap();
+        let canceled = rue_query::CancellationToken::new();
+        canceled.cancel();
+        assert!(matches!(
+            prework.canonical_semantic_with_cancellation(&options, canceled),
+            Err(SemanticRequestControl::Abort(
+                rue_query::QueryAbort::Canceled
+            ))
+        ));
+        assert_eq!(prework.queries.semantic.len(), 0);
+        prework.canonical_semantic(&options).unwrap();
+
+        let mut after_dependency = CompilerSession::new();
+        after_dependency.update(&source).into_result().unwrap();
+        after_dependency.cancel_semantic_after_dependency = true;
+        assert!(matches!(
+            after_dependency.canonical_semantic_with_cancellation(
+                &options,
+                rue_query::CancellationToken::new(),
+            ),
+            Err(SemanticRequestControl::Abort(
+                rue_query::QueryAbort::Canceled
+            ))
+        ));
+        assert_eq!(after_dependency.queries.semantic.len(), 0);
+        assert_eq!(after_dependency.queries.rir.len(), 1);
+        after_dependency.canonical_semantic(&options).unwrap();
+    }
+
+    #[test]
     fn semantic_cancellation_preserves_completed_dependencies_and_last_good() {
         let mut session = CompilerSession::new();
         session.update(&base()).into_result().unwrap();
@@ -8704,8 +8969,14 @@ mod tests {
 
         let mut variant = default.clone();
         variant.opt_level = OptLevel::O1;
-        session.cancel_semantic_after_first_mutation = true;
-        assert!(session.canonical_semantic(&variant).is_err());
+        session.cancel_semantic_before_publication = true;
+        let cancellation = rue_query::CancellationToken::new();
+        assert!(matches!(
+            session.canonical_semantic_with_cancellation(&variant, cancellation),
+            Err(SemanticRequestControl::Abort(
+                rue_query::QueryAbort::Canceled
+            ))
+        ));
         assert_eq!(session.queries.semantic.len(), 1);
         assert!(!Arc::ptr_eq(
             session.latest_diagnostics().unwrap(),
@@ -8758,10 +9029,7 @@ mod tests {
             canceled.attempt.outcome(),
             crate::typed_query_store::AttemptOutcomeKind::Aborted(AbortedQueryReason::Canceled)
         );
-        assert!(matches!(
-            canceled.attempt.work(),
-            QueryStructuralWork::Semantic(_)
-        ));
+        assert!(matches!(canceled.attempt.work(), QueryStructuralWork::None));
 
         let recomputed = session.canonical_semantic(&variant).unwrap();
         assert_eq!(session.queries.semantic.len(), 2);
@@ -8807,6 +9075,164 @@ mod tests {
             session.adopt_test_import_graph(graph);
         }
         work
+    }
+
+    fn legacy_air_declaration_shell_oracle(
+        merged: &CanonicalMergedProgram,
+        rir: &CanonicalRirOutput,
+        preview_features: PreviewFeatures,
+    ) -> Result<Vec<rue_air::SemanticDeclarationShell>, CompileErrors> {
+        let shells = rue_air::Sema::new_synthetic(
+            rir.rir(),
+            rir.semantic_symbols().interner(),
+            preview_features,
+        )
+        .predeclare_declaration_shells()?
+        .declaration_shells()
+        .cloned()
+        .collect::<Vec<_>>();
+        let modules = merged
+            .ast()
+            .modules()
+            .iter()
+            .map(|module| (module.file_id(), module.module_id().clone()))
+            .collect::<HashMap<_, _>>();
+        let mut shells = shells
+            .into_iter()
+            .map(|mut shell| {
+                let module = &modules[&shell.declaration_span.file_id];
+                shell.identity.module_path = Arc::from(module.as_str());
+                shell.identity.is_trusted_standard_library = module.is_trusted_standard_library();
+                shell.signature_fingerprint = [0; 32];
+                shell
+            })
+            .collect::<Vec<_>>();
+        sort_shell_comparison_algebra(&mut shells);
+        Ok(shells)
+    }
+
+    fn sort_shell_comparison_algebra(shells: &mut [rue_air::SemanticDeclarationShell]) {
+        let mut spans_by_file = HashMap::<FileId, Vec<rue_span::Span>>::new();
+        for shell in shells.iter() {
+            spans_by_file
+                .entry(shell.declaration_span.file_id)
+                .or_default()
+                .push(shell.declaration_span);
+        }
+        let mut normalized_source_order = HashMap::new();
+        for spans in spans_by_file.values_mut() {
+            spans.sort_by_key(|span| (span.start, span.end));
+            spans.dedup();
+            for (source_order, span) in spans.iter().enumerate() {
+                normalized_source_order.insert(*span, source_order as u32);
+            }
+        }
+        for shell in shells.iter_mut() {
+            shell.source_order = normalized_source_order[&shell.declaration_span];
+        }
+        shells.sort_by(|left, right| {
+            let category = |shell: &rue_air::SemanticDeclarationShell| {
+                u8::from(shell.identity.namespace != rue_air::StableDefinitionNamespace::Type)
+            };
+            category(left)
+                .cmp(&category(right))
+                .then(left.identity.cmp(&right.identity))
+        });
+    }
+
+    fn independently_expected_signature_fingerprints(
+        merged: &CanonicalMergedProgram,
+    ) -> HashMap<rue_span::Span, [u8; 32]> {
+        fn prefix(declaration: rue_span::Span, payload: rue_span::Span) -> rue_span::Span {
+            rue_span::Span::with_file(declaration.file_id, declaration.start, payload.start)
+        }
+        fn fingerprint(
+            module: &crate::parsed_modules::ParsedModule,
+            spans: &[rue_span::Span],
+        ) -> [u8; 32] {
+            let mut hasher = Sha256::new();
+            for span in spans {
+                for token in module.tokens().iter().filter(|token| {
+                    token.span.start >= span.start
+                        && token.span.end <= span.end
+                        && !matches!(token.kind, rue_lexer::TokenKind::Eof)
+                }) {
+                    let value = match token.kind {
+                        rue_lexer::TokenKind::Ident(symbol) => {
+                            format!("ident:{}", module.resolve_raw_symbol(symbol))
+                        }
+                        rue_lexer::TokenKind::String(symbol) => {
+                            format!("string:{}", module.resolve_raw_symbol(symbol))
+                        }
+                        rue_lexer::TokenKind::Int(value) => format!("int:{value}"),
+                        kind => kind.name().to_owned(),
+                    };
+                    hasher.update((value.len() as u64).to_le_bytes());
+                    hasher.update(value.as_bytes());
+                }
+                hasher.update(0_u64.to_le_bytes());
+            }
+            hasher.finalize().into()
+        }
+
+        let mut expected = HashMap::new();
+        for module in merged.ast().modules() {
+            for item in &module.ast().items {
+                match item {
+                    rue_parser::Item::Function(value) => {
+                        expected.insert(
+                            value.span,
+                            fingerprint(module, &[prefix(value.span, value.body.span())]),
+                        );
+                    }
+                    rue_parser::Item::Struct(value) => {
+                        let mut spans = Vec::with_capacity(value.methods.len() + 1);
+                        let mut cursor = value.span.start;
+                        for method in &value.methods {
+                            let body = method.body.span();
+                            spans.push(rue_span::Span::with_file(
+                                value.span.file_id,
+                                cursor,
+                                body.start,
+                            ));
+                            cursor = body.end;
+                            expected.insert(
+                                method.span,
+                                fingerprint(module, &[prefix(method.span, body)]),
+                            );
+                        }
+                        spans.push(rue_span::Span::with_file(
+                            value.span.file_id,
+                            cursor,
+                            value.span.end,
+                        ));
+                        expected.insert(value.span, fingerprint(module, &spans));
+                    }
+                    rue_parser::Item::Enum(value) => {
+                        expected.insert(value.span, fingerprint(module, &[value.span]));
+                    }
+                    rue_parser::Item::Const(value) => {
+                        expected.insert(
+                            value.span,
+                            fingerprint(module, &[prefix(value.span, value.init.span())]),
+                        );
+                    }
+                    rue_parser::Item::DropFn(value) => {
+                        expected.insert(
+                            value.span,
+                            fingerprint(module, &[prefix(value.span, value.body.span())]),
+                        );
+                    }
+                    rue_parser::Item::Extern(value) => {
+                        for function in &value.fns {
+                            expected.insert(function.span, fingerprint(module, &[function.span]));
+                        }
+                    }
+                    rue_parser::Item::Error(_) => {}
+                }
+            }
+        }
+        expected
     }
 
     fn function_modules(count: usize, edited: Option<usize>) -> SourceSnapshot {
@@ -8963,7 +9389,12 @@ mod tests {
 
         publish_with_test_imports(&mut session, &relocated_edit);
         let reused = session.canonical_semantic(&options).unwrap();
-        assert_eq!(reused.work().binding.declaration_resolution_invocations, 0);
+        assert_eq!(
+            reused.work().binding.declaration_resolution_invocations,
+            0,
+            "{:#?}",
+            reused.work()
+        );
         assert_eq!(reused.work().binding.durable_payloads_installed, 3);
         assert_eq!(reused.work().declaration_reuse.durable_records_reused, 3);
         assert_eq!(
@@ -9025,7 +9456,12 @@ mod tests {
         );
         assert_eq!(fallback.work().binding.durable_install_invocations, 0);
         assert_eq!(fallback.work().binding.durable_payloads_installed, 0);
-        assert_eq!(fallback.work().declaration_reuse.fallbacks, 1);
+        assert_eq!(
+            fallback.work().declaration_reuse.fallbacks,
+            1,
+            "{:#?}",
+            fallback.work()
+        );
         assert_eq!(fallback.work().declaration_reuse.fallback_epochs_started, 0);
 
         let mut fresh = CompilerSession::new();
@@ -10987,7 +11423,7 @@ mod tests {
     }
 
     #[test]
-    fn stable_definitions_are_lazy_reused_and_make_two_bind_boundary_explicit() {
+    fn stable_definitions_are_lazy_reused_semantic_projections() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<BoundDefinitionSet>();
 
@@ -11029,6 +11465,254 @@ mod tests {
         std::thread::spawn(move || assert!(!published.definitions().is_empty()))
             .join()
             .unwrap();
+    }
+
+    #[test]
+    fn file_const_anonymous_types_use_epoch_local_comptime_producers() {
+        for source in [
+            r#"
+const T: type = struct { value: i32 };
+fn main() -> i32 {
+    let value: T = T { value: 42 };
+    value.value
+}
+"#,
+            r#"
+const T: type = enum { A, B(i32) };
+fn main() -> i32 { 0 }
+"#,
+        ] {
+            let source = snapshot(&[(7, "/p/main.rue", "main.rue", source)], 7);
+            let mut session = CompilerSession::new();
+            session.update(&source).into_result().unwrap();
+            session
+                .canonical_semantic(&CompileOptions::default())
+                .unwrap();
+            let definitions = session
+                .stable_definitions(&CompileOptions::default())
+                .unwrap();
+            assert!(definitions.definitions().iter().any(|record| {
+                record.stable_key().kind() == StableDefinitionKind::ValueConst
+                    && record.stable_key().name() == "T"
+            }));
+        }
+    }
+
+    #[test]
+    fn query_owned_declaration_shells_match_independent_air_and_token_oracles() {
+        let source = snapshot(
+            &[(
+                7,
+                "/p/main.rue",
+                "main.rue",
+                r#"
+pub struct Box {
+    fn get(mut self, comptime T: type) -> i32 { 0 }
+    fn inspect(borrow self) -> i32 { 1 }
+    fn make() -> Box { Box {} }
+}
+enum Choice { A, B(i32) }
+const selected = 1;
+const alias = selected;
+drop fn Box(self) {}
+unchecked fn main(value: i32) -> i32 { value }
+extern "C" { fn getpid() -> i32; }
+"#,
+            )],
+            7,
+        );
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        let imports = session.accepted_semantic_import_graph().unwrap();
+        let rir = session.canonical_rir().unwrap();
+        let merged = session
+            .queries
+            .rir
+            .selected_record(&session.queries.graph)
+            .and_then(|entry| entry.merged.clone())
+            .unwrap();
+        let revision = session.queries.revisioned.current_parse_revision().unwrap();
+        let query_shells = session
+            .queries
+            .revisioned
+            .projected_declaration_shells(
+                revision,
+                merged.ast(),
+                rue_query::CancellationToken::new(),
+            )
+            .unwrap();
+
+        let legacy =
+            legacy_air_declaration_shell_oracle(&merged, &rir, options.preview_features.clone())
+                .unwrap();
+        let expected_fingerprints = independently_expected_signature_fingerprints(&merged);
+        for shell in &query_shells {
+            assert_eq!(
+                shell.signature_fingerprint, expected_fingerprints[&shell.declaration_span],
+                "query fingerprint differs from independent AST/token partition"
+            );
+        }
+        let mut comparable_query_shells = query_shells.clone();
+        for shell in &mut comparable_query_shells {
+            shell.signature_fingerprint = [0; 32];
+        }
+        sort_shell_comparison_algebra(&mut comparable_query_shells);
+        assert_eq!(legacy, comparable_query_shells);
+
+        let mut foreign_locator = query_shells;
+        let first = &mut foreign_locator[0];
+        first.declaration_span.start += 1;
+        let locator_error = crate::bound_definitions::configure_canonical_sema(
+            &merged,
+            &rir,
+            options.preview_features,
+            options.target,
+            &imports,
+        )
+        .unwrap()
+        .predeclare_imported_declaration_shells(&foreign_locator)
+        .err()
+        .unwrap();
+        assert!(matches!(
+            locator_error.first().map(|error| &error.kind),
+            Some(ErrorKind::InternalError(message))
+                if message.contains("current RIR locator")
+        ));
+    }
+
+    #[test]
+    fn declaration_shell_oracles_cover_import_alias_trusted_and_multimodule_inputs() {
+        let root = FileId::new(1);
+        let standard = FileId::new(2);
+        let metadata = SourceMetadata::new_with_trusted_standard_library(
+            root,
+            HashMap::from([
+                (root, "/project/main.rue".to_owned()),
+                (standard, "/project/std/lib.rue".to_owned()),
+            ]),
+            HashMap::from([
+                (root, "main.rue".to_owned()),
+                (standard, "\0rue-std/lib.rue".to_owned()),
+            ]),
+            HashSet::from([standard]),
+        )
+        .unwrap();
+        let source = SourceSnapshot::new(
+            metadata,
+            vec![
+                (
+                    root,
+                    Arc::new(
+                        r#"
+pub const direct = @import("std/lib.rue");
+pub const alias = direct;
+fn main() -> i32 { 0 }
+"#
+                        .to_owned(),
+                    ),
+                ),
+                (
+                    standard,
+                    Arc::new("pub struct Library {} pub const value: i32 = 1;".to_owned()),
+                ),
+            ],
+        )
+        .unwrap();
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        publish_with_test_imports(&mut session, &source);
+        let rir = session.canonical_rir().unwrap();
+        let merged = session
+            .queries
+            .rir
+            .selected_record(&session.queries.graph)
+            .and_then(|entry| entry.merged.clone())
+            .unwrap();
+        let revision = session.queries.revisioned.current_parse_revision().unwrap();
+        let query = session
+            .queries
+            .revisioned
+            .projected_declaration_shells(
+                revision,
+                merged.ast(),
+                rue_query::CancellationToken::new(),
+            )
+            .unwrap();
+        let legacy =
+            legacy_air_declaration_shell_oracle(&merged, &rir, options.preview_features.clone())
+                .unwrap();
+        let expected_fingerprints = independently_expected_signature_fingerprints(&merged);
+        let mut comparable = query.clone();
+        for shell in &mut comparable {
+            assert_eq!(
+                shell.signature_fingerprint,
+                expected_fingerprints[&shell.declaration_span]
+            );
+            shell.signature_fingerprint = [0; 32];
+        }
+        sort_shell_comparison_algebra(&mut comparable);
+        assert_eq!(legacy, comparable);
+        assert!(
+            query
+                .iter()
+                .any(|shell| shell.identity.is_trusted_standard_library)
+        );
+        session.canonical_semantic(&options).unwrap();
+        let definitions = session.stable_definitions(&options).unwrap();
+        for name in ["direct", "alias"] {
+            let record = definitions
+                .definitions()
+                .iter()
+                .find(|record| {
+                    record.stable_key().module().as_str() == "main.rue"
+                        && record.stable_key().name() == name
+                        && record.stable_key().kind() == StableDefinitionKind::ModuleBinding
+                })
+                .unwrap_or_else(|| panic!("missing public module-binding definition for {name}"));
+            assert_eq!(
+                record.visibility(),
+                Some(rue_parser::ast::Visibility::Public)
+            );
+        }
+    }
+
+    #[test]
+    fn query_and_retired_air_paths_reject_the_same_declaration_failures() {
+        for text in [
+            "const value: i32 = 1; const value: i32 = 2; fn main() {}",
+            "struct Value {} drop fn Value(self) {} drop fn Value(self) {} fn main() {}",
+            "drop fn Missing(self) {} fn main() {}",
+        ] {
+            let source = snapshot(&[(1, "/main.rue", "main.rue", text)], 1);
+            let parsed = crate::parsed_modules::parse_source_snapshot_modules(&source).unwrap();
+            let merged = crate::merge_parsed_modules(&parsed).unwrap();
+            let rir = crate::lower_canonical_rir(&merged).unwrap();
+            let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+            let retired = match rue_air::Sema::new_synthetic(
+                rir.rir(),
+                rir.semantic_symbols().interner(),
+                PreviewFeatures::new(),
+            )
+            .bind_declarations()
+            {
+                Err(errors) => errors,
+                Ok(_) => panic!("retired AIR path unexpectedly accepted failure fixture"),
+            };
+            let query = match crate::canonical_semantic::bind_query_owned_declarations_for_test(
+                &merged,
+                &rir,
+                PreviewFeatures::new(),
+                Target::default(),
+                &imports,
+            ) {
+                Err(errors) => errors,
+                Ok(_) => panic!("query path unexpectedly accepted failure fixture"),
+            };
+            let messages =
+                |errors: CompileErrors| errors.iter().map(ToString::to_string).collect::<Vec<_>>();
+            assert_eq!(messages(retired), messages(query));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a parser-owned exact declaration-candidate index and keyed, position-free declaration-shell query family
- make canonical semantic preparation and durable fallback import query-owned shells, removing the compiler's peer declaration bind
- preserve const classification through type-distinct epoch-local candidate producers, then promote to final `ValueConst` or `ModuleBinding` identities
- propagate cancellation as query control flow, use typed stable failures, and keep joins/reuse linear
- add independent retired-AIR differential oracles plus source-level authority retirement gates

This is the first family-by-family RUE-1026 authority transfer. The old raw AIR discovery path is guarded for synthetic component tests only; canonical compiler epochs cannot invoke it. RUE-1026 remains open for the remaining exact declaration families and final broad-resolver retirement.

## Validation

- `scripts/rue unit compiler` (638/638)
- `scripts/rue quick` (34/34; frontend differential 640/640 + 2 probes)
- `scripts/rue test`
  - CLI: 1687 passed, 11 ignored
  - spec: 2153 passed, 18 ignored
  - UI: 200 passed
  - generated oracle: 64/64
  - reproducibility and all lightweight suites passed
- independent adversarial review: sign-off

Refs RUE-1026
