### PR TITLE
RUE-1057: C aggregate classification and byval arguments (ADR-0064 P3)

### DIFF
--- a/crates/rue-air/src/call_abi.rs
+++ b/crates/rue-air/src/call_abi.rs
@@ -395,6 +395,73 @@ impl ScalarAbiExtension {
     }
 }
 
+/// How a C-classifiable aggregate crosses a target-C boundary as an *argument*
+/// (ADR-0064 P3, RUE-1057).
+///
+/// The classification is computed from the aggregate's byte size (and alignment
+/// for the memory paths) by [`TargetCCallAbi::classify_aggregate_arg`]. In the
+/// integer-only core every eightbyte classifies INTEGER (a field type that would
+/// classify SSE cannot exist until RUE-714), so the two ≤16-byte psABIs coincide:
+/// the struct packs into one or two general-purpose integer registers **in C
+/// field order**. That C order is the register-packing audit's key finding — the
+/// native slot model decomposes one slot per leaf and *reverses* multi-slot
+/// values, which disagrees with C packing even for a two-field struct — so a
+/// target-C aggregate is marshaled through its physical memory image (ascending
+/// C order) rather than reusing the native decomposition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AggregateArgClass {
+    /// Packed into `eightbytes` (1 or 2) consecutive integer argument registers,
+    /// low eightbyte first, i.e. C field order. Covers SysV AMD64 INTEGER-class
+    /// ≤16-byte structs and AAPCS64 ≤16-byte composites.
+    IntegerRegisters {
+        /// Number of eightbyte integer registers (1 or 2).
+        eightbytes: u32,
+    },
+    /// SysV AMD64 MEMORY class (>16 bytes): the whole struct image is passed by
+    /// value in the outgoing stack argument area — `size` bytes at `align`
+    /// alignment — consuming no integer registers.
+    ByValueStack {
+        /// The struct's byte size.
+        size: u32,
+        /// The struct's alignment.
+        align: u32,
+    },
+    /// AAPCS64 composite >16 bytes (AAPCS64 §6.8.2 B.4/C.12): passed **by
+    /// reference to a caller-owned copy** — the caller copies the struct and
+    /// passes the copy's address in one integer register. This is *not* the SysV
+    /// byval-on-stack rule.
+    ByReferenceCopy {
+        /// The struct's byte size (the caller copy's size).
+        size: u32,
+        /// The struct's alignment (the caller copy's alignment).
+        align: u32,
+    },
+}
+
+/// How a C-classifiable aggregate crosses a target-C boundary as a *return value*
+/// (ADR-0064 P3, RUE-1057). Computed by
+/// [`TargetCCallAbi::classify_aggregate_return`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AggregateReturnClass {
+    /// Returned in `eightbytes` (1 or 2) result registers — `rax:rdx` on SysV,
+    /// `x0:x1` on AAPCS64 — low eightbyte first (C field order), ≤16 bytes.
+    IntegerRegisters {
+        /// Number of eightbyte result registers (1 or 2).
+        eightbytes: u32,
+    },
+    /// Returned indirectly through caller-provided storage (sret), >16 bytes.
+    /// SysV passes the hidden pointer in `rdi` and the callee **echoes it in
+    /// `rax`**; AAPCS64 passes it in the dedicated `x8` and does not echo (see
+    /// [`TargetCCallAbi::sret_pointer_echoed_in_result_register`] and
+    /// [`TargetCCallAbi::sret_pointer_in_dedicated_register`]).
+    Indirect {
+        /// The struct's byte size (caller storage size).
+        size: u32,
+        /// The struct's alignment.
+        align: u32,
+    },
+}
+
 /// The guaranteed target-C call-ABI classifier: the [`CallAbi::TargetC`]
 /// implementation for scalars and pointers (ADR-0064 P2, RUE-1056).
 ///
@@ -483,12 +550,83 @@ impl TargetCCallAbi {
     /// Whether the callee echoes the hidden sret pointer back in the primary
     /// return register: SysV requires `rax` to hold the sret pointer on return;
     /// AAPCS64 uses the dedicated indirect-result register `x8`, which is **not**
-    /// echoed. Documented here for the P3/P4 aggregate/export work; scalars in P2
-    /// never take an sret path.
+    /// echoed. Reachable from P3: an aggregate return >16 bytes takes the sret
+    /// path; scalars in P2 never do.
     pub const fn sret_pointer_echoed_in_result_register(&self) -> bool {
         match self.flavor {
             TargetCAbiFlavor::SysVAmd64 => true,
             TargetCAbiFlavor::Aapcs64 => false,
+        }
+    }
+
+    /// Whether the hidden sret pointer is passed in a **dedicated** indirect-
+    /// result register rather than the first ordinary integer argument register.
+    /// AAPCS64 uses the dedicated `x8` (§6.9), so the sret pointer does not
+    /// consume `x0` and the ordinary arguments still start at `x0`. SysV AMD64
+    /// passes the sret pointer as the hidden first argument in `rdi`, consuming
+    /// the first integer argument register. P3 aggregate returns exercise both.
+    pub const fn sret_pointer_in_dedicated_register(&self) -> bool {
+        match self.flavor {
+            TargetCAbiFlavor::SysVAmd64 => false,
+            TargetCAbiFlavor::Aapcs64 => true,
+        }
+    }
+
+    /// The maximum aggregate size, in bytes, that a target-C boundary passes or
+    /// returns in integer registers rather than in memory. Both psABIs use two
+    /// eightbytes (16 bytes): a larger INTEGER-class aggregate goes to memory
+    /// (SysV MEMORY class / AAPCS64 by-reference).
+    pub const fn max_aggregate_register_bytes(&self) -> u64 {
+        16
+    }
+
+    /// Number of eightbytes a `size`-byte aggregate occupies (ceil(size / 8)).
+    const fn eightbytes(size: u64) -> u32 {
+        ((size + 7) / 8) as u32
+    }
+
+    /// Classify how a C-classifiable aggregate of `size` bytes at `align`
+    /// alignment crosses as an *argument* under this psABI (ADR-0064 P3).
+    ///
+    /// Integer-only core: every eightbyte classifies INTEGER (SSE is unreachable
+    /// until RUE-714), so a ≤16-byte aggregate packs into one or two integer
+    /// registers in C field order on both psABIs. A larger aggregate diverges:
+    /// SysV MEMORY class is byval-on-stack, AAPCS64 passes a pointer to a
+    /// caller-owned copy. `size` is the aggregate's `@size_of`; `align` its
+    /// `@align_of` — the caller has already gated the type through
+    /// [`c_passable_by_value`](crate::c_passable_by_value), so `size >= 1`.
+    pub fn classify_aggregate_arg(&self, size: u64, align: u64) -> AggregateArgClass {
+        if size <= self.max_aggregate_register_bytes() {
+            return AggregateArgClass::IntegerRegisters {
+                eightbytes: Self::eightbytes(size),
+            };
+        }
+        let size = size as u32;
+        let align = align as u32;
+        match self.flavor {
+            TargetCAbiFlavor::SysVAmd64 => AggregateArgClass::ByValueStack { size, align },
+            TargetCAbiFlavor::Aapcs64 => AggregateArgClass::ByReferenceCopy { size, align },
+        }
+    }
+
+    /// Classify how a C-classifiable aggregate of `size` bytes at `align`
+    /// alignment crosses as a *return value* under this psABI (ADR-0064 P3).
+    ///
+    /// ≤16 bytes returns in one or two result registers (`rax:rdx` / `x0:x1`) in
+    /// C field order; a larger aggregate returns indirectly through caller
+    /// storage (sret) on both psABIs, differing only in the sret-pointer register
+    /// and echo ([`Self::sret_pointer_in_dedicated_register`],
+    /// [`Self::sret_pointer_echoed_in_result_register`]).
+    pub fn classify_aggregate_return(&self, size: u64, align: u64) -> AggregateReturnClass {
+        if size <= self.max_aggregate_register_bytes() {
+            AggregateReturnClass::IntegerRegisters {
+                eightbytes: Self::eightbytes(size),
+            }
+        } else {
+            AggregateReturnClass::Indirect {
+                size: size as u32,
+                align: align as u32,
+            }
         }
     }
 
@@ -644,6 +782,83 @@ mod tests {
         assert_eq!(ReturnClass::Indirect { slot_count: 9 }.slot_count(), 9);
         assert!(!ReturnClass::Registers { slot_count: 3 }.uses_sret());
         assert!(ReturnClass::Indirect { slot_count: 9 }.uses_sret());
+    }
+
+    #[test]
+    fn aggregate_arg_classification_packs_by_size_in_c_order() {
+        let sysv = TargetCCallAbi::sysv_amd64();
+        let aapcs = TargetCCallAbi::aapcs64();
+        // A two-`i32` struct is 8 bytes: ONE eightbyte register on both psABIs.
+        // (Native would decompose it to two reversed slots — the packing the
+        // audit warns disagrees; the target-C classifier packs one eightbyte.)
+        assert_eq!(
+            sysv.classify_aggregate_arg(8, 4),
+            AggregateArgClass::IntegerRegisters { eightbytes: 1 }
+        );
+        assert_eq!(
+            aapcs.classify_aggregate_arg(8, 4),
+            AggregateArgClass::IntegerRegisters { eightbytes: 1 }
+        );
+        // A 16-byte struct packs into two eightbyte registers on both.
+        assert_eq!(
+            sysv.classify_aggregate_arg(16, 8),
+            AggregateArgClass::IntegerRegisters { eightbytes: 2 }
+        );
+        assert_eq!(
+            aapcs.classify_aggregate_arg(16, 8),
+            AggregateArgClass::IntegerRegisters { eightbytes: 2 }
+        );
+        // >16 bytes diverges: SysV byval-on-stack, AAPCS64 by-reference copy.
+        assert_eq!(
+            sysv.classify_aggregate_arg(24, 8),
+            AggregateArgClass::ByValueStack { size: 24, align: 8 }
+        );
+        assert_eq!(
+            aapcs.classify_aggregate_arg(24, 8),
+            AggregateArgClass::ByReferenceCopy { size: 24, align: 8 }
+        );
+        // A non-multiple-of-8 size rounds up to whole eightbytes.
+        assert_eq!(
+            sysv.classify_aggregate_arg(12, 4),
+            AggregateArgClass::IntegerRegisters { eightbytes: 2 }
+        );
+    }
+
+    #[test]
+    fn aggregate_return_classification_registers_then_sret() {
+        let sysv = TargetCCallAbi::sysv_amd64();
+        let aapcs = TargetCCallAbi::aapcs64();
+        assert_eq!(
+            sysv.classify_aggregate_return(8, 4),
+            AggregateReturnClass::IntegerRegisters { eightbytes: 1 }
+        );
+        assert_eq!(
+            sysv.classify_aggregate_return(16, 8),
+            AggregateReturnClass::IntegerRegisters { eightbytes: 2 }
+        );
+        // >16 bytes returns via sret on both psABIs.
+        assert_eq!(
+            sysv.classify_aggregate_return(24, 8),
+            AggregateReturnClass::Indirect { size: 24, align: 8 }
+        );
+        assert_eq!(
+            aapcs.classify_aggregate_return(24, 8),
+            AggregateReturnClass::Indirect { size: 24, align: 8 }
+        );
+    }
+
+    #[test]
+    fn sret_pointer_register_and_echo_diverge_by_psabi() {
+        let sysv = TargetCCallAbi::sysv_amd64();
+        let aapcs = TargetCCallAbi::aapcs64();
+        // SysV: sret pointer in rdi (first arg reg), echoed in rax.
+        assert!(!sysv.sret_pointer_in_dedicated_register());
+        assert!(sysv.sret_pointer_echoed_in_result_register());
+        // AAPCS64: dedicated x8, not echoed.
+        assert!(aapcs.sret_pointer_in_dedicated_register());
+        assert!(!aapcs.sret_pointer_echoed_in_result_register());
+        assert_eq!(sysv.max_aggregate_register_bytes(), 16);
+        assert_eq!(aapcs.max_aggregate_register_bytes(), 16);
     }
 
     #[test]

--- a/crates/rue-air/src/ffi_predicates.rs
+++ b/crates/rue-air/src/ffi_predicates.rs
@@ -303,19 +303,28 @@ fn check_c_ffi_safe<P: FfiTypePool>(
 /// Predicate 3: can `ty` cross a C boundary *by value* in the current phase?
 ///
 /// This is the classifier seam, kept in lock-step with the
-/// [`TargetCCallAbi`](crate::call_abi::TargetCCallAbi) scalar classifier that
-/// lowers each crossing. P2 (RUE-1056) widens it from the P1 register-only set
-/// (`i64`/`u64`/pointers) to the **full integer scalar set** — every signed and
-/// unsigned integer width (`i8`/`u8`/`i16`/`u16`/`i32`/`u32`/`i64`/`u64`),
-/// `bool` as the 1-byte `_Bool` with the 0/1 contract, and raw pointers. These
-/// are exactly the scalars the target-C classifier assigns to a single integer
-/// register with a defined narrow-integer extension at the boundary
+/// [`TargetCCallAbi`](crate::call_abi::TargetCCallAbi) classifier that lowers
+/// each crossing. P2 (RUE-1056) widened it from the P1 register-only set to the
+/// **full integer scalar set** — every signed and unsigned integer width, `bool`
+/// as the 1-byte `_Bool`, and raw pointers, the scalars the target-C classifier
+/// assigns to a single integer register with a defined narrow-integer extension
 /// ([`ScalarAbiExtension`](crate::call_abi::ScalarAbiExtension)).
 ///
-/// Aggregates (eightbyte classification, register packing, byval stack args)
-/// stay rejected until P3; floating-point scalars are unreachable until RUE-714
-/// adds the type (P5). Neither widening touches the other two predicates.
-pub fn c_passable_by_value<P: FfiTypePool>(_pool: &P, ty: Type) -> Result<(), FfiPredicateFailure> {
+/// P3 (RUE-1057) widens it again to **C-classifiable aggregates**: a struct that
+/// is marked `@repr(c)` and satisfies [`has_c_layout`] and [`c_ffi_safe`] (i.e.
+/// is [`repr_c_marker_eligible`]) is now passable by value. The target-C
+/// classifier assigns it eightbyte-wise — ≤16-byte structs pack into one or two
+/// integer registers in C field order; larger structs go to memory
+/// ([`AggregateArgClass`](crate::call_abi::AggregateArgClass) /
+/// [`AggregateReturnClass`](crate::call_abi::AggregateReturnClass)). In the
+/// integer-only core every eightbyte classifies INTEGER; a field type that would
+/// classify SSE cannot exist until RUE-714 adds floats (P5).
+///
+/// Fixed arrays stay rejected here (`NotRegisterPassable`) — C decays an array
+/// parameter to a pointer, so a by-value array is not a boundary type; it is
+/// eligible only as a *struct field*. As a direct `extern` parameter/return it
+/// is diagnosed earlier as `ExternArrayByValue`. Enums are not FFI-safe in v0.
+pub fn c_passable_by_value<P: FfiTypePool>(pool: &P, ty: Type) -> Result<(), FfiPredicateFailure> {
     match ty.kind() {
         TypeKind::I8
         | TypeKind::U8
@@ -328,6 +337,11 @@ pub fn c_passable_by_value<P: FfiTypePool>(_pool: &P, ty: Type) -> Result<(), Ff
         | TypeKind::Bool
         | TypeKind::PtrConst(_)
         | TypeKind::PtrMut(_) => Ok(()),
+        // A C-classifiable aggregate is passable by value iff it is a marked and
+        // eligible `@repr(c)` struct (P3). `repr_c_marker_eligible` runs the
+        // has_c_layout + c_ffi_safe checks and reports the failing predicate,
+        // field path, and reason for a struct that is marked but not eligible.
+        TypeKind::Struct(_) => repr_c_marker_eligible(pool, ty),
         _ => Err(FfiPredicateFailure::new(
             FfiPredicate::CPassableByValue,
             &[],
@@ -444,7 +458,8 @@ mod tests {
                 "{ty:?} should be passable by value in P2"
             );
         }
-        // Aggregates are still not passable by value (the P3 seam).
+        // P3 (RUE-1057): an eligible `@repr(c)` aggregate is now passable by
+        // value; the classifier assigns it eightbyte-wise.
         let mut agg_pool = MockPool::default();
         let agg = agg_pool.add_struct(
             9,
@@ -454,7 +469,28 @@ mod tests {
                 ..Default::default()
             },
         );
-        let fail = c_passable_by_value(&agg_pool, agg).unwrap_err();
+        assert!(
+            c_passable_by_value(&agg_pool, agg).is_ok(),
+            "an eligible @repr(c) struct is passable by value in P3"
+        );
+        // A non-`@repr(c)` struct is still not passable — it fails the marker
+        // gate (has_c_layout), reported through the eligibility check.
+        let mut bad_pool = MockPool::default();
+        let unmarked = bad_pool.add_struct(
+            9,
+            MockStruct {
+                repr_c: false,
+                fields: vec![field("x", Type::I64)],
+                ..Default::default()
+            },
+        );
+        let fail = c_passable_by_value(&bad_pool, unmarked).unwrap_err();
+        assert_eq!(fail.predicate, FfiPredicate::HasCLayout);
+        assert_eq!(fail.reason, FfiRejectReason::NonReprCAggregate);
+        // A fixed array is never passable directly by value (array decay).
+        let mut arr_pool = MockPool::default();
+        let arr = arr_pool.add_array(0, Type::I64);
+        let fail = c_passable_by_value(&arr_pool, arr).unwrap_err();
         assert_eq!(fail.predicate, FfiPredicate::CPassableByValue);
         assert_eq!(fail.reason, FfiRejectReason::NotRegisterPassable);
     }

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -37,8 +37,8 @@ mod type_properties;
 mod types;
 
 pub use call_abi::{
-    ArgClass, ArgConvention, CallAbi, NativeCallAbi, ReturnClass, ScalarAbiExtension,
-    TargetCAbiFlavor, TargetCCallAbi, is_slot_identical_layout,
+    AggregateArgClass, AggregateReturnClass, ArgClass, ArgConvention, CallAbi, NativeCallAbi,
+    ReturnClass, ScalarAbiExtension, TargetCAbiFlavor, TargetCCallAbi, is_slot_identical_layout,
 };
 pub use canonical_imports::CanonicalImportView;
 pub use ffi_predicates::{

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1218,23 +1218,24 @@ impl<'a> Sema<'a> {
     ///
     /// ## Diagnostic layering
     ///
-    /// P2 (RUE-1056) widens the by-value scalar set to every integer width plus
-    /// `bool` and pointers via the `c_passable_by_value` predicate; aggregates
-    /// stay phase-gated until P3. Amendment 1 adds the marker/array rules *on
-    /// top*, so the gate is already in place. The order below picks the most
-    /// specific, forward-looking diagnostic:
+    /// P3 (RUE-1057) widens the by-value type set to **C-classifiable
+    /// aggregates**: a `@repr(c)` struct satisfying `c_passable_by_value` (marker
+    /// eligible: `has_c_layout` ∧ `c_ffi_safe`) now crosses by value, joining the
+    /// full scalar set P2 accepts. Amendment 1's marker/array rules still layer
+    /// on top. The order below picks the most specific, forward-looking
+    /// diagnostic:
     ///
     /// 1. A **fixed array** as a direct parameter/return is the array-decay
     ///    rejection (`ExternArrayByValue`) — C has no by-value array parameter;
     ///    arrays are eligible only as struct fields.
     /// 2. A **struct** without `@repr(c)` names the missing marker
-    ///    (`ExternAggregateNotReprC`). A `@repr(c)` struct is already
-    ///    marker-eligible (checked at declaration), but by-value aggregate
-    ///    passing is not implemented until P2/P3, so it takes the phase
-    ///    diagnostic (`ExternSignatureTypeUnsupported`) — the same "not yet"
-    ///    story as a narrow scalar, now behind a satisfied marker gate.
-    /// 3. Any remaining type that is not register-passable in this phase
-    ///    (narrow integers, `bool`, enums, …) takes the phase diagnostic via the
+    ///    (`ExternAggregateNotReprC`). A marked-and-eligible `@repr(c)` struct is
+    ///    now *accepted* by value (P3); a marked struct that is not marker
+    ///    eligible was already rejected at its declaration, so reaching the phase
+    ///    diagnostic here would be a marker the declaration let through — mapped
+    ///    to `ExternSignatureTypeUnsupported` defensively.
+    /// 3. Any remaining type that is not passable in this phase (enums, and — once
+    ///    RUE-714 adds them — floats) takes the phase diagnostic via the
     ///    `c_passable_by_value` predicate seam.
     fn check_extern_signature_type(&self, ty: Type, span: Span) -> CompileResult<()> {
         match ty.kind() {
@@ -1253,13 +1254,17 @@ impl<'a> Sema<'a> {
                         span,
                     ));
                 }
-                // Marker-eligible, but by-value aggregate passing awaits P2/P3.
-                Err(CompileError::new(
-                    ErrorKind::ExternSignatureTypeUnsupported {
-                        ty: self.format_type_name(ty),
-                    },
-                    span,
-                ))
+                // A marked, eligible `@repr(c)` struct now crosses by value (P3):
+                // the target-C classifier packs it eightbyte-wise. Delegating to
+                // the predicate keeps the accept/reject boundary in one authority.
+                crate::c_passable_by_value(&self.type_pool, ty).map_err(|_| {
+                    CompileError::new(
+                        ErrorKind::ExternSignatureTypeUnsupported {
+                            ty: self.format_type_name(ty),
+                        },
+                        span,
+                    )
+                })
             }
             _ => crate::c_passable_by_value(&self.type_pool, ty).map_err(|_| {
                 CompileError::new(

--- a/crates/rue-cli-tests/cases/c_ffi.toml
+++ b/crates/rue-cli-tests/cases/c_ffi.toml
@@ -207,6 +207,89 @@ execute_if_native = true
 stdout = "-9\n-300\n50000\nfalse\n"
 exit_code = 0
 
+# --- P3 aggregate by-value round-trips, execution-verified (both backends) ----
+# Each case exercises one of the four target-C aggregate paths against a
+# hand-assembled C member that follows the psABI exactly, so a *wrong* caller
+# packing produces WRONG OUTPUT, not an accidental pass:
+#   (a) two-field struct arg combined order-sensitively (catches reversed slots),
+#   (b) >16-byte struct arg passed in memory, tail field read,
+#   (c) two-register struct return,
+#   (d) large struct return via sret.
+# Target-pinned like cli.abi_conformance; the native host executes. The @offset_of
+# assertions embed the expected C-side field offsets so a layout drift is caught
+# in the same program that relies on them.
+
+[[case]]
+name = "x86_64_linux_extern_struct_by_value_roundtrips"
+description = "P3 aggregate by-value arg/return round-trips on x86-64 (SysV): two-field combine, byval tail, two-register + sret returns."
+files = [{ path = "main.rue", source = """
+@repr(c)
+struct Pair { a: i32, b: i32 }
+@repr(c)
+struct Triple { a: i64, b: i64, c: i64 }
+extern "C" {
+    fn ffi_pair_combine(p: Pair) -> i32;
+    fn ffi_triple_tail(t: Triple) -> i64;
+    fn ffi_make_pair(x: i32) -> Pair;
+    fn ffi_fill_triple(x: i64) -> Triple;
+}
+fn main() -> i32 {
+    // Layout cross-check: the C members assume these exact offsets.
+    @dbg(@offset_of(Pair, b));
+    @dbg(@offset_of(Triple, c));
+    // (a) two-field struct by value, combined a*1000 + b = 3005 (order-sensitive).
+    @dbg(checked { ffi_pair_combine(Pair { a: 3, b: 5 }) });
+    // (b) >16-byte struct byval, read tail c = 300.
+    @dbg(checked { ffi_triple_tail(Triple { a: 100, b: 200, c: 300 }) });
+    // (c) two-register struct return {a: 10, b: 11}.
+    @dbg(checked { ffi_make_pair(10).a });
+    @dbg(checked { ffi_make_pair(10).b });
+    // (d) large struct return via sret {a: 1000, b: 1001, c: 1002}.
+    @dbg(checked { ffi_fill_triple(1000).a });
+    @dbg(checked { ffi_fill_triple(1000).c });
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "x86-64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = "4\n16\n3005\n300\n10\n11\n1000\n1002\n"
+exit_code = 0
+
+[[case]]
+name = "aarch64_linux_extern_struct_by_value_roundtrips"
+description = "P3 aggregate by-value arg/return round-trips on AArch64 (AAPCS64): two-field combine, by-reference tail, two-register + x8-sret returns."
+files = [{ path = "main.rue", source = """
+@repr(c)
+struct Pair { a: i32, b: i32 }
+@repr(c)
+struct Triple { a: i64, b: i64, c: i64 }
+extern "C" {
+    fn ffi_pair_combine(p: Pair) -> i32;
+    fn ffi_triple_tail(t: Triple) -> i64;
+    fn ffi_make_pair(x: i32) -> Pair;
+    fn ffi_fill_triple(x: i64) -> Triple;
+}
+fn main() -> i32 {
+    @dbg(@offset_of(Pair, b));
+    @dbg(@offset_of(Triple, c));
+    @dbg(checked { ffi_pair_combine(Pair { a: 3, b: 5 }) });
+    @dbg(checked { ffi_triple_tail(Triple { a: 100, b: 200, c: 300 }) });
+    @dbg(checked { ffi_make_pair(10).a });
+    @dbg(checked { ffi_make_pair(10).b });
+    @dbg(checked { ffi_fill_triple(1000).a });
+    @dbg(checked { ffi_fill_triple(1000).c });
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "aarch64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "aarch64-linux"
+execute_if_native = true
+stdout = "4\n16\n3005\n300\n10\n11\n1000\n1002\n"
+exit_code = 0
+
 [[case]]
 name = "extern_unsupported_abi_rejected"
 description = "Only the \"C\" ABI is accepted in v0."
@@ -372,19 +455,33 @@ compile_fail = true
 error_contains = ["aggregate type `Pt`", "must be marked", "@repr(c)"]
 
 [[case]]
-name = "extern_repr_c_aggregate_by_value_is_phase_gated"
-description = "A marker-eligible @repr(c) aggregate is still not passable by value until P2/P3: the phase diagnostic."
+name = "extern_repr_c_aggregate_by_value_accepted"
+description = "A marker-eligible @repr(c) aggregate now crosses by value (P3, RUE-1057): the signature is accepted."
 files = [{ path = "main.rue", source = """
 @repr(c)
 struct Pt { x: i64, y: i64 }
 extern "C" {
     fn f(p: Pt) -> i64;
+    fn g(x: i64) -> Pt;
+}
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+exit_code = 0
+
+[[case]]
+name = "extern_enum_by_value_still_rejected"
+description = "A Rue enum is not FFI-safe: it still takes the phase diagnostic in an extern signature."
+files = [{ path = "main.rue", source = """
+enum Color { Red, Green, Blue }
+extern "C" {
+    fn f(c: Color) -> i64;
 }
 fn main() -> i32 { 0 }
 """ }]
 args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
 compile_fail = true
-error_contains = ["Pt", "not yet supported", "ADR-0064"]
+error_contains = ["Color", "not supported", "ADR-0064"]
 
 [[case]]
 name = "extern_fixed_array_param_decays"

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -118,6 +118,24 @@ use rue_target::{Arch, Target};
 /// - `ffi_bool_norm(int) -> _Bool` — a `_Bool` normalizer returning `x != 0` as a
 ///   1-byte 0/1 value, again with dirty high bits; the `false`/dirty case is the
 ///   load-bearing check that the boundary materializes exactly 0/1.
+///
+/// P3 aggregate members (ADR-0064 P3, RUE-1057) — each hand-assembled from
+/// `llvm-mc` and following the target psABI exactly, so a *wrong* caller packing
+/// produces WRONG OUTPUT rather than an accidental pass:
+/// - `ffi_pair_combine(Pair{i32 a, i32 b}) -> i32` returns `a*1000 + b` — an
+///   order-sensitive combination of a two-field struct passed by value in one
+///   register (a in the low eightbyte half, b in the high half). A caller that
+///   reused the native *reversed*-slot packing would swap a and b and compute a
+///   different number.
+/// - `ffi_triple_tail(Triple{i64 a, b, c}) -> i64` returns the TAIL field `c` of a
+///   24-byte struct passed in memory (SysV byval-on-stack; AAPCS64 by reference to
+///   a caller copy). Reading the tail specifically catches a wrong memory image or
+///   a struct wrongly squeezed into registers.
+/// - `ffi_make_pair(i32 x) -> Pair` returns `{a: x, b: x+1}` in the two result
+///   registers (a low half, b high half) — the two-register aggregate return.
+/// - `ffi_fill_triple(i64 x) -> Triple` returns `{a: x, b: x+1, c: x+2}` via sret:
+///   the callee writes the caller storage (SysV echoes the pointer in rax; AAPCS64
+///   uses the dedicated x8, no echo) — the large indirect aggregate return.
 fn synthesize_answer_archive(target: Target) -> TestResult<Vec<u8>> {
     // A leaf function returning 42 (P1).
     let answer: Vec<u8> = match target.arch() {
@@ -187,6 +205,70 @@ fn synthesize_answer_archive(target: Target) -> TestResult<Vec<u8>> {
             .code(bool_norm)
             .build(),
     ));
+
+    // --- P3 aggregate members (ADR-0064 P3, RUE-1057) ------------------------
+
+    // ffi_pair_combine(Pair{i32 a, i32 b}) -> i32 == a*1000 + b, order-sensitive.
+    let pair_combine: Vec<u8> = match target.arch() {
+        // mov eax,edi ; imul eax,eax,1000 ; mov rcx,rdi ; shr rcx,32 ; add eax,ecx ; ret
+        Arch::X86_64 => vec![
+            0x89, 0xF8, 0x69, 0xC0, 0xE8, 0x03, 0x00, 0x00, 0x48, 0x89, 0xF9, 0x48, 0xC1, 0xE9,
+            0x20, 0x01, 0xC8, 0xC3,
+        ],
+        // mov w1,w0 ; mov w2,#1000 ; mul w1,w1,w2 ; lsr x0,x0,#32 ; add w0,w1,w0 ; ret
+        Arch::Aarch64 => vec![
+            0xE1, 0x03, 0x00, 0x2A, 0x02, 0x7D, 0x80, 0x52, 0x21, 0x7C, 0x02, 0x1B, 0x00, 0xFC,
+            0x60, 0xD3, 0x20, 0x00, 0x00, 0x0B, 0xC0, 0x03, 0x5F, 0xD6,
+        ],
+    };
+    // ffi_triple_tail(Triple{i64 a,b,c}) -> i64 == c (the tail).
+    let triple_tail: Vec<u8> = match target.arch() {
+        // SysV byval-on-stack: c is at [rsp+24] (return addr + a + b). mov rax,[rsp+24] ; ret
+        Arch::X86_64 => vec![0x48, 0x8B, 0x44, 0x24, 0x18, 0xC3],
+        // AAPCS64 by-reference: x0 = &Triple; ldr x0,[x0,#16] ; ret
+        Arch::Aarch64 => vec![0x00, 0x08, 0x40, 0xF9, 0xC0, 0x03, 0x5F, 0xD6],
+    };
+    // ffi_make_pair(i32 x) -> Pair{a: x, b: x+1} in two result registers.
+    let make_pair: Vec<u8> = match target.arch() {
+        // mov eax,edi ; lea rcx,[rdi+1] ; shl rcx,32 ; or rax,rcx ; ret
+        Arch::X86_64 => vec![
+            0x89, 0xF8, 0x48, 0x8D, 0x4F, 0x01, 0x48, 0xC1, 0xE1, 0x20, 0x48, 0x09, 0xC8, 0xC3,
+        ],
+        // mov w1,w0 ; add w2,w0,#1 ; mov w0,w1 ; lsl x2,x2,#32 ; orr x0,x0,x2 ; ret
+        Arch::Aarch64 => vec![
+            0xE1, 0x03, 0x00, 0x2A, 0x02, 0x04, 0x00, 0x11, 0xE0, 0x03, 0x01, 0x2A, 0x42, 0x7C,
+            0x60, 0xD3, 0x00, 0x00, 0x02, 0xAA, 0xC0, 0x03, 0x5F, 0xD6,
+        ],
+    };
+    // ffi_fill_triple(i64 x) -> Triple{a: x, b: x+1, c: x+2} via sret.
+    let fill_triple: Vec<u8> = match target.arch() {
+        // SysV: rdi=sret ptr, rsi=x, echo rax=rdi.
+        // mov rax,rdi ; mov [rdi],rsi ; lea rcx,[rsi+1] ; mov [rdi+8],rcx
+        //             ; lea rcx,[rsi+2] ; mov [rdi+16],rcx ; ret
+        Arch::X86_64 => vec![
+            0x48, 0x89, 0xF8, 0x48, 0x89, 0x37, 0x48, 0x8D, 0x4E, 0x01, 0x48, 0x89, 0x4F, 0x08,
+            0x48, 0x8D, 0x4E, 0x02, 0x48, 0x89, 0x4F, 0x10, 0xC3,
+        ],
+        // AAPCS64: x8=sret ptr (dedicated, no echo), x0=x.
+        // str x0,[x8] ; add x1,x0,#1 ; str x1,[x8,#8] ; add x1,x0,#2 ; str x1,[x8,#16] ; ret
+        Arch::Aarch64 => vec![
+            0x00, 0x01, 0x00, 0xF9, 0x01, 0x04, 0x00, 0x91, 0x01, 0x05, 0x00, 0xF9, 0x01, 0x08,
+            0x00, 0x91, 0x01, 0x09, 0x00, 0xF9, 0xC0, 0x03, 0x5F, 0xD6,
+        ],
+    };
+    for (symbol, code) in [
+        ("ffi_pair_combine", pair_combine),
+        ("ffi_triple_tail", triple_tail),
+        ("ffi_make_pair", make_pair),
+        ("ffi_fill_triple", fill_triple),
+    ] {
+        objects.push((
+            format!("{symbol}.o"),
+            rue_linker::ObjectBuilder::new(target, symbol)
+                .code(code)
+                .build(),
+        ));
+    }
 
     let members: Vec<(&str, &[u8])> = objects
         .iter()

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -47,6 +47,11 @@ pub(super) const RET_REGS: [Reg; 8] = [
     Reg::X7,
 ];
 
+/// Round `value` up to a multiple of `alignment` (a power of two ≥ 1).
+const fn align_up_u32(value: u32, alignment: u32) -> u32 {
+    value.div_ceil(alignment) * alignment
+}
+
 /// CFG to Aarch64Mir lowering.
 pub struct CfgLower<'a> {
     /// Shared context with type helpers and chain tracing.
@@ -952,6 +957,254 @@ impl<'a> CfgLower<'a> {
                 panic!("unexpected target-C scalar extension width {from_bits}")
             }
         }
+    }
+
+    /// Lower an `extern "C"` foreign call that crosses one or more aggregates by
+    /// value under AAPCS64 (ADR-0064 P3). The classification comes from the shared
+    /// [`ForeignCallInputs`](crate::foreign_call::ForeignCallInputs) authority;
+    /// every aggregate is marshaled through its compact physical image (C field
+    /// order). Differs from SysV in two documented ways: a >16-byte aggregate is
+    /// passed **by reference to a caller-owned copy** (not byval-on-stack), and
+    /// the sret pointer uses the dedicated `x8` (not the first argument register)
+    /// and is not echoed.
+    fn lower_foreign_call(
+        &mut self,
+        inputs: crate::foreign_call::ForeignCallInputs,
+        primary: VReg,
+    ) -> crate::value_plan::MaterializedValue {
+        use crate::foreign_call::{ForeignArg, ForeignReturn};
+        let abi = rue_air::TargetCCallAbi::new(inputs.flavor);
+        let budget = ARG_REGS.len();
+
+        // sret storage first (survives the call); its pointer goes in x8.
+        let mut sret_ptr: Option<VReg> = None;
+        let mut sret_storage: u32 = 0;
+        if let ForeignReturn::AggregateSret { image } = &inputs.ret {
+            sret_storage = image.storage_bytes;
+            self.mir.push(Aarch64Inst::SubImm {
+                dst: Operand::Physical(Reg::Sp),
+                src: Operand::Physical(Reg::Sp),
+                imm: sret_storage as i32,
+            });
+            let p = self.mir.alloc_vreg();
+            self.mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Virtual(p),
+                src: Operand::Physical(Reg::Sp),
+            });
+            sret_ptr = Some(p);
+        }
+
+        let mut int_ops: Vec<VReg> = Vec::new();
+        let mut stack_ops: Vec<VReg> = Vec::new();
+        // Caller-owned by-reference copies (AAPCS64 >16-byte composites) are
+        // allocated below the sret storage and must survive the call; freed
+        // together after the outgoing stack area.
+        let mut byref_bytes: u32 = 0;
+
+        for arg in &inputs.args {
+            match arg {
+                ForeignArg::Scalar { value } => {
+                    let v = self.get_vreg(*value);
+                    if int_ops.len() < budget {
+                        int_ops.push(v);
+                    } else {
+                        stack_ops.push(v);
+                    }
+                }
+                ForeignArg::AggregateRegisters { value, image } => {
+                    let ebs = self.image_arg_eightbytes(*value, image);
+                    if int_ops.len() + ebs.len() <= budget {
+                        int_ops.extend(ebs);
+                    } else {
+                        stack_ops.extend(ebs);
+                    }
+                }
+                ForeignArg::AggregateByRefCopy { value, image } => {
+                    // Copy the struct into a caller-owned buffer and pass its
+                    // address in one integer register (AAPCS64 §6.8.2 C.12).
+                    self.mir.push(Aarch64Inst::SubImm {
+                        dst: Operand::Physical(Reg::Sp),
+                        src: Operand::Physical(Reg::Sp),
+                        imm: image.storage_bytes as i32,
+                    });
+                    byref_bytes += image.storage_bytes;
+                    let ptr = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Virtual(ptr),
+                        src: Operand::Physical(Reg::Sp),
+                    });
+                    let slots = self.require_aggregate_slots(*value);
+                    crate::agg_slots::store_enum_slots_through_ptr(
+                        self,
+                        &slots,
+                        ptr,
+                        &image.map,
+                        &image.padding,
+                    );
+                    if int_ops.len() < budget {
+                        int_ops.push(ptr);
+                    } else {
+                        stack_ops.push(ptr);
+                    }
+                }
+                ForeignArg::AggregateByvalStack { .. } => {
+                    panic!(
+                        "AAPCS64 passes a >16-byte aggregate by reference to a caller copy, not \
+                         byval-on-stack; ByValueStack is a SysV-only class"
+                    )
+                }
+            }
+        }
+
+        let num_stack = stack_ops.len();
+        let stack_bytes = align_up_u32((num_stack * 8) as u32, 16);
+        if stack_bytes > 0 {
+            self.mir.push(Aarch64Inst::SubImm {
+                dst: Operand::Physical(Reg::Sp),
+                src: Operand::Physical(Reg::Sp),
+                imm: stack_bytes as i32,
+            });
+        }
+        for (index, v) in stack_ops.iter().enumerate() {
+            self.mir.push(Aarch64Inst::Str {
+                src: Operand::Virtual(*v),
+                base: Reg::Sp,
+                offset: (index * 8) as i32,
+            });
+        }
+        for (index, v) in int_ops.iter().enumerate() {
+            self.mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(ARG_REGS[index]),
+                src: Operand::Virtual(*v),
+            });
+        }
+        // The dedicated indirect-result register x8 holds the sret pointer.
+        if let Some(p) = sret_ptr {
+            debug_assert!(abi.sret_pointer_in_dedicated_register());
+            self.mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X8),
+                src: Operand::Virtual(p),
+            });
+        }
+        let symbol_id = self.intern_symbol(inputs.symbol_ref());
+        self.mir.push(Aarch64Inst::Bl { symbol_id });
+        if stack_bytes > 0 {
+            self.mir.push(Aarch64Inst::AddImm {
+                dst: Operand::Physical(Reg::Sp),
+                src: Operand::Physical(Reg::Sp),
+                imm: stack_bytes as i32,
+            });
+        }
+        if byref_bytes > 0 {
+            self.mir.push(Aarch64Inst::AddImm {
+                dst: Operand::Physical(Reg::Sp),
+                src: Operand::Physical(Reg::Sp),
+                imm: byref_bytes as i32,
+            });
+        }
+
+        let slots = match &inputs.ret {
+            ForeignReturn::ZeroSized => {
+                self.mir.push(Aarch64Inst::MovImm {
+                    dst: Operand::Virtual(primary),
+                    imm: 0,
+                });
+                Vec::new()
+            }
+            ForeignReturn::Scalar { ext } => {
+                self.mir.push(Aarch64Inst::MovRR {
+                    dst: Operand::Virtual(primary),
+                    src: Operand::Physical(Reg::X0),
+                });
+                self.emit_c_return_extension(primary, *ext);
+                Vec::new()
+            }
+            ForeignReturn::AggregateRegisters { image } => {
+                // x0:x1 hold the return eightbytes (C field order). Bridge them
+                // through a scratch buffer to reconstruct the native slots.
+                let eb = image.eightbytes();
+                self.mir.push(Aarch64Inst::SubImm {
+                    dst: Operand::Physical(Reg::Sp),
+                    src: Operand::Physical(Reg::Sp),
+                    imm: image.storage_bytes as i32,
+                });
+                let buf = self.mir.alloc_vreg();
+                self.mir.push(Aarch64Inst::MovRR {
+                    dst: Operand::Virtual(buf),
+                    src: Operand::Physical(Reg::Sp),
+                });
+                let mut eb_vals = Vec::with_capacity(eb as usize);
+                for index in 0..eb as usize {
+                    let v = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Virtual(v),
+                        src: Operand::Physical(RET_REGS[index]),
+                    });
+                    eb_vals.push(v);
+                }
+                crate::agg_slots::store_slots_through_ptr(self, &eb_vals, buf, 0);
+                let native = crate::agg_slots::load_enum_slots_through_ptr(self, buf, &image.map);
+                self.mir.push(Aarch64Inst::AddImm {
+                    dst: Operand::Physical(Reg::Sp),
+                    src: Operand::Physical(Reg::Sp),
+                    imm: image.storage_bytes as i32,
+                });
+                native
+            }
+            ForeignReturn::AggregateSret { image } => {
+                let p = sret_ptr.expect("an sret return reserved its storage pointer");
+                let native = crate::agg_slots::load_enum_slots_through_ptr(self, p, &image.map);
+                self.mir.push(Aarch64Inst::AddImm {
+                    dst: Operand::Physical(Reg::Sp),
+                    src: Operand::Physical(Reg::Sp),
+                    imm: sret_storage as i32,
+                });
+                native
+            }
+        };
+        if let Some(&slot) = slots.first() {
+            self.mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Virtual(primary),
+                src: Operand::Virtual(slot),
+            });
+        }
+        crate::value_plan::MaterializedValue { primary, slots }
+    }
+
+    /// Materialize an aggregate argument's eightbytes (ADR-0064 P3): write its
+    /// native slots into a scratch buffer as the compact C image, then load the
+    /// whole eightbytes back so they pack in ascending C field order. rsp-neutral
+    /// — a register aggregate argument's bytes live only in the returned vregs.
+    fn image_arg_eightbytes(
+        &mut self,
+        value: CfgValue,
+        image: &crate::foreign_call::AggregateImage,
+    ) -> Vec<VReg> {
+        self.mir.push(Aarch64Inst::SubImm {
+            dst: Operand::Physical(Reg::Sp),
+            src: Operand::Physical(Reg::Sp),
+            imm: image.storage_bytes as i32,
+        });
+        let buf = self.mir.alloc_vreg();
+        self.mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Virtual(buf),
+            src: Operand::Physical(Reg::Sp),
+        });
+        let slots = self.require_aggregate_slots(value);
+        crate::agg_slots::store_enum_slots_through_ptr(
+            self,
+            &slots,
+            buf,
+            &image.map,
+            &image.padding,
+        );
+        let ebs = crate::agg_slots::load_slots_through_ptr(self, buf, image.eightbytes());
+        self.mir.push(Aarch64Inst::AddImm {
+            dst: Operand::Physical(Reg::Sp),
+            src: Operand::Physical(Reg::Sp),
+            imm: image.storage_bytes as i32,
+        });
+        ebs
     }
 
     fn lower_residual_value(
@@ -2957,6 +3210,13 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     }
     fn emit_call(&mut self, plan: crate::call_plan::CallPlan) -> crate::value_plan::ValueResult {
         crate::value_plan::ValueResult::Materialized(self.lower_call_plan(plan))
+    }
+    fn emit_foreign_call(
+        &mut self,
+        inputs: crate::foreign_call::ForeignCallInputs,
+        result: VReg,
+    ) -> crate::value_plan::ValueResult {
+        crate::value_plan::ValueResult::Materialized(self.lower_foreign_call(inputs, result))
     }
     fn emit_runtime_call(
         &mut self,

--- a/crates/rue-codegen/src/foreign_call.rs
+++ b/crates/rue-codegen/src/foreign_call.rs
@@ -1,0 +1,228 @@
+//! Target-independent planning for `extern "C"` foreign calls (ADR-0064 P3).
+//!
+//! P2 crossed only scalars and pointers, which occupy one integer register each
+//! and reuse the native call plan with a boundary return extension. P3 adds
+//! **C-classifiable aggregates**, whose target-C crossing disagrees with the
+//! native slot model — the native planner decomposes an aggregate one slot per
+//! leaf and *reverses* the slots (the register-packing audit's key finding),
+//! whereas C packs fields into eightbytes in ascending memory order. So a foreign
+//! call that touches an aggregate is planned here, entirely separate from the
+//! native `CallPlan`, and lowered through each aggregate's **physical memory
+//! image** (which, for a `@repr(c)` struct of scalar/pointer fields, is exactly
+//! the C object layout under the compact-layout default).
+//!
+//! This module only *classifies*: it names, per argument and for the return,
+//! which target-C class ([`rue_air::AggregateArgClass`] /
+//! [`rue_air::AggregateReturnClass`]) governs the crossing and carries the
+//! aggregate's compact image map. The two backends' `emit_foreign_call` own the
+//! physical register/stack/sret sequence — the only genuinely per-architecture
+//! part — consuming this shared authority so neither makes a local ABI decision.
+
+use rue_air::layout::PaddingRange;
+use rue_air::{
+    AggregateArgClass, AggregateReturnClass, FrozenTypeInternPool, ScalarAbiExtension,
+    TargetCAbiFlavor, TargetCCallAbi, Type,
+};
+use rue_cfg::{Cfg, CfgCallArg, CfgValue};
+
+use crate::types::{self, PhysicalEnumSlot};
+
+/// The compact physical memory image of an aggregate crossing the C boundary —
+/// its C object layout under the compact-layout default. Every by-value
+/// aggregate crossing (register-packed, byval-stack, by-reference, and every
+/// aggregate return) is marshaled through this image, so C field order is
+/// honored by construction and the native reversed-slot packing is never used.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AggregateImage {
+    /// Internal-slot → physical-byte map (the compact/C image). Writing an
+    /// aggregate's native slots through this map lays out the C image; reading it
+    /// back reconstructs the native slots.
+    pub map: Vec<PhysicalEnumSlot>,
+    /// Padding byte ranges zeroed before the field stores so the image buffer is
+    /// deterministically initialized (ADR-0052 ruling 5).
+    pub padding: Vec<PaddingRange>,
+    /// Number of internal value-decomposition slots (native slot count).
+    pub slot_count: u32,
+    /// The aggregate's byte size (`@size_of`).
+    pub size: u32,
+    /// The aggregate's alignment (`@align_of`).
+    pub align: u32,
+    /// Backing-buffer size: `size` rounded up to the 16-byte call-stack
+    /// alignment, so whole-eightbyte loads/stores never run past the buffer.
+    pub storage_bytes: u32,
+}
+
+impl AggregateImage {
+    fn for_type(type_pool: &FrozenTypeInternPool, ty: Type) -> Self {
+        let map = types::aggregate_physical_slot_map(type_pool, ty).expect(
+            "an FFI-eligible @repr(c) aggregate (no enums, variant-independent) must have a \
+             single compact memory image; c_passable_by_value gated this before lowering",
+        );
+        let layout = type_pool.layout(ty);
+        AggregateImage {
+            map,
+            padding: type_pool.compact_image_padding_ranges(ty),
+            slot_count: types::type_slot_count(type_pool, ty),
+            size: layout.size as u32,
+            align: layout.alignment as u32,
+            storage_bytes: align_up(layout.size as u32, 16),
+        }
+    }
+
+    /// Number of eightbytes (8-byte integer registers / stack slots) the image
+    /// spans: `ceil(size / 8)`.
+    pub fn eightbytes(&self) -> u32 {
+        self.size.div_ceil(8)
+    }
+}
+
+/// How one foreign-call argument crosses the target-C boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ForeignArg {
+    /// A scalar or pointer, already canonically extended in its vreg by Rue's
+    /// internal invariant — occupies one integer register (or spills to the
+    /// stack once the integer registers are exhausted).
+    Scalar { value: CfgValue },
+    /// A ≤16-byte aggregate packed into one or two integer registers in C field
+    /// order ([`AggregateArgClass::IntegerRegisters`]).
+    AggregateRegisters {
+        value: CfgValue,
+        image: AggregateImage,
+    },
+    /// A >16-byte aggregate passed by value in the outgoing stack argument area
+    /// (SysV MEMORY class, [`AggregateArgClass::ByValueStack`]).
+    AggregateByvalStack {
+        value: CfgValue,
+        image: AggregateImage,
+    },
+    /// A >16-byte aggregate passed as a pointer to a caller-owned copy (AAPCS64,
+    /// [`AggregateArgClass::ByReferenceCopy`]).
+    AggregateByRefCopy {
+        value: CfgValue,
+        image: AggregateImage,
+    },
+}
+
+/// How a foreign call's return value crosses the target-C boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ForeignReturn {
+    /// Unit / never / empty: no materialized value.
+    ZeroSized,
+    /// A scalar returned in the primary result register; `ext` re-extends it to
+    /// Rue's canonical 64-bit form (a C callee leaves the high bits unspecified).
+    Scalar { ext: ScalarAbiExtension },
+    /// A ≤16-byte aggregate returned in one or two result registers (`rax:rdx` /
+    /// `x0:x1`) in C field order; the backend bridges the registers through the
+    /// image buffer to reconstruct the native slots.
+    AggregateRegisters { image: AggregateImage },
+    /// A >16-byte aggregate returned indirectly through caller storage (sret);
+    /// the callee writes the C image, the backend reads the native slots back.
+    AggregateSret { image: AggregateImage },
+}
+
+/// A classified foreign call: the C symbol, every argument and the return, plus
+/// the psABI flavor whose classifier produced them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForeignCallInputs {
+    /// The resolved (unmangled) C symbol the undefined reference targets.
+    pub symbol: String,
+    pub flavor: TargetCAbiFlavor,
+    pub args: Vec<ForeignArg>,
+    pub ret: ForeignReturn,
+}
+
+impl ForeignCallInputs {
+    /// The C symbol this call targets.
+    pub fn symbol_ref(&self) -> &str {
+        &self.symbol
+    }
+}
+
+impl ForeignCallInputs {
+    /// Whether a foreign call to `return_ty` with `args` needs the aggregate
+    /// path at all: true when the return or any argument is an aggregate
+    /// (struct/array) type. A scalars-only foreign call keeps P2's native-plan
+    /// route with a boundary return extension.
+    pub(crate) fn call_touches_aggregate(cfg: &Cfg, return_ty: Type, args: &[CfgCallArg]) -> bool {
+        is_aggregate(return_ty)
+            || args
+                .iter()
+                .any(|arg| is_aggregate(cfg.get_inst(arg.value).ty))
+    }
+
+    /// Classify a foreign call through the shared [`TargetCCallAbi`] authority.
+    pub(crate) fn from_cfg(
+        symbol: String,
+        cfg: &Cfg,
+        type_pool: &FrozenTypeInternPool,
+        return_ty: Type,
+        args: &[CfgCallArg],
+        flavor: TargetCAbiFlavor,
+    ) -> Self {
+        let abi = TargetCCallAbi::new(flavor);
+        let planned_args = args
+            .iter()
+            .map(|arg| {
+                let value = arg.value;
+                let ty = cfg.get_inst(value).ty;
+                assert!(
+                    matches!(arg.mode, rue_cfg::CfgArgMode::Normal),
+                    "an `extern \"C\"` argument is always by value; inout/borrow do not cross a \
+                     C boundary"
+                );
+                if !is_aggregate(ty) {
+                    return ForeignArg::Scalar { value };
+                }
+                let image = AggregateImage::for_type(type_pool, ty);
+                match abi.classify_aggregate_arg(image.size as u64, image.align as u64) {
+                    AggregateArgClass::IntegerRegisters { .. } => {
+                        ForeignArg::AggregateRegisters { value, image }
+                    }
+                    AggregateArgClass::ByValueStack { .. } => {
+                        ForeignArg::AggregateByvalStack { value, image }
+                    }
+                    AggregateArgClass::ByReferenceCopy { .. } => {
+                        ForeignArg::AggregateByRefCopy { value, image }
+                    }
+                }
+            })
+            .collect();
+
+        let ret = if !is_aggregate(return_ty) {
+            match type_pool.abi_slot_count(return_ty) {
+                0 => ForeignReturn::ZeroSized,
+                _ => ForeignReturn::Scalar {
+                    ext: abi.scalar_return_extension(return_ty),
+                },
+            }
+        } else {
+            let image = AggregateImage::for_type(type_pool, return_ty);
+            match abi.classify_aggregate_return(image.size as u64, image.align as u64) {
+                AggregateReturnClass::IntegerRegisters { .. } => {
+                    ForeignReturn::AggregateRegisters { image }
+                }
+                AggregateReturnClass::Indirect { .. } => ForeignReturn::AggregateSret { image },
+            }
+        };
+
+        Self {
+            symbol,
+            flavor,
+            args: planned_args,
+            ret,
+        }
+    }
+}
+
+/// Whether `ty` is an aggregate (struct or fixed array) — the types whose
+/// target-C crossing needs the image-based foreign path.
+fn is_aggregate(ty: Type) -> bool {
+    matches!(
+        ty.kind(),
+        rue_air::TypeKind::Struct(_) | rue_air::TypeKind::Array(_)
+    )
+}
+
+const fn align_up(value: u32, alignment: u32) -> u32 {
+    value.div_ceil(alignment) * alignment
+}

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -44,6 +44,7 @@ macro_rules! end_inst {
 mod allocation;
 pub mod call_plan;
 mod codegen_pipeline;
+pub mod foreign_call;
 pub mod runtime_call_plan;
 mod schedule_core;
 mod stack_frame;

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -427,6 +427,16 @@ pub trait ValueLowerAdapter:
     fn return_register_budget(&self) -> u32;
     fn emit_value(&mut self, plan: ValueEmissionPlan) -> ValueResult;
     fn emit_call(&mut self, plan: CallPlan) -> ValueResult;
+    /// Emit an `extern "C"` foreign call that crosses one or more aggregates by
+    /// value (ADR-0064 P3). The classification comes from the shared
+    /// [`ForeignCallInputs`](crate::foreign_call::ForeignCallInputs) authority;
+    /// the backend owns only the physical register/stack/sret sequence.
+    /// `result` is the pre-reserved result vreg.
+    fn emit_foreign_call(
+        &mut self,
+        inputs: crate::foreign_call::ForeignCallInputs,
+        result: VReg,
+    ) -> ValueResult;
     fn emit_runtime_call(&mut self, plan: crate::runtime_call_plan::RuntimeCallPlan)
     -> ValueResult;
     fn emit_intrinsic(&mut self, plan: IntrinsicPlan) -> ValueResult;
@@ -1449,33 +1459,57 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                 adapter.emit_runtime_call(plan)
             } else {
                 let symbol = adapter.resolve_symbol(*name);
-                // An `extern "C"` foreign call crosses under the target-C ABI
-                // (ADR-0064 P2): a scalar return is re-extended to Rue's canonical
-                // 64-bit form because a C callee leaves the bits above the
-                // return's declared width unspecified. The rule comes from the
-                // shared `TargetCCallAbi` classifier, not a backend-local choice.
-                let foreign_return_extension = if adapter.is_foreign_symbol(&symbol)
-                    && matches!(inputs.return_plan, crate::call_plan::ReturnPlan::Scalar)
+                let is_foreign = adapter.is_foreign_symbol(&symbol);
+                // A foreign call that crosses an aggregate by value takes the
+                // dedicated target-C path (ADR-0064 P3): the native slot plan
+                // reverses multi-slot aggregates, disagreeing with C packing, so
+                // aggregates are marshaled through their physical memory image in
+                // C field order. A scalars-only foreign call keeps P2's native
+                // plan with a boundary return extension.
+                if is_foreign
+                    && crate::foreign_call::ForeignCallInputs::call_touches_aggregate(
+                        ctx.cfg, inst.ty, call_args,
+                    )
                 {
-                    let ext = rue_air::TargetCCallAbi::new(adapter.target_c_flavor())
-                        .scalar_return_extension(inst.ty);
-                    (!ext.is_noop()).then_some(ext)
+                    let foreign_inputs = crate::foreign_call::ForeignCallInputs::from_cfg(
+                        symbol,
+                        ctx.cfg,
+                        ctx.type_pool,
+                        inst.ty,
+                        call_args,
+                        adapter.target_c_flavor(),
+                    );
+                    let result_vreg = adapter.reserve_value_result();
+                    adapter.emit_foreign_call(foreign_inputs, result_vreg)
                 } else {
-                    None
-                };
-                let result_vreg = adapter.reserve_value_result();
-                let mut plan = crate::call_plan::CallPlan::from_inputs_with_result(
-                    crate::call_plan::CallTarget::rue(symbol),
-                    inputs.return_plan,
-                    inputs.compact_return_image.clone(),
-                    inputs.compact_return_dispatch.clone(),
-                    &inputs.args,
-                    adapter.call_arg_register_budget(),
-                    adapter,
-                    Some(result_vreg),
-                );
-                plan.foreign_return_extension = foreign_return_extension;
-                adapter.emit_call(plan)
+                    // An `extern "C"` scalar/pointer call (ADR-0064 P2): a scalar
+                    // return is re-extended to Rue's canonical 64-bit form because
+                    // a C callee leaves the bits above the return's declared width
+                    // unspecified. The rule comes from the shared `TargetCCallAbi`
+                    // classifier, not a backend-local choice.
+                    let foreign_return_extension = if is_foreign
+                        && matches!(inputs.return_plan, crate::call_plan::ReturnPlan::Scalar)
+                    {
+                        let ext = rue_air::TargetCCallAbi::new(adapter.target_c_flavor())
+                            .scalar_return_extension(inst.ty);
+                        (!ext.is_noop()).then_some(ext)
+                    } else {
+                        None
+                    };
+                    let result_vreg = adapter.reserve_value_result();
+                    let mut plan = crate::call_plan::CallPlan::from_inputs_with_result(
+                        crate::call_plan::CallTarget::rue(symbol),
+                        inputs.return_plan,
+                        inputs.compact_return_image.clone(),
+                        inputs.compact_return_dispatch.clone(),
+                        &inputs.args,
+                        adapter.call_arg_register_budget(),
+                        adapter,
+                        Some(result_vreg),
+                    );
+                    plan.foreign_return_extension = foreign_return_extension;
+                    adapter.emit_call(plan)
+                }
             };
             cache_result(adapter, value, result);
             Some(ValueKind::Call)

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -51,6 +51,11 @@ pub(super) const ARG_REGS: [Reg; 6] = [Reg::Rdi, Reg::Rsi, Reg::Rdx, Reg::Rcx, R
 /// `crate::cfg_lower::type_uses_sret_return`. (RUE-106)
 pub(super) const RET_REGS: [Reg; 6] = [Reg::Rax, Reg::Rdx, Reg::Rcx, Reg::R8, Reg::R9, Reg::R10];
 
+/// Round `value` up to a multiple of `alignment` (a power of two ≥ 1).
+const fn align_up_u32(value: u32, alignment: u32) -> u32 {
+    value.div_ceil(alignment) * alignment
+}
+
 /// CFG to X86Mir lowering.
 pub struct CfgLower<'a> {
     /// Shared context with type helpers and chain tracing.
@@ -1142,6 +1147,232 @@ impl<'a> CfgLower<'a> {
                 panic!("unexpected target-C scalar extension width {from_bits}")
             }
         }
+    }
+
+    /// Lower an `extern "C"` foreign call that crosses one or more aggregates by
+    /// value under SysV AMD64 (ADR-0064 P3). The classification comes from the
+    /// shared [`ForeignCallInputs`](crate::foreign_call::ForeignCallInputs)
+    /// authority; every aggregate is marshaled through its compact physical image
+    /// (C field order), so the native reversed-slot packing is never used.
+    fn lower_foreign_call(
+        &mut self,
+        inputs: crate::foreign_call::ForeignCallInputs,
+        primary: VReg,
+    ) -> crate::value_plan::MaterializedValue {
+        use crate::foreign_call::{ForeignArg, ForeignReturn};
+        let abi = rue_air::TargetCCallAbi::new(inputs.flavor);
+        let budget = ARG_REGS.len();
+
+        // Reserve sret storage first: a >16-byte aggregate return writes here and
+        // the buffer must survive the call. Its size is 16-aligned, preserving
+        // the call site's 16-byte stack alignment.
+        let mut sret_ptr: Option<VReg> = None;
+        let mut sret_storage: u32 = 0;
+        if let ForeignReturn::AggregateSret { image } = &inputs.ret {
+            sret_storage = image.storage_bytes;
+            self.mir.push(X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rsp),
+                imm: -(sret_storage as i32),
+            });
+            let p = self.mir.alloc_vreg();
+            self.mir.push(X86Inst::MovRR {
+                dst: Operand::Virtual(p),
+                src: Operand::Physical(Reg::Rsp),
+            });
+            sret_ptr = Some(p);
+        }
+
+        // Physical argument operands: `int_ops` fill ARG_REGS in order, `stack_ops`
+        // are 8-byte outgoing-stack slots (ascending). The SysV sret pointer is the
+        // hidden first integer argument (rdi); AAPCS64's dedicated x8 never reaches
+        // this x86 path.
+        let mut int_ops: Vec<VReg> = Vec::new();
+        let mut stack_ops: Vec<VReg> = Vec::new();
+        if let Some(p) = sret_ptr {
+            debug_assert!(!abi.sret_pointer_in_dedicated_register());
+            int_ops.push(p);
+        }
+
+        for arg in &inputs.args {
+            match arg {
+                ForeignArg::Scalar { value } => {
+                    let v = self.get_vreg(*value);
+                    if int_ops.len() < budget {
+                        int_ops.push(v);
+                    } else {
+                        stack_ops.push(v);
+                    }
+                }
+                ForeignArg::AggregateRegisters { value, image } => {
+                    let ebs = self.image_arg_eightbytes(*value, image);
+                    // All-or-nothing: an aggregate uses registers only if all its
+                    // eightbytes fit in the remaining integer registers (SysV).
+                    if int_ops.len() + ebs.len() <= budget {
+                        int_ops.extend(ebs);
+                    } else {
+                        stack_ops.extend(ebs);
+                    }
+                }
+                ForeignArg::AggregateByvalStack { value, image } => {
+                    // SysV MEMORY class: the whole struct image sits in the
+                    // outgoing stack area (contiguous, ascending), consuming no
+                    // integer registers.
+                    let ebs = self.image_arg_eightbytes(*value, image);
+                    stack_ops.extend(ebs);
+                }
+                ForeignArg::AggregateByRefCopy { .. } => {
+                    panic!(
+                        "SysV AMD64 passes a >16-byte aggregate byval-on-stack, not by reference; \
+                         ByReferenceCopy is an AAPCS64-only class"
+                    )
+                }
+            }
+        }
+
+        // Emit the call frame: stack args first (reverse push so the first stack
+        // arg lands at the lowest address), then the integer args pushed and popped
+        // into ARG_REGS, matching the native `lower_call_plan` idiom.
+        let num_stack = stack_ops.len();
+        let stack_bytes = align_up_u32((num_stack * 8) as u32, 16);
+        let needs_alignment = stack_bytes > (num_stack * 8) as u32;
+        if needs_alignment {
+            self.mir.push(X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rsp),
+                imm: -8,
+            });
+        }
+        for v in stack_ops.iter().rev() {
+            self.mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rax),
+                src: Operand::Virtual(*v),
+            });
+            self.mir.push(X86Inst::Push {
+                src: Operand::Physical(Reg::Rax),
+            });
+        }
+        for v in int_ops.iter().rev() {
+            self.mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rax),
+                src: Operand::Virtual(*v),
+            });
+            self.mir.push(X86Inst::Push {
+                src: Operand::Physical(Reg::Rax),
+            });
+        }
+        for index in 0..int_ops.len() {
+            self.mir.push(X86Inst::Pop {
+                dst: Operand::Physical(ARG_REGS[index]),
+            });
+        }
+        let symbol_id = self.intern_symbol(inputs.symbol_ref());
+        self.mir.push(X86Inst::CallRel { symbol_id });
+        if num_stack > 0 || needs_alignment {
+            self.mir.push(X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rsp),
+                imm: stack_bytes as i32,
+            });
+        }
+
+        // Reconstruct the Rue value from the C result.
+        let slots = match &inputs.ret {
+            ForeignReturn::ZeroSized => {
+                self.mir.push(X86Inst::MovRI32 {
+                    dst: Operand::Virtual(primary),
+                    imm: 0,
+                });
+                Vec::new()
+            }
+            ForeignReturn::Scalar { ext } => {
+                self.mir.push(X86Inst::MovRR {
+                    dst: Operand::Virtual(primary),
+                    src: Operand::Physical(Reg::Rax),
+                });
+                self.emit_c_return_extension(primary, *ext);
+                Vec::new()
+            }
+            ForeignReturn::AggregateRegisters { image } => {
+                // rax:rdx hold the return eightbytes (C field order). Store them to
+                // a scratch buffer, then read the native slots back through the
+                // compact image map so downstream sees the ascending decomposition.
+                let eb = image.eightbytes();
+                self.mir.push(X86Inst::AddRI {
+                    dst: Operand::Physical(Reg::Rsp),
+                    imm: -(image.storage_bytes as i32),
+                });
+                let buf = self.mir.alloc_vreg();
+                self.mir.push(X86Inst::MovRR {
+                    dst: Operand::Virtual(buf),
+                    src: Operand::Physical(Reg::Rsp),
+                });
+                let mut eb_vals = Vec::with_capacity(eb as usize);
+                for index in 0..eb as usize {
+                    let v = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(v),
+                        src: Operand::Physical(RET_REGS[index]),
+                    });
+                    eb_vals.push(v);
+                }
+                crate::agg_slots::store_slots_through_ptr(self, &eb_vals, buf, 0);
+                let native = crate::agg_slots::load_enum_slots_through_ptr(self, buf, &image.map);
+                self.mir.push(X86Inst::AddRI {
+                    dst: Operand::Physical(Reg::Rsp),
+                    imm: image.storage_bytes as i32,
+                });
+                native
+            }
+            ForeignReturn::AggregateSret { image } => {
+                let p = sret_ptr.expect("an sret return reserved its storage pointer");
+                let native = crate::agg_slots::load_enum_slots_through_ptr(self, p, &image.map);
+                self.mir.push(X86Inst::AddRI {
+                    dst: Operand::Physical(Reg::Rsp),
+                    imm: sret_storage as i32,
+                });
+                native
+            }
+        };
+        if let Some(&slot) = slots.first() {
+            self.mir.push(X86Inst::MovRR {
+                dst: Operand::Virtual(primary),
+                src: Operand::Virtual(slot),
+            });
+        }
+        crate::value_plan::MaterializedValue { primary, slots }
+    }
+
+    /// Materialize an aggregate argument's eightbytes (ADR-0064 P3): write its
+    /// native slots into a scratch buffer as the compact C image, then load the
+    /// whole eightbytes back so they pack in ascending C field order. The scratch
+    /// buffer is freed immediately — a register/byval aggregate argument's bytes
+    /// live only in the returned eightbyte vregs, so this is rsp-neutral.
+    fn image_arg_eightbytes(
+        &mut self,
+        value: CfgValue,
+        image: &crate::foreign_call::AggregateImage,
+    ) -> Vec<VReg> {
+        self.mir.push(X86Inst::AddRI {
+            dst: Operand::Physical(Reg::Rsp),
+            imm: -(image.storage_bytes as i32),
+        });
+        let buf = self.mir.alloc_vreg();
+        self.mir.push(X86Inst::MovRR {
+            dst: Operand::Virtual(buf),
+            src: Operand::Physical(Reg::Rsp),
+        });
+        let slots = self.require_aggregate_slots(value);
+        crate::agg_slots::store_enum_slots_through_ptr(
+            self,
+            &slots,
+            buf,
+            &image.map,
+            &image.padding,
+        );
+        let ebs = crate::agg_slots::load_slots_through_ptr(self, buf, image.eightbytes());
+        self.mir.push(X86Inst::AddRI {
+            dst: Operand::Physical(Reg::Rsp),
+            imm: image.storage_bytes as i32,
+        });
+        ebs
     }
 
     fn lower_residual_value(
@@ -2781,6 +3012,13 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     }
     fn emit_call(&mut self, plan: crate::call_plan::CallPlan) -> crate::value_plan::ValueResult {
         crate::value_plan::ValueResult::Materialized(self.lower_call_plan(plan))
+    }
+    fn emit_foreign_call(
+        &mut self,
+        inputs: crate::foreign_call::ForeignCallInputs,
+        result: VReg,
+    ) -> crate::value_plan::ValueResult {
+        crate::value_plan::ValueResult::Materialized(self.lower_foreign_call(inputs, result))
     }
     fn emit_runtime_call(
         &mut self,

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1592,14 +1592,16 @@ pub enum ErrorKind {
     },
 
     /// A type appeared in an `extern "C"` signature that the current FFI phase
-    /// cannot yet classify. C FFI P2 (ADR-0064, RUE-1056) supports every integer
-    /// and pointer scalar (`i8`/`u8`/`i16`/`u16`/`i32`/`u32`/`i64`/`u64`, `bool`
-    /// as `_Bool`, and raw pointers). Aggregates await by-value classification
-    /// (P3), floating-point awaits RUE-714 (P5), and enums are not FFI-safe.
+    /// cannot classify. C FFI P3 (ADR-0064, RUE-1057) supports every integer and
+    /// pointer scalar (`i8`/`u8`/`i16`/`u16`/`i32`/`u32`/`i64`/`u64`, `bool` as
+    /// `_Bool`, and raw pointers) *and* C-classifiable `@repr(c)` aggregates.
+    /// What remains rejected here: a Rue enum (not FFI-safe in v0), and — until
+    /// RUE-714 adds the type (P5) — floating-point.
     #[error(
-        "type `{ty}` is not yet supported in an `extern \"C\"` signature: \
-         C FFI (ADR-0064) supports integer and pointer scalars — aggregates \
-         await a later phase and floating-point awaits RUE-714"
+        "type `{ty}` is not supported in an `extern \"C\"` signature: \
+         C FFI (ADR-0064) supports integer and pointer scalars and \
+         C-classifiable `@repr(c)` aggregates — enums are not FFI-safe and \
+         floating-point awaits RUE-714"
     )]
     ExternSignatureTypeUnsupported {
         /// The rejected type, as rendered for the user.


### PR DESCRIPTION
Fixes RUE-1057

ADR-0064 phase P3, the largest integer phase: `@repr(c)` structs passing the Amendment 1 predicates are now passable by value across the C boundary on both backends.

- **SysV AMD64**: eightbyte classification (INTEGER class; SSE defers with floats/RUE-714). ≤16-byte structs pack into integer registers **in C field order** — not Native's reversed-slot decomposition, the ADR audit's key finding — with all-or-nothing register spill against the remaining budget; >16 bytes go byval on the stack. Returns in rax:rdx, or sret with the rax echo.
- **AAPCS64**: composite rules — ≤16 bytes in x-registers; larger passed *by reference to a caller-owned copy* (not byval-on-stack); returns in x0:x1 or via the dedicated x8 indirect-result register (no echo). P2's documented sret semantics become reachable here.
- **New target-independent `foreign_call` classification** (`ForeignCallInputs`/`AggregateImage`) consumed by both backends' dedicated foreign-call lowering — aggregates marshal through their compact memory image, so C field order is honored by construction; no backend-local ABI decisions.
- `c_passable_by_value` widens to marked+eligible aggregates; E1101 layering stays truthful (enums/floats still reject, arrays still decay-diagnose, unmarked structs still E1102).
- **Proof by execution** (native x86-64): order-sensitive cases whose outputs distinguish wrong packing (a reversed two-field combine yields 5003, not the expected 3005), a >16-byte byval tail read, a two-register return, and a large sret return — additionally **cross-checked against a real `cc`-assembled archive** producing identical output, so the caller ABI matches an actual C toolchain, not just the hand-encoded members. Layouts cross-checked via `@offset_of`. AArch64 members assemble+link locally and execute under ARM64 CI.
- Documented follow-up (not silently wrong): byval stack placement is 8-byte granular; a future >8-aligned eligible type needs stack-area padding the classifier already carries.

Verification: worker diff re-verified on current trunk (0c0ae35) — c_ffi corpus 25/25 with native execution, hand seam checks (std.c-field `@repr(c)` struct accepted by value; unmarked still E1102). First full-suite run hit three `examples_rill` 10s timeouts from disk contention (worktree cleanup ran concurrently); all 12 rill cases pass in isolation and a clean full re-run on a quiet host exited 0 with zero failures in both formats.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_