### PR TITLE
RUE-714: Floating-point design ADR (0065)

### DIFF
--- a/docs/designs/0065-floating-point.md
+++ b/docs/designs/0065-floating-point.md
@@ -1,0 +1,307 @@
+---
+id: 0065
+title: "Floating point: f32/f64, IEEE-754 semantics, and register classes"
+status: proposal
+tags: [types, semantics, codegen, numerics, abi]
+feature-flag: floats
+created: 2026-07-19
+accepted:
+implemented:
+spec-sections: []
+superseded-by:
+---
+
+# ADR-0065: Floating point — f32/f64, IEEE-754 semantics, and register classes
+
+## Status
+
+Proposal. This is the design gate for **M9 · Floating point** (RUE-714). It needs
+a maintainer decision before any implementation issue is opened. Today Rue has
+**zero** float support: the lexer emits only `Int(u64)`
+(`crates/rue-lexer/src/logos_lexer.rs`), the packed `Type` encoding has no
+F32/F64 tags (`crates/rue-air/src/types.rs`), neither backend has XMM/V
+registers, and the register allocator has **no register-class concept at all**
+(`crates/rue-codegen/src/vreg.rs` is `struct VReg(u32)`, single-class). The only
+existing traces are a forward reference in spec `4.3` ("once floating-point types
+exist") and `comptime_float` marked *future* in [ADR-0025](0025-comptime.md).
+
+## Summary
+
+Rue gains two floating-point types, **`f32`** (IEEE-754 binary32) and **`f64`**
+(binary64), with `f64` as the default. Arithmetic follows **IEEE-754 exactly**:
+`/0.0` yields `±inf`, `0.0/0.0` yields `NaN`, and nothing traps — the deliberate
+opposite of integer division, which traps on `/0`. There are **no implicit
+conversions** — not int↔float, not `f32`↔`f64`; every width or domain change is
+an explicit intrinsic (`@int_to_float`, `@float_to_int`, `@float_cast`). Literals
+are **`comptime_float`** (arbitrary precision, per ADR-0025), coerced to a
+concrete type by context with round-to-nearest, so no literal suffixes are
+introduced. Comparison operators (`==`, `<`, …) use **IEEE partial** semantics —
+`NaN != NaN`, `NaN` is unordered — which formally resolves the open question in
+spec 4.3 and is the concrete motivation for the future `PartialEq`/`Eq` split
+(RUE-246). The enabling compiler change is a **register-class split (GP vs FP)**
+threaded through `VReg`, liveness, register allocation, and scheduling; it lands
+as a no-op refactor *before* any float instruction selection. Runtime `float →
+string` adopts the already-vendored `zmij` dtoa crate. The whole feature is gated
+behind `PreviewFeature::Floats`.
+
+## Context
+
+Floats do not shard into small independent issues: the literal grammar, the type
+tags, the inference rule, both backends, the calling convention, and the runtime
+formatter are one decision wearing many hats. Two things in particular make this
+a genuine design gate rather than a mechanical port:
+
+1. **The register-class change is structural.** Every prior type in Rue lives in
+   a general-purpose register. Floats live in a *separate* register file (SSE/XMM
+   on x86-64, the FP/NEON V-registers on aarch64) that the allocator, liveness,
+   and scheduler must model as a distinct class. `VReg` is currently classless.
+   This is the deepest lift and it touches both backends at once.
+
+2. **IEEE-754 collides with two of Rue's own principles.** `NaN != NaN` breaks
+   the "structural equality is a total equivalence" invariant that
+   [ADR-0035](0035-string-model-byte-strings.md) and spec 4.3 rely on. And float
+   arithmetic is *fully defined for every input* (`÷0 → ±inf`, invalid `→ NaN`,
+   overflow `→ inf`), which is **more** defined than integer division — so
+   [ADR-0036](0036-behavior-classification-preference.md) ("prefer the
+   most-defined category") actually points *toward* the non-trapping IEEE
+   behavior, even though it diverges from how integers behave.
+
+### Prior art
+
+The six languages the design was checked against cluster cleanly on the choices
+that matter.
+
+| Language | Default literal type | Implicit int↔float | Implicit f32↔f64 | `NaN == NaN` | Literal model |
+|---|---|---|---|---|---|
+| **C** | `double` | yes (usual arithmetic conversions) | yes (widening) | false | typed constants, `f`/`l` suffixes |
+| **Go** | `float64` (untyped const) | no (untyped constant coercion only) | no | false | arbitrary-precision untyped constants |
+| **Rust** | inferred, else `f64` | no (`as` casts only) | no (`as` casts) | false (`PartialOrd`; `total_cmp` for total) | typed, `f32`/`f64` suffixes |
+| **Zig** | `comptime_float` (→ `f64` default) | no (`@floatFromInt`/`@intFromFloat`) | widening coerces; narrowing explicit | false | `comptime_float` = f128 precision, no suffixes |
+| **Swift** | `Double` | no (explicit `Double(x)`) | no (explicit) | false (`==` is IEEE; separate total order) | `ExpressibleByFloatLiteral` |
+| **Hylo** | `Float64` | no | no | false | stdlib literal conformance |
+
+The consensus is strong and modern: **f64 default, no implicit conversions, IEEE
+comparison**. The two real disagreements are (a) *how* literals reach a concrete
+type — C/Rust use typed constants and suffixes, Go/Zig use an abstract
+arbitrary-precision constant that coerces by context — and (b) how to reconcile
+IEEE partial ordering with containers/sorting/hashing that need a total order.
+
+## Decision
+
+Take the modern consensus wholesale and resolve the two disagreements in the
+direction of Rue's existing grain.
+
+### 1. Types and IEEE-754 semantics
+
+- **Two types: `f32` (binary32) and `f64` (binary64).** Both, not f64-only:
+  `f32` earns its place for memory footprint, GPU/graphics interop, and C FFI
+  (RUE-1059), and once register classes exist a second float width is nearly
+  free. `f64` is the **default** wherever inference has no other signal
+  (Go/Swift/Hylo/C consensus).
+- **Arithmetic is IEEE-754, and total.** `+ - * / %` map to hardware scalar FP
+  ops. Division by zero does **not** trap: `x/0.0 → ±inf`, `0.0/0.0 → NaN`,
+  overflow `→ ±inf`, invalid `→ NaN`. This is the deliberate divergence from
+  integer division (which traps on `/0`, spec 4.2), and the spec must state it
+  explicitly. It is *consistent* with [ADR-0036](0036-behavior-classification-preference.md):
+  IEEE floats are the most-defined category — no operation is undefined, so none
+  needs a trap.
+- **`-0.0`, `inf`, `NaN` are ordinary runtime values.** There is no `NaN`/`inf`
+  literal syntax (matching Zig); they arise from arithmetic or from `std.math`
+  constants/intrinsics (`@is_nan`, `std.math.inf`, `std.math.nan`).
+
+### 2. Comparison and equality (resolves spec 4.3)
+
+- **Operators are IEEE partial.** `==`, `!=`, `<`, `<=`, `>`, `>=` on floats
+  follow IEEE-754: `NaN` compares **unordered** (`NaN == NaN` is false, every
+  ordering against `NaN` is false), and `-0.0 == +0.0` is true. This is what all
+  six surveyed languages do and what the hardware compare instructions
+  (`ucomisd`, `fcmp`) produce; deviating would be both surprising and slow.
+- **This is the motivating case for the `PartialEq`/`Eq` split.** Spec 4.3
+  already predicts it: today structural equality is a total equivalence because
+  no leaf type has a value that is unequal to itself. `f32`/`f64` introduce
+  exactly such a value. Under this ADR, a structural `==` on an aggregate
+  containing a float leaf inherits IEEE partiality (a struct holding a `NaN` is
+  not equal to itself). We accept that as the honest consequence and **defer the
+  total-order machinery to traits** (RUE-246): the eventual `Eq`/`Ord` refinement
+  supplies the total path that containers, sorting, and hashing need, realized by
+  a `total_cmp`-style total order (IEEE `totalOrder`: `-0.0 < +0.0`, `NaN` a
+  distinct maximal bit pattern), following Rust and Swift. No trait work is in
+  scope here; this ADR only records that float `==` is IEEE and that the split is
+  now *required*, not merely anticipated.
+
+### 3. Literals and inference
+
+- **Literals are `comptime_float`** — arbitrary precision, per the ADR-0025
+  table, mirroring `comptime_int`. Grammar: `1.5`, `1e9`, `1.5e-3`, `6.022e23`
+  (a digit run, then either a `.` fraction or an exponent or both). A leading or
+  trailing dot (`.5`, `5.`) is **rejected** for the same readability reason Rue
+  rejects other ambiguous lexemes; write `0.5` / `5.0`.
+- **No literal suffixes.** Rue has no integer suffixes either (the lexer's only
+  numeric token is `Int(u64)`); adding float suffixes would be a new precedent
+  for no gain. A `comptime_float` coerces to the concrete type demanded by
+  context — `let x: f32 = 1.5;`, `fn f(y: f64)`, `1.0 + x` — exactly as
+  `comptime_int` already does. This is the Go/Zig abstract-constant model, chosen
+  over C/Rust typed-suffix constants because it composes with Rue's existing
+  comptime story.
+- **Coercion rounds to nearest.** A `comptime_float` that is not exactly
+  representable in the target type is rounded round-half-to-even (IEEE default).
+  A literal whose magnitude exceeds the target's finite range is a **compile
+  error**, not a silent `inf` (matches Rust's "literal out of range").
+- **`comptime_int` → `comptime_float`** is allowed (an integer literal is valid
+  where a float is expected: `let x: f64 = 3;`), mirroring Zig. The reverse
+  (`comptime_float` → integer) is **not**, even for integral values.
+
+### 4. Conversions: explicit only
+
+No implicit int↔float or f32↔f64 conversion ever happens at runtime. Three
+intrinsics, named in Rue's existing `@x_to_y` convention (`@int_to_ptr`,
+`@ptr_to_int`):
+
+- **`@int_to_float(x)`** — integer → float, rounding to nearest.
+- **`@float_to_int(x)`** — float → integer, **truncating toward zero**, and it
+  **traps** on `NaN` or an out-of-range magnitude. Trapping (rather than Rust's
+  saturating `as` or C's UB) is the loud-pragmatism choice and is consistent with
+  Rue's trapping integer overflow. A saturating variant can be added later if a
+  concrete need appears.
+- **`@float_cast(x)`** — `f32` ↔ `f64`. Widening is exact; narrowing rounds to
+  nearest (and may produce `±inf`). Both directions are explicit precisely
+  because narrowing is lossy — the same "lossiness is never implicit" discipline
+  as [ADR-0035](0035-string-model-byte-strings.md).
+
+### 5. Codegen: register classes first, then float instructions
+
+This is the structural pre-work and it must land **before** any float
+instruction selection, as its own reviewed change.
+
+- **Add a `RegClass` (GP, FP) to `VReg`** and thread it through liveness,
+  register allocation, and scheduling. The refactor is a **no-op**: every
+  existing virtual register is `RegClass::Gp`, so behavior is identical and the
+  change is validated by the existing suite passing unchanged. Physical register
+  sets, spill slots, and move insertion become class-aware.
+- **x86-64:** SSE2 scalar ops (`movss`/`movsd`, `addsd`, `subsd`, `mulsd`,
+  `divsd`, `sqrtsd`, `cvtsi2sd`/`cvttsd2si`, `cvtss2sd`/`cvtsd2ss`), the XMM0–15
+  register file, and `ucomisd`/`ucomiss` for comparisons (unordered → the IEEE
+  partial result). SSE2 is baseline for x86-64, so no feature detection.
+- **aarch64:** scalar FP/NEON ops (`fadd`, `fsub`, `fmul`, `fdiv`, `fsqrt`,
+  `scvtf`/`fcvtzs`, `fcvt`), the V0–31 register file (Sn/Dn views), and `fcmp`.
+- **Calling conventions:** SysV passes/returns floats in XMM0–7 / XMM0; AAPCS64
+  in V0–7 / V0. Both backends land in the **same PR** per the repository's
+  multi-backend rule, with encoding and execution tests each. Where the two
+  backends share lowering shape, prefer the shared middle layer of
+  [ADR-0048](0048-shared-codegen-middle-layer.md) rather than duplicating.
+
+### 6. Runtime and formatting
+
+- **`float → string` adopts the vendored `zmij` dtoa crate** (`third-party/vendor/zmij-0.1.7`,
+  a shortest-round-trip decimal converter), wired as `__rue_to_string_float`.
+  A host-only runtime symbol is fine here because `@to_string` already routes
+  through the runtime. This unblocks printing, `@dbg`, and `std.fmt` for floats.
+- **`string → float` (`strtod`) is deferred.** Nothing in v1 needs runtime float
+  parsing — literals are handled at compile time by the lexer/comptime path, not
+  by a runtime parser. A later ADR/issue can add it alongside the broader parsing
+  surface.
+
+### 7. Standard library surface
+
+- **`std.math`:** the float operations that are a *single hardware instruction* —
+  `sqrt`, `floor`, `ceil`, `trunc`, `round` (via `roundsd` / `frintX`) — plus the
+  `inf`/`nan`/`is_nan` primitives. Transcendentals (`sin`, `cos`, `exp`, `log`,
+  `pow`) are **deferred**: they need a `libm`-class implementation and Rue has no
+  libm dependency. `std.math` today is integer-only; the float functions are
+  additive.
+- **`std.fmt`:** float formatting through the dtoa runtime (default shortest
+  round-trip; precision/width control can follow).
+- **`@dbg`** gains float support.
+
+## Implementation Phases
+
+Sub-issues are filed under an M9 epic **after this ADR is accepted**; the
+register-class pre-work (Phase 1) is a hard prerequisite for Phases 5–6.
+
+- [ ] **Phase 1: Register classes (GP/FP) in codegen** — no-op refactor of
+  `VReg`/liveness/regalloc/scheduling. RUE-NNN
+- [ ] **Phase 2: Lexer** — `comptime_float` literal token (`1.5`, `1e9`). RUE-NNN
+- [ ] **Phase 3: Parser + RIR** — float literal node through untyped IR. RUE-NNN
+- [ ] **Phase 4: AIR types + inference** — `f32`/`f64` tags in the packed `Type`,
+  `comptime_float`, context coercion, `@int_to_float`/`@float_to_int`/`@float_cast`. RUE-NNN
+- [ ] **Phase 5: x86-64 backend** — SSE2 scalar ops, XMM regs, SysV FP ABI. RUE-NNN
+- [ ] **Phase 6: aarch64 backend** — FP/NEON scalar ops, V-regs, AAPCS64 FP ABI. RUE-NNN
+- [ ] **Phase 7: Runtime dtoa** — wire `zmij` as `__rue_to_string_float`. RUE-NNN
+- [ ] **Phase 8: std.math / std.fmt / @dbg** — hardware-instruction math, float formatting. RUE-NNN
+- [ ] **Phase 9: Spec + spec tests** — a `03-types/` float chapter, division-divergence
+  and NaN-comparison paragraphs, traceability. RUE-NNN
+- [ ] **Phase 10: Stabilization** — remove the `Floats` preview gate. RUE-NNN
+
+## Consequences
+
+### Positive
+- Rue gets real, hardware-speed IEEE-754 arithmetic on both backends, matching
+  the strong cross-language consensus (no implicit conversions, f64 default,
+  IEEE comparison) — nothing here will surprise a Rust, Go, Swift, or Zig user.
+- The register-class split is a **reusable capability**, not float-specific
+  plumbing: SIMD, fixed-register intrinsics, and future multi-class work all
+  build on it.
+- The `comptime_float` literal model composes with the existing comptime story,
+  so no new suffix grammar and no new constant-typing rules are introduced.
+- Non-trapping IEEE arithmetic aligns with ADR-0036, while trapping
+  `@float_to_int` aligns with Rue's loud-pragmatism trapping elsewhere — each
+  choice is justified by an existing principle, not invented ad hoc.
+
+### Negative
+- **IEEE `==` breaks total structural equality.** An aggregate containing a
+  float leaf is no longer guaranteed equal to itself (a struct holding `NaN`).
+  This forces the `PartialEq`/`Eq` split (RUE-246) to become required work rather
+  than a someday-refinement.
+- **No total order until traits.** Sorting, hashing, and ordered containers of
+  floats cannot be fully correct until the `Ord`/`total_cmp` path exists; a
+  `NaN` in a sort key is ill-defined under IEEE ordering. This is deferred, not
+  solved, by this ADR.
+- The register-class refactor touches both backends' hottest code (regalloc,
+  scheduling); a subtle bug there is a broad blast radius, which is why Phase 1
+  is isolated and validated as a pure no-op first.
+- Two float widths double the backend surface (instruction variants, ABI slots,
+  conversion matrix) versus an f64-only start.
+
+### Neutral
+- `std.math` transcendentals and runtime `strtod` are out of scope; the feature
+  ships useful without them and they are additive later.
+- `zmij` is already vendored; adopting it adds a runtime symbol but no new
+  third-party dependency decision.
+
+## Open Questions
+
+- **Total-order timing.** Should a `@total_cmp`-style intrinsic (giving sorting
+  and hashing a usable total order) ship *with* v1 as a stopgap, or wait for the
+  full `Eq`/`Ord` trait split? Shipping the intrinsic early unblocks float keys
+  in containers without committing the trait design.
+- **`%` on floats.** Provide IEEE remainder / `fmod` semantics via the `%`
+  operator, or leave float `%` out of v1 and expose `std.math.rem` explicitly?
+- **`@float_to_int` on out-of-range:** trap (this proposal) vs saturate. Trapping
+  matches integer overflow; saturating matches Rust's `as`. Confirm the trap.
+- **`f16`/`f128`:** confirmed out of scope for this ADR (no hardware `f16` on
+  baseline targets; `f128` needs soft-float). Reconsider only with a concrete
+  need.
+
+## Future Work
+
+- Traits (`PartialEq`/`Eq`, `PartialOrd`/`Ord`) and the `total_cmp` total order
+  for float containers/sorting (RUE-246).
+- `std.math` transcendentals once a libm-class strategy exists.
+- Runtime `string → float` parsing (`strtod`).
+- SIMD / vector float types, building on the register-class infrastructure.
+- FP calling-convention completion for C FFI floats (RUE-1059).
+
+## References
+
+- RUE-714 (this design gate); related FFI work RUE-1059, RUE-1054, RUE-742/745.
+- [ADR-0025: Compile-Time Execution](0025-comptime.md) — `comptime_float` table entry.
+- [ADR-0035: String model](0035-string-model-byte-strings.md) — "lossiness is never implicit".
+- [ADR-0036: Behavior classification preference](0036-behavior-classification-preference.md) — most-defined category.
+- [ADR-0048: Shared codegen middle layer](0048-shared-codegen-middle-layer.md) — reuse across backends.
+- Spec 4.2 (integer division traps) and 4.3 (comparison/equality; the `NaN` forward reference).
+- Prior art: [Rust `f64::total_cmp`](https://doc.rust-lang.org/std/primitive.f64.html#method.total_cmp),
+  [Zig floats](https://ziglang.org/documentation/master/#Floats),
+  [Go constants](https://go.dev/ref/spec#Constants),
+  [Swift `FloatingPoint`](https://developer.apple.com/documentation/swift/floatingpoint),
+  [Hylo specification](https://hylo-lang.org/docs/reference/specification/),
+  C ISO/IEC 9899 §6.3 (usual arithmetic conversions).

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -227,4 +227,5 @@ The table is generated from ADR frontmatter. Run
 | [0062](0062-place-returning-borrow-accessors.md) | Place-returning borrow accessors: projection reads of owned elements | Accepted | ownership, borrows, collections, accessors, stdlib, formal-semantics |
 | [0063](0063-parallel-demand-driven-incremental-compilation.md) | Parallel demand-driven incremental compilation | Accepted | architecture, compiler, incremental, parallelism, codegen, linker, performance |
 | [0064](0064-c-ffi.md) | C FFI: a guaranteed target-C boundary for imports and exports | Accepted | ffi, abi, codegen, linker, types, semantics, unsafe, interop |
+| [0065](0065-floating-point.md) | Floating point: f32/f64, IEEE-754 semantics, and register classes | Proposal | types, semantics, codegen, numerics, abi |
 <!-- ADR-INDEX:END -->


### PR DESCRIPTION
## Summary

Adds `docs/designs/0065-floating-point.md`, the design gate (ADR) for **M9 · Floating point** (RUE-714). This is design only — **no implementation** — since the compiler is being worked on concurrently. The ADR is a `proposal` and needs a maintainer decision before any implementation issue is opened.

The design was checked against C, Go, Rust, Zig, Swift, and Hylo, and takes the modern consensus while resolving the two real disagreements in the direction of Rue's existing grain:

- **Types:** `f32` (binary32) + `f64` (binary64), with `f64` the default.
- **IEEE-754, total arithmetic:** `/0.0 → ±inf`, `0.0/0.0 → NaN`, nothing traps — the deliberate opposite of integer division (which traps on `/0`), and consistent with ADR-0036's "most-defined category". The spec must state the divergence.
- **No implicit conversions** (int↔float or f32↔f64); explicit intrinsics only: `@int_to_float`, `@float_to_int` (truncating, **traps** on NaN/out-of-range), `@float_cast`.
- **`comptime_float` literals** (arbitrary precision, per ADR-0025), coerced by context with round-to-nearest — **no literal suffixes** (Rue has none for ints either).
- **IEEE-partial comparison:** `NaN != NaN`, unordered. This formally resolves the open question in spec 4.3 and makes the `PartialEq`/`Eq` split (RUE-246) required work; total order (`total_cmp`) is deferred to traits.
- **Codegen pre-work:** a **GP/FP register-class split** threaded through `VReg`/liveness/regalloc/scheduling, landing as a no-op refactor *before* any float instruction selection. Then SSE2/XMM + SysV FP ABI (x86-64) and FP-NEON/V-regs + AAPCS64 FP ABI (aarch64), both backends same PR.
- **Runtime:** adopt the already-vendored `zmij` dtoa crate as `__rue_to_string_float`; `strtod` deferred.
- **Std:** hardware-instruction `std.math` (`sqrt`/`floor`/`ceil`/`trunc`/`round`); transcendentals deferred (no libm).
- Gated behind `PreviewFeature::Floats`.

The ADR lists 10 implementation phases (register-class pre-work → lexer → parser/RIR → AIR types+inference → x86-64 → aarch64 → runtime dtoa → std → spec → stabilization) with `RUE-NNN` placeholders; the M9 epic and sub-issues are to be filed once the ADR is accepted.

## Changes

- `docs/designs/0065-floating-point.md` — new ADR.
- `docs/designs/README.md` — regenerated ADR index (`scripts/validate-adrs.py --write`; registry validates, 66 records).

## Testing

- `scripts/validate-adrs.py --write` → `ADR registry valid: 66 records`.

Docs-only; no compiler code touched.

Fixes RUE-714
