### PR TITLE
RUE-1026: unify const resolution storage

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -50,6 +50,94 @@ fn canonical_import_consumers_do_not_grow_resolution_policy() {
 }
 
 #[test]
+fn const_classification_has_one_tagged_authority_and_no_retired_maps() {
+    let air_production = [
+        include_str!("call_abi.rs"),
+        include_str!("canonical_imports.rs"),
+        include_str!("drop_glue_names.rs"),
+        include_str!("ffi_predicates.rs"),
+        include_str!("inference/constraint.rs"),
+        include_str!("inference/generate.rs"),
+        include_str!("inference/mod.rs"),
+        include_str!("inference/types.rs"),
+        include_str!("inference/unify.rs"),
+        include_str!("inst.rs"),
+        include_str!("inst/payload_support.rs"),
+        include_str!("intern_pool.rs"),
+        include_str!("layout.rs"),
+        include_str!("lib.rs"),
+        include_str!("module_registry.rs"),
+        include_str!("param_arena.rs"),
+        include_str!("path_norm.rs"),
+        include_str!("runtime_call.rs"),
+        include_str!("scope.rs"),
+        include_str!("sema/aggregates.rs"),
+        include_str!("sema/analysis.rs"),
+        include_str!("sema/analysis/anon_methods.rs"),
+        include_str!("sema/analysis/builtin_ops.rs"),
+        include_str!("sema/analysis/calls.rs"),
+        include_str!("sema/analysis/functions.rs"),
+        include_str!("sema/analysis/instructions.rs"),
+        include_str!("sema/analysis/intrinsics.rs"),
+        include_str!("sema/analysis/ownership.rs"),
+        include_str!("sema/analysis/pointers.rs"),
+        include_str!("sema/analysis/type_inference.rs"),
+        include_str!("sema/analyze_ops.rs"),
+        include_str!("sema/anon_structs.rs"),
+        include_str!("sema/binding_manifest.rs"),
+        include_str!("sema/builtins.rs"),
+        include_str!("sema/comptime_eval.rs"),
+        include_str!("sema/context.rs"),
+        include_str!("sema/control_flow.rs"),
+        include_str!("sema/declaration_index.rs"),
+        include_str!("sema/declarations.rs"),
+        include_str!("sema/file_paths.rs"),
+        include_str!("sema/inference_ctx.rs"),
+        include_str!("sema/info.rs"),
+        include_str!("sema/known_symbols.rs"),
+        include_str!("sema/metadata.rs"),
+        include_str!("sema/mod.rs"),
+        include_str!("sema/output.rs"),
+        include_str!("sema/semantic_body_export.rs"),
+        include_str!("sema/typeck.rs"),
+        include_str!("sema/visibility.rs"),
+        include_str!("semantic_body.rs"),
+        include_str!("semantic_identity.rs"),
+        include_str!("semantic_import.rs"),
+        include_str!("semantic_type_resolution.rs"),
+        include_str!("specialize.rs"),
+        include_str!("type_encoding.rs"),
+        include_str!("type_properties.rs"),
+        include_str!("types.rs"),
+    ]
+    .concat();
+
+    assert_eq!(
+        air_production
+            .matches("const_resolutions: HashMap<")
+            .count(),
+        1,
+        "AIR must retain exactly one tagged const-resolution table"
+    );
+    assert_eq!(
+        air_production
+            .matches("pub(crate) enum ConstResolution")
+            .count(),
+        1,
+        "AIR must classify value constants and module bindings in one internal enum"
+    );
+    for retired_map in [
+        ["constants_by_", "file_name: HashMap"].concat(),
+        ["module_", "bindings: HashMap"].concat(),
+    ] {
+        assert!(
+            !air_production.contains(&retired_map),
+            "retired const storage map returned: {retired_map}"
+        );
+    }
+}
+
+#[test]
 fn canonical_type_surface_has_one_checked_handle_and_private_storage_ids() {
     let types = include_str!("types.rs");
     let pool = include_str!("intern_pool.rs");

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -33,9 +33,7 @@ impl<'a> BodySema<'a> {
         if let Some(&ty) = ctx.comptime_type_vars.get(&type_name) {
             return ty.as_enum().map(|id| (id, true));
         }
-        if let Some(info) = self
-            .constants_by_file_name
-            .get(&(ctx.current_file_id, type_name))
+        if let Some(info) = self.value_const(&(ctx.current_file_id, type_name))
             && let ConstValue::Type(ty) = info.value
         {
             return ty.as_enum().map(|id| (id, true));
@@ -55,7 +53,7 @@ impl<'a> BodySema<'a> {
     /// through a `let`/`const` binding (an anonymous struct from a comptime type
     /// function), so privacy does not apply — the exact mirror of
     /// `resolve_enum_type_name` for the struct side (RUE-595). Without the
-    /// `constants_by_file_name` arm a module-`const`-bound struct type resolved
+    /// tagged value-const arm a module-`const`-bound struct type resolved
     /// as a type namespace nowhere, so `const C = Counter(i32); C.zero()` failed
     /// (E0413) and `const P = Point(i32); P { .. }` failed (E0204) while the
     /// enum-bound and local-`let`-bound forms worked.
@@ -67,9 +65,7 @@ impl<'a> BodySema<'a> {
         if let Some(&ty) = ctx.comptime_type_vars.get(&type_name) {
             return ty.as_struct().map(|id| (id, true));
         }
-        if let Some(info) = self
-            .constants_by_file_name
-            .get(&(ctx.current_file_id, type_name))
+        if let Some(info) = self.value_const(&(ctx.current_file_id, type_name))
             && let ConstValue::Type(ty) = info.value
         {
             return ty.as_struct().map(|id| (id, true));
@@ -403,7 +399,7 @@ impl<'a> BodySema<'a> {
                     ));
                 }
             }
-        } else if let Some(info) = self.constants_by_file_name.get(&(span.file_id, type_name))
+        } else if let Some(info) = self.value_const(&(span.file_id, type_name))
             && let ConstValue::Type(ty) = info.value
         {
             // Module-level `const P = Point(i32); P { .. }` (RUE-595): the
@@ -735,13 +731,12 @@ impl<'a> BodySema<'a> {
         // facade — where the const's type is itself a module: accessing it
         // yields that module, so chains like `std.math.abs(...)` resolve
         // member-by-member (RUE-136). Module bindings live in the per-file
-        // `module_bindings` table keyed by the facade's FileId (RUE-113);
+        // tagged module-binding variant keyed by the facade's FileId (RUE-113);
         // value consts are found by defining file and member name.
         let member_const = module_file_id
-            .and_then(|file_id| self.module_bindings.get(&(file_id, member_name)))
+            .and_then(|file_id| self.module_binding(&(file_id, member_name)))
             .or_else(|| {
-                module_file_id
-                    .and_then(|file_id| self.constants_by_file_name.get(&(file_id, member_name)))
+                module_file_id.and_then(|file_id| self.value_const(&(file_id, member_name)))
             });
         if let Some(const_info) = member_const.cloned() {
             if !const_info.is_pub {
@@ -923,8 +918,7 @@ impl<'a> BodySema<'a> {
                         return Some(module_id);
                     }
                 }
-                self.module_bindings
-                    .get(&(span.file_id, name))
+                self.module_binding(&(span.file_id, name))
                     .and_then(|binding| binding.ty.as_module())
             }
             // Nested submodule: `parent.sub` where `parent` is a module and `sub`
@@ -934,8 +928,7 @@ impl<'a> BodySema<'a> {
                 let parent_id = self.try_module_id_of(base, span, ctx)?;
                 let parent_def = self.module_registry.get_def(parent_id);
                 let parent_file = parent_def.file_id;
-                self.module_bindings
-                    .get(&(parent_file, field))
+                self.module_binding(&(parent_file, field))
                     .and_then(|binding| binding.ty.as_module())
             }
             _ => None,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -850,8 +850,8 @@ fn finalize_function_body_analysis(
         supported_type_call_heads_complete: true,
         named_const_dependencies: {
             let bound_constants = sema
-                .constants_by_file_name
-                .keys()
+                .value_consts()
+                .map(|(key, _)| key)
                 .map(|(file, name)| (file.index(), sema.interner.resolve(name).to_owned()))
                 .collect::<HashSet<_>>();
             sema.named_const_dependencies.retain(|event| {

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -1125,13 +1125,12 @@ impl<'a> BodySema<'a> {
         if function_key.is_none()
             && let Some(mfile) = module_file_id
         {
-            let reexport = self
-                .constants_by_file_name
-                .get(&(mfile, function_name))
-                .and_then(|info| match info.value {
-                    ConstValue::Function(fkey) => Some((fkey, info.is_pub)),
-                    _ => None,
-                });
+            let reexport =
+                self.value_const(&(mfile, function_name))
+                    .and_then(|info| match info.value {
+                        ConstValue::Function(fkey) => Some((fkey, info.is_pub)),
+                        _ => None,
+                    });
             if let Some((fkey, is_pub)) = reexport {
                 if !self.is_accessible(span.file_id, mfile, is_pub) {
                     return Err(CompileError::new(
@@ -1267,9 +1266,7 @@ impl<'a> BodySema<'a> {
                     ));
                 }
             }
-        } else if let Some(info) = self
-            .constants_by_file_name
-            .get(&(ctx.current_file_id, type_name))
+        } else if let Some(info) = self.value_const(&(ctx.current_file_id, type_name))
             && let ConstValue::Type(ty) = info.value
         {
             // Module-level `const C = Counter(i32); C.zero()` (RUE-595): the

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -1345,7 +1345,7 @@ impl<'a> BodySema<'a> {
         // @import("math")`). Module bindings are per-file scoped (RUE-113),
         // so the lookup is keyed by the reference's own file and takes
         // precedence over file-local value constants.
-        if let Some(binding) = self.module_bindings.get(&(span.file_id, name)).cloned() {
+        if let Some(binding) = self.module_binding(&(span.file_id, name)).cloned() {
             self.record_body_named_dependency(
                 super::super::NamedConstDependencyTargetEvent::ModuleBinding {
                     file: span.file_id.index(),
@@ -1363,7 +1363,7 @@ impl<'a> BodySema<'a> {
 
         // Check if it's a value constant (e.g., `const VALUE: i32 = -42;`).
         // Module-typed constants never appear here: module bindings AND
-        // aliases (`const m2 = std.math;`) live in `module_bindings`,
+        // aliases (`const m2 = std.math;`) are tagged module bindings,
         // checked above. The value was evaluated once during declaration
         // gathering (RUE-171); materialize it directly — the initializer is
         // never re-analyzed at use sites.

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -814,14 +814,14 @@ impl<'a> DeclarationShells<'a> {
                         .sema
                         .interner
                         .get_or_intern(pending.shell.identity.name.as_ref());
-                    self.sema.module_bindings.insert(
+                    self.sema.const_resolutions.insert(
                         (pending.shell.declaration_span.file_id, name),
-                        super::ConstInfo {
+                        super::ConstResolution::ModuleBinding(super::ConstInfo {
                             is_pub: pending.shell.is_public,
                             ty: target,
                             value: ConstValue::Type(target),
                             span: pending.shell.declaration_span,
-                        },
+                        }),
                     );
                 }
                 (_, DeclarationPayloadSource::Const { .. }) => {
@@ -2146,7 +2146,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
             // the owned declaration boundary.
             let mut identity = identity.clone();
             if identity.kind == StableDefinitionKind::ValueConst
-                && self.module_bindings.contains_key(&(identity.file_id, name))
+                && self.module_binding(&(identity.file_id, name)).is_some()
             {
                 identity.kind = StableDefinitionKind::ModuleBinding;
             }
@@ -2250,8 +2250,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                 }
                 StableDefinitionKind::ValueConst => {
                     let info = self
-                        .constants_by_file_name
-                        .get(&(identity.file_id, name))
+                        .value_const(&(identity.file_id, name))
                         .ok_or(SemanticExportFailure::UnmappedFunction)?;
                     let value = match info.value {
                         ConstValue::Integer(v) => SemanticExportConstValue::Integer(v),
@@ -2283,8 +2282,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                 }
                 StableDefinitionKind::ModuleBinding => {
                     let info = self
-                        .module_bindings
-                        .get(&(identity.file_id, name))
+                        .module_binding(&(identity.file_id, name))
                         .ok_or(SemanticExportFailure::UnmappedFunction)?;
                     SemanticDeclarationPayload::ModuleBinding {
                         target: self.export_type(info.ty, &mut Vec::new())?,
@@ -2424,10 +2422,10 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                 }
                 InstData::ConstDecl { name, is_pub, .. } => {
                     let key = (inst.span.file_id, *name);
-                    let kind = if self.module_bindings.contains_key(&key) {
+                    let kind = if self.module_binding(&key).is_some() {
                         work.module_bindings_emitted += 1;
                         StableDefinitionKind::ModuleBinding
-                    } else if self.constants_by_file_name.contains_key(&key) {
+                    } else if self.value_const(&key).is_some() {
                         work.constants_emitted += 1;
                         StableDefinitionKind::ValueConst
                     } else {

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -112,7 +112,7 @@ pub(crate) struct ComptimeEnv<'a> {
     /// module-qualified comptime call written in a `-> type` constructor body
     /// (`let O = b.Mk(T)`) names an import (`b`) of *this* file's import graph,
     /// not of the file that triggered the instantiation — so resolving the
-    /// receiver as a module binding must key `module_bindings` by this file, not
+    /// receiver as a module binding must key the tagged resolution by this file, not
     /// the instantiation site. Set from `ctx.current_file_id` when analyzing a
     /// body, and to the callee's `FunctionInfo.file_id` when reducing a
     /// type-constructor body. `None` where no file context is available (the
@@ -1174,18 +1174,14 @@ impl<D: DeclarationPhase> Sema<'_, D> {
                 //    declaration collector can resolve (module member
                 //    access, RUE-160) and was exponential for const chains.
                 //    Module-typed constants never appear in this table
-                //    (module bindings live in `Sema::module_bindings`).
+                //    (module bindings are a distinct tagged resolution).
                 //    Privacy applies here too (E0460, RUE-183): the table is
                 //    global, so a const initializer in one directory could
                 //    otherwise read a private constant from another. The
                 //    VarRef's own span locates the referencing file;
                 //    speculative callers (`try_evaluate_const*`) swallow the
                 //    error and defer to runtime analysis, which re-checks.
-                if let Some(info) = self
-                    .constants_by_file_name
-                    .get(&(span.file_id, *name))
-                    .cloned()
-                {
+                if let Some(info) = self.value_const(&(span.file_id, *name)).cloned() {
                     self.record_named_const_dependency(
                         super::NamedConstDependencyTargetEvent::ValueConst {
                             file: info.span.file_id.index(),
@@ -1601,9 +1597,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         }
         // The root must name a module import of the current file for this to be
         // a module-qualified member-access path at all.
-        let binding = self
-            .module_bindings
-            .get(&(ctx.current_file_id, root_name))?;
+        let binding = self.module_binding(&(ctx.current_file_id, root_name))?;
         binding.ty.as_module()?;
         let mut segments: Vec<&str> = vec![self.interner.resolve(&root_name)];
         segments.extend(fields_rev.iter().rev().map(|s| self.interner.resolve(s)));

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -92,7 +92,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         name: Spur,
         file_id: FileId,
     ) -> Option<&ConstInfo> {
-        self.constants_by_file_name.get(&(file_id, name))
+        self.value_const(&(file_id, name))
     }
 
     pub(crate) fn resolve_builtin_struct_name(&self, name: Spur) -> Option<StructId> {
@@ -229,8 +229,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         // distinct declarations, so every inference lookup carries the
         // reference file or receiver-module identity (RUE-638).
         let const_types: HashMap<(FileId, Spur), Type> = self
-            .constants_by_file_name
-            .iter()
+            .value_consts()
             .map(|(key, info)| {
                 let ty = match info.value {
                     ConstValue::Type(_) => Type::COMPTIME_TYPE,
@@ -245,8 +244,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         // consults this in type positions; expression positions still use
         // `const_types` above and see the binding itself as `type`.
         let const_type_aliases: HashMap<(FileId, Spur), Type> = self
-            .constants_by_file_name
-            .iter()
+            .value_consts()
             .filter_map(|(key, info)| match info.value {
                 ConstValue::Type(ty) => Some((*key, ty)),
                 _ => None,
@@ -256,16 +254,14 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         // Integer constant values, so an array length naming a `const`
         // (`[i32; K]`) resolves to a concrete length during inference (RUE-16).
         let const_values: HashMap<(FileId, Spur), i128> = self
-            .constants_by_file_name
-            .iter()
+            .value_consts()
             .filter_map(|(key, info)| info.value.as_int_value().map(|v| (*key, v)))
             .collect();
 
         // Function-valued constants are callable aliases only. Constraint
         // generation uses this map to type `alias(...)` like the real callee.
         let const_function_aliases: HashMap<(FileId, Spur), Spur> = self
-            .constants_by_file_name
-            .iter()
+            .value_consts()
             .filter_map(|(key, info)| info.value.as_function().map(|callee| (*key, callee)))
             .collect();
 
@@ -273,8 +269,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         // declaring file: bindings are per-file scoped (RUE-113), so a
         // reference resolves against the file it appears in.
         let module_binding_types: HashMap<(FileId, Spur), Type> = self
-            .module_bindings
-            .iter()
+            .module_binding_consts()
             .map(|(key, info)| (*key, info.ty))
             .collect();
 
@@ -343,7 +338,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     /// This remains a semantic check because only initializer evaluation can
     /// distinguish value constants from per-file module bindings.
     pub(crate) fn check_const_cross_kind_collisions(&self) -> CompileResult<()> {
-        for ((file_id, name), info) in self.constants_by_file_name.iter() {
+        for ((file_id, name), info) in self.value_consts() {
             if self.functions_by_file_name.contains_key(&(*file_id, *name))
                 || self.structs_by_file_name.contains_key(&(*file_id, *name))
                 || self.enums_by_file_name.contains_key(&(*file_id, *name))
@@ -671,8 +666,7 @@ impl<'a> Sema<'a> {
             }
         }
         let constants = self
-            .constants_by_file_name
-            .iter()
+            .value_consts()
             .map(|((file, name), info)| (*file, *name, info.ty))
             .collect::<Vec<_>>();
         for (file, name, ty) in constants {
@@ -1773,7 +1767,7 @@ impl<'a> Sema<'a> {
     ///   of another module binding (`const m = other;`), or a member-access
     ///   chain ending at a re-export (`const math = std.math;`). These are
     ///   **per-file scoped** (ADR-0026: every file writes its own imports),
-    ///   stored in `module_bindings` keyed by the declaring file — two files
+    ///   stored as tagged resolutions keyed by the declaring file — two files
     ///   binding the same name, even to different modules, is fine (RUE-113).
     /// - **Value constants** — everything else: the initializer is evaluated
     ///   through the comptime engine (`sema::comptime_eval`), so negated
@@ -1788,8 +1782,7 @@ impl<'a> Sema<'a> {
     /// declaration order does not matter. Cyclic initializers are E0461.
     fn collect_const_by_key(&mut self, key: (FileId, Spur)) -> CompileResult<()> {
         debug_assert!(self.declaration_binding_active);
-        if self.constants_by_file_name.contains_key(&key) || self.module_bindings.contains_key(&key)
-        {
+        if self.const_resolutions.contains_key(&key) {
             return Ok(());
         }
         if self.const_resolution_in_progress.contains(&key) {
@@ -1862,14 +1855,14 @@ impl<'a> Sema<'a> {
                         p.span,
                     ));
                 }
-                self.module_bindings.insert(
+                self.const_resolutions.insert(
                     (file_id, name),
-                    ConstInfo {
+                    super::ConstResolution::ModuleBinding(ConstInfo {
                         is_pub: p.is_pub,
                         ty: module_ty,
                         value: ConstValue::Type(module_ty),
                         span: p.span,
-                    },
+                    }),
                 );
             }
             ConstInit::Value(value) => {
@@ -1880,7 +1873,8 @@ impl<'a> Sema<'a> {
                     value,
                     span: p.span,
                 };
-                self.constants_by_file_name.insert(key, info);
+                self.const_resolutions
+                    .insert(key, super::ConstResolution::Value(info));
             }
         }
         Ok(())
@@ -2019,7 +2013,7 @@ impl<'a> Sema<'a> {
             InstData::VarRef { name, .. } => {
                 let name = *name;
                 self.ensure_const_collected(name, file_id)?;
-                if let Some(binding) = self.module_bindings.get(&(file_id, name)).cloned() {
+                if let Some(binding) = self.module_binding(&(file_id, name)).cloned() {
                     self.record_named_const_dependency(
                         super::NamedConstDependencyTargetEvent::ModuleBinding {
                             file: file_id.index(),
@@ -2272,14 +2266,11 @@ impl<'a> Sema<'a> {
             InstData::FieldGet { base, field } => {
                 let (base, field) = (*base, *field);
                 let via_module = if let InstData::VarRef { name, .. } = &self.rir.get(base).data {
-                    self.module_bindings
-                        .get(&(file_id, *name))
+                    self.module_binding(&(file_id, *name))
                         .and_then(|info| info.ty.as_module())
                         .map(|module_id| self.module_registry.get_def(module_id).file_id)
                         .and_then(|module_file| {
-                            self.constants_by_file_name
-                                .get(&(module_file, field))
-                                .map(|info| info.ty)
+                            self.value_const(&(module_file, field)).map(|info| info.ty)
                         })
                 } else {
                     None
@@ -2597,7 +2588,7 @@ impl<'a> Sema<'a> {
 
         // A module-binding member (re-export or alias) yields its module.
         if let Some(mfile) = module_file_id {
-            if let Some(info) = self.module_bindings.get(&(mfile, member)) {
+            if let Some(info) = self.module_binding(&(mfile, member)) {
                 let (is_pub, ty) = (info.is_pub, info.ty);
                 self.check_const_member_visibility(
                     is_pub,
@@ -2618,7 +2609,7 @@ impl<'a> Sema<'a> {
 
         // A value constant declared in the module's file yields its value.
         if let Some(mfile) = module_file_id {
-            if let Some(info) = self.constants_by_file_name.get(&(mfile, member)) {
+            if let Some(info) = self.value_const(&(mfile, member)) {
                 let (is_pub, value) = (info.is_pub, info.value);
                 self.check_const_member_visibility(
                     is_pub,

--- a/crates/rue-air/src/sema/info.rs
+++ b/crates/rue-air/src/sema/info.rs
@@ -158,3 +158,53 @@ pub struct ConstInfo {
     /// Span of the const declaration
     pub span: Span,
 }
+
+/// The authoritative post-evaluation classification of a source `const`.
+/// Keeping the variants in one table prevents value and module namespaces
+/// from drifting or accepting the same candidate twice.
+#[derive(Debug, Clone)]
+pub(crate) enum ConstResolution {
+    Value(ConstInfo),
+    ModuleBinding(ConstInfo),
+}
+
+impl ConstResolution {
+    pub(crate) fn value(&self) -> Option<&ConstInfo> {
+        match self {
+            Self::Value(info) => Some(info),
+            Self::ModuleBinding(_) => None,
+        }
+    }
+
+    pub(crate) fn module_binding(&self) -> Option<&ConstInfo> {
+        match self {
+            Self::Value(_) => None,
+            Self::ModuleBinding(info) => Some(info),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn info() -> ConstInfo {
+        ConstInfo {
+            is_pub: false,
+            ty: Type::I32,
+            value: crate::sema::ConstValue::Integer(1),
+            span: Span::new(0, 1),
+        }
+    }
+
+    #[test]
+    fn const_resolution_accessors_keep_variants_disjoint() {
+        let value = ConstResolution::Value(info());
+        assert!(value.value().is_some());
+        assert!(value.module_binding().is_none());
+
+        let module_binding = ConstResolution::ModuleBinding(info());
+        assert!(module_binding.value().is_none());
+        assert!(module_binding.module_binding().is_some());
+    }
+}

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -60,6 +60,7 @@ pub use binding_manifest::{
 pub use context::ConstValue;
 pub use declaration_index::RirDeclarationIndexWork;
 pub use inference_ctx::InferenceContext;
+use info::ConstResolution;
 pub use info::{AnonMethodSig, AnonMethodType, ConstInfo, FunctionInfo, MethodInfo};
 pub use known_symbols::KnownSymbols;
 pub use metadata::SemaMetadata;
@@ -123,8 +124,7 @@ pub struct DeclarationNamespace {
     enums_by_file_name: HashMap<(FileId, Spur), EnumId>,
     methods: HashMap<(StructId, Spur), MethodInfo>,
     named_method_declarations: HashMap<(StructId, Spur), rue_rir::InstRef>,
-    constants_by_file_name: HashMap<(FileId, Spur), ConstInfo>,
-    module_bindings: HashMap<(FileId, Spur), ConstInfo>,
+    const_resolutions: HashMap<(FileId, Spur), ConstResolution>,
 }
 
 impl DeclarationNamespace {
@@ -139,9 +139,32 @@ impl DeclarationNamespace {
             enums_by_file_name: HashMap::new(),
             methods: HashMap::new(),
             named_method_declarations: HashMap::new(),
-            constants_by_file_name: HashMap::new(),
-            module_bindings: HashMap::new(),
+            const_resolutions: HashMap::new(),
         }
+    }
+
+    fn value_const(&self, key: &(FileId, Spur)) -> Option<&ConstInfo> {
+        self.const_resolutions
+            .get(key)
+            .and_then(ConstResolution::value)
+    }
+
+    fn module_binding(&self, key: &(FileId, Spur)) -> Option<&ConstInfo> {
+        self.const_resolutions
+            .get(key)
+            .and_then(ConstResolution::module_binding)
+    }
+
+    fn value_consts(&self) -> impl Iterator<Item = (&(FileId, Spur), &ConstInfo)> {
+        self.const_resolutions
+            .iter()
+            .filter_map(|(key, value)| value.value().map(|info| (key, info)))
+    }
+
+    fn module_binding_consts(&self) -> impl Iterator<Item = (&(FileId, Spur), &ConstInfo)> {
+        self.const_resolutions
+            .iter()
+            .filter_map(|(key, value)| value.module_binding().map(|info| (key, info)))
     }
 }
 
@@ -875,8 +898,8 @@ impl BodySema<'_> {
             ^ fingerprint(6, self.enums_by_file_name.iter())
             ^ fingerprint(7, self.methods.keys())
             ^ fingerprint(8, self.named_method_declarations.iter())
-            ^ fingerprint(9, self.constants_by_file_name.keys())
-            ^ fingerprint(10, self.module_bindings.keys());
+            ^ fingerprint(9, self.value_consts().map(|(key, _)| key))
+            ^ fingerprint(10, self.module_binding_consts().map(|(key, _)| key));
 
         NamespaceBoundarySnapshot {
             source_counts: [
@@ -889,8 +912,8 @@ impl BodySema<'_> {
                 self.enums_by_file_name.len(),
                 self.methods.len(),
                 self.named_method_declarations.len(),
-                self.constants_by_file_name.len(),
-                self.module_bindings.len(),
+                self.value_consts().count(),
+                self.module_binding_consts().count(),
             ],
             source_fingerprint,
             generated_structs: self.generated_structs.len(),

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -304,19 +304,14 @@ impl<D: DeclarationPhase>
     ) -> SemaProviderResult<Option<crate::SemanticTypeFact<Type, FileId>>> {
         let file = self.sema.module_registry.get_def(*module).file_id;
         let symbol = self.sema.interner.get_or_intern(name);
-        if self.sema.declaration_binding_active
-            && self
-                .sema
-                .constants_by_file_name
-                .get(&(file, symbol))
-                .is_none()
+        if self.sema.declaration_binding_active && self.sema.value_const(&(file, symbol)).is_none()
         {
             provider_failure(
                 self.sema
                     .try_resolve_indexed_const_during_binding(symbol, file),
             )?;
         }
-        let Some(info) = self.sema.constants_by_file_name.get(&(file, symbol)) else {
+        let Some(info) = self.sema.value_const(&(file, symbol)) else {
             return Ok(None);
         };
         let ConstValue::Type(value) = info.value else {
@@ -2344,7 +2339,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         file_id: FileId,
         name: Spur,
     ) -> CompileResult<Option<super::info::ConstInfo>> {
-        if let Some(binding) = self.module_bindings.get(&(file_id, name)) {
+        if let Some(binding) = self.module_binding(&(file_id, name)) {
             return Ok(Some(binding.clone()));
         }
         if !self.declaration_binding_active {
@@ -2352,7 +2347,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         }
 
         self.try_resolve_indexed_const_during_binding(name, file_id)?;
-        Ok(self.module_bindings.get(&(file_id, name)).cloned())
+        Ok(self.module_binding(&(file_id, name)).cloned())
     }
 
     /// Return one flag per source parameter identifying declarations of the

--- a/crates/rue-air/src/sema/visibility.rs
+++ b/crates/rue-air/src/sema/visibility.rs
@@ -144,15 +144,13 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         let module_ty = match inst.data {
             InstData::VarRef { name, .. } => {
                 ctx.locals.get(&name).map(|local| local.ty).or_else(|| {
-                    self.module_bindings
-                        .get(&(inst.span.file_id, name))
+                    self.module_binding(&(inst.span.file_id, name))
                         .map(|binding| binding.ty)
                 })
             }
             InstData::FieldGet { base, field } => {
                 let parent_file = self.module_file_for_ref(base, ctx)?;
-                self.module_bindings
-                    .get(&(parent_file, field))
+                self.module_binding(&(parent_file, field))
                     .map(|binding| binding.ty)
             }
             _ => None,


### PR DESCRIPTION
## Summary

- replace AIR’s separate value-constant and module-binding maps with one tagged `ConstResolution` table
- route all declaration and body consumers through disjoint tagged accessors while preserving lookup precedence and fingerprints
- add an AIR-wide source gate preventing the retired peer storage maps from returning

This is a preparatory single-authority slice for RUE-1026. It deliberately does not claim the keyed const query cutover; the existing evaluator and cycle machinery are unchanged.

## Validation

- `/opt/homebrew/bin/bash ./clippy.sh`
- `scripts/rue quick`
- `scripts/rue cli modules`
- `scripts/rue test`

Refs RUE-1026