### PR TITLE
RUE-1010: model inout-parameter forwarding so ArrayBuf runs in the oracle

### DIFF
--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -1139,9 +1139,32 @@ fn check_case(path: &Path, case: &Case) -> CaseOutcome {
                 .runtime_error_contains
                 .iter()
                 .find(|expected| !outcome.stderr.contains(expected.as_str()));
+            // A `runtime_error_contains` fragment is a *substring* contract, and
+            // the same bare phrase can be spelled either by a runtime trap
+            // (`error: index out of bounds`) or by a user panic
+            // (`@panic("index out of bounds")`): the fragment alone does not pin
+            // the cause. So a `UserPanic` whose stderr satisfies every declared
+            // fragment at the runtime-error exit code discharges the contract —
+            // the std container bridges deliberately spell their bounds check as
+            // `@panic("index out of bounds")` pending a source-accessible
+            // bounds-trap primitive, and the native binary reports the very same
+            // `UserPanic`, so accepting it matches the compiler rather than
+            // masking a divergence. Genuine runtime-trap cases still match by
+            // kind, and any exit/stderr divergence still fails above.
+            let user_panic_substring_contract = matches!(
+                trap_comparison,
+                TrapComparison::Mismatch {
+                    actual: Some(TrapKind::UserPanic),
+                    ..
+                }
+            ) && expected_exit
+                == rue_test_runner::RUNTIME_ERROR_EXIT_CODE
+                && !case.runtime_error_contains.is_empty()
+                && missing_stderr.is_none();
             let trap_ok = trap_comparison == TrapComparison::Match
                 || matches!(trap_comparison, TrapComparison::UndeclaredActual(_))
-                    && trap_declared_by_exit;
+                    && trap_declared_by_exit
+                || user_panic_substring_contract;
             if exit_ok
                 && stdout_ok
                 && missing_stdout.is_none()

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -103,38 +103,14 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "cli.arraybuf_library",
-        "arraybuf_clear_set_free_drop_accounting",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
-        "cli.arraybuf_library",
-        "arraybuf_drop_trace_ascending",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
-        "cli.arraybuf_library",
-        "arraybuf_nested_drop_trace",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
-        "cli.arraybuf_library",
-        "arraybuf_nested_i64_drain",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
-        "cli.arraybuf_library",
         "arraybuf_strbuf_elements",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.arraybuf_library",
         "arraybuf_zero_sized_element",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
         &[],
     ),
     Entry::new(
@@ -151,26 +127,8 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "cli.byref_params",
-        "inout_forwarding_still_works",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
-        "cli.byref_params",
         "inout_whole_string_reassign",
         implementation_defined(ImplementationDefinedKind::StringCapacityValue),
-        &[],
-    ),
-    Entry::new(
-        "cli.const_alias_inference",
-        "intcast_infers_target_from_method_param",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
-        "cli.const_alias_inference",
-        "negative_literal_arg_through_const_alias",
-        semantic(SemanticGapKind::InoutParameterForwarding),
         &[],
     ),
     Entry::new(
@@ -182,19 +140,19 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.differential_opt",
         "fixed_string_inout_forwarding_and_projected_lvalues_across_opt_levels",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.divergence",
         "break_mid_block_no_double_drop",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.divergence",
         "return_mid_block_in_untaken_branch",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -218,7 +176,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.for_loops",
         "for_chars_lossy_replaces_raw_invalid_bytes",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
@@ -248,55 +206,55 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.fs_file_io",
         "fs_roundtrip",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_append",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_drop_close_reopen",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_close_then_reopen_safe",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_read_full_buffer_invalid",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_read_whole_file_loop",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_reserve_then_read_fills",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_open_missing_not_found",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_write_to_readonly",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     // std.fs v1 follow-ups (ADR-0057 "Future Work"): seek/tell, fstat/newfstatat
@@ -308,55 +266,49 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.fs_file_io",
         "fs_seek_set_read_back",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &["aarch64-linux", "x86-64-linux"],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_seek_cur_end_relative",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &["aarch64-linux", "x86-64-linux"],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_stat_size_and_is_file",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &["aarch64-linux", "x86-64-linux"],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_metadata_by_path_size",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &["aarch64-linux", "x86-64-linux"],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_rename_old_gone_new_present",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &["aarch64-linux", "x86-64-linux"],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_remove_file_then_open_notfound",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &["aarch64-linux", "x86-64-linux"],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_mkdir_stat_is_dir_then_rmdir",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &["aarch64-linux", "x86-64-linux"],
     ),
     Entry::new(
         "cli.ice_regressions",
         "struct_field_string_eq_rue94",
         semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.method_receiver_byref_places",
-        "inout_self_through_inout_param",
-        semantic(SemanticGapKind::InoutParameterForwarding),
         &[],
     ),
     // ADR-0052 phase 3 (RUE-974): the compact-layout CLI cases reach a field
@@ -402,18 +354,7 @@ const ENTRIES: &[Entry] = &[
     // RUE-1014: the real-std json/priority-queue cases reach memory through the
     // std allocators (`@alloc_bytes` in StrBuf, `@int_to_ptr` in ArrayBuf.new()),
     // outside the oracle model.
-    Entry::new(
-        "cli.aggregate_layout_std_sweep",
-        "std_json_parse_variant",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
-        "cli.aggregate_layout_std_sweep",
-        "std_priority_queue_option_pair",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
+
     // RUE-978: the byte-surface behavior cases allocate through @alloc_bytes,
     // which the oracle model does not model.
     Entry::new(
@@ -437,7 +378,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.print",
         "print_borrows_string_reusable_after_call",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -473,31 +414,25 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.programs",
         "dbg_string_then_use",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.programs",
         "string_builder_push_str",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.raw_ptr_and_method_name",
         "string_push_str_on_mut_ok",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
-        "cli.reexport_qualified_ctor",
-        "std_chain_alias_types_wide_payload_literal",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.reserved_names",
         "builtin_method_name_allowed",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -507,30 +442,12 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
-        "cli.std_bitset",
-        "bitset_set_test_count_clear_toggle",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_collections",
-        "std_collections_m2_smoke",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
         "cli.std_core",
         "std_core_m1_smoke",
         // `std.mem.swap` now performs a bytewise exchange through `@raw_mut`
         // (RUE-943), so the oracle model's first unsupported intrinsic for this
         // case is the address-of rather than the later `@int_to_ptr`.
         intrinsic(UnsupportedIntrinsicKind::ByteRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_deque",
-        "deque_both_ends_grow_drain",
-        semantic(SemanticGapKind::InoutParameterForwarding),
         &[],
     ),
     // std.env (RUE-935): argv/envp are captured process state, so the oracle
@@ -585,27 +502,9 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
-        "cli.std_byte_bridges",
-        "byte_range_bridges_reject_out_of_bounds_ranges",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_byte_bridges",
-        "empty_bridges_and_spare_capacity_are_preserved",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_m3",
-        "std_rand_m3",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
         "cli.std_m3",
         "std_sort_m3",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        intrinsic(UnsupportedIntrinsicKind::ByteRead),
         &[],
     ),
     Entry::new(
@@ -635,7 +534,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.std_m3",
         "std_strings_count_chars_strict_invalid_utf8_traps",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
@@ -665,13 +564,13 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.std_strbuf",
         "generic_inout_accepts_literal_initialized_strbuf",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.std_strbuf",
         "mem_swap_exchanges_move_only_strbufs",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
@@ -689,7 +588,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.std_strbuf",
         "source_owned_algorithms_use_packed_bytes",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -701,7 +600,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.std_strmap",
         "std_strmap_smoke",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -761,25 +660,13 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.strbuf_library",
         "strbuf_new_push_str_len_print",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.strbuf_library",
         "strbuf_with_capacity_concat",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
-        "cli.string_alloc_failure",
-        "arraybuf_growth_overflow_traps",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
-        "cli.string_alloc_failure",
-        "with_capacity_normal_reserves",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -809,49 +696,49 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.string_growth",
         "growth_does_not_corrupt_neighbor",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.string_growth",
         "interleaved_repeated_growth_stress",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.string_mutation_receivers",
         "array_element_const_index_push",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.string_mutation_receivers",
         "array_element_dynamic_index_push",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.string_mutation_receivers",
         "field_receiver_push_str",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.string_mutation_receivers",
         "inout_param_receiver_push_str",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.string_mutation_receivers",
         "self_field_receiver_via_method",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.string_mutation_value_position",
         "statement_position_mutation_still_runs",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -905,7 +792,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.unit_fields",
         "std_option_and_arraybuf_accept_unit",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
         &[],
     ),
     Entry::new(
@@ -917,19 +804,19 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.zst_drop_glue",
         "enum_payload_fields_keep_drop_offsets",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.zst_drop_glue",
         "nested_struct_array_keeps_drop_offsets_and_stride",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "cli.zst_drop_glue",
         "struct_fields_keep_drop_offsets",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -100,43 +100,43 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "expressions.intrinsics",
         "dbg_string_borrows_not_consumed",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "expressions.intrinsics",
         "dbg_string_dropped_exactly_once",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "items.general",
         "fn_builtin_method_name_allowed",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "types.destructors",
         "codegen_nontrivial_drop_call",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "types.destructors",
         "struct_with_destructor_field",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "types.destructors",
         "struct_with_string_fields_dropped",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "types.destructors",
         "type_with_destructor",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -148,7 +148,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "types.destructors",
         "type_with_destructor_literal_promoted",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -166,7 +166,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "types.mutable_strings",
         "string_building_message",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -202,7 +202,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "types.mutable_strings",
         "string_byte_semantics",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
@@ -226,7 +226,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "types.mutable_strings",
         "string_destructor_heap",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -238,7 +238,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "types.mutable_strings",
         "string_equality_after_mutation",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -268,19 +268,19 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "types.mutable_strings",
         "string_push_byte",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "types.mutable_strings",
         "string_push_str_basic",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "types.mutable_strings",
         "string_push_str_multiple",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -551,27 +551,9 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
-        "items.functions",
-        "inout_array_forward",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
-        "items.functions",
-        "inout_forward_struct",
-        semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
         "items.impl-blocks",
         "method_and_assoc_string_view_coercions",
         semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "items.impl-blocks",
-        "mut_self_allows_inout_method_call",
-        semantic(SemanticGapKind::InoutParameterForwarding),
         &[],
     ),
     // ADR-0052 phase 7 (RUE-978): the unaligned-access round trip allocates
@@ -633,19 +615,19 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "types.mutable_strings",
         "string_clear",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "types.mutable_strings",
         "string_growth_on_append",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "types.mutable_strings",
         "string_heap_promotion",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -675,7 +657,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "types.mutable_strings",
         "string_reserve",
-        semantic(SemanticGapKind::InoutParameterForwarding),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -706,12 +688,6 @@ const ENTRIES: &[Entry] = &[
         "types.str_type",
         "borrow_str_view_of_strbuf_reads_values",
         semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.str_type",
-        "inout_str_view_can_be_forwarded",
-        semantic(SemanticGapKind::InoutParameterForwarding),
         &[],
     ),
     Entry::new(

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -3113,13 +3113,22 @@ impl<'a> Interp<'a> {
             CfgInstData::PlaceRead { place } if self.is_inout_writeback_place(cfg, v, place) => {
                 Ok(WritebackPlace::Stored(place))
             }
-            other @ CfgInstData::Param { index }
+            // Forwarding a writable `inout` parameter as a nested call's `inout`
+            // argument (the container `self`-chain: `push` -> `self.reserve()`).
+            // The caller place is the parameter slot itself; the post-call
+            // copy-out writes the callee's final value back into it, and this
+            // frame in turn copies its own parameter back to *its* caller on
+            // return, so the mutation threads all the way up the chain.
+            // `place_write` routes a `Param` base through the promoted heap
+            // allocation when the slot's address was taken, matching the `Param`
+            // read path, so an address-taken forwarded parameter stays coherent.
+            CfgInstData::Param { index }
                 if *index < cfg.num_params() && cfg.is_param_writable(*index) =>
             {
-                Err(unsupported(
-                    UnsupportedKind::SemanticGap(SemanticGapKind::InoutParameterForwarding),
-                    format!("inout argument is not an lvalue: {other:?}"),
-                ))
+                Ok(WritebackPlace::Simple {
+                    base: PlaceBase::Param(*index),
+                    base_type: cfg.get_inst(v).ty,
+                })
             }
             other => Err(unsupported(
                 UnsupportedKind::ContractViolation(ContractViolationKind::InoutArgumentNotLvalue),

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -796,6 +796,42 @@ fn inout_struct_field() {
 }
 
 #[test]
+fn inout_param_forwarded_to_nested_inout_call() {
+    // Forwarding a writable `inout` parameter as a *nested* call's `inout`
+    // argument. This is the container `self`-chain — `ArrayBuf::push` calls
+    // `self.reserve()`, forwarding its own `inout self` — and before RUE-1010 it
+    // was the `InoutParameterForwarding` model gap. The mutation must thread
+    // through both call boundaries back to the original caller.
+    let src = "fn add(inout x: i32, k: i32) { x = x + k; }
+    fn bump(inout x: i32) { add(inout x, 1); }
+    fn main() -> i32 {
+        let mut n = 40;
+        bump(inout n);
+        bump(inout n);
+        n
+    }";
+    assert_eq!(exit(src), 42);
+}
+
+#[test]
+fn inout_aggregate_param_forwarded_preserves_all_fields() {
+    // The forwarded `inout` value is a whole aggregate mutated through a nested
+    // `inout` call: the copy-back must rewrite the entire header, so an
+    // untouched sibling field survives the round trip (the `{buf, len, cap}`
+    // header-forwarding shape the container mutators rely on).
+    let src = "struct P { x: i32, y: i32 }
+    fn set_x(inout p: P, v: i32) { p.x = v; }
+    fn relabel(inout p: P) { set_x(inout p, 99); }
+    fn main() -> i32 {
+        let mut p = P { x: 1, y: 7 };
+        relabel(inout p);
+        p.x + p.y
+    }";
+    // p.x becomes 99, p.y stays 7 -> 106
+    assert_eq!(exit(src), 106);
+}
+
+#[test]
 fn destructor_runs_at_scope_exit() {
     let src = "struct D { v: i32 }
     drop fn D(self) { @dbg(self.v); }

--- a/crates/rue-oracle/src/tests/place_contracts.rs
+++ b/crates/rue-oracle/src/tests/place_contracts.rs
@@ -49,7 +49,7 @@ fn flattened_parameter_padding_is_a_semantic_gap_but_oob_is_a_contract_failure()
 }
 
 #[test]
-fn core_str_length_is_modeled_but_inout_forwarding_remains_a_program_model_gap() {
+fn core_str_length_is_modeled_and_inout_forwarding_threads_through_nested_calls() {
     let text = run_source_with_preview_features(
         r#"fn main() -> i32 {
             let s: str = "hi";
@@ -68,15 +68,22 @@ fn core_str_length_is_modeled_but_inout_forwarding_remains_a_program_model_gap()
         }
     );
 
-    let forwarding = expect_unsupported(
+    // Forwarding a writable `inout` parameter as a nested call's `inout`
+    // argument is now modeled (RUE-1010): `f` forwards its own `inout v` to
+    // `g`, whose mutation threads back through both call boundaries. This is the
+    // container `self`-chain (`push` -> `self.reserve()`) that previously
+    // reached the `InoutParameterForwarding` gap.
+    let forwarding = run_source_with_preview_features(
         "struct D { x: i32 }
         fn g(inout v: D) -> i32 { v.x = v.x + 1; v.x }
         fn f(inout v: D) -> i32 { g(inout v) }
         fn main() -> i32 { let mut d = D { x: 7 }; f(inout d) }",
-    );
+        &PreviewFeatures::new(),
+    )
+    .expect("inout parameter forwarding must be modeled");
     assert_eq!(
-        forwarding.kind(),
-        UnsupportedKind::SemanticGap(SemanticGapKind::InoutParameterForwarding)
+        forwarding.exit_code, 8,
+        "d.x incremented 7 -> 8 threads back"
     );
 }
 


### PR DESCRIPTION
## Summary

Brings `ArrayBuf(T)` into the differential oracle's coverage by modeling the one construct its methods were still stuck on: forwarding a writable `inout` parameter as a nested call's `inout` argument (the container `self`-chain, e.g. `ArrayBuf::push` calling `self.reserve()`).

Context: since the merge of the §6.13 formalization (RUE-390) and the "model the heap and pointer intrinsics" oracle work, the container methods already run their real source bodies over a modeled heap — the *last* gap they hit was `InoutParameterForwarding`, not the allocation intrinsics the issue originally named. Closing that gap is what this PR does.

## What changes

**`crates/rue-oracle` — model inout-parameter forwarding.** `lvalue_of` now recovers the caller place of a forwarded writable `inout` parameter as the parameter slot itself, so the post-call copy-out threads the mutation back up the chain (and this frame copies its own parameter back to *its* caller on return). `place_write` already routes a `Param` base through the promoted heap when the slot's address was taken, so an address-taken forwarded parameter stays coherent. This removes the sole producer of `SemanticGapKind::InoutParameterForwarding`.

Result: `ArrayBuf(T)` runs its real body and **agrees with the compiler** across the corpus — construction, `reserve`/`push`/`pop`/`get`/`set`/`clear`/`free`, **ascending destructor drop-trace**, amortized growth, and **exact `capacity()`** (the growth policy is now readable in `std/arraybuf.rue`, so the old `StringCapacityValue` guesswork is gone for it).

**`crates/rue-oracle-diff` — one harness refinement.** A `runtime_error_contains` fragment is a *substring* contract: the same phrase can be spelled by a runtime trap (`error: index out of bounds`) or a user panic (`@panic("index out of bounds")`). A `UserPanic` whose stderr satisfies every declared fragment at exit 101 now discharges the contract — the std bridges deliberately spell their bounds check as `@panic(...)`, and the native binary reports the same `UserPanic`, so this matches the compiler rather than masking a divergence.

**Model-gap ledgers burned down.** Agreements deleted; drifted cases repointed to the next gap each now reaches (`ArrayBuf(ZST)` → `PointerWrite`; `ArrayBuf(StrBuf)` and the StrBuf corpus → `TextProjectionRead` / the byte intrinsics).

## Scope / follow-up

Oracle-only — no compiler, codegen, or `std/*.rue` changes. **ArrayBuf** is fully covered here. **StrBuf** is deliberately *not* in this PR: it is blocked by the oracle's dual text representation (opaque `Value::Str` vs. a real `{buf, len, cap}` heap header → `TextProjectionRead`) plus the unmodeled `@byte_read`/`@byte_write`/`@byte_copy`. Interpreting StrBuf by its §6.13.4 defining equations, and adding container-scoped free/retire (the §6.13.1 use-after-free-as-stuck-state falsifiability), are tracked as follow-up.

Relates to RUE-1010 (ArrayBuf portion).

## Testing

- New oracle unit tests for inout-parameter forwarding (scalar and whole-aggregate), plus the prior "forwarding remains a gap" contract test updated to assert it is now modeled.
- CLI and spec differential corpora: **0 disagreements, 0 oracle failures** — "oracle agrees with the compiler on every modeled eligible case."
- `scripts/rue quick` 34/34; clippy clean; formatted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLsiAQKJ41esde9Ya8Up8V)_