### PR TITLE
RUE-1060: variadic diagnostic and StrBuf/char* interop (ADR-0064 P6)

### DIFF
--- a/crates/rue-cli-tests/cases/c_ffi.toml
+++ b/crates/rue-cli-tests/cases/c_ffi.toml
@@ -509,3 +509,84 @@ fn main() -> i32 { 0 }
 """ }]
 args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
 exit_code = 0
+
+# --- P6: StrBuf <-> char* interop, execution-verified (both backends) ---------
+# A Rue StrBuf is built, exported to a caller-owned NUL-terminated `char*` via
+# `std.c.owned_c_string`, and its length is measured by the archive's
+# `ffi_strlen` foreign function (a real C-shape strlen call through the FFI
+# boundary). Then the C string is imported back into a StrBuf with
+# `std.c.strbuf_from_c_string` and compared to the original, closing the
+# round-trip. Prints: the C strlen (11), the local scan agreeing (11), the
+# round-trip equality (true), and the reimported length (11). Target-pinned like
+# cli.abi_conformance; the native host executes and checks exact output.
+
+[[case]]
+name = "x86_64_linux_strbuf_char_star_interop_roundtrip"
+description = "StrBuf exported to char*, measured by an archive strlen, reimported and compared on x86-64."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+extern "C" {
+    fn ffi_strlen(s: ptr mut u8) -> u64;
+}
+
+fn main() -> i32 {
+    let text = "hello world";
+    let sb = std.strbuf.StrBuf.from_str(borrow text);
+
+    // Export to a caller-owned, NUL-terminated C string and hand it to a real
+    // foreign strlen-shape function.
+    let cstr = std.c.owned_c_string(borrow sb);
+    @dbg(checked { ffi_strlen(cstr) });
+    @dbg(std.c.c_strlen(cstr));
+
+    // Import the C string back and compare with the original StrBuf.
+    let back = std.c.strbuf_from_c_string(cstr);
+    @dbg(std.strbuf.StrBuf.equals_borrowed(borrow sb, borrow back));
+    @dbg(back.len());
+
+    std.c.free_c_string(cstr);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "x86-64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = "11\n11\ntrue\n11\n"
+exit_code = 0
+
+[[case]]
+name = "aarch64_linux_strbuf_char_star_interop_roundtrip"
+description = "StrBuf exported to char*, measured by an archive strlen, reimported and compared on AArch64."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+extern "C" {
+    fn ffi_strlen(s: ptr mut u8) -> u64;
+}
+
+fn main() -> i32 {
+    let text = "hello world";
+    let sb = std.strbuf.StrBuf.from_str(borrow text);
+
+    let cstr = std.c.owned_c_string(borrow sb);
+    @dbg(checked { ffi_strlen(cstr) });
+    @dbg(std.c.c_strlen(cstr));
+
+    let back = std.c.strbuf_from_c_string(cstr);
+    @dbg(std.strbuf.StrBuf.equals_borrowed(borrow sb, borrow back));
+    @dbg(back.len());
+
+    std.c.free_c_string(cstr);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "aarch64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "aarch64-linux"
+execute_if_native = true
+stdout = "11\n11\ntrue\n11\n"
+exit_code = 0

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -136,6 +136,10 @@ use rue_target::{Arch, Target};
 /// - `ffi_fill_triple(i64 x) -> Triple` returns `{a: x, b: x+1, c: x+2}` via sret:
 ///   the callee writes the caller storage (SysV echoes the pointer in rax; AAPCS64
 ///   uses the dedicated x8, no echo) — the large indirect aggregate return.
+/// - `ffi_strlen(char*) -> size_t` — a `strlen`-shape length scan for the P6
+///   `StrBuf`<->`char*` interop proof: it counts bytes before the NUL terminator
+///   of the pointer argument, so a `StrBuf` exported via `std.c.owned_c_string`
+///   round-trips its length through a real foreign call.
 fn synthesize_answer_archive(target: Target) -> TestResult<Vec<u8>> {
     // A leaf function returning 42 (P1).
     let answer: Vec<u8> = match target.arch() {
@@ -159,6 +163,25 @@ fn synthesize_answer_archive(target: Target) -> TestResult<Vec<u8>> {
         Arch::Aarch64 => vec![
             0xE0, 0x03, 0x00, 0x2A, 0x0A, 0x1E, 0xFE, 0xD2, 0x0A, 0x1E, 0xDE, 0xF2, 0x00, 0x00,
             0x0A, 0xAA, 0xC0, 0x03, 0x5F, 0xD6,
+        ],
+    };
+    // A `strlen`-shape length scan over a NUL-terminated `char*` in the first
+    // pointer argument (rdi / x0), returning the byte count before the `0` in the
+    // result register (rax / x0). This is the P6 StrBuf<->char* interop proof
+    // callee: a Rue `StrBuf` exported through `std.c.owned_c_string` is passed
+    // here and its length is checked. Byte-for-byte a hand-assembled leaf loop;
+    // no C toolchain is involved (matching the other members).
+    let strlen: Vec<u8> = match target.arch() {
+        // xor eax,eax ; L: cmp byte [rdi+rax],0 ; je +5 ; inc rax ; jmp L ; ret
+        Arch::X86_64 => vec![
+            0x31, 0xC0, 0x80, 0x3C, 0x07, 0x00, 0x74, 0x05, 0x48, 0xFF, 0xC0, 0xEB, 0xF5, 0xC3,
+        ],
+        // movz x2,#0 ; L: ldrb w3,[x0] ; cbz w3,done ; add x0,x0,#1 ; add x2,x2,#1
+        //           ; b L ; done: mov x0,x2 ; ret
+        Arch::Aarch64 => vec![
+            0x02, 0x00, 0x80, 0xD2, 0x03, 0x00, 0x40, 0x39, 0x83, 0x00, 0x00, 0x34, 0x00, 0x04,
+            0x00, 0x91, 0x42, 0x04, 0x00, 0x91, 0xFC, 0xFF, 0xFF, 0x17, 0xE0, 0x03, 0x02, 0xAA,
+            0xC0, 0x03, 0x5F, 0xD6,
         ],
     };
     // A `_Bool` normalizer: al/w0 = (x != 0), then the same dirty-high pattern.
@@ -203,6 +226,12 @@ fn synthesize_answer_archive(target: Target) -> TestResult<Vec<u8>> {
         "ffi_bool_norm.o".to_string(),
         rue_linker::ObjectBuilder::new(target, "ffi_bool_norm")
             .code(bool_norm)
+            .build(),
+    ));
+    objects.push((
+        "ffi_strlen.o".to_string(),
+        rue_linker::ObjectBuilder::new(target, "ffi_strlen")
+            .code(strlen)
             .build(),
     ));
 

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -383,6 +383,7 @@ impl ErrorCode {
     pub const EXTERN_AGGREGATE_NOT_REPR_C: Self = Self(1102);
     pub const EXTERN_ARRAY_BY_VALUE: Self = Self(1103);
     pub const REPR_C_STRUCT_INELIGIBLE: Self = Self(1104);
+    pub const EXTERN_VARIADIC_UNSUPPORTED: Self = Self(1105);
 
     // ========================================================================
     // Comptime errors (E1200-E1299)
@@ -1636,6 +1637,19 @@ pub enum ErrorKind {
         ty: String,
     },
 
+    /// A C variadic marker (`...`) appeared in an `extern "C"` parameter list.
+    /// Variadic foreign calls are rejected in v0 (ADR-0064 secondary ruling B,
+    /// P6): the target-C classifier implements a fixed-signature calling
+    /// convention only, and matching C's variadic argument-promotion and
+    /// register-save-area contract is a later, separate design. The parser
+    /// recognizes the `...` token specifically so the boundary reports this
+    /// rather than a generic "unexpected token".
+    #[error(
+        "variadic parameters (`...`) are not supported in an `extern \"C\"` \
+         signature: C variadic calls are rejected in v0 (ADR-0064)"
+    )]
+    ExternVariadicUnsupported,
+
     /// A `@repr(c)` struct failed the reject-don't-guess eligibility check
     /// (ADR-0064 Amendment 1): an empty struct, an enum/aggregate field without
     /// its own `@repr(c)` marker, or a linear / destructor-bearing field. The
@@ -1885,6 +1899,7 @@ impl ErrorKind {
             }
             ErrorKind::ExternAggregateNotReprC { .. } => ErrorCode::EXTERN_AGGREGATE_NOT_REPR_C,
             ErrorKind::ExternArrayByValue { .. } => ErrorCode::EXTERN_ARRAY_BY_VALUE,
+            ErrorKind::ExternVariadicUnsupported => ErrorCode::EXTERN_VARIADIC_UNSUPPORTED,
             ErrorKind::ReprCStructIneligible(_) => ErrorCode::REPR_C_STRUCT_INELIGIBLE,
             ErrorKind::SliceNotYetImplemented => ErrorCode::SLICE_NOT_YET_IMPLEMENTED,
             ErrorKind::SliceReturnNotAllowed => ErrorCode::SLICE_RETURN_NOT_ALLOWED,

--- a/crates/rue-parser/src/parser/declarations.rs
+++ b/crates/rue-parser/src/parser/declarations.rs
@@ -134,7 +134,7 @@ impl Parser {
         let start = self.start();
         self.expect(TokenKind::Fn)?;
         let name = self.ident()?;
-        let params = self.params()?;
+        let params = self.extern_params()?;
         let return_type = if self.eat(TokenKind::Arrow) {
             Some(self.ty()?)
         } else {
@@ -147,6 +147,50 @@ impl Parser {
             return_type,
             span: self.span_from(start),
         })
+    }
+
+    /// Parse a foreign function's parameter list, recognizing the C variadic
+    /// marker `...` where a parameter is expected.
+    ///
+    /// Ordinary parameter lists (`self.params()`) reach `...` only as a stray
+    /// `.` and report a generic "unexpected token". Variadics are a real C
+    /// surface a reader will reach for, so the extern boundary detects the
+    /// marker specifically and routes it to the dedicated
+    /// [`ErrorKind::ExternVariadicUnsupported`] diagnostic (ADR-0064 secondary
+    /// ruling B, P6): variadic foreign calls are rejected in v0. The marker is
+    /// valid only after zero or more fixed parameters, so it is checked at each
+    /// position a parameter would begin — covering both `fn f(...)` and
+    /// `fn f(a: i32, ...)`.
+    fn extern_params(&mut self) -> PResult<Vec<Param>> {
+        self.expect(TokenKind::LParen)?;
+        let mut params = Vec::new();
+        while !self.at(TokenKind::RParen) && !self.at(TokenKind::Eof) {
+            if self.at(TokenKind::Dot) {
+                return self.reject_variadic_ellipsis();
+            }
+            params.push(self.param()?);
+            if !self.eat(TokenKind::Comma) {
+                break;
+            }
+        }
+        self.expect(TokenKind::RParen)?;
+        Ok(params)
+    }
+
+    /// Record the variadic-rejection diagnostic spanning the `...` marker and
+    /// abort the current declaration. `...` lexes as three consecutive `.`
+    /// tokens; the span covers the whole marker so the caret underlines it.
+    fn reject_variadic_ellipsis(&mut self) -> PResult<Vec<Param>> {
+        let start = self.start();
+        let mut end = start;
+        while self.at(TokenKind::Dot) {
+            end = self.bump().span.end;
+        }
+        self.record_error(CompileError::new(
+            ErrorKind::ExternVariadicUnsupported,
+            Span::with_file(self.file_id, start, end),
+        ));
+        Err(())
     }
 
     fn struct_decl(

--- a/crates/rue-ui-tests/cases/diagnostics/extern_variadic.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/extern_variadic.toml
@@ -1,0 +1,83 @@
+[section]
+id = "diagnostics.extern-variadic"
+name = "Variadic extern signatures are rejected (ADR-0064 P6)"
+description = """
+C variadic foreign calls are rejected in v0 (ADR-0064 secondary ruling B,
+phase P6): the target-C classifier implements a fixed-signature calling
+convention only, and matching C's variadic argument-promotion and
+register-save-area contract is a later, separate design.
+
+The `...` marker lexes as three `.` tokens, so without dedicated recognition
+an `extern "C"` signature using it reports a generic "unexpected token"
+(E0100). The parser instead recognizes `...` where a foreign parameter is
+expected and routes it to the dedicated E1105 diagnostic, which names the
+ADR. These cases pin the diagnostic text, its E-code, and its span (the caret
+underlines exactly the `...` marker).
+
+Recognition is at parse time, so the diagnostic fires whether or not
+`--preview c_ffi` is supplied — a reader spelling a variadic is told why it is
+rejected before the preview gate is consulted.
+"""
+
+[[case]]
+name = "variadic_after_fixed_param_is_e1105"
+description = "A `...` after a fixed parameter reports E1105 naming the ADR, spanning the marker at 2:34."
+source = """
+extern "C" {
+    fn printf(fmt: ptr const u8, ...) -> i32;
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+# Pins the E-code, the marker span (line:col of the first `.`), the message,
+# and the ADR citation.
+error_contains = [
+    "E1105",
+    "2:34",
+    "variadic parameters (`...`) are not supported",
+    "ADR-0064",
+]
+
+[[case]]
+name = "variadic_span_underlines_the_marker"
+description = "The caret rendering underlines exactly the three-dot `...` marker."
+source = """
+extern "C" {
+    fn printf(fmt: ptr const u8, ...) -> i32;
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+# The golden caret line underlines the whole `...` (three carets), not a single
+# stray dot — the whole marker is the span.
+error_contains = "^^^"
+
+[[case]]
+name = "variadic_as_sole_param_is_e1105"
+description = "A `...` as the only parameter is recognized as a variadic marker (not a missing name)."
+source = """
+extern "C" {
+    fn f(...) -> i32;
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E1105", "2:10", "variadic parameters"]
+
+[[case]]
+name = "variadic_rejected_before_preview_gate"
+description = "Recognition is at parse time: the variadic diagnostic fires under --preview c_ffi too, as a single clean error."
+preview = "c_ffi"
+preview_should_pass = true
+source = """
+extern "C" {
+    fn printf(fmt: ptr const u8, ...) -> i32;
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E1105", "variadic parameters", "ADR-0064"]

--- a/std/c.rue
+++ b/std/c.rue
@@ -25,6 +25,10 @@
 // machine-readably and is the hook a future ILP32/LLP64 target would branch on
 // once const-context target selection exists (see the c_char note below).
 
+// The StrBuf <-> char* bridges at the bottom of this module copy through the
+// growable byte-string type.
+const strbuf = @import("strbuf.rue");
+
 // ---------------------------------------------------------------------------
 // Character types
 // ---------------------------------------------------------------------------
@@ -122,3 +126,109 @@ pub const c_bool = bool;
 // is out of scope for this change. The signed/unsigned char types (`c_schar`,
 // `c_uchar`) are provided unconditionally in the meantime; the WIDTHS above are
 // all target-invariant across the supported LP64 set and so are fully correct.
+
+// ---------------------------------------------------------------------------
+// StrBuf <-> char* interop (ADR-0064 P6)
+// ---------------------------------------------------------------------------
+//
+// A C `char*` is Rue's `ptr mut u8`. A StrBuf is a length-carrying byte buffer
+// that is NOT NUL-terminated, so it cannot be handed to a C function expecting a
+// NUL-terminated string as-is. Per ADR-0064, NUL termination and ownership are
+// an EXPLICIT MANUAL CONTRACT, not an automatic conversion: these helpers make
+// that contract a single documented call each rather than open-coded pointer
+// arithmetic at every call site.
+//
+// POINTER MUTABILITY. These are typed `ptr mut u8` (C `char*`), not
+// `ptr const u8` (C `const char*`), because Rue v0 provides no way to construct
+// or coerce to a `ptr const u8` value: `@alloc_bytes` and `@int_to_ptr` both
+// yield `ptr mut u8`, and there is no `ptr mut → ptr const` coercion, so a
+// `ptr const u8` parameter is currently uncallable with a constructed pointer.
+// `char*` is the callable spelling of a C string boundary today; a `const
+// char*`-only foreign function is reachable once a const-pointer view exists (a
+// later, additive design). A `char*` argument satisfies a C `const char*`
+// parameter on the C side regardless.
+//
+// All are unchecked-boundary operations (raw-pointer reads/writes and the byte
+// allocator), consistent with the FFI rule that foreign interop is
+// unchecked-context work (ADR-0064 ruling 3): a pointer received from or handed
+// to C carries no Rue lifetime, aliasing, or validity guarantee, and the caller
+// is responsible for keeping it live and for freeing what it owns.
+
+/// Scan a NUL-terminated C string and return its length in bytes, EXCLUDING the
+/// terminator — the `strlen(3)` shape.
+///
+/// `cstr` must point at a `0`-terminated buffer the caller keeps valid for the
+/// duration of the call. There is no length bound: a buffer without a
+/// terminator reads out of bounds, exactly as C `strlen` does. This is the
+/// scan both `strbuf_from_c_string` and `free_c_string` share.
+pub fn c_strlen(cstr: ptr mut u8) -> u64 {
+    let mut len: u64 = 0;
+    while checked { @byte_read(cstr, len) } != 0 {
+        len = len + 1;
+    }
+    len
+}
+
+/// Copy `source`'s bytes into a freshly allocated, NUL-terminated C string and
+/// return a pointer the CALLER OWNS.
+///
+/// The returned buffer holds `source.len() + 1` bytes at alignment one — the
+/// string bytes followed by a `0` terminator — and is suitable for a C `char*`
+/// (or `const char*`) parameter. It is an INDEPENDENT allocation: `source`
+/// is borrowed, remains valid, and is not consumed. Ownership transfers to the
+/// caller, who MUST release the buffer with [`free_c_string`] (never a StrBuf
+/// free — this buffer is not a StrBuf and carries no capacity header). If
+/// `source` itself contains an interior `0` byte, the C string is effectively
+/// truncated at that byte from a C consumer's point of view; the full
+/// `len + 1` bytes are still what `free_c_string` reclaims via its own scan, so
+/// interior NULs are a caller concern, not a leak. Allocation failure is
+/// fail-fast, matching StrBuf's allocator convention.
+pub fn owned_c_string(borrow source: strbuf.StrBuf) -> ptr mut u8 {
+    let len = source.len();
+    let buf: ptr mut u8 = checked { @alloc_bytes(len + 1, 1) };
+    if checked { @ptr_to_int(buf) } == 0 {
+        @panic("out of memory");
+    }
+    let mut i: u64 = 0;
+    while i < len {
+        let byte = strbuf.StrBuf.byte_at_borrowed(borrow source, i);
+        checked { @byte_write(buf, i, byte); };
+        i = i + 1;
+    }
+    checked { @byte_write(buf, len, 0); };
+    buf
+}
+
+/// Import a NUL-terminated C string into a NEW owned StrBuf by scanning for the
+/// terminator (`strlen`-shape) and copying the bytes before it.
+///
+/// The terminator is NOT copied — the resulting StrBuf's length is the C
+/// string's `strlen`. `cstr` is only READ and must stay valid for the duration
+/// of the call; its ownership is unaffected (freeing it, if the caller owns it,
+/// remains the caller's responsibility). The returned StrBuf is an independent
+/// owner with its own allocation and the ordinary StrBuf destructor.
+pub fn strbuf_from_c_string(cstr: ptr mut u8) -> strbuf.StrBuf {
+    let len = c_strlen(cstr);
+    let mut out = strbuf.StrBuf.with_capacity(len);
+    let mut i: u64 = 0;
+    while i < len {
+        out.push(checked { @byte_read(cstr, i) });
+        i = i + 1;
+    }
+    out
+}
+
+/// Release a buffer returned by [`owned_c_string`].
+///
+/// `cstr` must be a pointer `owned_c_string` returned and not yet freed. The
+/// length is recovered by scanning to the terminator (the buffer was allocated
+/// as `strlen + 1` bytes at alignment one), so the caller does not track the
+/// size. Passing any other pointer — a StrBuf's backing buffer, a C-owned
+/// string, or an already-freed pointer — is a contract violation.
+pub fn free_c_string(cstr: ptr mut u8) {
+    let mut len: u64 = 0;
+    while checked { @byte_read(cstr, len) } != 0 {
+        len = len + 1;
+    }
+    checked { @free_bytes(cstr, len + 1, 1); };
+}


### PR DESCRIPTION
Fixes RUE-1060

ADR-0064 phase P6: the two remaining C-boundary pieces below the export phase.

**Variadic rejection.** The parser now recognizes the C variadic marker `...` (three `.` tokens) where an `extern "C"` parameter is expected and routes it to a dedicated **E1105**, spanning exactly the marker and naming ADR-0064 — replacing the generic "unexpected token" a bare `...` used to produce. Fires at parse time, with or without the `c_ffi` preview, for both sole-parameter `fn f(...)` and trailing `fn f(a, ...)` forms. Four UI cases pin the text, code, ADR citation, and span.

**StrBuf↔char* interop** in `std.c` (the C-boundary module):
- `owned_c_string(borrow StrBuf) -> ptr mut u8` — StrBuf to a caller-owned NUL-terminated buffer
- `strbuf_from_c_string(ptr mut u8) -> StrBuf` — length-scan import
- `c_strlen` — shared strlen-shape scan; `free_c_string` — companion free

The NUL/ownership manual contract is documented in-source. Helpers are typed `ptr mut u8` (C `char*`) rather than the ADR's illustrative `ptr const u8`: Rue v0 cannot construct or coerce to a `ptr const u8` value (allocation intrinsics yield `ptr mut`, and there is no mut→const coercion — verified E0702/E0206), so a const-pointer parameter would be uncallable with any constructed pointer. `char*` is the callable spelling and satisfies a C `const char*` parameter anyway; a const-pointer view is flagged as later additive work.

**Proof by execution**: a round-trip case — build a StrBuf, export via `owned_c_string`, measure with a new hand-assembled `ffi_strlen` archive member (both targets), reimport with `strbuf_from_c_string`, compare, free — printing `11 / 11 / true / 11` natively on x86-64; plus the variadic UI diagnostic cases.

Lane note: E1105 is a fresh code (the aggregate-classification sibling, now landed as #1861, owns E1101/E1104); this PR touches only the parser, std, error registry, and test corpora.

Verification: integrated on trunk including #1861 (P3). The `main.rs` archive-member doc conflict (both phases appended members) resolved keeping both sets; c_ffi corpus 27/27 with native execution of the strlen round-trip, 4/4 variadic UI cases, E1105 hand-verified with its `...`-span. Full `./test.sh` alone on the host: exit 0, zero failures in both formats.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_