### PR TITLE
RUE-1058: Rue-to-C export thunks and the abort-at-boundary policy (ADR-0064 P4)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1395,6 +1395,20 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
         // Work queue: functions/methods to analyze
         // Start with main().
         let mut pending_functions: Vec<Spur> = vec![main_sym];
+        // Rue-to-C exports (`pub extern "C" fn`, ADR-0064 P4) are additional
+        // reachability roots: a separately compiled C caller may invoke an
+        // exported function even when nothing in this program calls it, so its
+        // body must be analyzed and code-generated exactly like `main`. Seeded
+        // in a deterministic (interned-symbol) order so analysis order — and the
+        // resulting object/link layout — stays reproducible.
+        let mut export_roots: Vec<Spur> = sema
+            .functions
+            .iter()
+            .filter(|(_, info)| info.is_c_export)
+            .map(|(name, _)| *name)
+            .collect();
+        export_roots.sort_unstable();
+        pending_functions.extend(export_roots);
         let mut analyzed_functions: HashSet<Spur> = HashSet::new();
         let mut pending_methods: Vec<(StructId, Spur)> = Vec::new();
         let mut analyzed_methods: HashSet<(StructId, Spur)> = HashSet::new();

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -680,11 +680,16 @@ impl<'a> DeclarationShells<'a> {
                         self_mode,
                         self_is_mut,
                         directives,
+                        // The Rue-to-C export marker (ADR-0064 P4) is a property
+                        // of the current RIR, so it is read here rather than
+                        // threaded through the durable declaration shell.
+                        is_c_export,
                         ..
                     } = &self.sema.rir.get(pending.declaration).data
                     else {
                         return Err(DeclarationInstallFailure::KindMismatch);
                     };
+                    let is_c_export = *is_c_export;
                     let type_name = self.sema.interner.get_or_intern("type");
                     let rir_parameters = self.sema.rir.params(params);
                     if parameters
@@ -780,6 +785,7 @@ impl<'a> DeclarationShells<'a> {
                                 is_pub: pending.shell.is_public,
                                 is_unchecked: pending.shell.is_unchecked,
                                 is_extern: pending.shell.is_extern,
+                                is_c_export,
                                 allow_unused_function,
                                 allow_unused_variable,
                                 allow_unreachable_code,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1087,6 +1087,7 @@ impl<'a> Sema<'a> {
                     is_pub,
                     is_unchecked,
                     is_extern,
+                    is_c_export,
                     name,
                     params,
                     return_type,
@@ -1131,6 +1132,7 @@ impl<'a> Sema<'a> {
                         *is_pub,
                         *is_unchecked,
                         *is_extern,
+                        *is_c_export,
                     )?;
                 }
 
@@ -1237,6 +1239,12 @@ impl<'a> Sema<'a> {
     /// 3. Any remaining type that is not passable in this phase (enums, and — once
     ///    RUE-714 adds them — floats) takes the phase diagnostic via the
     ///    `c_passable_by_value` predicate seam.
+    /// Whether `ty` is a by-value aggregate (struct or fixed array) — the types
+    /// the P4 export thunk cannot yet repack across the C boundary.
+    fn is_aggregate_type(ty: Type) -> bool {
+        matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_))
+    }
+
     fn check_extern_signature_type(&self, ty: Type, span: Span) -> CompileResult<()> {
         match ty.kind() {
             TypeKind::Array(_) => Err(CompileError::new(
@@ -1477,6 +1485,7 @@ impl<'a> Sema<'a> {
         is_pub: bool,
         is_unchecked: bool,
         is_extern: bool,
+        is_c_export: bool,
     ) -> CompileResult<()> {
         // Reject user functions whose name collides with a runtime/codegen helper
         // symbol (e.g. `__rue_str_eq`, `__rue_alloc`, `_start`). Without this, such a
@@ -1627,6 +1636,86 @@ impl<'a> Sema<'a> {
             }
         }
 
+        // Rue-to-C exports (`pub extern "C" fn`, ADR-0064 P4) share the FFI
+        // signature-type contract with imports, and add the P4 export-thunk's
+        // narrower scope: the callee thunk marshals only integer/pointer scalars
+        // that fit the argument-register budget shared by both targets, so an
+        // aggregate parameter/return, a by-reference or generic parameter, or a
+        // parameter list wider than that budget is rejected rather than
+        // silently mis-marshaled. The C name must also not collide with the
+        // program entry point.
+        if is_c_export {
+            self.require_preview(PreviewFeature::CFfi, "a `pub extern \"C\" fn` export", span)?;
+            let reject = |reason: String| -> CompileResult<()> {
+                Err(CompileError::new(
+                    ErrorKind::ExportSignatureUnsupported {
+                        name: name_str.to_string(),
+                        reason,
+                    },
+                    span,
+                ))
+            };
+            if name_str == "main" {
+                reject(
+                    "an export named `main` collides with the program entry point; \
+                     give it a different C name"
+                        .to_string(),
+                )?;
+            }
+            if is_generic {
+                reject(
+                    "a generic function has no single C symbol; export a concrete \
+                     (non-`comptime`) function"
+                        .to_string(),
+                )?;
+            }
+            // Shared FFI-safety type gate (rejects floats, enums, by-value
+            // arrays, and non-`@repr(c)` aggregates with their own diagnostics).
+            for &param_type in &param_types {
+                self.check_extern_signature_type(param_type, span)?;
+            }
+            if ret_type != Type::UNIT {
+                self.check_extern_signature_type(ret_type, span)?;
+            }
+            // P4 thunk scope: integer/pointer scalars only, within the smaller
+            // (SysV, 6) register budget so one export is valid on both targets.
+            const P4_EXPORT_REGISTER_BUDGET: usize = 6;
+            for (index, mode) in param_modes.iter().enumerate() {
+                if *mode != RirParamMode::Normal {
+                    reject(format!(
+                        "parameter {} uses a by-reference (`borrow`/`inout`) mode, which \
+                         does not cross a C boundary; pass a raw pointer instead",
+                        index + 1
+                    ))?;
+                }
+            }
+            for &param_type in &param_types {
+                if Self::is_aggregate_type(param_type) {
+                    reject(format!(
+                        "aggregate parameter `{}` is not supported by the P4 export thunk \
+                         (register repacking of `@repr(c)` aggregates across the export \
+                         boundary is future work); pass a pointer to the aggregate instead",
+                        self.format_type_name(param_type)
+                    ))?;
+                }
+            }
+            if ret_type != Type::UNIT && Self::is_aggregate_type(ret_type) {
+                reject(format!(
+                    "aggregate return `{}` is not supported by the P4 export thunk; \
+                     return a scalar or write through an out-pointer parameter instead",
+                    self.format_type_name(ret_type)
+                ))?;
+            }
+            if param_types.len() > P4_EXPORT_REGISTER_BUDGET {
+                reject(format!(
+                    "{} scalar parameters exceed the {}-register argument budget the P4 \
+                     export thunk supports; reduce the parameter count",
+                    param_types.len(),
+                    P4_EXPORT_REGISTER_BUDGET
+                ))?;
+            }
+        }
+
         // Allocate parameter data in the arena
         let params_range = self.param_arena.alloc(
             param_names.into_iter(),
@@ -1653,6 +1742,7 @@ impl<'a> Sema<'a> {
                 is_pub,
                 is_unchecked,
                 is_extern,
+                is_c_export,
                 allow_unused_function,
                 allow_unused_variable,
                 allow_unreachable_code,
@@ -2938,7 +3028,7 @@ impl<'a> Sema<'a> {
         let Some(inst_ref) = self.declaration_index.first_free_function(target, file_id) else {
             return Ok(None);
         };
-        let (span, is_pub, return_type, body, is_unchecked, is_extern) = {
+        let (span, is_pub, return_type, body, is_unchecked, is_extern, is_c_export) = {
             let inst = self.rir.get(inst_ref);
             let InstData::FnDecl {
                 is_pub,
@@ -2946,6 +3036,7 @@ impl<'a> Sema<'a> {
                 body,
                 is_unchecked,
                 is_extern,
+                is_c_export,
                 ..
             } = &inst.data
             else {
@@ -2958,6 +3049,7 @@ impl<'a> Sema<'a> {
                 *body,
                 *is_unchecked,
                 *is_extern,
+                *is_c_export,
             )
         };
 
@@ -2980,6 +3072,7 @@ impl<'a> Sema<'a> {
                 is_pub,
                 is_unchecked,
                 is_extern,
+                is_c_export,
             );
             self.fn_signatures_in_flight.remove(&internal_target);
             collected?;

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1215,6 +1215,12 @@ impl<'a> Sema<'a> {
         Ok(())
     }
 
+    /// Whether `ty` is a by-value aggregate (struct or fixed array) — the types
+    /// the P4 export thunk cannot yet repack across the C boundary.
+    fn is_aggregate_type(ty: Type) -> bool {
+        matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_))
+    }
+
     /// Enforce one `extern "C"` parameter or return type (ADR-0064 P1 +
     /// Amendment 1).
     ///
@@ -1239,12 +1245,6 @@ impl<'a> Sema<'a> {
     /// 3. Any remaining type that is not passable in this phase (enums, and — once
     ///    RUE-714 adds them — floats) takes the phase diagnostic via the
     ///    `c_passable_by_value` predicate seam.
-    /// Whether `ty` is a by-value aggregate (struct or fixed array) — the types
-    /// the P4 export thunk cannot yet repack across the C boundary.
-    fn is_aggregate_type(ty: Type) -> bool {
-        matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_))
-    }
-
     fn check_extern_signature_type(&self, ty: Type, span: Span) -> CompileResult<()> {
         match ty.kind() {
             TypeKind::Array(_) => Err(CompileError::new(

--- a/crates/rue-air/src/sema/info.rs
+++ b/crates/rue-air/src/sema/info.rs
@@ -40,6 +40,12 @@ pub struct FunctionInfo {
     /// a `checked` block; codegen emits an undefined linker symbol rather than a
     /// definition.
     pub is_extern: bool,
+    /// Whether this is a Rue-to-C export (`pub extern "C" fn`, ADR-0064 P4): an
+    /// ordinary Rue function body (analyzed, with a CFG, code-generated) that is
+    /// *also* exposed to C callers under its unmangled source name via a C-ABI
+    /// callee thunk. Unlike `is_extern`, an export is a reachability root and
+    /// requires codegen to emit its entry thunk.
+    pub is_c_export: bool,
     /// Whether `@allow(unused_function)` was applied to this function.
     pub allow_unused_function: bool,
     /// Whether `@allow(unused_variable)` was applied to this function.

--- a/crates/rue-cli-tests/cases/c_ffi.toml
+++ b/crates/rue-cli-tests/cases/c_ffi.toml
@@ -590,3 +590,224 @@ executable_target = "aarch64-linux"
 execute_if_native = true
 stdout = "11\n11\ntrue\n11\n"
 exit_code = 0
+
+# ===========================================================================
+# P4: Rue-to-C export thunks (ADR-0064 P4, RUE-1058)
+# ===========================================================================
+# A `pub extern "C" fn` exposes a Rue function to C callers under its unmangled
+# name via a C-ABI entry thunk. The proof is the inverse of every case above: a
+# C-convention caller (a synthesized archive member) invokes the Rue export and
+# observes its result. The Rue program keeps a `main` (the compiler requires one
+# and it is the process entry), imports the archive caller as an ordinary
+# `extern "C"` leaf, and prints what the C code observed. Each pinned pair
+# compiles+links+structurally-validates on every host and executes only the
+# native one.
+
+[[case]]
+name = "x86_64_linux_export_called_from_c"
+description = "A C caller (archive member) invokes two Rue exports through their C-ABI thunks; rue_add(3,5)=8 and the order-sensitive rue_sub(10,4)=6 encode to 806 on x86-64 (SysV)."
+files = [{ path = "main.rue", source = """
+pub extern "C" fn rue_add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+pub extern "C" fn rue_sub(a: i32, b: i32) -> i32 {
+    a - b
+}
+
+extern "C" {
+    fn ffi_call_exports() -> i64;
+}
+
+fn main() -> i32 {
+    @dbg(checked { ffi_call_exports() });
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "x86-64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = "806\n"
+exit_code = 0
+
+[[case]]
+name = "aarch64_linux_export_called_from_c"
+description = "A C caller (archive member) invokes two Rue exports through their C-ABI thunks; rue_add(3,5)=8 and the order-sensitive rue_sub(10,4)=6 encode to 806 on AArch64 (AAPCS64)."
+files = [{ path = "main.rue", source = """
+pub extern "C" fn rue_add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+pub extern "C" fn rue_sub(a: i32, b: i32) -> i32 {
+    a - b
+}
+
+extern "C" {
+    fn ffi_call_exports() -> i64;
+}
+
+fn main() -> i32 {
+    @dbg(checked { ffi_call_exports() });
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "aarch64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "aarch64-linux"
+execute_if_native = true
+stdout = "806\n"
+exit_code = 0
+
+[[case]]
+name = "x86_64_linux_trapping_export_aborts_at_boundary"
+description = "A Rue export that overflows under a C caller aborts the process (exit 101) rather than unwinding the C frame; the C caller's post-call code never runs (ADR-0064 abort-at-boundary), x86-64."
+files = [{ path = "main.rue", source = """
+pub extern "C" fn rue_trap(x: i32) -> i32 {
+    x + x
+}
+
+extern "C" {
+    fn ffi_call_trap() -> i64;
+}
+
+fn main() -> i32 {
+    @dbg(checked { ffi_call_trap() });
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "x86-64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = ""
+runtime_error_contains = ["integer overflow"]
+exit_code = 101
+
+[[case]]
+name = "aarch64_linux_trapping_export_aborts_at_boundary"
+description = "A Rue export that overflows under a C caller aborts the process (exit 101) rather than unwinding the C frame; the C caller's post-call code never runs (ADR-0064 abort-at-boundary), AArch64."
+files = [{ path = "main.rue", source = """
+pub extern "C" fn rue_trap(x: i32) -> i32 {
+    x + x
+}
+
+extern "C" {
+    fn ffi_call_trap() -> i64;
+}
+
+fn main() -> i32 {
+    @dbg(checked { ffi_call_trap() });
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "--link-archive", "${FFI_ARCHIVE}", "--target", "aarch64-linux", "-o", "prog"]
+ffi_answer_archive = true
+executable_target = "aarch64-linux"
+execute_if_native = true
+stdout = ""
+runtime_error_contains = ["integer overflow"]
+exit_code = 101
+
+# --- P4 export diagnostics (compile-fail) -----------------------------------
+
+[[case]]
+name = "export_aggregate_parameter_rejected"
+description = "An aggregate parameter in a `pub extern \"C\" fn` export is rejected: the P4 thunk marshals only register scalars (E1106)."
+files = [{ path = "main.rue", source = """
+@repr(c)
+struct Pair { a: i32, b: i32 }
+
+pub extern "C" fn f(p: Pair) -> i32 {
+    p.a
+}
+
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["E1106", "export `f`", "aggregate parameter"]
+
+[[case]]
+name = "export_too_many_parameters_rejected"
+description = "A scalar parameter list wider than the shared argument-register budget is rejected by the P4 export thunk (E1106)."
+files = [{ path = "main.rue", source = """
+pub extern "C" fn f(a: i32, b: i32, c: i32, d: i32, e: i32, g: i32, h: i32) -> i32 {
+    a
+}
+
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["E1106", "exceed", "budget"]
+
+[[case]]
+name = "export_named_main_rejected"
+description = "An export whose C name collides with the program entry point (`main`) is rejected (E1106)."
+files = [{ path = "main.rue", source = """
+pub extern "C" fn main() -> i32 {
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["E1106", "collides with the program entry point"]
+
+[[case]]
+name = "export_enum_parameter_rejected"
+description = "An enum parameter is not FFI-safe and is rejected in an export signature (E1101), same as an import."
+files = [{ path = "main.rue", source = """
+enum Color { Red, Green }
+
+pub extern "C" fn f(c: Color) -> i32 {
+    0
+}
+
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["E1101", "enums are not FFI-safe"]
+
+[[case]]
+name = "export_reserved_name_rejected"
+description = "An export whose name collides with a reserved runtime symbol (`_start`) is rejected (E0435), same guard as any function."
+files = [{ path = "main.rue", source = """
+pub extern "C" fn _start() -> i32 {
+    0
+}
+
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0435", "_start", "reserved"]
+
+[[case]]
+name = "export_c_unwind_abi_rejected"
+description = "`\"C-unwind\"` stays reserved: an export declared with it is rejected, only `\"C\"` is accepted (ADR-0064)."
+files = [{ path = "main.rue", source = """
+pub extern "C-unwind" fn f() -> i32 {
+    0
+}
+
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+compile_fail = true
+error_contains = ["unsupported extern ABI", "C-unwind"]
+
+[[case]]
+name = "export_requires_c_ffi_preview"
+description = "A `pub extern \"C\" fn` export is gated behind the `c_ffi` preview feature (E1100)."
+files = [{ path = "main.rue", source = """
+pub extern "C" fn f(a: i32) -> i32 {
+    a
+}
+
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["c_ffi"]

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -299,6 +299,92 @@ fn synthesize_answer_archive(target: Target) -> TestResult<Vec<u8>> {
         ));
     }
 
+    // --- P4 export-thunk C-caller members (ADR-0064 P4, RUE-1058) ------------
+    //
+    // These are the *inverse* of every member above: instead of a leaf a Rue
+    // program calls, each is a C-convention caller that invokes a Rue function
+    // *exported* to C (`pub extern "C" fn`) through its C-ABI entry thunk. A P4
+    // program imports one of these as an ordinary `extern "C"` leaf; the member
+    // then calls back into the Rue export, proving a separately compiled C
+    // caller reaches an exported Rue function across the target-C boundary. The
+    // bytes are the `.text` of `cc`/`clang -O2` output for the callers below,
+    // with the call sites left as relocations against the Rue export symbols
+    // (resolved from the main program's own objects at link time), exactly as a
+    // real C object references an external function.
+    //
+    //   long ffi_call_exports(void) {          // success driver
+    //       long a = rue_add(3, 5);            // 8
+    //       long b = rue_sub(10, 4);           // 6  (order-sensitive)
+    //       return a * 100 + b;                // 806
+    //   }
+    //   long ffi_call_trap(void) {             // abort driver
+    //       rue_trap(2000000000);              // overflows -> aborts (exit 101)
+    //       return 999;                        // unreachable
+    //   }
+    let plt = |offset: u64, symbol: &str| rue_linker::CodeRelocation {
+        offset,
+        symbol: symbol.to_string(),
+        rel_type: match target.arch() {
+            Arch::X86_64 => rue_linker::RelocationType::Plt32,
+            Arch::Aarch64 => rue_linker::RelocationType::Call26,
+        },
+        addend: match target.arch() {
+            Arch::X86_64 => -4,
+            Arch::Aarch64 => 0,
+        },
+    };
+    let (call_exports_code, call_exports_relocs): (Vec<u8>, Vec<(u64, &str)>) = match target.arch()
+    {
+        Arch::X86_64 => (
+            vec![
+                0x53, 0xBE, 0x05, 0x00, 0x00, 0x00, 0xBF, 0x03, 0x00, 0x00, 0x00, 0xE8, 0x00, 0x00,
+                0x00, 0x00, 0xBE, 0x04, 0x00, 0x00, 0x00, 0xBF, 0x0A, 0x00, 0x00, 0x00, 0x89, 0xC3,
+                0xE8, 0x00, 0x00, 0x00, 0x00, 0x89, 0xC2, 0x48, 0x63, 0xC3, 0x5B, 0x48, 0x8D, 0x04,
+                0x80, 0x48, 0x8D, 0x0C, 0x80, 0x48, 0x63, 0xC2, 0x48, 0x8D, 0x04, 0x88, 0xC3,
+            ],
+            vec![(12, "rue_add"), (29, "rue_sub")],
+        ),
+        Arch::Aarch64 => (
+            vec![
+                0xFD, 0x7B, 0xBE, 0xA9, 0xF3, 0x0B, 0x00, 0xF9, 0xFD, 0x03, 0x00, 0x91, 0x60, 0x00,
+                0x80, 0x52, 0xA1, 0x00, 0x80, 0x52, 0x00, 0x00, 0x00, 0x94, 0xF3, 0x03, 0x00, 0x2A,
+                0x40, 0x01, 0x80, 0x52, 0x81, 0x00, 0x80, 0x52, 0x00, 0x00, 0x00, 0x94, 0x09, 0x7C,
+                0x40, 0x93, 0x88, 0x0C, 0x80, 0x52, 0x60, 0x26, 0x28, 0x9B, 0xF3, 0x0B, 0x40, 0xF9,
+                0xFD, 0x7B, 0xC2, 0xA8, 0xC0, 0x03, 0x5F, 0xD6,
+            ],
+            vec![(20, "rue_add"), (36, "rue_sub")],
+        ),
+    };
+    let (call_trap_code, call_trap_relocs): (Vec<u8>, Vec<(u64, &str)>) = match target.arch() {
+        Arch::X86_64 => (
+            vec![
+                0x48, 0x83, 0xEC, 0x08, 0xBF, 0x00, 0x94, 0x35, 0x77, 0xE8, 0x00, 0x00, 0x00, 0x00,
+                0xB8, 0xE7, 0x03, 0x00, 0x00, 0x48, 0x83, 0xC4, 0x08, 0xC3,
+            ],
+            vec![(10, "rue_trap")],
+        ),
+        Arch::Aarch64 => (
+            vec![
+                0xFD, 0x7B, 0xBF, 0xA9, 0xFD, 0x03, 0x00, 0x91, 0x00, 0x80, 0x92, 0x52, 0xA0, 0xE6,
+                0xAE, 0x72, 0x00, 0x00, 0x00, 0x94, 0xE0, 0x7C, 0x80, 0x52, 0xFD, 0x7B, 0xC1, 0xA8,
+                0xC0, 0x03, 0x5F, 0xD6,
+            ],
+            vec![(16, "rue_trap")],
+        ),
+    };
+    let mut caller_objects: Vec<(String, Vec<u8>)> = Vec::new();
+    for (symbol, code, relocs) in [
+        ("ffi_call_exports", call_exports_code, call_exports_relocs),
+        ("ffi_call_trap", call_trap_code, call_trap_relocs),
+    ] {
+        let mut builder = rue_linker::ObjectBuilder::new(target, symbol).code(code);
+        for (offset, target_symbol) in relocs {
+            builder = builder.relocation(plt(offset, target_symbol));
+        }
+        caller_objects.push((format!("{symbol}.o"), builder.build()));
+    }
+    objects.extend(caller_objects);
+
     let members: Vec<(&str, &[u8])> = objects
         .iter()
         .map(|(name, bytes)| (name.as_str(), bytes.as_slice()))

--- a/crates/rue-codegen/src/export_thunk.rs
+++ b/crates/rue-codegen/src/export_thunk.rs
@@ -1,0 +1,278 @@
+//! Rue-to-C export thunks (ADR-0064 P4).
+//!
+//! The mirror of the P1/P2/P3 foreign-call path. A foreign *call* adapts the
+//! native convention to the target-C convention on the way *out* to a C callee;
+//! an *export* thunk adapts the target-C convention to the native convention on
+//! the way *in* from a C caller. A `pub extern "C" fn` is compiled like any other
+//! Rue function (a native-conventioned body under a mangled symbol); this module
+//! emits an additional, globally-visible, **unmangled** entry symbol — the C
+//! symbol — whose body is a small prologue that receives arguments per the psABI
+//! and forwards to the native body.
+//!
+//! ## Why scalars/pointers are a prologue, not a repack
+//!
+//! For the integer/pointer scalars this phase supports, the native Rue argument
+//! convention and both target-C conventions already agree on *where* each
+//! argument lives: the first arguments occupy the same integer registers (`rdi,
+//! rsi, rdx, rcx, r8, r9` on SysV; `x0..x7` on AAPCS64), a scalar return comes
+//! back in the same primary result register, and Rue's internal invariant keeps
+//! a scalar canonically extended — which is *stronger* than what a C caller
+//! guarantees. The one place the conventions disagree is the **narrow-integer
+//! extension**: a C caller may leave the bits above a narrow argument's declared
+//! width unspecified (SysV) or extended only to 32 bits (AAPCS64), whereas the
+//! native body assumes the program-wide canonical 64-bit form. So the thunk
+//! re-extends each narrow argument register in place — reusing the shared
+//! [`TargetCCallAbi`] authority so it cannot disagree with the import side about
+//! *which* extension a type needs — and then calls the native body. The scalar
+//! return needs no fix-up: the native body already produces the canonical form a
+//! C caller accepts (including a 0/1 `_Bool`).
+//!
+//! ## Abort at the boundary (ratified, ADR-0064 ruling 3)
+//!
+//! A trap that occurs while a C caller is on the stack must abort the process,
+//! never unwind a C frame. Rue has **no unwinding machinery at all**: every trap
+//! (overflow, bounds, `@panic`, failed checked assertion) lowers to a runtime
+//! call that writes a diagnostic and performs a direct `exit(2)` syscall, and
+//! `unreachable` lowers to an illegal instruction. Executing a native body
+//! through this thunk therefore inherits abort-at-boundary for free — there is
+//! no code path by which a trap could return into the thunk and propagate an
+//! unwind into C. This module adds no guard because none is needed; the property
+//! is structural, and the P4 CLI suite proves it by observing a trapping export
+//! terminate a C caller with the runtime's deterministic exit status.
+//!
+//! Aggregate (`@repr(c)` struct/array) parameters and returns, and argument
+//! lists wider than the shared register budget, are rejected in semantic
+//! analysis (`ExportSignatureUnsupported`, E1106); this module only ever sees
+//! register-resident scalar/pointer signatures.
+
+use rue_air::{ScalarAbiExtension, TargetCAbiFlavor, TargetCCallAbi, Type};
+use rue_target::{Arch, Target};
+
+use crate::{EmittedRelocation, MachineCode};
+
+/// Build the machine code for a Rue-to-C export thunk.
+///
+/// `native_symbol` is the mangled symbol of the natively-conventioned body the
+/// thunk forwards to; `param_types` are the export's scalar parameter types in
+/// source (argument-register) order. The returned [`MachineCode`] carries one
+/// call/branch relocation targeting `native_symbol` and no string data.
+pub fn generate_export_thunk(
+    target: Target,
+    native_symbol: &str,
+    param_types: &[Type],
+) -> MachineCode {
+    match target.arch() {
+        Arch::X86_64 => generate_x86_64(native_symbol, param_types),
+        Arch::Aarch64 => generate_aarch64(native_symbol, param_types),
+    }
+}
+
+/// The classifier flavor for a target's architecture. Both directions of the C
+/// boundary consult the same authority (`TargetCCallAbi`), so the export thunk
+/// and the import call agree on every scalar extension.
+fn flavor_for(target: Target) -> TargetCAbiFlavor {
+    match target.arch() {
+        Arch::X86_64 => TargetCAbiFlavor::SysVAmd64,
+        Arch::Aarch64 => TargetCAbiFlavor::Aapcs64,
+    }
+}
+
+/// The extension each argument register needs, in register order. Shared by both
+/// backends and by the import side.
+fn arg_extensions(target: Target, param_types: &[Type]) -> Vec<ScalarAbiExtension> {
+    let abi = TargetCCallAbi::new(flavor_for(target));
+    param_types
+        .iter()
+        .map(|ty| abi.scalar_arg_extension(*ty))
+        .collect()
+}
+
+// ============================================================================
+// x86-64 / SysV AMD64
+// ============================================================================
+
+/// SysV integer argument registers, in order, as `(modrm_code, needs_rex_ext)`.
+/// `rdi, rsi, rdx, rcx, r8, r9`.
+const X86_ARG_REGS: [(u8, bool); 6] = [
+    (7, false), // rdi
+    (6, false), // rsi
+    (2, false), // rdx
+    (1, false), // rcx
+    (0, true),  // r8
+    (1, true),  // r9
+];
+
+fn generate_x86_64(native_symbol: &str, param_types: &[Type]) -> MachineCode {
+    let extensions = arg_extensions(Target::X86_64Linux, param_types);
+    let mut code = Vec::new();
+
+    // Re-extend each narrow argument register in place before forwarding.
+    for (index, ext) in extensions.iter().enumerate() {
+        let (reg, ext_bit) = X86_ARG_REGS[index];
+        x86_extend_reg(&mut code, reg, ext_bit, *ext);
+    }
+
+    // Framed forward to the native body. On entry `rsp % 16 == 8` (the C caller's
+    // `call` pushed the return address); subtract 8 so the `call` below leaves
+    // the native body's entry 16-byte aligned, then restore and return. The
+    // native scalar/pointer return already sits in `rax` in the canonical form a
+    // C caller accepts, so no epilogue fix-up is needed.
+    code.extend_from_slice(&[0x48, 0x83, 0xEC, 0x08]); // sub rsp, 8
+    code.push(0xE8); // call rel32
+    let reloc_offset = code.len() as u64;
+    code.extend_from_slice(&[0, 0, 0, 0]); // rel32 placeholder
+    let relocations = vec![EmittedRelocation::x86_call(reloc_offset, native_symbol)];
+    code.extend_from_slice(&[0x48, 0x83, 0xC4, 0x08]); // add rsp, 8
+    code.push(0xC3); // ret
+
+    MachineCode {
+        code,
+        relocations,
+        strings: Vec::new(),
+    }
+}
+
+/// Emit an in-place canonical extension of the register `(code, ext_bit)`.
+fn x86_extend_reg(code: &mut Vec<u8>, reg: u8, ext_bit: bool, ext: ScalarAbiExtension) {
+    // (opcode bytes, REX.W set?) for a reg←reg extension.
+    let (opcode, rex_w): (&[u8], bool) = match ext {
+        ScalarAbiExtension::None => return,
+        ScalarAbiExtension::Signed { from_bits: 8 } => (&[0x0F, 0xBE], true), // movsx r64, r8
+        ScalarAbiExtension::Signed { from_bits: 16 } => (&[0x0F, 0xBF], true), // movsx r64, r16
+        ScalarAbiExtension::Signed { from_bits: 32 } => (&[0x63], true),      // movsxd r64, r32
+        ScalarAbiExtension::Unsigned { from_bits: 8 } => (&[0x0F, 0xB6], true), // movzx r64, r8
+        ScalarAbiExtension::Unsigned { from_bits: 16 } => (&[0x0F, 0xB7], true), // movzx r64, r16
+        ScalarAbiExtension::Unsigned { from_bits: 32 } => (&[0x8B], false), // mov r32, r32 (zero-extends)
+        other => panic!("unexpected scalar extension for a target-C export argument: {other:?}"),
+    };
+    // REX: W from the operation, R and B both track the single register's
+    // extension bit (destination is the ModRM reg field, source the rm field,
+    // and both name the same physical register).
+    let mut rex = 0x40;
+    if rex_w {
+        rex |= 0x08;
+    }
+    if ext_bit {
+        rex |= 0x04 | 0x01;
+    }
+    if rex_w || ext_bit {
+        code.push(rex);
+    }
+    code.extend_from_slice(opcode);
+    code.push(0xC0 | (reg << 3) | reg); // ModRM: reg←reg
+}
+
+// ============================================================================
+// AArch64 / AAPCS64
+// ============================================================================
+
+fn generate_aarch64(native_symbol: &str, param_types: &[Type]) -> MachineCode {
+    let extensions = arg_extensions(Target::Aarch64Linux, param_types);
+    let mut words: Vec<u32> = Vec::new();
+
+    for (index, ext) in extensions.iter().enumerate() {
+        let reg = index as u32; // x0..x7 in order
+        if let Some(word) = aarch64_extend_reg(reg, *ext) {
+            words.push(word);
+        }
+    }
+
+    // Framed forward to the native body: save FP/LR (keeping the 16-byte stack
+    // alignment), branch-with-link to the native body, restore, and return. The
+    // native scalar/pointer return already sits in `x0` canonically.
+    words.push(0xA9BF_7BFD); // stp x29, x30, [sp, #-16]!
+    words.push(0x9100_03FD); // mov x29, sp
+    let bl_offset = (words.len() * 4) as u64;
+    words.push(0x9400_0000); // bl <native>  (imm26 filled by relocation)
+    words.push(0xA8C1_7BFD); // ldp x29, x30, [sp], #16
+    words.push(0xD65F_03C0); // ret
+
+    let mut code = Vec::with_capacity(words.len() * 4);
+    for word in words {
+        code.extend_from_slice(&word.to_le_bytes());
+    }
+    let relocations = vec![EmittedRelocation::aarch64_call(bl_offset, native_symbol)];
+
+    MachineCode {
+        code,
+        relocations,
+        strings: Vec::new(),
+    }
+}
+
+/// The 32-bit instruction that canonically extends `x{reg}`/`w{reg}` in place,
+/// or `None` when the value already fills its register.
+fn aarch64_extend_reg(reg: u32, ext: ScalarAbiExtension) -> Option<u32> {
+    let rd_rn = |base: u32| base | (reg << 5) | reg;
+    Some(match ext {
+        ScalarAbiExtension::None => return None,
+        ScalarAbiExtension::Signed { from_bits: 8 } => rd_rn(0x9340_1C00), // sxtb x, w
+        ScalarAbiExtension::Signed { from_bits: 16 } => rd_rn(0x9340_3C00), // sxth x, w
+        ScalarAbiExtension::Signed { from_bits: 32 } => rd_rn(0x9340_7C00), // sxtw x, w
+        ScalarAbiExtension::Unsigned { from_bits: 8 } => rd_rn(0x5300_1C00), // uxtb w, w
+        ScalarAbiExtension::Unsigned { from_bits: 16 } => rd_rn(0x5300_3C00), // uxth w, w
+        // uxtw: mov w, w (ORR Wd, WZR, Wm) zero-extends into the 64-bit register.
+        ScalarAbiExtension::Unsigned { from_bits: 32 } => 0x2A00_03E0 | (reg << 16) | reg,
+        other => panic!("unexpected scalar extension for a target-C export argument: {other:?}"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RelocationKind;
+
+    #[test]
+    fn x86_scalar_passthrough_forwards_with_plt32_call() {
+        // A u64 + i64 signature (both register-width) needs no extension: just
+        // the framed call. Pointers classify identically (`None`).
+        let code = generate_export_thunk(
+            Target::X86_64Linux,
+            "__rue_sem_native",
+            &[Type::U64, Type::I64],
+        );
+        assert_eq!(code.relocations.len(), 1);
+        assert_eq!(code.relocations[0].kind, RelocationKind::X86Plt32);
+        assert_eq!(code.relocations[0].symbol, "__rue_sem_native");
+        // sub rsp,8 / call rel32 / add rsp,8 / ret with a 4-byte displacement.
+        assert_eq!(&code.code[..4], &[0x48, 0x83, 0xEC, 0x08]);
+        assert_eq!(code.code[4], 0xE8);
+        assert_eq!(
+            &code.code[code.code.len() - 5..],
+            &[0x48, 0x83, 0xC4, 0x08, 0xC3]
+        );
+    }
+
+    #[test]
+    fn x86_narrow_args_are_extended_in_place() {
+        // i32 (arg0=rdi) sign-extends via movsxd; bool (arg1=rsi) zero-extends
+        // from its byte via movzx.
+        let code = generate_export_thunk(Target::X86_64Linux, "native", &[Type::I32, Type::BOOL]);
+        // movsxd rdi, edi = 48 63 FF ; movzx rsi, sil = 48 0F B6 F6
+        assert_eq!(&code.code[..3], &[0x48, 0x63, 0xFF]);
+        assert_eq!(&code.code[3..7], &[0x48, 0x0F, 0xB6, 0xF6]);
+    }
+
+    #[test]
+    fn aarch64_scalar_passthrough_forwards_with_call26() {
+        let code = generate_export_thunk(Target::Aarch64Linux, "native", &[Type::I64, Type::U64]);
+        assert_eq!(code.relocations.len(), 1);
+        assert_eq!(code.relocations[0].kind, RelocationKind::Aarch64Call26);
+        assert_eq!(code.relocations[0].symbol, "native");
+        // No extension instructions, so the whole body is the 5-word frame.
+        assert_eq!(code.code.len(), 5 * 4);
+        assert_eq!(&code.code[..4], &0xA9BF_7BFDu32.to_le_bytes());
+        assert_eq!(
+            &code.code[code.code.len() - 4..],
+            &0xD65F_03C0u32.to_le_bytes()
+        );
+    }
+
+    #[test]
+    fn aarch64_narrow_args_are_extended_in_place() {
+        // i16 (x0) -> sxth x0,w0 ; u8 (x1) -> uxtb w1,w1
+        let code = generate_export_thunk(Target::Aarch64Linux, "native", &[Type::I16, Type::U8]);
+        assert_eq!(&code.code[..4], &(0x9340_3C00u32).to_le_bytes()); // sxth x0, w0
+        assert_eq!(&code.code[4..8], &(0x5300_1C21u32).to_le_bytes()); // uxtb w1, w1
+    }
+}

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -44,6 +44,7 @@ macro_rules! end_inst {
 mod allocation;
 pub mod call_plan;
 mod codegen_pipeline;
+pub mod export_thunk;
 pub mod foreign_call;
 pub mod runtime_call_plan;
 mod schedule_core;

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -18,6 +18,23 @@ pub(crate) fn collect_foreign_symbols(rir: &rue_rir::Rir, interner: &ThreadedRod
         .collect()
 }
 
+/// Collect the unmangled C symbol names of every `pub extern "C" fn` export in
+/// the lowered program (ADR-0064 P4). Each is the raw name under which a C-ABI
+/// entry thunk exposes the exported Rue function to separately compiled C
+/// callers; the name is the export's source identifier (no mangling).
+pub(crate) fn collect_export_symbols(rir: &rue_rir::Rir, interner: &ThreadedRodeo) -> Vec<String> {
+    rir.iter()
+        .filter_map(|(_, inst)| match &inst.data {
+            rue_rir::InstData::FnDecl {
+                is_c_export: true,
+                name,
+                ..
+            } => Some(interner.resolve(name).to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
 /// Project live callable legacy names to their machine symbols, plus an
 /// identity mapping for every `extern "C"` foreign declaration.
 ///
@@ -62,6 +79,9 @@ pub(crate) fn compile_backend(
     // undefined symbol a call site references by its raw (unmangled) name and
     // that the linker resolves from a supplied static archive.
     foreign_symbols: &[String],
+    // Unmangled C names of `pub extern "C" fn` exports (ADR-0064 P4). Each gets
+    // an additional C-ABI entry thunk object exposing that name globally.
+    export_symbols: &[String],
 ) -> MultiErrorResult<CompileOutput> {
     // Check for main function
     let _main_fn = functions
@@ -97,7 +117,7 @@ pub(crate) fn compile_backend(
     }
 
     // Generate object files based on target architecture
-    let object_files = match options.target.arch() {
+    let mut object_files = match options.target.arch() {
         Arch::X86_64 => generate_x86_64_objects(
             functions,
             type_pool,
@@ -115,6 +135,15 @@ pub(crate) fn compile_backend(
             foreign_symbols,
         )?,
     };
+
+    // Emit a C-ABI entry thunk object for every `pub extern "C" fn` export
+    // (ADR-0064 P4). The native body was already generated above under its
+    // mangled symbol; the thunk adds the unmangled global C entry point.
+    object_files.extend(generate_export_thunk_objects(
+        functions,
+        options,
+        export_symbols,
+    ));
 
     // Link to executable
     match &options.linker {
@@ -279,6 +308,80 @@ fn generate_aarch64_objects(
         .collect();
 
     collect_codegen_results(results, functions.len())
+}
+
+/// Emit the C-ABI entry thunk objects for every `pub extern "C" fn` export
+/// (ADR-0064 P4).
+///
+/// Each exported function was already code-generated as an ordinary native body
+/// under its mangled `machine_name`; this adds one extra object per export whose
+/// single global symbol is the unmangled C name (`legacy_name`, the source
+/// identifier) and whose body receives arguments per the target-C convention,
+/// re-extends narrow scalars, and forwards to the native body. The signature was
+/// gated to register-resident scalars/pointers in semantic analysis
+/// (`ExportSignatureUnsupported`), so the entry block's parameters are exactly
+/// the argument-register scalars the thunk marshals.
+fn generate_export_thunk_objects(
+    functions: &[FunctionWithCfg],
+    options: &CompileOptions,
+    export_symbols: &[String],
+) -> Vec<Vec<u8>> {
+    if export_symbols.is_empty() {
+        return Vec::new();
+    }
+    let export_set: std::collections::BTreeSet<&str> =
+        export_symbols.iter().map(String::as_str).collect();
+    let mut objects = Vec::new();
+    for function in functions {
+        if !export_set.contains(function.legacy_name.as_str()) {
+            continue;
+        }
+        let cfg = &function.cfg;
+        // A scalar parameter is materialized as a `Param { index }` instruction
+        // carrying its type; parameter `index` arrives in the matching argument
+        // register. Default every slot to a register-width scalar (no extension)
+        // so an *unused* parameter — which the body never reads and therefore
+        // needs no re-extension — is harmless. Semantic analysis restricted the
+        // signature to register-resident scalars, so `num_params` slots map 1:1
+        // to argument registers.
+        let mut param_types: Vec<rue_air::Type> =
+            vec![rue_air::Type::I64; cfg.num_params() as usize];
+        for block in cfg.blocks() {
+            for &value in &block.insts {
+                let inst = cfg.get_inst(value);
+                if let rue_cfg::CfgInstData::Param { index } = inst.data {
+                    if let Some(slot) = param_types.get_mut(index as usize) {
+                        *slot = inst.ty;
+                    }
+                }
+            }
+        }
+        let machine_code = rue_codegen::export_thunk::generate_export_thunk(
+            options.target,
+            &function.machine_name,
+            &param_types,
+        );
+        let mut obj_builder = ObjectBuilder::new(options.target, &function.legacy_name)
+            .code(machine_code.code)
+            .strings(machine_code.strings);
+        for reloc in machine_code.relocations {
+            let rel_type = match reloc.kind {
+                RelocationKind::X86Plt32 => RelocationType::Plt32,
+                RelocationKind::Aarch64Call26 => RelocationType::Call26,
+                other => {
+                    unreachable!("export thunk emitted unexpected relocation kind {other:?}")
+                }
+            };
+            obj_builder = obj_builder.relocation(CodeRelocation {
+                offset: reloc.offset,
+                symbol: reloc.symbol,
+                rel_type,
+                addend: reloc.addend,
+            });
+        }
+        objects.push(obj_builder.build());
+    }
+    objects
 }
 
 /// Collect codegen results, propagating errors and logging stats.
@@ -904,6 +1007,7 @@ drop fn StrBuf(self) { }
             semantic.strings(),
             interner,
             &options,
+            &[],
             &[],
             &[],
         )

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -862,6 +862,8 @@ pub(crate) fn compile_with_session(
     let session_work = session.work();
     let foreign_symbols =
         crate::backend::collect_foreign_symbols(rir.rir(), rir.semantic_symbols().interner());
+    let export_symbols =
+        crate::backend::collect_export_symbols(rir.rir(), rir.semantic_symbols().interner());
     let mut output = crate::backend::compile_backend(
         semantic.functions(),
         semantic.type_pool(),
@@ -870,6 +872,7 @@ pub(crate) fn compile_with_session(
         options,
         semantic.warnings(),
         &foreign_symbols,
+        &export_symbols,
     )?;
     output.source_stats = SourceStats {
         files: snapshot.len(),

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -384,6 +384,7 @@ impl ErrorCode {
     pub const EXTERN_ARRAY_BY_VALUE: Self = Self(1103);
     pub const REPR_C_STRUCT_INELIGIBLE: Self = Self(1104);
     pub const EXTERN_VARIADIC_UNSUPPORTED: Self = Self(1105);
+    pub const EXPORT_SIGNATURE_UNSUPPORTED: Self = Self(1106);
 
     // ========================================================================
     // Comptime errors (E1200-E1299)
@@ -1650,6 +1651,21 @@ pub enum ErrorKind {
     )]
     ExternVariadicUnsupported,
 
+    /// A `pub extern "C" fn` Rue-to-C export (ADR-0064 P4) has a signature the
+    /// export-thunk lowering cannot bridge yet. The P4 export thunk marshals
+    /// only integer/pointer scalars that fit the target's argument-register
+    /// budget: an aggregate parameter or return, or a scalar parameter list
+    /// wider than the register budget, is rejected here rather than silently
+    /// mis-marshaled, and an export whose C name collides with the program
+    /// entry point (`main`) is rejected to keep the entry symbol unambiguous.
+    #[error("`pub extern \"C\" fn` export `{name}` is not supported: {reason} (ADR-0064 P4)")]
+    ExportSignatureUnsupported {
+        /// The export's C symbol name.
+        name: String,
+        /// Why the export cannot be lowered, phrased for the user.
+        reason: String,
+    },
+
     /// A `@repr(c)` struct failed the reject-don't-guess eligibility check
     /// (ADR-0064 Amendment 1): an empty struct, an enum/aggregate field without
     /// its own `@repr(c)` marker, or a linear / destructor-bearing field. The
@@ -1900,6 +1916,7 @@ impl ErrorKind {
             ErrorKind::ExternAggregateNotReprC { .. } => ErrorCode::EXTERN_AGGREGATE_NOT_REPR_C,
             ErrorKind::ExternArrayByValue { .. } => ErrorCode::EXTERN_ARRAY_BY_VALUE,
             ErrorKind::ExternVariadicUnsupported => ErrorCode::EXTERN_VARIADIC_UNSUPPORTED,
+            ErrorKind::ExportSignatureUnsupported { .. } => ErrorCode::EXPORT_SIGNATURE_UNSUPPORTED,
             ErrorKind::ReprCStructIneligible(_) => ErrorCode::REPR_C_STRUCT_INELIGIBLE,
             ErrorKind::SliceNotYetImplemented => ErrorCode::SLICE_NOT_YET_IMPLEMENTED,
             ErrorKind::SliceReturnNotAllowed => ErrorCode::SLICE_RETURN_NOT_ALLOWED,

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -271,6 +271,12 @@ pub struct Function {
     pub return_type: Option<TypeExpr>,
     /// Function body
     pub body: Expr,
+    /// The C ABI string when this function is a `pub extern "C" fn` export
+    /// (ADR-0064 P4): `Some("C")` for an export exposed to C callers under its
+    /// unmangled name, `None` for an ordinary Rue function. The slot reserves
+    /// room for later ABI variants without a re-spelling, exactly as the import
+    /// `extern` block does.
+    pub export_abi: Option<String>,
     /// Span covering the entire function
     pub span: Span,
 }
@@ -1877,6 +1883,9 @@ fn fmt_call_arg(f: &mut fmt::Formatter<'_>, arg: &CallArg, level: usize) -> fmt:
 
 fn fmt_function(f: &mut fmt::Formatter<'_>, func: &Function, level: usize) -> fmt::Result {
     indent(f, level)?;
+    if let Some(abi) = &func.export_abi {
+        write!(f, "pub extern \"{abi}\" ")?;
+    }
     if func.is_unchecked {
         write!(f, "unchecked ")?;
     }

--- a/crates/rue-parser/src/parser/declarations.rs
+++ b/crates/rue-parser/src/parser/declarations.rs
@@ -45,6 +45,14 @@ impl Parser {
             TokenKind::Drop if directives.is_empty() && visibility == Visibility::Private => {
                 self.drop_fn(start).map(Item::DropFn)
             }
+            // `pub extern "C" fn name(...) { body }` is a Rue-to-C *export*
+            // (ADR-0064 P4): an ordinary Rue function body also exposed to C
+            // callers under its unmangled name. It is distinguished from the
+            // private import block below purely by its `pub` visibility and its
+            // trailing `fn` (the block form has no `fn` after the ABI string).
+            TokenKind::Extern if directives.is_empty() && visibility == Visibility::Public => self
+                .extern_export_fn(start, directives, visibility)
+                .map(Item::Function),
             TokenKind::Extern if directives.is_empty() && visibility == Visibility::Private => {
                 self.extern_block(start).map(Item::Extern)
             }
@@ -64,6 +72,51 @@ impl Parser {
         directives: Directives,
         visibility: Visibility,
     ) -> PResult<Function> {
+        self.function_inner(start, directives, visibility, None)
+    }
+
+    /// Parse a `pub extern "C" fn name(...) { body }` Rue-to-C export
+    /// (ADR-0064 P4). The `extern` token is consumed here, then the ABI string
+    /// is captured verbatim and validated (`"C"` only) exactly as the import
+    /// block does, and the rest is an ordinary function with a body. The parsed
+    /// ABI is attached to the `Function` so semantic analysis can gate it behind
+    /// the `c_ffi` preview and validate the C-boundary signature.
+    fn extern_export_fn(
+        &mut self,
+        start: u32,
+        directives: Directives,
+        visibility: Visibility,
+    ) -> PResult<Function> {
+        self.expect(TokenKind::Extern)?;
+        let (abi, abi_span) = match self.kind() {
+            TokenKind::String(spur) => {
+                let span = self.bump().span;
+                (self.interner.resolve(&spur).to_string(), span)
+            }
+            _ => {
+                self.unexpected("an ABI string such as \"C\"");
+                return Err(());
+            }
+        };
+        if abi != "C" {
+            self.error_at(
+                format!(
+                    "unsupported extern ABI \"{abi}\": only \"C\" is supported \
+                     (ADR-0064 C FFI)"
+                ),
+                abi_span,
+            );
+        }
+        self.function_inner(start, directives, visibility, Some(abi))
+    }
+
+    fn function_inner(
+        &mut self,
+        start: u32,
+        directives: Directives,
+        visibility: Visibility,
+        export_abi: Option<String>,
+    ) -> PResult<Function> {
         let is_unchecked = self.eat(TokenKind::Unchecked);
         self.expect(TokenKind::Fn)?;
         let name = self.ident()?;
@@ -82,6 +135,7 @@ impl Parser {
             params,
             return_type,
             body,
+            export_abi,
             span: self.span_from(start),
         })
     }

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -574,6 +574,8 @@ impl<'a> AstGen<'a> {
                 false,
                 false,
                 false,
+                // Methods are never C exports.
+                false,
                 name,
                 &params,
                 return_type,
@@ -680,6 +682,8 @@ impl<'a> AstGen<'a> {
                 func.visibility == Visibility::Public,
                 func.is_unchecked,
                 false,
+                // `pub extern "C" fn` marks a Rue-to-C export (ADR-0064 P4).
+                func.export_abi.is_some(),
                 name,
                 &params,
                 return_type,
@@ -741,6 +745,8 @@ impl<'a> AstGen<'a> {
                 false,
                 false,
                 true,
+                // A foreign import is not an export.
+                false,
                 name,
                 &params,
                 return_type,

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -1194,6 +1194,7 @@ impl RirEditor {
         is_pub: bool,
         is_unchecked: bool,
         is_extern: bool,
+        is_c_export: bool,
         name: Spur,
         params: &[RirParam],
         return_type: Spur,
@@ -1212,6 +1213,7 @@ impl RirEditor {
                     is_pub,
                     is_unchecked,
                     is_extern,
+                    is_c_export,
                     name,
                     params,
                     return_type,
@@ -1655,6 +1657,7 @@ impl RirEditor {
                         is_pub,
                         is_unchecked,
                         is_extern,
+                        is_c_export,
                         name,
                         params,
                         return_type,
@@ -1680,6 +1683,7 @@ impl RirEditor {
                             *is_pub,
                             *is_unchecked,
                             *is_extern,
+                            *is_c_export,
                             symbol(*name),
                             &params,
                             symbol(*return_type),
@@ -4186,6 +4190,13 @@ pub enum InstData {
         /// `body` is a synthesized placeholder that is never analyzed or
         /// code-generated.
         is_extern: bool,
+        /// Whether this is a Rue-to-C export (`pub extern "C" fn`, ADR-0064 P4):
+        /// an ordinary Rue function body that is *also* exposed to C callers
+        /// under its unmangled source name via a C-ABI callee thunk. Unlike
+        /// `is_extern`, an export keeps a real body, is analyzed, gets a CFG,
+        /// and is code-generated; the flag only marks that a C entry thunk must
+        /// be emitted and that the signature is validated for the C boundary.
+        is_c_export: bool,
         name: Spur,
         /// Index into extra data where params start
         params: RirParamsRange,
@@ -4939,6 +4950,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     is_pub,
                     is_unchecked,
                     is_extern,
+                    is_c_export,
                     name,
                     params,
                     return_type,
@@ -4947,7 +4959,13 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     self_mode,
                     self_is_mut,
                 } => {
-                    let pub_str = if *is_pub { "pub " } else { "" };
+                    let pub_str = if *is_c_export {
+                        "pub extern \"C\" "
+                    } else if *is_pub {
+                        "pub "
+                    } else {
+                        ""
+                    };
                     let unchecked_str = if *is_unchecked {
                         "unchecked "
                     } else if *is_extern {
@@ -5602,6 +5620,7 @@ mod typed_payload_tests {
             .add_fn_decl(
                 &directives,
                 true,
+                false,
                 false,
                 false,
                 a,
@@ -6340,6 +6359,7 @@ mod typed_payload_tests {
                 is_pub: false,
                 is_unchecked: false,
                 is_extern: false,
+                is_c_export: false,
                 name: a,
                 params,
                 return_type: a,

--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -161,7 +161,33 @@ pub struct TraceabilityReport {
 /// you to remove it (see [`TraceabilityReport::stale_known_uncovered`]). This
 /// mirrors the `known_bug` xfail convention: an exemption that starts passing
 /// must be retired so it converts back into an enforced check.
-pub const KNOWN_UNCOVERED_NORMATIVE: &[(&str, &str)] = &[];
+pub const KNOWN_UNCOVERED_NORMATIVE: &[(&str, &str)] = &[
+    // ADR-0064 P4 (RUE-1058) foreign-boundary rules. These are normative but not
+    // coverable by the standalone spec corpus: the abort proof needs a C caller
+    // linked to a Rue export (a harness only the preview-gated `c_ffi` CLI suite
+    // provides), and the other two describe undefined / programmer-responsibility
+    // behavior that is not positively testable.
+    (
+        "9.3:2",
+        "Abort-at-boundary for a trapping `pub extern \"C\" fn` export: verified by \
+         execution in the preview-gated c_ffi CLI suite \
+         (crates/rue-cli-tests, `*_trapping_export_aborts_at_boundary`), which links \
+         a C caller to a Rue export — a setup the standalone spec corpus cannot build.",
+    ),
+    (
+        "9.3:3",
+        "Reverse-direction undefined behavior (a foreign exception or `longjmp` \
+         crossing a Rue frame): undefined behavior is not positively testable; it is \
+         documented as the mirror of the abort-at-boundary rule (9.3:2).",
+    ),
+    (
+        "9.3:4",
+        "Ownership/linear-move across the C boundary: a by-value linear or \
+         destructor-bearing crossing is a hard error (not FFI-safe), so the \
+         move-without-destructor rule governs `@raw`/`@raw_mut` pointer escapes under \
+         ADR-0028 programmer responsibility, which is not positively testable.",
+    ),
+];
 
 impl TraceabilityReport {
     /// Whether `id` is on the [`KNOWN_UNCOVERED_NORMATIVE`] allowlist.

--- a/docs/spec/src/09-unchecked-code/03-foreign-boundary.md
+++ b/docs/spec/src/09-unchecked-code/03-foreign-boundary.md
@@ -1,0 +1,63 @@
++++
+title = "Foreign-Boundary Semantics"
+weight = 3
+template = "spec/page.html"
++++
+
+# Foreign-Boundary Semantics
+
+This section defines the dynamic semantics of the target-C foreign boundary
+introduced by ADR-0064 (the `c_ffi` preview feature): calling a C function from
+Rue (`extern "C"` imports) and exposing a Rue function to C callers
+(`pub extern "C" fn` exports). It complements the calling-convention and
+FFI-safety rules of ADR-0064 with the trap, unwinding, and ownership contract at
+the boundary, carried from the RUE-740 conformance requirements.
+
+{{ rule(id="9.3:1", cat="informative") }}
+
+A foreign call and a foreign export cross between Rue's convention and the
+platform C ABI. Both directions are permitted only in unchecked context (a
+foreign *call* requires a `checked` block, § 9.1); an *export* body is ordinary
+Rue code. The rules below govern what happens when control, a trap, or ownership
+crosses this boundary.
+
+## Abort at the boundary
+
+{{ rule(id="9.3:2", cat="dynamic-semantics") }}
+
+When execution under a C caller — the body of a `pub extern "C" fn` export, or any
+Rue call frame reached transitively from such an export — would trap (arithmetic
+overflow § 8.1, a failed bounds check § 8.2, division by zero § 8.3, an explicit
+`@panic`, or any other abort-class failure), the implementation terminates the
+process deterministically at the boundary using the runtime's trap status. No C
+call frame is unwound: the trap does not return into, and is not observable by,
+the C code that is on the stack. Rue has no unwinding mechanism, so this
+abort-at-boundary behavior is the only defined outcome; the `"C-unwind"` ABI
+string is reserved for a future richer policy and is rejected in this version.
+
+## Reverse-direction undefined behavior
+
+{{ rule(id="9.3:3", cat="undefined-behavior") }}
+
+It is undefined behavior for a foreign transfer of control that crosses a Rue
+call frame — a C++ or Objective-C exception, or a `longjmp` whose matching
+`setjmp` is on the far side of one or more Rue frames — to propagate through Rue
+code. Rue defines no mechanism to intercept, unwind, or resume such a transfer,
+and a compiled Rue frame preserves no state that would make one well-defined.
+This is the mirror of the abort-at-boundary rule (§ 9.3:2): just as a Rue trap
+never unwinds a C frame, a foreign non-local exit must never unwind a Rue frame.
+
+## Ownership at the boundary
+
+{{ rule(id="9.3:4", cat="normative") }}
+
+Passing a value to a foreign function is a move: its storage is handed to the
+foreign side and the Rue destructor does not run for it. A linear or
+destructor-bearing value may not cross the boundary *by value* — it is not
+FFI-safe (ADR-0064 Amendment 1) and is rejected — so ownership of such a value
+crosses only as a `@raw` / `@raw_mut` raw pointer that escapes into C under the
+programmer-responsibility rules of § 9 (ADR-0028). Across the boundary the
+compiler enforces no lifetime, exclusivity, aliasing, or destructor guarantee on
+a pointer handed to or received from C; honoring the foreign side's ownership and
+lifetime contract is the programmer's responsibility, exactly as for the raw
+pointer and heap intrinsics of § 9.2.


### PR DESCRIPTION
Fixes RUE-1058

ADR-0064 phase P4: the export direction of the C-ABI surface — a Rue function callable from C.

- **Export surface.** `pub extern "C" fn name(...) { body }` is recognized by the parser (public extern-with-body, distinct from the private extern import block), its signature validated in sema. Unsupported export signatures (aggregate/enum by-value params, over-budget arity) diagnose as **E1106**; `"C-unwind"` is rejected as an unsupported ABI.
- **The thunk** (`codegen/export_thunk.rs`): a C-convention prologue that unpacks the C-ABI argument locations into the native convention, calls the natively-conventioned Rue body, and marshals the return into the C-ABI return location — reusing the `TargetCCallAbi` authority (P2/P3) *in reverse*, no forked ABI logic. The exported symbol is **unmangled and global** (the native body stays internal), compatible with the RUE-178 mangling decision; a reserved or `main` export name is rejected.
- **Abort-at-boundary (ratified).** A trap while executing under a C caller terminates the process deterministically — no unwind through C frames.
- **Three foreign-boundary rules carried from RUE-740** are now normative spec text (`docs/spec/.../09-unchecked-code/03-foreign-boundary.md`) with traceability:
  - abort-at-boundary (§9.3:2);
  - reverse-direction UB — a foreign exception or `longjmp` crossing a Rue frame is undefined behavior, the mirror of the abort rule (§9.3:3, `undefined-behavior`);
  - ownership — passing a value to a foreign function is a move, the Rue destructor does not run, and a linear or destructor-bearing value may not cross by value.
- **Proof by execution**: a C caller (archive member) invokes two Rue exports through their thunks and computes an order-sensitive result (`806` on x86-64); a trapping export aborts cleanly at the boundary. Both targets; native execution on x86-64.

Verification: worker diff re-integrated cleanly on current trunk (1f3b448) after a container restart — build clean, c_ffi corpus 38/38 with native execution of the C-calls-Rue and trapping-abort cases, unmangled-symbol emission confirmed via the C-linkage proof (an unreferenced export is GC'd from a final executable, which is why it resolves only through a real C caller), E1100 preview gate / E1106 signature / C-unwind rejections hand-checked. Full `./test.sh` alone on the host: exit 0, zero failures in both formats.

Traceability note: the abort and export proofs live in the `c_ffi` CLI harness (which links a real C caller to a Rue export) — a setup the standalone spec corpus cannot build — so the new §9.3 rules are anchored there rather than in the spec-test corpus.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_