### PR TITLE
RUE-1026: bind const candidates to query shells

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -138,6 +138,48 @@ fn const_classification_has_one_tagged_authority_and_no_retired_maps() {
 }
 
 #[test]
+fn const_resolution_uses_only_shell_bound_candidate_locators() {
+    let declaration_index = include_str!("sema/declaration_index.rs")
+        .split("#[cfg(test)]")
+        .next()
+        .unwrap();
+    let resolver = include_str!("sema/declarations.rs");
+    let shell_boundary = include_str!("sema/binding_manifest.rs");
+
+    for retired_index_authority in [
+        ["const_", "candidates: Vec<InstRef>"].concat(),
+        ["const_candidates_by_", "file_name: HashMap"].concat(),
+        ["fn all_const_", "candidates("].concat(),
+    ] {
+        assert!(
+            !declaration_index.contains(&retired_index_authority),
+            "RIR declaration index regained const lookup authority: {retired_index_authority}"
+        );
+    }
+    for retired_resolver_read in [
+        ["declaration_index.", "const_candidates("].concat(),
+        ["declaration_index.", "all_const_candidates("].concat(),
+    ] {
+        assert!(
+            !resolver.contains(&retired_resolver_read),
+            "const resolver bypassed the shell-bound candidate set: {retired_resolver_read}"
+        );
+    }
+    assert_eq!(
+        shell_boundary
+            .matches("self.sema.bound_const_candidates =")
+            .count(),
+        1,
+        "declaration resolution must install the exact shell-bound const set once"
+    );
+    assert_eq!(
+        resolver.matches(".bound_const_candidates").count(),
+        4,
+        "all const occurrence traversal and point lookup must use the bound set"
+    );
+}
+
+#[test]
 fn canonical_type_surface_has_one_checked_handle_and_private_storage_ids() {
     let types = include_str!("types.rs");
     let pool = include_str!("intern_pool.rs");

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -404,10 +404,11 @@ impl<'a> DeclarationShells<'a> {
     pub fn resolve_declarations_with_work(
         mut self,
     ) -> Result<BoundSema<'a>, DeclarationResolutionFailure> {
-        // This is the explicit payload-install boundary. The ordinary adapter
-        // deliberately resolves from the authoritative current-revision RIR in
-        // historical order. A future importer may validate durable payloads
-        // against these shells before choosing an installation path.
+        // This is the explicit payload-install boundary. Const resolution may
+        // inspect only the exact occurrence set admitted by these shells. In a
+        // canonical epoch that set came from keyed compiler queries; the RIR
+        // supplies current-epoch locators and initializer payloads, not an
+        // independent declaration-discovery authority.
         debug_assert!(
             self.pending_payloads
                 .iter()
@@ -427,6 +428,14 @@ impl<'a> DeclarationShells<'a> {
                 .iter()
                 .all(|pending| pending.declaration.as_u32() < self.sema.rir.len() as u32)
         );
+        self.sema.bound_const_candidates =
+            Some(super::declaration_index::BoundConstCandidateIndex::new(
+                self.sema.rir,
+                self.pending_payloads.iter().filter_map(|pending| {
+                    matches!(pending.source, DeclarationPayloadSource::Const { .. })
+                        .then_some((pending.shell.source_order, pending.declaration))
+                }),
+            ));
         self.binding_work.declaration_resolution_invocations += 1;
         if let Err(error) = self.sema.resolve_declarations() {
             self.binding_work.declaration_resolution_failures += 1;

--- a/crates/rue-air/src/sema/declaration_index.rs
+++ b/crates/rue-air/src/sema/declaration_index.rs
@@ -78,10 +78,65 @@ pub(super) struct RirDeclarationIndex {
     /// receiverless `FnDecl` counts, including associated functions.
     non_receiver_name_multiplicity: HashMap<Spur, usize>,
     destructors: Vec<RirDestructorDeclaration>,
-    const_candidates: Vec<InstRef>,
-    const_candidates_by_file_name: HashMap<(FileId, Spur), Vec<InstRef>>,
     shell_declarations: Vec<RirShellDeclaration>,
     work: RirDeclarationIndexWork,
+}
+
+/// Exact current-epoch locators for the const occurrence set admitted at the
+/// declaration-shell boundary.
+///
+/// Canonical compiler epochs build this index from query-owned shells after
+/// they have been joined to the current RIR arena. Synthetic component tests
+/// use shells discovered from that synthetic arena. The declaration resolver
+/// never falls back to the independent RIR declaration index.
+#[derive(Debug)]
+pub(super) struct BoundConstCandidateIndex {
+    candidates: Vec<InstRef>,
+    candidate_set: HashSet<InstRef>,
+    candidates_by_file_name: HashMap<(FileId, Spur), Vec<InstRef>>,
+}
+
+impl BoundConstCandidateIndex {
+    pub(super) fn new(rir: &Rir, candidates: impl IntoIterator<Item = (u32, InstRef)>) -> Self {
+        let mut candidates = candidates.into_iter().collect::<Vec<_>>();
+        candidates.sort_by_key(|(source_order, declaration)| (*source_order, declaration.as_u32()));
+        let mut candidates_by_file_name = HashMap::<(FileId, Spur), Vec<InstRef>>::new();
+        let candidates: Vec<InstRef> = candidates
+            .into_iter()
+            .map(|(_, declaration)| {
+                let inst = rir.get(declaration);
+                let InstData::ConstDecl { name, .. } = inst.data else {
+                    unreachable!("bound const candidate must locate a ConstDecl")
+                };
+                candidates_by_file_name
+                    .entry((inst.span.file_id, name))
+                    .or_default()
+                    .push(declaration);
+                declaration
+            })
+            .collect();
+        let candidate_set = candidates.iter().copied().collect();
+        Self {
+            candidates,
+            candidate_set,
+            candidates_by_file_name,
+        }
+    }
+
+    pub(super) fn candidates(&self, file_id: FileId, name: Spur) -> &[InstRef] {
+        self.candidates_by_file_name
+            .get(&(file_id, name))
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    pub(super) fn all_candidates(&self) -> &[InstRef] {
+        &self.candidates
+    }
+
+    pub(super) fn contains(&self, declaration: InstRef) -> bool {
+        self.candidate_set.contains(&declaration)
+    }
 }
 
 impl RirDeclarationIndex {
@@ -93,8 +148,7 @@ impl RirDeclarationIndex {
         let mut declaration_source_orders = HashMap::new();
         let mut non_receiver_name_multiplicity = HashMap::<Spur, usize>::new();
         let mut destructors = Vec::new();
-        let mut const_candidates = Vec::new();
-        let mut const_candidates_by_file_name = HashMap::<(FileId, Spur), Vec<InstRef>>::new();
+        let mut const_shell_declarations = Vec::new();
         let mut work = RirDeclarationIndexWork {
             build_invocations: 1,
             ..RirDeclarationIndexWork::default()
@@ -145,13 +199,12 @@ impl RirDeclarationIndex {
                         span: inst.span,
                     });
                 }
-                InstData::ConstDecl { name, .. } => {
-                    declaration_source_orders.insert(inst_ref, source_order as u32);
-                    const_candidates.push(inst_ref);
-                    const_candidates_by_file_name
-                        .entry((inst.span.file_id, *name))
-                        .or_default()
-                        .push(inst_ref);
+                InstData::ConstDecl { .. } => {
+                    const_shell_declarations.push(RirShellDeclaration {
+                        declaration: inst_ref,
+                        source_order: source_order as u32,
+                        named_method_owner: None,
+                    });
                 }
                 InstData::EnumDecl { .. } => {
                     nominal_candidates.push((source_order as u32, inst_ref));
@@ -204,20 +257,14 @@ impl RirDeclarationIndex {
             source_order: declaration_source_orders[&candidate.declaration],
             named_method_owner: None,
         }));
-        shell_declarations.extend(const_candidates.iter().map(|&declaration| {
-            RirShellDeclaration {
-                declaration,
-                source_order: declaration_source_orders[&declaration],
-                named_method_owner: None,
-            }
-        }));
+        work.const_candidates_indexed = const_shell_declarations.len();
+        shell_declarations.extend(const_shell_declarations);
         shell_declarations.sort_by_key(|candidate| candidate.source_order);
 
         work.free_functions_indexed = free_functions.len();
         work.named_methods_indexed = named_methods.len();
         work.anonymous_methods_indexed = anonymous_methods.len();
         work.destructors_indexed = destructors.len();
-        work.const_candidates_indexed = const_candidates.len();
 
         Self {
             free_functions,
@@ -229,8 +276,6 @@ impl RirDeclarationIndex {
             anonymous_method_refs,
             non_receiver_name_multiplicity,
             destructors,
-            const_candidates,
-            const_candidates_by_file_name,
             shell_declarations,
             work,
         }
@@ -245,17 +290,6 @@ impl RirDeclarationIndex {
             self.anonymous_methods.len()
         );
         debug_assert_eq!(self.work.destructors_indexed, self.destructors.len());
-        debug_assert_eq!(
-            self.work.const_candidates_indexed,
-            self.const_candidates.len()
-        );
-        debug_assert_eq!(
-            self.const_candidates_by_file_name
-                .values()
-                .map(Vec::len)
-                .sum::<usize>(),
-            self.const_candidates.len()
-        );
         self.work
     }
 
@@ -335,17 +369,6 @@ impl RirDeclarationIndex {
     pub(super) fn destructors(&self) -> &[RirDestructorDeclaration] {
         &self.destructors
     }
-
-    pub(super) fn const_candidates(&self, file_id: FileId, name: Spur) -> &[InstRef] {
-        self.const_candidates_by_file_name
-            .get(&(file_id, name))
-            .map(Vec::as_slice)
-            .unwrap_or_default()
-    }
-
-    pub(super) fn all_const_candidates(&self) -> &[InstRef] {
-        &self.const_candidates
-    }
 }
 
 #[cfg(test)]
@@ -396,6 +419,19 @@ mod tests {
                 .all(|pair| pair[0].as_u32() < pair[1].as_u32()),
             "declarations are not in RIR order: {refs:?}"
         );
+    }
+
+    fn bound_const_candidates(rir: &Rir, index: &RirDeclarationIndex) -> BoundConstCandidateIndex {
+        BoundConstCandidateIndex::new(
+            rir,
+            index.shell_declarations().iter().filter_map(|candidate| {
+                matches!(
+                    rir.get(candidate.declaration).data,
+                    InstData::ConstDecl { .. }
+                )
+                .then_some((candidate.source_order, candidate.declaration))
+            }),
+        )
     }
 
     #[test]
@@ -464,8 +500,9 @@ mod tests {
         ));
 
         let alias = interner.get("alias").unwrap();
-        assert_eq!(index.const_candidates(FileId::new(7), alias).len(), 1);
-        assert_eq!(index.all_const_candidates().len(), 1);
+        let bound_consts = bound_const_candidates(&rir, &index);
+        assert_eq!(bound_consts.candidates(FileId::new(7), alias).len(), 1);
+        assert_eq!(bound_consts.all_candidates().len(), 1);
 
         let expected_work = RirDeclarationIndexWork {
             build_invocations: 1,
@@ -523,15 +560,46 @@ mod tests {
             second_candidates.first().copied()
         );
         assert_eq!(index.non_receiver_name_multiplicity(same), 3);
-        assert_eq!(index.const_candidates(second, same).len(), 1);
+        let bound_consts = bound_const_candidates(&rir, &index);
+        assert_eq!(bound_consts.candidates(second, same).len(), 1);
 
         let rebuilt = RirDeclarationIndex::new(&rir);
+        let rebuilt_bound_consts = bound_const_candidates(&rir, &rebuilt);
         assert_eq!(rebuilt.work(), index.work());
         assert_eq!(rebuilt.free_functions(), index.free_functions());
         assert_eq!(
-            rebuilt.const_candidates(second, same),
-            index.const_candidates(second, same)
+            rebuilt_bound_consts.candidates(second, same),
+            bound_consts.candidates(second, same)
         );
+    }
+
+    #[test]
+    fn bound_const_index_admits_only_the_supplied_occurrence_set() {
+        let file = FileId::new(12);
+        let (rir, interner) = lower_files(&[(
+            "const first = 1; const second = 2; fn main() -> i32 { first }",
+            file,
+        )]);
+        let index = RirDeclarationIndex::new(&rir);
+        let const_locators = index
+            .shell_declarations()
+            .iter()
+            .filter(|candidate| {
+                matches!(
+                    rir.get(candidate.declaration).data,
+                    InstData::ConstDecl { .. }
+                )
+            })
+            .map(|candidate| (candidate.source_order, candidate.declaration))
+            .collect::<Vec<_>>();
+        assert_eq!(const_locators.len(), 2);
+
+        let bound = BoundConstCandidateIndex::new(&rir, [const_locators[0]]);
+        let first = interner.get("first").unwrap();
+        let second = interner.get("second").unwrap();
+        assert_eq!(bound.all_candidates(), [const_locators[0].1]);
+        assert_eq!(bound.candidates(file, first), [const_locators[0].1]);
+        assert!(bound.candidates(file, second).is_empty());
     }
 
     #[test]

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1134,7 +1134,16 @@ impl<'a> Sema<'a> {
                     // May already be collected: another constant's
                     // initializer can pull declarations in early (the
                     // collector is dependency-ordered, RUE-171).
-                    self.collect_const_by_key((inst.span.file_id, *name))?;
+                    if self
+                        .bound_const_candidates
+                        .as_ref()
+                        .expect(
+                            "const candidate authority must be installed before declaration resolution",
+                        )
+                        .contains(inst_ref)
+                    {
+                        self.collect_const_by_key((inst.span.file_id, *name))?;
+                    }
                 }
 
                 _ => {}
@@ -1995,8 +2004,10 @@ impl<'a> Sema<'a> {
 
     fn indexed_const(&self, key: (FileId, Spur)) -> Option<PendingConst> {
         let declaration = *self
-            .declaration_index
-            .const_candidates(key.0, key.1)
+            .bound_const_candidates
+            .as_ref()
+            .expect("const candidate authority must be installed before declaration resolution")
+            .candidates(key.0, key.1)
             .first()?;
         let inst = self.rir.get(declaration);
         let InstData::ConstDecl {
@@ -2015,7 +2026,12 @@ impl<'a> Sema<'a> {
 
     fn validate_indexed_const_declarations(&self) -> CompileResult<()> {
         let mut seen = HashSet::new();
-        for &declaration in self.declaration_index.all_const_candidates() {
+        for &declaration in self
+            .bound_const_candidates
+            .as_ref()
+            .expect("const candidate authority must be installed before declaration resolution")
+            .all_candidates()
+        {
             let inst = self.rir.get(declaration);
             let InstData::ConstDecl { name, .. } = inst.data else {
                 unreachable!("constant declaration index contains only ConstDecl instructions")
@@ -2042,8 +2058,10 @@ impl<'a> Sema<'a> {
     ) -> CompileResult<()> {
         let same_file_key = (referencing_file, name);
         if !self
-            .declaration_index
-            .const_candidates(referencing_file, name)
+            .bound_const_candidates
+            .as_ref()
+            .expect("const candidate authority must be installed before declaration resolution")
+            .candidates(referencing_file, name)
             .is_empty()
         {
             self.collect_const_by_key(same_file_key)?;

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -257,6 +257,10 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
     pub(crate) interner: &'a ThreadedRodeo,
     /// Request-local declaration candidates for this exact RIR arena.
     declaration_index: declaration_index::RirDeclarationIndex,
+    /// Const locators admitted by the declaration-shell boundary. Canonical
+    /// epochs populate this only from query-owned shells; it is installed
+    /// immediately before declaration resolution begins.
+    bound_const_candidates: Option<declaration_index::BoundConstCandidateIndex>,
     /// Raw RIR declaration discovery is confined to synthetic component-test
     /// epochs. Canonical compiler epochs must import query-owned shells.
     synthetic_declaration_discovery: bool,
@@ -461,6 +465,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             rir,
             interner,
             declaration_index,
+            bound_const_candidates,
             synthetic_declaration_discovery,
             anonymous_methods,
             named_callable_methods_by_symbol,
@@ -532,6 +537,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             rir,
             interner,
             declaration_index,
+            bound_const_candidates,
             synthetic_declaration_discovery,
             anonymous_methods,
             named_callable_methods_by_symbol,
@@ -976,6 +982,22 @@ impl<'a> Sema<'a> {
                 .expect("Rue cannot choose a default sema target on this unsupported host"),
         );
         sema.synthetic_declaration_discovery = true;
+        let synthetic_const_candidates = sema
+            .declaration_index
+            .shell_declarations()
+            .iter()
+            .filter_map(|candidate| {
+                matches!(
+                    sema.rir.get(candidate.declaration).data,
+                    rue_rir::InstData::ConstDecl { .. }
+                )
+                .then_some((candidate.source_order, candidate.declaration))
+            })
+            .collect::<Vec<_>>();
+        sema.bound_const_candidates = Some(declaration_index::BoundConstCandidateIndex::new(
+            sema.rir,
+            synthetic_const_candidates,
+        ));
         sema
     }
 
@@ -999,6 +1021,7 @@ impl<'a> Sema<'a> {
             rir,
             interner,
             declaration_index: declaration_index::RirDeclarationIndex::new(rir),
+            bound_const_candidates: None,
             synthetic_declaration_discovery: false,
             anonymous_methods: HashMap::new(),
             named_callable_methods_by_symbol: HashMap::new(),


### PR DESCRIPTION
## Summary

- admit constant candidates only through exact, query-owned declaration shells joined to current RIR locators
- replace peer RIR const-candidate maps and vectors with one private bound candidate index consumed by declaration resolution
- add omitted-candidate and source-retirement gates so the broad producer cannot return

## Testing

- `scripts/rue quick` (34/34; frontend differential corpus passed)
- `/opt/homebrew/bin/bash ./clippy.sh` (61 targets)
- `git diff --check upstream/trunk...HEAD`

Refs RUE-1026