### PR TITLE
RUE-1066 (PR A): make StrBuf layout-independent in the compiler

### DIFF
--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -207,6 +207,12 @@ impl<'a> BodySema<'a> {
             .expect("print builtin must map to a runtime helper");
         let call_name = self.interner.get_or_intern(runtime_helper.symbol);
 
+        // A StrBuf source reads its `{ptr, len}` prefix through the trusted
+        // accessors and passes them as separate scalars (the `*Projected`
+        // helpers), so print never depends on StrBuf's field layout
+        // (RUE-1066). Since `source_strbuf` already covers every StrBuf value,
+        // the remaining case is a `str`/`Str(N)` view, forwarded by value to
+        // the `*Aggregate` helpers.
         let extra_data = if source_strbuf {
             let (ptr, len, temp_scope) =
                 self.project_strbuf_text_fields(air, arg_result.air_ref, arg_result.ty, span, ctx)?;
@@ -221,21 +227,6 @@ impl<'a> BodySema<'a> {
                 },
             ];
             (args, temp_scope)
-        } else if self.is_strbuf(arg_result.ty) {
-            let (arg, temp_scope) = self.materialize_borrow_argument(
-                air,
-                arg_result.air_ref,
-                arg_result.ty,
-                span,
-                ctx,
-            )?;
-            (
-                vec![AirCallArg {
-                    value: arg,
-                    mode: AirArgMode::Normal,
-                }],
-                temp_scope,
-            )
         } else {
             (
                 vec![AirCallArg {

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -761,8 +761,12 @@ impl<'a> BodySema<'a> {
         let source_strbuf = arg_type.as_struct().is_some_and(|struct_id| {
             self.type_pool.struct_lang_item(struct_id) == Some(crate::LangItem::StrBuf)
         });
+        // A StrBuf argument is passed as a layout-stable `{ptr, len}` str view
+        // rather than the buffer header, so `@dbg`'s `DebugStr` text lowering
+        // never depends on StrBuf's field layout (RUE-1066). A `str`/`Str(N)`
+        // argument already has that shape and is forwarded by value.
         let (arg_ref, temp_scope) = if source_strbuf {
-            self.materialize_borrow_argument(air, arg_result.air_ref, arg_type, span, ctx)?
+            self.strbuf_text_view(air, arg_result.air_ref, arg_type, span, ctx)?
         } else {
             (arg_result.air_ref, Vec::new())
         };
@@ -926,8 +930,11 @@ impl<'a> BodySema<'a> {
         let source_strbuf = arg_result.ty.as_struct().is_some_and(|struct_id| {
             self.type_pool.struct_lang_item(struct_id) == Some(crate::LangItem::StrBuf)
         });
+        // Narrow a StrBuf message to a layout-stable `{ptr, len}` str view so
+        // the `Panic` text lowering reads a `str`, not the StrBuf header
+        // (RUE-1066). `str`/`Str(N)` messages already have that shape.
         let (arg_ref, temp_scope) = if source_strbuf {
-            self.materialize_borrow_argument(air, arg_result.air_ref, arg_result.ty, span, ctx)?
+            self.strbuf_text_view(air, arg_result.air_ref, arg_result.ty, span, ctx)?
         } else {
             (arg_result.air_ref, Vec::new())
         };

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -424,6 +424,36 @@ impl<'a> BodySema<'a> {
         Ok((ptr_ref, len_ref, prefix))
     }
 
+    /// Build a by-value, layout-stable `str` view `{ptr, len}` from a StrBuf
+    /// source.
+    ///
+    /// The `{ptr, len}` prefix is read through the trusted `as_ptr()`/`len()`
+    /// accessors (see [`Self::project_strbuf_text_fields`]), then packed into
+    /// the synthetic `str` struct — whose 2-word `{ptr, len}` layout is fixed
+    /// (ADR-0043 Phase 3). Routing `@dbg`/`@panic`/`borrow str` coercion
+    /// through this view means no consumer ever depends on StrBuf's own field
+    /// layout (RUE-1066): the runtime text helpers see a `str`, and StrBuf's
+    /// header can be reordered freely.
+    ///
+    /// The returned prefix must wrap the view (or a value derived from it) via
+    /// [`Self::wrap_value_with_temp_scope`] so any materialized owner stays
+    /// live across the borrow — the view is a second-class borrow into the
+    /// StrBuf's buffer and must not outlive it.
+    pub(crate) fn strbuf_text_view(
+        &mut self,
+        air: &mut Air,
+        value: AirRef,
+        ty: Type,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<(AirRef, Vec<AirRef>)> {
+        let (ptr, len, prefix) = self.project_strbuf_text_fields(air, value, ty, span, ctx)?;
+        let str_ty = self.get_or_create_str_struct(span)?;
+        let str_struct_id = str_ty.as_struct().expect("str is a synthetic struct");
+        let view = air.add_struct_init(str_struct_id, &[ptr, len], &[0, 1], str_ty, span)?;
+        Ok((view, prefix))
+    }
+
     /// Peel the synthetic scope produced by [`Self::emit_projected_rvalue_read`].
     ///
     /// A projected read from a computed owner must keep that owner alive when
@@ -4415,30 +4445,22 @@ impl<'a> BodySema<'a> {
             }));
         }
 
-        // `StrBuf` source: the view is the `{ptr, len}` prefix of the 3-word
-        // buffer header, read field-by-field from the borrowed place.
+        // `StrBuf` source: narrow the buffer header to the `{ptr, len}` view.
+        // The prefix is read through the trusted `as_ptr()`/`len()` accessors
+        // rather than by projecting fields 0/1, so this coercion is independent
+        // of StrBuf's internal layout (RUE-1066). Reading the whole StrBuf as a
+        // `PlaceRead` keeps it addressable, so the accessor calls borrow it in
+        // place without moving it.
         if self.is_strbuf(src_ty) {
-            let buf_struct_id = src_ty.as_struct().expect("StrBuf lang item is a struct");
-            let str_struct_id = str_ty.as_struct().expect("str is a synthetic struct");
-            let mut field_words = Vec::with_capacity(2);
-            for field_index in 0..2u32 {
-                let mut projs: Vec<AirProjection> =
-                    trace.projections.iter().map(|p| p.proj).collect();
-                projs.push(AirProjection::Field {
-                    struct_id: buf_struct_id,
-                    field_index,
-                });
-                let place_ref = air.make_place(trace.base, trace.base_type, projs)?;
-                let field_ty =
-                    self.type_pool.struct_def(buf_struct_id).fields[field_index as usize].ty;
-                let word = air.add_inst(AirInst {
-                    data: AirInstData::PlaceRead { place: place_ref },
-                    ty: field_ty,
-                    span,
-                });
-                field_words.push(word);
-            }
-            return Ok(air.add_struct_init(str_struct_id, &field_words, &[0, 1], str_ty, span)?);
+            let projs: Vec<AirProjection> = trace.projections.iter().map(|p| p.proj).collect();
+            let place_ref = air.make_place(trace.base, trace.base_type, projs)?;
+            let strbuf_read = air.add_inst(AirInst {
+                data: AirInstData::PlaceRead { place: place_ref },
+                ty: src_ty,
+                span,
+            });
+            let (view, prefix) = self.strbuf_text_view(air, strbuf_read, src_ty, span, ctx)?;
+            return self.wrap_value_with_temp_scope(air, view, str_ty, span, prefix);
         }
 
         Err(self.type_mismatch_error(str_ty, src_ty, span))

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -363,51 +363,65 @@ impl<'a> BodySema<'a> {
         ctx: &mut AnalysisContext,
     ) -> CompileResult<(AirRef, AirRef, Vec<AirRef>)> {
         let struct_id = ty.as_struct().expect("StrBuf is a struct");
-        let (value, mut prefix) = self.peel_projected_rvalue_scope(air, value);
-        let (base, base_type, projections) = match air.get(value).data {
-            AirInstData::Load { slot } => (AirPlaceBase::Local(slot), ty, Vec::new()),
-            AirInstData::Param { index } => (AirPlaceBase::Param(index), ty, Vec::new()),
-            AirInstData::PlaceRead { place } => {
-                let place = air.get_place(place);
-                (
-                    place.base,
-                    place.base_type,
-                    air.get_place_projections(place).to_vec(),
-                )
-            }
-            _ => {
-                let slot = ctx.next_slot;
-                ctx.next_slot += self.require_layout_slots(ty, span)?;
-                let live = air.add_inst(AirInst {
-                    data: AirInstData::StorageLive { slot },
-                    ty,
-                    span,
-                });
-                let alloc = air.add_inst(AirInst {
-                    data: AirInstData::Alloc { slot, init: value },
-                    ty: Type::UNIT,
-                    span,
-                });
-                prefix.extend([live, alloc]);
-                (AirPlaceBase::Local(slot), ty, Vec::new())
-            }
-        };
-        let fields = self.type_pool.struct_def(struct_id).fields;
-        let mut reads = Vec::with_capacity(2);
-        for field_index in 0..2u32 {
-            let mut field_projections = projections.clone();
-            field_projections.push(AirProjection::Field {
-                struct_id,
-                field_index,
-            });
-            let place = air.make_place(base, base_type, field_projections)?;
-            reads.push(air.add_inst(AirInst {
-                data: AirInstData::PlaceRead { place },
-                ty: fields[field_index as usize].ty,
+        // Read the `{ptr, len}` prefix through the trusted source accessors
+        // (`as_ptr()`, `len()`) rather than by projecting fields 0 and 1, so the
+        // compiler never depends on StrBuf's internal field layout (RUE-1066).
+        // Both accessors are `borrow self`, so one materialized borrow of the
+        // owner backs both calls.
+        let ptr_method = self.interner.get_or_intern("as_ptr");
+        let len_method = self.interner.get_or_intern("len");
+        let Some(ptr_ty) = self
+            .method_info((struct_id, ptr_method))
+            .map(|m| m.return_type)
+        else {
+            return Err(CompileError::new(
+                ErrorKind::InternalError(
+                    "trusted std StrBuf is missing its source `as_ptr` method".to_string(),
+                ),
                 span,
-            }));
-        }
-        Ok((reads[0], reads[1], prefix))
+            ));
+        };
+        let Some(len_ty) = self
+            .method_info((struct_id, len_method))
+            .map(|m| m.return_type)
+        else {
+            return Err(CompileError::new(
+                ErrorKind::InternalError(
+                    "trusted std StrBuf is missing its source `len` method".to_string(),
+                ),
+                span,
+            ));
+        };
+        ctx.referenced_methods.insert((struct_id, ptr_method));
+        ctx.referenced_methods.insert((struct_id, len_method));
+        let (receiver, prefix) = self.materialize_borrow_argument(air, value, ty, span, ctx)?;
+        let ptr_call_name = self
+            .interner
+            .get_or_intern(&self.method_symbol(struct_id, "as_ptr", true));
+        let len_call_name = self
+            .interner
+            .get_or_intern(&self.method_symbol(struct_id, "len", true));
+        let ptr_ref = air.add_call(
+            None,
+            ptr_call_name,
+            &[AirCallArg {
+                value: receiver,
+                mode: AirArgMode::Borrow,
+            }],
+            ptr_ty,
+            span,
+        )?;
+        let len_ref = air.add_call(
+            None,
+            len_call_name,
+            &[AirCallArg {
+                value: receiver,
+                mode: AirArgMode::Borrow,
+            }],
+            len_ty,
+            span,
+        )?;
+        Ok((ptr_ref, len_ref, prefix))
     }
 
     /// Peel the synthetic scope produced by [`Self::emit_projected_rvalue_read`].

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -579,9 +579,6 @@ pub struct ValuePlan {
     pub comparison: Option<ComparisonPreparation>,
     pub storage: StoragePolicy,
     pub aggregate_primary: AggregatePrimary,
-    /// StrBuf has a fixed three-slot ownership representation even though it
-    /// is otherwise handled through the ordinary aggregate slot machinery.
-    pub is_strbuf: bool,
 }
 
 impl ValuePlan {
@@ -615,7 +612,6 @@ impl ValuePlan {
             } else {
                 AggregatePrimary::FirstSlot
             },
-            is_strbuf: ctx.is_strbuf(ty),
         };
 
         plan.storage = match &inst.data {
@@ -2752,7 +2748,6 @@ mod tests {
                 comparison: None,
                 storage: super::StoragePolicy::None,
                 aggregate_primary: super::AggregatePrimary::FirstSlot,
-                is_strbuf: false,
             },
             2,
         );
@@ -2950,7 +2945,6 @@ mod tests {
         strbuf_cfg.set_return(strbuf_entry, Some(strbuf_value));
         let strbuf_ctx = crate::cfg_lower::CfgLowerContext::new(&strbuf_cfg, &strbuf_pool);
         let strbuf_plan = ValuePlan::for_value(&strbuf_ctx, dummy_value());
-        assert!(strbuf_plan.is_strbuf);
         assert_eq!(strbuf_plan.shape.slot_count(), 3);
         assert!(strbuf_plan.shape.requires_complete_slots());
     }

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -664,6 +664,9 @@ pub struct StrBuf {
     fn concat_borrowed(borrow first: Self, borrow second: Self) -> Self {
         Self { buf: first.buf, len: first.len + second.len, cap: 0 }
     }
+
+    fn len(borrow self) -> u64 { self.len }
+    fn as_ptr(borrow self) -> ptr mut u8 { self.buf }
 }
 
 drop fn StrBuf(self) { }

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -1000,6 +1000,7 @@ pub struct StrBuf {
     }
 
     fn len(borrow self) -> u64 { self.len }
+    fn as_ptr(borrow self) -> ptr mut u8 { self.buf }
 }
 
 drop fn StrBuf(self) { }

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -86,7 +86,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.aggregate_slots",
         "dbg_string_from_field",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -768,7 +768,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.string_phase1",
         "to_string_demo",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -322,37 +322,37 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "types.strings",
         "to_string_i32_default_literal",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "types.strings",
         "to_string_i64_extremes",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "types.strings",
         "to_string_negative_and_zero",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "types.strings",
         "to_string_positive",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "types.strings",
         "to_string_signed_widths",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
         "types.strings",
         "to_string_unsigned_widths_high_bit",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(

--- a/std/strbuf.rue
+++ b/std/strbuf.rue
@@ -114,6 +114,13 @@ pub struct StrBuf {
     fn capacity(borrow self) -> u64 { self.cap }
     fn is_empty(borrow self) -> bool { self.len == 0 }
 
+    // The address of the packed byte buffer, for the trusted text lowering
+    // (`@dbg`/`@panic`/`print`/str-view coercion). Returning the pointer through
+    // a source accessor is what lets the compiler read a StrBuf's `{ptr, len}`
+    // without projecting its fields by layout (RUE-1066) — so StrBuf's internal
+    // representation stays a private implementation detail of this source type.
+    fn as_ptr(borrow self) -> ptr mut u8 { self.buf }
+
     fn initial_capacity(required: u64) -> u64 {
         if required < 16 { 16 } else { required }
     }


### PR DESCRIPTION
## Summary

First of the three PRs that unify `StrBuf` onto the shared `RawBuf(u8)` growable-buffer core (RUE-1066, follow-up to the ArrayBuf work in #1864 / #1866). This PR contains **no layout change and no behavior change** — it removes every place where the compiler reads `StrBuf`'s fields by position, so PR B can freely reorder the header.

After this, the compiler never projects a `StrBuf`'s fields: all `{ptr, len}` extraction goes through the trusted source accessors (`as_ptr()` / `len()`), and the runtime text helpers only ever see a layout-stable 2-word `str` view.

## What changed

- **`print` / `println` / char-index** (already on this branch): read the `{ptr, len}` prefix through `as_ptr()` + `len()` and pass them as separate scalars to the `*Projected` runtime helpers, instead of projecting fields 0/1.
- **`@dbg` / `@panic`**: build a layout-stable `{ptr, len}` `str` view from those same accessors (new `strbuf_text_view` helper) and route it through the existing `str` text path, rather than handing the whole `StrBuf` header to `DebugStr` / `Panic` (which extract the prefix from aggregate slots 0/1).
- **`borrow str` coercion** (`coerce_borrow_str_place_to_view`): narrows a `StrBuf` source to the `str` view through the same helper instead of reading fields 0/1 by index.
- **Dead code removed**: the unreachable `is_strbuf` branch in `print` that fed a whole `StrBuf` to `StrPrintAggregate` (`source_strbuf` already covers every `StrBuf`, so the remaining case is only `str` / `Str(N)`), and the never-read `ValuePlan.is_strbuf` flag.

## Tests / ledger

- Inline `StrBuf` test fixtures gain `as_ptr()` / `len()`, required now that the text paths read the prefix through accessors.
- Model-gap ledger: the `@dbg` / `@to_string` cases that no longer expose `StrBuf`'s capacity move from `StringCapacityValue` to `TextProjectionRead` (2 CLI + 6 spec), matching the newly observed gap kind. PR C closes those `TextProjectionRead` entries once StrBuf rides the modeled `RawBuf` path.

## Validation

`scripts/rue quick`, `./clippy.sh`, and the CLI/spec string, print, dbg, panic, `str_type`, abi, aggregate, and byref suites all green; both oracle-diff corpora agree on every modeled case.

Part of RUE-1066 (PR A of A/B/C); the issue stays open for PR B (nest `RawBuf(u8)`) and PR C (oracle coverage + container-scoped retire).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RLsiAQKJ41esde9Ya8Up8V)_