### PR TITLE
RUE-1024: sync diagnostic_recovery benchmark manifest to measured work

### DIFF
--- a/benchmarks/manifest.toml
+++ b/benchmarks/manifest.toml
@@ -45,7 +45,7 @@ scenarios = [
   { name = "widely_depended_definition_edit", modules = [1, 6], semantic_bodies = [6, 0], cfgs = [4, 2], semantic_queries = [1, 0] },
   { name = "import_change", modules = [2, 5], semantic_bodies = [6, 0], cfgs = [4, 2], semantic_queries = [1, 0] },
   { name = "diagnostic_error_edit", modules = [1, 6], semantic_bodies = [5, 0], cfgs = [0, 0], semantic_queries = [1, 0] },
-  { name = "diagnostic_recovery", modules = [2, 5], semantic_bodies = [6, 0], cfgs = [4, 2], semantic_queries = [1, 0] },
+  { name = "diagnostic_recovery", modules = [1, 6], semantic_bodies = [6, 0], cfgs = [4, 2], semantic_queries = [1, 0] },
 ]
 
 [[benchmark]]


### PR DESCRIPTION
## What

Fixes the red **Benchmarks** workflow on `trunk` by updating one stale row in `benchmarks/manifest.toml`:

```diff
-  { name = "diagnostic_recovery", modules = [2, 5], semantic_bodies = [6, 0], cfgs = [4, 2], semantic_queries = [1, 0] },
+  { name = "diagnostic_recovery", modules = [1, 6], semantic_bodies = [6, 0], cfgs = [4, 2], semantic_queries = [1, 0] },
```

## Why

The Benchmarks workflow has failed on every `trunk` push for ~a day at `scripts/validate-benchmark.py`:

```
representative scenario 'diagnostic_recovery' structural work does not match manifest
```

**Root cause:** RUE-1024 ("query demanded module syntax and RIR", `1ef9c08`) changed diagnostic recovery so the failed `ParseModule` terminal is retained — only that module's source leaf is re-parsed on recovery, so `modules_required` drops 2→1 and `modules_reused` rises 5→6. That commit updated the mirror assertion in `crates/rue-compiler-session-bench/src/representative.rs` (`assert_structure`, which asserts `[1, 6, 6, 0, 4, 2, 1, 0]`) but left `benchmarks/manifest.toml` at the old `[2, 5]`.

`validate_scenario_results` compares the compiler's measured `required_vs_reused_work` against the manifest. The Rust assertion runs in the **CI**/**Sanitizer** merge-queue gates (green), but the manifest is only read by **Benchmarks**, which runs on `push` to `trunk` — outside the `merge_group` gate — so the divergence merged cleanly and only turned post-merge trunk red.

Only `diagnostic_recovery` drifted; `import_change` (also `[2, 5]`) was unchanged by RUE-1024 and remains correct.

## Verification

- Cross-checked all 6 scenario rows in `manifest.toml` against the arrays asserted in `representative.rs :: assert_structure` — every row now matches exactly (`diagnostic_recovery` was the only mismatch).
- `python3 scripts/test-benchmark-tools.py` → 114 tests pass (manifest loads and validates).
- The measured `[1, 6, …]` value is already proven by the passing merge-queue tests that assert it on trunk.

## Follow-up (out of scope)

The expected structural work is encoded in two places (`manifest.toml` and `representative.rs`) with nothing gating them together in the merge queue. Worth a separate ticket: a cross-check test, or making manifest validation a required PR/merge-queue check, so this class of drift can't land green again.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWyuGfTpr6cCPbG48evJ2n)_