### PR TITLE
RUE-1026: query exact const syntax

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1548,6 +1548,11 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
             "declaration_shell_cache",
             "warm_declaration_shell",
             "eager_declaration_shell",
+            "legacy_raw_const_syntax",
+            "fallback_raw_const_syntax",
+            "raw_const_syntax_cache",
+            "warm_raw_const_syntax",
+            "eager_raw_const_syntax",
         ] {
             assert!(
                 !source.contains(retired),
@@ -1557,6 +1562,7 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         if !matches!(*name, "parsed_modules" | "revisioned_query_database") {
             for evaluator_only in [
                 ".evaluate_declaration_shell(",
+                ".evaluate_raw_const_syntax(",
                 ".declaration_capabilities()",
                 "project_semantic_shell(",
             ] {
@@ -1566,11 +1572,24 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
                 );
             }
         }
+        if !matches!(
+            *name,
+            "declaration_candidate" | "parsed_modules" | "revisioned_query_database"
+        ) {
+            assert!(
+                !source.contains("RawConstSyntax"),
+                "compiler production module {name} escaped the raw-constant authority allowlist"
+            );
+        }
     }
     assert!(canonical.contains("predeclare_imported_declaration_shells"));
     assert!(!canonical.contains("fn analyze_canonical_program("));
     assert_eq!(runtime.matches(".evaluate_declaration_shell(").count(), 1);
     assert_eq!(parsed.matches("fn evaluate_declaration_shell(").count(), 1);
+    assert_eq!(runtime.matches(".evaluate_raw_const_syntax(").count(), 1);
+    assert_eq!(parsed.matches("fn evaluate_raw_const_syntax(").count(), 1);
+    assert_eq!(runtime.matches("\"compiler.raw-const-syntax\"").count(), 1);
+    assert_eq!(parsed.matches("RawConstSyntax {").count(), 1);
     assert!(!runtime.contains("Vec::remove"));
 
     let occurrence = runtime
@@ -1593,10 +1612,7 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
     let shell_terminal = runtime
         .split("enum DeclarationShellQueryValue")
         .nth(1)
-        .and_then(|tail| {
-            tail.split("pub(crate) enum DeclarationShellBatchFailure")
-                .next()
-        })
+        .and_then(|tail| tail.split("struct RawConstSyntaxQueryKey").next())
         .unwrap();
     for forbidden in [
         "CompileErrors",
@@ -1610,6 +1626,40 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         assert!(
             !shell_terminal.contains(forbidden),
             "shell terminal regained positioned/live semantic payload: {forbidden}"
+        );
+    }
+    let raw_const_terminal = runtime
+        .split("enum RawConstSyntaxQueryValue")
+        .nth(1)
+        .and_then(|tail| {
+            tail.split("pub(crate) enum DeclarationShellBatchFailure")
+                .next()
+        })
+        .unwrap();
+    for forbidden in [
+        "CompileErrors",
+        "Span",
+        "FileId",
+        "Spur",
+        "InstRef",
+        "Rir",
+        "SemanticDefinitionToken",
+        "SemanticModuleToken",
+    ] {
+        assert!(
+            !raw_const_terminal.contains(forbidden),
+            "raw-constant terminal regained positioned/live parser or semantic payload: {forbidden}"
+        );
+    }
+    let raw_const_payload = module("declaration_candidate")
+        .split("pub(crate) struct RawConstSyntax")
+        .nth(1)
+        .and_then(|tail| tail.split("pub(crate) enum RawConstSyntaxFailure").next())
+        .unwrap();
+    for forbidden in ["Span", "FileId", "Spur", "Ast", "Rir", "InstRef"] {
+        assert!(
+            !raw_const_payload.contains(forbidden),
+            "raw-constant payload regained a positioned or live parser handle: {forbidden}"
         );
     }
     let failure_algebra = module("declaration_candidate")

--- a/crates/rue-compiler/src/declaration_candidate.rs
+++ b/crates/rue-compiler/src/declaration_candidate.rs
@@ -82,6 +82,30 @@ pub(crate) enum DeclarationShellFailure {
     ParserCapabilityMismatch(DeclarationCandidateKey),
 }
 
+/// Parser-validated source syntax for one constant, detached from its source
+/// epoch and parser symbol universe.
+///
+/// Each fragment is the exact UTF-8 source spelling of the corresponding
+/// syntax node, excluding the declaration's `:` / `=` / `;` separators. The
+/// fragments contain no positional or interned handles and can therefore be
+/// reparsed by a later standalone constant evaluator without retaining an AST,
+/// RIR, resolver, or file table.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct RawConstSyntax {
+    pub(crate) declared_type: Option<Arc<str>>,
+    pub(crate) initializer: Arc<str>,
+}
+
+/// Stable, position-free failure retained by the exact raw-constant family.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RawConstSyntaxFailure {
+    OccurrencesUnavailable(DeclarationOccurrenceFailure),
+    Absent(DeclarationCandidateKey),
+    Ambiguous(DeclarationCandidateKey),
+    CategoryMismatch(DeclarationCandidateKey),
+    ParserCapabilityMismatch(DeclarationCandidateKey),
+}
+
 impl DeclarationCandidateKey {
     pub(crate) fn stable_identity(&self) -> String {
         // Length-prefix every user-authored component. Query identities must

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -11,6 +11,8 @@ use std::sync::Arc;
 #[cfg(test)]
 use std::cell::Cell;
 use std::collections::BTreeMap;
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[cfg(test)]
 use lasso::Key;
@@ -29,7 +31,7 @@ use crate::{
     declaration_candidate::{
         DeclarationCandidateCategory, DeclarationCandidateKey, DeclarationCandidateOwner,
         DeclarationOccurrenceCapability, DeclarationParameterHeader, DeclarationParameterMode,
-        DeclarationShellFact, DeclarationShellFailure,
+        DeclarationShellFact, DeclarationShellFailure, RawConstSyntax,
     },
 };
 
@@ -152,6 +154,8 @@ pub struct ParsedDefinitionIndex {
     declaration_by_key: BTreeMap<DeclarationCandidateKey, usize>,
     declaration_capabilities: Arc<[DeclarationOccurrenceCapability]>,
     #[cfg(test)]
+    raw_const_syntax_materializations: Arc<AtomicUsize>,
+    #[cfg(test)]
     by_name: BTreeMap<(DefinitionNamespace, Arc<str>), Arc<[ParsedDefinitionOccurrence]>>,
 }
 
@@ -181,6 +185,46 @@ impl ParsedDefinitionIndex {
             ));
         }
         Ok(candidate.fact.clone())
+    }
+
+    /// Select the parser-owned raw syntax for exactly one constant key.
+    ///
+    /// The declaration table is constructed once with the module. This lookup
+    /// must remain an exact `declaration_by_key` lookup so a demand for one
+    /// constant never projects or scans unrelated declarations.
+    fn materialize_raw_const_syntax(
+        &self,
+        key: &DeclarationCandidateKey,
+        source_text: &str,
+    ) -> Option<RawConstSyntax> {
+        let index = self.declaration_by_key.get(key).copied()?;
+        let candidate = self.declarations.get(index)?;
+        if candidate.fact.key != *key {
+            return None;
+        }
+        let spans = candidate.raw_const_syntax_spans?;
+        let fragment = |span: Span| {
+            source_text
+                .get(span.start as usize..span.end as usize)
+                .map(Arc::from)
+        };
+        let syntax = RawConstSyntax {
+            declared_type: match spans.declared_type {
+                Some(span) => Some(fragment(span)?),
+                None => None,
+            },
+            initializer: fragment(spans.initializer)?,
+        };
+        #[cfg(test)]
+        self.raw_const_syntax_materializations
+            .fetch_add(1, Ordering::Relaxed);
+        Some(syntax)
+    }
+
+    #[cfg(test)]
+    fn raw_const_syntax_materialization_count(&self) -> usize {
+        self.raw_const_syntax_materializations
+            .load(Ordering::Relaxed)
     }
 
     pub(crate) fn declaration_locator(
@@ -215,6 +259,16 @@ impl ParsedDefinitionIndex {
 pub(crate) struct ParsedDeclarationCandidate {
     fact: DeclarationShellFact,
     declaration_span: Span,
+    raw_const_syntax_spans: Option<RawConstSyntaxSpans>,
+}
+
+/// Parser-private locators for syntax that is materialized only after an exact
+/// declaration-key lookup. Keeping these current-epoch spans private also
+/// leaves diagnostic projection independent from the durable query terminal.
+#[derive(Debug, Clone, Copy)]
+struct RawConstSyntaxSpans {
+    declared_type: Option<Span>,
+    initializer: Span,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -334,6 +388,19 @@ impl ParsedItemView {
 }
 
 impl ParsedModule {
+    pub(crate) fn evaluate_raw_const_syntax(
+        &self,
+        key: &DeclarationCandidateKey,
+    ) -> Option<RawConstSyntax> {
+        self.definitions
+            .materialize_raw_const_syntax(key, self.source_text())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn raw_const_syntax_materialization_count(&self) -> usize {
+        self.definitions.raw_const_syntax_materialization_count()
+    }
+
     #[cfg(test)]
     pub(crate) fn with_test_foreign_ast_symbol(&self) -> Arc<Self> {
         let mut ast = (*self.ast).clone();
@@ -1081,13 +1148,24 @@ fn bind_payload(
             .iter()
             .cloned()
             .map(|candidate| ParsedDeclarationCandidate {
+                fact: candidate.fact,
                 declaration_span: remap_span(candidate.declaration_span),
-                ..candidate
+                raw_const_syntax_spans: candidate.raw_const_syntax_spans.map(|spans| {
+                    RawConstSyntaxSpans {
+                        declared_type: spans.declared_type.map(remap_span),
+                        initializer: remap_span(spans.initializer),
+                    }
+                }),
             })
             .collect::<Vec<_>>()
             .into(),
         declaration_by_key: payload.definitions.declaration_by_key.clone(),
         declaration_capabilities: payload.definitions.declaration_capabilities.clone(),
+        #[cfg(test)]
+        raw_const_syntax_materializations: payload
+            .definitions
+            .raw_const_syntax_materializations
+            .clone(),
         #[cfg(test)]
         by_name: payload.definitions.by_name.clone(),
     };
@@ -1472,7 +1550,8 @@ fn build_definition_index(
     resolver: &FrozenSymbolResolver,
 ) -> CompileResult<ParsedDefinitionIndex> {
     let mut pending = Vec::new();
-    let mut pending_declarations = Vec::<(DeclarationShellFact, Span)>::new();
+    let mut pending_declarations =
+        Vec::<(DeclarationShellFact, Span, Option<RawConstSyntaxSpans>)>::new();
     let resolve_name = |ident: rue_parser::Ident| -> CompileResult<Arc<str>> {
         let symbol = resolver.symbol(ident.name)?;
         Ok(Arc::from(resolver.resolve(&symbol)?))
@@ -1548,7 +1627,8 @@ fn build_definition_index(
                         is_unchecked,
                         is_extern,
                         declaration_span,
-                        signature_spans: Vec<Span>|
+                        signature_spans: Vec<Span>,
+                        raw_const_syntax_spans: Option<RawConstSyntaxSpans>|
          -> CompileResult<()> {
             let signature_fingerprint = declaration_signature_fingerprint(
                 file_id,
@@ -1576,6 +1656,7 @@ fn build_definition_index(
                     signature_fingerprint,
                 },
                 declaration_span,
+                raw_const_syntax_spans,
             ));
             Ok(())
         };
@@ -1594,6 +1675,7 @@ fn build_definition_index(
                 false,
                 function.span,
                 vec![signature_prefix(function.span, function.body.span())?],
+                None,
             )?,
             Item::Struct(structure) => {
                 let owner_name = resolve_name(structure.name)?;
@@ -1610,6 +1692,7 @@ fn build_definition_index(
                     false,
                     structure.span,
                     signature_fragments_excluding_method_bodies(structure)?,
+                    None,
                 )?;
                 let owner = DeclarationCandidateOwner {
                     category: DeclarationCandidateCategory::Struct,
@@ -1640,6 +1723,7 @@ fn build_definition_index(
                         false,
                         method.span,
                         vec![signature_prefix(method.span, method.body.span())?],
+                        None,
                     )?;
                 }
             }
@@ -1656,21 +1740,35 @@ fn build_definition_index(
                 false,
                 value.span,
                 vec![value.span],
-            )?,
-            Item::Const(value) => push(
-                DeclarationCandidateCategory::ConstCandidate,
-                resolve_name(value.name)?,
                 None,
-                value.visibility == Visibility::Public,
-                Arc::from([]),
-                None,
-                false,
-                false,
-                false,
-                false,
-                value.span,
-                vec![signature_prefix(value.span, value.init.span())?],
             )?,
+            Item::Const(value) => {
+                let declared_type = value.ty.as_ref().map(TypeExpr::span);
+                if let Some(span) = declared_type {
+                    validate_span("constant declared type", span, file_id, source_text)?;
+                }
+                let initializer = value.init.span();
+                validate_span("constant initializer", initializer, file_id, source_text)?;
+                let raw_const_syntax_spans = RawConstSyntaxSpans {
+                    declared_type,
+                    initializer,
+                };
+                push(
+                    DeclarationCandidateCategory::ConstCandidate,
+                    resolve_name(value.name)?,
+                    None,
+                    value.visibility == Visibility::Public,
+                    Arc::from([]),
+                    None,
+                    false,
+                    false,
+                    false,
+                    false,
+                    value.span,
+                    vec![signature_prefix(value.span, value.init.span())?],
+                    Some(raw_const_syntax_spans),
+                )?;
+            }
             Item::DropFn(value) => push(
                 DeclarationCandidateCategory::Destructor,
                 resolve_name(value.type_name)?,
@@ -1687,6 +1785,7 @@ fn build_definition_index(
                 false,
                 value.span,
                 vec![signature_prefix(value.span, value.body.span())?],
+                None,
             )?,
             Item::Extern(block) => {
                 for function in &block.fns {
@@ -1703,6 +1802,7 @@ fn build_definition_index(
                         true,
                         function.span,
                         vec![function.span],
+                        None,
                     )?;
                 }
             }
@@ -1770,7 +1870,7 @@ fn build_definition_index(
     let mut duplicate_counts = BTreeMap::new();
     let declarations = pending_declarations
         .into_iter()
-        .map(|(mut fact, declaration_span)| {
+        .map(|(mut fact, declaration_span, raw_const_syntax_spans)| {
             let duplicate = duplicate_counts
                 .entry((
                     fact.key.category,
@@ -1785,6 +1885,7 @@ fn build_definition_index(
             Ok(ParsedDeclarationCandidate {
                 fact,
                 declaration_span,
+                raw_const_syntax_spans,
             })
         })
         .collect::<CompileResult<Vec<_>>>()?;
@@ -1813,6 +1914,8 @@ fn build_definition_index(
         declarations: declarations.into(),
         declaration_by_key,
         declaration_capabilities: declaration_capabilities.into(),
+        #[cfg(test)]
+        raw_const_syntax_materializations: Arc::new(AtomicUsize::new(0)),
         #[cfg(test)]
         by_name,
     })

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -392,6 +392,10 @@ pub(crate) struct RevisionedQueryDatabase {
     module_indexes: QueryFamily<ModuleQueryKey, ModuleIndexValue>,
     declaration_occurrence_indexes: QueryFamily<ModuleQueryKey, DeclarationOccurrenceIndexValue>,
     declaration_shells: QueryFamily<DeclarationShellQueryKey, DeclarationShellQueryValue>,
+    // This registered input boundary is intentionally not a production
+    // semantic dependency until the keyed constant evaluator consumes it.
+    #[cfg_attr(not(test), allow(dead_code))]
+    raw_const_syntax: QueryFamily<RawConstSyntaxQueryKey, RawConstSyntaxQueryValue>,
     module_rirs: QueryFamily<ModuleQueryKey, ModuleRirValue>,
     resolve_imports: QueryFamily<ResolveImportKey, ResolveImportValue>,
     lookup_names: QueryFamily<LookupNameKey, LookupNameValue>,
@@ -471,6 +475,21 @@ impl QueryKey for DeclarationShellQueryKey {
 enum DeclarationShellQueryValue {
     Available(crate::declaration_candidate::DeclarationShellFact),
     Failure(crate::declaration_candidate::DeclarationShellFailure),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RawConstSyntaxQueryKey(crate::declaration_candidate::DeclarationCandidateKey);
+
+impl QueryKey for RawConstSyntaxQueryKey {
+    fn stable_identity(&self) -> String {
+        self.0.stable_identity()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RawConstSyntaxQueryValue {
+    Available(crate::declaration_candidate::RawConstSyntax),
+    Failure(crate::declaration_candidate::RawConstSyntaxFailure),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1027,6 +1046,143 @@ impl Default for RevisionedQueryDatabase {
                 },
             )
             .expect("the DeclarationShell family has one canonical name");
+        let occurrences_for_raw_const = declaration_occurrence_indexes.clone();
+        let shells_for_raw_const = declaration_shells.clone();
+        let parse_for_raw_const = parse_modules.clone();
+        let raw_const_syntax = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.raw-const-syntax",
+                MODULE_QUERY_MEMO_RETENTION,
+                |left: &RawConstSyntaxQueryValue, right: &RawConstSyntaxQueryValue| left == right,
+                move |context, _, key: &RawConstSyntaxQueryKey| {
+                    use crate::declaration_candidate::{
+                        DeclarationCandidateCategory, DeclarationOccurrenceCapability,
+                        DeclarationShellFailure, RawConstSyntaxFailure,
+                    };
+
+                    let indexed = context.query_registered(
+                        &occurrences_for_raw_const,
+                        ModuleQueryKey(key.0.module.clone()),
+                    )?;
+                    let rue_query::QueryOutcome::Success(indexed) = indexed.outcome() else {
+                        unreachable!("DeclarationOccurrenceIndex publishes typed values")
+                    };
+                    let value = match indexed {
+                        DeclarationOccurrenceIndexValue::Failure(failure) => {
+                            RawConstSyntaxQueryValue::Failure(
+                                RawConstSyntaxFailure::OccurrencesUnavailable(failure.clone()),
+                            )
+                        }
+                        DeclarationOccurrenceIndexValue::Available(index) => {
+                            match index.capabilities.get(&key.0) {
+                                None => RawConstSyntaxQueryValue::Failure(
+                                    RawConstSyntaxFailure::Absent(key.0.clone()),
+                                ),
+                                Some(DeclarationOccurrenceCapability::Ambiguous { .. }) => {
+                                    RawConstSyntaxQueryValue::Failure(
+                                    RawConstSyntaxFailure::Ambiguous(key.0.clone()),
+                                    )
+                                }
+                                Some(DeclarationOccurrenceCapability::Exact {
+                                    duplicate_multiplicity: 0,
+                                    ..
+                                }) => RawConstSyntaxQueryValue::Failure(
+                                    RawConstSyntaxFailure::ParserCapabilityMismatch(key.0.clone()),
+                                ),
+                                Some(DeclarationOccurrenceCapability::Exact { .. }) => {
+                                    let shell = context.query_registered(
+                                        &shells_for_raw_const,
+                                        DeclarationShellQueryKey(key.0.clone()),
+                                    )?;
+                                    let rue_query::QueryOutcome::Success(shell) = shell.outcome()
+                                    else {
+                                        unreachable!("DeclarationShell publishes typed values")
+                                    };
+                                    match shell {
+                                        DeclarationShellQueryValue::Failure(failure) => {
+                                            let failure = match failure {
+                                                DeclarationShellFailure::OccurrencesUnavailable(
+                                                    failure,
+                                                ) => RawConstSyntaxFailure::OccurrencesUnavailable(
+                                                    failure.clone(),
+                                                ),
+                                                DeclarationShellFailure::Absent(key) => {
+                                                    RawConstSyntaxFailure::Absent(key.clone())
+                                                }
+                                                DeclarationShellFailure::Ambiguous(key) => {
+                                                    RawConstSyntaxFailure::Ambiguous(key.clone())
+                                                }
+                                                DeclarationShellFailure::ParserCapabilityMismatch(
+                                                    key,
+                                                ) => RawConstSyntaxFailure::ParserCapabilityMismatch(
+                                                    key.clone(),
+                                                ),
+                                            };
+                                            RawConstSyntaxQueryValue::Failure(failure)
+                                        }
+                                        DeclarationShellQueryValue::Available(fact)
+                                            if fact.key.category
+                                                != DeclarationCandidateCategory::ConstCandidate =>
+                                        {
+                                            RawConstSyntaxQueryValue::Failure(
+                                                RawConstSyntaxFailure::CategoryMismatch(
+                                                    key.0.clone(),
+                                                ),
+                                            )
+                                        }
+                                        DeclarationShellQueryValue::Available(fact)
+                                            if fact.key != key.0 =>
+                                        {
+                                            RawConstSyntaxQueryValue::Failure(
+                                                RawConstSyntaxFailure::ParserCapabilityMismatch(
+                                                    key.0.clone(),
+                                                ),
+                                            )
+                                        }
+                                        DeclarationShellQueryValue::Available(_) => {
+                                            let parsed = context.query_registered(
+                                                &parse_for_raw_const,
+                                                ModuleQueryKey(key.0.module.clone()),
+                                            )?;
+                                            let rue_query::QueryOutcome::Success(parsed) =
+                                                parsed.outcome()
+                                            else {
+                                                unreachable!("ParseModule publishes typed values")
+                                            };
+                                            match &parsed.result {
+                                                Err(_) => RawConstSyntaxQueryValue::Failure(
+                                                    RawConstSyntaxFailure::OccurrencesUnavailable(
+                                                        crate::declaration_candidate::DeclarationOccurrenceFailure::ParseRejected {
+                                                            module: key.0.module.clone(),
+                                                        },
+                                                    ),
+                                                ),
+                                                Ok(module) => module
+                                                    .evaluate_raw_const_syntax(&key.0)
+                                                    .map_or_else(
+                                                        || RawConstSyntaxQueryValue::Failure(
+                                                            RawConstSyntaxFailure::ParserCapabilityMismatch(
+                                                                key.0.clone(),
+                                                            ),
+                                                        ),
+                                                        RawConstSyntaxQueryValue::Available,
+                                                    ),
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    };
+                    let kind = if matches!(value, RawConstSyntaxQueryValue::Available(_)) {
+                        QueryTerminalKind::Success
+                    } else {
+                        QueryTerminalKind::Failure
+                    };
+                    Ok(QueryOutput::success(value).with_terminal_kind(kind))
+                },
+            )
+            .expect("the RawConstSyntax family has one canonical name");
         let index_for_lookup = module_indexes.clone();
         let lookup_names = runtime
             .family_with_evaluator(
@@ -1164,6 +1320,7 @@ impl Default for RevisionedQueryDatabase {
             module_indexes,
             declaration_occurrence_indexes,
             declaration_shells,
+            raw_const_syntax,
             module_rirs,
             resolve_imports,
             lookup_names,
@@ -2189,6 +2346,295 @@ mod tests {
             rue_query::QueryOutcome::Success(DeclarationShellQueryValue::Failure(
                 crate::declaration_candidate::DeclarationShellFailure::Absent(absent)
             )) if absent == &key
+        ));
+    }
+
+    #[test]
+    fn raw_const_syntax_queries_select_exactly_and_reuse_across_unrelated_edits() {
+        let first = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "const selected: ptr const u8 = @import(\"dep.rue\").value; const other = 1; fn main() {}",
+            )],
+            1,
+        );
+        let edited = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "const selected: ptr const u8 = @import(\"dep.rue\").value; const other = 999; fn main() { let x = 2; }",
+            )],
+            1,
+        );
+        let key = crate::declaration_candidate::DeclarationCandidateKey {
+            module: ModuleId::from_logical_path("main.rue").unwrap(),
+            category: crate::declaration_candidate::DeclarationCandidateCategory::ConstCandidate,
+            name: Arc::from("selected"),
+            owner: None,
+            duplicate_discriminator: 0,
+        };
+        let mut database = RevisionedQueryDatabase::default();
+        let first_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&first),
+            &first,
+        );
+        let parsed = database.runtime.request_registered(
+            &database.parse_modules,
+            first_revision,
+            ModuleQueryKey(key.module.clone()),
+            CancellationToken::new(),
+        );
+        let parsed_module = match parsed.terminal().unwrap().outcome() {
+            rue_query::QueryOutcome::Success(value) => value.result.clone().unwrap(),
+            rue_query::QueryOutcome::Failure(_) => unreachable!(),
+        };
+        assert_eq!(
+            parsed_module.raw_const_syntax_materialization_count(),
+            0,
+            "module indexing must retain only private locators"
+        );
+        let selected = database.runtime.request_registered(
+            &database.raw_const_syntax,
+            first_revision,
+            RawConstSyntaxQueryKey(key.clone()),
+            CancellationToken::new(),
+        );
+        assert_eq!(execution(&selected), RequestExecution::Computed);
+        assert_eq!(
+            selected
+                .dependencies()
+                .iter()
+                .map(|dependency| dependency.node.family())
+                .collect::<Vec<_>>(),
+            vec![
+                "compiler.declaration-occurrence-index",
+                "compiler.declaration-shell",
+                "compiler.parse-module",
+            ]
+        );
+        let terminal = selected.terminal().unwrap();
+        let first_stamp = terminal.stamp();
+        assert_eq!(terminal.kind(), QueryTerminalKind::Success);
+        assert!(terminal.diagnostics().is_empty());
+        assert!(matches!(
+            terminal.outcome(),
+            rue_query::QueryOutcome::Success(RawConstSyntaxQueryValue::Available(syntax))
+                if syntax.declared_type.as_deref() == Some("ptr const u8")
+                    && syntax.initializer.as_ref() == "@import(\"dep.rue\").value"
+        ));
+        assert_eq!(
+            parsed_module.raw_const_syntax_materialization_count(),
+            1,
+            "demanding one key must materialize only that constant"
+        );
+
+        let warm = database.runtime.request_registered(
+            &database.raw_const_syntax,
+            first_revision,
+            RawConstSyntaxQueryKey(key.clone()),
+            CancellationToken::new(),
+        );
+        assert_eq!(execution(&warm), RequestExecution::Reused);
+        assert_eq!(parsed_module.raw_const_syntax_materialization_count(), 1);
+
+        let edited_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&edited),
+            &edited,
+        );
+        let revalidated = database.runtime.request_registered(
+            &database.raw_const_syntax,
+            edited_revision,
+            RawConstSyntaxQueryKey(key),
+            CancellationToken::new(),
+        );
+        assert_eq!(
+            revalidated.terminal().unwrap().stamp(),
+            first_stamp,
+            "an unrelated declaration edit must preserve the exact syntax terminal stamp"
+        );
+    }
+
+    #[test]
+    fn raw_const_syntax_duplicate_discriminators_select_distinct_occurrences() {
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "const duplicate = 11; const duplicate = 22;",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+        for (duplicate_discriminator, expected) in [(0, "11"), (1, "22")] {
+            let key = crate::declaration_candidate::DeclarationCandidateKey {
+                module: module.clone(),
+                category:
+                    crate::declaration_candidate::DeclarationCandidateCategory::ConstCandidate,
+                name: Arc::from("duplicate"),
+                owner: None,
+                duplicate_discriminator,
+            };
+            let requested = database.runtime.request_registered(
+                &database.raw_const_syntax,
+                revision,
+                RawConstSyntaxQueryKey(key),
+                CancellationToken::new(),
+            );
+            assert!(matches!(
+                requested.terminal().unwrap().outcome(),
+                rue_query::QueryOutcome::Success(RawConstSyntaxQueryValue::Available(syntax))
+                    if syntax.initializer.as_ref() == expected
+            ));
+        }
+    }
+
+    #[test]
+    fn raw_const_syntax_failures_are_stable_and_position_free() {
+        use crate::declaration_candidate::{
+            DeclarationCandidateCategory as Category, DeclarationOccurrenceFailure,
+            RawConstSyntaxFailure,
+        };
+
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "const present = 1; fn callable() {}",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+        let key =
+            |category, name: &'static str| crate::declaration_candidate::DeclarationCandidateKey {
+                module: module.clone(),
+                category,
+                name: Arc::from(name),
+                owner: None,
+                duplicate_discriminator: 0,
+            };
+        let absent = key(Category::ConstCandidate, "absent");
+        let non_const = key(Category::Function, "callable");
+        for (requested_key, expected) in [
+            (absent.clone(), RawConstSyntaxFailure::Absent(absent)),
+            (
+                non_const.clone(),
+                RawConstSyntaxFailure::CategoryMismatch(non_const),
+            ),
+        ] {
+            let requested = database.runtime.request_registered(
+                &database.raw_const_syntax,
+                revision,
+                RawConstSyntaxQueryKey(requested_key),
+                CancellationToken::new(),
+            );
+            let terminal = requested.terminal().unwrap();
+            assert_eq!(terminal.kind(), QueryTerminalKind::Failure);
+            assert!(terminal.diagnostics().is_empty());
+            assert!(matches!(
+                terminal.outcome(),
+                rue_query::QueryOutcome::Success(RawConstSyntaxQueryValue::Failure(actual))
+                    if actual == &expected
+            ));
+        }
+
+        let rejected = source_snapshot(&[(1, "/main.rue", "main.rue", "const broken = ;")], 1);
+        let rejected_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&rejected),
+            &rejected,
+        );
+        let rejected_key = key(Category::ConstCandidate, "broken");
+        let requested = database.runtime.request_registered(
+            &database.raw_const_syntax,
+            rejected_revision,
+            RawConstSyntaxQueryKey(rejected_key),
+            CancellationToken::new(),
+        );
+        assert!(matches!(
+            requested.terminal().unwrap().outcome(),
+            rue_query::QueryOutcome::Success(RawConstSyntaxQueryValue::Failure(
+                RawConstSyntaxFailure::OccurrencesUnavailable(
+                    DeclarationOccurrenceFailure::ParseRejected { module: failed_module }
+                )
+            )) if failed_module == &module
+        ));
+    }
+
+    #[test]
+    fn canceled_and_evicted_raw_const_syntax_requests_recover() {
+        let source_text = (0..=MODULE_QUERY_MEMO_RETENTION)
+            .map(|index| format!("const c{index} = {index};"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let source = source_snapshot(&[(1, "/main.rue", "main.rue", &source_text)], 1);
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+        let key = |index| crate::declaration_candidate::DeclarationCandidateKey {
+            module: module.clone(),
+            category: crate::declaration_candidate::DeclarationCandidateCategory::ConstCandidate,
+            name: Arc::from(format!("c{index}")),
+            owner: None,
+            duplicate_discriminator: 0,
+        };
+
+        let canceled = CancellationToken::new();
+        canceled.cancel();
+        let aborted = database.runtime.request_registered(
+            &database.raw_const_syntax,
+            revision,
+            RawConstSyntaxQueryKey(key(0)),
+            canceled,
+        );
+        assert_eq!(execution(&aborted), RequestExecution::Aborted);
+        assert!(aborted.terminal().is_none());
+
+        for index in 0..=MODULE_QUERY_MEMO_RETENTION {
+            let requested = database.runtime.request_registered(
+                &database.raw_const_syntax,
+                revision,
+                RawConstSyntaxQueryKey(key(index)),
+                CancellationToken::new(),
+            );
+            assert!(matches!(
+                requested.terminal().unwrap().outcome(),
+                rue_query::QueryOutcome::Success(RawConstSyntaxQueryValue::Available(_))
+            ));
+        }
+        assert_eq!(
+            database.raw_const_syntax.retention().terminals,
+            MODULE_QUERY_MEMO_RETENTION
+        );
+        assert!(database.runtime.metrics().evictions >= 2);
+
+        let recovered = database.runtime.request_registered(
+            &database.raw_const_syntax,
+            revision,
+            RawConstSyntaxQueryKey(key(0)),
+            CancellationToken::new(),
+        );
+        assert_eq!(execution(&recovered), RequestExecution::Computed);
+        assert!(matches!(
+            recovered.terminal().unwrap().outcome(),
+            rue_query::QueryOutcome::Success(RawConstSyntaxQueryValue::Available(syntax))
+                if syntax.initializer.as_ref() == "0"
         ));
     }
 


### PR DESCRIPTION
## Summary

- add an exact `compiler.raw-const-syntax` query keyed by stable declaration candidate identity
- retain parser-owned spans privately and materialize position-free type and initializer syntax only after exact demand
- record occurrence, shell, and parse dependencies while preserving stable failures across reuse, recovery, cancellation, and eviction
- add work counters and source-retirement gates proving unrelated declarations are not materialized and broad semantic inputs cannot enter this family

## Why

The declaration semantic query nucleus needs reparsable constant syntax without forcing module RIR or whole-program semantic analysis. This establishes that narrow input boundary without becoming a second constant-resolution authority.

## Testing

- `scripts/rue quick` (34/34; frontend differential 641/641)
- `/opt/homebrew/bin/bash ./clippy.sh` (61 targets)
- `git diff --check upstream/trunk...HEAD`

Refs RUE-1026
