### PR TITLE
RUE-1026: query exact signature syntax

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1553,6 +1553,11 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
             "raw_const_syntax_cache",
             "warm_raw_const_syntax",
             "eager_raw_const_syntax",
+            "legacy_raw_declaration_signature",
+            "fallback_raw_declaration_signature",
+            "raw_declaration_signature_cache",
+            "warm_raw_declaration_signature",
+            "eager_raw_declaration_signature",
         ] {
             assert!(
                 !source.contains(retired),
@@ -1563,6 +1568,7 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
             for evaluator_only in [
                 ".evaluate_declaration_shell(",
                 ".evaluate_raw_const_syntax(",
+                ".evaluate_raw_declaration_signature(",
                 ".declaration_capabilities()",
                 "project_semantic_shell(",
             ] {
@@ -1581,6 +1587,15 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
                 "compiler production module {name} escaped the raw-constant authority allowlist"
             );
         }
+        if !matches!(
+            *name,
+            "declaration_candidate" | "parsed_modules" | "revisioned_query_database"
+        ) {
+            assert!(
+                !source.contains("RawDeclarationSignature"),
+                "compiler production module {name} escaped the raw-signature authority allowlist"
+            );
+        }
     }
     assert!(canonical.contains("predeclare_imported_declaration_shells"));
     assert!(!canonical.contains("fn analyze_canonical_program("));
@@ -1590,6 +1605,25 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
     assert_eq!(parsed.matches("fn evaluate_raw_const_syntax(").count(), 1);
     assert_eq!(runtime.matches("\"compiler.raw-const-syntax\"").count(), 1);
     assert_eq!(parsed.matches("RawConstSyntax {").count(), 1);
+    assert_eq!(
+        runtime
+            .matches(".evaluate_raw_declaration_signature(")
+            .count(),
+        1
+    );
+    assert_eq!(
+        parsed
+            .matches("fn evaluate_raw_declaration_signature(")
+            .count(),
+        1
+    );
+    assert_eq!(
+        runtime
+            .matches("\"compiler.raw-declaration-signature\"")
+            .count(),
+        1
+    );
+    assert_eq!(parsed.matches("RawDeclarationSignatureSyntax {").count(), 1);
     assert!(!runtime.contains("Vec::remove"));
 
     let occurrence = runtime
@@ -1631,10 +1665,7 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
     let raw_const_terminal = runtime
         .split("enum RawConstSyntaxQueryValue")
         .nth(1)
-        .and_then(|tail| {
-            tail.split("pub(crate) enum DeclarationShellBatchFailure")
-                .next()
-        })
+        .and_then(|tail| tail.split("struct RawDeclarationSignatureQueryKey").next())
         .unwrap();
     for forbidden in [
         "CompileErrors",
@@ -1651,6 +1682,31 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
             "raw-constant terminal regained positioned/live parser or semantic payload: {forbidden}"
         );
     }
+    let raw_signature_terminal = runtime
+        .split("enum RawDeclarationSignatureQueryValue")
+        .nth(1)
+        .and_then(|tail| {
+            tail.split("pub(crate) enum DeclarationShellBatchFailure")
+                .next()
+        })
+        .unwrap();
+    for forbidden in [
+        "CompileErrors",
+        "Span",
+        "FileId",
+        "Spur",
+        "Ast",
+        "InstRef",
+        "Rir",
+        "TypeId",
+        "SemanticDefinitionToken",
+        "SemanticModuleToken",
+    ] {
+        assert!(
+            !raw_signature_terminal.contains(forbidden),
+            "raw-signature terminal regained positioned/live parser or semantic payload: {forbidden}"
+        );
+    }
     let raw_const_payload = module("declaration_candidate")
         .split("pub(crate) struct RawConstSyntax")
         .nth(1)
@@ -1660,6 +1716,40 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         assert!(
             !raw_const_payload.contains(forbidden),
             "raw-constant payload regained a positioned or live parser handle: {forbidden}"
+        );
+    }
+    let raw_signature_payload = module("declaration_candidate")
+        .split("pub(crate) struct RawDeclarationSignatureSyntax")
+        .nth(1)
+        .and_then(|tail| {
+            tail.split("pub(crate) enum RawDeclarationSignatureFailure")
+                .next()
+        })
+        .unwrap();
+    for forbidden in ["Span", "FileId", "Spur", "Ast", "Rir", "InstRef", "TypeId"] {
+        assert!(
+            !raw_signature_payload.contains(forbidden),
+            "raw-signature payload regained a positioned or live parser/semantic handle: {forbidden}"
+        );
+    }
+    let raw_signature_locator = parsed
+        .split("enum RawDeclarationSignatureLocator")
+        .nth(1)
+        .and_then(|tail| {
+            tail.split("pub(crate) struct ParsedDeclarationLocator")
+                .next()
+        })
+        .unwrap();
+    for forbidden in ["Vec<", "Arc<[Span]>", "Box<"] {
+        assert!(
+            !raw_signature_locator.contains(forbidden),
+            "raw-signature parser locator regained per-declaration heap storage: {forbidden}"
+        );
+    }
+    for required in ["Contiguous", "SplitStruct", "Extern"] {
+        assert!(
+            raw_signature_locator.contains(required),
+            "raw-signature parser locator lost bounded inline shape {required}"
         );
     }
     let failure_algebra = module("declaration_candidate")

--- a/crates/rue-compiler/src/declaration_candidate.rs
+++ b/crates/rue-compiler/src/declaration_candidate.rs
@@ -106,6 +106,29 @@ pub(crate) enum RawConstSyntaxFailure {
     ParserCapabilityMismatch(DeclarationCandidateKey),
 }
 
+/// Parser-validated syntax for one declaration signature, detached from its
+/// source epoch and parser symbol universe.
+///
+/// Concatenating `declaration_fragments` reconstructs a body-free declaration
+/// for the exact key. Struct fragments omit every method declaration while
+/// retaining the struct header, directives, fields, and closing brace.
+/// `extern_abi` retains the surrounding ABI literal for an extern member.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct RawDeclarationSignatureSyntax {
+    pub(crate) declaration_fragments: Arc<[Arc<str>]>,
+    pub(crate) extern_abi: Option<Arc<str>>,
+}
+
+/// Stable, position-free failure retained by the exact raw-signature family.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RawDeclarationSignatureFailure {
+    OccurrencesUnavailable(DeclarationOccurrenceFailure),
+    Absent(DeclarationCandidateKey),
+    Ambiguous(DeclarationCandidateKey),
+    CategoryMismatch(DeclarationCandidateKey),
+    ParserCapabilityMismatch(DeclarationCandidateKey),
+}
+
 impl DeclarationCandidateKey {
     pub(crate) fn stable_identity(&self) -> String {
         // Length-prefix every user-authored component. Query identities must

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -32,6 +32,7 @@ use crate::{
         DeclarationCandidateCategory, DeclarationCandidateKey, DeclarationCandidateOwner,
         DeclarationOccurrenceCapability, DeclarationParameterHeader, DeclarationParameterMode,
         DeclarationShellFact, DeclarationShellFailure, RawConstSyntax,
+        RawDeclarationSignatureSyntax,
     },
 };
 
@@ -156,6 +157,8 @@ pub struct ParsedDefinitionIndex {
     #[cfg(test)]
     raw_const_syntax_materializations: Arc<AtomicUsize>,
     #[cfg(test)]
+    raw_declaration_signature_terminal_materializations: Arc<AtomicUsize>,
+    #[cfg(test)]
     by_name: BTreeMap<(DefinitionNamespace, Arc<str>), Arc<[ParsedDefinitionOccurrence]>>,
 }
 
@@ -227,6 +230,56 @@ impl ParsedDefinitionIndex {
             .load(Ordering::Relaxed)
     }
 
+    /// Materialize the body-free syntax for exactly one declaration key.
+    /// Locators are indexed with the module, but source fragments are copied
+    /// only after this exact `declaration_by_key` lookup succeeds.
+    fn materialize_raw_declaration_signature(
+        &self,
+        key: &DeclarationCandidateKey,
+        source_text: &str,
+    ) -> Option<RawDeclarationSignatureSyntax> {
+        let index = self.declaration_by_key.get(key).copied()?;
+        let candidate = self.declarations.get(index)?;
+        if candidate.fact.key != *key {
+            return None;
+        }
+        let locator = candidate.raw_signature_locator?;
+        let fragment = |span: Span| {
+            source_text
+                .get(span.start as usize..span.end as usize)
+                .map(Arc::from)
+        };
+        let (declaration_fragments, extern_abi) = match locator {
+            RawDeclarationSignatureLocator::Contiguous { declaration } => {
+                (vec![fragment(declaration)?].into(), None)
+            }
+            RawDeclarationSignatureLocator::SplitStruct {
+                retained_prefix,
+                closing_brace,
+            } => (
+                vec![fragment(retained_prefix)?, fragment(closing_brace)?].into(),
+                None,
+            ),
+            RawDeclarationSignatureLocator::Extern { declaration, abi } => {
+                (vec![fragment(declaration)?].into(), Some(fragment(abi)?))
+            }
+        };
+        let syntax = RawDeclarationSignatureSyntax {
+            declaration_fragments,
+            extern_abi,
+        };
+        #[cfg(test)]
+        self.raw_declaration_signature_terminal_materializations
+            .fetch_add(1, Ordering::Relaxed);
+        Some(syntax)
+    }
+
+    #[cfg(test)]
+    fn raw_declaration_signature_terminal_materialization_count(&self) -> usize {
+        self.raw_declaration_signature_terminal_materializations
+            .load(Ordering::Relaxed)
+    }
+
     pub(crate) fn declaration_locator(
         &self,
         key: &DeclarationCandidateKey,
@@ -260,6 +313,7 @@ pub(crate) struct ParsedDeclarationCandidate {
     fact: DeclarationShellFact,
     declaration_span: Span,
     raw_const_syntax_spans: Option<RawConstSyntaxSpans>,
+    raw_signature_locator: Option<RawDeclarationSignatureLocator>,
 }
 
 /// Parser-private locators for syntax that is materialized only after an exact
@@ -269,6 +323,24 @@ pub(crate) struct ParsedDeclarationCandidate {
 struct RawConstSyntaxSpans {
     declared_type: Option<Span>,
     initializer: Span,
+}
+
+/// Parser-private signature locators. These current-epoch spans are also the
+/// only source of future diagnostic projection; they never enter the durable
+/// raw-signature terminal.
+#[derive(Debug, Clone, Copy)]
+enum RawDeclarationSignatureLocator {
+    Contiguous {
+        declaration: Span,
+    },
+    SplitStruct {
+        retained_prefix: Span,
+        closing_brace: Span,
+    },
+    Extern {
+        declaration: Span,
+        abi: Span,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -399,6 +471,20 @@ impl ParsedModule {
     #[cfg(test)]
     pub(crate) fn raw_const_syntax_materialization_count(&self) -> usize {
         self.definitions.raw_const_syntax_materialization_count()
+    }
+
+    pub(crate) fn evaluate_raw_declaration_signature(
+        &self,
+        key: &DeclarationCandidateKey,
+    ) -> Option<RawDeclarationSignatureSyntax> {
+        self.definitions
+            .materialize_raw_declaration_signature(key, self.source_text())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn raw_declaration_signature_terminal_materialization_count(&self) -> usize {
+        self.definitions
+            .raw_declaration_signature_terminal_materialization_count()
     }
 
     #[cfg(test)]
@@ -1156,6 +1242,28 @@ fn bind_payload(
                         initializer: remap_span(spans.initializer),
                     }
                 }),
+                raw_signature_locator: candidate.raw_signature_locator.map(
+                    |locator| match locator {
+                        RawDeclarationSignatureLocator::Contiguous { declaration } => {
+                            RawDeclarationSignatureLocator::Contiguous {
+                                declaration: remap_span(declaration),
+                            }
+                        }
+                        RawDeclarationSignatureLocator::SplitStruct {
+                            retained_prefix,
+                            closing_brace,
+                        } => RawDeclarationSignatureLocator::SplitStruct {
+                            retained_prefix: remap_span(retained_prefix),
+                            closing_brace: remap_span(closing_brace),
+                        },
+                        RawDeclarationSignatureLocator::Extern { declaration, abi } => {
+                            RawDeclarationSignatureLocator::Extern {
+                                declaration: remap_span(declaration),
+                                abi: remap_span(abi),
+                            }
+                        }
+                    },
+                ),
             })
             .collect::<Vec<_>>()
             .into(),
@@ -1165,6 +1273,11 @@ fn bind_payload(
         raw_const_syntax_materializations: payload
             .definitions
             .raw_const_syntax_materializations
+            .clone(),
+        #[cfg(test)]
+        raw_declaration_signature_terminal_materializations: payload
+            .definitions
+            .raw_declaration_signature_terminal_materializations
             .clone(),
         #[cfg(test)]
         by_name: payload.definitions.by_name.clone(),
@@ -1550,8 +1663,12 @@ fn build_definition_index(
     resolver: &FrozenSymbolResolver,
 ) -> CompileResult<ParsedDefinitionIndex> {
     let mut pending = Vec::new();
-    let mut pending_declarations =
-        Vec::<(DeclarationShellFact, Span, Option<RawConstSyntaxSpans>)>::new();
+    let mut pending_declarations = Vec::<(
+        DeclarationShellFact,
+        Span,
+        Option<RawConstSyntaxSpans>,
+        Option<RawDeclarationSignatureLocator>,
+    )>::new();
     let resolve_name = |ident: rue_parser::Ident| -> CompileResult<Arc<str>> {
         let symbol = resolver.symbol(ident.name)?;
         Ok(Arc::from(resolver.resolve(&symbol)?))
@@ -1628,7 +1745,8 @@ fn build_definition_index(
                         is_extern,
                         declaration_span,
                         signature_spans: Vec<Span>,
-                        raw_const_syntax_spans: Option<RawConstSyntaxSpans>|
+                        raw_const_syntax_spans: Option<RawConstSyntaxSpans>,
+                        raw_signature_locator: Option<RawDeclarationSignatureLocator>|
          -> CompileResult<()> {
             let signature_fingerprint = declaration_signature_fingerprint(
                 file_id,
@@ -1637,6 +1755,27 @@ fn build_definition_index(
                 resolver,
                 &signature_spans,
             )?;
+            if let Some(locator) = raw_signature_locator {
+                let (first, second, abi) = match locator {
+                    RawDeclarationSignatureLocator::Contiguous { declaration } => {
+                        (declaration, None, None)
+                    }
+                    RawDeclarationSignatureLocator::SplitStruct {
+                        retained_prefix,
+                        closing_brace,
+                    } => (retained_prefix, Some(closing_brace), None),
+                    RawDeclarationSignatureLocator::Extern { declaration, abi } => {
+                        (declaration, None, Some(abi))
+                    }
+                };
+                validate_span("raw declaration signature", first, file_id, source_text)?;
+                if let Some(span) = second {
+                    validate_span("raw declaration signature", span, file_id, source_text)?;
+                }
+                if let Some(span) = abi {
+                    validate_span("raw extern ABI", span, file_id, source_text)?;
+                }
+            }
             pending_declarations.push((
                 DeclarationShellFact {
                     key: DeclarationCandidateKey {
@@ -1657,6 +1796,7 @@ fn build_definition_index(
                 },
                 declaration_span,
                 raw_const_syntax_spans,
+                raw_signature_locator,
             ));
             Ok(())
         };
@@ -1676,6 +1816,13 @@ fn build_definition_index(
                 function.span,
                 vec![signature_prefix(function.span, function.body.span())?],
                 None,
+                Some(RawDeclarationSignatureLocator::Contiguous {
+                    declaration: token_bounded_signature_prefix(
+                        function.span,
+                        function.body.span(),
+                        tokens,
+                    )?,
+                }),
             )?,
             Item::Struct(structure) => {
                 let owner_name = resolve_name(structure.name)?;
@@ -1693,6 +1840,7 @@ fn build_definition_index(
                     structure.span,
                     signature_fragments_excluding_method_bodies(structure)?,
                     None,
+                    Some(struct_signature_locator(structure, tokens)?),
                 )?;
                 let owner = DeclarationCandidateOwner {
                     category: DeclarationCandidateCategory::Struct,
@@ -1724,6 +1872,13 @@ fn build_definition_index(
                         method.span,
                         vec![signature_prefix(method.span, method.body.span())?],
                         None,
+                        Some(RawDeclarationSignatureLocator::Contiguous {
+                            declaration: token_bounded_signature_prefix(
+                                method.span,
+                                method.body.span(),
+                                tokens,
+                            )?,
+                        }),
                     )?;
                 }
             }
@@ -1741,6 +1896,9 @@ fn build_definition_index(
                 value.span,
                 vec![value.span],
                 None,
+                Some(RawDeclarationSignatureLocator::Contiguous {
+                    declaration: token_bounded_declaration(value.span, tokens)?,
+                }),
             )?,
             Item::Const(value) => {
                 let declared_type = value.ty.as_ref().map(TypeExpr::span);
@@ -1767,6 +1925,7 @@ fn build_definition_index(
                     value.span,
                     vec![signature_prefix(value.span, value.init.span())?],
                     Some(raw_const_syntax_spans),
+                    None,
                 )?;
             }
             Item::DropFn(value) => push(
@@ -1786,6 +1945,13 @@ fn build_definition_index(
                 value.span,
                 vec![signature_prefix(value.span, value.body.span())?],
                 None,
+                Some(RawDeclarationSignatureLocator::Contiguous {
+                    declaration: token_bounded_signature_prefix(
+                        value.span,
+                        value.body.span(),
+                        tokens,
+                    )?,
+                }),
             )?,
             Item::Extern(block) => {
                 for function in &block.fns {
@@ -1803,6 +1969,10 @@ fn build_definition_index(
                         function.span,
                         vec![function.span],
                         None,
+                        Some(RawDeclarationSignatureLocator::Extern {
+                            declaration: token_bounded_declaration(function.span, tokens)?,
+                            abi: block.abi_span,
+                        }),
                     )?;
                 }
             }
@@ -1870,24 +2040,27 @@ fn build_definition_index(
     let mut duplicate_counts = BTreeMap::new();
     let declarations = pending_declarations
         .into_iter()
-        .map(|(mut fact, declaration_span, raw_const_syntax_spans)| {
-            let duplicate = duplicate_counts
-                .entry((
-                    fact.key.category,
-                    fact.key.name.clone(),
-                    fact.key.owner.clone(),
-                ))
-                .or_insert(0_u32);
-            fact.key.duplicate_discriminator = *duplicate;
-            *duplicate = duplicate
-                .checked_add(1)
-                .ok_or_else(|| invalid_input("declaration duplicate discriminator exceeds u32"))?;
-            Ok(ParsedDeclarationCandidate {
-                fact,
-                declaration_span,
-                raw_const_syntax_spans,
-            })
-        })
+        .map(
+            |(mut fact, declaration_span, raw_const_syntax_spans, raw_signature_locator)| {
+                let duplicate = duplicate_counts
+                    .entry((
+                        fact.key.category,
+                        fact.key.name.clone(),
+                        fact.key.owner.clone(),
+                    ))
+                    .or_insert(0_u32);
+                fact.key.duplicate_discriminator = *duplicate;
+                *duplicate = duplicate.checked_add(1).ok_or_else(|| {
+                    invalid_input("declaration duplicate discriminator exceeds u32")
+                })?;
+                Ok(ParsedDeclarationCandidate {
+                    fact,
+                    declaration_span,
+                    raw_const_syntax_spans,
+                    raw_signature_locator,
+                })
+            },
+        )
         .collect::<CompileResult<Vec<_>>>()?;
     let mut declaration_by_key = BTreeMap::new();
     let mut declaration_capabilities = Vec::with_capacity(declarations.len());
@@ -1916,6 +2089,8 @@ fn build_definition_index(
         declaration_capabilities: declaration_capabilities.into(),
         #[cfg(test)]
         raw_const_syntax_materializations: Arc::new(AtomicUsize::new(0)),
+        #[cfg(test)]
+        raw_declaration_signature_terminal_materializations: Arc::new(AtomicUsize::new(0)),
         #[cfg(test)]
         by_name,
     })
@@ -1972,6 +2147,110 @@ fn signature_fragments_excluding_method_bodies(
         structure.span.end,
     ));
     Ok(fragments)
+}
+
+/// Bound a body-bearing declaration at the last signature token. Lexer trivia
+/// before the body belongs to neither the signature nor the body and therefore
+/// must not perturb the durable signature terminal.
+fn token_bounded_signature_prefix(
+    declaration: Span,
+    body: Span,
+    tokens: &[rue_lexer::Token],
+) -> CompileResult<Span> {
+    signature_prefix(declaration, body)?;
+    let signature_end = tokens
+        .iter()
+        .filter(|token| {
+            token.span.file_id == declaration.file_id
+                && token.span.start >= declaration.start
+                && token.span.end <= body.start
+                && !matches!(token.kind, rue_lexer::TokenKind::Eof)
+        })
+        .map(|token| token.span.end)
+        .max()
+        .ok_or_else(|| invalid_input("declaration signature contains no token before its body"))?;
+    if signature_end <= declaration.start {
+        return Err(invalid_input(
+            "declaration signature token boundary is empty",
+        ));
+    }
+    Ok(Span::with_file(
+        declaration.file_id,
+        declaration.start,
+        signature_end,
+    ))
+}
+
+/// Trim a body-free declaration to its first and last tokens.
+fn token_bounded_declaration(
+    declaration: Span,
+    tokens: &[rue_lexer::Token],
+) -> CompileResult<Span> {
+    let mut declaration_tokens = tokens.iter().filter(|token| {
+        token.span.file_id == declaration.file_id
+            && token.span.start >= declaration.start
+            && token.span.end <= declaration.end
+            && !matches!(token.kind, rue_lexer::TokenKind::Eof)
+    });
+    let first = declaration_tokens
+        .next()
+        .ok_or_else(|| invalid_input("declaration contains no tokens"))?;
+    let last = declaration_tokens.next_back().unwrap_or(first);
+    Ok(Span::with_file(
+        declaration.file_id,
+        first.span.start,
+        last.span.end,
+    ))
+}
+
+/// Retain only a struct's header/directives/fields and its closing-brace token.
+/// The two inline spans exclude the delimiter and all trivia before the first
+/// method, all methods, and all trivia after the last method. Omitting a
+/// trailing field comma is valid Rue syntax, so concatenating these fragments
+/// remains a deterministic, reparsable struct declaration.
+fn struct_signature_locator(
+    structure: &rue_parser::ast::StructDecl,
+    tokens: &[rue_lexer::Token],
+) -> CompileResult<RawDeclarationSignatureLocator> {
+    let declaration_tokens = || {
+        tokens.iter().filter(|token| {
+            token.span.file_id == structure.span.file_id
+                && token.span.start >= structure.span.start
+                && token.span.end <= structure.span.end
+                && !matches!(token.kind, rue_lexer::TokenKind::Eof)
+        })
+    };
+    let first = declaration_tokens()
+        .next()
+        .ok_or_else(|| invalid_input("struct declaration contains no tokens"))?;
+    let opening_brace = declaration_tokens()
+        .find(|token| matches!(token.kind, rue_lexer::TokenKind::LBrace))
+        .ok_or_else(|| invalid_input("struct declaration has no opening-brace token"))?;
+    let closing_brace = declaration_tokens()
+        .rev()
+        .find(|token| matches!(token.kind, rue_lexer::TokenKind::RBrace))
+        .ok_or_else(|| invalid_input("struct declaration has no closing-brace token"))?;
+    let retained_end = if let Some(field) = structure.fields.last() {
+        let field_end_is_token_boundary =
+            declaration_tokens().any(|token| token.span.end == field.span.end);
+        if !field_end_is_token_boundary {
+            return Err(invalid_input(
+                "struct field does not end at a token boundary",
+            ));
+        }
+        field.span.end
+    } else {
+        opening_brace.span.end
+    };
+    if first.span.start >= retained_end || retained_end > closing_brace.span.start {
+        return Err(invalid_input(
+            "struct retained signature tokens are not ordered before its closing brace",
+        ));
+    }
+    Ok(RawDeclarationSignatureLocator::SplitStruct {
+        retained_prefix: Span::with_file(structure.span.file_id, first.span.start, retained_end),
+        closing_brace: closing_brace.span,
+    })
 }
 
 fn declaration_signature_fingerprint(

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -396,6 +396,11 @@ pub(crate) struct RevisionedQueryDatabase {
     // semantic dependency until the keyed constant evaluator consumes it.
     #[cfg_attr(not(test), allow(dead_code))]
     raw_const_syntax: QueryFamily<RawConstSyntaxQueryKey, RawConstSyntaxQueryValue>,
+    // Registered now as the syntax boundary for the later keyed signature and
+    // type evaluators; production semantic resolution does not consume it yet.
+    #[cfg_attr(not(test), allow(dead_code))]
+    raw_declaration_signatures:
+        QueryFamily<RawDeclarationSignatureQueryKey, RawDeclarationSignatureQueryValue>,
     module_rirs: QueryFamily<ModuleQueryKey, ModuleRirValue>,
     resolve_imports: QueryFamily<ResolveImportKey, ResolveImportValue>,
     lookup_names: QueryFamily<LookupNameKey, LookupNameValue>,
@@ -490,6 +495,21 @@ impl QueryKey for RawConstSyntaxQueryKey {
 enum RawConstSyntaxQueryValue {
     Available(crate::declaration_candidate::RawConstSyntax),
     Failure(crate::declaration_candidate::RawConstSyntaxFailure),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RawDeclarationSignatureQueryKey(crate::declaration_candidate::DeclarationCandidateKey);
+
+impl QueryKey for RawDeclarationSignatureQueryKey {
+    fn stable_identity(&self) -> String {
+        self.0.stable_identity()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RawDeclarationSignatureQueryValue {
+    Available(crate::declaration_candidate::RawDeclarationSignatureSyntax),
+    Failure(crate::declaration_candidate::RawDeclarationSignatureFailure),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1183,6 +1203,155 @@ impl Default for RevisionedQueryDatabase {
                 },
             )
             .expect("the RawConstSyntax family has one canonical name");
+        let occurrences_for_raw_signature = declaration_occurrence_indexes.clone();
+        let shells_for_raw_signature = declaration_shells.clone();
+        let parse_for_raw_signature = parse_modules.clone();
+        let raw_declaration_signatures = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.raw-declaration-signature",
+                MODULE_QUERY_MEMO_RETENTION,
+                |left: &RawDeclarationSignatureQueryValue,
+                 right: &RawDeclarationSignatureQueryValue| { left == right },
+                move |context, _, key: &RawDeclarationSignatureQueryKey| {
+                    use crate::declaration_candidate::{
+                        DeclarationCandidateCategory, DeclarationOccurrenceCapability,
+                        DeclarationShellFailure, RawDeclarationSignatureFailure,
+                    };
+
+                    let indexed = context.query_registered(
+                        &occurrences_for_raw_signature,
+                        ModuleQueryKey(key.0.module.clone()),
+                    )?;
+                    let rue_query::QueryOutcome::Success(indexed) = indexed.outcome() else {
+                        unreachable!("DeclarationOccurrenceIndex publishes typed values")
+                    };
+                    let value = match indexed {
+                        DeclarationOccurrenceIndexValue::Failure(failure) => {
+                            RawDeclarationSignatureQueryValue::Failure(
+                                RawDeclarationSignatureFailure::OccurrencesUnavailable(
+                                    failure.clone(),
+                                ),
+                            )
+                        }
+                        DeclarationOccurrenceIndexValue::Available(index) => {
+                            match index.capabilities.get(&key.0) {
+                                None => RawDeclarationSignatureQueryValue::Failure(
+                                    RawDeclarationSignatureFailure::Absent(key.0.clone()),
+                                ),
+                                Some(DeclarationOccurrenceCapability::Ambiguous { .. }) => {
+                                    RawDeclarationSignatureQueryValue::Failure(
+                                        RawDeclarationSignatureFailure::Ambiguous(key.0.clone()),
+                                    )
+                                }
+                                Some(DeclarationOccurrenceCapability::Exact {
+                                    duplicate_multiplicity: 0,
+                                    ..
+                                }) => RawDeclarationSignatureQueryValue::Failure(
+                                    RawDeclarationSignatureFailure::ParserCapabilityMismatch(
+                                        key.0.clone(),
+                                    ),
+                                ),
+                                Some(DeclarationOccurrenceCapability::Exact { .. }) => {
+                                    let shell = context.query_registered(
+                                        &shells_for_raw_signature,
+                                        DeclarationShellQueryKey(key.0.clone()),
+                                    )?;
+                                    let rue_query::QueryOutcome::Success(shell) = shell.outcome()
+                                    else {
+                                        unreachable!("DeclarationShell publishes typed values")
+                                    };
+                                    match shell {
+                                        DeclarationShellQueryValue::Failure(failure) => {
+                                            let failure = match failure {
+                                                DeclarationShellFailure::OccurrencesUnavailable(
+                                                    failure,
+                                                ) => RawDeclarationSignatureFailure::OccurrencesUnavailable(
+                                                    failure.clone(),
+                                                ),
+                                                DeclarationShellFailure::Absent(key) => {
+                                                    RawDeclarationSignatureFailure::Absent(
+                                                        key.clone(),
+                                                    )
+                                                }
+                                                DeclarationShellFailure::Ambiguous(key) => {
+                                                    RawDeclarationSignatureFailure::Ambiguous(
+                                                        key.clone(),
+                                                    )
+                                                }
+                                                DeclarationShellFailure::ParserCapabilityMismatch(
+                                                    key,
+                                                ) => RawDeclarationSignatureFailure::ParserCapabilityMismatch(
+                                                    key.clone(),
+                                                ),
+                                            };
+                                            RawDeclarationSignatureQueryValue::Failure(failure)
+                                        }
+                                        DeclarationShellQueryValue::Available(fact)
+                                            if fact.key.category
+                                                == DeclarationCandidateCategory::ConstCandidate =>
+                                        {
+                                            RawDeclarationSignatureQueryValue::Failure(
+                                                RawDeclarationSignatureFailure::CategoryMismatch(
+                                                    key.0.clone(),
+                                                ),
+                                            )
+                                        }
+                                        DeclarationShellQueryValue::Available(fact)
+                                            if fact.key != key.0 =>
+                                        {
+                                            RawDeclarationSignatureQueryValue::Failure(
+                                                RawDeclarationSignatureFailure::ParserCapabilityMismatch(
+                                                    key.0.clone(),
+                                                ),
+                                            )
+                                        }
+                                        DeclarationShellQueryValue::Available(_) => {
+                                            let parsed = context.query_registered(
+                                                &parse_for_raw_signature,
+                                                ModuleQueryKey(key.0.module.clone()),
+                                            )?;
+                                            let rue_query::QueryOutcome::Success(parsed) =
+                                                parsed.outcome()
+                                            else {
+                                                unreachable!("ParseModule publishes typed values")
+                                            };
+                                            match &parsed.result {
+                                                Err(_) => RawDeclarationSignatureQueryValue::Failure(
+                                                    RawDeclarationSignatureFailure::OccurrencesUnavailable(
+                                                        crate::declaration_candidate::DeclarationOccurrenceFailure::ParseRejected {
+                                                            module: key.0.module.clone(),
+                                                        },
+                                                    ),
+                                                ),
+                                                Ok(module) => module
+                                                    .evaluate_raw_declaration_signature(&key.0)
+                                                    .map_or_else(
+                                                        || RawDeclarationSignatureQueryValue::Failure(
+                                                            RawDeclarationSignatureFailure::ParserCapabilityMismatch(
+                                                                key.0.clone(),
+                                                            ),
+                                                        ),
+                                                        RawDeclarationSignatureQueryValue::Available,
+                                                    ),
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    };
+                    let kind = if matches!(
+                        value,
+                        RawDeclarationSignatureQueryValue::Available(_)
+                    ) {
+                        QueryTerminalKind::Success
+                    } else {
+                        QueryTerminalKind::Failure
+                    };
+                    Ok(QueryOutput::success(value).with_terminal_kind(kind))
+                },
+            )
+            .expect("the RawDeclarationSignature family has one canonical name");
         let index_for_lookup = module_indexes.clone();
         let lookup_names = runtime
             .family_with_evaluator(
@@ -1321,6 +1490,7 @@ impl Default for RevisionedQueryDatabase {
             declaration_occurrence_indexes,
             declaration_shells,
             raw_const_syntax,
+            raw_declaration_signatures,
             module_rirs,
             resolve_imports,
             lookup_names,
@@ -2635,6 +2805,546 @@ mod tests {
             recovered.terminal().unwrap().outcome(),
             rue_query::QueryOutcome::Success(RawConstSyntaxQueryValue::Available(syntax))
                 if syntax.initializer.as_ref() == "0"
+        ));
+    }
+
+    fn raw_signature_text(
+        syntax: &crate::declaration_candidate::RawDeclarationSignatureSyntax,
+    ) -> String {
+        syntax
+            .declaration_fragments
+            .iter()
+            .map(AsRef::as_ref)
+            .collect::<String>()
+    }
+
+    #[test]
+    fn raw_declaration_signature_is_exact_lazy_and_red_green() {
+        fn program(selected_type: &str, unrelated_body: u32) -> String {
+            let mut source = String::new();
+            for index in 0..128 {
+                let body = if index == 64 { unrelated_body } else { index };
+                source.push_str(&format!("fn unrelated{index}() -> i32 {{ {body} }}\n"));
+            }
+            source.push_str(&format!(
+                "fn selected(value: {selected_type}) -> {selected_type} {{ value }}\n"
+            ));
+            source
+        }
+
+        let first_text = program("i32", 64);
+        let unrelated_edit_text = program("i32", 999);
+        let selected_edit_text = program("i64", 999);
+        let first = source_snapshot(&[(1, "/main.rue", "main.rue", &first_text)], 1);
+        let unrelated_edit =
+            source_snapshot(&[(1, "/main.rue", "main.rue", &unrelated_edit_text)], 1);
+        let selected_edit =
+            source_snapshot(&[(1, "/main.rue", "main.rue", &selected_edit_text)], 1);
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let key = crate::declaration_candidate::DeclarationCandidateKey {
+            module: module.clone(),
+            category: crate::declaration_candidate::DeclarationCandidateCategory::Function,
+            name: Arc::from("selected"),
+            owner: None,
+            duplicate_discriminator: 0,
+        };
+        let mut database = RevisionedQueryDatabase::default();
+        let first_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&first),
+            &first,
+        );
+        let parsed = database.runtime.request_registered(
+            &database.parse_modules,
+            first_revision,
+            ModuleQueryKey(module),
+            CancellationToken::new(),
+        );
+        let parsed_module = match parsed.terminal().unwrap().outcome() {
+            rue_query::QueryOutcome::Success(value) => value.result.clone().unwrap(),
+            rue_query::QueryOutcome::Failure(_) => unreachable!(),
+        };
+        assert_eq!(
+            parsed_module.raw_declaration_signature_terminal_materialization_count(),
+            0,
+            "indexing 129 declarations must allocate no raw-signature terminal fragments"
+        );
+
+        let first_request = database.runtime.request_registered(
+            &database.raw_declaration_signatures,
+            first_revision,
+            RawDeclarationSignatureQueryKey(key.clone()),
+            CancellationToken::new(),
+        );
+        assert_eq!(execution(&first_request), RequestExecution::Computed);
+        assert_eq!(
+            first_request
+                .dependencies()
+                .iter()
+                .map(|dependency| dependency.node.family())
+                .collect::<Vec<_>>(),
+            vec![
+                "compiler.declaration-occurrence-index",
+                "compiler.declaration-shell",
+                "compiler.parse-module",
+            ]
+        );
+        let first_terminal = first_request.terminal().unwrap();
+        let first_stamp = first_terminal.stamp();
+        assert!(matches!(
+            first_terminal.outcome(),
+            rue_query::QueryOutcome::Success(
+                RawDeclarationSignatureQueryValue::Available(syntax)
+            ) if raw_signature_text(syntax).trim_end() == "fn selected(value: i32) -> i32"
+                && syntax.extern_abi.is_none()
+        ));
+        assert_eq!(
+            parsed_module.raw_declaration_signature_terminal_materialization_count(),
+            1,
+            "one exact cold demand must materialize one raw-signature terminal"
+        );
+
+        let warm = database.runtime.request_registered(
+            &database.raw_declaration_signatures,
+            first_revision,
+            RawDeclarationSignatureQueryKey(key.clone()),
+            CancellationToken::new(),
+        );
+        assert_eq!(execution(&warm), RequestExecution::Reused);
+        assert_eq!(
+            parsed_module.raw_declaration_signature_terminal_materialization_count(),
+            1,
+            "warm reuse must not rematerialize raw-signature terminal fragments"
+        );
+
+        let unrelated_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&unrelated_edit),
+            &unrelated_edit,
+        );
+        let unrelated_request = database.runtime.request_registered(
+            &database.raw_declaration_signatures,
+            unrelated_revision,
+            RawDeclarationSignatureQueryKey(key.clone()),
+            CancellationToken::new(),
+        );
+        assert_eq!(unrelated_request.terminal().unwrap().stamp(), first_stamp);
+
+        let selected_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&selected_edit),
+            &selected_edit,
+        );
+        let selected_request = database.runtime.request_registered(
+            &database.raw_declaration_signatures,
+            selected_revision,
+            RawDeclarationSignatureQueryKey(key),
+            CancellationToken::new(),
+        );
+        let selected_terminal = selected_request.terminal().unwrap();
+        assert_ne!(selected_terminal.stamp(), first_stamp);
+        assert!(matches!(
+            selected_terminal.outcome(),
+            rue_query::QueryOutcome::Success(
+                RawDeclarationSignatureQueryValue::Available(syntax)
+            ) if raw_signature_text(syntax).trim_end() == "fn selected(value: i64) -> i64"
+        ));
+    }
+
+    #[test]
+    fn raw_declaration_signatures_cover_categories_without_struct_method_peers() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "@copy linear struct Box { value: i32, fn get(borrow self) -> i32 { self.value } @allow(unused_function) fn make(value: i32) -> Box { Box { value } } }\n\
+                 enum Choice { Empty, Value(i32, u64) }\n\
+                 drop fn Box(self) {}\n\
+                 extern \"C\" { fn foreign(value: ptr const u8) -> i32; }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let owner = crate::declaration_candidate::DeclarationCandidateOwner {
+            category: Category::Struct,
+            name: Arc::from("Box"),
+        };
+        let key = |category, name: &'static str, owner| {
+            crate::declaration_candidate::DeclarationCandidateKey {
+                module: module.clone(),
+                category,
+                name: Arc::from(name),
+                owner,
+                duplicate_discriminator: 0,
+            }
+        };
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+        let request = |key| {
+            database.runtime.request_registered(
+                &database.raw_declaration_signatures,
+                revision,
+                RawDeclarationSignatureQueryKey(key),
+                CancellationToken::new(),
+            )
+        };
+
+        let structure = request(key(Category::Struct, "Box", None));
+        let structure_terminal = structure.terminal().unwrap();
+        let structure_stamp = structure_terminal.stamp();
+        let structure = match structure_terminal.outcome() {
+            rue_query::QueryOutcome::Success(RawDeclarationSignatureQueryValue::Available(
+                syntax,
+            )) => syntax,
+            other => panic!("expected struct signature, got {other:?}"),
+        };
+        let structure_text = raw_signature_text(structure);
+        assert!(structure_text.contains("@copy linear struct Box"));
+        assert!(structure_text.contains("value: i32"));
+        assert!(!structure_text.contains("fn get"));
+        assert!(!structure_text.contains("fn make"));
+        assert!(structure_text.trim_end().ends_with('}'));
+        assert_eq!(structure.declaration_fragments.len(), 2);
+
+        for (candidate, expected) in [
+            (
+                key(Category::Method, "get", Some(owner.clone())),
+                "fn get(borrow self) -> i32",
+            ),
+            (
+                key(Category::AssociatedFunction, "make", Some(owner.clone())),
+                "@allow(unused_function) fn make(value: i32) -> Box",
+            ),
+            (
+                key(Category::Enum, "Choice", None),
+                "enum Choice { Empty, Value(i32, u64) }",
+            ),
+            (
+                key(Category::Destructor, "Box", Some(owner)),
+                "drop fn Box(self)",
+            ),
+        ] {
+            let requested = request(candidate);
+            assert!(matches!(
+                requested.terminal().unwrap().outcome(),
+                rue_query::QueryOutcome::Success(
+                    RawDeclarationSignatureQueryValue::Available(syntax)
+                ) if raw_signature_text(syntax).trim_end() == expected
+                    && syntax.extern_abi.is_none()
+            ));
+        }
+
+        let foreign = request(key(Category::ExternFunction, "foreign", None));
+        assert!(matches!(
+            foreign.terminal().unwrap().outcome(),
+            rue_query::QueryOutcome::Success(
+                RawDeclarationSignatureQueryValue::Available(syntax)
+            ) if raw_signature_text(syntax) == "fn foreign(value: ptr const u8) -> i32;"
+                && syntax.extern_abi.as_deref() == Some("\"C\"")
+        ));
+
+        let peer_signature_edit = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "@copy linear struct Box { value: i32, fn get(borrow self) -> u64 { 0 } @allow(unused_function) fn make(value: i32) -> Box { Box { value } } }\n\
+                 enum Choice { Empty, Value(i32, u64) }\n\
+                 drop fn Box(self) {}\n\
+                 extern \"C\" { fn foreign(value: ptr const u8) -> i32; }",
+            )],
+            1,
+        );
+        let peer_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&peer_signature_edit),
+            &peer_signature_edit,
+        );
+        let unchanged_structure = database.runtime.request_registered(
+            &database.raw_declaration_signatures,
+            peer_revision,
+            RawDeclarationSignatureQueryKey(key(Category::Struct, "Box", None)),
+            CancellationToken::new(),
+        );
+        assert_eq!(
+            unchanged_structure.terminal().unwrap().stamp(),
+            structure_stamp,
+            "a peer method signature must not change the struct signature terminal"
+        );
+    }
+
+    #[test]
+    fn raw_declaration_signature_boundaries_exclude_body_and_method_trivia() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+
+        let first = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn free(value: i32) -> i32 // free boundary one\n\
+                     { value }\n\
+                 struct Box { value: i32, // before first method one\n\
+                     fn get(borrow self) -> i32 // method boundary one\n\
+                         { self.value }\n\
+                     // between methods one\n\
+                     fn make(value: i32) -> Box // associated boundary one\n\
+                         { Box { value } }\n\
+                     // after last method one\n\
+                 }\n\
+                 drop fn Box(self) // destructor boundary one\n\
+                     {}",
+            )],
+            1,
+        );
+        let trivia_edit = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn free(value: i32) -> i32         // free boundary two\n\
+\n\
+                 { value }\n\
+                 struct Box { value: i32,             // before first method two\n\
+\n\
+                     fn get(borrow self) -> i32       // method boundary two\n\
+\n\
+                     { self.value }\n\
+                         // between methods two\n\
+                     fn make(value: i32) -> Box       // associated boundary two\n\
+\n\
+                     { Box { value } }\n\
+                         // after last method two\n\
+\n\
+                 }\n\
+                 drop fn Box(self)                    // destructor boundary two\n\
+\n\
+                 {}",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let owner = crate::declaration_candidate::DeclarationCandidateOwner {
+            category: Category::Struct,
+            name: Arc::from("Box"),
+        };
+        let key = |category, name: &'static str, owner| {
+            crate::declaration_candidate::DeclarationCandidateKey {
+                module: module.clone(),
+                category,
+                name: Arc::from(name),
+                owner,
+                duplicate_discriminator: 0,
+            }
+        };
+        let cases = [
+            (
+                key(Category::Function, "free", None),
+                "fn free(value: i32) -> i32",
+            ),
+            (
+                key(Category::Struct, "Box", None),
+                "struct Box { value: i32}",
+            ),
+            (
+                key(Category::Method, "get", Some(owner.clone())),
+                "fn get(borrow self) -> i32",
+            ),
+            (
+                key(Category::AssociatedFunction, "make", Some(owner.clone())),
+                "fn make(value: i32) -> Box",
+            ),
+            (
+                key(Category::Destructor, "Box", Some(owner)),
+                "drop fn Box(self)",
+            ),
+        ];
+        let mut database = RevisionedQueryDatabase::default();
+        let first_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&first),
+            &first,
+        );
+        let mut first_terminals = Vec::new();
+        for (candidate, expected) in &cases {
+            let requested = database.runtime.request_registered(
+                &database.raw_declaration_signatures,
+                first_revision,
+                RawDeclarationSignatureQueryKey(candidate.clone()),
+                CancellationToken::new(),
+            );
+            let terminal = requested.terminal().unwrap();
+            assert!(matches!(
+                terminal.outcome(),
+                rue_query::QueryOutcome::Success(
+                    RawDeclarationSignatureQueryValue::Available(syntax)
+                ) if raw_signature_text(syntax) == *expected
+            ));
+            first_terminals.push((candidate.clone(), terminal.stamp()));
+        }
+
+        let edited_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&trivia_edit),
+            &trivia_edit,
+        );
+        for (candidate, first_stamp) in first_terminals {
+            let requested = database.runtime.request_registered(
+                &database.raw_declaration_signatures,
+                edited_revision,
+                RawDeclarationSignatureQueryKey(candidate),
+                CancellationToken::new(),
+            );
+            assert_eq!(
+                requested.terminal().unwrap().stamp(),
+                first_stamp,
+                "body-boundary and method-adjacent trivia must stay outside the signature terminal"
+            );
+        }
+    }
+
+    #[test]
+    fn raw_declaration_signature_duplicate_discriminators_are_exact() {
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn duplicate(value: i32) {} fn duplicate(value: i64) {}",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+        for (duplicate_discriminator, expected) in [
+            (0, "fn duplicate(value: i32)"),
+            (1, "fn duplicate(value: i64)"),
+        ] {
+            let key = crate::declaration_candidate::DeclarationCandidateKey {
+                module: module.clone(),
+                category: crate::declaration_candidate::DeclarationCandidateCategory::Function,
+                name: Arc::from("duplicate"),
+                owner: None,
+                duplicate_discriminator,
+            };
+            let requested = database.runtime.request_registered(
+                &database.raw_declaration_signatures,
+                revision,
+                RawDeclarationSignatureQueryKey(key),
+                CancellationToken::new(),
+            );
+            assert!(matches!(
+                requested.terminal().unwrap().outcome(),
+                rue_query::QueryOutcome::Success(
+                    RawDeclarationSignatureQueryValue::Available(syntax)
+                ) if raw_signature_text(syntax).trim_end() == expected
+            ));
+        }
+    }
+
+    #[test]
+    fn raw_declaration_signature_failures_cancel_and_recover() {
+        use crate::declaration_candidate::{
+            DeclarationCandidateCategory as Category, DeclarationOccurrenceFailure,
+            RawDeclarationSignatureFailure,
+        };
+
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "const value = 1; fn present() {}",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let key =
+            |category, name: &'static str| crate::declaration_candidate::DeclarationCandidateKey {
+                module: module.clone(),
+                category,
+                name: Arc::from(name),
+                owner: None,
+                duplicate_discriminator: 0,
+            };
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+        let constant = key(Category::ConstCandidate, "value");
+        let absent = key(Category::Function, "absent");
+        for (candidate, expected) in [
+            (
+                constant.clone(),
+                RawDeclarationSignatureFailure::CategoryMismatch(constant),
+            ),
+            (
+                absent.clone(),
+                RawDeclarationSignatureFailure::Absent(absent),
+            ),
+        ] {
+            let requested = database.runtime.request_registered(
+                &database.raw_declaration_signatures,
+                revision,
+                RawDeclarationSignatureQueryKey(candidate),
+                CancellationToken::new(),
+            );
+            assert!(matches!(
+                requested.terminal().unwrap().outcome(),
+                rue_query::QueryOutcome::Success(
+                    RawDeclarationSignatureQueryValue::Failure(actual)
+                ) if actual == &expected
+            ));
+        }
+
+        let present = key(Category::Function, "present");
+        let canceled = CancellationToken::new();
+        canceled.cancel();
+        let aborted = database.runtime.request_registered(
+            &database.raw_declaration_signatures,
+            revision,
+            RawDeclarationSignatureQueryKey(present.clone()),
+            canceled,
+        );
+        assert_eq!(execution(&aborted), RequestExecution::Aborted);
+        assert!(aborted.terminal().is_none());
+        let recovered = database.runtime.request_registered(
+            &database.raw_declaration_signatures,
+            revision,
+            RawDeclarationSignatureQueryKey(present),
+            CancellationToken::new(),
+        );
+        assert!(matches!(
+            recovered.terminal().unwrap().outcome(),
+            rue_query::QueryOutcome::Success(RawDeclarationSignatureQueryValue::Available(_))
+        ));
+
+        let rejected = source_snapshot(&[(1, "/main.rue", "main.rue", "fn broken(")], 1);
+        let rejected_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&rejected),
+            &rejected,
+        );
+        let rejected_key = key(Category::Function, "broken");
+        let requested = database.runtime.request_registered(
+            &database.raw_declaration_signatures,
+            rejected_revision,
+            RawDeclarationSignatureQueryKey(rejected_key),
+            CancellationToken::new(),
+        );
+        assert!(matches!(
+            requested.terminal().unwrap().outcome(),
+            rue_query::QueryOutcome::Success(
+                RawDeclarationSignatureQueryValue::Failure(
+                    RawDeclarationSignatureFailure::OccurrencesUnavailable(
+                        DeclarationOccurrenceFailure::ParseRejected { module: failed_module }
+                    )
+                )
+            ) if failed_module == &module
         ));
     }
 


### PR DESCRIPTION
## Summary

- add an exact `compiler.raw-declaration-signature` query keyed by stable declaration candidate identity
- retain only fixed-size parser-owned locators and materialize position-free signature syntax after exact demand
- use token-bounded ranges for functions, methods, destructors, extern declarations, and aggregate signatures so bodies, methods, and adjacent trivia cannot leak into the terminal
- add laziness, relocation, failure-recovery, cancellation, eviction, and source-retirement coverage

## Why

The declaration semantic query nucleus needs exact signature inputs without forcing module RIR or broad semantic analysis. This establishes that narrow reparsable boundary while leaving semantic signature resolution to the forthcoming cycle-owning query family.

## Testing

- `scripts/rue quick` (34/34; frontend differential 641/641)
- `/opt/homebrew/bin/bash ./clippy.sh` (61 targets)
- `git diff --check upstream/trunk...HEAD`

Refs RUE-1026
