### PR TITLE
RUE-1079: fold constant field offsets into narrow load/store addressing

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1922,6 +1922,7 @@ impl<'a> CfgLower<'a> {
                             self.mir.push(Aarch64Inst::NarrowLoadIndexed {
                                 dst: Operand::Virtual(dst),
                                 base: ptr,
+                                offset: 0,
                                 width: narrow.width,
                                 signed: narrow.signed,
                             });
@@ -1976,6 +1977,7 @@ impl<'a> CfgLower<'a> {
                     self.mir.push(Aarch64Inst::NarrowStoreIndexed {
                         src: Operand::Virtual(value.primary),
                         base: ptr,
+                        offset: 0,
                         width: narrow.width,
                     });
                 } else {
@@ -3264,6 +3266,18 @@ impl CfgLower<'_> {
     }
 }
 
+/// Whether an AArch64 narrow load/store can fold `byte_offset` into its scaled
+/// `imm12` addressing mode (RUE-1079). `ldrb`/`strb` scale the immediate by 1,
+/// `ldrh`/`strh` by 2, and `ldr w`/`str w` by 4, so the byte offset is encodable
+/// iff it is non-negative, an exact multiple of `width`, and its scaled index
+/// fits the unsigned 12-bit immediate (`<= 0xFFF`). Anything else — a negative,
+/// misaligned, or too-large offset — is NOT foldable and must fall back to
+/// materializing `base + offset` in a register (correctness first).
+fn aarch64_narrow_offset_encodable(byte_offset: i32, width: u8) -> bool {
+    let width = width as i32;
+    byte_offset >= 0 && byte_offset % width == 0 && byte_offset / width <= 0xFFF
+}
+
 impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     fn ctx(&self) -> &crate::cfg_lower::CfgLowerContext<'_> {
         &self.ctx
@@ -3320,14 +3334,25 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
         byte_offset: i32,
         access: crate::types::NarrowScalar,
     ) {
-        // The narrow store addresses `[base]` with no offset, so materialize the
-        // base pointer plus the byte offset first (RUE-1000).
-        let base = self.narrow_ptr_base(ptr, byte_offset);
-        self.mir.push(Aarch64Inst::NarrowStoreIndexed {
-            src: Operand::Virtual(src),
-            base,
-            width: access.width,
-        });
+        // Fold the byte offset into the store's scaled imm12 when the scaled
+        // form can encode it (RUE-1079); otherwise materialize `base + offset`
+        // and address `[base]` with offset 0 — always correct (RUE-1000).
+        if aarch64_narrow_offset_encodable(byte_offset, access.width) {
+            self.mir.push(Aarch64Inst::NarrowStoreIndexed {
+                src: Operand::Virtual(src),
+                base: ptr,
+                offset: byte_offset,
+                width: access.width,
+            });
+        } else {
+            let base = self.narrow_ptr_base(ptr, byte_offset);
+            self.mir.push(Aarch64Inst::NarrowStoreIndexed {
+                src: Operand::Virtual(src),
+                base,
+                offset: 0,
+                width: access.width,
+            });
+        }
     }
     fn emit_narrow_load_through_ptr(
         &mut self,
@@ -3336,13 +3361,26 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
         byte_offset: i32,
         access: crate::types::NarrowScalar,
     ) {
-        let base = self.narrow_ptr_base(ptr, byte_offset);
-        self.mir.push(Aarch64Inst::NarrowLoadIndexed {
-            dst: Operand::Virtual(dst),
-            base,
-            width: access.width,
-            signed: access.signed,
-        });
+        // Fold when the scaled imm12 form can encode the offset, else materialize
+        // (RUE-1079); see `emit_narrow_store_through_ptr`.
+        if aarch64_narrow_offset_encodable(byte_offset, access.width) {
+            self.mir.push(Aarch64Inst::NarrowLoadIndexed {
+                dst: Operand::Virtual(dst),
+                base: ptr,
+                offset: byte_offset,
+                width: access.width,
+                signed: access.signed,
+            });
+        } else {
+            let base = self.narrow_ptr_base(ptr, byte_offset);
+            self.mir.push(Aarch64Inst::NarrowLoadIndexed {
+                dst: Operand::Virtual(dst),
+                base,
+                offset: 0,
+                width: access.width,
+                signed: access.signed,
+            });
+        }
     }
     fn emit_zero_vreg(&mut self) -> VReg {
         let dst = self.mir.alloc_vreg();

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -65,6 +65,32 @@ use super::mir::{
 };
 use crate::{EmittedCode, EmittedInst, EmittedRelocation};
 
+/// Scale a folded byte `offset` into the unsigned scaled `imm12` field of a
+/// narrow load/store (RUE-1079). The immediate is scaled by the access `width`
+/// (`ldrb`/`strb` by 1, `ldrh`/`strh` by 2, `ldr w`/`str w` by 4), so the
+/// encoded index is `offset / width`. CFG-lowering only folds an offset the
+/// scaled form can encode; the asserts (kept in release) re-check that invariant
+/// so a mis-threaded offset traps rather than encoding a wrong address.
+fn narrow_scaled_imm12(offset: i32, width: u8) -> u32 {
+    let width = width as i32;
+    assert!(
+        offset >= 0 && offset % width == 0 && offset / width <= 0xFFF,
+        "narrow access offset {offset} not encodable in scaled imm12 for width {width}"
+    );
+    (offset / width) as u32 & 0xFFF
+}
+
+/// Format a folded narrow addressing offset for the textual assembly dump:
+/// `, #N` for a nonzero offset, the empty string for offset 0 (so a zero-offset
+/// narrow access prints `[base]`, byte-identical to before RUE-1079).
+fn fmt_narrow_offset(offset: i32) -> String {
+    if offset == 0 {
+        String::new()
+    } else {
+        format!(", #{offset}")
+    }
+}
+
 // ========== AArch64 Instruction Encoding Constants ==========
 //
 // These constants represent the base opcodes for AArch64 instructions.
@@ -713,44 +739,54 @@ impl<'a> Emitter<'a> {
             Aarch64Inst::NarrowLoad {
                 dst,
                 base,
+                offset,
                 width,
                 signed,
             } => {
                 let rd = dst.as_physical();
                 self.begin_inst();
-                self.emit_narrow_load(rd, *base, *width, *signed);
+                self.emit_narrow_load(rd, *base, *offset, *width, *signed);
                 // A sign-extending load targets the 64-bit X register; a
                 // zero-extending load targets the 32-bit W register (which
                 // implicitly clears the upper half).
+                let disp = fmt_narrow_offset(*offset);
                 if *signed {
                     end_inst!(
                         self,
-                        "{} {}, [{}]",
+                        "{} {}, [{}{}]",
                         narrow_load_mnemonic(*width, *signed),
                         rd,
-                        base
+                        base,
+                        disp
                     );
                 } else {
                     end_inst!(
                         self,
-                        "{} {}, [{}]",
+                        "{} {}, [{}{}]",
                         narrow_load_mnemonic(*width, *signed),
                         rd.as_w(),
-                        base
+                        base,
+                        disp
                     );
                 }
             }
 
-            Aarch64Inst::NarrowStore { src, base, width } => {
+            Aarch64Inst::NarrowStore {
+                src,
+                base,
+                offset,
+                width,
+            } => {
                 let rs = src.as_physical();
                 self.begin_inst();
-                self.emit_narrow_store(rs, *base, *width);
+                self.emit_narrow_store(rs, *base, *offset, *width);
                 end_inst!(
                     self,
-                    "{} {}, [{}]",
+                    "{} {}, [{}{}]",
                     narrow_store_mnemonic(*width),
                     rs.as_w(),
-                    base
+                    base,
+                    fmt_narrow_offset(*offset)
                 );
             }
 
@@ -1699,12 +1735,13 @@ impl<'a> Emitter<'a> {
         }
     }
 
-    /// Emit a narrow (1/2/4-byte) load of `[base]` extended into the 64-bit `rd`
-    /// (RUE-989). The address is fully materialized in `base` (imm12 = 0), so
-    /// there is no offset to scale. The unsigned forms (`ldrb`/`ldrh`/`ldr w`)
-    /// zero-extend into the X register; the signed forms
+    /// Emit a narrow (1/2/4-byte) load of `[base, #offset]` extended into the
+    /// 64-bit `rd` (RUE-989). `offset` is a byte displacement folded into the
+    /// scaled `imm12` field (RUE-1079): the immediate is scaled by the access
+    /// width, so the encoded index is `offset / width`. The unsigned forms
+    /// (`ldrb`/`ldrh`/`ldr w`) zero-extend into the X register; the signed forms
     /// (`ldrsb`/`ldrsh`/`ldrsw`, 64-bit variant) sign-extend into it.
-    fn emit_narrow_load(&mut self, rd: Reg, base: Reg, width: u8, signed: bool) {
+    fn emit_narrow_load(&mut self, rd: Reg, base: Reg, offset: i32, width: u8, signed: bool) {
         let base_opcode: u32 = match (width, signed) {
             (1, false) => 0x3940_0000, // ldrb  w, [base]
             (1, true) => 0x3980_0000,  // ldrsb x, [base]
@@ -1714,20 +1751,25 @@ impl<'a> Emitter<'a> {
             (4, true) => 0xB980_0000,  // ldrsw x, [base]
             _ => unreachable!("narrow load width must be 1, 2, or 4: {width}"),
         };
-        let inst = base_opcode | ((base.encoding() as u32) << 5) | rd.encoding() as u32;
+        let imm12 = narrow_scaled_imm12(offset, width);
+        let inst =
+            base_opcode | (imm12 << 10) | ((base.encoding() as u32) << 5) | rd.encoding() as u32;
         self.emit_u32(inst);
     }
 
     /// Emit a narrow (1/2/4-byte) store of the low `width` bytes of `rs` to
-    /// `[base]` (RUE-989), the address fully materialized in `base` (imm12 = 0).
-    fn emit_narrow_store(&mut self, rs: Reg, base: Reg, width: u8) {
+    /// `[base, #offset]` (RUE-989); `offset` is folded into the scaled `imm12`
+    /// field (RUE-1079), encoded index `offset / width`.
+    fn emit_narrow_store(&mut self, rs: Reg, base: Reg, offset: i32, width: u8) {
         let base_opcode: u32 = match width {
             1 => 0x3900_0000, // strb w, [base]
             2 => 0x7900_0000, // strh w, [base]
             4 => 0xB900_0000, // str  w, [base]
             _ => unreachable!("narrow store width must be 1, 2, or 4: {width}"),
         };
-        let inst = base_opcode | ((base.encoding() as u32) << 5) | rs.encoding() as u32;
+        let imm12 = narrow_scaled_imm12(offset, width);
+        let inst =
+            base_opcode | (imm12 << 10) | ((base.encoding() as u32) << 5) | rs.encoding() as u32;
         self.emit_u32(inst);
     }
 
@@ -2618,6 +2660,7 @@ mod tests {
             let code = emit_single(Aarch64Inst::NarrowLoad {
                 dst: Operand::Physical(Reg::X0),
                 base: Reg::X1,
+                offset: 0,
                 width,
                 signed,
             });
@@ -2631,6 +2674,30 @@ mod tests {
         assert_eq!(word(4, true), 0xB980_0020); // ldrsw x0, [x1]
     }
 
+    /// RUE-1079: a nonzero byte offset folds into the narrow load's scaled imm12
+    /// (encoded index = offset / width), not a materialized `base + offset`.
+    #[test]
+    fn test_narrow_load_encoding_folded_offset() {
+        let word = |base: Reg, offset, width, signed| {
+            let code = emit_single(Aarch64Inst::NarrowLoad {
+                dst: Operand::Physical(Reg::X0),
+                base,
+                offset,
+                width,
+                signed,
+            });
+            u32::from_le_bytes(code[0..4].try_into().unwrap())
+        };
+        // ldr w0, [x1, #4] -> base ldr(w) opcode with scaled imm12 = 4/4 = 1.
+        assert_eq!(word(Reg::X1, 4, 4, false), 0xB940_0020 | (1 << 10));
+        // ldrb w0, [x1, #3] -> ldrb scales by 1, imm12 = 3.
+        assert_eq!(word(Reg::X1, 3, 1, false), 0x3940_0020 | (3 << 10));
+        // ldrh w0, [x1, #2] -> ldrh scales by 2, imm12 = 2/2 = 1.
+        assert_eq!(word(Reg::X1, 2, 2, false), 0x7940_0020 | (1 << 10));
+        // ldr w0, [x1, #12] -> imm12 = 12/4 = 3.
+        assert_eq!(word(Reg::X1, 12, 4, false), 0xB940_0020 | (3 << 10));
+    }
+
     /// RUE-989: the narrow physical store through a pointer selects
     /// strb/strh/str(w) per width. src X2, base X3.
     #[test]
@@ -2639,6 +2706,7 @@ mod tests {
             let code = emit_single(Aarch64Inst::NarrowStore {
                 src: Operand::Physical(Reg::X2),
                 base: Reg::X3,
+                offset: 0,
                 width,
             });
             u32::from_le_bytes(code[0..4].try_into().unwrap())
@@ -2646,6 +2714,27 @@ mod tests {
         assert_eq!(word(1), 0x3900_0062); // strb w2, [x3]
         assert_eq!(word(2), 0x7900_0062); // strh w2, [x3]
         assert_eq!(word(4), 0xB900_0062); // str  w2, [x3]
+    }
+
+    /// RUE-1079: a nonzero byte offset folds into the narrow store's scaled
+    /// imm12 (encoded index = offset / width).
+    #[test]
+    fn test_narrow_store_encoding_folded_offset() {
+        let word = |offset, width| {
+            let code = emit_single(Aarch64Inst::NarrowStore {
+                src: Operand::Physical(Reg::X2),
+                base: Reg::X3,
+                offset,
+                width,
+            });
+            u32::from_le_bytes(code[0..4].try_into().unwrap())
+        };
+        // str w2, [x3, #4] -> str(w) scales by 4, imm12 = 1.
+        assert_eq!(word(4, 4), 0xB900_0062 | (1 << 10));
+        // strb w2, [x3, #3] -> strb scales by 1, imm12 = 3.
+        assert_eq!(word(3, 1), 0x3900_0062 | (3 << 10));
+        // strh w2, [x3, #2] -> strh scales by 2, imm12 = 1.
+        assert_eq!(word(2, 2), 0x7900_0062 | (1 << 10));
     }
 
     #[test]

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -428,32 +428,50 @@ pub enum Aarch64Inst {
     /// Pre-register-allocation narrow (1/2/4-byte) load through a virtual
     /// address, extended into the 64-bit `dst` (ADR-0052, RUE-989). `signed`
     /// selects `ldrsb`/`ldrsh`/`ldrsw` (sign-extend) versus `ldrb`/`ldrh`/`ldr w`
-    /// (zero-extend). The address is fully materialized in `base`, so no offset
-    /// is encoded. Register allocation lowers this to [`Aarch64Inst::NarrowLoad`].
+    /// (zero-extend). `offset` is a constant byte displacement folded into the
+    /// scaled `imm12` addressing mode (RUE-1079); cfg-lowering only emits an
+    /// `offset` the scaled form can encode (`offset >= 0`, a multiple of `width`,
+    /// scaled index <= 0xFFF), otherwise the base is materialized and `offset` is
+    /// 0. Register allocation lowers this to [`Aarch64Inst::NarrowLoad`].
     NarrowLoadIndexed {
         dst: Operand,
         base: VReg,
+        offset: i32,
         width: u8,
         signed: bool,
     },
 
     /// Pre-register-allocation narrow (1/2/4-byte) store of the low `width` bytes
-    /// of `src` through a virtual address (`strb`/`strh`/`str w`). Register
-    /// allocation lowers this to [`Aarch64Inst::NarrowStore`].
-    NarrowStoreIndexed { src: Operand, base: VReg, width: u8 },
+    /// of `src` through a virtual address (`strb`/`strh`/`str w`). `offset` is a
+    /// constant byte displacement folded into the scaled `imm12` addressing mode
+    /// (RUE-1079); see [`Aarch64Inst::NarrowLoadIndexed`] for the encodability
+    /// rule. Register allocation lowers this to [`Aarch64Inst::NarrowStore`].
+    NarrowStoreIndexed {
+        src: Operand,
+        base: VReg,
+        offset: i32,
+        width: u8,
+    },
 
-    /// Narrow (1/2/4-byte) load of `[base]` extended into the 64-bit `dst`, the
-    /// physical-base form of [`Aarch64Inst::NarrowLoadIndexed`].
+    /// Narrow (1/2/4-byte) load of `[base, #offset]` extended into the 64-bit
+    /// `dst`, the physical-base form of [`Aarch64Inst::NarrowLoadIndexed`].
     NarrowLoad {
         dst: Operand,
         base: Reg,
+        offset: i32,
         width: u8,
         signed: bool,
     },
 
-    /// Narrow (1/2/4-byte) store of the low `width` bytes of `src` to `[base]`,
-    /// the physical-base form of [`Aarch64Inst::NarrowStoreIndexed`].
-    NarrowStore { src: Operand, base: Reg, width: u8 },
+    /// Narrow (1/2/4-byte) store of the low `width` bytes of `src` to
+    /// `[base, #offset]`, the physical-base form of
+    /// [`Aarch64Inst::NarrowStoreIndexed`].
+    NarrowStore {
+        src: Operand,
+        base: Reg,
+        offset: i32,
+        width: u8,
+    },
 
     /// `ldr dst, [base, #offset]` - Load from memory via register with offset.
     LdrIndexedOffset {
@@ -857,6 +875,17 @@ impl Aarch64Inst {
     }
 }
 
+/// Format a constant addressing-mode offset for the `Display` dump: `, #N` for
+/// a nonzero offset, the empty string for offset 0 — so a zero-offset narrow
+/// access prints `[base]`, byte-identical to before RUE-1079.
+fn fmt_addr_offset(offset: i32) -> String {
+    if offset == 0 {
+        String::new()
+    } else {
+        format!(", #{offset}")
+    }
+}
+
 /// The load mnemonic for a narrow access width and extension, used in the
 /// textual MIR dump of the narrow load instructions.
 pub(crate) fn narrow_load_mnemonic(width: u8, signed: bool) -> &'static str {
@@ -906,32 +935,60 @@ impl fmt::Display for Aarch64Inst {
             Aarch64Inst::NarrowLoadIndexed {
                 dst,
                 base,
+                offset,
                 width,
                 signed,
             } => write!(
                 f,
-                "{} {}, [{}]",
+                "{} {}, [{}{}]",
                 narrow_load_mnemonic(*width, *signed),
                 dst,
-                base
+                base,
+                fmt_addr_offset(*offset),
             ),
-            Aarch64Inst::NarrowStoreIndexed { src, base, width } => {
-                write!(f, "{} {}, [{}]", narrow_store_mnemonic(*width), src, base)
+            Aarch64Inst::NarrowStoreIndexed {
+                src,
+                base,
+                offset,
+                width,
+            } => {
+                write!(
+                    f,
+                    "{} {}, [{}{}]",
+                    narrow_store_mnemonic(*width),
+                    src,
+                    base,
+                    fmt_addr_offset(*offset),
+                )
             }
             Aarch64Inst::NarrowLoad {
                 dst,
                 base,
+                offset,
                 width,
                 signed,
             } => write!(
                 f,
-                "{} {}, [{}]",
+                "{} {}, [{}{}]",
                 narrow_load_mnemonic(*width, *signed),
                 dst,
-                base
+                base,
+                fmt_addr_offset(*offset),
             ),
-            Aarch64Inst::NarrowStore { src, base, width } => {
-                write!(f, "{} {}, [{}]", narrow_store_mnemonic(*width), src, base)
+            Aarch64Inst::NarrowStore {
+                src,
+                base,
+                offset,
+                width,
+            } => {
+                write!(
+                    f,
+                    "{} {}, [{}{}]",
+                    narrow_store_mnemonic(*width),
+                    src,
+                    base,
+                    fmt_addr_offset(*offset),
+                )
             }
             Aarch64Inst::LdrIndexedOffset { dst, base, offset } => {
                 if *offset == 0 {

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -745,6 +745,7 @@ impl RegAlloc {
             Aarch64Inst::NarrowLoadIndexed {
                 dst,
                 base,
+                offset: addr_offset,
                 width,
                 signed,
             } => {
@@ -754,6 +755,7 @@ impl RegAlloc {
                     Some(Allocation::Register(reg)) => mir.push(Aarch64Inst::NarrowLoad {
                         dst: Operand::Physical(reg),
                         base: base_phys,
+                        offset: addr_offset,
                         width,
                         signed,
                     }),
@@ -761,6 +763,7 @@ impl RegAlloc {
                         mir.push(Aarch64Inst::NarrowLoad {
                             dst: Operand::Physical(Reg::X10),
                             base: base_phys,
+                            offset: addr_offset,
                             width,
                             signed,
                         });
@@ -776,18 +779,25 @@ impl RegAlloc {
                     None => mir.push(Aarch64Inst::NarrowLoad {
                         dst,
                         base: base_phys,
+                        offset: addr_offset,
                         width,
                         signed,
                     }),
                 }
             }
 
-            Aarch64Inst::NarrowStoreIndexed { src, base, width } => {
+            Aarch64Inst::NarrowStoreIndexed {
+                src,
+                base,
+                offset,
+                width,
+            } => {
                 let src_op = Self::load_operand(context, mir, src, Reg::X9)?;
                 let base_reg = Self::load_operand(context, mir, Operand::Virtual(base), Reg::X10)?;
                 mir.push(Aarch64Inst::NarrowStore {
                     src: src_op,
                     base: base_reg.as_physical(),
+                    offset,
                     width,
                 });
             }
@@ -974,17 +984,27 @@ impl RegAlloc {
             Aarch64Inst::NarrowLoad {
                 dst,
                 base,
+                offset,
                 width,
                 signed,
             } => mir.push(Aarch64Inst::NarrowLoad {
                 dst,
                 base,
+                offset,
                 width,
                 signed,
             }),
-            Aarch64Inst::NarrowStore { src, base, width } => {
-                mir.push(Aarch64Inst::NarrowStore { src, base, width })
-            }
+            Aarch64Inst::NarrowStore {
+                src,
+                base,
+                offset,
+                width,
+            } => mir.push(Aarch64Inst::NarrowStore {
+                src,
+                base,
+                offset,
+                width,
+            }),
         }
         Ok(())
     }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2145,6 +2145,7 @@ impl<'a> CfgLower<'a> {
                             self.mir.push(X86Inst::NarrowLoadIndexed {
                                 dst: Operand::Virtual(dst),
                                 base: ptr,
+                                offset: 0,
                                 width: narrow.width,
                                 signed: narrow.signed,
                             });
@@ -2200,6 +2201,7 @@ impl<'a> CfgLower<'a> {
                     self.mir.push(X86Inst::NarrowStoreIndexed {
                         base: ptr,
                         src: Operand::Virtual(value.primary),
+                        offset: 0,
                         width: narrow.width,
                     });
                 } else {
@@ -3049,27 +3051,6 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     }
 }
 
-impl CfgLower<'_> {
-    /// Materialize `ptr + byte_offset` for a narrow access that encodes no
-    /// displacement, returning `ptr` unchanged when the offset is zero
-    /// (RUE-1000).
-    fn narrow_ptr_base(&mut self, ptr: VReg, byte_offset: i32) -> VReg {
-        if byte_offset == 0 {
-            return ptr;
-        }
-        let base = self.mir.alloc_vreg();
-        self.mir.push(X86Inst::MovRR {
-            dst: Operand::Virtual(base),
-            src: Operand::Virtual(ptr),
-        });
-        self.mir.push(X86Inst::AddRI {
-            dst: Operand::Virtual(base),
-            imm: byte_offset,
-        });
-        base
-    }
-}
-
 impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     fn ctx(&self) -> &crate::cfg_lower::CfgLowerContext<'_> {
         &self.ctx
@@ -3126,12 +3107,13 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
         byte_offset: i32,
         access: crate::types::NarrowScalar,
     ) {
-        // The narrow store addresses `[base]` with no displacement, so fold the
-        // byte offset into a materialized base pointer first (RUE-1000).
-        let base = self.narrow_ptr_base(ptr, byte_offset);
+        // x86 `[base+disp]` encodes any i32 displacement (disp8/disp32), so fold
+        // the byte offset straight into the narrow store's addressing mode
+        // (RUE-1079) rather than materializing `base+offset` into a register.
         self.mir.push(X86Inst::NarrowStoreIndexed {
-            base,
+            base: ptr,
             src: Operand::Virtual(src),
+            offset: byte_offset,
             width: access.width,
         });
     }
@@ -3142,10 +3124,11 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
         byte_offset: i32,
         access: crate::types::NarrowScalar,
     ) {
-        let base = self.narrow_ptr_base(ptr, byte_offset);
+        // x86 folds any i32 displacement into the load's ModRM byte (RUE-1079).
         self.mir.push(X86Inst::NarrowLoadIndexed {
             dst: Operand::Virtual(dst),
-            base,
+            base: ptr,
+            offset: byte_offset,
             width: access.width,
             signed: access.signed,
         });

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -743,29 +743,37 @@ impl<'a> Emitter<'a> {
             X86Inst::NarrowLoadRM {
                 dst,
                 base,
+                offset,
                 width,
                 signed,
             } => {
                 self.begin_inst();
-                self.emit_narrow_load_rm(dst.as_physical(), *base, *width, *signed);
+                self.emit_narrow_load_rm(dst.as_physical(), *base, *offset, *width, *signed);
                 let ext = if *signed { "movsx" } else { "movzx" };
                 end_inst!(
                     self,
-                    "{} {}, {}[{}]",
+                    "{} {}, {}[{}{}]",
                     ext,
                     dst.as_physical(),
                     narrow_width_keyword(*width),
-                    base
+                    base,
+                    format_offset(*offset),
                 );
             }
-            X86Inst::NarrowStoreMR { base, src, width } => {
+            X86Inst::NarrowStoreMR {
+                base,
+                src,
+                offset,
+                width,
+            } => {
                 self.begin_inst();
-                self.emit_narrow_store_mr(*base, src.as_physical(), *width);
+                self.emit_narrow_store_mr(*base, src.as_physical(), *offset, *width);
                 end_inst!(
                     self,
-                    "mov {}[{}], {}",
+                    "mov {}[{}{}], {}",
                     narrow_width_keyword(*width),
                     base,
+                    format_offset(*offset),
                     src.as_physical()
                 );
             }
@@ -1520,7 +1528,7 @@ impl<'a> Emitter<'a> {
     /// - width 2, sign: `movsx r64, word [m]`  = REX.W 0F BF /r
     /// - width 4, zero: `mov r32, dword [m]`   = 8B /r (no REX.W; zero-extends)
     /// - width 4, sign: `movsxd r64, dword [m]`= REX.W 63 /r
-    fn emit_narrow_load_rm(&mut self, dst: Reg, base: Reg, width: u8, signed: bool) {
+    fn emit_narrow_load_rm(&mut self, dst: Reg, base: Reg, disp: i32, width: u8, signed: bool) {
         if width == 4 && !signed {
             // 32-bit `mov` writes the low dword and zeroes the upper dword of the
             // 64-bit destination, so no REX.W (a bare REX only if a high register
@@ -1531,7 +1539,7 @@ impl<'a> Emitter<'a> {
                 self.code.push(0x40 | rex);
             }
             self.code.push(0x8b);
-            self.emit_modrm_memory(dst.encoding(), base.encoding(), 0);
+            self.emit_modrm_memory(dst.encoding(), base.encoding(), disp);
             return;
         }
         let rex =
@@ -1545,18 +1553,18 @@ impl<'a> Emitter<'a> {
             (4, true) => self.code.push(0x63),
             _ => unreachable!("narrow load width must be 1, 2, or 4: {width}"),
         }
-        self.emit_modrm_memory(dst.encoding(), base.encoding(), 0);
+        self.emit_modrm_memory(dst.encoding(), base.encoding(), disp);
     }
 
     /// Emit a narrow (1/2/4-byte) store of the low `width` bytes of `src` to
-    /// `[base]` (RUE-989).
+    /// `[base + disp]` (RUE-989, displacement folded per RUE-1079).
     ///
     /// - width 1: `mov byte [m], r8`   = [REX] 88 /r
     /// - width 2: `mov word [m], r16`  = 66 [REX] 89 /r
     /// - width 4: `mov dword [m], r32` = [REX] 89 /r
-    fn emit_narrow_store_mr(&mut self, base: Reg, src: Reg, width: u8) {
+    fn emit_narrow_store_mr(&mut self, base: Reg, src: Reg, disp: i32, width: u8) {
         match width {
-            1 => self.emit_mov_mr8(base, 0, src),
+            1 => self.emit_mov_mr8(base, disp, src),
             2 | 4 => {
                 if width == 2 {
                     // 16-bit operand-size override; must precede any REX prefix.
@@ -1568,7 +1576,7 @@ impl<'a> Emitter<'a> {
                     self.code.push(0x40 | rex);
                 }
                 self.code.push(0x89);
-                self.emit_modrm_memory(src.encoding(), base.encoding(), 0);
+                self.emit_modrm_memory(src.encoding(), base.encoding(), disp);
             }
             _ => unreachable!("narrow store width must be 1, 2, or 4: {width}"),
         }
@@ -3953,6 +3961,7 @@ mod tests {
             emit_single(X86Inst::NarrowLoadRM {
                 dst: Operand::Physical(Reg::Rax),
                 base: Reg::Rbx,
+                offset: 0,
                 width,
                 signed,
             })
@@ -3971,6 +3980,38 @@ mod tests {
         assert_eq!(load(4, true), vec![0x48, 0x63, 0x43, 0x00]);
     }
 
+    /// RUE-1079: a nonzero constant byte offset folds into the narrow load's
+    /// ModRM displacement rather than materializing `base+offset` in a register.
+    #[test]
+    fn test_narrow_load_encoding_folded_offset() {
+        let load = |base, offset, width, signed| {
+            emit_single(X86Inst::NarrowLoadRM {
+                dst: Operand::Physical(Reg::Rax),
+                base,
+                offset,
+                width,
+                signed,
+            })
+        };
+        // mov eax, dword [rcx+4] -> 8B /r, mod=01 rm=001 (rcx), disp8=4
+        assert_eq!(load(Reg::Rcx, 4, 4, false), vec![0x8b, 0x41, 0x04]);
+        // movzx rax, byte [rbx+3] -> REX.W 0F B6, mod=01 rm=011 (rbx), disp8=3
+        assert_eq!(
+            load(Reg::Rbx, 3, 1, false),
+            vec![0x48, 0x0f, 0xb6, 0x43, 0x03]
+        );
+        // movzx rax, word [rbx+8] -> REX.W 0F B7, disp8=8
+        assert_eq!(
+            load(Reg::Rbx, 8, 2, false),
+            vec![0x48, 0x0f, 0xb7, 0x43, 0x08]
+        );
+        // mov eax, dword [rbx+256] -> disp32 form (mod=10), 00 01 00 00 LE
+        assert_eq!(
+            load(Reg::Rbx, 256, 4, false),
+            vec![0x8b, 0x83, 0x00, 0x01, 0x00, 0x00]
+        );
+    }
+
     /// RUE-989: the narrow physical store through a pointer truncates the source
     /// to 1/2/4 bytes. Base Rbx (no REX), src Rcx.
     #[test]
@@ -3979,6 +4020,7 @@ mod tests {
             emit_single(X86Inst::NarrowStoreMR {
                 base: Reg::Rbx,
                 src: Operand::Physical(Reg::Rcx),
+                offset: 0,
                 width,
             })
         };
@@ -3988,6 +4030,26 @@ mod tests {
         assert_eq!(store(2), vec![0x66, 0x89, 0x4b, 0x00]);
         // mov dword [rbx], ecx -> 89 (no prefix, no REX needed)
         assert_eq!(store(4), vec![0x89, 0x4b, 0x00]);
+    }
+
+    /// RUE-1079: a nonzero constant byte offset folds into the narrow store's
+    /// ModRM displacement.
+    #[test]
+    fn test_narrow_store_encoding_folded_offset() {
+        let store = |offset, width| {
+            emit_single(X86Inst::NarrowStoreMR {
+                base: Reg::Rbx,
+                src: Operand::Physical(Reg::Rcx),
+                offset,
+                width,
+            })
+        };
+        // mov byte [rbx+4], cl -> [REX] 88, mod=01 rm=011, disp8=4
+        assert_eq!(store(4, 1), vec![0x40, 0x88, 0x4b, 0x04]);
+        // mov word [rbx+2], cx -> 66 89, disp8=2
+        assert_eq!(store(2, 2), vec![0x66, 0x89, 0x4b, 0x02]);
+        // mov dword [rbx+12], ecx -> 89, disp8=12
+        assert_eq!(store(12, 4), vec![0x89, 0x4b, 0x0c]);
     }
 
     // --- Add with immediate ---

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -485,37 +485,51 @@ pub enum X86Inst {
         src: Operand,
     },
 
-    /// Pre-register-allocation narrow (1/2/4-byte) load of `[base]` extended
-    /// into the 64-bit `dst` (ADR-0052, RUE-989). `signed` selects `movsx`
-    /// (sign-extend) versus `movzx`/`mov r32` (zero-extend). The pointer address
-    /// is fully materialized in `base`, so no displacement is encoded. Register
+    /// Pre-register-allocation narrow (1/2/4-byte) load of `[base + offset]`
+    /// extended into the 64-bit `dst` (ADR-0052, RUE-989). `signed` selects
+    /// `movsx` (sign-extend) versus `movzx`/`mov r32` (zero-extend). `offset` is
+    /// a constant byte displacement folded into the ModRM addressing mode
+    /// (RUE-1079); any `i32` is encodable on x86 (disp8/disp32). Register
     /// allocation lowers this to [`X86Inst::NarrowLoadRM`].
     NarrowLoadIndexed {
         dst: Operand,
         base: VReg,
+        offset: i32,
         width: u8,
         signed: bool,
     },
 
     /// Pre-register-allocation narrow (1/2/4-byte) store of the low `width`
-    /// bytes of `src` to `[base]` (ADR-0052, RUE-989). Register allocation lowers
-    /// this to [`X86Inst::NarrowStoreMR`].
-    NarrowStoreIndexed { base: VReg, src: Operand, width: u8 },
+    /// bytes of `src` to `[base + offset]` (ADR-0052, RUE-989). `offset` is a
+    /// constant byte displacement folded into the ModRM addressing mode
+    /// (RUE-1079). Register allocation lowers this to [`X86Inst::NarrowStoreMR`].
+    NarrowStoreIndexed {
+        base: VReg,
+        src: Operand,
+        offset: i32,
+        width: u8,
+    },
 
-    /// Narrow (1/2/4-byte) load of `[base]` extended into the 64-bit `dst`
-    /// (`movzx`/`movsx`/`movsxd`/`mov r32`), the physical-base form of
+    /// Narrow (1/2/4-byte) load of `[base + offset]` extended into the 64-bit
+    /// `dst` (`movzx`/`movsx`/`movsxd`/`mov r32`), the physical-base form of
     /// [`X86Inst::NarrowLoadIndexed`].
     NarrowLoadRM {
         dst: Operand,
         base: Reg,
+        offset: i32,
         width: u8,
         signed: bool,
     },
 
-    /// Narrow (1/2/4-byte) store of the low `width` bytes of `src` to `[base]`
-    /// (`mov byte/word/dword [m], r`), the physical-base form of
-    /// [`X86Inst::NarrowStoreIndexed`].
-    NarrowStoreMR { base: Reg, src: Operand, width: u8 },
+    /// Narrow (1/2/4-byte) store of the low `width` bytes of `src` to
+    /// `[base + offset]` (`mov byte/word/dword [m], r`), the physical-base form
+    /// of [`X86Inst::NarrowStoreIndexed`].
+    NarrowStoreMR {
+        base: Reg,
+        src: Operand,
+        offset: i32,
+        width: u8,
+    },
 
     /// `mov dst, [base + index*scale + disp]` - Load from memory with SIB addressing.
     ///
@@ -601,6 +615,13 @@ fn mem_width_keyword(width: u8) -> &'static str {
         4 => "dword ",
         _ => "",
     }
+}
+
+/// Format a constant addressing-mode displacement for `Display`: `+N`/`-N` for
+/// a nonzero offset, the empty string for offset 0 — so zero-offset narrow
+/// accesses print byte-identically to before RUE-1079.
+fn fmt_disp(offset: i32) -> String {
+    crate::format_offset(offset)
 }
 
 impl fmt::Display for X86Inst {
@@ -735,40 +756,68 @@ impl fmt::Display for X86Inst {
             X86Inst::NarrowLoadIndexed {
                 dst,
                 base,
+                offset,
                 width,
                 signed,
             } => {
                 let ext = if *signed { "movsx" } else { "movzx" };
                 write!(
                     f,
-                    "{} {}, {}[{}]",
+                    "{} {}, {}[{}{}]",
                     ext,
                     dst,
                     mem_width_keyword(*width),
-                    base
+                    base,
+                    fmt_disp(*offset),
                 )
             }
-            X86Inst::NarrowStoreIndexed { base, src, width } => {
-                write!(f, "mov {}[{}], {}", mem_width_keyword(*width), base, src)
+            X86Inst::NarrowStoreIndexed {
+                base,
+                src,
+                offset,
+                width,
+            } => {
+                write!(
+                    f,
+                    "mov {}[{}{}], {}",
+                    mem_width_keyword(*width),
+                    base,
+                    fmt_disp(*offset),
+                    src
+                )
             }
             X86Inst::NarrowLoadRM {
                 dst,
                 base,
+                offset,
                 width,
                 signed,
             } => {
                 let ext = if *signed { "movsx" } else { "movzx" };
                 write!(
                     f,
-                    "{} {}, {}[{}]",
+                    "{} {}, {}[{}{}]",
                     ext,
                     dst,
                     mem_width_keyword(*width),
-                    base
+                    base,
+                    fmt_disp(*offset),
                 )
             }
-            X86Inst::NarrowStoreMR { base, src, width } => {
-                write!(f, "mov {}[{}], {}", mem_width_keyword(*width), base, src)
+            X86Inst::NarrowStoreMR {
+                base,
+                src,
+                offset,
+                width,
+            } => {
+                write!(
+                    f,
+                    "mov {}[{}{}], {}",
+                    mem_width_keyword(*width),
+                    base,
+                    fmt_disp(*offset),
+                    src
+                )
             }
             X86Inst::MovRMSib {
                 dst,

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -731,6 +731,7 @@ impl RegAlloc {
             X86Inst::NarrowLoadIndexed {
                 dst,
                 base,
+                offset,
                 width,
                 signed,
             } => {
@@ -740,6 +741,7 @@ impl RegAlloc {
                     Some(Allocation::Register(reg)) => mir.push(X86Inst::NarrowLoadRM {
                         dst: Operand::Physical(reg),
                         base: base_phys,
+                        offset,
                         width,
                         signed,
                     }),
@@ -747,6 +749,7 @@ impl RegAlloc {
                         mir.push(X86Inst::NarrowLoadRM {
                             dst: Operand::Physical(Reg::Rdx),
                             base: base_phys,
+                            offset,
                             width,
                             signed,
                         });
@@ -762,18 +765,25 @@ impl RegAlloc {
                     None => mir.push(X86Inst::NarrowLoadRM {
                         dst,
                         base: base_phys,
+                        offset,
                         width,
                         signed,
                     }),
                 }
             }
 
-            X86Inst::NarrowStoreIndexed { base, src, width } => {
+            X86Inst::NarrowStoreIndexed {
+                base,
+                src,
+                offset,
+                width,
+            } => {
                 let src_op = Self::load_operand(context, mir, src, Reg::Rdx)?;
                 let base_reg = Self::load_operand(context, mir, Operand::Virtual(base), Reg::Rax)?;
                 mir.push(X86Inst::NarrowStoreMR {
                     base: base_reg.as_physical(),
                     src: src_op,
+                    offset,
                     width,
                 });
             }
@@ -923,17 +933,27 @@ impl RegAlloc {
             X86Inst::NarrowLoadRM {
                 dst,
                 base,
+                offset,
                 width,
                 signed,
             } => mir.push(X86Inst::NarrowLoadRM {
                 dst,
                 base,
+                offset,
                 width,
                 signed,
             }),
-            X86Inst::NarrowStoreMR { base, src, width } => {
-                mir.push(X86Inst::NarrowStoreMR { base, src, width })
-            }
+            X86Inst::NarrowStoreMR {
+                base,
+                src,
+                offset,
+                width,
+            } => mir.push(X86Inst::NarrowStoreMR {
+                base,
+                src,
+                offset,
+                width,
+            }),
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

Under the compact physical layout (ADR-0052, default since RUE-987), a **narrow** (1/2/4-byte) struct-field or aggregate-slot access at a **nonzero constant byte offset** did not fold the offset into the load/store addressing mode. Codegen materialized `base + offset` into a fresh register (`narrow_ptr_base`, RUE-1000) and addressed `[base]`, because the `NarrowLoad/StoreIndexed` MIR ops carried no displacement. Full-width (8-byte) accesses and offset-0 narrow accesses already folded — only nonzero-offset narrow accesses paid an extra base-copy + `add` per field.

This was found to be the dominant contributor to the produced-program throughput regression investigated in RUE-1077 (compact layout vs. the old slot-model layout).

## Change

Thread a folded `offset` through the narrow load/store MIR ops (`*Indexed` → physical form → encoder) on both backends:

- **x86-64**: `emit_modrm_memory` already selects disp8/disp32; the narrow emitters were passing a hardcoded `0`. Pass the real displacement — any `i32` offset folds into `movzx dst, dword [base+disp]` / narrow store.
- **AArch64**: fold into the scaled `imm12` form (`ldrb`/`strb` ×1, `ldrh`/`strh` ×2, `ldr w`/`str w` ×4) when the offset is non-negative, a multiple of `width`, and its scaled index fits `imm12`; otherwise fall back to `narrow_ptr_base` materialization (never miscompiles).

Before → after (fields at offsets 4/8/12):
- x86-64: `mov r14, r12; add r14, 4; movzx r15, dword [r14]` → `movzx r14, dword [r12+4]`
- AArch64: `add x21, x19, #4; ldr w22, [x21]` → `ldr w21, [x19, #4]`

## Verification

- Harbor selftest digest unchanged (`85530708304687882`, `failures=0`) — pure codegen change, identical behavior.
- Harbor `add reg,imm` count: **1657 → 0** (matches the old slot-model layout); total instructions 220164 → 217653.
- `//crates/rue-codegen/...` 605 passed (incl. 4 new folded-offset encoder tests on both backends); `scripts/rue quick` 34 passed, oracle 0 disagreements; spec 2156 passed; cli-abi 61 passed (struct/aggregate marshalling). AArch64 native execution is CI-validated.

Fixes RUE-1079


---
_Generated by [Claude Code](https://claude.ai/code/session_01CSSAeJ3bsMGKNtvg7nyNhs)_