### PR TITLE
RUE-1020: make cached Rust sysroots relocatable

### DIFF
--- a/toolchains/rust/BUCK
+++ b/toolchains/rust/BUCK
@@ -5,6 +5,17 @@
 
 load(":defs.bzl", "RUST_VERSION", "RUST_RELEASES", "RUST_STD_RELEASES", "hermetic_rust_toolchain", "rustfmt", "host_rustfmt")
 
+export_file(
+    name = "merge-sysroot",
+    src = "merge_sysroot.sh",
+)
+
+sh_test(
+    name = "merge-sysroot-test",
+    test = "merge_sysroot_test.sh",
+    args = ["$(location :merge-sysroot)"],
+)
+
 # Download Rust for Linux x86_64
 http_archive(
     name = "rust-linux-x86_64",
@@ -184,6 +195,7 @@ _CLIPPY_ALLOW = [
 hermetic_rust_toolchain(
     name = "hermetic-linux-x86_64",
     distribution = ":rust-linux-x86_64",
+    merge_script = ":merge-sysroot",
     target_triple = "x86_64-unknown-linux-gnu",
     default_edition = "2024",
     deny_lints = ["warnings"],
@@ -196,6 +208,7 @@ hermetic_rust_toolchain(
 hermetic_rust_toolchain(
     name = "hermetic-linux-aarch64",
     distribution = ":rust-linux-aarch64",
+    merge_script = ":merge-sysroot",
     target_triple = "aarch64-unknown-linux-gnu",
     default_edition = "2024",
     deny_lints = ["warnings"],
@@ -208,6 +221,7 @@ hermetic_rust_toolchain(
 hermetic_rust_toolchain(
     name = "hermetic-macos-aarch64",
     distribution = ":rust-macos-aarch64",
+    merge_script = ":merge-sysroot",
     target_triple = "aarch64-apple-darwin",
     default_edition = "2024",
     deny_lints = ["warnings"],
@@ -220,6 +234,7 @@ hermetic_rust_toolchain(
 hermetic_rust_toolchain(
     name = "hermetic-macos-x86_64",
     distribution = ":rust-macos-x86_64",
+    merge_script = ":merge-sysroot",
     target_triple = "x86_64-apple-darwin",
     default_edition = "2024",
     deny_lints = ["warnings"],

--- a/toolchains/rust/defs.bzl
+++ b/toolchains/rust/defs.bzl
@@ -111,51 +111,16 @@ def _hermetic_rust_toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
     )
     clippy_driver = RunInfo(args = cmd_args(clippy_wrapper, hidden = [clippy_bin, clippy_lib_dir]))
 
-    # Build a merged sysroot by running a shell script
+    # Build a merged sysroot by running the checked-in shell script. Keeping the
+    # script as an explicit action input ensures content changes invalidate the
+    # action cache along with the generated sysroot.
     # The Rust distribution has components in separate directories that need merging:
     #   rustc/                                      - compiler and core libs
     #   rust-std-{triple}/lib/rustlib/{triple}/lib/ - stdlib rlibs
     #
     # We use a shell action to create symlinks properly merging these.
     sysroot = ctx.actions.declare_output("sysroot", dir = True)
-    merge_script = ctx.actions.write(
-        "merge_sysroot.sh",
-        [
-            "#!/bin/bash",
-            "set -e",
-            "DIST=$(cd \"$1\" && pwd)",  # Convert to absolute path
-            "SYSROOT=$2",
-            "TRIPLE=$3",
-            "",
-            "# Create sysroot structure",
-            "mkdir -p \"$SYSROOT\"",
-            "",
-            "# Link top-level dirs from rustc",
-            "ln -s \"$DIST/rustc/bin\" \"$SYSROOT/bin\"",
-            "ln -s \"$DIST/rustc/libexec\" \"$SYSROOT/libexec\"",
-            "",
-            "# Create lib structure manually to merge rustlib",
-            "mkdir -p \"$SYSROOT/lib/rustlib/$TRIPLE\"",
-            "",
-            "# Link compiler libs (dylibs at lib/)",
-            "for f in \"$DIST/rustc/lib/\"*; do",
-            "    name=$(basename \"$f\")",
-            "    if [ \"$name\" != \"rustlib\" ]; then",
-            "        ln -s \"$f\" \"$SYSROOT/lib/$name\"",
-            "    fi",
-            "done",
-            "",
-            "# Link rustlib/etc",
-            "ln -s \"$DIST/rustc/lib/rustlib/etc\" \"$SYSROOT/lib/rustlib/etc\"",
-            "",
-            "# Link target bin (rust-lld)",
-            "ln -s \"$DIST/rustc/lib/rustlib/$TRIPLE/bin\" \"$SYSROOT/lib/rustlib/$TRIPLE/bin\"",
-            "",
-            "# Link target lib (stdlib from rust-std)",
-            "ln -s \"$DIST/rust-std-$TRIPLE/lib/rustlib/$TRIPLE/lib\" \"$SYSROOT/lib/rustlib/$TRIPLE/lib\"",
-        ],
-        is_executable = True,
-    )
+    merge_script = ctx.attrs.merge_script
 
     ctx.actions.run(
         cmd_args(
@@ -198,6 +163,9 @@ hermetic_rust_toolchain = rule(
     attrs = {
         "distribution": attrs.dep(
             doc = "The downloaded Rust distribution (from http_archive)",
+        ),
+        "merge_script": attrs.source(
+            doc = "Portable script that assembles a relocatable Rust sysroot",
         ),
         "target_triple": attrs.string(
             doc = "The target triple (e.g., x86_64-unknown-linux-gnu)",

--- a/toolchains/rust/merge_sysroot.sh
+++ b/toolchains/rust/merge_sysroot.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -euo pipefail
+
+dist=$1
+sysroot=$2
+triple=$3
+
+# Work with absolute paths while calculating each link, but only store the
+# relative path between the link's directory and its target. Unlike `ln -r` or
+# `realpath --relative-to`, this uses only shell path manipulation available in
+# the Bash shipped by macOS as well as Linux.
+dist=$(cd "$dist" && pwd)
+sysroot_parent=$(cd "$(dirname "$sysroot")" && pwd)
+sysroot="$sysroot_parent/$(basename "$sysroot")"
+
+relative_path() {
+    local from=${1#/}
+    local to=${2#/}
+    local from_head
+    local to_head
+    local result=
+
+    # Remove the common path prefix one component at a time.
+    while [ -n "$from" ] && [ -n "$to" ]; do
+        from_head=${from%%/*}
+        to_head=${to%%/*}
+        if [ "$from_head" != "$to_head" ]; then
+            break
+        fi
+
+        if [ "$from" = "$from_head" ]; then
+            from=
+        else
+            from=${from#*/}
+        fi
+        if [ "$to" = "$to_head" ]; then
+            to=
+        else
+            to=${to#*/}
+        fi
+    done
+
+    # Walk up once for every component left in the link's directory.
+    while [ -n "$from" ]; do
+        result="../$result"
+        if [ "$from" = "${from%%/*}" ]; then
+            from=
+        else
+            from=${from#*/}
+        fi
+    done
+
+    result="$result$to"
+    if [ -z "$result" ]; then
+        result=.
+    fi
+    printf '%s\n' "$result"
+}
+
+link_relative() {
+    local target=$1
+    local link=$2
+    local link_dir
+    local target_dir
+    local target_path
+
+    link_dir=$(cd "$(dirname "$link")" && pwd)
+    target_dir=$(cd "$(dirname "$target")" && pwd)
+    target_path="$target_dir/$(basename "$target")"
+    ln -s "$(relative_path "$link_dir" "$target_path")" "$link"
+}
+
+# Create the sysroot structure and merge the separately packaged compiler and
+# standard-library components into the layout rustc expects.
+mkdir -p "$sysroot"
+link_relative "$dist/rustc/bin" "$sysroot/bin"
+link_relative "$dist/rustc/libexec" "$sysroot/libexec"
+
+mkdir -p "$sysroot/lib/rustlib/$triple"
+
+# Link compiler libraries while reserving rustlib for the merged structure.
+for file in "$dist/rustc/lib/"*; do
+    name=$(basename "$file")
+    if [ "$name" != "rustlib" ]; then
+        link_relative "$file" "$sysroot/lib/$name"
+    fi
+done
+
+link_relative \
+    "$dist/rustc/lib/rustlib/etc" \
+    "$sysroot/lib/rustlib/etc"
+link_relative \
+    "$dist/rustc/lib/rustlib/$triple/bin" \
+    "$sysroot/lib/rustlib/$triple/bin"
+link_relative \
+    "$dist/rust-std-$triple/lib/rustlib/$triple/lib" \
+    "$sysroot/lib/rustlib/$triple/lib"

--- a/toolchains/rust/merge_sysroot_test.sh
+++ b/toolchains/rust/merge_sysroot_test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -euo pipefail
+
+merge_script=$1
+triple=x86_64-unknown-linux-gnu
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/rue-merge-sysroot.XXXXXX")
+trap 'rm -rf "$test_root"' EXIT
+
+producer="$test_root/original/producer"
+dist="$producer/dist"
+sysroot="$producer/sysroot"
+
+mkdir -p \
+    "$dist/rustc/bin" \
+    "$dist/rustc/libexec" \
+    "$dist/rustc/lib/rustlib/etc" \
+    "$dist/rustc/lib/rustlib/$triple/bin" \
+    "$dist/rust-std-$triple/lib/rustlib/$triple/lib"
+
+printf 'rustc\n' > "$dist/rustc/bin/rustc"
+printf 'rustdoc\n' > "$dist/rustc/bin/rustdoc"
+printf 'libexec\n' > "$dist/rustc/libexec/rust-analyzer-proc-macro-srv"
+printf 'compiler dylib\n' > "$dist/rustc/lib/librustc_driver.fake"
+printf 'debugger helpers\n' > "$dist/rustc/lib/rustlib/etc/gdb_load_rust_pretty_printers.py"
+printf 'linker\n' > "$dist/rustc/lib/rustlib/$triple/bin/rust-lld"
+printf 'standard library\n' > \
+    "$dist/rust-std-$triple/lib/rustlib/$triple/lib/libstd.fake.rlib"
+
+/bin/bash "$merge_script" "$dist" "$sysroot" "$triple"
+
+assert_relative_link() {
+    local path=$1
+    local target
+
+    if [ ! -L "$path" ]; then
+        echo "expected symlink: $path" >&2
+        exit 1
+    fi
+    target=$(readlink "$path")
+    case "$target" in
+        /*)
+            echo "expected relative symlink, got $path -> $target" >&2
+            exit 1
+            ;;
+    esac
+    if [ ! -e "$path" ]; then
+        echo "symlink does not resolve: $path -> $target" >&2
+        exit 1
+    fi
+}
+
+assert_sysroot() {
+    local root=$1
+
+    assert_relative_link "$root/bin"
+    assert_relative_link "$root/libexec"
+    assert_relative_link "$root/lib/librustc_driver.fake"
+    assert_relative_link "$root/lib/rustlib/etc"
+    assert_relative_link "$root/lib/rustlib/$triple/bin"
+    assert_relative_link "$root/lib/rustlib/$triple/lib"
+
+    [ "$(cat "$root/bin/rustc")" = rustc ]
+    [ "$(cat "$root/libexec/rust-analyzer-proc-macro-srv")" = libexec ]
+    [ "$(cat "$root/lib/librustc_driver.fake")" = "compiler dylib" ]
+    [ "$(cat "$root/lib/rustlib/etc/gdb_load_rust_pretty_printers.py")" = "debugger helpers" ]
+    [ "$(cat "$root/lib/rustlib/$triple/bin/rust-lld")" = linker ]
+    [ "$(cat "$root/lib/rustlib/$triple/lib/libstd.fake.rlib")" = "standard library" ]
+}
+
+assert_sysroot "$sysroot"
+
+mkdir -p "$test_root/relocated"
+mv "$producer" "$test_root/relocated/producer"
+assert_sysroot "$test_root/relocated/producer/sysroot"


### PR DESCRIPTION
## Summary

- assemble the hermetic Rust sysroot with portable relative symlinks
- make the checked-in merge script an explicit Buck action input so old non-relocatable cache entries cannot reuse the action key
- add a regression that produces a sysroot under one root, relocates it, and verifies every compiler and standard-library path remains consumable

## Root cause

The generated merge action canonicalized the Rust distribution to an absolute producer path before creating symlinks. BuildBuddy preserved those targets in the cached output, so a GitHub-produced artifact pointed local macOS builds into the runner checkout.

## Impact

Cached macOS Rust toolchains can now materialize in a different checkout without losing `std` or other sysroot components. Cache misses and local execution behavior are unchanged.

## Validation

- `./buck2 test toolchains//rust:merge-sysroot-test`
- `scripts/rue build`
- `scripts/rue quick`
- inspected the generated macOS sysroot: 27 relative links, 0 absolute links, all sampled links resolving

Fixes RUE-1020