### PR TITLE
RUE-1026: query exact declaration bodies

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1558,6 +1558,11 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
             "raw_declaration_signature_cache",
             "warm_raw_declaration_signature",
             "eager_raw_declaration_signature",
+            "legacy_raw_declaration_body",
+            "fallback_raw_declaration_body",
+            "raw_declaration_body_cache",
+            "warm_raw_declaration_body",
+            "eager_raw_declaration_body",
         ] {
             assert!(
                 !source.contains(retired),
@@ -1569,6 +1574,7 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
                 ".evaluate_declaration_shell(",
                 ".evaluate_raw_const_syntax(",
                 ".evaluate_raw_declaration_signature(",
+                ".evaluate_raw_declaration_body(",
                 ".declaration_capabilities()",
                 "project_semantic_shell(",
             ] {
@@ -1594,6 +1600,15 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
             assert!(
                 !source.contains("RawDeclarationSignature"),
                 "compiler production module {name} escaped the raw-signature authority allowlist"
+            );
+        }
+        if !matches!(
+            *name,
+            "declaration_candidate" | "parsed_modules" | "revisioned_query_database"
+        ) {
+            assert!(
+                !source.contains("RawDeclarationBody"),
+                "compiler production module {name} escaped the raw-body authority allowlist"
             );
         }
     }
@@ -1624,7 +1639,38 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         1
     );
     assert_eq!(parsed.matches("RawDeclarationSignatureSyntax {").count(), 1);
+    assert_eq!(
+        runtime.matches(".evaluate_raw_declaration_body(").count(),
+        1
+    );
+    assert_eq!(
+        parsed.matches("fn evaluate_raw_declaration_body(").count(),
+        1
+    );
+    assert_eq!(
+        runtime.matches("\"compiler.raw-declaration-body\"").count(),
+        1
+    );
+    assert_eq!(parsed.matches("RawDeclarationBodySyntax {").count(), 1);
     assert!(!runtime.contains("Vec::remove"));
+
+    let raw_body_evaluator = runtime
+        .split("let occurrences_for_raw_body")
+        .nth(1)
+        .and_then(|tail| tail.split("let index_for_lookup").next())
+        .unwrap();
+    for forbidden in [
+        "module_rirs",
+        "lower_module_rir",
+        "CanonicalMergedProgram",
+        "Sema",
+        "SemanticView",
+    ] {
+        assert!(
+            !raw_body_evaluator.contains(forbidden),
+            "raw-body syntax evaluator gained a broad compiler dependency: {forbidden}"
+        );
+    }
 
     let occurrence = runtime
         .split("struct DeclarationOccurrenceIndex {")
@@ -1685,6 +1731,28 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
     let raw_signature_terminal = runtime
         .split("enum RawDeclarationSignatureQueryValue")
         .nth(1)
+        .and_then(|tail| tail.split("struct RawDeclarationBodyQueryKey").next())
+        .unwrap();
+    for forbidden in [
+        "CompileErrors",
+        "Span",
+        "FileId",
+        "Spur",
+        "Ast",
+        "InstRef",
+        "Rir",
+        "TypeId",
+        "SemanticDefinitionToken",
+        "SemanticModuleToken",
+    ] {
+        assert!(
+            !raw_signature_terminal.contains(forbidden),
+            "raw-signature terminal regained positioned/live parser or semantic payload: {forbidden}"
+        );
+    }
+    let raw_body_terminal = runtime
+        .split("enum RawDeclarationBodyQueryValue")
+        .nth(1)
         .and_then(|tail| {
             tail.split("pub(crate) enum DeclarationShellBatchFailure")
                 .next()
@@ -1703,8 +1771,8 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         "SemanticModuleToken",
     ] {
         assert!(
-            !raw_signature_terminal.contains(forbidden),
-            "raw-signature terminal regained positioned/live parser or semantic payload: {forbidden}"
+            !raw_body_terminal.contains(forbidden),
+            "raw-body terminal regained positioned/live parser or semantic payload: {forbidden}"
         );
     }
     let raw_const_payload = module("declaration_candidate")
@@ -1730,6 +1798,20 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         assert!(
             !raw_signature_payload.contains(forbidden),
             "raw-signature payload regained a positioned or live parser/semantic handle: {forbidden}"
+        );
+    }
+    let raw_body_payload = module("declaration_candidate")
+        .split("pub(crate) struct RawDeclarationBodySyntax")
+        .nth(1)
+        .and_then(|tail| {
+            tail.split("pub(crate) enum RawDeclarationBodyFailure")
+                .next()
+        })
+        .unwrap();
+    for forbidden in ["Span", "FileId", "Spur", "Ast", "Rir", "InstRef", "TypeId"] {
+        assert!(
+            !raw_body_payload.contains(forbidden),
+            "raw-body payload regained a positioned or live parser/semantic handle: {forbidden}"
         );
     }
     let raw_signature_locator = parsed

--- a/crates/rue-compiler/src/declaration_candidate.rs
+++ b/crates/rue-compiler/src/declaration_candidate.rs
@@ -129,6 +129,30 @@ pub(crate) enum RawDeclarationSignatureFailure {
     ParserCapabilityMismatch(DeclarationCandidateKey),
 }
 
+/// Parser-validated syntax for one body-bearing declaration, detached from its
+/// source epoch and parser symbol universe.
+///
+/// The fragment is exactly the declaration's body expression, including its
+/// delimiters. It deliberately excludes the signature and trivia between the
+/// signature's last token and the body. This is a syntax input only: runtime
+/// body analysis remains a later query family, while declaration-time
+/// comptime reduction can reparse this exact demanded producer without
+/// requesting a whole-module RIR.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct RawDeclarationBodySyntax {
+    pub(crate) body: Arc<str>,
+}
+
+/// Stable, position-free failure retained by the exact raw-body family.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RawDeclarationBodyFailure {
+    OccurrencesUnavailable(DeclarationOccurrenceFailure),
+    Absent(DeclarationCandidateKey),
+    Ambiguous(DeclarationCandidateKey),
+    CategoryMismatch(DeclarationCandidateKey),
+    ParserCapabilityMismatch(DeclarationCandidateKey),
+}
+
 impl DeclarationCandidateKey {
     pub(crate) fn stable_identity(&self) -> String {
         // Length-prefix every user-authored component. Query identities must

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -31,7 +31,7 @@ use crate::{
     declaration_candidate::{
         DeclarationCandidateCategory, DeclarationCandidateKey, DeclarationCandidateOwner,
         DeclarationOccurrenceCapability, DeclarationParameterHeader, DeclarationParameterMode,
-        DeclarationShellFact, DeclarationShellFailure, RawConstSyntax,
+        DeclarationShellFact, DeclarationShellFailure, RawConstSyntax, RawDeclarationBodySyntax,
         RawDeclarationSignatureSyntax,
     },
 };
@@ -159,6 +159,8 @@ pub struct ParsedDefinitionIndex {
     #[cfg(test)]
     raw_declaration_signature_terminal_materializations: Arc<AtomicUsize>,
     #[cfg(test)]
+    raw_declaration_body_terminal_materializations: Arc<AtomicUsize>,
+    #[cfg(test)]
     by_name: BTreeMap<(DefinitionNamespace, Arc<str>), Arc<[ParsedDefinitionOccurrence]>>,
 }
 
@@ -280,6 +282,35 @@ impl ParsedDefinitionIndex {
             .load(Ordering::Relaxed)
     }
 
+    /// Materialize the syntax for exactly one body-bearing declaration key.
+    /// The current-epoch span stays parser-private; only owned source text may
+    /// cross the revisioned query boundary.
+    fn materialize_raw_declaration_body(
+        &self,
+        key: &DeclarationCandidateKey,
+        source_text: &str,
+    ) -> Option<RawDeclarationBodySyntax> {
+        let index = self.declaration_by_key.get(key).copied()?;
+        let candidate = self.declarations.get(index)?;
+        if candidate.fact.key != *key {
+            return None;
+        }
+        let body = candidate.raw_body_span?;
+        let syntax = RawDeclarationBodySyntax {
+            body: Arc::from(source_text.get(body.start as usize..body.end as usize)?),
+        };
+        #[cfg(test)]
+        self.raw_declaration_body_terminal_materializations
+            .fetch_add(1, Ordering::Relaxed);
+        Some(syntax)
+    }
+
+    #[cfg(test)]
+    fn raw_declaration_body_terminal_materialization_count(&self) -> usize {
+        self.raw_declaration_body_terminal_materializations
+            .load(Ordering::Relaxed)
+    }
+
     pub(crate) fn declaration_locator(
         &self,
         key: &DeclarationCandidateKey,
@@ -314,6 +345,7 @@ pub(crate) struct ParsedDeclarationCandidate {
     declaration_span: Span,
     raw_const_syntax_spans: Option<RawConstSyntaxSpans>,
     raw_signature_locator: Option<RawDeclarationSignatureLocator>,
+    raw_body_span: Option<Span>,
 }
 
 /// Parser-private locators for syntax that is materialized only after an exact
@@ -485,6 +517,20 @@ impl ParsedModule {
     pub(crate) fn raw_declaration_signature_terminal_materialization_count(&self) -> usize {
         self.definitions
             .raw_declaration_signature_terminal_materialization_count()
+    }
+
+    pub(crate) fn evaluate_raw_declaration_body(
+        &self,
+        key: &DeclarationCandidateKey,
+    ) -> Option<RawDeclarationBodySyntax> {
+        self.definitions
+            .materialize_raw_declaration_body(key, self.source_text())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn raw_declaration_body_terminal_materialization_count(&self) -> usize {
+        self.definitions
+            .raw_declaration_body_terminal_materialization_count()
     }
 
     #[cfg(test)]
@@ -1264,6 +1310,7 @@ fn bind_payload(
                         }
                     },
                 ),
+                raw_body_span: candidate.raw_body_span.map(remap_span),
             })
             .collect::<Vec<_>>()
             .into(),
@@ -1278,6 +1325,11 @@ fn bind_payload(
         raw_declaration_signature_terminal_materializations: payload
             .definitions
             .raw_declaration_signature_terminal_materializations
+            .clone(),
+        #[cfg(test)]
+        raw_declaration_body_terminal_materializations: payload
+            .definitions
+            .raw_declaration_body_terminal_materializations
             .clone(),
         #[cfg(test)]
         by_name: payload.definitions.by_name.clone(),
@@ -1668,6 +1720,7 @@ fn build_definition_index(
         Span,
         Option<RawConstSyntaxSpans>,
         Option<RawDeclarationSignatureLocator>,
+        Option<Span>,
     )>::new();
     let resolve_name = |ident: rue_parser::Ident| -> CompileResult<Arc<str>> {
         let symbol = resolver.symbol(ident.name)?;
@@ -1746,7 +1799,8 @@ fn build_definition_index(
                         declaration_span,
                         signature_spans: Vec<Span>,
                         raw_const_syntax_spans: Option<RawConstSyntaxSpans>,
-                        raw_signature_locator: Option<RawDeclarationSignatureLocator>|
+                        raw_signature_locator: Option<RawDeclarationSignatureLocator>,
+                        raw_body_span: Option<Span>|
          -> CompileResult<()> {
             let signature_fingerprint = declaration_signature_fingerprint(
                 file_id,
@@ -1776,6 +1830,9 @@ fn build_definition_index(
                     validate_span("raw extern ABI", span, file_id, source_text)?;
                 }
             }
+            if let Some(body) = raw_body_span {
+                validate_span("raw declaration body", body, file_id, source_text)?;
+            }
             pending_declarations.push((
                 DeclarationShellFact {
                     key: DeclarationCandidateKey {
@@ -1797,6 +1854,7 @@ fn build_definition_index(
                 declaration_span,
                 raw_const_syntax_spans,
                 raw_signature_locator,
+                raw_body_span,
             ));
             Ok(())
         };
@@ -1823,6 +1881,7 @@ fn build_definition_index(
                         tokens,
                     )?,
                 }),
+                Some(function.body.span()),
             )?,
             Item::Struct(structure) => {
                 let owner_name = resolve_name(structure.name)?;
@@ -1841,6 +1900,7 @@ fn build_definition_index(
                     signature_fragments_excluding_method_bodies(structure)?,
                     None,
                     Some(struct_signature_locator(structure, tokens)?),
+                    None,
                 )?;
                 let owner = DeclarationCandidateOwner {
                     category: DeclarationCandidateCategory::Struct,
@@ -1879,6 +1939,7 @@ fn build_definition_index(
                                 tokens,
                             )?,
                         }),
+                        Some(method.body.span()),
                     )?;
                 }
             }
@@ -1899,6 +1960,7 @@ fn build_definition_index(
                 Some(RawDeclarationSignatureLocator::Contiguous {
                     declaration: token_bounded_declaration(value.span, tokens)?,
                 }),
+                None,
             )?,
             Item::Const(value) => {
                 let declared_type = value.ty.as_ref().map(TypeExpr::span);
@@ -1926,6 +1988,7 @@ fn build_definition_index(
                     vec![signature_prefix(value.span, value.init.span())?],
                     Some(raw_const_syntax_spans),
                     None,
+                    None,
                 )?;
             }
             Item::DropFn(value) => push(
@@ -1952,6 +2015,7 @@ fn build_definition_index(
                         tokens,
                     )?,
                 }),
+                Some(value.body.span()),
             )?,
             Item::Extern(block) => {
                 for function in &block.fns {
@@ -1973,6 +2037,7 @@ fn build_definition_index(
                             declaration: token_bounded_declaration(function.span, tokens)?,
                             abi: block.abi_span,
                         }),
+                        None,
                     )?;
                 }
             }
@@ -2041,7 +2106,13 @@ fn build_definition_index(
     let declarations = pending_declarations
         .into_iter()
         .map(
-            |(mut fact, declaration_span, raw_const_syntax_spans, raw_signature_locator)| {
+            |(
+                mut fact,
+                declaration_span,
+                raw_const_syntax_spans,
+                raw_signature_locator,
+                raw_body_span,
+            )| {
                 let duplicate = duplicate_counts
                     .entry((
                         fact.key.category,
@@ -2058,6 +2129,7 @@ fn build_definition_index(
                     declaration_span,
                     raw_const_syntax_spans,
                     raw_signature_locator,
+                    raw_body_span,
                 })
             },
         )
@@ -2091,6 +2163,8 @@ fn build_definition_index(
         raw_const_syntax_materializations: Arc::new(AtomicUsize::new(0)),
         #[cfg(test)]
         raw_declaration_signature_terminal_materializations: Arc::new(AtomicUsize::new(0)),
+        #[cfg(test)]
+        raw_declaration_body_terminal_materializations: Arc::new(AtomicUsize::new(0)),
         #[cfg(test)]
         by_name,
     })

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -401,6 +401,11 @@ pub(crate) struct RevisionedQueryDatabase {
     #[cfg_attr(not(test), allow(dead_code))]
     raw_declaration_signatures:
         QueryFamily<RawDeclarationSignatureQueryKey, RawDeclarationSignatureQueryValue>,
+    // Exact body text is an input for the later declaration-time comptime
+    // evaluator. It is not runtime body semantics and must never request a
+    // whole-module RIR.
+    #[cfg_attr(not(test), allow(dead_code))]
+    raw_declaration_bodies: QueryFamily<RawDeclarationBodyQueryKey, RawDeclarationBodyQueryValue>,
     module_rirs: QueryFamily<ModuleQueryKey, ModuleRirValue>,
     resolve_imports: QueryFamily<ResolveImportKey, ResolveImportValue>,
     lookup_names: QueryFamily<LookupNameKey, LookupNameValue>,
@@ -510,6 +515,21 @@ impl QueryKey for RawDeclarationSignatureQueryKey {
 enum RawDeclarationSignatureQueryValue {
     Available(crate::declaration_candidate::RawDeclarationSignatureSyntax),
     Failure(crate::declaration_candidate::RawDeclarationSignatureFailure),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RawDeclarationBodyQueryKey(crate::declaration_candidate::DeclarationCandidateKey);
+
+impl QueryKey for RawDeclarationBodyQueryKey {
+    fn stable_identity(&self) -> String {
+        self.0.stable_identity()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RawDeclarationBodyQueryValue {
+    Available(crate::declaration_candidate::RawDeclarationBodySyntax),
+    Failure(crate::declaration_candidate::RawDeclarationBodyFailure),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1352,6 +1372,151 @@ impl Default for RevisionedQueryDatabase {
                 },
             )
             .expect("the RawDeclarationSignature family has one canonical name");
+        let occurrences_for_raw_body = declaration_occurrence_indexes.clone();
+        let shells_for_raw_body = declaration_shells.clone();
+        let parse_for_raw_body = parse_modules.clone();
+        let raw_declaration_bodies = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.raw-declaration-body",
+                MODULE_QUERY_MEMO_RETENTION,
+                |left: &RawDeclarationBodyQueryValue,
+                 right: &RawDeclarationBodyQueryValue| { left == right },
+                move |context, _, key: &RawDeclarationBodyQueryKey| {
+                    use crate::declaration_candidate::{
+                        DeclarationCandidateCategory, DeclarationOccurrenceCapability,
+                        DeclarationShellFailure, RawDeclarationBodyFailure,
+                    };
+
+                    let indexed = context.query_registered(
+                        &occurrences_for_raw_body,
+                        ModuleQueryKey(key.0.module.clone()),
+                    )?;
+                    let rue_query::QueryOutcome::Success(indexed) = indexed.outcome() else {
+                        unreachable!("DeclarationOccurrenceIndex publishes typed values")
+                    };
+                    let value = match indexed {
+                        DeclarationOccurrenceIndexValue::Failure(failure) => {
+                            RawDeclarationBodyQueryValue::Failure(
+                                RawDeclarationBodyFailure::OccurrencesUnavailable(failure.clone()),
+                            )
+                        }
+                        DeclarationOccurrenceIndexValue::Available(index) => {
+                            match index.capabilities.get(&key.0) {
+                                None => RawDeclarationBodyQueryValue::Failure(
+                                    RawDeclarationBodyFailure::Absent(key.0.clone()),
+                                ),
+                                Some(DeclarationOccurrenceCapability::Ambiguous { .. }) => {
+                                    RawDeclarationBodyQueryValue::Failure(
+                                        RawDeclarationBodyFailure::Ambiguous(key.0.clone()),
+                                    )
+                                }
+                                Some(DeclarationOccurrenceCapability::Exact {
+                                    duplicate_multiplicity: 0,
+                                    ..
+                                }) => RawDeclarationBodyQueryValue::Failure(
+                                    RawDeclarationBodyFailure::ParserCapabilityMismatch(
+                                        key.0.clone(),
+                                    ),
+                                ),
+                                Some(DeclarationOccurrenceCapability::Exact { .. }) => {
+                                    let shell = context.query_registered(
+                                        &shells_for_raw_body,
+                                        DeclarationShellQueryKey(key.0.clone()),
+                                    )?;
+                                    let rue_query::QueryOutcome::Success(shell) = shell.outcome()
+                                    else {
+                                        unreachable!("DeclarationShell publishes typed values")
+                                    };
+                                    match shell {
+                                        DeclarationShellQueryValue::Failure(failure) => {
+                                            let failure = match failure {
+                                                DeclarationShellFailure::OccurrencesUnavailable(
+                                                    failure,
+                                                ) => RawDeclarationBodyFailure::OccurrencesUnavailable(
+                                                    failure.clone(),
+                                                ),
+                                                DeclarationShellFailure::Absent(key) => {
+                                                    RawDeclarationBodyFailure::Absent(key.clone())
+                                                }
+                                                DeclarationShellFailure::Ambiguous(key) => {
+                                                    RawDeclarationBodyFailure::Ambiguous(key.clone())
+                                                }
+                                                DeclarationShellFailure::ParserCapabilityMismatch(
+                                                    key,
+                                                ) => RawDeclarationBodyFailure::ParserCapabilityMismatch(
+                                                    key.clone(),
+                                                ),
+                                            };
+                                            RawDeclarationBodyQueryValue::Failure(failure)
+                                        }
+                                        DeclarationShellQueryValue::Available(fact)
+                                            if !matches!(
+                                                fact.key.category,
+                                                DeclarationCandidateCategory::Function
+                                                    | DeclarationCandidateCategory::Method
+                                                    | DeclarationCandidateCategory::AssociatedFunction
+                                                    | DeclarationCandidateCategory::Destructor
+                                            ) =>
+                                        {
+                                            RawDeclarationBodyQueryValue::Failure(
+                                                RawDeclarationBodyFailure::CategoryMismatch(
+                                                    key.0.clone(),
+                                                ),
+                                            )
+                                        }
+                                        DeclarationShellQueryValue::Available(fact)
+                                            if fact.key != key.0 =>
+                                        {
+                                            RawDeclarationBodyQueryValue::Failure(
+                                                RawDeclarationBodyFailure::ParserCapabilityMismatch(
+                                                    key.0.clone(),
+                                                ),
+                                            )
+                                        }
+                                        DeclarationShellQueryValue::Available(_) => {
+                                            let parsed = context.query_registered(
+                                                &parse_for_raw_body,
+                                                ModuleQueryKey(key.0.module.clone()),
+                                            )?;
+                                            let rue_query::QueryOutcome::Success(parsed) =
+                                                parsed.outcome()
+                                            else {
+                                                unreachable!("ParseModule publishes typed values")
+                                            };
+                                            match &parsed.result {
+                                                Err(_) => RawDeclarationBodyQueryValue::Failure(
+                                                    RawDeclarationBodyFailure::OccurrencesUnavailable(
+                                                        crate::declaration_candidate::DeclarationOccurrenceFailure::ParseRejected {
+                                                            module: key.0.module.clone(),
+                                                        },
+                                                    ),
+                                                ),
+                                                Ok(module) => module
+                                                    .evaluate_raw_declaration_body(&key.0)
+                                                    .map_or_else(
+                                                        || RawDeclarationBodyQueryValue::Failure(
+                                                            RawDeclarationBodyFailure::ParserCapabilityMismatch(
+                                                                key.0.clone(),
+                                                            ),
+                                                        ),
+                                                        RawDeclarationBodyQueryValue::Available,
+                                                    ),
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    };
+                    let kind = if matches!(value, RawDeclarationBodyQueryValue::Available(_)) {
+                        QueryTerminalKind::Success
+                    } else {
+                        QueryTerminalKind::Failure
+                    };
+                    Ok(QueryOutput::success(value).with_terminal_kind(kind))
+                },
+            )
+            .expect("the RawDeclarationBody family has one canonical name");
         let index_for_lookup = module_indexes.clone();
         let lookup_names = runtime
             .family_with_evaluator(
@@ -1491,6 +1656,7 @@ impl Default for RevisionedQueryDatabase {
             declaration_shells,
             raw_const_syntax,
             raw_declaration_signatures,
+            raw_declaration_bodies,
             module_rirs,
             resolve_imports,
             lookup_names,
@@ -3346,6 +3512,269 @@ mod tests {
                 )
             ) if failed_module == &module
         ));
+    }
+
+    #[test]
+    fn raw_declaration_body_is_exact_lazy_and_red_green() {
+        fn program(selected_body: &str, unrelated_body: u32) -> String {
+            let mut source = String::new();
+            for index in 0..128 {
+                let body = if index == 64 { unrelated_body } else { index };
+                source.push_str(&format!("fn unrelated{index}() -> i32 {{ {body} }}\n"));
+            }
+            source.push_str(&format!(
+                "fn selected(comptime T: type) -> type // boundary trivia\n{{ {selected_body} }}\n"
+            ));
+            source
+        }
+
+        let first_text = program("struct { value: T }", 64);
+        let unrelated_edit_text = program("struct { value: T }", 999);
+        let selected_edit_text = program("enum { Value(T), Empty }", 999);
+        let first = source_snapshot(&[(1, "/main.rue", "main.rue", &first_text)], 1);
+        let unrelated_edit =
+            source_snapshot(&[(1, "/main.rue", "main.rue", &unrelated_edit_text)], 1);
+        let selected_edit =
+            source_snapshot(&[(1, "/main.rue", "main.rue", &selected_edit_text)], 1);
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let key = crate::declaration_candidate::DeclarationCandidateKey {
+            module: module.clone(),
+            category: crate::declaration_candidate::DeclarationCandidateCategory::Function,
+            name: Arc::from("selected"),
+            owner: None,
+            duplicate_discriminator: 0,
+        };
+        let mut database = RevisionedQueryDatabase::default();
+        let first_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&first),
+            &first,
+        );
+        let parsed = database.runtime.request_registered(
+            &database.parse_modules,
+            first_revision,
+            ModuleQueryKey(module),
+            CancellationToken::new(),
+        );
+        let parsed_module = match parsed.terminal().unwrap().outcome() {
+            rue_query::QueryOutcome::Success(value) => value.result.clone().unwrap(),
+            rue_query::QueryOutcome::Failure(_) => unreachable!(),
+        };
+        assert_eq!(
+            parsed_module.raw_declaration_body_terminal_materialization_count(),
+            0,
+            "indexing must not allocate raw-body terminal text"
+        );
+
+        let first_request = database.runtime.request_registered(
+            &database.raw_declaration_bodies,
+            first_revision,
+            RawDeclarationBodyQueryKey(key.clone()),
+            CancellationToken::new(),
+        );
+        assert_eq!(execution(&first_request), RequestExecution::Computed);
+        assert_eq!(
+            first_request
+                .dependencies()
+                .iter()
+                .map(|dependency| dependency.node.family())
+                .collect::<Vec<_>>(),
+            vec![
+                "compiler.declaration-occurrence-index",
+                "compiler.declaration-shell",
+                "compiler.parse-module",
+            ]
+        );
+        let first_terminal = first_request.terminal().unwrap();
+        let first_stamp = first_terminal.stamp();
+        assert!(matches!(
+            first_terminal.outcome(),
+            rue_query::QueryOutcome::Success(RawDeclarationBodyQueryValue::Available(syntax))
+                if syntax.body.as_ref() == "{ struct { value: T } }"
+        ));
+        assert_eq!(
+            parsed_module.raw_declaration_body_terminal_materialization_count(),
+            1
+        );
+
+        let warm = database.runtime.request_registered(
+            &database.raw_declaration_bodies,
+            first_revision,
+            RawDeclarationBodyQueryKey(key.clone()),
+            CancellationToken::new(),
+        );
+        assert_eq!(execution(&warm), RequestExecution::Reused);
+        assert_eq!(
+            parsed_module.raw_declaration_body_terminal_materialization_count(),
+            1,
+            "warm reuse must not rematerialize body text"
+        );
+
+        let unrelated_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&unrelated_edit),
+            &unrelated_edit,
+        );
+        let unrelated_request = database.runtime.request_registered(
+            &database.raw_declaration_bodies,
+            unrelated_revision,
+            RawDeclarationBodyQueryKey(key.clone()),
+            CancellationToken::new(),
+        );
+        assert_eq!(unrelated_request.terminal().unwrap().stamp(), first_stamp);
+
+        let selected_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&selected_edit),
+            &selected_edit,
+        );
+        let selected_request = database.runtime.request_registered(
+            &database.raw_declaration_bodies,
+            selected_revision,
+            RawDeclarationBodyQueryKey(key),
+            CancellationToken::new(),
+        );
+        let selected_terminal = selected_request.terminal().unwrap();
+        assert_ne!(selected_terminal.stamp(), first_stamp);
+        assert!(matches!(
+            selected_terminal.outcome(),
+            rue_query::QueryOutcome::Success(RawDeclarationBodyQueryValue::Available(syntax))
+                if syntax.body.as_ref() == "{ enum { Value(T), Empty } }"
+        ));
+    }
+
+    #[test]
+    fn raw_declaration_bodies_cover_body_categories_and_boundaries() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn free() -> i32 // excluded one\n{ 1 }\n\
+                 struct Box { value: i32, fn get(borrow self) -> i32 // excluded two\n{ self.value } fn make(value: i32) -> Box { Box { value } } }\n\
+                 drop fn Box(self) // excluded three\n{ let x = self; }\n\
+                 const value = 1; extern \"C\" { fn foreign() -> i32; }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let owner = crate::declaration_candidate::DeclarationCandidateOwner {
+            category: Category::Struct,
+            name: Arc::from("Box"),
+        };
+        let key = |category, name: &'static str, owner| {
+            crate::declaration_candidate::DeclarationCandidateKey {
+                module: module.clone(),
+                category,
+                name: Arc::from(name),
+                owner,
+                duplicate_discriminator: 0,
+            }
+        };
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+        for (candidate, expected) in [
+            (key(Category::Function, "free", None), "{ 1 }"),
+            (
+                key(Category::Method, "get", Some(owner.clone())),
+                "{ self.value }",
+            ),
+            (
+                key(Category::AssociatedFunction, "make", Some(owner.clone())),
+                "{ Box { value } }",
+            ),
+            (
+                key(Category::Destructor, "Box", Some(owner)),
+                "{ let x = self; }",
+            ),
+        ] {
+            let requested = database.runtime.request_registered(
+                &database.raw_declaration_bodies,
+                revision,
+                RawDeclarationBodyQueryKey(candidate),
+                CancellationToken::new(),
+            );
+            match requested.terminal().unwrap().outcome() {
+                rue_query::QueryOutcome::Success(RawDeclarationBodyQueryValue::Available(
+                    syntax,
+                )) => assert_eq!(syntax.body.as_ref(), expected),
+                other => panic!("expected raw body {expected:?}, got {other:?}"),
+            }
+        }
+
+        for candidate in [
+            key(Category::Struct, "Box", None),
+            key(Category::ConstCandidate, "value", None),
+            key(Category::ExternFunction, "foreign", None),
+        ] {
+            let requested = database.runtime.request_registered(
+                &database.raw_declaration_bodies,
+                revision,
+                RawDeclarationBodyQueryKey(candidate.clone()),
+                CancellationToken::new(),
+            );
+            assert!(matches!(
+                requested.terminal().unwrap().outcome(),
+                rue_query::QueryOutcome::Success(RawDeclarationBodyQueryValue::Failure(
+                    crate::declaration_candidate::RawDeclarationBodyFailure::CategoryMismatch(
+                        actual
+                    )
+                )) if actual == &candidate
+            ));
+        }
+    }
+
+    #[test]
+    fn raw_declaration_body_duplicate_discriminators_cancel_and_recover() {
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn duplicate() -> i32 { 11 } fn duplicate() -> i32 { 22 }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let key = |duplicate_discriminator| crate::declaration_candidate::DeclarationCandidateKey {
+            module: module.clone(),
+            category: crate::declaration_candidate::DeclarationCandidateCategory::Function,
+            name: Arc::from("duplicate"),
+            owner: None,
+            duplicate_discriminator,
+        };
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+
+        let canceled = CancellationToken::new();
+        canceled.cancel();
+        let aborted = database.runtime.request_registered(
+            &database.raw_declaration_bodies,
+            revision,
+            RawDeclarationBodyQueryKey(key(0)),
+            canceled,
+        );
+        assert_eq!(execution(&aborted), RequestExecution::Aborted);
+        assert!(aborted.terminal().is_none());
+
+        for (discriminator, expected) in [(0, "{ 11 }"), (1, "{ 22 }")] {
+            let requested = database.runtime.request_registered(
+                &database.raw_declaration_bodies,
+                revision,
+                RawDeclarationBodyQueryKey(key(discriminator)),
+                CancellationToken::new(),
+            );
+            assert!(matches!(
+                requested.terminal().unwrap().outcome(),
+                rue_query::QueryOutcome::Success(RawDeclarationBodyQueryValue::Available(syntax))
+                    if syntax.body.as_ref() == expected
+            ));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add an exact `compiler.raw-declaration-body` query keyed by declaration identity
- preserve declaration bodies as position-free syntax so later semantic queries can request one body without materializing module RIR
- add cold/warm laziness, invalidation, and source-authority retirement coverage

## Validation

- `scripts/rue quick` (34/34 targets; compiler 650/650; frontend differential 641/641; zero oracle disagreements)
- `/opt/homebrew/bin/bash ./clippy.sh` (61 targets)
- `git diff --check`

Refs RUE-1026
