### PR TITLE
RUE-1026: query declaration imports

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1563,6 +1563,11 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
             "raw_declaration_body_cache",
             "warm_raw_declaration_body",
             "eager_raw_declaration_body",
+            "legacy_declaration_import",
+            "fallback_declaration_import",
+            "declaration_import_cache",
+            "warm_declaration_import",
+            "eager_declaration_import",
         ] {
             assert!(
                 !source.contains(retired),
@@ -1575,6 +1580,7 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
                 ".evaluate_raw_const_syntax(",
                 ".evaluate_raw_declaration_signature(",
                 ".evaluate_raw_declaration_body(",
+                ".declaration_import(",
                 ".declaration_capabilities()",
                 "project_semantic_shell(",
             ] {
@@ -1609,6 +1615,15 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
             assert!(
                 !source.contains("RawDeclarationBody"),
                 "compiler production module {name} escaped the raw-body authority allowlist"
+            );
+        }
+        if !matches!(
+            *name,
+            "declaration_candidate" | "parsed_modules" | "revisioned_query_database"
+        ) {
+            assert!(
+                !source.contains("DeclarationImport"),
+                "compiler production module {name} escaped the declaration-import authority allowlist"
             );
         }
     }
@@ -1652,6 +1667,12 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         1
     );
     assert_eq!(parsed.matches("RawDeclarationBodySyntax {").count(), 1);
+    assert_eq!(runtime.matches(".declaration_import(").count(), 1);
+    assert_eq!(parsed.matches("fn declaration_import(").count(), 1);
+    assert_eq!(
+        runtime.matches("\"compiler.declaration-import\"").count(),
+        1
+    );
     assert!(!runtime.contains("Vec::remove"));
 
     let raw_body_evaluator = runtime
@@ -1775,6 +1796,28 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
             "raw-body terminal regained positioned/live parser or semantic payload: {forbidden}"
         );
     }
+    let declaration_import_terminal = runtime
+        .split("enum DeclarationImportQueryValue")
+        .nth(1)
+        .and_then(|tail| tail.split("struct LookupNameKey").next())
+        .unwrap();
+    for forbidden in [
+        "CompileErrors",
+        "Span",
+        "FileId",
+        "Spur",
+        "Ast",
+        "InstRef",
+        "Rir",
+        "TypeId",
+        "SemanticDefinitionToken",
+        "SemanticModuleToken",
+    ] {
+        assert!(
+            !declaration_import_terminal.contains(forbidden),
+            "declaration-import terminal regained positioned/live parser or semantic payload: {forbidden}"
+        );
+    }
     let raw_const_payload = module("declaration_candidate")
         .split("pub(crate) struct RawConstSyntax")
         .nth(1)
@@ -1814,6 +1857,28 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
             "raw-body payload regained a positioned or live parser/semantic handle: {forbidden}"
         );
     }
+    let declaration_import_payload = module("declaration_candidate")
+        .split("pub(crate) struct DeclarationImportSiteKey")
+        .nth(1)
+        .and_then(|tail| tail.split("impl DeclarationCandidateKey").next())
+        .unwrap();
+    for forbidden in [
+        "CompileErrors",
+        "Span",
+        "FileId",
+        "Spur",
+        "Ast",
+        "Rir",
+        "InstRef",
+        "TypeId",
+        "SemanticDefinitionToken",
+        "SemanticModuleToken",
+    ] {
+        assert!(
+            !declaration_import_payload.contains(forbidden),
+            "declaration-import payload regained a positioned or live parser/semantic handle: {forbidden}"
+        );
+    }
     let raw_signature_locator = parsed
         .split("enum RawDeclarationSignatureLocator")
         .nth(1)
@@ -1832,6 +1897,89 @@ fn declaration_shell_queries_are_the_only_compiler_semantic_discovery_authority(
         assert!(
             raw_signature_locator.contains(required),
             "raw-signature parser locator lost bounded inline shape {required}"
+        );
+    }
+    let declaration_import_locator = parsed
+        .split("struct RawDeclarationImportRange")
+        .nth(1)
+        .and_then(|tail| {
+            tail.split("pub(crate) enum ParsedDeclarationImportFailure")
+                .next()
+        })
+        .unwrap();
+    for forbidden in ["Vec<", "Arc<", "Box<"] {
+        assert!(
+            !declaration_import_locator.contains(forbidden),
+            "declaration-import parser locator regained per-declaration heap storage: {forbidden}"
+        );
+    }
+    for required in ["start: u32", "len: u32"] {
+        assert!(
+            declaration_import_locator.contains(required),
+            "declaration-import parser locator lost fixed range field {required}"
+        );
+    }
+    let declaration_import_evaluator = runtime
+        .split("let occurrences_for_declaration_import")
+        .nth(1)
+        .and_then(|tail| tail.split("        Self {").next())
+        .unwrap();
+    for forbidden in [
+        "module_rirs",
+        "lower_module_rir",
+        "CanonicalMergedProgram",
+        "Sema",
+        "SemanticView",
+    ] {
+        assert!(
+            !declaration_import_evaluator.contains(forbidden),
+            "declaration-import evaluator gained a broad compiler dependency: {forbidden}"
+        );
+    }
+    for required in [
+        ".query_registered(",
+        "ResolveImportKey",
+        "ImportDemandMode::Rooted",
+    ] {
+        assert!(
+            declaration_import_evaluator.contains(required),
+            "declaration-import evaluator lost canonical query delegation: {required}"
+        );
+    }
+    let resolve_import_evaluator = runtime
+        .split("let parse_for_import")
+        .nth(1)
+        .and_then(|tail| tail.split("let occurrences_for_declaration_import").next())
+        .unwrap();
+    for required in [
+        "exact_import_winner(",
+        "resolve_exact_import_winner(",
+        "accepted_import_provenance_input(",
+        "source.metadata_identity()",
+    ] {
+        assert!(
+            resolve_import_evaluator.contains(required),
+            "resolve-import lost exact winning-provenance dependency: {required}"
+        );
+    }
+    for forbidden in [
+        "reduce_exact_import_graph(",
+        "canonical ResolveImport inputs reduce deterministically",
+    ] {
+        assert!(
+            !resolve_import_evaluator.contains(forbidden),
+            "resolve-import regained broad or panicking reduction: {forbidden}"
+        );
+    }
+    let physical_provenance_identity = runtime
+        .split("fn accepted_import_provenance_input")
+        .nth(1)
+        .and_then(|tail| tail.split("fn import_observation_input").next())
+        .unwrap();
+    for required in ["identity.volume()", "identity.file()"] {
+        assert!(
+            physical_provenance_identity.contains(required),
+            "accepted-import provenance input lost exact physical identity component: {required}"
         );
     }
     let failure_algebra = module("declaration_candidate")

--- a/crates/rue-compiler/src/declaration_candidate.rs
+++ b/crates/rue-compiler/src/declaration_candidate.rs
@@ -153,6 +153,39 @@ pub(crate) enum RawDeclarationBodyFailure {
     ParserCapabilityMismatch(DeclarationCandidateKey),
 }
 
+/// Position-independent identity of one valid `@import` occurrence inside an
+/// exact declaration.
+///
+/// `occurrence` is counted in source order within the declaration, across all
+/// specifiers. Keeping the exact decoded specifier in the key makes a stale or
+/// malformed caller fail closed instead of silently selecting a different
+/// import after an edit.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct DeclarationImportSiteKey {
+    pub(crate) declaration: DeclarationCandidateKey,
+    pub(crate) occurrence: u32,
+    pub(crate) specifier: Arc<str>,
+}
+
+/// Stable, position-free failure retained by the declaration-import family.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DeclarationImportFailure {
+    OccurrencesUnavailable(DeclarationOccurrenceFailure),
+    AbsentDeclaration(DeclarationImportSiteKey),
+    AmbiguousDeclaration(DeclarationImportSiteKey),
+    CategoryMismatch(DeclarationImportSiteKey),
+    SiteOutOfRange {
+        key: DeclarationImportSiteKey,
+        available: u32,
+    },
+    SpecifierMismatch {
+        key: DeclarationImportSiteKey,
+        actual: Arc<str>,
+    },
+    ParserCapabilityMismatch(DeclarationImportSiteKey),
+    ResolutionUnavailable(DeclarationImportSiteKey),
+}
+
 impl DeclarationCandidateKey {
     pub(crate) fn stable_identity(&self) -> String {
         // Length-prefix every user-authored component. Query identities must
@@ -170,6 +203,18 @@ impl DeclarationCandidateKey {
             self.name,
             owner,
             self.duplicate_discriminator
+        )
+    }
+}
+
+impl DeclarationImportSiteKey {
+    pub(crate) fn stable_identity(&self) -> String {
+        format!(
+            "{}:import:{}:{}:{}",
+            self.declaration.stable_identity(),
+            self.occurrence,
+            self.specifier.len(),
+            self.specifier
         )
     }
 }

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -954,15 +954,7 @@ pub(crate) fn reduce_exact_import_graph(
     accepted_reads: &[AcceptedReadManifestEntry],
 ) -> CompileResult<crate::CanonicalImportGraph> {
     validate_exact_import_ledger(groups, ledger)?;
-    let manifest = accepted_reads
-        .iter()
-        .map(|entry| (entry.metadata_identity(), entry))
-        .collect::<BTreeMap<_, _>>();
-    if manifest.len() != accepted_reads.len() {
-        return Err(invalid_input(
-            "accepted read manifest contains duplicate physical identities",
-        ));
-    }
+    let manifest = accepted_import_manifest(accepted_reads)?;
     let mut by_site: BTreeMap<&ImportOccurrenceKey, Vec<&Arc<[ImportDiscoveryRequest]>>> =
         BTreeMap::new();
     for group in groups {
@@ -973,36 +965,10 @@ pub(crate) fn reduce_exact_import_graph(
     }
     let mut records = Vec::with_capacity(by_site.len());
     for (site, groups) in by_site {
-        let winning = groups.iter().find_map(|group| {
-            let present = group
-                .iter()
-                .filter_map(|request| ledger.get(request))
-                .filter_map(ImportObservation::accepted_source)
-                .collect::<Vec<_>>();
-            (!present.is_empty()).then_some(present)
-        });
-        let module_for = |source: &AcceptedImportSource| -> CompileResult<ModuleId> {
-            let entry = manifest.get(&source.metadata_identity()).ok_or_else(|| {
-                invalid_input("accepted observation is absent from accepted read provenance")
-            })?;
-            if entry.metadata_fingerprint() != source.metadata_fingerprint()
-                || entry.content_fingerprint() != source.content_fingerprint()
-            {
-                return Err(invalid_input(
-                    "accepted observation does not match accepted read provenance",
-                ));
-            }
-            Ok(entry.module().clone())
-        };
-        let resolution = match winning.as_deref() {
-            Some([source]) => crate::CanonicalImportResolution::Resolved(module_for(source)?),
-            Some([file, directory, ..]) => crate::CanonicalImportResolution::Ambiguous {
-                file_module: module_for(file)?,
-                directory_module: module_for(directory)?,
-            },
-            Some([]) => unreachable!(),
-            None => crate::CanonicalImportResolution::Missing,
-        };
+        let winner = exact_import_winner(groups.iter().copied(), ledger);
+        let resolution = resolve_exact_import_winner(winner, |source| {
+            module_for_accepted_source(source, &manifest)
+        })?;
         records.push(crate::CanonicalImportRecord::new(
             site.importer().clone(),
             site.specifier(),
@@ -1012,6 +978,158 @@ pub(crate) fn reduce_exact_import_graph(
     Ok(crate::CanonicalImportGraph::from_discovery_records(
         root, records,
     ))
+}
+
+/// Validate one demand-scoped exact occurrence before applying the canonical
+/// winning-group policy. Observations for other occurrences may coexist in the
+/// ledger because declaration queries intentionally share an import revision.
+pub(crate) fn validate_exact_import_occurrence(
+    groups: &[Arc<[ImportDiscoveryRequest]>],
+    ledger: &ImportObservationLedger,
+) -> CompileResult<()> {
+    let first = groups
+        .first()
+        .and_then(|group| group.first())
+        .ok_or_else(|| invalid_input("exact import occurrence has no candidate groups"))?;
+    if groups.iter().any(|group| {
+        group.is_empty()
+            || group
+                .iter()
+                .any(|request| request.occurrence() != first.occurrence())
+    }) {
+        return Err(invalid_input(
+            "exact import occurrence groups contain mixed or empty sites",
+        ));
+    }
+    let requests = groups
+        .iter()
+        .flat_map(|group| group.iter())
+        .collect::<BTreeSet<_>>();
+    if ledger.iter().any(|observation| {
+        observation.request().occurrence() == first.occurrence()
+            && !requests.contains(observation.request())
+    }) {
+        return Err(invalid_input(
+            "observation ledger contains a non-canonical request for the exact occurrence",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_accepted_import_manifest(
+    accepted_reads: &[AcceptedReadManifestEntry],
+) -> CompileResult<()> {
+    accepted_import_manifest(accepted_reads).map(drop)
+}
+
+fn accepted_import_manifest(
+    accepted_reads: &[AcceptedReadManifestEntry],
+) -> CompileResult<BTreeMap<PhysicalFileIdentity, &AcceptedReadManifestEntry>> {
+    let manifest = accepted_reads
+        .iter()
+        .map(|entry| (entry.metadata_identity(), entry))
+        .collect::<BTreeMap<_, _>>();
+    if manifest.len() != accepted_reads.len() {
+        return Err(invalid_input(
+            "accepted read manifest contains duplicate physical identities",
+        ));
+    }
+    Ok(manifest)
+}
+
+/// The one canonical precedence decision for an exact occurrence. The winner
+/// borrows accepted-source evidence from the immutable observation ledger;
+/// consumers decide how exact provenance maps those identities to modules.
+pub(crate) enum ExactImportWinner<'a> {
+    Missing,
+    Resolved(&'a AcceptedImportSource),
+    Ambiguous {
+        file: &'a AcceptedImportSource,
+        directory: &'a AcceptedImportSource,
+    },
+}
+
+pub(crate) fn exact_import_winner<'ledger, 'groups>(
+    groups: impl IntoIterator<Item = &'groups Arc<[ImportDiscoveryRequest]>>,
+    ledger: &'ledger ImportObservationLedger,
+) -> ExactImportWinner<'ledger> {
+    let winning = groups.into_iter().find_map(|group| {
+        let present = group
+            .iter()
+            .filter_map(|request| ledger.get(request))
+            .filter_map(ImportObservation::accepted_source)
+            .collect::<Vec<_>>();
+        (!present.is_empty()).then_some(present)
+    });
+    match winning.as_deref() {
+        Some([source]) => ExactImportWinner::Resolved(source),
+        Some([file, directory, ..]) => ExactImportWinner::Ambiguous { file, directory },
+        Some([]) => unreachable!(),
+        None => ExactImportWinner::Missing,
+    }
+}
+
+/// Obtain the canonical resolution by visiting exactly the accepted sources
+/// selected by precedence. Query consumers inject an exact provenance lookup;
+/// whole-graph closure injects its already-validated manifest map.
+pub(crate) fn resolve_exact_import_winner<E>(
+    winner: ExactImportWinner<'_>,
+    mut module_for: impl FnMut(&AcceptedImportSource) -> Result<ModuleId, E>,
+) -> Result<crate::CanonicalImportResolution, E> {
+    Ok(match winner {
+        ExactImportWinner::Missing => crate::CanonicalImportResolution::Missing,
+        ExactImportWinner::Resolved(source) => {
+            crate::CanonicalImportResolution::Resolved(module_for(source)?)
+        }
+        ExactImportWinner::Ambiguous { file, directory } => {
+            crate::CanonicalImportResolution::Ambiguous {
+                file_module: module_for(file)?,
+                directory_module: module_for(directory)?,
+            }
+        }
+    })
+}
+
+fn module_for_accepted_source(
+    source: &AcceptedImportSource,
+    manifest: &BTreeMap<PhysicalFileIdentity, &AcceptedReadManifestEntry>,
+) -> CompileResult<ModuleId> {
+    let entry = manifest.get(&source.metadata_identity()).ok_or_else(|| {
+        invalid_input("accepted observation is absent from accepted read provenance")
+    })?;
+    validate_accepted_import_source(source, entry)
+}
+
+pub(crate) fn accepted_import_module(
+    source: &AcceptedImportSource,
+    accepted_reads: &[AcceptedReadManifestEntry],
+) -> CompileResult<ModuleId> {
+    let mut matches = accepted_reads
+        .iter()
+        .filter(|entry| entry.metadata_identity() == source.metadata_identity());
+    let entry = matches.next().ok_or_else(|| {
+        invalid_input("accepted observation is absent from accepted read provenance")
+    })?;
+    if matches.next().is_some() {
+        return Err(invalid_input(
+            "accepted read manifest contains duplicate physical identities",
+        ));
+    }
+    validate_accepted_import_source(source, entry)
+}
+
+fn validate_accepted_import_source(
+    source: &AcceptedImportSource,
+    entry: &AcceptedReadManifestEntry,
+) -> CompileResult<ModuleId> {
+    if entry.metadata_fingerprint() != source.metadata_fingerprint()
+        || entry.content_fingerprint() != source.content_fingerprint()
+    {
+        return Err(invalid_input(
+            "accepted observation does not match accepted read provenance",
+        ));
+    }
+    Ok(entry.module().clone())
 }
 
 /// Compiler-owned durable identity assembly for a discovery epoch.

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -161,6 +161,8 @@ pub struct ParsedDefinitionIndex {
     #[cfg(test)]
     raw_declaration_body_terminal_materializations: Arc<AtomicUsize>,
     #[cfg(test)]
+    declaration_import_locator_materializations: Arc<AtomicUsize>,
+    #[cfg(test)]
     by_name: BTreeMap<(DefinitionNamespace, Arc<str>), Arc<[ParsedDefinitionOccurrence]>>,
 }
 
@@ -311,6 +313,23 @@ impl ParsedDefinitionIndex {
             .load(Ordering::Relaxed)
     }
 
+    fn declaration_import_range(
+        &self,
+        key: &DeclarationCandidateKey,
+    ) -> Option<RawDeclarationImportRange> {
+        let index = self.declaration_by_key.get(key).copied()?;
+        let candidate = self.declarations.get(index)?;
+        (candidate.fact.key == *key)
+            .then_some(candidate.raw_import_range)
+            .flatten()
+    }
+
+    #[cfg(test)]
+    fn declaration_import_locator_materialization_count(&self) -> usize {
+        self.declaration_import_locator_materializations
+            .load(Ordering::Relaxed)
+    }
+
     pub(crate) fn declaration_locator(
         &self,
         key: &DeclarationCandidateKey,
@@ -346,6 +365,7 @@ pub(crate) struct ParsedDeclarationCandidate {
     raw_const_syntax_spans: Option<RawConstSyntaxSpans>,
     raw_signature_locator: Option<RawDeclarationSignatureLocator>,
     raw_body_span: Option<Span>,
+    raw_import_range: Option<RawDeclarationImportRange>,
 }
 
 /// Parser-private locators for syntax that is materialized only after an exact
@@ -373,6 +393,21 @@ enum RawDeclarationSignatureLocator {
         declaration: Span,
         abi: Span,
     },
+}
+
+/// Parser-private range into the module's source-ordered import table for one
+/// declaration. Runtime query values retain neither field.
+#[derive(Debug, Clone, Copy)]
+struct RawDeclarationImportRange {
+    start: u32,
+    len: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ParsedDeclarationImportFailure {
+    SiteOutOfRange { available: u32 },
+    SpecifierMismatch { actual: Arc<str> },
+    CapabilityMismatch,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -531,6 +566,55 @@ impl ParsedModule {
     pub(crate) fn raw_declaration_body_terminal_materialization_count(&self) -> usize {
         self.definitions
             .raw_declaration_body_terminal_materialization_count()
+    }
+
+    pub(crate) fn declaration_import(
+        &self,
+        key: &crate::declaration_candidate::DeclarationImportSiteKey,
+    ) -> Result<ImportDirective, ParsedDeclarationImportFailure> {
+        let range = self
+            .definitions
+            .declaration_import_range(&key.declaration)
+            .ok_or(ParsedDeclarationImportFailure::CapabilityMismatch)?;
+        if key.occurrence >= range.len {
+            return Err(ParsedDeclarationImportFailure::SiteOutOfRange {
+                available: range.len,
+            });
+        }
+        let index = range
+            .start
+            .checked_add(key.occurrence)
+            .and_then(|value| usize::try_from(value).ok())
+            .ok_or(ParsedDeclarationImportFailure::CapabilityMismatch)?;
+        let site = self
+            .imports
+            .get(index)
+            .ok_or(ParsedDeclarationImportFailure::CapabilityMismatch)?;
+        let Some(locator) = self.definitions.declaration_locator(&key.declaration) else {
+            return Err(ParsedDeclarationImportFailure::CapabilityMismatch);
+        };
+        if site.importer() != self.module_id()
+            || site.source_offset() < locator.declaration_span.start
+            || site.source_end() > locator.declaration_span.end
+        {
+            return Err(ParsedDeclarationImportFailure::CapabilityMismatch);
+        }
+        if site.specifier() != key.specifier.as_ref() {
+            return Err(ParsedDeclarationImportFailure::SpecifierMismatch {
+                actual: Arc::from(site.specifier()),
+            });
+        }
+        #[cfg(test)]
+        self.definitions
+            .declaration_import_locator_materializations
+            .fetch_add(1, Ordering::Relaxed);
+        Ok(site.clone())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn declaration_import_locator_materialization_count(&self) -> usize {
+        self.definitions
+            .declaration_import_locator_materialization_count()
     }
 
     #[cfg(test)]
@@ -1208,6 +1292,7 @@ fn build_module_with_resolver(
         &tokens,
         &provenanced_ast.ast,
         &resolver,
+        &import_sites.valid,
     )?;
     let payload = Arc::new(ParsedSyntaxPayload {
         source,
@@ -1311,6 +1396,7 @@ fn bind_payload(
                     },
                 ),
                 raw_body_span: candidate.raw_body_span.map(remap_span),
+                raw_import_range: candidate.raw_import_range,
             })
             .collect::<Vec<_>>()
             .into(),
@@ -1330,6 +1416,11 @@ fn bind_payload(
         raw_declaration_body_terminal_materializations: payload
             .definitions
             .raw_declaration_body_terminal_materializations
+            .clone(),
+        #[cfg(test)]
+        declaration_import_locator_materializations: payload
+            .definitions
+            .declaration_import_locator_materializations
             .clone(),
         #[cfg(test)]
         by_name: payload.definitions.by_name.clone(),
@@ -1706,6 +1797,27 @@ fn validate_pair(
     Ok(())
 }
 
+fn declaration_import_range(
+    declaration: Span,
+    import_sites: &[ImportDirective],
+) -> CompileResult<RawDeclarationImportRange> {
+    let start_index = import_sites.partition_point(|site| site.source_offset() < declaration.start);
+    let end = import_sites.partition_point(|site| site.source_offset() < declaration.end);
+    if import_sites[start_index..end]
+        .iter()
+        .any(|site| site.source_end() > declaration.end)
+    {
+        return Err(invalid_input(
+            "declaration import site crosses its declaration boundary",
+        ));
+    }
+    let start =
+        u32::try_from(start_index).map_err(|_| invalid_input("module import index exceeds u32"))?;
+    let len = u32::try_from(end - start_index)
+        .map_err(|_| invalid_input("declaration import count exceeds u32"))?;
+    Ok(RawDeclarationImportRange { start, len })
+}
+
 fn build_definition_index(
     module: ModuleId,
     file_id: FileId,
@@ -1713,7 +1825,16 @@ fn build_definition_index(
     tokens: &[rue_lexer::Token],
     ast: &Ast,
     resolver: &FrozenSymbolResolver,
+    import_sites: &[ImportDirective],
 ) -> CompileResult<ParsedDefinitionIndex> {
+    if import_sites.windows(2).any(|sites| {
+        (sites[0].source_offset(), sites[0].source_end())
+            > (sites[1].source_offset(), sites[1].source_end())
+    }) {
+        return Err(invalid_input(
+            "module import sites are not in canonical source order",
+        ));
+    }
     let mut pending = Vec::new();
     let mut pending_declarations = Vec::<(
         DeclarationShellFact,
@@ -1721,6 +1842,7 @@ fn build_definition_index(
         Option<RawConstSyntaxSpans>,
         Option<RawDeclarationSignatureLocator>,
         Option<Span>,
+        Option<RawDeclarationImportRange>,
     )>::new();
     let resolve_name = |ident: rue_parser::Ident| -> CompileResult<Arc<str>> {
         let symbol = resolver.symbol(ident.name)?;
@@ -1833,6 +1955,18 @@ fn build_definition_index(
             if let Some(body) = raw_body_span {
                 validate_span("raw declaration body", body, file_id, source_text)?;
             }
+            let raw_import_range = if matches!(
+                category,
+                DeclarationCandidateCategory::Function
+                    | DeclarationCandidateCategory::ConstCandidate
+                    | DeclarationCandidateCategory::Destructor
+                    | DeclarationCandidateCategory::Method
+                    | DeclarationCandidateCategory::AssociatedFunction
+            ) {
+                Some(declaration_import_range(declaration_span, import_sites)?)
+            } else {
+                None
+            };
             pending_declarations.push((
                 DeclarationShellFact {
                     key: DeclarationCandidateKey {
@@ -1855,6 +1989,7 @@ fn build_definition_index(
                 raw_const_syntax_spans,
                 raw_signature_locator,
                 raw_body_span,
+                raw_import_range,
             ));
             Ok(())
         };
@@ -2112,6 +2247,7 @@ fn build_definition_index(
                 raw_const_syntax_spans,
                 raw_signature_locator,
                 raw_body_span,
+                raw_import_range,
             )| {
                 let duplicate = duplicate_counts
                     .entry((
@@ -2130,6 +2266,7 @@ fn build_definition_index(
                     raw_const_syntax_spans,
                     raw_signature_locator,
                     raw_body_span,
+                    raw_import_range,
                 })
             },
         )
@@ -2165,6 +2302,8 @@ fn build_definition_index(
         raw_declaration_signature_terminal_materializations: Arc::new(AtomicUsize::new(0)),
         #[cfg(test)]
         raw_declaration_body_terminal_materializations: Arc::new(AtomicUsize::new(0)),
+        #[cfg(test)]
+        declaration_import_locator_materializations: Arc::new(AtomicUsize::new(0)),
         #[cfg(test)]
         by_name,
     })

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -408,6 +408,8 @@ pub(crate) struct RevisionedQueryDatabase {
     raw_declaration_bodies: QueryFamily<RawDeclarationBodyQueryKey, RawDeclarationBodyQueryValue>,
     module_rirs: QueryFamily<ModuleQueryKey, ModuleRirValue>,
     resolve_imports: QueryFamily<ResolveImportKey, ResolveImportValue>,
+    #[cfg_attr(not(test), allow(dead_code))]
+    declaration_imports: QueryFamily<DeclarationImportQueryKey, DeclarationImportQueryValue>,
     lookup_names: QueryFamily<LookupNameKey, LookupNameValue>,
     next_import_request: u64,
     current_import_revision: Option<ImportInputRevision>,
@@ -581,8 +583,9 @@ struct ResolveImportKey {
 impl QueryKey for ResolveImportKey {
     fn stable_identity(&self) -> String {
         format!(
-            "{}:{}..{}:{}",
+            "{}:{:?}:{}..{}:{}",
             self.occurrence.importer(),
+            self.mode,
             self.occurrence.source_offset(),
             self.occurrence.source_end(),
             self.occurrence.specifier()
@@ -592,9 +595,26 @@ impl QueryKey for ResolveImportKey {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ResolveImportValue {
+    site_found: bool,
     groups: Arc<[Arc<[ImportDiscoveryRequest]>]>,
     requests: Arc<[ImportDiscoveryRequest]>,
     speculative_blocked: bool,
+    resolution: Option<crate::CanonicalImportResolution>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DeclarationImportQueryKey(crate::declaration_candidate::DeclarationImportSiteKey);
+
+impl QueryKey for DeclarationImportQueryKey {
+    fn stable_identity(&self) -> String {
+        self.0.stable_identity()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DeclarationImportQueryValue {
+    Available(crate::CanonicalImportResolution),
+    Failure(crate::declaration_candidate::DeclarationImportFailure),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -671,6 +691,13 @@ fn accepted_read_input(module: &ModuleId) -> InputIdentity {
     InputIdentity::new(
         "accepted-read-provenance",
         Arc::<str>::from(module.as_str()),
+    )
+}
+
+fn accepted_import_provenance_input(identity: crate::PhysicalFileIdentity) -> InputIdentity {
+    InputIdentity::new(
+        "accepted-import-provenance",
+        format!("{}:{}", identity.volume(), identity.file()),
     )
 }
 
@@ -1576,7 +1603,7 @@ impl Default for RevisionedQueryDatabase {
             .expect("the ModuleRir family has one canonical name");
         let import_store = Arc::new(Mutex::new(ImportInputStore::default()));
         let evaluator_store = import_store.clone();
-        let index_for_import = module_indexes.clone();
+        let parse_for_import = parse_modules.clone();
         let resolve_imports = runtime
             .family_with_evaluator(
                 "compiler.resolve-import",
@@ -1592,22 +1619,30 @@ impl Default for RevisionedQueryDatabase {
                     }
                     .ok_or_else(|| QueryAbort::UnpublishedRevision(context.revision()))?;
                     context.input(import_context_input())?;
-                    let indexed = context.query_registered(
-                        &index_for_import,
+                    let parsed = context.query_registered(
+                        &parse_for_import,
                         ModuleQueryKey(key.occurrence.importer().clone()),
                     )?;
-                    let rue_query::QueryOutcome::Success(indexed) = indexed.outcome() else {
-                        unreachable!("ModuleIndex publishes typed values")
+                    let rue_query::QueryOutcome::Success(parsed) = parsed.outcome() else {
+                        unreachable!("ParseModule publishes typed values")
                     };
-                    let site = indexed.0.as_ref().ok().and_then(|index| {
-                        index.imports.iter().find(|site| {
+                    let site = parsed.result.as_ref().ok().and_then(|module| {
+                        module.imports().iter().find(|site| {
                             site.importer() == key.occurrence.importer()
                                 && site.source_offset() == key.occurrence.source_offset()
                                 && site.source_end() == key.occurrence.source_end()
                                 && site.specifier() == key.occurrence.specifier()
                         })
                     });
-                    let site = site.expect("ResolveImport key is absent from ModuleIndex");
+                    let Some(site) = site else {
+                        return Ok(QueryOutput::success(ResolveImportValue {
+                            site_found: false,
+                            groups: Arc::from([]),
+                            requests: Arc::from([]),
+                            speculative_blocked: false,
+                            resolution: None,
+                        }));
+                    };
                     context.input(accepted_read_input(key.occurrence.importer()))?;
                     let importer = view
                         .accepted_reads
@@ -1630,7 +1665,53 @@ impl Default for RevisionedQueryDatabase {
                     let pending = pending_occurrence_requests(&groups, &view.ledger);
                     let speculative_blocked =
                         key.mode == ImportDemandMode::Speculative && !pending.is_empty();
+                    let resolution = if pending.is_empty()
+                        && !crate::import_discovery::exact_import_has_failures(
+                            &groups,
+                            &view.ledger,
+                        ) {
+                        enum ProvenanceLookupFailure {
+                            Query(QueryAbort),
+                            Invalid,
+                        }
+
+                        if crate::import_discovery::validate_exact_import_occurrence(
+                            &groups,
+                            &view.ledger,
+                        )
+                        .is_err()
+                        {
+                            None
+                        } else {
+                            let winner = crate::import_discovery::exact_import_winner(
+                                groups.iter(),
+                                &view.ledger,
+                            );
+                            match crate::import_discovery::resolve_exact_import_winner(
+                                winner,
+                                |source| {
+                                    context
+                                        .input(accepted_import_provenance_input(
+                                            source.metadata_identity(),
+                                        ))
+                                        .map_err(ProvenanceLookupFailure::Query)?;
+                                    crate::import_discovery::accepted_import_module(
+                                        source,
+                                        &view.accepted_reads,
+                                    )
+                                    .map_err(|_| ProvenanceLookupFailure::Invalid)
+                                },
+                            ) {
+                                Ok(resolution) => Some(resolution),
+                                Err(ProvenanceLookupFailure::Query(abort)) => return Err(abort),
+                                Err(ProvenanceLookupFailure::Invalid) => None,
+                            }
+                        }
+                    } else {
+                        None
+                    };
                     Ok(QueryOutput::success(ResolveImportValue {
+                        site_found: true,
                         groups: groups.into(),
                         requests: if speculative_blocked {
                             Arc::from([])
@@ -1638,10 +1719,215 @@ impl Default for RevisionedQueryDatabase {
                             pending.into()
                         },
                         speculative_blocked,
+                        resolution,
                     }))
                 },
             )
             .expect("the ResolveImport family has one canonical name");
+        let occurrences_for_declaration_import = declaration_occurrence_indexes.clone();
+        let shells_for_declaration_import = declaration_shells.clone();
+        let parse_for_declaration_import = parse_modules.clone();
+        let resolve_for_declaration_import = resolve_imports.clone();
+        let declaration_imports = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.declaration-import",
+                MODULE_QUERY_MEMO_RETENTION,
+                |left: &DeclarationImportQueryValue, right: &DeclarationImportQueryValue| {
+                    left == right
+                },
+                move |context, _, key: &DeclarationImportQueryKey| {
+                    use crate::declaration_candidate::{
+                        DeclarationCandidateCategory, DeclarationImportFailure,
+                        DeclarationOccurrenceCapability, DeclarationShellFailure,
+                    };
+                    use crate::parsed_modules::ParsedDeclarationImportFailure;
+
+                    let indexed = context.query_registered(
+                        &occurrences_for_declaration_import,
+                        ModuleQueryKey(key.0.declaration.module.clone()),
+                    )?;
+                    let rue_query::QueryOutcome::Success(indexed) = indexed.outcome() else {
+                        unreachable!("DeclarationOccurrenceIndex publishes typed values")
+                    };
+                    let value = match indexed {
+                        DeclarationOccurrenceIndexValue::Failure(failure) => {
+                            DeclarationImportQueryValue::Failure(
+                                DeclarationImportFailure::OccurrencesUnavailable(failure.clone()),
+                            )
+                        }
+                        DeclarationOccurrenceIndexValue::Available(index) => {
+                            match index.capabilities.get(&key.0.declaration) {
+                                None => DeclarationImportQueryValue::Failure(
+                                    DeclarationImportFailure::AbsentDeclaration(key.0.clone()),
+                                ),
+                                Some(DeclarationOccurrenceCapability::Ambiguous { .. }) => {
+                                    DeclarationImportQueryValue::Failure(
+                                        DeclarationImportFailure::AmbiguousDeclaration(
+                                            key.0.clone(),
+                                        ),
+                                    )
+                                }
+                                Some(DeclarationOccurrenceCapability::Exact {
+                                    duplicate_multiplicity: 0,
+                                    ..
+                                }) => DeclarationImportQueryValue::Failure(
+                                    DeclarationImportFailure::ParserCapabilityMismatch(
+                                        key.0.clone(),
+                                    ),
+                                ),
+                                Some(DeclarationOccurrenceCapability::Exact { .. }) => {
+                                    let shell = context.query_registered(
+                                        &shells_for_declaration_import,
+                                        DeclarationShellQueryKey(key.0.declaration.clone()),
+                                    )?;
+                                    let rue_query::QueryOutcome::Success(shell) = shell.outcome()
+                                    else {
+                                        unreachable!("DeclarationShell publishes typed values")
+                                    };
+                                    match shell {
+                                        DeclarationShellQueryValue::Failure(failure) => {
+                                            let failure = match failure {
+                                                DeclarationShellFailure::OccurrencesUnavailable(
+                                                    failure,
+                                                ) => DeclarationImportFailure::OccurrencesUnavailable(
+                                                    failure.clone(),
+                                                ),
+                                                DeclarationShellFailure::Absent(_) => {
+                                                    DeclarationImportFailure::AbsentDeclaration(
+                                                        key.0.clone(),
+                                                    )
+                                                }
+                                                DeclarationShellFailure::Ambiguous(_) => {
+                                                    DeclarationImportFailure::AmbiguousDeclaration(
+                                                        key.0.clone(),
+                                                    )
+                                                }
+                                                DeclarationShellFailure::ParserCapabilityMismatch(
+                                                    _,
+                                                ) => DeclarationImportFailure::ParserCapabilityMismatch(
+                                                    key.0.clone(),
+                                                ),
+                                            };
+                                            DeclarationImportQueryValue::Failure(failure)
+                                        }
+                                        DeclarationShellQueryValue::Available(fact)
+                                            if !matches!(
+                                                fact.key.category,
+                                                DeclarationCandidateCategory::ConstCandidate
+                                                    | DeclarationCandidateCategory::Function
+                                                    | DeclarationCandidateCategory::Method
+                                                    | DeclarationCandidateCategory::AssociatedFunction
+                                                    | DeclarationCandidateCategory::Destructor
+                                            ) =>
+                                        {
+                                            DeclarationImportQueryValue::Failure(
+                                                DeclarationImportFailure::CategoryMismatch(
+                                                    key.0.clone(),
+                                                ),
+                                            )
+                                        }
+                                        DeclarationShellQueryValue::Available(fact)
+                                            if fact.key != key.0.declaration =>
+                                        {
+                                            DeclarationImportQueryValue::Failure(
+                                                DeclarationImportFailure::ParserCapabilityMismatch(
+                                                    key.0.clone(),
+                                                ),
+                                            )
+                                        }
+                                        DeclarationShellQueryValue::Available(_) => {
+                                            let parsed = context.query_registered(
+                                                &parse_for_declaration_import,
+                                                ModuleQueryKey(key.0.declaration.module.clone()),
+                                            )?;
+                                            let rue_query::QueryOutcome::Success(parsed) =
+                                                parsed.outcome()
+                                            else {
+                                                unreachable!("ParseModule publishes typed values")
+                                            };
+                                            match &parsed.result {
+                                                Err(_) => DeclarationImportQueryValue::Failure(
+                                                    DeclarationImportFailure::OccurrencesUnavailable(
+                                                        crate::declaration_candidate::DeclarationOccurrenceFailure::ParseRejected {
+                                                            module: key.0.declaration.module.clone(),
+                                                        },
+                                                    ),
+                                                ),
+                                                Ok(module) => match module.declaration_import(&key.0)
+                                                {
+                                                    Err(ParsedDeclarationImportFailure::SiteOutOfRange {
+                                                        available,
+                                                    }) => DeclarationImportQueryValue::Failure(
+                                                        DeclarationImportFailure::SiteOutOfRange {
+                                                            key: key.0.clone(),
+                                                            available,
+                                                        },
+                                                    ),
+                                                    Err(ParsedDeclarationImportFailure::SpecifierMismatch {
+                                                        actual,
+                                                    }) => DeclarationImportQueryValue::Failure(
+                                                        DeclarationImportFailure::SpecifierMismatch {
+                                                            key: key.0.clone(),
+                                                            actual,
+                                                        },
+                                                    ),
+                                                    Err(ParsedDeclarationImportFailure::CapabilityMismatch) => {
+                                                        DeclarationImportQueryValue::Failure(
+                                                            DeclarationImportFailure::ParserCapabilityMismatch(
+                                                                key.0.clone(),
+                                                            ),
+                                                        )
+                                                    }
+                                                    Ok(site) => {
+                                                        let resolved = context.query_registered(
+                                                            &resolve_for_declaration_import,
+                                                            ResolveImportKey {
+                                                                occurrence: crate::ImportOccurrenceKey::from_directive(&site),
+                                                                mode: ImportDemandMode::Rooted,
+                                                            },
+                                                        )?;
+                                                        let rue_query::QueryOutcome::Success(resolved) =
+                                                            resolved.outcome()
+                                                        else {
+                                                            unreachable!("ResolveImport publishes typed values")
+                                                        };
+                                                        if !resolved.site_found {
+                                                            DeclarationImportQueryValue::Failure(
+                                                                DeclarationImportFailure::ParserCapabilityMismatch(
+                                                                    key.0.clone(),
+                                                                ),
+                                                            )
+                                                        } else if let Some(resolution) =
+                                                            &resolved.resolution
+                                                        {
+                                                            DeclarationImportQueryValue::Available(
+                                                                resolution.clone(),
+                                                            )
+                                                        } else {
+                                                            DeclarationImportQueryValue::Failure(
+                                                                DeclarationImportFailure::ResolutionUnavailable(
+                                                                    key.0.clone(),
+                                                                ),
+                                                            )
+                                                        }
+                                                    }
+                                                },
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    };
+                    let kind = if matches!(value, DeclarationImportQueryValue::Available(_)) {
+                        QueryTerminalKind::Success
+                    } else {
+                        QueryTerminalKind::Failure
+                    };
+                    Ok(QueryOutput::success(value).with_terminal_kind(kind))
+                },
+            )
+            .expect("the DeclarationImport family has one canonical name");
         Self {
             parse: RevisionedFamily::new(&runtime, "compiler.parse"),
             runtime,
@@ -1659,6 +1945,7 @@ impl Default for RevisionedQueryDatabase {
             raw_declaration_bodies,
             module_rirs,
             resolve_imports,
+            declaration_imports,
             lookup_names,
             next_import_request: 0,
             current_import_revision: None,
@@ -1866,6 +2153,11 @@ impl RevisionedQueryDatabase {
             let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
                 unreachable!("ResolveImport publishes typed success values")
             };
+            if !value.site_found {
+                return Err(import_input_error(
+                    "import demand occurrence is absent from the current parsed module",
+                ));
+            }
             speculative_blocked |= value.speculative_blocked;
             for request in value.requests.iter() {
                 let operation = ImportHostOperationKey::new(request);
@@ -1927,6 +2219,11 @@ impl RevisionedQueryDatabase {
             let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
                 unreachable!("ResolveImport publishes typed values")
             };
+            if !value.site_found {
+                return Err(import_input_error(
+                    "exact import projection occurrence is absent from the current parsed module",
+                ));
+            }
             groups.extend(value.groups.iter().cloned());
         }
         groups.sort_by(|left, right| left[0].cmp(&right[0]));
@@ -2014,6 +2311,12 @@ impl RevisionedQueryDatabase {
             .iter()
             .map(|entry| (entry.module(), entry))
             .collect::<BTreeMap<_, _>>();
+        crate::import_discovery::validate_accepted_import_manifest(&accepted_reads)?;
+        if provenance.len() != accepted_reads.len() {
+            return Err(import_input_error(
+                "accepted read manifest contains duplicate logical modules",
+            ));
+        }
         if sources
             .iter()
             .any(|source| !provenance.contains_key(&source.module))
@@ -2029,6 +2332,9 @@ impl RevisionedQueryDatabase {
             return Err(import_input_error(
                 "import observation belongs to a different discovery epoch",
             ));
+        }
+        for source in ledger.iter().filter_map(ImportObservation::accepted_source) {
+            crate::import_discovery::accepted_import_module(source, &accepted_reads)?;
         }
         let revision = Revision::new(self.next_revision, generation);
         self.next_revision += 1;
@@ -2050,6 +2356,12 @@ impl RevisionedQueryDatabase {
                 let accepted = provenance[&source.module];
                 leaves.push((
                     accepted_read_input(&source.module),
+                    exact_value_stamp(next_stamp, provenance_stamps, accepted),
+                ));
+            }
+            for accepted in accepted_reads.iter() {
+                leaves.push((
+                    accepted_import_provenance_input(accepted.metadata_identity()),
                     exact_value_stamp(next_stamp, provenance_stamps, accepted),
                 ));
             }
@@ -4158,6 +4470,959 @@ mod tests {
             )
             .unwrap();
         (revision, plan)
+    }
+
+    fn begin_database_plan(
+        database: &mut RevisionedQueryDatabase,
+        assembler: &DiscoverySourceAssembler,
+        context: ImportDiscoveryContext,
+    ) -> (
+        SourceSnapshot,
+        Arc<[crate::AcceptedReadManifestEntry]>,
+        ImportInputRevision,
+        ImportDiscoveryPlan,
+    ) {
+        let snapshot = assembler.snapshot().unwrap();
+        let reads = assembler.accepted_read_manifest();
+        let revision = database
+            .begin_import_inputs(&snapshot, context.clone(), reads.clone())
+            .unwrap();
+        let runtime_revision = Revision::new(revision.revision_id, revision.request_generation);
+        let root = ModuleId::from_logical_path("main.rue").unwrap();
+        let modules = snapshot
+            .source_revision()
+            .modules()
+            .iter()
+            .map(|module| module.module.clone())
+            .collect::<Vec<_>>();
+        let (program, _) = database.parse_program(runtime_revision, &root, modules);
+        let plan = ImportDiscoveryPlan::new(&program.unwrap(), context).unwrap();
+        (snapshot, reads, revision, plan)
+    }
+
+    fn publish_manifest_observations(
+        database: &mut RevisionedQueryDatabase,
+        snapshot: &SourceSnapshot,
+        reads: Arc<[crate::AcceptedReadManifestEntry]>,
+        plan: &ImportDiscoveryPlan,
+        mut revision: ImportInputRevision,
+    ) -> ImportInputRevision {
+        let roots = ImportDemandRoots::whole_plan(plan);
+        loop {
+            let frontier = database
+                .import_frontier(revision, plan, ImportDemandMode::Rooted, &roots)
+                .unwrap();
+            if frontier.requests().is_empty() {
+                return revision;
+            }
+            let observations = frontier
+                .requests()
+                .iter()
+                .cloned()
+                .map(|request| {
+                    let Some(entry) = reads
+                        .iter()
+                        .find(|entry| entry.requested_path() == request.requested_path())
+                    else {
+                        return ImportObservation::absent(request);
+                    };
+                    let file_id = snapshot
+                        .files()
+                        .find(|source| snapshot.module_id(source.file_id) == Some(entry.module()))
+                        .unwrap()
+                        .file_id;
+                    let accepted = crate::AcceptedImportSource::new(
+                        entry.requested_path(),
+                        entry.canonical_path(),
+                        entry.metadata_identity(),
+                        entry.metadata_fingerprint(),
+                        snapshot.shared_source_text(file_id).unwrap(),
+                    )
+                    .unwrap();
+                    ImportObservation::accepted(request, accepted).unwrap()
+                })
+                .collect();
+            revision = database
+                .publish_import_batch(&frontier, snapshot, reads.clone(), observations)
+                .unwrap();
+        }
+    }
+
+    fn publish_remapped_observations(
+        database: &mut RevisionedQueryDatabase,
+        snapshot: &SourceSnapshot,
+        reads: Arc<[crate::AcceptedReadManifestEntry]>,
+        plan: &ImportDiscoveryPlan,
+        mut revision: ImportInputRevision,
+        remaps: &[(&str, PhysicalFileIdentity)],
+    ) -> ImportInputRevision {
+        let roots = ImportDemandRoots::whole_plan(plan);
+        loop {
+            let frontier = database
+                .import_frontier(revision, plan, ImportDemandMode::Rooted, &roots)
+                .unwrap();
+            if frontier.requests().is_empty() {
+                return revision;
+            }
+            let observations = frontier
+                .requests()
+                .iter()
+                .cloned()
+                .map(|request| {
+                    let Some((_, identity)) = remaps
+                        .iter()
+                        .find(|(path, _)| *path == request.requested_path())
+                    else {
+                        return ImportObservation::absent(request);
+                    };
+                    let entry = reads
+                        .iter()
+                        .find(|entry| entry.metadata_identity() == *identity)
+                        .unwrap();
+                    let file_id = snapshot
+                        .files()
+                        .find(|source| snapshot.module_id(source.file_id) == Some(entry.module()))
+                        .unwrap()
+                        .file_id;
+                    let accepted = crate::AcceptedImportSource::new(
+                        request.requested_path(),
+                        entry.canonical_path(),
+                        entry.metadata_identity(),
+                        entry.metadata_fingerprint(),
+                        snapshot.shared_source_text(file_id).unwrap(),
+                    )
+                    .unwrap();
+                    ImportObservation::accepted(request, accepted).unwrap()
+                })
+                .collect();
+            revision = database
+                .publish_import_batch(&frontier, snapshot, reads.clone(), observations)
+                .unwrap();
+        }
+    }
+
+    fn declaration_import_key(
+        module: &ModuleId,
+        category: crate::declaration_candidate::DeclarationCandidateCategory,
+        name: impl Into<Arc<str>>,
+        owner: Option<crate::declaration_candidate::DeclarationCandidateOwner>,
+        occurrence: u32,
+        specifier: &str,
+    ) -> DeclarationImportQueryKey {
+        DeclarationImportQueryKey(crate::declaration_candidate::DeclarationImportSiteKey {
+            declaration: crate::declaration_candidate::DeclarationCandidateKey {
+                module: module.clone(),
+                category,
+                name: name.into(),
+                owner,
+                duplicate_discriminator: 0,
+            },
+            occurrence,
+            specifier: Arc::from(specifier),
+        })
+    }
+
+    #[test]
+    fn declaration_imports_are_exact_lazy_and_distinguish_duplicate_specifiers() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+
+        let source = "const selected = if true { @import(\"same\") } else { @import(\"same\") }; const untouched = @import(\"other\"); fn main() {}";
+        let (_, assembler, context) = import_fixture(301, source);
+        let mut database = RevisionedQueryDatabase::default();
+        let (snapshot, reads, revision, plan) =
+            begin_database_plan(&mut database, &assembler, context);
+        let revision =
+            publish_manifest_observations(&mut database, &snapshot, reads, &plan, revision);
+        let runtime_revision = Revision::new(revision.revision_id, revision.request_generation);
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let parsed = database.runtime.request_registered(
+            &database.parse_modules,
+            runtime_revision,
+            ModuleQueryKey(module.clone()),
+            CancellationToken::new(),
+        );
+        let parsed_module = match parsed.terminal().unwrap().outcome() {
+            rue_query::QueryOutcome::Success(value) => value.result.clone().unwrap(),
+            rue_query::QueryOutcome::Failure(_) => unreachable!(),
+        };
+        assert_eq!(
+            parsed_module.declaration_import_locator_materialization_count(),
+            0,
+            "indexing and import discovery must retain only fixed parser locators"
+        );
+
+        let first_key = declaration_import_key(
+            &module,
+            Category::ConstCandidate,
+            "selected",
+            None,
+            0,
+            "same",
+        );
+        let second_key = declaration_import_key(
+            &module,
+            Category::ConstCandidate,
+            "selected",
+            None,
+            1,
+            "same",
+        );
+        assert_ne!(first_key.stable_identity(), second_key.stable_identity());
+        for key in [first_key.clone(), second_key] {
+            let requested = database.runtime.request_registered(
+                &database.declaration_imports,
+                runtime_revision,
+                key,
+                CancellationToken::new(),
+            );
+            assert_eq!(execution(&requested), RequestExecution::Computed);
+            assert_eq!(
+                requested
+                    .dependencies()
+                    .iter()
+                    .map(|dependency| dependency.node.family())
+                    .collect::<Vec<_>>(),
+                vec![
+                    "compiler.declaration-occurrence-index",
+                    "compiler.declaration-shell",
+                    "compiler.parse-module",
+                    "compiler.resolve-import",
+                ]
+            );
+            let terminal = requested.terminal().unwrap();
+            assert_eq!(terminal.kind(), QueryTerminalKind::Success);
+            assert!(matches!(
+                terminal.outcome(),
+                rue_query::QueryOutcome::Success(DeclarationImportQueryValue::Available(
+                    crate::CanonicalImportResolution::Missing
+                ))
+            ));
+        }
+        assert_eq!(
+            parsed_module.declaration_import_locator_materialization_count(),
+            2,
+            "only the two demanded sites in selected may materialize"
+        );
+        let warm = database.runtime.request_registered(
+            &database.declaration_imports,
+            runtime_revision,
+            first_key,
+            CancellationToken::new(),
+        );
+        assert_eq!(execution(&warm), RequestExecution::Reused);
+        assert_eq!(
+            parsed_module.declaration_import_locator_materialization_count(),
+            2
+        );
+        let out_of_range = database.runtime.request_registered(
+            &database.declaration_imports,
+            runtime_revision,
+            declaration_import_key(
+                &module,
+                Category::ConstCandidate,
+                "selected",
+                None,
+                2,
+                "same",
+            ),
+            CancellationToken::new(),
+        );
+        assert!(matches!(
+            out_of_range.terminal().unwrap().outcome(),
+            rue_query::QueryOutcome::Success(DeclarationImportQueryValue::Failure(
+                crate::declaration_candidate::DeclarationImportFailure::SiteOutOfRange {
+                    available: 2,
+                    ..
+                }
+            ))
+        ));
+        let wrong_specifier = database.runtime.request_registered(
+            &database.declaration_imports,
+            runtime_revision,
+            declaration_import_key(
+                &module,
+                Category::ConstCandidate,
+                "selected",
+                None,
+                0,
+                "different",
+            ),
+            CancellationToken::new(),
+        );
+        assert!(matches!(
+            wrong_specifier.terminal().unwrap().outcome(),
+            rue_query::QueryOutcome::Success(DeclarationImportQueryValue::Failure(
+                crate::declaration_candidate::DeclarationImportFailure::SpecifierMismatch {
+                    actual,
+                    ..
+                }
+            )) if actual.as_ref() == "same"
+        ));
+    }
+
+    #[test]
+    fn declaration_import_relocation_reuses_and_stale_absolute_site_fails_typed() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+
+        let first_source = "const selected = @import(\"missing\"); fn main() {}";
+        let (_, first_assembler, first_context) = import_fixture(302, first_source);
+        let mut database = RevisionedQueryDatabase::default();
+        let (first_snapshot, first_reads, first_revision, first_plan) =
+            begin_database_plan(&mut database, &first_assembler, first_context);
+        let old_occurrence = first_plan.groups()[0][0].occurrence().clone();
+        assert_ne!(
+            ResolveImportKey {
+                occurrence: old_occurrence.clone(),
+                mode: ImportDemandMode::Rooted,
+            }
+            .stable_identity(),
+            ResolveImportKey {
+                occurrence: old_occurrence.clone(),
+                mode: ImportDemandMode::Speculative,
+            }
+            .stable_identity(),
+            "resolve-import stable identities must include demand mode"
+        );
+        let first_revision = publish_manifest_observations(
+            &mut database,
+            &first_snapshot,
+            first_reads,
+            &first_plan,
+            first_revision,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let key = declaration_import_key(
+            &module,
+            Category::ConstCandidate,
+            "selected",
+            None,
+            0,
+            "missing",
+        );
+        let first = database.runtime.request_registered(
+            &database.declaration_imports,
+            Revision::new(
+                first_revision.revision_id,
+                first_revision.request_generation,
+            ),
+            key.clone(),
+            CancellationToken::new(),
+        );
+        let first_stamp = first.terminal().unwrap().stamp();
+
+        let shifted_source =
+            "// position-only relocation\n\nconst selected = @import(\"missing\"); fn main() {}";
+        let (_, shifted_assembler, shifted_context) = import_fixture(303, shifted_source);
+        let (shifted_snapshot, shifted_reads, shifted_revision, shifted_plan) =
+            begin_database_plan(&mut database, &shifted_assembler, shifted_context);
+        let shifted_revision = publish_manifest_observations(
+            &mut database,
+            &shifted_snapshot,
+            shifted_reads,
+            &shifted_plan,
+            shifted_revision,
+        );
+        let shifted_runtime = Revision::new(
+            shifted_revision.revision_id,
+            shifted_revision.request_generation,
+        );
+        let relocated = database.runtime.request_registered(
+            &database.declaration_imports,
+            shifted_runtime,
+            key,
+            CancellationToken::new(),
+        );
+        assert_eq!(
+            relocated.terminal().unwrap().stamp(),
+            first_stamp,
+            "position-free declaration import results must stay green across trivia relocation"
+        );
+
+        let stale = database.runtime.request_registered(
+            &database.resolve_imports,
+            shifted_runtime,
+            ResolveImportKey {
+                occurrence: old_occurrence,
+                mode: ImportDemandMode::Rooted,
+            },
+            CancellationToken::new(),
+        );
+        assert!(matches!(
+            stale.terminal().unwrap().outcome(),
+            rue_query::QueryOutcome::Success(ResolveImportValue {
+                site_found: false,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn declaration_import_recovers_when_resolution_observations_arrive() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+
+        let (_, assembler, context) =
+            import_fixture(306, "const selected = @import(\"missing\"); fn main() {}");
+        let mut database = RevisionedQueryDatabase::default();
+        let (snapshot, reads, revision, plan) =
+            begin_database_plan(&mut database, &assembler, context);
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let key = declaration_import_key(
+            &module,
+            Category::ConstCandidate,
+            "selected",
+            None,
+            0,
+            "missing",
+        );
+        let pending = database.runtime.request_registered(
+            &database.declaration_imports,
+            Revision::new(revision.revision_id, revision.request_generation),
+            key.clone(),
+            CancellationToken::new(),
+        );
+        assert!(matches!(
+            pending.terminal().unwrap().outcome(),
+            rue_query::QueryOutcome::Success(DeclarationImportQueryValue::Failure(
+                crate::declaration_candidate::DeclarationImportFailure::ResolutionUnavailable(_)
+            ))
+        ));
+
+        let completed =
+            publish_manifest_observations(&mut database, &snapshot, reads, &plan, revision);
+        let recovered = database.runtime.request_registered(
+            &database.declaration_imports,
+            Revision::new(completed.revision_id, completed.request_generation),
+            key,
+            CancellationToken::new(),
+        );
+        assert_eq!(execution(&recovered), RequestExecution::Computed);
+        assert!(matches!(
+            recovered.terminal().unwrap().outcome(),
+            rue_query::QueryOutcome::Success(DeclarationImportQueryValue::Available(
+                crate::CanonicalImportResolution::Missing
+            ))
+        ));
+    }
+
+    #[test]
+    fn declaration_imports_preserve_canonical_ambiguity_and_category_boundaries() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+
+        let source = "const selected = @import(\"dep\"); struct Box { value: i32, fn get(borrow self) { @import(\"method\"); } fn make() -> Box { @import(\"associated\"); Box { value: 0 } } } drop fn Box(self) { @import(\"drop\"); } fn free() { @import(\"free\"); } enum Choice { A } extern \"C\" { fn foreign() -> i32; }";
+        let (_, mut assembler, context) = import_fixture(304, source);
+        assembler
+            .add_explicit(
+                "/project/dep.rue",
+                "/physical/dep-file.rue",
+                PhysicalFileIdentity::new(2, 1),
+                FileMetadataFingerprint::new(2, 2, 3),
+                Arc::new("const value = 1;".to_owned()),
+            )
+            .unwrap();
+        assembler
+            .add_explicit(
+                "/project/dep/_dep.rue",
+                "/physical/dep-dir.rue",
+                PhysicalFileIdentity::new(3, 1),
+                FileMetadataFingerprint::new(3, 2, 3),
+                Arc::new("const value = 2;".to_owned()),
+            )
+            .unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let (snapshot, reads, revision, plan) =
+            begin_database_plan(&mut database, &assembler, context);
+        let revision =
+            publish_manifest_observations(&mut database, &snapshot, reads, &plan, revision);
+        let runtime_revision = Revision::new(revision.revision_id, revision.request_generation);
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let selected = database.runtime.request_registered(
+            &database.declaration_imports,
+            runtime_revision,
+            declaration_import_key(
+                &module,
+                Category::ConstCandidate,
+                "selected",
+                None,
+                0,
+                "dep",
+            ),
+            CancellationToken::new(),
+        );
+        let selected_terminal = selected.terminal().unwrap();
+        assert!(
+            matches!(
+                selected_terminal.outcome(),
+                rue_query::QueryOutcome::Success(DeclarationImportQueryValue::Available(
+                    crate::CanonicalImportResolution::Ambiguous { .. }
+                ))
+            ),
+            "unexpected declaration import outcome: {:#?}",
+            selected_terminal.outcome()
+        );
+
+        let owner = crate::declaration_candidate::DeclarationCandidateOwner {
+            category: Category::Struct,
+            name: Arc::from("Box"),
+        };
+        for (category, name, owner, specifier) in [
+            (Category::Method, "get", Some(owner.clone()), "method"),
+            (
+                Category::AssociatedFunction,
+                "make",
+                Some(owner.clone()),
+                "associated",
+            ),
+            (Category::Destructor, "Box", Some(owner), "drop"),
+            (Category::Function, "free", None, "free"),
+        ] {
+            let requested = database.runtime.request_registered(
+                &database.declaration_imports,
+                runtime_revision,
+                declaration_import_key(&module, category, name, owner, 0, specifier),
+                CancellationToken::new(),
+            );
+            assert!(matches!(
+                requested.terminal().unwrap().outcome(),
+                rue_query::QueryOutcome::Success(DeclarationImportQueryValue::Available(
+                    crate::CanonicalImportResolution::Missing
+                ))
+            ));
+        }
+
+        for (category, name) in [
+            (Category::Struct, "Box"),
+            (Category::Enum, "Choice"),
+            (Category::ExternFunction, "foreign"),
+        ] {
+            let key = declaration_import_key(&module, category, name, None, 0, "none");
+            let requested = database.runtime.request_registered(
+                &database.declaration_imports,
+                runtime_revision,
+                key.clone(),
+                CancellationToken::new(),
+            );
+            assert!(matches!(
+                requested.terminal().unwrap().outcome(),
+                rue_query::QueryOutcome::Success(DeclarationImportQueryValue::Failure(
+                    crate::declaration_candidate::DeclarationImportFailure::CategoryMismatch(
+                        actual
+                    )
+                )) if actual == &key.0
+            ));
+        }
+    }
+
+    #[test]
+    fn resolved_declaration_import_observes_only_winning_physical_provenance() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+
+        let source = "const selected = @import(\"dep.rue\"); fn main() {}";
+        let (_, mut first_assembler, first_context) = import_fixture(307, source);
+        first_assembler
+            .add_explicit(
+                "/project/dep.rue",
+                "/physical/dep.rue",
+                PhysicalFileIdentity::new(2, 1),
+                FileMetadataFingerprint::new(4, 5, 6),
+                Arc::new("const value = 1;".to_owned()),
+            )
+            .unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let (first_snapshot, first_reads, first_revision, first_plan) =
+            begin_database_plan(&mut database, &first_assembler, first_context);
+        let first_revision = publish_manifest_observations(
+            &mut database,
+            &first_snapshot,
+            first_reads,
+            &first_plan,
+            first_revision,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let key = declaration_import_key(
+            &module,
+            Category::ConstCandidate,
+            "selected",
+            None,
+            0,
+            "dep.rue",
+        );
+        let first = database.runtime.request_registered(
+            &database.declaration_imports,
+            Revision::new(
+                first_revision.revision_id,
+                first_revision.request_generation,
+            ),
+            key.clone(),
+            CancellationToken::new(),
+        );
+        assert!(matches!(
+            first.terminal().unwrap().outcome(),
+            rue_query::QueryOutcome::Success(DeclarationImportQueryValue::Available(
+                crate::CanonicalImportResolution::Resolved(target)
+            )) if target.as_str() == "dep.rue"
+        ));
+        let first_stamp = first.terminal().unwrap().stamp();
+
+        let (_, mut remapped_assembler, remapped_context) = import_fixture(307, source);
+        remapped_assembler
+            .add_explicit(
+                "/project/other.rue",
+                "/physical/other.rue",
+                PhysicalFileIdentity::new(2, 1),
+                FileMetadataFingerprint::new(4, 5, 6),
+                Arc::new("const value = 1;".to_owned()),
+            )
+            .unwrap();
+        let (remapped_snapshot, remapped_reads, remapped_revision, remapped_plan) =
+            begin_database_plan(&mut database, &remapped_assembler, remapped_context);
+        let remapped_revision = publish_remapped_observations(
+            &mut database,
+            &remapped_snapshot,
+            remapped_reads,
+            &remapped_plan,
+            remapped_revision,
+            &[("/project/dep.rue", PhysicalFileIdentity::new(2, 1))],
+        );
+        let remapped = database.runtime.request_registered(
+            &database.declaration_imports,
+            Revision::new(
+                remapped_revision.revision_id,
+                remapped_revision.request_generation,
+            ),
+            key.clone(),
+            CancellationToken::new(),
+        );
+        let remapped_terminal = remapped.terminal().unwrap();
+        assert_ne!(remapped_terminal.stamp(), first_stamp);
+        assert!(matches!(
+            remapped_terminal.outcome(),
+            rue_query::QueryOutcome::Success(DeclarationImportQueryValue::Available(
+                crate::CanonicalImportResolution::Resolved(target)
+            )) if target.as_str() == "other.rue"
+        ));
+        let remapped_stamp = remapped_terminal.stamp();
+
+        let mut green_assembler = remapped_assembler.clone();
+        green_assembler
+            .add_explicit(
+                "/project/unrelated.rue",
+                "/physical/unrelated.rue",
+                PhysicalFileIdentity::new(9, 1),
+                FileMetadataFingerprint::new(9, 2, 3),
+                Arc::new("const unrelated = 9;".to_owned()),
+            )
+            .unwrap();
+        let green_context =
+            ImportDiscoveryContext::new(307, "/project", Some("/sdk"), "test-policy").unwrap();
+        let (green_snapshot, green_reads, green_revision, green_plan) =
+            begin_database_plan(&mut database, &green_assembler, green_context);
+        let green_revision = publish_remapped_observations(
+            &mut database,
+            &green_snapshot,
+            green_reads,
+            &green_plan,
+            green_revision,
+            &[("/project/dep.rue", PhysicalFileIdentity::new(2, 1))],
+        );
+        let green = database.runtime.request_registered(
+            &database.declaration_imports,
+            Revision::new(
+                green_revision.revision_id,
+                green_revision.request_generation,
+            ),
+            key,
+            CancellationToken::new(),
+        );
+        assert_eq!(green.terminal().unwrap().stamp(), remapped_stamp);
+    }
+
+    #[test]
+    fn ambiguous_declaration_import_observes_both_winning_provenance_leaves() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+
+        let source = "const selected = @import(\"dep\"); fn main() {}";
+        let (_, mut first_assembler, first_context) = import_fixture(308, source);
+        for (path, canonical, identity, value) in [
+            (
+                "/project/dep.rue",
+                "/physical/dep-file.rue",
+                PhysicalFileIdentity::new(2, 1),
+                1,
+            ),
+            (
+                "/project/dep/_dep.rue",
+                "/physical/dep-dir.rue",
+                PhysicalFileIdentity::new(3, 1),
+                2,
+            ),
+        ] {
+            first_assembler
+                .add_explicit(
+                    path,
+                    canonical,
+                    identity,
+                    FileMetadataFingerprint::new(value, 5, 6),
+                    Arc::new(format!("const value = {value};")),
+                )
+                .unwrap();
+        }
+        let mut database = RevisionedQueryDatabase::default();
+        let (first_snapshot, first_reads, first_revision, first_plan) =
+            begin_database_plan(&mut database, &first_assembler, first_context);
+        let first_revision = publish_manifest_observations(
+            &mut database,
+            &first_snapshot,
+            first_reads,
+            &first_plan,
+            first_revision,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let key = declaration_import_key(
+            &module,
+            Category::ConstCandidate,
+            "selected",
+            None,
+            0,
+            "dep",
+        );
+        let first = database.runtime.request_registered(
+            &database.declaration_imports,
+            Revision::new(
+                first_revision.revision_id,
+                first_revision.request_generation,
+            ),
+            key.clone(),
+            CancellationToken::new(),
+        );
+        assert!(matches!(
+            first.terminal().unwrap().outcome(),
+            rue_query::QueryOutcome::Success(DeclarationImportQueryValue::Available(
+                crate::CanonicalImportResolution::Ambiguous {
+                    file_module,
+                    directory_module,
+                }
+            )) if file_module.as_str() == "dep.rue"
+                && directory_module.as_str() == "dep/_dep.rue"
+        ));
+        let first_stamp = first.terminal().unwrap().stamp();
+
+        let (_, mut remapped_assembler, remapped_context) = import_fixture(308, source);
+        for (path, canonical, identity, value) in [
+            (
+                "/project/left.rue",
+                "/physical/left.rue",
+                PhysicalFileIdentity::new(2, 1),
+                1,
+            ),
+            (
+                "/project/right.rue",
+                "/physical/right.rue",
+                PhysicalFileIdentity::new(3, 1),
+                2,
+            ),
+        ] {
+            remapped_assembler
+                .add_explicit(
+                    path,
+                    canonical,
+                    identity,
+                    FileMetadataFingerprint::new(value, 5, 6),
+                    Arc::new(format!("const value = {value};")),
+                )
+                .unwrap();
+        }
+        let (remapped_snapshot, remapped_reads, remapped_revision, remapped_plan) =
+            begin_database_plan(&mut database, &remapped_assembler, remapped_context);
+        let remaps = [
+            ("/project/dep.rue", PhysicalFileIdentity::new(2, 1)),
+            ("/project/dep/_dep.rue", PhysicalFileIdentity::new(3, 1)),
+        ];
+        let remapped_revision = publish_remapped_observations(
+            &mut database,
+            &remapped_snapshot,
+            remapped_reads,
+            &remapped_plan,
+            remapped_revision,
+            &remaps,
+        );
+        let remapped = database.runtime.request_registered(
+            &database.declaration_imports,
+            Revision::new(
+                remapped_revision.revision_id,
+                remapped_revision.request_generation,
+            ),
+            key.clone(),
+            CancellationToken::new(),
+        );
+        let remapped_terminal = remapped.terminal().unwrap();
+        assert_ne!(remapped_terminal.stamp(), first_stamp);
+        assert!(matches!(
+            remapped_terminal.outcome(),
+            rue_query::QueryOutcome::Success(DeclarationImportQueryValue::Available(
+                crate::CanonicalImportResolution::Ambiguous {
+                    file_module,
+                    directory_module,
+                }
+            )) if file_module.as_str() == "left.rue"
+                && directory_module.as_str() == "right.rue"
+        ));
+        let remapped_stamp = remapped_terminal.stamp();
+
+        let mut green_assembler = remapped_assembler.clone();
+        green_assembler
+            .add_explicit(
+                "/project/unrelated.rue",
+                "/physical/unrelated.rue",
+                PhysicalFileIdentity::new(9, 1),
+                FileMetadataFingerprint::new(9, 2, 3),
+                Arc::new("const unrelated = 9;".to_owned()),
+            )
+            .unwrap();
+        let green_context =
+            ImportDiscoveryContext::new(308, "/project", Some("/sdk"), "test-policy").unwrap();
+        let (green_snapshot, green_reads, green_revision, green_plan) =
+            begin_database_plan(&mut database, &green_assembler, green_context);
+        let green_revision = publish_remapped_observations(
+            &mut database,
+            &green_snapshot,
+            green_reads,
+            &green_plan,
+            green_revision,
+            &remaps,
+        );
+        let green = database.runtime.request_registered(
+            &database.declaration_imports,
+            Revision::new(
+                green_revision.revision_id,
+                green_revision.request_generation,
+            ),
+            key,
+            CancellationToken::new(),
+        );
+        assert_eq!(green.terminal().unwrap().stamp(), remapped_stamp);
+    }
+
+    #[test]
+    fn import_publication_rejects_duplicate_and_unmatched_physical_provenance() {
+        let source = "const selected = @import(\"dep\"); fn main() {}";
+        let (_, assembler, context) = import_fixture(309, source);
+        let snapshot = assembler.snapshot().unwrap();
+        let reads = assembler.accepted_read_manifest();
+        let duplicated = reads
+            .iter()
+            .cloned()
+            .chain(std::iter::once(reads[0].clone()))
+            .collect::<Vec<_>>();
+        let mut database = RevisionedQueryDatabase::default();
+        assert!(
+            database
+                .begin_import_inputs(&snapshot, context.clone(), duplicated.into())
+                .is_err(),
+            "duplicate physical provenance must fail before revision publication"
+        );
+
+        let (snapshot, reads, revision, plan) =
+            begin_database_plan(&mut database, &assembler, context);
+        let roots = ImportDemandRoots::whole_plan(&plan);
+        let frontier = database
+            .import_frontier(revision, &plan, ImportDemandMode::Rooted, &roots)
+            .unwrap();
+        let observations = frontier
+            .requests()
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(index, request)| {
+                if index == 0 {
+                    let accepted = crate::AcceptedImportSource::new(
+                        request.requested_path(),
+                        request.requested_path(),
+                        PhysicalFileIdentity::new(99, 99),
+                        FileMetadataFingerprint::new(1, 2, 3),
+                        Arc::new("const value = 1;".to_owned()),
+                    )
+                    .unwrap();
+                    ImportObservation::accepted(request, accepted).unwrap()
+                } else {
+                    ImportObservation::absent(request)
+                }
+            })
+            .collect();
+        assert!(
+            database
+                .publish_import_batch(&frontier, &snapshot, reads, observations)
+                .is_err(),
+            "accepted observations without exact manifest provenance must not publish"
+        );
+        assert_eq!(database.current_import_revision(), Some(revision));
+    }
+
+    #[test]
+    fn canceled_and_evicted_declaration_import_requests_recover() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+
+        let source_text = (0..=MODULE_QUERY_MEMO_RETENTION)
+            .map(|index| format!("const c{index} = @import(\"x{index}\");"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let (_, assembler, context) = import_fixture(305, &source_text);
+        let snapshot = assembler.snapshot().unwrap();
+        let reads = assembler.accepted_read_manifest();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database
+            .begin_import_inputs(&snapshot, context, reads)
+            .unwrap();
+        let runtime_revision = Revision::new(revision.revision_id, revision.request_generation);
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let key = |index| {
+            declaration_import_key(
+                &module,
+                Category::ConstCandidate,
+                format!("c{index}"),
+                None,
+                0,
+                &format!("x{index}"),
+            )
+        };
+
+        let canceled = CancellationToken::new();
+        canceled.cancel();
+        let aborted = database.runtime.request_registered(
+            &database.declaration_imports,
+            runtime_revision,
+            key(0),
+            canceled,
+        );
+        assert_eq!(execution(&aborted), RequestExecution::Aborted);
+        assert!(aborted.terminal().is_none());
+
+        for index in 0..=MODULE_QUERY_MEMO_RETENTION {
+            let requested = database.runtime.request_registered(
+                &database.declaration_imports,
+                runtime_revision,
+                key(index),
+                CancellationToken::new(),
+            );
+            assert!(matches!(
+                requested.terminal().unwrap().outcome(),
+                rue_query::QueryOutcome::Success(DeclarationImportQueryValue::Failure(
+                    crate::declaration_candidate::DeclarationImportFailure::ResolutionUnavailable(
+                        _
+                    )
+                ))
+            ));
+        }
+        assert_eq!(
+            database.declaration_imports.retention().terminals,
+            MODULE_QUERY_MEMO_RETENTION
+        );
+        let recovered = database.runtime.request_registered(
+            &database.declaration_imports,
+            runtime_revision,
+            key(0),
+            CancellationToken::new(),
+        );
+        assert_eq!(execution(&recovered), RequestExecution::Computed);
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

- add an exact declaration-import query keyed by declaration identity and parser-owned raw import ranges
- record physical-file provenance as a durable input leaf and fail closed on invalid provenance
- share canonical declaration-winner selection and preserve demand mode in stable query identity
- add cold/warm laziness, invalidation, provenance, cancellation, eviction, and source-authority retirement coverage

## Validation

- `scripts/rue quick` (34/34 targets; compiler 658/658; frontend differential 641/641; zero oracle disagreements)
- `scripts/rue test` (full serialized suite, including 1705/1716 CLI, 64/64 generated oracle, 2153/2171 spec, and 204/204 UI)
- `/opt/homebrew/bin/bash ./clippy.sh` (61 targets)
- `git diff --check`

Refs RUE-1026
