### PR TITLE
RUE-1066: nest RawBuf(u8) in StrBuf; reorder header to [buf, cap, len]

### DIFF
--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -1485,7 +1485,11 @@ impl<'a> BodySema<'a> {
             self.type_pool.struct_lang_item(struct_id) == Some(crate::LangItem::StrBuf)
         });
         let (arg_ref, temp_scope) = if source_strbuf {
-            self.materialize_borrow_argument(air, arg_result.air_ref, arg_type, span, ctx)?
+            // RUE-1066: consume the StrBuf through its method-routed `{ptr, len}`
+            // view so the parse helper receives the same 2-word `str` shape as a
+            // native `str` argument and never reads the reordered 3-word header
+            // by offset.
+            self.strbuf_text_view(air, arg_result.air_ref, arg_type, span, ctx)?
         } else {
             (arg_result.air_ref, Vec::new())
         };

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -4283,6 +4283,32 @@ impl<'a> BodySema<'a> {
                     self.rir.get(arg.value).span,
                     ctx,
                 )?;
+                // RUE-1066: a `StrBuf` source no longer shares `str`'s `{ptr,
+                // len}` prefix now that its growable storage nests in a RawBuf
+                // core (`[buf, cap, len]`). Passing the raw 3-word storage by
+                // reference would let the callee read `cap` as `len`. Narrow to
+                // a method-routed `{ptr, len}` view materialized in a temporary
+                // and pass an exclusive reference to that instead: the view's
+                // pointer is `as_ptr()` (the real buffer), so byte writes still
+                // reach the caller's storage, while `len` reads the correct
+                // word. Whole-view rebinding is already rejected
+                // (StrViewReassignment), so the snapshot length stays valid.
+                if self.is_strbuf(arg_result.ty) {
+                    let span = self.rir.get(arg.value).span;
+                    let (view, prefix) =
+                        self.strbuf_text_view(air, arg_result.air_ref, arg_result.ty, span, ctx)?;
+                    let view =
+                        self.wrap_value_with_temp_scope(air, view, param_ty, span, prefix)?;
+                    let (load, mat_prefix) =
+                        self.materialize_borrow_argument(air, view, param_ty, span, ctx)?;
+                    let value =
+                        self.wrap_value_with_temp_scope(air, load, param_ty, span, mat_prefix)?;
+                    air_args.push(AirCallArg {
+                        value,
+                        mode: AirArgMode::Inout,
+                    });
+                    continue;
+                }
             }
             air_args.push(AirCallArg {
                 value: arg_result.air_ref,

--- a/crates/rue-cli-tests/cases/std_strbuf.toml
+++ b/crates/rue-cli-tests/cases/std_strbuf.toml
@@ -59,11 +59,11 @@ fn main() -> i32 {
     bytes.reserve_source(20);
     if bytes.len() != 17 || bytes.capacity() < 37 { return 2; }
     checked {
-        if @byte_read(bytes.buf, 0) != 1 { return 3; }
-        if @byte_read(bytes.buf, 7) != 8 { return 4; }
-        if @byte_read(bytes.buf, 8) != 9 { return 5; }
-        if @byte_read(bytes.buf, 15) != 16 { return 6; }
-        if @byte_read(bytes.buf, 16) != 17 { return 7; }
+        if @byte_read(bytes.core.buf, 0) != 1 { return 3; }
+        if @byte_read(bytes.core.buf, 7) != 8 { return 4; }
+        if @byte_read(bytes.core.buf, 8) != 9 { return 5; }
+        if @byte_read(bytes.core.buf, 15) != 16 { return 6; }
+        if @byte_read(bytes.core.buf, 16) != 17 { return 7; }
     };
 
     let value: S = "abcdefghijklmnopq";
@@ -105,11 +105,11 @@ fn main() -> i32 {
     if value != "abcdefghijkabcdefghijk" { return 1; }
     if value.capacity() < value.len() { return 2; }
     checked {
-        if @byte_read(value.buf, 7) != 104 { return 3; }
-        if @byte_read(value.buf, 8) != 105 { return 4; }
-        if @byte_read(value.buf, 10) != 107 { return 5; }
-        if @byte_read(value.buf, 11) != 97 { return 6; }
-        if @byte_read(value.buf, 21) != 107 { return 7; }
+        if @byte_read(value.core.buf, 7) != 104 { return 3; }
+        if @byte_read(value.core.buf, 8) != 105 { return 4; }
+        if @byte_read(value.core.buf, 10) != 107 { return 5; }
+        if @byte_read(value.core.buf, 11) != 97 { return 6; }
+        if @byte_read(value.core.buf, 21) != 107 { return 7; }
     };
 
     let mut reserved: S = "stay";
@@ -160,9 +160,10 @@ const std = @import("std");
 const S = std.strbuf.StrBuf;
 
 fn main() -> i32 {
-    let zero: u64 = 0;
-    let p: ptr mut u8 = checked { @int_to_ptr(zero) };
-    let mut impossible = S { buf: p, len: 18446744073709551615, cap: 0 };
+    // White-box: force a length at the u64 ceiling so the next grow's
+    // len + additional overflows. The buffer lives in the RawBuf core (RUE-1066).
+    let mut impossible = S.new();
+    impossible.len = 18446744073709551615;
     impossible.grow(1);
     0
 }
@@ -320,7 +321,13 @@ const S = std.strbuf.StrBuf;
 fn owned(byte: u8) -> S {
     let p: ptr mut u8 = checked { @alloc_bytes(4, 1) };
     checked { @byte_write(p, 0, byte); };
-    std.strbuf.StrBuf { buf: p, len: 1, cap: 4 }
+    // White-box: assemble an owned header (cap = 4 exactly, below the 16 floor)
+    // over the RawBuf core (RUE-1066).
+    let mut s = S.new();
+    s.core.buf = p;
+    s.core.cap = 4;
+    s.len = 1;
+    s
 }
 
 fn consume(s: S) -> i32 {
@@ -347,7 +354,7 @@ exit_code = 0
 
 [[case]]
 name = "aliased_three_word_layout_and_scope_drop"
-description = "An alias preserves the ptr/len/cap three-word layout and source-defined scope-exit destructor."
+description = "An alias preserves the ptr/cap/len three-word layout (buf/cap nested in the RawBuf core) and source-defined scope-exit destructor."
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -358,14 +365,15 @@ fn make() -> S {
 }
 
 fn main() -> i32 {
+    // StrBuf nests its growable storage in a RawBuf(u8) core (RUE-1066), so the
+    // three machine words are still [buf, cap, len] in memory: the RawBuf core
+    // (a two-word {buf, cap}) sits at offset 0, and len follows at offset 16.
     let size = @size_of(S);
-    let buf_offset: u64 = @offset_of(S, buf);
+    let core_offset: u64 = @offset_of(S, core);
     let len_offset: u64 = @offset_of(S, len);
-    let cap_offset: u64 = @offset_of(S, cap);
     if size != 24 { return 1; }
-    if buf_offset != 0 { return 2; }
-    if len_offset != 8 { return 3; }
-    if cap_offset != 16 { return 4; }
+    if core_offset != 0 { return 2; }
+    if len_offset != 16 { return 3; }
 
     // Moving the value returned by make leaves one final owner. Its named,
     // source-defined destructor runs exactly once at this scope exit; cap == 0

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1243,14 +1243,18 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(len),
                     string_id,
                 });
-                slots = vec![ptr, len];
+                // A `str` view is `{ptr, len}`; an owned `StrBuf` header is
+                // `{buf, cap, len}` — the `RawBuf(u8)` core's `{buf, cap}` then
+                // the length (RUE-1066), so `cap` precedes `len`.
                 if plan.policy.shape.slot_count() >= 3 {
                     let cap = self.mir.alloc_vreg();
                     self.mir.push(Aarch64Inst::StringConstCap {
                         dst: Operand::Virtual(cap),
                         string_id,
                     });
-                    slots.push(cap);
+                    slots = vec![ptr, cap, len];
+                } else {
+                    slots = vec![ptr, len];
                 }
                 ptr
             }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1418,14 +1418,18 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(len),
                     string_id,
                 });
-                slots = vec![ptr, len];
+                // A `str` view is `{ptr, len}`; an owned `StrBuf` header is
+                // `{buf, cap, len}` — the `RawBuf(u8)` core's `{buf, cap}` then
+                // the length (RUE-1066), so `cap` precedes `len`.
                 if plan.policy.shape.slot_count() >= 3 {
                     let cap = self.mir.alloc_vreg();
                     self.mir.push(X86Inst::StringConstCap {
                         dst: Operand::Virtual(cap),
                         string_id,
                     });
-                    slots.push(cap);
+                    slots = vec![ptr, cap, len];
+                } else {
+                    slots = vec![ptr, len];
                 }
                 ptr
             }

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -80,7 +80,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.abi",
         "string_return_with_args",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -92,7 +92,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.aggregate_slots",
         "store_string_from_field",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -116,7 +116,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.borrow_sibling_moves",
         "byref_method_receiver_stays_usable_control",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -128,7 +128,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.byref_params",
         "inout_whole_string_reassign",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -827,12 +827,6 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "string_field",
-        "string_param_rebound_to_local",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
-        &[],
-    ),
-    Entry::new(
-        "string_field",
         "string_struct_field_eq_false",
         semantic(SemanticGapKind::TextProjectionRead),
         &[],
@@ -841,12 +835,6 @@ const ENTRIES: &[Entry] = &[
         "string_field",
         "string_struct_field_eq_true",
         semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "string_field",
-        "struct_with_string_field_eq",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
         &[],
     ),
 ];

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -141,12 +141,6 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "types.destructors",
-        "type_with_destructor_literal_no_heap",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
-        &[],
-    ),
-    Entry::new(
-        "types.destructors",
         "type_with_destructor_literal_promoted",
         semantic(SemanticGapKind::TextProjectionRead),
         &[],
@@ -154,13 +148,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "types.move-semantics",
         "borrow_method_receiver_still_usable_after",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_affine_move",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     Entry::new(
@@ -299,18 +287,6 @@ const ENTRIES: &[Entry] = &[
         "types.strings",
         "string_new_equality_with_empty",
         semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "string_type_annotation",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "string_type_annotation_empty",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
         &[],
     ),
     Entry::new(

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -1019,9 +1019,59 @@ impl<'a> Interp<'a> {
         else {
             return None;
         };
+        // The nested RawBuf core's buffer pointer (`core.buf`, field 0) is the
+        // text pointer of a three-slot owned StrBuf (RUE-1066). The base value
+        // is the two-slot core view left by the `.core` passthrough, so it
+        // certifies the owned width via the `expected == 3` reconciliation in
+        // `is_matching_text_projection`.
+        if self.is_strbuf_core_struct(struct_id) {
+            return (field_index == 0).then_some(3);
+        }
         let slots = self.text_struct_slots(struct_id)?;
         let def = self.state.type_pool.struct_def(struct_id);
-        (def.field_count() == slots && (field_index as usize) < 2).then_some(slots)
+        // Flat text struct: str/Str(N) (2 fields) or a legacy flat StrBuf
+        // (3 fields, `{ptr, len, cap}`); its `{ptr, len}` prefix is fields 0/1.
+        if def.field_count() == slots && (field_index as usize) < 2 {
+            return Some(slots);
+        }
+        // Nested StrBuf (RUE-1066): `{core, len}` is two fields but three ABI
+        // slots. Its length header is field 1; the buffer pointer lives in the
+        // core (matched above).
+        if self.is_owned_string_struct(struct_id) && def.field_count() == 2 && field_index == 1 {
+            return Some(slots);
+        }
+        None
+    }
+
+    /// Whether `struct_id` is the nested `RawBuf(u8)` core of an owned StrBuf
+    /// (RUE-1066): a two-field `{buf: ptr, cap: u64}` aggregate that is neither
+    /// a `str`/`Str(N)` view nor the StrBuf wrapper itself. It is only ever
+    /// consulted while projecting an opaque `Value::Str`, where the base is
+    /// already known to be text, so this shape check cannot misfire on an
+    /// unrelated user struct.
+    fn is_strbuf_core_struct(&self, struct_id: rue_air::StructId) -> bool {
+        if self.is_str_like_struct(struct_id) || self.is_owned_string_struct(struct_id) {
+            return false;
+        }
+        let def = self.state.type_pool.struct_def(struct_id);
+        def.field_count() == 2 && def.fields[0].ty.is_ptr() && def.fields[1].ty == Type::U64
+    }
+
+    /// The `.core` step of a nested StrBuf (`{core: RawBuf(u8), len}`, field 0).
+    /// Projecting it leaves the opaque text value in place, narrowed to the
+    /// two-slot core view so the buffer-pointer and capacity projections that
+    /// follow resolve against the RawBuf core.
+    fn is_strbuf_core_projection(&self, projection: Projection) -> bool {
+        let Projection::Field {
+            struct_id,
+            field_index,
+        } = projection
+        else {
+            return false;
+        };
+        field_index == 0
+            && self.is_owned_string_struct(struct_id)
+            && self.state.type_pool.struct_def(struct_id).field_count() == 2
     }
 
     fn is_matching_text_projection(&self, projection: Projection, actual_slots: usize) -> bool {
@@ -1060,9 +1110,15 @@ impl<'a> Interp<'a> {
         else {
             return false;
         };
-        self.is_owned_string_struct(struct_id)
+        // Legacy flat StrBuf `{ptr, len, cap}`: capacity is field 2.
+        if self.is_owned_string_struct(struct_id)
             && self.state.type_pool.struct_def(struct_id).field_count() == 3
             && field_index == 2
+        {
+            return true;
+        }
+        // Nested RawBuf core `{buf, cap}` (RUE-1066): capacity is field 1.
+        self.is_strbuf_core_struct(struct_id) && field_index == 1
     }
 
     fn is_owned_string_type(&self, ty: Type) -> bool {
@@ -3034,6 +3090,13 @@ impl<'a> Interp<'a> {
                         UnsupportedKind::SemanticGap(SemanticGapKind::TextProjectionRead),
                         "projection of non-aggregate",
                     ));
+                }
+                // The `.core` step of a nested StrBuf (RUE-1066) is transparent:
+                // keep the opaque bytes and narrow to the two-slot RawBuf core
+                // so the `core.buf` / `core.cap` projections that follow resolve
+                // to the text-pointer / capacity model gaps.
+                Value::Str { bytes, .. } if self.is_strbuf_core_projection(projection) => {
+                    Value::Str { bytes, slots: 2 }
                 }
                 _ => {
                     return Err(unsupported(

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -1191,7 +1191,13 @@ fn read_line_requires_trusted_source_strbuf_payload_metadata() {
             .to_owned(),
     );
     let strbuf = Arc::new(
-        r#"pub struct StrBuf { buf: ptr mut u8, len: u64, cap: u64 }
+        r#"pub struct StrBuf {
+            buf: ptr mut u8,
+            len: u64,
+            cap: u64,
+            fn len(borrow self) -> u64 { self.len }
+            fn as_ptr(borrow self) -> ptr mut u8 { self.buf }
+        }
         drop fn StrBuf(self) { }"#
             .to_owned(),
     );

--- a/crates/rue-runtime-abi/src/lib.rs
+++ b/crates/rue-runtime-abi/src/lib.rs
@@ -219,17 +219,19 @@ pub struct AggregateShape {
     pub slots: &'static [AggregateSlot],
 }
 
+// Slot order mirrors `StrBuf`'s flattened `{buf, cap, len}` layout (RUE-1066):
+// the `RawBuf(u8)` core contributes `{buf, cap}`, then the length.
 const STR_BUF_SLOTS: &[AggregateSlot] = &[
     AggregateSlot {
         name: "ptr",
         ty: AbiType::MutBytePointer,
     },
     AggregateSlot {
-        name: "len",
+        name: "cap",
         ty: AbiType::U64,
     },
     AggregateSlot {
-        name: "cap",
+        name: "len",
         ty: AbiType::U64,
     },
 ];
@@ -244,11 +246,11 @@ const OPTION_STR_BUF_SLOTS: &[AggregateSlot] = &[
         ty: AbiType::MutBytePointer,
     },
     AggregateSlot {
-        name: "len",
+        name: "cap",
         ty: AbiType::U64,
     },
     AggregateSlot {
-        name: "cap",
+        name: "len",
         ty: AbiType::U64,
     },
 ];
@@ -282,12 +284,16 @@ pub const AGGREGATE_SHAPES: [AggregateShape; 3] = [
     },
 ];
 
-/// The three-word growable-string result written by formatting helpers.
+/// The three-word growable-string result written by formatting helpers. The
+/// field order mirrors `StrBuf`'s flattened slot layout `{buf, cap, len}` — the
+/// buffer and capacity live in the shared `RawBuf(u8)` core, then the length
+/// (RUE-1066) — so a `StrBuf`-shaped value is copied slot-for-slot from this
+/// result. Nothing outside the compiler/runtime depends on this order.
 #[repr(C)]
 pub struct StrBufResult {
     pub ptr: *mut u8,
-    pub len: u64,
     pub cap: u64,
+    pub len: u64,
 }
 
 /// The tagged growable-string option written by `__rue_read_line`.
@@ -295,8 +301,8 @@ pub struct StrBufResult {
 pub struct OptionStrBufResult {
     pub disc: u64,
     pub ptr: *mut u8,
-    pub len: u64,
     pub cap: u64,
+    pub len: u64,
 }
 
 /// The tagged integer option written by the parsing helpers.
@@ -310,14 +316,14 @@ const _: () = {
     assert!(core::mem::size_of::<StrBufResult>() == 24);
     assert!(core::mem::align_of::<StrBufResult>() == 8);
     assert!(core::mem::offset_of!(StrBufResult, ptr) == 0);
-    assert!(core::mem::offset_of!(StrBufResult, len) == 8);
-    assert!(core::mem::offset_of!(StrBufResult, cap) == 16);
+    assert!(core::mem::offset_of!(StrBufResult, cap) == 8);
+    assert!(core::mem::offset_of!(StrBufResult, len) == 16);
     assert!(core::mem::size_of::<OptionStrBufResult>() == 32);
     assert!(core::mem::align_of::<OptionStrBufResult>() == 8);
     assert!(core::mem::offset_of!(OptionStrBufResult, disc) == 0);
     assert!(core::mem::offset_of!(OptionStrBufResult, ptr) == 8);
-    assert!(core::mem::offset_of!(OptionStrBufResult, len) == 16);
-    assert!(core::mem::offset_of!(OptionStrBufResult, cap) == 24);
+    assert!(core::mem::offset_of!(OptionStrBufResult, cap) == 16);
+    assert!(core::mem::offset_of!(OptionStrBufResult, len) == 24);
     assert!(core::mem::size_of::<OptionIntResult>() == 16);
     assert!(core::mem::align_of::<OptionIntResult>() == 8);
     assert!(core::mem::offset_of!(OptionIntResult, disc) == 0);
@@ -1622,11 +1628,11 @@ mod tests {
                     ty: AbiType::MutBytePointer
                 },
                 AggregateSlot {
-                    name: "len",
+                    name: "cap",
                     ty: AbiType::U64
                 },
                 AggregateSlot {
-                    name: "cap",
+                    name: "len",
                     ty: AbiType::U64
                 },
             ]
@@ -1643,11 +1649,11 @@ mod tests {
                     ty: AbiType::MutBytePointer
                 },
                 AggregateSlot {
-                    name: "len",
+                    name: "cap",
                     ty: AbiType::U64
                 },
                 AggregateSlot {
-                    name: "cap",
+                    name: "len",
                     ty: AbiType::U64
                 },
             ]

--- a/std/strbuf.rue
+++ b/std/strbuf.rue
@@ -5,6 +5,14 @@
 // Allocation failure is fail-fast, and an owner header is changed only after
 // its replacement allocation has succeeded.
 //
+// The `{buf, cap}` allocation lives in the shared `RawBuf(u8)` growable-buffer
+// core (RUE-1066), the same core `ArrayBuf(T)` builds on — so both canonical
+// growable containers own their heap through one primitive. StrBuf adds the
+// length and the byte-string algorithms on top. The packed bytes are still
+// read/written through the byte intrinsics (`@byte_read`/`@byte_write`/
+// `@byte_copy`) for the memcpy-shaped bulk copies; only the raw `{buf, cap}`
+// ownership (allocate / grow / free / teardown) is delegated to the core.
+//
 // Interoperability with core `str` and `ArrayBuf(u8)` is explicit and copying:
 // `from_str`, `from_bytes`, and `to_bytes` create independent owners, while
 // `append_str`, `append_bytes`, and `append_borrowed` keep their source usable.
@@ -12,6 +20,7 @@
 
 const option = @import("option.rue");
 const arraybuf = @import("arraybuf.rue");
+const rawbuf = @import("rawbuf.rue");
 
 // Raw-pointer operations are private module implementation details. Keeping
 // them outside the public struct prevents callers from laundering unchecked
@@ -46,13 +55,13 @@ fn copy_packed_bytes(
 }
 
 pub struct StrBuf {
-    buf: ptr mut u8,
+    // The `{buf, cap}` allocation, shared with ArrayBuf via the RawBuf core.
+    core: rawbuf.RawBuf(u8),
     len: u64,
-    cap: u64,
 
     fn new() -> Self {
-        let zero: u64 = 0;
-        Self { buf: checked { @int_to_ptr(zero) }, len: 0, cap: 0 }
+        let R = rawbuf.RawBuf(u8);
+        Self { core: R.new(), len: 0 }
     }
 
     fn with_capacity(requested: u64) -> Self {
@@ -66,7 +75,7 @@ pub struct StrBuf {
         let mut out = Self.allocate(source.len());
         let mut i: u64 = 0;
         while i < source.len() {
-            write_packed_byte(out.buf, i, source[i]);
+            write_packed_byte(out.core.buf, i, source[i]);
             i = i + 1;
         }
         out.len = source.len();
@@ -90,28 +99,29 @@ pub struct StrBuf {
         let mut out = Self.allocate(count);
         let mut i: u64 = 0;
         while i < count {
-            write_packed_byte(out.buf, i, source.get_or(start + i, 0));
+            write_packed_byte(out.core.buf, i, source.get_or(start + i, 0));
             i = i + 1;
         }
         out.len = count;
         out
     }
 
-    // Shared allocator used by constructors and owned algorithms.
+    // Shared allocator used by constructors and owned algorithms. Delegates the
+    // fresh allocation to the core's `grow_to` (an owning realloc from the empty
+    // state), which performs the byte-size and null-result checks.
     fn allocate(requested: u64) -> Self {
         if requested == 0 {
             return Self.new();
         }
         let cap = Self.initial_capacity(requested);
-        let allocation: ptr mut u8 = checked { @alloc_bytes(cap, 1) };
-        if checked { @ptr_to_int(allocation) } == 0 {
-            @panic("out of memory");
-        }
-        Self { buf: allocation, len: 0, cap: cap }
+        let R = rawbuf.RawBuf(u8);
+        let mut out = Self { core: R.new(), len: 0 };
+        out.core.grow_to(cap);
+        out
     }
 
     fn len(borrow self) -> u64 { self.len }
-    fn capacity(borrow self) -> u64 { self.cap }
+    fn capacity(borrow self) -> u64 { self.core.cap }
     fn is_empty(borrow self) -> bool { self.len == 0 }
 
     // The address of the packed byte buffer, for the trusted text lowering
@@ -119,7 +129,7 @@ pub struct StrBuf {
     // a source accessor is what lets the compiler read a StrBuf's `{ptr, len}`
     // without projecting its fields by layout (RUE-1066) — so StrBuf's internal
     // representation stays a private implementation detail of this source type.
-    fn as_ptr(borrow self) -> ptr mut u8 { self.buf }
+    fn as_ptr(borrow self) -> ptr mut u8 { self.core.buf }
 
     fn initial_capacity(required: u64) -> u64 {
         if required < 16 { 16 } else { required }
@@ -148,34 +158,33 @@ pub struct StrBuf {
         self.grow(additional);
     }
 
-    // Literal promotion allocates before copying. Owned growth uses realloc;
-    // on failure, @realloc_bytes leaves the old allocation valid, and this
-    // method leaves the header unchanged before taking the fail-fast path.
+    // Literal promotion allocates before copying; owned growth reallocs through
+    // the core. On the `cap == 0` arm the buffer may be a non-owned static
+    // literal, so it must NOT be reallocated — a fresh block is minted and the
+    // live bytes copied, leaving the immortal literal untouched. On the owning
+    // arm the core's `grow_to` reallocs and leaves the old allocation valid on
+    // failure (fail-fast before the header changes).
     fn grow(inout self, additional: u64) {
         if additional > 18446744073709551615 - self.len {
             @panic("out of memory");
         }
         let required = self.len + additional;
-        if required <= self.cap {
+        if required <= self.core.cap {
             return;
         }
 
-        let new_cap = Self.growth_capacity(self.cap, required);
-        if self.cap == 0 {
+        let new_cap = Self.growth_capacity(self.core.cap, required);
+        if self.core.cap == 0 {
             let replacement: ptr mut u8 = checked { @alloc_bytes(new_cap, 1) };
             if checked { @ptr_to_int(replacement) } == 0 {
                 @panic("out of memory");
             }
-            copy_packed_bytes(self.buf, 0, replacement, 0, self.len);
-            self.buf = replacement;
+            copy_packed_bytes(self.core.buf, 0, replacement, 0, self.len);
+            self.core.buf = replacement;
+            self.core.cap = new_cap;
         } else {
-            let replacement = checked { @realloc_bytes(self.buf, self.cap, 1, new_cap) };
-            if checked { @ptr_to_int(replacement) } == 0 {
-                @panic("out of memory");
-            }
-            self.buf = replacement;
+            self.core.grow_to(new_cap);
         }
-        self.cap = new_cap;
     }
 
     fn push(inout self, byte: u8) {
@@ -184,7 +193,7 @@ pub struct StrBuf {
 
     fn append_byte(inout self, byte: u8) {
         self.grow(1);
-        write_packed_byte(self.buf, self.len, byte);
+        write_packed_byte(self.core.buf, self.len, byte);
         self.len = self.len + 1;
     }
 
@@ -202,7 +211,7 @@ pub struct StrBuf {
         if source_len == 0 {
             return;
         }
-        copy_packed_bytes(other.buf, 0, self.buf, destination_start, source_len);
+        copy_packed_bytes(other.core.buf, 0, self.core.buf, destination_start, source_len);
         self.len = destination_start + source_len;
     }
 
@@ -214,7 +223,7 @@ pub struct StrBuf {
         let destination_start = self.len;
         let mut i: u64 = 0;
         while i < source.len() {
-            write_packed_byte(self.buf, destination_start + i, source[i]);
+            write_packed_byte(self.core.buf, destination_start + i, source[i]);
             i = i + 1;
         }
         self.len = destination_start + source.len();
@@ -240,7 +249,7 @@ pub struct StrBuf {
         let destination_start = self.len;
         let mut i: u64 = 0;
         while i < count {
-            write_packed_byte(self.buf, destination_start + i, source.get_or(start + i, 0));
+            write_packed_byte(self.core.buf, destination_start + i, source.get_or(start + i, 0));
             i = i + 1;
         }
         self.len = destination_start + count;
@@ -256,7 +265,7 @@ pub struct StrBuf {
         if source_len == 0 {
             return;
         }
-        copy_packed_bytes(other.buf, 0, target.buf, destination_start, source_len);
+        copy_packed_bytes(other.core.buf, 0, target.core.buf, destination_start, source_len);
         target.len = destination_start + source_len;
     }
 
@@ -266,7 +275,7 @@ pub struct StrBuf {
     fn duplicate(inout self) {
         let old_len = self.len;
         self.grow(old_len);
-        copy_packed_bytes(self.buf, 0, self.buf, old_len, old_len);
+        copy_packed_bytes(self.core.buf, 0, self.core.buf, old_len, old_len);
         self.len = old_len + old_len;
     }
 
@@ -281,7 +290,7 @@ pub struct StrBuf {
     // Clone always allocates, including for an empty or literal-backed value.
     fn copy(borrow self) -> Self {
         let mut result = Self.allocate(Self.initial_capacity(self.len));
-        copy_packed_bytes(self.buf, 0, result.buf, 0, self.len);
+        copy_packed_bytes(self.core.buf, 0, result.core.buf, 0, self.len);
         result.len = self.len;
         result
     }
@@ -293,7 +302,7 @@ pub struct StrBuf {
         let mut out = Bytes.with_capacity(self.len);
         let mut i: u64 = 0;
         while i < self.len {
-            out.push(read_packed_byte(self.buf, i));
+            out.push(read_packed_byte(self.core.buf, i));
             i = i + 1;
         }
         out
@@ -307,7 +316,7 @@ pub struct StrBuf {
         if index >= value.len {
             @panic("index out of bounds");
         }
-        read_packed_byte(value.buf, index)
+        read_packed_byte(value.core.buf, index)
     }
 
     // Bounds-checked byte read. Returns `None` when `index` is at or past the
@@ -319,7 +328,7 @@ pub struct StrBuf {
         if index >= self.len {
             return O.None;
         }
-        O.Some(read_packed_byte(self.buf, index))
+        O.Some(read_packed_byte(self.core.buf, index))
     }
 
     fn starts_with(borrow self, borrow prefix: str) -> bool {
@@ -328,7 +337,7 @@ pub struct StrBuf {
         }
         let mut i: u64 = 0;
         while i < prefix.len() {
-            if read_packed_byte(self.buf, i) != prefix[i] {
+            if read_packed_byte(self.core.buf, i) != prefix[i] {
                 return false;
             }
             i = i + 1;
@@ -346,7 +355,7 @@ pub struct StrBuf {
             let mut i: u64 = 0;
             let mut equal = true;
             while equal && i < needle.len() {
-                if read_packed_byte(self.buf, start + i) != needle[i] {
+                if read_packed_byte(self.core.buf, start + i) != needle[i] {
                     equal = false;
                 }
                 i = i + 1;
@@ -369,7 +378,7 @@ pub struct StrBuf {
             return Self.new();
         }
         let mut result = Self.allocate(count);
-        copy_packed_bytes(self.buf, start, result.buf, 0, count);
+        copy_packed_bytes(self.core.buf, start, result.core.buf, 0, count);
         result.len = count;
         result
     }
@@ -384,7 +393,7 @@ pub struct StrBuf {
         }
         let mut i: u64 = 0;
         while i < first.len {
-            if read_packed_byte(first.buf, i) != read_packed_byte(second.buf, i) {
+            if read_packed_byte(first.core.buf, i) != read_packed_byte(second.core.buf, i) {
                 return false;
             }
             i = i + 1;
@@ -402,26 +411,18 @@ pub struct StrBuf {
             return Self.new();
         }
         let mut result = Self.allocate(total);
-        copy_packed_bytes(first.buf, 0, result.buf, 0, first.len);
-        copy_packed_bytes(second.buf, 0, result.buf, first.len, second.len);
+        copy_packed_bytes(first.core.buf, 0, result.core.buf, 0, first.len);
+        copy_packed_bytes(second.core.buf, 0, result.core.buf, first.len, second.len);
         result.len = total;
         result
     }
 
-    // Reset after freeing so the later destructor is a no-op.
+    // Release the buffer early and reset to the empty state. Delegates to the
+    // core's `free` (a no-op when `cap == 0`, so a non-owned literal is never
+    // freed), which nulls the buffer and zeroes the capacity; the later
+    // scope-exit destructor of the core field is then a no-op.
     fn free(inout self) {
-        if self.cap > 0 {
-            checked { @free_bytes(self.buf, self.cap, 1); };
-        }
-        let zero: u64 = 0;
-        self.buf = checked { @int_to_ptr(zero) };
+        self.core.free();
         self.len = 0;
-        self.cap = 0;
-    }
-}
-
-drop fn StrBuf(self) {
-    if self.cap > 0 {
-        checked { @free_bytes(self.buf, self.cap, 1); };
     }
 }


### PR DESCRIPTION
## Summary

PR B of the StrBuf→RawBuf sequence. StrBuf's growable storage now lives in a shared `RawBuf(u8)` core (`{core: RawBuf(u8), len}`), mirroring ArrayBuf and Rust's `String`→`RawVec`. The flattened header becomes `[buf, cap, len]`, so the three layout sites move in lockstep:

- `std/strbuf.rue`: `{buf, cap}` moves into the nested `RawBuf(u8)` core (`self.buf`→`self.core.buf`, `self.cap`→`self.core.cap`); the byte helpers and `@byte_copy`/`@alloc_bytes` allocation logic are unchanged. StrBuf's own `drop fn` is deleted — the core's `RawBuf` destructor (`@free(buf, cap)`, a no-op at `cap == 0`) now covers both the empty and non-owning literal states.
- `rue-runtime-abi`: `StrBufResult` reorders to `{ptr@0, cap@8, len@16}` and `OptionStrBufResult` to `{disc@0, ptr@8, cap@16, len@24}`, with the `static_assert`ed offsets and slot inventory updated to match.
- `rue-codegen` (x86-64 + aarch64): string-literal header construction builds slots in `[ptr, cap, len]` order.

## Decoupling the last two str-view puns

A nested `{buf, cap}` core no longer shares `str`'s `{ptr, len}` prefix, so the two remaining compiler paths that punned StrBuf storage as a str view are routed through the trusted `as_ptr()`/`len()` accessors (extending PR A):

- `@parse_i32`/`i64`/`u32`/`u64` consume a StrBuf through its method-routed `{ptr, len}` view, receiving the same 2-word shape as a native `str` argument instead of the raw 3-word header.
- An `inout str` view over a StrBuf materializes a method-routed `{ptr, len}` view in a temporary and passes an exclusive reference to it. The view's pointer is the real buffer, so byte writes still reach the caller's storage while `len` reads the correct word; whole-view rebinding stays rejected (`StrViewReassignment`), so the snapshot length remains valid.

## Oracle

The opaque `Value::Str` projection model learns the nested shape: `.core` is a transparent passthrough to the two-slot core view, `core.buf` is the text-pointer gap, `core.cap` is the capacity gap, and StrBuf's `len` (field 1) is the length header — all producing the **same registered model gaps** as the flat layout, so StrBuf oracle coverage is unchanged (PR C closes the gaps). The differential ledger is refreshed: whole-value StrBuf ops now surface `TextProjectionRead` before a capacity read, and four cases the oracle now models exactly are retired from the registry.

## Validation

- Full CLI suite: 1714 passed, 0 failed
- Spec suite: 2156 passed
- Both oracle-diff corpora (CLI + spec): 0 disagreements, 0 oracle failures
- Oracle unit (103), differential-oracle (103), and changed-crate unit tests (rue-air 558, rue-codegen 601, rue-runtime-abi 11, rue-compiler 638) all green
- `scripts/rue fmt`

Refs RUE-1066

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLsiAQKJ41esde9Ya8Up8V

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLsiAQKJ41esde9Ya8Up8V)_