### PR TITLE
Add a recycling runtime allocator

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -6,8 +6,8 @@ name: Sanitizer
 # plus `valgrind` from apt.
 #
 # Scope (see scripts/run-sanitizer.sh for the full rationale): memcheck hooks
-# libc malloc/free, but the Rue runtime bump-allocates inside mmap'd arenas and
-# never calls libc, so to memcheck each program does "0 allocs". The `valgrind`
+# libc malloc/free, but the Rue runtime allocates from mmap'd arenas and never
+# calls libc, so to memcheck each program does "0 allocs". The `valgrind`
 # job below is therefore a CODEGEN / generated-code memory-safety net (wild
 # pointers, stack overflow, bad syscall buffers, uninitialised-value use) that
 # the source-level fuzz job cannot provide. It does NOT catch intra-arena heap
@@ -84,8 +84,8 @@ jobs:
   # AddressSanitizer over rue-runtime's arena allocator (RUE-211, RUE-560).
   # Standalone cargo crate (crates/rue-runtime-asan) driven by nightly rustc —
   # no buck2 — because -Zsanitizer=address needs nightly, an explicit --target,
-  # and the compiler-rt asan runtime linked in. detect_leaks=0: arenas are
-  # intentionally never freed (bump allocator), which LeakSanitizer would
+  # and the compiler-rt asan runtime linked in. detect_leaks=0: retained small
+  # arenas intentionally live until process exit, which LeakSanitizer would
   # otherwise flag.
   #
   # The nightly is PINNED (RUE-560): an un-pinned `nightly` floats and a bad

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,7 @@ Crate ownership, when locating changes:
 | `rue-air`, `rue-cfg` | semantic analysis, typed IR, CFGs, optimization |
 | `rue-codegen` | x86-64 and AArch64 lowering and emission |
 | `rue-linker` | object generation and linking |
+| `rue-allocator`, `rue-runtime`, `rue-runtime-abi` | heap policy, target runtime, and compiler/runtime ABI contract |
 | `rue-error`, `rue-span` | diagnostics and source locations |
 | `rue-spec`, `rue-ui-tests`, `rue-cli-tests` | language and integration tests |
 

--- a/crates/rue-allocator/BUCK
+++ b/crates/rue-allocator/BUCK
@@ -1,0 +1,13 @@
+load("//crates:defs.bzl", "rue_crate")
+
+export_file(
+    name = "lib.rs",
+    src = "src/lib.rs",
+    visibility = ["//crates/rue-runtime:"],
+)
+
+# Allocation policy and bookkeeping are independent of the Rue runtime ABI and
+# platform syscall implementations. Consumers provide the page mapper.
+rue_crate(
+    name = "rue-allocator",
+)

--- a/crates/rue-allocator/Cargo.toml
+++ b/crates/rue-allocator/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rue-allocator"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[lib]
+path = "src/lib.rs"

--- a/crates/rue-allocator/src/lib.rs
+++ b/crates/rue-allocator/src/lib.rs
@@ -1,0 +1,647 @@
+//! Dependency-free allocation policy for Rue runtimes.
+//!
+//! [`Allocator`] combines power-of-two free lists for small allocations with
+//! dedicated mappings for large allocations. It is independent of any runtime
+//! ABI or operating-system syscall convention; consumers supply those details
+//! through [`PageMapper`].
+
+#![no_std]
+
+use core::cell::UnsafeCell;
+use core::marker::PhantomData;
+use core::ptr;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+/// Page size required from [`PageMapper`].
+pub const PAGE_SIZE: usize = 4096;
+
+/// Size of the arenas used for small allocations.
+pub const ARENA_SIZE: usize = 64 * 1024;
+
+/// Largest power-of-two class served from the arenas.
+pub const MAX_SMALL_SIZE: usize = 16 * 1024;
+
+const MIN_CLASS_SIZE: usize = core::mem::size_of::<*mut u8>();
+const MIN_CLASS_SHIFT: usize = MIN_CLASS_SIZE.trailing_zeros() as usize;
+const MAX_CLASS_SHIFT: usize = MAX_SMALL_SIZE.trailing_zeros() as usize;
+const CLASS_COUNT: usize = MAX_CLASS_SHIFT - MIN_CLASS_SHIFT + 1;
+
+const _: () = {
+    assert!(core::mem::size_of::<*mut u8>() == 8);
+    assert!(MIN_CLASS_SIZE.is_power_of_two());
+    assert!(MAX_SMALL_SIZE.is_power_of_two());
+    assert!(ARENA_SIZE.is_multiple_of(PAGE_SIZE));
+};
+
+/// Supplies page mappings to an [`Allocator`].
+///
+/// Implementations normally forward to anonymous `mmap` and `munmap` syscalls,
+/// but tests and instrumentation can provide host-allocator-backed mappings.
+///
+/// # Safety
+///
+/// Implementations must uphold the mapping validity, alignment, lifetime, and
+/// concurrency contracts below. [`Allocator`] dereferences returned mappings
+/// from safe methods and may call the mapper concurrently.
+pub unsafe trait PageMapper {
+    /// Decide whether an allocation attempt may proceed.
+    ///
+    /// Production mappers normally use the default. The hook lets a runtime
+    /// inject deterministic allocation failure in tests without adding mutable
+    /// failure state to the allocator or changing its allocation paths.
+    fn allocation_permitted() -> bool {
+        true
+    }
+
+    /// Map `size` readable and writable bytes.
+    ///
+    /// `size` is nonzero and a multiple of [`PAGE_SIZE`]. On success, the
+    /// returned pointer must be aligned to [`PAGE_SIZE`] and remain valid until
+    /// the matching [`unmap`](Self::unmap). Return null on failure.
+    fn map(size: usize) -> *mut u8;
+
+    /// Release a mapping previously returned by [`map`](Self::map).
+    ///
+    /// # Safety
+    ///
+    /// `pointer` and `size` must describe one currently live mapping returned
+    /// by this mapper, and no access to that mapping may occur after the call.
+    unsafe fn unmap(pointer: *mut u8, size: usize);
+}
+
+/// Header stored at the beginning of every small-allocation arena.
+#[repr(C)]
+struct ArenaHeader {
+    next: *mut ArenaHeader,
+    size: usize,
+    offset: usize,
+}
+
+const _: () = {
+    assert!(core::mem::size_of::<ArenaHeader>() == 24);
+    assert!(core::mem::align_of::<ArenaHeader>() == 8);
+};
+
+/// Link stored directly in a freed small block.
+#[repr(C)]
+struct FreeBlock {
+    next: *mut FreeBlock,
+}
+
+struct AllocatorState {
+    current_arena: *mut ArenaHeader,
+    free_lists: [*mut FreeBlock; CLASS_COUNT],
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SmallClass {
+    index: usize,
+    block_size: usize,
+    block_align: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AllocationKind {
+    Small(SmallClass),
+    Direct { mapping_size: usize },
+}
+
+/// A recycling arena allocator using mappings supplied by `M`.
+///
+/// Small requests are rounded to power-of-two classes from 8 bytes through
+/// 16 KiB. Freed blocks are linked into per-class intrusive free lists. Larger
+/// requests receive their own page-rounded mapping and return it immediately
+/// on deallocation. Arenas are retained for the allocator's lifetime, so small
+/// allocation memory follows a high-water mark.
+///
+/// One spin lock serializes the small-allocation state. Mapping implementations
+/// must independently support concurrent calls because dedicated mappings do
+/// not acquire that lock.
+pub struct Allocator<M: PageMapper> {
+    lock: AtomicBool,
+    state: UnsafeCell<AllocatorState>,
+    mapper: PhantomData<fn() -> M>,
+}
+
+// SAFETY: `lock` serializes every access to `state`, and PageMapper's contract
+// requires its static mapping operations to support concurrent calls.
+unsafe impl<M: PageMapper> Sync for Allocator<M> {}
+
+impl<M: PageMapper> Default for Allocator<M> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<M: PageMapper> Allocator<M> {
+    /// Construct an empty allocator without mapping any memory.
+    pub const fn new() -> Self {
+        Self {
+            lock: AtomicBool::new(false),
+            state: UnsafeCell::new(AllocatorState {
+                current_arena: ptr::null_mut(),
+                free_lists: [ptr::null_mut(); CLASS_COUNT],
+            }),
+            mapper: PhantomData,
+        }
+    }
+
+    /// Allocate `size` bytes with at least `align` alignment.
+    ///
+    /// Returns null for a zero size, an unsupported layout, integer overflow,
+    /// or mapping failure. Successful storage is uninitialized.
+    pub fn allocate(&self, size: u64, align: u64) -> *mut u8 {
+        if !M::allocation_permitted() {
+            return ptr::null_mut();
+        }
+
+        let Some(kind) = classify(size, align) else {
+            return ptr::null_mut();
+        };
+
+        match kind {
+            AllocationKind::Small(class) => self.allocate_small(class),
+            AllocationKind::Direct { mapping_size } => M::map(mapping_size),
+        }
+    }
+
+    /// Release an allocation described by its original layout.
+    ///
+    /// A null pointer is always accepted and has no effect. Unsupported layouts
+    /// are ignored defensively, although supplying one for a non-null pointer
+    /// violates the caller contract.
+    ///
+    /// # Safety
+    ///
+    /// A non-null `pointer` must identify a live allocation returned by this
+    /// allocator for exactly `size` and `align`. It must not be used afterward.
+    pub unsafe fn deallocate(&self, pointer: *mut u8, size: u64, align: u64) {
+        if pointer.is_null() {
+            return;
+        }
+
+        let Some(kind) = classify(size, align) else {
+            return;
+        };
+
+        match kind {
+            AllocationKind::Small(class) => {
+                let _guard = self.lock();
+                // SAFETY: the lock grants exclusive access to the allocator
+                // state, and the caller provided a live block in this class.
+                unsafe {
+                    let state = &mut *self.state.get();
+                    let block = pointer.cast::<FreeBlock>();
+                    (*block).next = state.free_lists[class.index];
+                    state.free_lists[class.index] = block;
+                }
+            }
+            AllocationKind::Direct { mapping_size } => {
+                // SAFETY: direct allocations return the mapping base, and the
+                // caller supplied the exact layout used to derive its size.
+                unsafe { M::unmap(pointer, mapping_size) };
+            }
+        }
+    }
+
+    /// Resize an allocation while preserving its initialized prefix.
+    ///
+    /// If the old and new layouts use the same size class or page-rounded
+    /// mapping, the pointer is returned unchanged. Otherwise this allocates a
+    /// replacement, copies `min(old_size, new_size)` bytes, and releases the
+    /// old allocation. Allocation failure returns null and leaves the old block
+    /// live and unchanged.
+    ///
+    /// # Safety
+    ///
+    /// A non-null `pointer` must identify a live allocation returned by this
+    /// allocator for exactly `old_size` and `align`, readable for `old_size`
+    /// bytes. After a successful resize, it must no longer be used through the
+    /// old pointer unless the returned pointer is equal to it.
+    pub unsafe fn reallocate(
+        &self,
+        pointer: *mut u8,
+        old_size: u64,
+        new_size: u64,
+        align: u64,
+    ) -> *mut u8 {
+        if pointer.is_null() {
+            return self.allocate(new_size, align);
+        }
+        if new_size == 0 {
+            // SAFETY: inherited from this function's caller contract.
+            unsafe { self.deallocate(pointer, old_size, align) };
+            return ptr::null_mut();
+        }
+
+        let Some(old_kind) = classify(old_size, align) else {
+            return ptr::null_mut();
+        };
+        let Some(new_kind) = classify(new_size, align) else {
+            return ptr::null_mut();
+        };
+
+        if old_kind == new_kind {
+            return pointer;
+        }
+
+        let replacement = self.allocate(new_size, align);
+        if replacement.is_null() {
+            return ptr::null_mut();
+        }
+
+        let copy_size = old_size.min(new_size) as usize;
+        // SAFETY: the two live allocations do not overlap, the old allocation
+        // is readable for old_size, and the new one is writable for new_size.
+        unsafe { ptr::copy_nonoverlapping(pointer, replacement, copy_size) };
+        // SAFETY: the successful copy retires the old allocation.
+        unsafe { self.deallocate(pointer, old_size, align) };
+        replacement
+    }
+
+    fn allocate_small(&self, class: SmallClass) -> *mut u8 {
+        let _guard = self.lock();
+        // SAFETY: the lock grants exclusive access to the allocator state.
+        let state = unsafe { &mut *self.state.get() };
+
+        let free = state.free_lists[class.index];
+        if !free.is_null() {
+            // SAFETY: every list entry is a class-sized, properly aligned freed
+            // block whose first word contains a FreeBlock link.
+            unsafe {
+                state.free_lists[class.index] = (*free).next;
+            }
+            return free.cast::<u8>();
+        }
+
+        loop {
+            if !state.current_arena.is_null() {
+                // SAFETY: current_arena is a live mapping owned by this state.
+                if let Some(pointer) = unsafe { allocate_from_arena(state.current_arena, class) } {
+                    return pointer;
+                }
+            }
+
+            let mapping = M::map(ARENA_SIZE);
+            if mapping.is_null() {
+                return ptr::null_mut();
+            }
+
+            let arena = mapping.cast::<ArenaHeader>();
+            // SAFETY: M returned an exclusive page-aligned ARENA_SIZE mapping,
+            // which has room for the header at its beginning.
+            unsafe {
+                arena.write(ArenaHeader {
+                    next: state.current_arena,
+                    size: ARENA_SIZE,
+                    offset: core::mem::size_of::<ArenaHeader>(),
+                });
+            }
+            state.current_arena = arena;
+        }
+    }
+
+    fn lock(&self) -> AllocatorLock<'_, M> {
+        while self
+            .lock
+            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            core::hint::spin_loop();
+        }
+        AllocatorLock { allocator: self }
+    }
+}
+
+struct AllocatorLock<'a, M: PageMapper> {
+    allocator: &'a Allocator<M>,
+}
+
+impl<M: PageMapper> Drop for AllocatorLock<'_, M> {
+    fn drop(&mut self) {
+        self.allocator.lock.store(false, Ordering::Release);
+    }
+}
+
+fn classify(size: u64, align: u64) -> Option<AllocationKind> {
+    if size == 0 || align == 0 || !align.is_power_of_two() || align > PAGE_SIZE as u64 {
+        return None;
+    }
+
+    let size = usize::try_from(size).ok()?;
+    let align = usize::try_from(align).ok()?;
+    if size <= MAX_SMALL_SIZE {
+        let required = size.max(align).max(MIN_CLASS_SIZE);
+        let block_size = required.checked_next_power_of_two()?;
+        if block_size <= MAX_SMALL_SIZE {
+            let shift = block_size.trailing_zeros() as usize;
+            return Some(AllocationKind::Small(SmallClass {
+                index: shift - MIN_CLASS_SHIFT,
+                block_size,
+                block_align: block_size.min(PAGE_SIZE),
+            }));
+        }
+    }
+
+    let mapping_size = size.checked_next_multiple_of(PAGE_SIZE)?;
+    Some(AllocationKind::Direct { mapping_size })
+}
+
+/// Try to bump one class-sized block from `arena`.
+///
+/// # Safety
+///
+/// The caller must hold the allocator lock and `arena` must point to the live
+/// current arena owned by that allocator.
+unsafe fn allocate_from_arena(arena: *mut ArenaHeader, class: SmallClass) -> Option<*mut u8> {
+    // SAFETY: guaranteed by the caller.
+    let header = unsafe { &mut *arena };
+    let aligned_offset = checked_align_up(header.offset, class.block_align)?;
+    let new_offset = aligned_offset.checked_add(class.block_size)?;
+    if new_offset > header.size {
+        return None;
+    }
+
+    header.offset = new_offset;
+    // SAFETY: the checked offsets place the complete block in the arena.
+    Some(unsafe { arena.cast::<u8>().add(aligned_offset) })
+}
+
+const fn checked_align_up(value: usize, align: usize) -> Option<usize> {
+    let Some(added) = value.checked_add(align - 1) else {
+        return None;
+    };
+    Some(added & !(align - 1))
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+    use core::sync::atomic::{AtomicBool, AtomicUsize};
+    use std::alloc::{Layout, alloc_zeroed, dealloc};
+
+    struct TestMapper;
+
+    // SAFETY: std's allocator returns exclusive page-aligned blocks for the
+    // requested layouts and supports concurrent allocation and deallocation.
+    unsafe impl PageMapper for TestMapper {
+        fn map(size: usize) -> *mut u8 {
+            let layout = Layout::from_size_align(size, PAGE_SIZE).unwrap();
+            // SAFETY: layout is nonzero and valid.
+            unsafe { alloc_zeroed(layout) }
+        }
+
+        unsafe fn unmap(pointer: *mut u8, size: usize) {
+            let layout = Layout::from_size_align(size, PAGE_SIZE).unwrap();
+            // SAFETY: inherited from PageMapper::unmap's contract.
+            unsafe { dealloc(pointer, layout) };
+        }
+    }
+
+    #[test]
+    fn layouts_select_expected_classes_and_mappings() {
+        assert_eq!(classify(1, 1), classify(8, 8));
+        assert_eq!(classify(17, 1), classify(32, 32));
+        assert_eq!(
+            classify(MAX_SMALL_SIZE as u64, 8),
+            Some(AllocationKind::Small(SmallClass {
+                index: CLASS_COUNT - 1,
+                block_size: MAX_SMALL_SIZE,
+                block_align: PAGE_SIZE,
+            }))
+        );
+        assert_eq!(
+            classify(MAX_SMALL_SIZE as u64 + 1, 8),
+            Some(AllocationKind::Direct {
+                mapping_size: 5 * PAGE_SIZE,
+            })
+        );
+    }
+
+    #[test]
+    fn invalid_layouts_are_rejected() {
+        assert!(classify(0, 8).is_none());
+        assert!(classify(8, 0).is_none());
+        assert!(classify(8, 3).is_none());
+        assert!(classify(8, (PAGE_SIZE * 2) as u64).is_none());
+        assert!(classify(u64::MAX, 1).is_none());
+    }
+
+    #[test]
+    fn allocations_honor_every_supported_alignment() {
+        let allocator = Allocator::<TestMapper>::new();
+        for align in [1u64, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 4096] {
+            let pointer = allocator.allocate(64, align);
+            assert!(!pointer.is_null());
+            assert_eq!(pointer as usize % align as usize, 0);
+            // SAFETY: pointer is live with the layout just requested.
+            unsafe { allocator.deallocate(pointer, 64, align) };
+        }
+    }
+
+    #[test]
+    fn freed_small_block_is_reused_by_its_class() {
+        let allocator = Allocator::<TestMapper>::new();
+        let first = allocator.allocate(6000, 8);
+        assert!(!first.is_null());
+        // SAFETY: first is live with this layout.
+        unsafe { allocator.deallocate(first, 6000, 8) };
+
+        let second = allocator.allocate(6000, 8);
+        assert_eq!(second, first);
+    }
+
+    #[test]
+    fn different_small_classes_do_not_share_blocks() {
+        let allocator = Allocator::<TestMapper>::new();
+        let larger = allocator.allocate(17, 1);
+        assert!(!larger.is_null());
+        // SAFETY: larger is live with this layout.
+        unsafe { allocator.deallocate(larger, 17, 1) };
+
+        let smaller = allocator.allocate(16, 1);
+        assert!(!smaller.is_null());
+        assert_ne!(smaller, larger);
+    }
+
+    #[test]
+    fn realloc_within_one_class_keeps_the_pointer() {
+        let allocator = Allocator::<TestMapper>::new();
+        let pointer = allocator.allocate(65, 8);
+        assert!(!pointer.is_null());
+        unsafe { pointer.write(0x5a) };
+
+        // SAFETY: pointer is live and readable for 65 bytes.
+        let grown = unsafe { allocator.reallocate(pointer, 65, 120, 8) };
+        assert_eq!(grown, pointer);
+        assert_eq!(unsafe { grown.read() }, 0x5a);
+    }
+
+    #[test]
+    fn realloc_between_classes_copies_and_recycles() {
+        let allocator = Allocator::<TestMapper>::new();
+        let pointer = allocator.allocate(32, 8);
+        assert!(!pointer.is_null());
+        unsafe {
+            for index in 0..32 {
+                pointer.add(index).write(index as u8);
+            }
+        }
+
+        // SAFETY: pointer is live and readable for 32 bytes.
+        let grown = unsafe { allocator.reallocate(pointer, 32, 128, 8) };
+        assert!(!grown.is_null());
+        assert_ne!(grown, pointer);
+        unsafe {
+            for index in 0..32 {
+                assert_eq!(grown.add(index).read(), index as u8);
+            }
+        }
+
+        // The old block was returned to the 32-byte class.
+        assert_eq!(allocator.allocate(32, 8), pointer);
+    }
+
+    #[test]
+    fn direct_allocation_is_usable_and_releasable() {
+        let allocator = Allocator::<TestMapper>::new();
+        let size = (MAX_SMALL_SIZE + 1) as u64;
+        let pointer = allocator.allocate(size, 8);
+        assert!(!pointer.is_null());
+        unsafe {
+            pointer.write(1);
+            pointer.add(size as usize - 1).write(2);
+            assert_eq!(pointer.read(), 1);
+            assert_eq!(pointer.add(size as usize - 1).read(), 2);
+            allocator.deallocate(pointer, size, 8);
+        }
+    }
+
+    #[test]
+    fn realloc_within_one_direct_mapping_keeps_the_pointer() {
+        let allocator = Allocator::<TestMapper>::new();
+        let old_size = (MAX_SMALL_SIZE + 1) as u64;
+        let new_size = old_size + 1000;
+        let pointer = allocator.allocate(old_size, 8);
+        assert!(!pointer.is_null());
+        unsafe { pointer.write(0xa5) };
+
+        // Both layouts round up to the same number of pages.
+        let grown = unsafe { allocator.reallocate(pointer, old_size, new_size, 8) };
+        assert_eq!(grown, pointer);
+        assert_eq!(unsafe { grown.read() }, 0xa5);
+
+        // SAFETY: grown is live with the new layout.
+        unsafe { allocator.deallocate(grown, new_size, 8) };
+    }
+
+    static COUNTED_MAPS: AtomicUsize = AtomicUsize::new(0);
+    static COUNTED_UNMAPS: AtomicUsize = AtomicUsize::new(0);
+
+    struct CountingMapper;
+
+    // SAFETY: delegates mapping operations to TestMapper; atomic counters do
+    // not weaken its validity or concurrency guarantees.
+    unsafe impl PageMapper for CountingMapper {
+        fn map(size: usize) -> *mut u8 {
+            COUNTED_MAPS.fetch_add(1, Ordering::Relaxed);
+            TestMapper::map(size)
+        }
+
+        unsafe fn unmap(pointer: *mut u8, size: usize) {
+            COUNTED_UNMAPS.fetch_add(1, Ordering::Relaxed);
+            // SAFETY: inherited from PageMapper::unmap's contract.
+            unsafe { TestMapper::unmap(pointer, size) };
+        }
+    }
+
+    #[test]
+    fn small_churn_reuses_one_arena_and_large_free_unmaps() {
+        COUNTED_MAPS.store(0, Ordering::Relaxed);
+        COUNTED_UNMAPS.store(0, Ordering::Relaxed);
+        let allocator = Allocator::<CountingMapper>::new();
+
+        for _ in 0..10_000 {
+            let pointer = allocator.allocate(64, 8);
+            assert!(!pointer.is_null());
+            // SAFETY: pointer is live with this exact layout.
+            unsafe { allocator.deallocate(pointer, 64, 8) };
+        }
+        assert_eq!(COUNTED_MAPS.load(Ordering::Relaxed), 1);
+        assert_eq!(COUNTED_UNMAPS.load(Ordering::Relaxed), 0);
+
+        let size = (MAX_SMALL_SIZE + 1) as u64;
+        let direct = allocator.allocate(size, 8);
+        assert!(!direct.is_null());
+        // SAFETY: direct is live with this exact layout.
+        unsafe { allocator.deallocate(direct, size, 8) };
+        assert_eq!(COUNTED_MAPS.load(Ordering::Relaxed), 2);
+        assert_eq!(COUNTED_UNMAPS.load(Ordering::Relaxed), 1);
+    }
+
+    static THREADED_ALLOCATOR: Allocator<TestMapper> = Allocator::new();
+
+    #[test]
+    fn concurrent_small_allocation_and_free_is_serialized() {
+        let mut threads = std::vec::Vec::new();
+        for thread_id in 0..8u8 {
+            threads.push(std::thread::spawn(move || {
+                for _ in 0..2_000 {
+                    let pointer = THREADED_ALLOCATOR.allocate(64, 8);
+                    assert!(!pointer.is_null());
+                    unsafe {
+                        pointer.write(thread_id);
+                        std::thread::yield_now();
+                        assert_eq!(pointer.read(), thread_id);
+                        THREADED_ALLOCATOR.deallocate(pointer, 64, 8);
+                    }
+                }
+            }));
+        }
+        for thread in threads {
+            thread.join().unwrap();
+        }
+    }
+
+    static FAIL_MAPPING: AtomicBool = AtomicBool::new(false);
+
+    struct FallibleMapper;
+
+    // SAFETY: successful operations delegate to TestMapper, and the atomic
+    // failure switch is safe to query concurrently.
+    unsafe impl PageMapper for FallibleMapper {
+        fn map(size: usize) -> *mut u8 {
+            if FAIL_MAPPING.load(Ordering::Relaxed) {
+                ptr::null_mut()
+            } else {
+                TestMapper::map(size)
+            }
+        }
+
+        unsafe fn unmap(pointer: *mut u8, size: usize) {
+            // SAFETY: inherited from PageMapper::unmap's contract.
+            unsafe { TestMapper::unmap(pointer, size) };
+        }
+    }
+
+    #[test]
+    fn failed_realloc_preserves_direct_allocation() {
+        let allocator = Allocator::<FallibleMapper>::new();
+        let old_size = (MAX_SMALL_SIZE + 1) as u64;
+        let pointer = allocator.allocate(old_size, 8);
+        assert!(!pointer.is_null());
+        unsafe { pointer.write(0xa5) };
+
+        FAIL_MAPPING.store(true, Ordering::Relaxed);
+        // SAFETY: pointer is live and readable for old_size bytes.
+        let result = unsafe { allocator.reallocate(pointer, old_size, old_size * 2, 8) };
+        FAIL_MAPPING.store(false, Ordering::Relaxed);
+
+        assert!(result.is_null());
+        assert_eq!(unsafe { pointer.read() }, 0xa5);
+        // SAFETY: failed realloc left pointer live.
+        unsafe { allocator.deallocate(pointer, old_size, 8) };
+    }
+}

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1796,6 +1796,15 @@ impl<'a> CfgBuilder<'a> {
                 let Some(scrutinee_val) = self.lower_value(*scrutinee) else {
                     return Self::diverged();
                 };
+                // A match evaluates its scrutinee exactly once. In particular,
+                // synthetic wrapper blocks may own temporaries whose cleanup
+                // runs while producing the enum value. Payload reads in the
+                // arms refer back to the same AIR scrutinee; cache its already
+                // lowered value so those reads cannot replay the wrapper and
+                // drop its temporaries a second time. The switch block
+                // dominates every arm, so this cached CFG value is valid on
+                // all of those paths.
+                self.cache(*scrutinee, scrutinee_val);
 
                 // Collect arms into a Vec for iteration
                 let arms: Vec<(AirPattern, AirRef)> = self.air.get_match_arms(arms).collect();
@@ -3642,6 +3651,31 @@ mod tests {
         assert_eq!(
             drop_count, 2,
             "expected exactly one Drop per droppable local (s, t)"
+        );
+        assert_all_blocks_terminated(&cfg);
+    }
+
+    #[test]
+    fn match_scrutinee_wrapper_drops_its_temporary_once() {
+        let cfg = build_cfg(
+            "fn O() -> type { enum { Some(i32), None } }\n\
+             fn make() -> O() { let E = O(); E.Some(1) }\n\
+             fn main() -> i32 {\n\
+                 let E = O();\n\
+                 match {\n\
+                     let scratch = StrBuf.with_capacity(8);\n\
+                     make()\n\
+                 } {\n\
+                     E.Some(value) => value,\n\
+                     E.None => 0,\n\
+                 }\n\
+             }",
+        );
+
+        assert_eq!(
+            count_drops(&cfg),
+            1,
+            "payload reads in match arms must not replay scrutinee cleanup"
         );
         assert_all_blocks_terminated(&cfg);
     }

--- a/crates/rue-cli-tests/cases/arraybuf_library.toml
+++ b/crates/rue-cli-tests/cases/arraybuf_library.toml
@@ -252,9 +252,8 @@ exit_code = 0
 # ArrayBuf destructor end-to-end (parse + monomorphize + drop-glue + @free), the
 # last gap to a real ArrayBuf (RUE-312). The `drop fn(self)` here mirrors
 # std/arraybuf.rue. Output is the same as the explicit-free dogfood; the
-# destructor's @free is a silent no-op under the bump allocator, so correctness
-# is that the program compiles, runs, and exits cleanly with the buffer released
-# by the destructor rather than a manual call.
+# destructor now returns the buffer to the allocator, so correctness includes
+# running that ownership path exactly once without an explicit free.
 [[case]]
 name = "arraybuf_i32_raii_auto_free"
 description = "ArrayBuf(i32) frees its buffer via its drop fn at scope exit — no explicit free() call (RUE-312)."

--- a/crates/rue-cli-tests/cases/divergence.toml
+++ b/crates/rue-cli-tests/cases/divergence.toml
@@ -12,9 +12,8 @@
 #    statement) leaked its block's scope_stack entry. The enclosing block's
 #    scope pop then drained the LEAKED scope instead of its own, re-emitting
 #    Drop/StorageDead for the inner local on the loop-exit path — a same-path
-#    double drop. (Runtime-silent today because heap::free is a no-op bump
-#    allocator, but pinned by a CFG unit test in rue-cfg; the cases here guard
-#    the construct end-to-end so a future real allocator stays safe.)
+#    double drop. The recycling allocator makes that a real double-free, so the
+#    CFG unit test and these end-to-end cases guard the ownership path directly.
 
 [section]
 id = "cli.divergence"

--- a/crates/rue-cli-tests/cases/heap_intrinsics.toml
+++ b/crates/rue-cli-tests/cases/heap_intrinsics.toml
@@ -25,8 +25,9 @@ fn main() -> i32 {
         @dbg(@ptr_read(p));
         @dbg(@ptr_read(@ptr_offset(p, 1)));
         @dbg(@ptr_read(@ptr_offset(p, 2)));
+        let sum = @ptr_read(p) + @ptr_read(@ptr_offset(p, 1)) + @ptr_read(@ptr_offset(p, 2));
         @free(p, 3);
-        @ptr_read(p) + @ptr_read(@ptr_offset(p, 1)) + @ptr_read(@ptr_offset(p, 2))
+        sum
     }
 }
 """ }]

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -606,7 +606,7 @@ const HEAP_BASE: u128 = HEAP_SEG;
 
 /// Largest byte size the modeled allocator satisfies before returning null.
 ///
-/// The real runtime bump allocator fails (returns null) once a request exceeds
+/// The real runtime allocator fails (returns null) once a request exceeds
 /// what `mmap` can back — astronomically large sizes such as the corpus's
 /// `2305843009213693951`-byte `@realloc`. Every legitimate corpus allocation is
 /// a few bytes to kilobytes, so any threshold between them models the platform
@@ -688,11 +688,9 @@ struct Allocation {
     /// projection): its single cell is the scalar, and a redirected `Load` of
     /// the owning slot must unwrap `root[0]` rather than return the aggregate.
     wrapped_scalar: bool,
-    /// `@free`/`@free_bytes` marked this released. The runtime bump allocator's
-    /// `free` is a documented no-op (memory stays valid until process exit), so
-    /// this is diagnostic only and never blocks access — modeling it as an error
-    /// would disagree with every compiled program that reads through a freed
-    /// pointer (see the heap-model notes).
+    /// `@free`/`@free_bytes` released this allocation. Pointer access checks the
+    /// flag so undefined use-after-free remains a typed oracle gap rather than
+    /// receiving a deterministic value that native execution does not promise.
     freed: bool,
 }
 
@@ -3198,7 +3196,8 @@ impl<'a> Interp<'a> {
         }
     }
 
-    /// The zero image of `ty`, matching the runtime's mmap-zeroed fresh cell.
+    /// A deterministic image for storage that Rue specifies as uninitialized.
+    /// Valid modeled programs initialize cells before observing them.
     fn zeroed_value(&self, ty: Type) -> Value {
         match ty.kind() {
             TypeKind::Bool => Value::Bool(false),
@@ -3307,6 +3306,9 @@ impl<'a> Interp<'a> {
             .heap
             .get(target.alloc)
             .ok_or_else(|| unsupported(gap, "pointer to unknown allocation"))?;
+        if alloc.freed {
+            return Err(unsupported(gap, "pointer read after free"));
+        }
         let container = Self::nav(&alloc.root, &target.path)
             .ok_or_else(|| unsupported(gap, "pointer path escapes allocation"))?;
         match container {
@@ -3326,6 +3328,9 @@ impl<'a> Interp<'a> {
             .heap
             .get_mut(target.alloc)
             .ok_or_else(|| unsupported(gap, "pointer to unknown allocation"))?;
+        if alloc.freed {
+            return Err(unsupported(gap, "pointer write after free"));
+        }
         let container = Self::nav_mut(&mut alloc.root, &target.path)
             .ok_or_else(|| unsupported(gap, "pointer path escapes allocation"))?;
         match container {
@@ -3450,14 +3455,16 @@ impl<'a> Interp<'a> {
                 Ok(Some(self.do_alloc_bytes(size)?))
             }
             "free" | "free_bytes" => {
-                // Evaluate every operand (side-effect-free here) then no-op, as
-                // the runtime bump allocator's free does.
+                // Evaluate every operand before releasing the allocation.
                 let p = self.eval(cfg, frame, args[0])?;
                 for a in &args[1..] {
                     self.eval(cfg, frame, *a)?;
                 }
                 if let Value::Ptr(Some(t)) = p {
                     if let Some(alloc) = self.heap.get_mut(t.alloc) {
+                        if alloc.freed {
+                            return Err(unsupported(gap, "double free"));
+                        }
                         alloc.freed = true;
                     }
                 }
@@ -3642,9 +3649,9 @@ impl<'a> Interp<'a> {
     }
 
     /// `@realloc`/`@realloc_bytes`: grow/shrink an allocation, preserving the
-    /// first `min(old, new)` cells and zero-filling growth. Shrinking returns the
-    /// original pointer (the bump runtime does); growing allocates fresh and
-    /// copies. Returns null on `new == 0` or allocator failure, leaving the
+    /// first `min(old, new)` cells and deterministically filling growth. This
+    /// model keeps shrink-in-place and move-on-grow behavior; native pointer
+    /// identity is deliberately unspecified. Returns null on `new == 0` or allocator failure, leaving the
     /// original allocation valid (spec 8.6:3), and traps on a `new * stride`
     /// overflow like the compiled size arithmetic (spec 8.6:1).
     fn do_realloc(
@@ -3668,6 +3675,17 @@ impl<'a> Interp<'a> {
             }
             _ => return Ok(Value::Ptr(None)),
         };
+        if self
+            .heap
+            .get(target.alloc)
+            .is_some_and(|allocation| allocation.freed)
+        {
+            let name = if bytes { "realloc_bytes" } else { "realloc" };
+            return Err(unsupported(
+                unsupported_intrinsic_kind(name),
+                "realloc after free",
+            ));
+        }
         if new_count == 0 {
             if let Some(alloc) = self.heap.get_mut(target.alloc) {
                 alloc.freed = true;
@@ -3701,6 +3719,7 @@ impl<'a> Interp<'a> {
             }
         }
         let alloc = self.heap_alloc(Value::Aggregate(cells), stride, false);
+        self.heap[target.alloc].freed = true;
         Ok(Value::Ptr(Some(PtrTarget {
             alloc,
             path: Vec::new(),

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -1142,11 +1142,10 @@ fn ptr_offset_strides_by_element() {
     assert_eq!(run(src).stdout, "20\n20\n");
 }
 
-/// A heap buffer round-trips values, and reads after `@free` still observe the
-/// stored bytes — the runtime bump allocator's `free` is a no-op, so the whole
-/// program is well defined and the oracle must agree with it.
+/// Use-after-free is undefined and stays a typed oracle gap rather than being
+/// assigned the stale bytes that happened to remain in the old bump allocator.
 #[test]
-fn alloc_write_read_survives_free() {
+fn alloc_read_after_free_is_unsupported() {
     let src = r#"fn main() -> i32 {
         checked {
             let p: ptr mut i32 = @alloc(3);
@@ -1160,9 +1159,14 @@ fn alloc_write_read_survives_free() {
             @ptr_read(p) + @ptr_read(@ptr_offset(p, 1)) + @ptr_read(@ptr_offset(p, 2))
         }
     }"#;
-    let outcome = run(src);
-    assert_eq!(outcome.stdout, "10\n20\n30\n");
-    assert_eq!(outcome.exit_code, 60);
+    let unsupported = expect_unsupported(src);
+    assert_eq!(
+        unsupported.kind(),
+        UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(
+            UnsupportedIntrinsicKind::PointerRead,
+        ))
+    );
+    assert_eq!(unsupported.detail(), "pointer read after free");
 }
 
 /// `@alloc` round-trips an aggregate element written and read whole.

--- a/crates/rue-runtime-abi/src/lib.rs
+++ b/crates/rue-runtime-abi/src/lib.rs
@@ -494,13 +494,11 @@ macro_rules! for_each_runtime_helper {
             safety: ALLOC_LAYOUT,
             returns: RETURNS
         },
-        Free => safe __rue_free(ptr: *mut u8, size: u64, align: u64) {
+        Free => unsafe __rue_free(ptr: *mut u8, size: u64, align: u64) {
             symbol: "__rue_free",
             parameters: params![MUT_BYTE_POINTER, U64_VALUE, U64_VALUE],
             result: VOID,
-            // The current bump allocator's free operation is a no-op and imposes
-            // no pointer or layout precondition.
-            safety: SafetyContract::NONE,
+            safety: VALID_ALLOC_LAYOUT,
             returns: RETURNS
         },
         Realloc => unsafe __rue_realloc(
@@ -1411,7 +1409,7 @@ mod tests {
             &[RuntimeHelperId::Free],
             &[MUT_BYTE_POINTER, U64_VALUE, U64_VALUE],
             VOID,
-            SafetyContract::NONE,
+            VALID_ALLOC_LAYOUT,
             RETURNS,
         );
         check(
@@ -1722,6 +1720,10 @@ mod tests {
         let realloc = RuntimeHelperId::Realloc.helper().safety;
         assert!(realloc.contains(SafetyContract::VALID_ALLOCATION));
         assert!(realloc.contains(SafetyContract::ALLOCATION_LAYOUT));
+
+        let free = RuntimeHelperId::Free.helper().safety;
+        assert!(free.contains(SafetyContract::VALID_ALLOCATION));
+        assert!(free.contains(SafetyContract::ALLOCATION_LAYOUT));
     }
 
     #[test]

--- a/crates/rue-runtime-asan/Cargo.lock
+++ b/crates/rue-runtime-asan/Cargo.lock
@@ -3,5 +3,12 @@
 version = 4
 
 [[package]]
+name = "rue-allocator"
+version = "0.0.0"
+
+[[package]]
 name = "rue-runtime-asan"
 version = "0.0.0"
+dependencies = [
+ "rue-allocator",
+]

--- a/crates/rue-runtime-asan/Cargo.toml
+++ b/crates/rue-runtime-asan/Cargo.toml
@@ -7,14 +7,17 @@
 # cargo crate driven by nightly rustc in a dedicated CI job is the minimal path
 # that actually works. See `src/main.rs` for the full rationale.
 #
-# It compiles the REAL allocator source (crates/rue-runtime/src/heap.rs) via a
-# `#[path]` include, so there is no copy to drift out of sync.
+# It depends on the same `rue-allocator` crate as `rue-runtime`, supplying a
+# host-backed page mapper so there is no allocator copy to drift out of sync.
 
 [package]
 name = "rue-runtime-asan"
 version = "0.0.0"
 edition = "2024"
 publish = false
+
+[dependencies]
+rue-allocator = { path = "../rue-allocator" }
 
 # No top-level Cargo workspace exists in this buck2 repo; declare an empty
 # workspace table so cargo does not walk upward hunting for one.

--- a/crates/rue-runtime-asan/src/main.rs
+++ b/crates/rue-runtime-asan/src/main.rs
@@ -1,11 +1,11 @@
-//! AddressSanitizer harness for `rue-runtime`'s arena allocator (RUE-211, RUE-560).
+//! AddressSanitizer harness for Rue's recycling allocator (RUE-211, RUE-560).
 //!
 //! # Why this exists
 //!
 //! The valgrind memcheck sanitizer job (RUE-49, `.github/workflows/sanitizer.yml`)
 //! runs compiled Rue programs under DBI and catches codegen / wild-pointer /
 //! stack / bad-syscall-buffer bugs. But memcheck hooks libc `malloc`/`free`,
-//! and `rue-runtime` bump-allocates inside `mmap`'d arenas without ever calling
+//! and Rue allocates directly inside `mmap`'d arenas without ever calling
 //! libc — so to memcheck every Rue program does "0 allocs". That leaves the
 //! **intra-arena heap overflow** class (RUE-34: a grow path recording more
 //! capacity than was actually reserved) completely uncovered: the overflowed
@@ -13,9 +13,8 @@
 //!
 //! # What it does
 //!
-//! This binary compiles the REAL allocator (`crates/rue-runtime/src/heap.rs`,
-//! pulled in verbatim via `#[path]` so there is nothing to drift) against a
-//! host `platform` shim, and runs it under `-Zsanitizer=address`. Every
+//! This binary uses the same `rue-allocator` crate as `rue-runtime` against a
+//! host page mapper and runs it under `-Zsanitizer=address`. Every
 //! allocation the harness makes goes through [`guarded_alloc`], which reserves
 //! a redzone immediately past the usable block and poisons it with ASan's
 //! manual API (`__asan_poison_memory_region`). A write past an allocation's
@@ -38,12 +37,6 @@
 //! harness's own poisoned redzone whose sole purpose is to make ASan fault; it
 //! exercises no external input and touches no memory outside the harness.
 
-// The real allocator source, included verbatim. It references `crate::platform`
-// and `core::*`; we satisfy the former with the module below and the latter is
-// available in this std crate.
-#[path = "../../rue-runtime/src/heap.rs"]
-mod heap;
-
 use std::process::Command;
 
 /// Environment variable that puts the harness into negative-control (self-test)
@@ -58,40 +51,47 @@ const SELFTEST_ENV: &str = "RUE_ASAN_SELFTEST";
 /// also holds valid bytes).
 const REDZONE: usize = 32;
 
-/// Host stand-in for the runtime's platform layer.
-///
-/// `heap.rs` only needs `mmap`/`munmap` with the same contract as the real
-/// syscall wrappers: `mmap` returns page-aligned, zero-initialized memory (or
-/// null), and `munmap` returns it. We back arenas with the global allocator so
-/// ASan tracks the underlying blocks; the manual poisoning in the harness adds
-/// the intra-arena redzones on top.
-mod platform {
+/// The real allocator with a host-backed mapper so ASan tracks every underlying
+/// arena or dedicated mapping.
+mod heap {
+    use rue_allocator::{Allocator, PAGE_SIZE, PageMapper};
     use std::alloc::{Layout, alloc_zeroed, dealloc};
 
-    /// Real `mmap` returns page-aligned memory; mirror that so `heap.rs`'s
-    /// page-alignment assumptions (it page-aligns arena sizes) hold.
-    const PAGE: usize = 4096;
+    struct HostPageMapper;
 
-    pub fn mmap(size: usize) -> *mut u8 {
-        if size == 0 {
-            return std::ptr::null_mut();
+    // SAFETY: std's allocator returns exclusive page-aligned blocks for the
+    // requested layouts and supports concurrent allocation and deallocation.
+    unsafe impl PageMapper for HostPageMapper {
+        fn map(size: usize) -> *mut u8 {
+            let Ok(layout) = Layout::from_size_align(size, PAGE_SIZE) else {
+                return std::ptr::null_mut();
+            };
+            // SAFETY: the allocator supplies a valid, nonzero mapping size.
+            unsafe { alloc_zeroed(layout) }
         }
-        let Ok(layout) = Layout::from_size_align(size, PAGE) else {
-            return std::ptr::null_mut();
-        };
-        // `alloc_zeroed` mirrors `mmap`'s zero-initialized guarantee.
-        unsafe { alloc_zeroed(layout) }
+
+        unsafe fn unmap(pointer: *mut u8, size: usize) {
+            let layout = Layout::from_size_align(size, PAGE_SIZE)
+                .expect("allocator supplied an invalid mapping layout");
+            // SAFETY: inherited from PageMapper::unmap's contract.
+            unsafe { dealloc(pointer, layout) };
+        }
     }
 
-    pub fn munmap(addr: *mut u8, size: usize) -> i64 {
-        if addr.is_null() || size == 0 {
-            return -1;
-        }
-        let Ok(layout) = Layout::from_size_align(size, PAGE) else {
-            return -1;
-        };
-        unsafe { dealloc(addr, layout) };
-        0
+    static ALLOCATOR: Allocator<HostPageMapper> = Allocator::new();
+
+    pub fn alloc(size: u64, align: u64) -> *mut u8 {
+        ALLOCATOR.allocate(size, align)
+    }
+
+    pub unsafe fn free(pointer: *mut u8, size: u64, align: u64) {
+        // SAFETY: inherited from this function's caller contract.
+        unsafe { ALLOCATOR.deallocate(pointer, size, align) };
+    }
+
+    pub unsafe fn realloc(pointer: *mut u8, old_size: u64, new_size: u64, align: u64) -> *mut u8 {
+        // SAFETY: inherited from this function's caller contract.
+        unsafe { ALLOCATOR.reallocate(pointer, old_size, new_size, align) }
     }
 }
 
@@ -126,6 +126,9 @@ struct Guarded {
     size: usize,
     /// Start of the poisoned redzone, kept so it can be cleared on drop.
     redzone: *mut u8,
+    /// Complete allocation layout, including the redzone.
+    reserved: usize,
+    align: usize,
 }
 
 /// Allocate `size` usable bytes through the REAL allocator with a poisoned
@@ -134,9 +137,8 @@ struct Guarded {
 /// The block reserved from the arena is `align_up_8(size) + REDZONE`; the
 /// caller sees only the first `size` bytes. The redzone begins at the
 /// 8-aligned boundary at or after `ptr+size` so it covers whole shadow
-/// granules. Because the bump allocator hands the *next* allocation an offset
-/// past the full reservation, poisoning the redzone can never collide with a
-/// later block.
+/// granules. The allocator reserves the full block including that redzone, so
+/// poisoning it cannot collide with another live allocation.
 fn guarded_alloc(size: usize, align: usize) -> Guarded {
     assert!(size > 0);
     let usable = align_up_8(size);
@@ -145,7 +147,13 @@ fn guarded_alloc(size: usize, align: usize) -> Guarded {
     assert!(!ptr.is_null(), "guarded_alloc({size}, {align}) OOM");
     let redzone = unsafe { ptr.add(usable) };
     poison(redzone, REDZONE);
-    Guarded { ptr, size, redzone }
+    Guarded {
+        ptr,
+        size,
+        redzone,
+        reserved: total,
+        align,
+    }
 }
 
 impl Guarded {
@@ -165,11 +173,11 @@ impl Guarded {
 
 impl Drop for Guarded {
     fn drop(&mut self) {
-        // Clear the shadow so a later (unrelated) allocation reusing nearby
-        // bytes is not falsely flagged. `free` is a no-op in the bump
-        // allocator, so nothing reclaims the block; this is purely shadow
-        // hygiene for the long-lived process.
+        // Clear the shadow before returning the complete block to its free
+        // list; a later allocation may immediately recycle this storage.
         unpoison(self.redzone, REDZONE);
+        // SAFETY: ptr is live with the complete reserved layout.
+        unsafe { heap::free(self.ptr, self.reserved as u64, self.align as u64) };
     }
 }
 
@@ -236,7 +244,8 @@ fn exercise_allocator() {
             *g.add(i) = (i as u8).wrapping_mul(3);
         }
     }
-    let g2 = heap::realloc(g, 32, 4096, 8);
+    // SAFETY: g is live and readable for 32 bytes.
+    let g2 = unsafe { heap::realloc(g, 32, 4096, 8) };
     assert!(!g2.is_null());
     unsafe {
         for i in 0..32 {
@@ -256,6 +265,13 @@ fn exercise_allocator() {
         *big.add(BIG - 1) = 2;
         assert_eq!(*big, 1);
         assert_eq!(*big.add(BIG - 1), 2);
+
+        heap::free(p, 64, 8);
+        for q in ptrs {
+            heap::free(q, 128, 8);
+        }
+        heap::free(g2, 4096, 8);
+        heap::free(big, BIG as u64, 8);
     }
 }
 
@@ -273,9 +289,8 @@ fn exercise_guarded_allocations() {
         g.write_and_verify(0xAB);
     }
 
-    // Many live guarded allocations at once: each keeps its own redzone, and
-    // the next bump-allocated block starts past the previous redzone, so the
-    // poison of one never overlaps the usable region of another.
+    // Many live guarded allocations at once: each reserves its own redzone, so
+    // one block's poison never overlaps another block's usable region.
     let blocks: Vec<Guarded> = (0..48).map(|i| guarded_alloc(24 + i, 8)).collect();
     for g in &blocks {
         g.write_and_verify(0xCD);

--- a/crates/rue-runtime/BUCK
+++ b/crates/rue-runtime/BUCK
@@ -15,6 +15,7 @@ rue_crate(
     tests = False,
     crate = "rue_runtime",
     deps = [
+        "//crates/rue-allocator:rue-allocator",
         "//crates/rue-runtime-abi:rue-runtime-abi",
     ],
     # Force static linkage to ensure the [staticlib] subtarget is available
@@ -72,6 +73,7 @@ rust_test(
     srcs = glob(["src/**/*.rs"]),
     crate = "rue_runtime",
     deps = [
+        "//crates/rue-allocator:rue-allocator",
         "//crates/rue-runtime-abi:rue-runtime-abi",
     ],
 )

--- a/crates/rue-runtime/runtime.bzl
+++ b/crates/rue-runtime/runtime.bzl
@@ -28,6 +28,7 @@ def _runtime_staticlib_impl(ctx: AnalysisContext) -> list[Provider]:
     # compiling the no_std ABI and runtime crates for the selected target.
     target_sysroot = target_std.project("rust-std-{}".format(target))
     abi_rlib = ctx.actions.declare_output("librue_runtime_abi-{}.rlib".format(target))
+    allocator_rlib = ctx.actions.declare_output("librue_allocator-{}.rlib".format(target))
     archive = ctx.actions.declare_output("librue_runtime-{}.a".format(target))
 
     abi_args = cmd_args(toolchain.compiler)
@@ -53,6 +54,32 @@ def _runtime_staticlib_impl(ctx: AnalysisContext) -> list[Provider]:
         identifier = target,
     )
 
+    allocator_args = cmd_args(toolchain.compiler)
+    allocator_args.add(
+        "--crate-name",
+        "rue_allocator",
+        "--crate-type",
+        "rlib",
+        "--edition",
+        "2024",
+        "--target",
+        target,
+        "--sysroot",
+        target_sysroot,
+    )
+    allocator_args.add(ctx.attrs.rustc_flags)
+    allocator_args.add(
+        ctx.attrs.allocator_crate_root,
+        "-o",
+        allocator_rlib.as_output(),
+    )
+
+    ctx.actions.run(
+        allocator_args,
+        category = "runtime_allocator_rlib",
+        identifier = target,
+    )
+
     args = cmd_args(toolchain.compiler)
     args.add(
         "--crate-name",
@@ -67,6 +94,10 @@ def _runtime_staticlib_impl(ctx: AnalysisContext) -> list[Provider]:
         target_sysroot,
     )
     args.add(ctx.attrs.rustc_flags)
+    args.add(
+        "--extern",
+        cmd_args("rue_allocator=", allocator_rlib, delimiter = ""),
+    )
     args.add(
         "--extern",
         cmd_args("rue_runtime_abi=", abi_rlib, delimiter = ""),
@@ -85,6 +116,7 @@ def _runtime_staticlib_impl(ctx: AnalysisContext) -> list[Provider]:
 _runtime_staticlib = rule(
     impl = _runtime_staticlib_impl,
     attrs = {
+        "allocator_crate_root": attrs.source(),
         "abi_crate_root": attrs.source(),
         "crate_root": attrs.source(),
         "srcs": attrs.list(attrs.source()),
@@ -103,6 +135,7 @@ def runtime_staticlib(name: str, target_triple: str, target_std: str, visibility
 
     _runtime_staticlib(
         name = name,
+        allocator_crate_root = "//crates/rue-allocator:lib.rs",
         abi_crate_root = "//crates/rue-runtime-abi:lib.rs",
         crate_root = "src/lib.rs",
         srcs = glob(["src/**/*.rs"]),

--- a/crates/rue-runtime/runtime.bzl
+++ b/crates/rue-runtime/runtime.bzl
@@ -68,6 +68,17 @@ def _runtime_staticlib_impl(ctx: AnalysisContext) -> list[Provider]:
         target_sysroot,
     )
     allocator_args.add(ctx.attrs.rustc_flags)
+    # Generic allocator code is instantiated into the runtime static library,
+    # including source locations used by panic paths. The exported source
+    # artifact lives under checkout-specific buck-out roots, so give rustc a
+    # stable virtual filename before those bytes are embedded in the compiler.
+    allocator_args.add(
+        "--remap-path-prefix",
+        cmd_args(
+            ctx.attrs.allocator_crate_root,
+            format = "{}=/rue/crates/rue-allocator/src/lib.rs",
+        ),
+    )
     allocator_args.add(
         ctx.attrs.allocator_crate_root,
         "-o",

--- a/crates/rue-runtime/src/heap.rs
+++ b/crates/rue-runtime/src/heap.rs
@@ -1,42 +1,13 @@
-//! Heap allocation for Rue programs.
+//! Rue runtime integration for the standalone recycling allocator.
 //!
-//! This module provides a simple bump allocator backed by `mmap` for heap
-//! allocation. It's designed for simplicity over memory efficiency - memory
-//! is only returned to the OS when the program exits.
-//!
-//! # Design
-//!
-//! The allocator uses a series of "arenas" - large chunks of memory obtained
-//! from the OS via `mmap`. Allocations bump a pointer forward within the
-//! current arena. When an arena fills up, a new one is allocated.
-//!
-//! ```text
-//! +------------------+------------------+
-//! |     Arena 1      |     Arena 2      |
-//! |  [alloc][alloc]  | [alloc][...free] |
-//! +------------------+------------------+
-//!                           ^
-//!                           bump pointer
-//! ```
-//!
-//! # Thread Safety
-//!
-//! This allocator uses atomic operations for the global arena pointer, making
-//! it safe to use from multiple threads. However, concurrent allocations may
-//! contend on the bump pointer within an arena. For Rue V1 (single-threaded),
-//! this is fine. For heavily concurrent workloads, a thread-local allocator
-//! would be more efficient.
-//!
-//! # Memory Efficiency
-//!
-//! Individual `free()` calls are deliberately no-ops: the bump allocator
-//! retains every arena until the process exits, when the OS reclaims it. This
-//! is the runtime ABI contract for this allocator and trades memory efficiency
-//! for simple, predictable allocation.
+//! Allocation policy and bookkeeping live in `rue-allocator`. This module
+//! supplies the runtime's direct-syscall page mapper and exposes the small API
+//! used by runtime helpers and internal consumers.
 
 use crate::platform;
+#[cfg(test)]
 use core::ptr;
-use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+use rue_allocator::{Allocator, PageMapper};
 
 #[cfg(test)]
 extern crate std;
@@ -62,427 +33,79 @@ pub(crate) fn disable_allocation_failure_for_test() {
 }
 
 #[cfg(test)]
-fn injected_allocation_failure() -> bool {
-    ALLOCATIONS_BEFORE_FAILURE.get().is_some_and(|remaining| {
+fn allocation_permitted_for_test() -> bool {
+    ALLOCATIONS_BEFORE_FAILURE.get().is_none_or(|remaining| {
         if remaining == 0 {
-            true
+            false
         } else {
             ALLOCATIONS_BEFORE_FAILURE.set(Some(remaining - 1));
-            false
+            true
         }
     })
 }
 
-/// Default arena size: 64 KiB
-///
-/// This is chosen to be:
-/// - Large enough to reduce mmap syscall overhead
-/// - Small enough to not waste too much memory for small programs
-/// - A multiple of typical page sizes (4 KiB)
-const DEFAULT_ARENA_SIZE: usize = 64 * 1024;
+struct RuntimePageMapper;
 
-/// Header at the start of each arena.
-///
-/// Arenas are linked together in a singly-linked list. This header
-/// sits at the very beginning of each mmap'd region.
-///
-/// The `offset` field is atomic to allow lock-free bump allocation.
-#[repr(C)]
-struct ArenaHeader {
-    /// Pointer to the next arena in the list (older arenas).
-    /// Only written during arena creation, so doesn't need to be atomic.
-    next: *mut ArenaHeader,
-    /// Total size of this arena (including header).
-    /// Immutable after creation.
-    size: usize,
-    /// Current allocation offset from the start of the arena.
-    /// Starts after the header, bumps forward with each allocation.
-    /// Atomic to support lock-free concurrent allocation.
-    offset: AtomicUsize,
-}
-
-// Static assertions to verify ArenaHeader layout assumptions.
-// These ensure the arena fits at the start of an mmap'd page.
-const _: () = {
-    // ArenaHeader is 24 bytes: 8 (next) + 8 (size) + 8 (offset)
-    assert!(core::mem::size_of::<ArenaHeader>() == 24);
-    // ArenaHeader is 8-byte aligned
-    assert!(core::mem::align_of::<ArenaHeader>() == 8);
-    // ArenaHeader fits in a single cache line (64 bytes)
-    assert!(core::mem::size_of::<ArenaHeader>() <= 64);
-};
-
-/// Global pointer to the current arena.
-///
-/// This is the head of a linked list of arenas. New arenas are prepended
-/// to the list. Using `AtomicPtr` makes this safe to access from multiple
-/// threads without any unsafe `Sync` implementations.
-static CURRENT_ARENA: AtomicPtr<ArenaHeader> = AtomicPtr::new(ptr::null_mut());
-
-/// Align a value up to the given alignment.
-///
-/// # Panics
-///
-/// Alignment must be a power of 2. This is not checked at runtime
-/// for performance - callers must ensure valid alignment.
-#[inline]
-const fn align_up(value: usize, align: usize) -> usize {
-    (value + align - 1) & !(align - 1)
-}
-
-/// Check if a value is a power of 2.
-#[inline]
-const fn is_power_of_two(n: u64) -> bool {
-    n != 0 && (n & (n - 1)) == 0
-}
-
-/// Allocate a new arena with room for a `min_size` allocation at `align`.
-///
-/// The arena must hold the header plus the requested block *after* the block
-/// has been aligned. The allocation is placed at `align_up(header_size, align)`
-/// (see `alloc_from_arena`), so the arena must be at least
-/// `align_up(header_size, align) + min_size` bytes — the alignment padding
-/// between the header and the block counts against the arena size. Sizing it
-/// as merely `header_size + min_size` (ignoring the padding) would under-size
-/// the region and let the fresh-arena fast path hand out a block past the
-/// mmap'd mapping (RUE-344).
-///
-/// Returns a pointer to the arena header, or null on failure.
-fn alloc_arena(min_size: usize, align: usize) -> *mut ArenaHeader {
-    // Ensure we have room for the header, the alignment padding, and the block.
-    let header_size = core::mem::size_of::<ArenaHeader>();
-
-    // Offset at which alloc_from_arena will place the block (header + padding).
-    let aligned_header = align_up(header_size, align);
-
-    // Use checked_add to prevent overflow
-    let Some(total) = aligned_header.checked_add(min_size) else {
-        return ptr::null_mut();
-    };
-    // Page-align with a CHECKED round-up: a `total` in the top page
-    // (> usize::MAX - 4095) would wrap `align_up` to 0, then clamp up to
-    // DEFAULT_ARENA_SIZE and hand out a huge block backed by a 64 KiB
-    // mapping — a heap overflow. Return null on overflow, honoring the
-    // documented OOM contract.
-    let Some(total_size) = total.checked_next_multiple_of(4096) else {
-        return ptr::null_mut();
-    };
-
-    // Use at least the default arena size
-    let arena_size = if total_size < DEFAULT_ARENA_SIZE {
-        DEFAULT_ARENA_SIZE
-    } else {
-        total_size
-    };
-
-    // Request memory from the OS
-    let ptr = platform::mmap(arena_size);
-    if ptr.is_null() {
-        return ptr::null_mut();
+// SAFETY: the platform mmap/munmap pair provides exclusive page-aligned
+// mappings and supports independent concurrent syscall invocations.
+unsafe impl PageMapper for RuntimePageMapper {
+    #[inline]
+    fn allocation_permitted() -> bool {
+        #[cfg(test)]
+        {
+            allocation_permitted_for_test()
+        }
+        #[cfg(not(test))]
+        {
+            true
+        }
     }
 
-    // Initialize the header
-    let header = ptr as *mut ArenaHeader;
-    // SAFETY: Writing to the header is safe because:
-    // - `ptr` was just returned by mmap, which returns page-aligned memory
-    // - The mmap succeeded (we checked for null above)
-    // - ArenaHeader is smaller than a page, so it fits in the allocation
-    // - We have exclusive access to this memory (just allocated)
-    // - ArenaHeader is repr(C) with no padding issues
-    unsafe {
-        (*header).next = ptr::null_mut();
-        (*header).size = arena_size;
-        (*header).offset = AtomicUsize::new(header_size); // Start allocations after header
+    #[inline]
+    fn map(size: usize) -> *mut u8 {
+        platform::mmap(size)
     }
 
-    header
+    #[inline]
+    unsafe fn unmap(pointer: *mut u8, size: usize) {
+        // SAFETY: rue-allocator only supplies complete mappings previously
+        // returned by this mapper with their original page-rounded size.
+        platform::munmap(pointer, size);
+    }
 }
 
-/// Allocate memory from the heap.
-///
-/// # Arguments
-///
-/// * `size` - Number of bytes to allocate
-/// * `align` - Required alignment (must be a power of 2)
-///
-/// # Returns
-///
-/// A pointer to the allocated memory, or null on failure.
-/// The memory is zero-initialized (from mmap).
-///
-/// # Failure Conditions
-///
-/// Returns null if:
-/// - `size` is 0
-/// - `align` is 0 or not a power of 2
-/// - Out of memory (mmap fails)
-///
-/// # Safety
-///
-/// The returned pointer (if non-null) is valid and properly aligned.
-/// The memory remains valid until the program exits.
+static ALLOCATOR: Allocator<RuntimePageMapper> = Allocator::new();
+
+/// Allocate uninitialized storage for the supplied layout.
 pub fn alloc(size: u64, align: u64) -> *mut u8 {
-    #[cfg(test)]
-    if injected_allocation_failure() {
-        return ptr::null_mut();
-    }
-
-    // Validate arguments. `align` is also capped at the page size: the arena
-    // base is only page-aligned (mmap), and blocks are placed at an offset
-    // aligned relative to that base, so an `align` greater than a page could
-    // yield a misaligned absolute address. No reachable caller exceeds 8;
-    // reject the rest cleanly rather than silently misalign (callers already
-    // handle a null return).
-    if size == 0 || align == 0 || !is_power_of_two(align) || align > 4096 {
-        return ptr::null_mut();
-    }
-
-    let size = size as usize;
-    let align = align as usize;
-
-    loop {
-        // Load current arena
-        let arena = CURRENT_ARENA.load(Ordering::Acquire);
-
-        if arena.is_null() {
-            // No arena yet - try to create one
-            let new_arena = alloc_arena(size, align);
-            if new_arena.is_null() {
-                return ptr::null_mut();
-            }
-
-            // Try to install our new arena as the current one
-            match CURRENT_ARENA.compare_exchange(
-                ptr::null_mut(),
-                new_arena,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => {
-                    // We installed the arena, now allocate from it
-                    return alloc_from_arena(new_arena, size, align);
-                }
-                Err(_) => {
-                    // Someone else beat us - free our arena and retry
-                    // SAFETY: Freeing this arena is safe because:
-                    // - `new_arena` was just created by us via alloc_arena
-                    // - The compare_exchange failed, so no one else has a reference
-                    // - We read the size from the header we initialized
-                    // - After munmap, we don't use this pointer again
-                    unsafe {
-                        platform::munmap(new_arena as *mut u8, (*new_arena).size);
-                    }
-                    continue;
-                }
-            }
-        }
-
-        // Try to allocate from the current arena
-        // SAFETY: Accessing the arena is safe because:
-        // - `arena` is non-null (we checked above)
-        // - `arena` points to memory from mmap that's still valid
-        // - The arena was initialized by alloc_arena before being published
-        // - ArenaHeader fields (except offset) are immutable after initialization
-        unsafe {
-            let arena_size = (*arena).size;
-
-            // Use compare-and-swap loop to atomically bump the offset
-            loop {
-                let current_offset = (*arena).offset.load(Ordering::Relaxed);
-
-                // Calculate aligned offset with overflow check
-                let aligned_offset = align_up(current_offset, align);
-                let Some(new_offset) = aligned_offset.checked_add(size) else {
-                    return ptr::null_mut();
-                };
-
-                if new_offset > arena_size {
-                    // Doesn't fit - need a new arena
-                    break;
-                }
-
-                // Try to claim this space
-                match (*arena).offset.compare_exchange_weak(
-                    current_offset,
-                    new_offset,
-                    Ordering::Relaxed,
-                    Ordering::Relaxed,
-                ) {
-                    Ok(_) => {
-                        // Success! Return the allocated memory
-                        // SAFETY: Computing the return pointer is safe because:
-                        // - `arena` points to valid mmap'd memory
-                        // - `aligned_offset` is within [0, arena_size) (checked above)
-                        // - The memory at this offset is part of our arena allocation
-                        // - We just atomically claimed this region via compare_exchange
-                        return (arena as *mut u8).add(aligned_offset);
-                    }
-                    Err(_) => {
-                        // Someone else modified the offset, retry
-                        continue;
-                    }
-                }
-            }
-
-            // Allocation doesn't fit in current arena - create a new one
-            let new_arena = alloc_arena(size, align);
-            if new_arena.is_null() {
-                return ptr::null_mut();
-            }
-
-            // Link new arena to the old one
-            // SAFETY: Writing to new_arena is safe because:
-            // - new_arena was just allocated by us
-            // - No one else has a reference to it yet (not published)
-            // - arena is a valid pointer we read earlier (may become stale, but that's ok)
-            (*new_arena).next = arena;
-
-            // Try to install our new arena as the current one
-            match CURRENT_ARENA.compare_exchange(
-                arena,
-                new_arena,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => {
-                    // We installed the arena, now allocate from it
-                    return alloc_from_arena(new_arena, size, align);
-                }
-                Err(_) => {
-                    // Someone else changed the arena - free ours and retry
-                    // SAFETY: Freeing is safe because:
-                    // - new_arena was allocated by us
-                    // - compare_exchange failed so no one else has a reference
-                    // - We read size from our own initialized header
-                    platform::munmap(new_arena as *mut u8, (*new_arena).size);
-                    continue;
-                }
-            }
-        }
-    }
+    ALLOCATOR.allocate(size, align)
 }
 
-/// Allocate from a freshly-created arena (no contention possible).
+/// Release storage previously returned by [`alloc`] or [`realloc`].
 ///
-/// This is a helper for the common case where we just created an arena
-/// and know we're the only thread using it.
-fn alloc_from_arena(arena: *mut ArenaHeader, size: usize, align: usize) -> *mut u8 {
-    // SAFETY: Accessing and modifying the arena is safe because:
-    // - `arena` was just created by alloc_arena and is valid
-    // - We just installed it via compare_exchange, so we have logical ownership
-    // - No other thread can see this arena yet (we're the first to allocate)
-    // - The offset store and pointer arithmetic are within the arena bounds:
-    //   alloc_arena was called with this same `align` and sized the region as
-    //   align_up(align_up(header_size, align) + size, 4096), so the block at
-    //   align_up(header_size, align) spanning `size` bytes fits with room to
-    //   spare. This is why no bounds check is needed on this fast path.
-    unsafe {
-        let header_size = core::mem::size_of::<ArenaHeader>();
-        let aligned_offset = align_up(header_size, align);
-        // Overflow is impossible: alloc_arena computed the same
-        // align_up(header_size, align) + size via checked_add and only returned
-        // non-null if it did not overflow, and the arena is at least that large.
-        let new_offset = aligned_offset + size;
-        (*arena).offset.store(new_offset, Ordering::Relaxed);
-        (arena as *mut u8).add(aligned_offset)
-    }
-}
-
-/// Free memory previously allocated by `alloc`.
-///
-/// # Arguments
-///
-/// * `ptr` - Pointer to the memory to free
-/// * `size` - Size supplied by the runtime allocation ABI
-/// * `align` - Alignment supplied by the runtime allocation ABI
-///
-/// # Bump-allocator contract
-///
-/// This is a **no-op**. Memory is reclaimed when the program exits. The
-/// `ptr`, `size`, and `align` parameters preserve the allocator ABI used by
-/// generated code, but no arena bookkeeping is changed.
+/// A null pointer is accepted and has no effect.
 ///
 /// # Safety
 ///
-/// The caller should ensure `ptr` was returned by a previous `alloc` call,
-/// but since this is a no-op, invalid pointers are harmless.
-#[allow(unused_variables)]
-pub fn free(ptr: *mut u8, size: u64, align: u64) {
-    // Deliberate ABI no-op; the OS reclaims all arenas at process exit.
+/// A non-null `pointer` must identify a live allocation with exactly `size` and
+/// `align`, and it must not be accessed after this call.
+pub unsafe fn free(pointer: *mut u8, size: u64, align: u64) {
+    // SAFETY: inherited from this function's caller contract.
+    unsafe { ALLOCATOR.deallocate(pointer, size, align) };
 }
 
-/// Reallocate memory to a new size.
+/// Resize an allocation, preserving `min(old_size, new_size)` bytes.
 ///
-/// # Arguments
-///
-/// * `ptr` - Pointer to the existing allocation (or null for new allocation)
-/// * `old_size` - Size of the existing allocation (ignored if ptr is null)
-/// * `new_size` - Desired new size
-/// * `align` - Required alignment (must be a power of 2)
-///
-/// # Returns
-///
-/// A pointer to the reallocated memory, or null on failure.
-///
-/// # Behavior
-///
-/// - If `ptr` is null: behaves like `alloc(new_size, align)`
-/// - If `new_size` is 0: behaves like `free(ptr, old_size, align)`, returns null
-/// - If `new_size <= old_size`: returns `ptr` unchanged (no shrinking needed)
-/// - If `new_size > old_size`: allocates new block, copies old data, returns new pointer
-///
-/// # Memory Contents
-///
-/// When growing, the contents up to `min(old_size, new_size)` are preserved.
-/// Any additional bytes are zero-initialized (from mmap).
+/// Allocation failure returns null and leaves the old allocation live and
+/// unchanged.
 ///
 /// # Safety
 ///
-/// The old pointer becomes invalid after a successful realloc that changes
-/// the address. The caller must use the returned pointer.
-pub fn realloc(ptr: *mut u8, old_size: u64, new_size: u64, align: u64) -> *mut u8 {
-    // Handle null pointer case - just allocate
-    if ptr.is_null() {
-        return alloc(new_size, align);
-    }
-
-    // Handle zero new_size - just free
-    if new_size == 0 {
-        free(ptr, old_size, align);
-        return ptr::null_mut();
-    }
-
-    // Validate alignment
-    if align == 0 || !is_power_of_two(align) {
-        return ptr::null_mut();
-    }
-
-    // If shrinking or same size, just return the original pointer
-    // (bump allocator can't reclaim the extra space anyway)
-    if new_size <= old_size {
-        return ptr;
-    }
-
-    // Need to grow - allocate new block and copy
-    let new_ptr = alloc(new_size, align);
-    if new_ptr.is_null() {
-        return ptr::null_mut();
-    }
-
-    // Copy old data to new location
-    // SAFETY: Copying is safe because:
-    // - `ptr` points to a valid allocation of at least `old_size` bytes (from caller)
-    // - `new_ptr` was just allocated with `new_size` bytes (which is > old_size)
-    // - `old_size <= new_size` (we only get here if new_size > old_size)
-    // - The regions don't overlap (new_ptr is a fresh allocation)
-    unsafe {
-        ptr::copy_nonoverlapping(ptr, new_ptr, old_size as usize);
-    }
-
-    // Note: We don't free the old pointer since free is a no-op.
-    // The old memory is "wasted" until program exit.
-
-    new_ptr
+/// A non-null `pointer` must identify a live allocation for `old_size` and
+/// `align` and be readable for `old_size` bytes.
+pub unsafe fn realloc(pointer: *mut u8, old_size: u64, new_size: u64, align: u64) -> *mut u8 {
+    // SAFETY: inherited from this function's caller contract.
+    unsafe { ALLOCATOR.reallocate(pointer, old_size, new_size, align) }
 }
 
 #[cfg(test)]
@@ -490,367 +113,132 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_align_up() {
-        assert_eq!(align_up(0, 8), 0);
-        assert_eq!(align_up(1, 8), 8);
-        assert_eq!(align_up(7, 8), 8);
-        assert_eq!(align_up(8, 8), 8);
-        assert_eq!(align_up(9, 8), 16);
-        assert_eq!(align_up(15, 16), 16);
-        assert_eq!(align_up(16, 16), 16);
-        assert_eq!(align_up(17, 16), 32);
+    fn invalid_layouts_return_null() {
+        assert!(alloc(0, 8).is_null());
+        assert!(alloc(16, 0).is_null());
+        assert!(alloc(16, 3).is_null());
+        assert!(alloc(16, 8192).is_null());
+        assert!(alloc(u64::MAX - 124, 1).is_null());
     }
 
     #[test]
-    fn test_is_power_of_two() {
-        assert!(!is_power_of_two(0));
-        assert!(is_power_of_two(1));
-        assert!(is_power_of_two(2));
-        assert!(!is_power_of_two(3));
-        assert!(is_power_of_two(4));
-        assert!(!is_power_of_two(5));
-        assert!(is_power_of_two(8));
-        assert!(is_power_of_two(16));
-        assert!(is_power_of_two(4096));
-        assert!(!is_power_of_two(4097));
+    fn allocation_is_aligned_and_usable() {
+        for align in [1u64, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 4096] {
+            let pointer = alloc(64, align);
+            assert!(!pointer.is_null(), "alloc failed for align={align}");
+            assert_eq!(pointer as usize % align as usize, 0);
+            unsafe {
+                pointer.write(42);
+                assert_eq!(pointer.read(), 42);
+                free(pointer, 64, align);
+            }
+        }
     }
 
     #[test]
-    fn test_alloc_zero_size() {
-        let ptr = alloc(0, 8);
-        assert!(ptr.is_null());
+    fn small_allocation_is_recycled() {
+        let first = alloc(6000, 8);
+        assert!(!first.is_null());
+        // SAFETY: first is live with this exact layout.
+        unsafe { free(first, 6000, 8) };
+
+        let second = alloc(6000, 8);
+        assert_eq!(second, first);
+        // SAFETY: second is live with this exact layout.
+        unsafe { free(second, 6000, 8) };
     }
 
     #[test]
-    fn test_alloc_zero_align() {
-        let ptr = alloc(16, 0);
-        assert!(ptr.is_null());
+    fn large_allocation_is_usable_and_releasable() {
+        let size = 200 * 1024u64;
+        let pointer = alloc(size, 8);
+        assert!(!pointer.is_null());
+        unsafe {
+            pointer.write(1);
+            pointer.add(size as usize - 1).write(2);
+            assert_eq!(pointer.read(), 1);
+            assert_eq!(pointer.add(size as usize - 1).read(), 2);
+            free(pointer, size, 8);
+        }
     }
 
     #[test]
-    fn test_alloc_bad_align() {
-        // 3 is not a power of 2
-        let ptr = alloc(16, 3);
-        assert!(ptr.is_null());
+    fn realloc_within_class_keeps_pointer() {
+        let pointer = alloc(65, 8);
+        assert!(!pointer.is_null());
+        unsafe { pointer.write(99) };
+
+        // SAFETY: pointer is live and readable for 65 bytes.
+        let grown = unsafe { realloc(pointer, 65, 120, 8) };
+        assert_eq!(grown, pointer);
+        assert_eq!(unsafe { grown.read() }, 99);
+        // SAFETY: grown now has the new logical layout.
+        unsafe { free(grown, 120, 8) };
     }
 
     #[test]
-    fn test_alloc_page_rounding_overflow_returns_null() {
-        // A size in the top page (> usize::MAX - 4095) once wrapped the
-        // page round-up to 0, clamped up to DEFAULT_ARENA_SIZE, and handed
-        // out a huge block backed by a 64 KiB mapping (heap overflow). It
-        // must now return null instead.
-        let ptr = alloc((usize::MAX as u64) - 124, 1);
-        assert!(ptr.is_null());
+    fn realloc_between_classes_copies_data() {
+        let pointer = alloc(32, 8);
+        assert!(!pointer.is_null());
+        unsafe {
+            for index in 0..32 {
+                pointer.add(index).write(index as u8);
+            }
+        }
+
+        // SAFETY: pointer is live and readable for 32 bytes.
+        let grown = unsafe { realloc(pointer, 32, 128, 8) };
+        assert!(!grown.is_null());
+        assert_ne!(grown, pointer);
+        unsafe {
+            for index in 0..32 {
+                assert_eq!(grown.add(index).read(), index as u8);
+            }
+            free(grown, 128, 8);
+        }
+    }
+
+    #[test]
+    fn realloc_zero_frees_and_null_realloc_allocates() {
+        let pointer = alloc(64, 8);
+        assert!(!pointer.is_null());
+        // SAFETY: pointer is live with this layout.
+        assert!(unsafe { realloc(pointer, 64, 0, 8) }.is_null());
+
+        // SAFETY: null is explicitly accepted.
+        let fresh = unsafe { realloc(ptr::null_mut(), 0, 64, 8) };
+        assert!(!fresh.is_null());
+        // SAFETY: fresh is live with this layout.
+        unsafe { free(fresh, 64, 8) };
     }
 
     #[test]
     fn failed_realloc_preserves_old_allocation() {
-        let old_ptr = alloc(4, 1);
-        assert!(!old_ptr.is_null());
+        let pointer = alloc(32, 8);
+        assert!(!pointer.is_null());
         unsafe {
-            old_ptr.write(11);
-            old_ptr.add(1).write(22);
-            old_ptr.add(2).write(33);
-            old_ptr.add(3).write(44);
+            for (index, byte) in [11u8, 22, 33, 44].into_iter().enumerate() {
+                pointer.add(index).write(byte);
+            }
         }
 
         fail_allocations_after_for_test(0);
-        let grown = realloc(old_ptr, 4, 8, 1);
+        // SAFETY: pointer is live and readable for 32 bytes.
+        let grown = unsafe { realloc(pointer, 32, 128, 8) };
         disable_allocation_failure_for_test();
 
         assert!(grown.is_null());
-        let bytes = unsafe { core::slice::from_raw_parts(old_ptr, 4) };
-        assert_eq!(bytes, &[11, 22, 33, 44]);
+        assert_eq!(
+            unsafe { core::slice::from_raw_parts(pointer, 4) },
+            &[11, 22, 33, 44]
+        );
+        // SAFETY: failed realloc left pointer live.
+        unsafe { free(pointer, 32, 8) };
     }
 
     #[test]
-    fn test_alloc_rejects_over_page_alignment() {
-        // Blocks are placed at an offset aligned relative to the page-aligned
-        // arena base, so an align larger than a page could yield a misaligned
-        // absolute address. Such requests are rejected cleanly (null).
-        assert!(alloc(64, 8192).is_null());
-        // Page-sized and smaller power-of-two alignments are still honored.
-        let ptr = alloc(64, 4096);
-        assert!(!ptr.is_null());
-        assert_eq!(ptr as usize % 4096, 0);
-    }
-
-    #[test]
-    fn test_alloc_basic() {
-        let ptr = alloc(64, 8);
-        assert!(!ptr.is_null());
-        assert_eq!(ptr as usize % 8, 0); // Check alignment
-
-        // Memory should be usable
-        unsafe {
-            *ptr = 42;
-            assert_eq!(*ptr, 42);
-        }
-    }
-
-    #[test]
-    fn test_alloc_alignment() {
-        // Test various alignments
-        for align in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 4096] {
-            let ptr = alloc(64, align);
-            assert!(!ptr.is_null(), "alloc failed for align={}", align);
-            assert_eq!(
-                ptr as usize % align as usize,
-                0,
-                "bad alignment for align={}",
-                align
-            );
-        }
-    }
-
-    #[test]
-    fn test_alloc_multiple() {
-        // Allocate multiple blocks
-        let mut ptrs = [ptr::null_mut(); 10];
-        for i in 0..10 {
-            ptrs[i] = alloc(128, 8);
-            assert!(!ptrs[i].is_null());
-        }
-
-        // All pointers should be different
-        for i in 0..10 {
-            for j in (i + 1)..10 {
-                assert_ne!(ptrs[i], ptrs[j]);
-            }
-        }
-
-        // All should be usable
-        for (i, ptr) in ptrs.iter().enumerate() {
-            unsafe {
-                **ptr = i as u8;
-            }
-        }
-        for (i, ptr) in ptrs.iter().enumerate() {
-            unsafe {
-                assert_eq!(**ptr, i as u8);
-            }
-        }
-    }
-
-    #[test]
-    fn test_alloc_large() {
-        // Allocate more than the default arena size
-        let large_size = DEFAULT_ARENA_SIZE as u64 * 2;
-        let ptr = alloc(large_size, 8);
-        assert!(!ptr.is_null());
-
-        // Should be usable across the entire range
-        unsafe {
-            *ptr = 1;
-            *ptr.add(large_size as usize - 1) = 2;
-            assert_eq!(*ptr, 1);
-            assert_eq!(*ptr.add(large_size as usize - 1), 2);
-        }
-    }
-
-    #[test]
-    fn test_free_is_noop() {
-        // Free should not crash even with various inputs
-        let ptr = alloc(64, 8);
-        assert!(!ptr.is_null());
-
-        // Free multiple times (should be fine since it's a no-op)
-        free(ptr, 64, 8);
-        free(ptr, 64, 8);
-        free(ptr::null_mut(), 0, 0);
-    }
-
-    #[test]
-    fn test_realloc_null_ptr() {
-        // realloc with null ptr should behave like alloc
-        let ptr = realloc(ptr::null_mut(), 0, 64, 8);
-        assert!(!ptr.is_null());
-        assert_eq!(ptr as usize % 8, 0);
-    }
-
-    #[test]
-    fn test_realloc_zero_size() {
-        // realloc with zero new_size should behave like free
-        let ptr = alloc(64, 8);
-        assert!(!ptr.is_null());
-
-        let result = realloc(ptr, 64, 0, 8);
-        assert!(result.is_null());
-    }
-
-    #[test]
-    fn test_realloc_shrink() {
-        // Shrinking should return the same pointer
-        let ptr = alloc(128, 8);
-        assert!(!ptr.is_null());
-
-        // Write some data
-        unsafe {
-            *ptr = 42;
-        }
-
-        // Shrink - should return same pointer
-        let new_ptr = realloc(ptr, 128, 64, 8);
-        assert_eq!(new_ptr, ptr);
-
-        // Data should still be there
-        unsafe {
-            assert_eq!(*new_ptr, 42);
-        }
-    }
-
-    #[test]
-    fn test_realloc_same_size() {
-        // Same size should return same pointer
-        let ptr = alloc(64, 8);
-        assert!(!ptr.is_null());
-
-        unsafe {
-            *ptr = 99;
-        }
-
-        let new_ptr = realloc(ptr, 64, 64, 8);
-        assert_eq!(new_ptr, ptr);
-
-        unsafe {
-            assert_eq!(*new_ptr, 99);
-        }
-    }
-
-    #[test]
-    fn test_realloc_grow() {
-        // Growing should return new pointer with copied data
-        let ptr = alloc(32, 8);
-        assert!(!ptr.is_null());
-
-        // Write pattern to original
-        unsafe {
-            for i in 0..32 {
-                *ptr.add(i) = i as u8;
-            }
-        }
-
-        // Grow
-        let new_ptr = realloc(ptr, 32, 128, 8);
-        assert!(!new_ptr.is_null());
-        assert_eq!(new_ptr as usize % 8, 0);
-
-        // Verify original data was copied
-        unsafe {
-            for i in 0..32 {
-                assert_eq!(*new_ptr.add(i), i as u8, "byte {} not copied", i);
-            }
-        }
-
-        // New area should be writable
-        unsafe {
-            *new_ptr.add(100) = 0xFF;
-            assert_eq!(*new_ptr.add(100), 0xFF);
-        }
-    }
-
-    #[test]
-    fn test_realloc_bad_align() {
-        let ptr = alloc(64, 8);
-        assert!(!ptr.is_null());
-
-        // Bad alignment should fail
-        let result = realloc(ptr, 64, 128, 3);
-        assert!(result.is_null());
-
-        // Zero alignment should fail
-        let result = realloc(ptr, 64, 128, 0);
-        assert!(result.is_null());
-    }
-
-    #[test]
-    fn test_alloc_arena_sizes_in_alignment_padding() {
-        // RUE-344: alloc_arena must reserve room for the alignment padding
-        // between the header and the block, not just header_size + min_size.
-        // For align > 8, alloc_from_arena places the block at
-        // align_up(header_size, align) > header_size, so that padding counts.
-        let header_size = core::mem::size_of::<ArenaHeader>();
-        for &align in &[1usize, 8, 16, 32, 64, 256, 4096] {
-            let min_size = 65512;
-            let arena = alloc_arena(min_size, align);
-            assert!(!arena.is_null(), "alloc_arena failed for align={align}");
-
-            // SAFETY: arena is a valid, freshly-created arena we own.
-            unsafe {
-                let arena_size = (*arena).size;
-                let aligned_offset = align_up(header_size, align);
-
-                // The whole aligned block must fit inside the mapping.
-                assert!(
-                    aligned_offset + min_size <= arena_size,
-                    "arena under-sized for align={align}: offset {aligned_offset} + \
-                     size {min_size} = {} exceeds arena_size {arena_size}",
-                    aligned_offset + min_size
-                );
-
-                // Now actually place the allocation and prove its end is within
-                // the mmap'd region, then write the final byte (would corrupt
-                // adjacent memory / segfault under the RUE-344 bug).
-                let base = arena as usize;
-                let block = alloc_from_arena(arena, min_size, align);
-                assert!(!block.is_null());
-                assert_eq!(block as usize % align, 0, "bad alignment for align={align}");
-                let end = block as usize + min_size;
-                assert!(
-                    end <= base + arena_size,
-                    "block end {end} past mapping end {} for align={align}",
-                    base + arena_size
-                );
-
-                // Touch first and last byte of the block.
-                *block = 0xAA;
-                *block.add(min_size - 1) = 0xBB;
-                assert_eq!(*block, 0xAA);
-                assert_eq!(*block.add(min_size - 1), 0xBB);
-
-                platform::munmap(arena as *mut u8, arena_size);
-            }
-        }
-    }
-
-    #[test]
-    fn test_alloc_high_align_boundary() {
-        // End-to-end through the public alloc() with a >8 alignment and a size
-        // near the arena boundary. Under RUE-344 the returned block spilled
-        // past the mmap region; writing the last byte must be safe now.
-        let ptr = alloc(65512, 16);
-        assert!(!ptr.is_null());
-        assert_eq!(ptr as usize % 16, 0);
-        unsafe {
-            *ptr = 1;
-            *ptr.add(65512 - 1) = 2;
-            assert_eq!(*ptr, 1);
-            assert_eq!(*ptr.add(65512 - 1), 2);
-        }
-    }
-
-    #[test]
-    fn test_realloc_grow_large() {
-        // Test growing to a large size
-        let ptr = alloc(64, 8);
-        assert!(!ptr.is_null());
-
-        unsafe {
-            *ptr = 0xAB;
-        }
-
-        // Grow to larger than default arena
-        let large_size = DEFAULT_ARENA_SIZE as u64 * 2;
-        let new_ptr = realloc(ptr, 64, large_size, 8);
-        assert!(!new_ptr.is_null());
-
-        // Original data preserved
-        unsafe {
-            assert_eq!(*new_ptr, 0xAB);
-            // Can write to end of new allocation
-            *new_ptr.add(large_size as usize - 1) = 0xCD;
-            assert_eq!(*new_ptr.add(large_size as usize - 1), 0xCD);
-        }
+    fn null_free_is_a_noop() {
+        // SAFETY: null is explicitly accepted regardless of layout.
+        unsafe { free(ptr::null_mut(), 0, 0) };
     }
 }

--- a/crates/rue-runtime/src/io.rs
+++ b/crates/rue-runtime/src/io.rs
@@ -186,7 +186,8 @@ fn read_line_impl(out: *mut OptionStrBufResult, some_disc: u64, none_disc: u64) 
 
         if result < 0 {
             // Read error - free buffer and panic
-            heap::free(ptr, cap, 1);
+            // SAFETY: ptr is the live cap-byte buffer allocated above.
+            unsafe { heap::free(ptr, cap, 1) };
             let mut msg = [0u8; 19];
             msg[0] = b'e';
             msg[1] = b'r';
@@ -217,7 +218,8 @@ fn read_line_impl(out: *mut OptionStrBufResult, some_disc: u64, none_disc: u64) 
                 // EOF with no data: this is not an error (RUE-6, ADR-0038).
                 // Free the empty buffer and report `None` so a read-until-EOF
                 // loop can terminate cleanly instead of trapping.
-                heap::free(ptr, cap, 1);
+                // SAFETY: ptr is the live cap-byte buffer allocated above.
+                unsafe { heap::free(ptr, cap, 1) };
                 // SAFETY: `out` points to caller-allocated space for the
                 // Option(StrBuf) result (4 slots). We write `None` and zero
                 // the payload; a `None` never has its payload dropped, so the
@@ -249,7 +251,8 @@ fn read_line_impl(out: *mut OptionStrBufResult, some_disc: u64, none_disc: u64) 
                 crate::error::allocation_failure();
             };
             let new_cap = new_cap.max(STRING_MIN_CAPACITY);
-            let new_ptr = heap::realloc(ptr, cap, new_cap, 1);
+            // SAFETY: ptr is live and readable for cap bytes.
+            let new_ptr = unsafe { heap::realloc(ptr, cap, new_cap, 1) };
             if new_ptr.is_null() {
                 // Keep the old allocation intact until the canonical trap.
                 crate::error::allocation_failure();

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -484,14 +484,6 @@ pub use aarch64_linux::{exit, write, write_all, write_stderr};
 #[cfg(test)]
 mod boundary_tests {
     #[test]
-    fn pointer_taking_safe_exports_have_no_pointer_precondition() {
-        // Free is a deliberate bump-allocator no-op, so it never inspects its
-        // pointer argument.
-        let arbitrary = core::ptr::dangling_mut::<u8>();
-        crate::string::__rue_free(arbitrary, u64::MAX, 3);
-    }
-
-    #[test]
     fn null_pointer_is_valid_at_zero_length_boundaries() {
         let null = core::ptr::null();
 
@@ -507,6 +499,7 @@ mod boundary_tests {
             assert_eq!(crate::memory::memcmp(null, null, 0), 0);
             assert_eq!(crate::memory::bcmp(null, null, 0), 0);
             assert_eq!(crate::string::__rue_str_eq(null, 0, null, 0), 1);
+            crate::string::__rue_free(core::ptr::null_mut(), 0, 1);
 
             let mut parsed = crate::parse::OptionIntResult { disc: 0, value: 1 };
             crate::parse::__rue_parse_i32(&mut parsed, null, 0, 7, 9);

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -82,8 +82,8 @@ crate::define_runtime_implementation! {
 crate::define_runtime_implementation! {
     /// Allocate memory from the heap.
     ///
-    /// This is the main allocation function for Rue programs. Memory is allocated
-    /// from a bump allocator backed by `mmap`.
+    /// This is the main allocation function for Rue programs. Small allocations
+    /// are recycled by size class and large allocations use dedicated mappings.
     ///
     /// # Arguments
     ///
@@ -93,7 +93,7 @@ crate::define_runtime_implementation! {
     /// # Returns
     ///
     /// A pointer to the allocated memory, or null on failure.
-    /// The memory is zero-initialized.
+    /// The memory is uninitialized.
     ///
     /// # ABI
     ///
@@ -118,19 +118,18 @@ crate::define_runtime_implementation! {
     /// * `size` - Size supplied by the runtime allocation ABI
     /// * `align` - Alignment supplied by the runtime allocation ABI
     ///
-    /// # Bump-allocator contract
-    ///
-    /// This is a **no-op**. Memory is reclaimed when the program exits. The
-    /// pointer, size, and alignment are retained in the generated-code ABI even
-    /// though this allocator does not use them.
-    ///
     /// # ABI
     ///
     /// ```text
     /// extern "C" fn __rue_free(ptr: *mut u8, size: u64, align: u64)
     /// ```
-    pub extern "C" fn __rue_free(ptr: *mut u8, size: u64, align: u64) {
-        heap::free(ptr, size, align)
+    /// # Safety
+    ///
+    /// A non-null `ptr` must identify a live Rue allocation described by
+    /// exactly `size` and `align`, and it must not be used after this call.
+    pub unsafe extern "C" fn __rue_free(ptr: *mut u8, size: u64, align: u64) {
+        // SAFETY: inherited from the exported helper's caller contract.
+        unsafe { heap::free(ptr, size, align) }
     }
 }
 
@@ -152,8 +151,8 @@ crate::define_runtime_implementation! {
     ///
     /// - If `ptr` is null: behaves like `__rue_alloc(new_size, align)`
     /// - If `new_size` is 0: frees the memory and returns null
-    /// - If `new_size <= old_size`: returns `ptr` unchanged
-    /// - If `new_size > old_size`: allocates new block, copies data, returns new pointer
+    /// - If both layouts share one storage class: returns `ptr` unchanged
+    /// - Otherwise: allocates a new block, copies the preserved prefix, and frees `ptr`
     ///
     /// # ABI
     ///
@@ -167,7 +166,8 @@ crate::define_runtime_implementation! {
     /// reads of `old_size` bytes. It must be either null or a pointer returned
     /// by this runtime allocator with the supplied allocation layout.
     pub unsafe extern "C" fn __rue_realloc(ptr: *mut u8, old_size: u64, new_size: u64, align: u64) -> *mut u8 {
-        heap::realloc(ptr, old_size, new_size, align)
+        // SAFETY: inherited from the exported helper's caller contract.
+        unsafe { heap::realloc(ptr, old_size, new_size, align) }
     }
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,8 +90,10 @@ run the resulting executable.
 
 ## Runtime, built-ins, and linking
 
-- **`rue-runtime`** supplies startup, allocation, memory, strings, I/O,
-  parsing, random data, and target-specific syscall support.
+- **`rue-allocator`** owns dependency-free heap policy and bookkeeping over a
+  consumer-supplied page mapper. **`rue-runtime`** supplies that mapper plus
+  startup, memory, strings, I/O, parsing, random data, and target-specific
+  syscall support.
 - **`rue-builtins`** describes compiler-visible built-in types, enums,
   functions, methods, and operators. Built-in aggregate types are injected as
   synthetic declarations so they use ordinary semantic paths where possible.

--- a/docs/designs/0011-runtime-heap.md
+++ b/docs/designs/0011-runtime-heap.md
@@ -17,6 +17,15 @@ superseded-by:
 
 Implemented
 
+### Implementation evolution (2026-07-20)
+
+This ADR records Rue's initial heap design and the ABI it established. The
+original no-op `free` policy has since been replaced by the recycling allocator
+in `crates/rue-allocator`: small allocations use power-of-two free lists over
+64 KiB arenas, allocations larger than 16 KiB use dedicated mappings, and
+`free` now recycles or unmaps the supplied allocation. The three exported
+helpers and their `(size, alignment)` layouts remain unchanged.
+
 ## Summary
 
 Add heap allocation support to the Rue runtime via a simple bump allocator backed by `mmap`/`munmap` syscalls. This provides the foundation for heap-allocated types like `String`, `Vec`, and `Box` without depending on libc. The implementation exposes `__rue_alloc`, `__rue_realloc`, and `__rue_free` functions that can be called from generated code.

--- a/docs/designs/0034-cross-target-runtime.md
+++ b/docs/designs/0034-cross-target-runtime.md
@@ -77,8 +77,9 @@ configuration transition (or `configured_alias`) to build
 
 ### B. Per-target staticlib build rules using the hermetic rustc directly
 
-`rue-runtime` is `#![no_std]`, has **zero dependencies**, and needs only
-`core`/`compiler_builtins`. Compiling it for a foreign target needs just:
+`rue-runtime` is `#![no_std]` and depends only on the no-std
+`rue-runtime-abi` and `rue-allocator` leaf crates. Compiling those crates for a
+foreign target needs just:
 
 1. The already-vendored host `rustc` invoked with `--target <triple>`.
 2. The target's std component: pin three extra

--- a/docs/development.md
+++ b/docs/development.md
@@ -97,6 +97,7 @@ Long-form Buck commands remain useful when working on build targets:
 | `crates/rue-cfg` | control flow and target-independent optimization |
 | `crates/rue-codegen` | x86-64 and AArch64 backends |
 | `crates/rue-linker` | ELF/Mach-O objects and linking |
+| `crates/rue-allocator` | target-independent runtime heap policy |
 | `crates/rue-runtime` | target runtime support |
 | `crates/rue-{spec,ui-tests,cli-tests}` | behavioral test harnesses |
 | `crates/rue-{oracle,oracle-diff}` | independent evaluator and differential tests |

--- a/rust-project.json
+++ b/rust-project.json
@@ -11,27 +11,27 @@
           "name": "rue_air"
         },
         {
-          "crate": 4,
+          "crate": 5,
           "name": "rue_cfg"
         },
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_rir"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_json"
         }
       ],
@@ -55,31 +55,31 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 3,
+          "crate": 4,
           "name": "rue_builtins"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_rir"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         }
       ],
@@ -103,43 +103,43 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 3,
+          "crate": 4,
           "name": "rue_builtins"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_parser"
         },
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_rir"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         },
         {
-          "crate": 97,
+          "crate": 98,
           "name": "rayon"
         }
       ],
@@ -158,12 +158,31 @@
       "is_proc_macro": false
     },
     {
+      "display_name": "rue-allocator",
+      "root_module": "crates/rue-allocator/src/lib.rs",
+      "edition": "2024",
+      "deps": [],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-allocator/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
       "display_name": "rue-builtins",
       "root_module": "crates/rue-builtins/src/lib.rs",
       "edition": "2024",
       "deps": [
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_runtime_abi"
         }
       ],
@@ -191,15 +210,15 @@
           "name": "rue_air"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         }
       ],
@@ -227,15 +246,15 @@
           "name": "rue_air"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         }
       ],
@@ -259,27 +278,31 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 27,
-          "name": "rue_target"
+          "crate": 15,
+          "name": "rue_linker"
         },
         {
           "crate": 28,
+          "name": "rue_target"
+        },
+        {
+          "crate": 29,
           "name": "rue_test_runner"
         },
         {
-          "crate": 76,
+          "crate": 77,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tempfile"
         },
         {
-          "crate": 114,
+          "crate": 115,
           "name": "toml"
         }
       ],
@@ -307,35 +330,35 @@
           "name": "rue_air"
         },
         {
-          "crate": 3,
+          "crate": 4,
           "name": "rue_builtins"
         },
         {
-          "crate": 4,
+          "crate": 5,
           "name": "rue_cfg"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 58,
+          "crate": 59,
           "name": "fixedbitset"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         }
       ],
@@ -363,19 +386,19 @@
           "name": "rue_air"
         },
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_json"
         },
         {
-          "crate": 107,
+          "crate": 108,
           "name": "sha2"
         }
       ],
@@ -403,87 +426,87 @@
           "name": "rue_air"
         },
         {
-          "crate": 3,
+          "crate": 4,
           "name": "rue_builtins"
         },
         {
-          "crate": 4,
+          "crate": 5,
           "name": "rue_cfg"
         },
         {
-          "crate": 7,
+          "crate": 8,
           "name": "rue_codegen"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 14,
+          "crate": 15,
           "name": "rue_linker"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_parser"
         },
         {
-          "crate": 20,
+          "crate": 21,
           "name": "rue_query"
         },
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_rir"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 39,
+          "crate": 40,
           "name": "annotate_snippets"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         },
         {
-          "crate": 72,
+          "crate": 73,
           "name": "libc"
         },
         {
-          "crate": 97,
+          "crate": 98,
           "name": "rayon"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_json"
         },
         {
-          "crate": 107,
+          "crate": 108,
           "name": "sha2"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tempfile"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing"
         }
       ],
@@ -507,11 +530,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "thiserror"
         }
       ],
@@ -535,23 +558,23 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_parser"
         },
         {
-          "crate": 28,
+          "crate": 29,
           "name": "rue_test_runner"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tempfile"
         }
       ],
@@ -583,51 +606,55 @@
           "name": "rue_air_fuzz_support"
         },
         {
-          "crate": 4,
+          "crate": 5,
           "name": "rue_cfg"
         },
         {
-          "crate": 5,
+          "crate": 6,
           "name": "rue_cfg_fuzz_support"
         },
         {
-          "crate": 7,
+          "crate": 8,
           "name": "rue_codegen"
         },
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_parser"
         },
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_rir"
         },
         {
-          "crate": 22,
+          "crate": 23,
           "name": "rue_rir_fuzz_support"
         },
         {
-          "crate": 42,
+          "crate": 29,
+          "name": "rue_test_runner"
+        },
+        {
+          "crate": 43,
           "name": "anyhow"
         },
         {
-          "crate": 72,
+          "crate": 73,
           "name": "libc"
         },
         {
-          "crate": 90,
+          "crate": 91,
           "name": "proptest"
         }
       ],
@@ -651,19 +678,19 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         },
         {
-          "crate": 79,
+          "crate": 80,
           "name": "logos"
         }
       ],
@@ -687,11 +714,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing"
         }
       ],
@@ -715,31 +742,31 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 16,
+          "crate": 17,
           "name": "rue_oracle"
         },
         {
-          "crate": 28,
+          "crate": 29,
           "name": "rue_test_runner"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tempfile"
         },
         {
-          "crate": 114,
+          "crate": 115,
           "name": "toml"
         }
       ],
@@ -767,15 +794,15 @@
           "name": "rue_air"
         },
         {
-          "crate": 4,
+          "crate": 5,
           "name": "rue_cfg"
         },
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         }
       ],
@@ -799,23 +826,23 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_parser"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_json"
         }
       ],
@@ -839,27 +866,27 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "smallvec"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing"
         }
       ],
@@ -883,7 +910,7 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 20,
+          "crate": 21,
           "name": "rue_query"
         }
       ],
@@ -926,19 +953,19 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_parser"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         }
       ],
@@ -962,19 +989,19 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_parser"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_span"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lasso"
         }
       ],
@@ -1017,7 +1044,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 23,
+          "crate": 3,
+          "name": "rue_allocator"
+        },
+        {
+          "crate": 24,
           "name": "rue_runtime_abi"
         }
       ],
@@ -1060,15 +1091,15 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 28,
+          "crate": 29,
           "name": "rue_test_runner"
         },
         {
-          "crate": 76,
+          "crate": 77,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tempfile"
         }
       ],
@@ -1111,27 +1142,27 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 72,
+          "crate": 73,
           "name": "libc"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tempfile"
         },
         {
-          "crate": 114,
+          "crate": 115,
           "name": "toml"
         }
       ],
@@ -1155,11 +1186,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 28,
+          "crate": 29,
           "name": "rue_test_runner"
         },
         {
-          "crate": 76,
+          "crate": 77,
           "name": "libtest2_mimic"
         }
       ],
@@ -1183,43 +1214,43 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_rir"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 72,
+          "crate": 73,
           "name": "libc"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_json"
         },
         {
-          "crate": 107,
+          "crate": 108,
           "name": "sha2"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing"
         },
         {
-          "crate": 122,
+          "crate": 123,
           "name": "tracing_subscriber"
         }
       ],
@@ -1243,43 +1274,43 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_rir"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_target"
         },
         {
-          "crate": 72,
+          "crate": 73,
           "name": "libc"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_json"
         },
         {
-          "crate": 107,
+          "crate": 108,
           "name": "sha2"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing"
         },
         {
-          "crate": 122,
+          "crate": 123,
           "name": "tracing_subscriber"
         }
       ],
@@ -1303,7 +1334,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 80,
+          "crate": 81,
           "name": "logos_codegen"
         }
       ],
@@ -1327,15 +1358,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 89,
+          "crate": 90,
           "name": "proc_macro2"
         },
         {
-          "crate": 92,
+          "crate": 93,
           "name": "quote"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "syn"
         }
       ],
@@ -1360,15 +1391,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 89,
+          "crate": 90,
           "name": "proc_macro2"
         },
         {
-          "crate": 92,
+          "crate": 93,
           "name": "quote"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "syn"
         }
       ],
@@ -1392,15 +1423,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 89,
+          "crate": 90,
           "name": "proc_macro2"
         },
         {
-          "crate": 92,
+          "crate": 93,
           "name": "quote"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "syn"
         }
       ],
@@ -1424,15 +1455,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 48,
+          "crate": 49,
           "name": "cfg_if"
         },
         {
-          "crate": 85,
+          "crate": 86,
           "name": "once_cell"
         },
         {
-          "crate": 129,
+          "crate": 130,
           "name": "zerocopy"
         }
       ],
@@ -1456,7 +1487,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 82,
+          "crate": 83,
           "name": "memchr"
         }
       ],
@@ -1502,11 +1533,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 41,
+          "crate": 42,
           "name": "anstyle"
         },
         {
-          "crate": 126,
+          "crate": 127,
           "name": "unicode_width"
         }
       ],
@@ -1615,7 +1646,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 45,
+          "crate": 46,
           "name": "bit_vec"
         }
       ],
@@ -1683,7 +1714,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 60,
+          "crate": 61,
           "name": "generic_array"
         }
       ],
@@ -1745,11 +1776,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 51,
+          "crate": 52,
           "name": "crossbeam_epoch"
         },
         {
-          "crate": 52,
+          "crate": 53,
           "name": "crossbeam_utils"
         }
       ],
@@ -1775,7 +1806,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 52,
+          "crate": 53,
           "name": "crossbeam_utils"
         }
       ],
@@ -1822,11 +1853,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 60,
+          "crate": 61,
           "name": "generic_array"
         },
         {
-          "crate": 123,
+          "crate": 124,
           "name": "typenum"
         }
       ],
@@ -1850,27 +1881,27 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 48,
+          "crate": 49,
           "name": "cfg_if"
         },
         {
-          "crate": 52,
+          "crate": 53,
           "name": "crossbeam_utils"
         },
         {
-          "crate": 62,
+          "crate": 63,
           "name": "hashbrown"
         },
         {
-          "crate": 77,
+          "crate": 78,
           "name": "lock_api"
         },
         {
-          "crate": 85,
+          "crate": 86,
           "name": "once_cell"
         },
         {
-          "crate": 86,
+          "crate": 87,
           "name": "parking_lot_core"
         }
       ],
@@ -1895,11 +1926,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 47,
+          "crate": 48,
           "name": "block_buffer"
         },
         {
-          "crate": 53,
+          "crate": 54,
           "name": "crypto_common"
         }
       ],
@@ -2006,7 +2037,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 123,
+          "crate": 124,
           "name": "typenum"
         }
       ],
@@ -2051,11 +2082,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 36,
+          "crate": 37,
           "name": "ahash"
         },
         {
-          "crate": 38,
+          "crate": 39,
           "name": "allocator_api2"
         }
       ],
@@ -2103,11 +2134,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 57,
+          "crate": 58,
           "name": "equivalent"
         },
         {
-          "crate": 63,
+          "crate": 64,
           "name": "hashbrown"
         }
       ],
@@ -2174,11 +2205,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 54,
+          "crate": 55,
           "name": "dashmap"
         },
         {
-          "crate": 62,
+          "crate": 63,
           "name": "hashbrown"
         }
       ],
@@ -2224,11 +2255,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 70,
+          "crate": 71,
           "name": "lexarg_error"
         },
         {
-          "crate": 71,
+          "crate": 72,
           "name": "lexarg_parser"
         }
       ],
@@ -2253,7 +2284,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 71,
+          "crate": 72,
           "name": "lexarg_parser"
         }
       ],
@@ -2319,7 +2350,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 66,
+          "crate": 67,
           "name": "json_write"
         }
       ],
@@ -2345,11 +2376,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 69,
+          "crate": 70,
           "name": "lexarg"
         },
         {
-          "crate": 70,
+          "crate": 71,
           "name": "lexarg_error"
         }
       ],
@@ -2374,27 +2405,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 40,
+          "crate": 41,
           "name": "anstream"
         },
         {
-          "crate": 41,
+          "crate": 42,
           "name": "anstyle"
         },
         {
-          "crate": 70,
+          "crate": 71,
           "name": "lexarg_error"
         },
         {
-          "crate": 71,
+          "crate": 72,
           "name": "lexarg_parser"
         },
         {
-          "crate": 73,
+          "crate": 74,
           "name": "libtest_json"
         },
         {
-          "crate": 74,
+          "crate": 75,
           "name": "libtest_lexarg"
         }
       ],
@@ -2421,11 +2452,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 73,
+          "crate": 74,
           "name": "libtest_json"
         },
         {
-          "crate": 75,
+          "crate": 76,
           "name": "libtest2_harness"
         }
       ],
@@ -2452,7 +2483,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 102,
+          "crate": 103,
           "name": "scopeguard"
         }
       ],
@@ -2498,7 +2529,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 32,
+          "crate": 33,
           "name": "logos_derive"
         }
       ],
@@ -2526,31 +2557,31 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 43,
+          "crate": 44,
           "name": "beef"
         },
         {
-          "crate": 59,
+          "crate": 60,
           "name": "fnv"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lazy_static"
         },
         {
-          "crate": 89,
+          "crate": 90,
           "name": "proc_macro2"
         },
         {
-          "crate": 92,
+          "crate": 93,
           "name": "quote"
         },
         {
-          "crate": 100,
+          "crate": 101,
           "name": "regex_syntax"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "syn"
         }
       ],
@@ -2574,7 +2605,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 99,
+          "crate": 100,
           "name": "regex_automata"
         }
       ],
@@ -2721,7 +2752,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 129,
+          "crate": 130,
           "name": "zerocopy"
         }
       ],
@@ -2747,7 +2778,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 125,
+          "crate": 126,
           "name": "unicode_ident"
         }
       ],
@@ -2773,47 +2804,47 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 44,
+          "crate": 45,
           "name": "bit_set"
         },
         {
-          "crate": 45,
+          "crate": 46,
           "name": "bit_vec"
         },
         {
-          "crate": 46,
+          "crate": 47,
           "name": "bitflags"
         },
         {
-          "crate": 84,
+          "crate": 85,
           "name": "num_traits"
         },
         {
-          "crate": 93,
+          "crate": 94,
           "name": "rand"
         },
         {
-          "crate": 94,
+          "crate": 95,
           "name": "rand_chacha"
         },
         {
-          "crate": 96,
+          "crate": 97,
           "name": "rand_xorshift"
         },
         {
-          "crate": 100,
+          "crate": 101,
           "name": "regex_syntax"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "rusty_fork"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tempfile"
         },
         {
-          "crate": 124,
+          "crate": 125,
           "name": "unarray"
         }
       ],
@@ -2864,7 +2895,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 89,
+          "crate": 90,
           "name": "proc_macro2"
         }
       ],
@@ -2890,7 +2921,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 95,
+          "crate": 96,
           "name": "rand_core"
         }
       ],
@@ -2917,11 +2948,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 88,
+          "crate": 89,
           "name": "ppv_lite86"
         },
         {
-          "crate": 95,
+          "crate": 96,
           "name": "rand_core"
         }
       ],
@@ -2946,7 +2977,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 61,
+          "crate": 62,
           "name": "getrandom"
         }
       ],
@@ -2972,7 +3003,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 95,
+          "crate": 96,
           "name": "rand_core"
         }
       ],
@@ -2996,11 +3027,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 56,
+          "crate": 57,
           "name": "either"
         },
         {
-          "crate": 98,
+          "crate": 99,
           "name": "rayon_core"
         }
       ],
@@ -3024,11 +3055,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 50,
+          "crate": 51,
           "name": "crossbeam_deque"
         },
         {
-          "crate": 52,
+          "crate": 53,
           "name": "crossbeam_utils"
         }
       ],
@@ -3052,15 +3083,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 37,
+          "crate": 38,
           "name": "aho_corasick"
         },
         {
-          "crate": 82,
+          "crate": 83,
           "name": "memchr"
         },
         {
-          "crate": 100,
+          "crate": 101,
           "name": "regex_syntax"
         }
       ],
@@ -3137,19 +3168,19 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 59,
+          "crate": 60,
           "name": "fnv"
         },
         {
-          "crate": 91,
+          "crate": 92,
           "name": "quick_error"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tempfile"
         },
         {
-          "crate": 127,
+          "crate": 128,
           "name": "wait_timeout"
         }
       ],
@@ -3194,11 +3225,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 33,
+          "crate": 34,
           "name": "serde_derive"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde_core"
         }
       ],
@@ -3247,19 +3278,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 65,
+          "crate": 66,
           "name": "itoa"
         },
         {
-          "crate": 82,
+          "crate": 83,
           "name": "memchr"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde_core"
         },
         {
-          "crate": 130,
+          "crate": 131,
           "name": "zmij"
         }
       ],
@@ -3285,7 +3316,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         }
       ],
@@ -3310,15 +3341,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 48,
+          "crate": 49,
           "name": "cfg_if"
         },
         {
-          "crate": 49,
+          "crate": 50,
           "name": "cpufeatures"
         },
         {
-          "crate": 55,
+          "crate": 56,
           "name": "digest"
         }
       ],
@@ -3342,7 +3373,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lazy_static"
         }
       ],
@@ -3385,15 +3416,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 89,
+          "crate": 90,
           "name": "proc_macro2"
         },
         {
-          "crate": 92,
+          "crate": 93,
           "name": "quote"
         },
         {
-          "crate": 125,
+          "crate": 126,
           "name": "unicode_ident"
         }
       ],
@@ -3447,7 +3478,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 34,
+          "crate": 35,
           "name": "thiserror_impl"
         }
       ],
@@ -3473,7 +3504,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 48,
+          "crate": 49,
           "name": "cfg_if"
         }
       ],
@@ -3497,19 +3528,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "serde_spanned"
         },
         {
-          "crate": 115,
+          "crate": 116,
           "name": "toml_datetime"
         },
         {
-          "crate": 116,
+          "crate": 117,
           "name": "toml_edit"
         }
       ],
@@ -3536,7 +3567,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         }
       ],
@@ -3561,27 +3592,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 64,
+          "crate": 65,
           "name": "indexmap"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "serde_spanned"
         },
         {
-          "crate": 115,
+          "crate": 116,
           "name": "toml_datetime"
         },
         {
-          "crate": 117,
+          "crate": 118,
           "name": "toml_write"
         },
         {
-          "crate": 128,
+          "crate": 129,
           "name": "winnow"
         }
       ],
@@ -3630,15 +3661,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 35,
+          "crate": 36,
           "name": "tracing_attributes"
         },
         {
-          "crate": 87,
+          "crate": 88,
           "name": "pin_project_lite"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing_core"
         }
       ],
@@ -3666,7 +3697,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 85,
+          "crate": 86,
           "name": "once_cell"
         }
       ],
@@ -3693,15 +3724,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 78,
+          "crate": 79,
           "name": "log"
         },
         {
-          "crate": 85,
+          "crate": 86,
           "name": "once_cell"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing_core"
         }
       ],
@@ -3727,11 +3758,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing_core"
         }
       ],
@@ -3755,55 +3786,55 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 81,
+          "crate": 82,
           "name": "matchers"
         },
         {
-          "crate": 83,
+          "crate": 84,
           "name": "nu_ansi_term"
         },
         {
-          "crate": 85,
+          "crate": 86,
           "name": "once_cell"
         },
         {
-          "crate": 99,
+          "crate": 100,
           "name": "regex_automata"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_json"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "sharded_slab"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "smallvec"
         },
         {
-          "crate": 113,
+          "crate": 114,
           "name": "thread_local"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing_core"
         },
         {
-          "crate": 120,
+          "crate": 121,
           "name": "tracing_log"
         },
         {
-          "crate": 121,
+          "crate": 122,
           "name": "tracing_serde"
         }
       ],

--- a/scripts/run-sanitizer.sh
+++ b/scripts/run-sanitizer.sh
@@ -23,10 +23,11 @@
 # works out of the box — no ASAN build needed.
 #
 # HOWEVER: memcheck's heap tracking hooks libc malloc/free. Rue's runtime never
-# calls libc; it mmaps 64 KiB arenas and bump-allocates within them
-# (crates/rue-runtime/src/heap.rs), with free() a no-op. To memcheck every Rue
-# program therefore does "0 allocs, 0 frees" — the whole arena is one opaque,
-# addressable, mmap'd region. Consequences:
+# calls libc; small allocations use recycled blocks in 64 KiB mmap'd arenas,
+# while large allocations use dedicated mappings
+# (crates/rue-allocator/src/lib.rs). To memcheck every Rue program therefore
+# still does "0 allocs, 0 frees" — each arena is one opaque, addressable mmap'd
+# region. Consequences:
 #
 #   CAUGHT: wild pointers / accesses outside any mapped region, stack overflow,
 #           jumps to bad addresses, uninitialised values used in branches or


### PR DESCRIPTION
## Summary

- add a standalone, `no_std` `rue-allocator` crate with power-of-two free lists for allocations through 16 KiB and dedicated page mappings above that threshold
- integrate the allocator into native and cross-target runtimes while preserving the existing allocation ABI
- make deallocation contracts explicit in the runtime ABI, oracle, sanitizer harness, tests, and documentation
- ensure match scrutinees are evaluated once in CFG lowering, fixing a latent temporary double-drop exposed by real deallocation

## Why

Rue's bump allocator retained every allocation until process exit and treated `free` as a no-op. Long-running and allocation-heavy programs therefore grew without bound, while ownership bugs stayed invisible at runtime.

## Impact

Small allocations are now recycled from retained 64 KiB arenas, so their mapped memory follows a high-water mark. Allocations larger than 16 KiB are page-rounded and unmapped immediately on free. Reallocation stays in place within the same size class or page mapping and otherwise preserves the initialized prefix through allocate-copy-free.

## Root cause addressed during validation

The full CLI suite exposed that match payload lowering could lower a block-wrapped scrutinee twice: once for the switch and once for payload extraction. That duplicated cleanup for a temporary `StrBuf`. Caching the dominating scrutinee value makes all match consumers share the single evaluation, and a CFG unit test pins that ownership behavior.

## Checks

- `scripts/rue fmt`
- `scripts/rue quick`
- `scripts/rue test`
- `scripts/rue cli` (1,705 passed; 11 ignored)
- `./buck2 test //crates/rue-runtime:runtime-archives-test`
- repository-wide Buck2 clippy gate (63 first-party targets)
- stable Cargo check and clippy for `crates/rue-runtime-asan`
- `python3 scripts/validate-rust-project.py`
