### PR TITLE
RUE-1084: extract one-body semantic transactions

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -1,6 +1,72 @@
 //! Structural guard for AIR's read-only canonical import consumption boundary.
 
 #[test]
+fn one_body_authority_is_repository_wide_and_test_only() {
+    fn visit(directory: &std::path::Path, files: &mut Vec<std::path::PathBuf>) {
+        for entry in std::fs::read_dir(directory).expect("read Rust source directory") {
+            let path = entry.expect("read source entry").path();
+            if path.is_dir() {
+                visit(&path, files);
+            } else if path.extension().is_some_and(|extension| extension == "rs") {
+                files.push(path);
+            }
+        }
+    }
+
+    let root = std::env::current_dir().expect("repository working directory");
+    let crates = root.join("crates");
+    assert!(
+        crates.is_dir(),
+        "inventory must run from the repository root"
+    );
+    let mut files = Vec::new();
+    visit(&crates, &mut files);
+    files.sort();
+
+    let declaration_marker = ["fn analyze_", "one_body"].concat();
+    let mut declarations = Vec::new();
+    for path in &files {
+        let source = std::fs::read_to_string(path).expect("read Rust source");
+        for (line, text) in source.lines().enumerate() {
+            if text.contains(&declaration_marker) {
+                declarations.push((
+                    path.strip_prefix(&root).unwrap_or(path).to_path_buf(),
+                    line + 1,
+                    text.trim().to_owned(),
+                ));
+            }
+        }
+    }
+    let declared_paths = declarations
+        .iter()
+        .map(|(path, _, _)| path.as_path())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        declared_paths,
+        [
+            std::path::Path::new("crates/rue-air/src/sema/binding_manifest.rs"),
+            std::path::Path::new("crates/rue-air/src/sema/one_body.rs"),
+        ],
+        "another repository source installed a one-body entrypoint: {declarations:?}"
+    );
+
+    let sema_module = include_str!("sema/mod.rs");
+    assert!(sema_module.contains("#[cfg(test)]\nmod one_body;"));
+    let binding = include_str!("sema/binding_manifest.rs");
+    let binding_entrypoint = [
+        "#[cfg(test)]\n    pub(crate) fn analyze_",
+        "one_body_for_test",
+    ]
+    .concat();
+    assert!(binding.contains(&binding_entrypoint));
+    let transaction_entrypoint = ["pub(super) fn analyze_", "one_body"].concat();
+    assert!(
+        include_str!("sema/one_body.rs").contains(&transaction_entrypoint),
+        "the sole transaction authority moved without updating the inventory"
+    );
+}
+
+#[test]
 fn canonical_import_consumers_do_not_grow_resolution_policy() {
     let consumers = [
         include_str!("canonical_imports.rs"),

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -21,6 +21,121 @@ use rue_rir::{InstData, InstRef, RepeatCount, Rir};
 use rue_span::{FileId, Span};
 use std::collections::HashMap;
 
+/// Exact callable selections made while the test-only one-body transaction is
+/// generating constraints.  These observations are consumed only when HM
+/// unification fails before AIR analysis can publish its normal dependencies.
+#[cfg(test)]
+#[derive(Debug, Clone)]
+pub(crate) enum InferenceCallRoute {
+    Unqualified {
+        alias: Option<Spur>,
+    },
+    Module {
+        module: crate::types::ModuleId,
+        member: Spur,
+        via_alias: bool,
+    },
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone)]
+pub(crate) enum InferenceBodyDependency {
+    Function {
+        function: Spur,
+        span: Span,
+        route: InferenceCallRoute,
+        checked: bool,
+    },
+    Method {
+        structure: StructId,
+        method: Spur,
+        span: Span,
+        associated: bool,
+    },
+    ModuleBinding(FileId, Spur),
+    ValueConst {
+        file: FileId,
+        name: Spur,
+        access_file: FileId,
+        qualified: bool,
+    },
+    Specialization {
+        function: Spur,
+        type_arguments: Vec<Type>,
+        value_arguments: Vec<ConstValue>,
+        span: Span,
+        route: InferenceCallRoute,
+        checked: bool,
+    },
+    IncompleteCallable,
+}
+
+#[cfg(test)]
+fn generic_body_dependency(
+    function: Spur,
+    signature: &FunctionSig,
+    type_subst: &HashMap<Spur, Type>,
+    value_subst: &HashMap<Spur, i128>,
+    span: Span,
+    route: InferenceCallRoute,
+    checked: bool,
+) -> InferenceBodyDependency {
+    let mut type_arguments = Vec::new();
+    let mut value_arguments = Vec::new();
+    for (index, name) in signature.param_names.iter().enumerate() {
+        if !signature
+            .param_comptime
+            .get(index)
+            .copied()
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        if signature
+            .param_comptime_type
+            .get(index)
+            .copied()
+            .unwrap_or(false)
+        {
+            let Some(argument) = type_subst.get(name).copied() else {
+                return InferenceBodyDependency::IncompleteCallable;
+            };
+            type_arguments.push(argument);
+        } else {
+            let Some(argument) = value_subst.get(name).copied() else {
+                return InferenceBodyDependency::IncompleteCallable;
+            };
+            value_arguments.push(ConstValue::Integer(argument));
+        }
+    }
+    InferenceBodyDependency::Specialization {
+        function,
+        type_arguments,
+        value_arguments,
+        span,
+        route,
+        checked,
+    }
+}
+
+#[cfg(test)]
+fn call_contract_matches<A>(args: A, param_modes: &[rue_rir::RirParamMode]) -> bool
+where
+    A: IntoIterator,
+    A::IntoIter: ExactSizeIterator,
+    A::Item: std::ops::Deref<Target = rue_rir::RirCallArg>,
+{
+    use rue_rir::{RirArgMode as A, RirParamMode as P};
+    let args = args.into_iter();
+    args.len() == param_modes.len()
+        && args.zip(param_modes).all(|(arg, mode)| {
+            matches!(
+                (arg.mode, mode),
+                (A::Normal, P::Normal) | (A::Inout, P::Inout) | (A::Borrow, P::Borrow)
+            )
+        })
+}
+
 /// Information about a local variable during constraint generation.
 #[derive(Debug, Clone)]
 pub struct LocalVarInfo {
@@ -118,6 +233,8 @@ pub struct ConstraintContext<'a> {
     /// `break` targeting that loop is seen. An infinite loop containing a
     /// break has type `()`; without one it has type `!` (see spec 4.8).
     pub loop_break_stack: Vec<bool>,
+    #[cfg(test)]
+    checked_depth: u32,
     /// Scope stack for efficient scope management.
     scope_stack: Vec<Vec<(Spur, Option<LocalVarInfo>)>>,
 }
@@ -131,6 +248,8 @@ impl<'a> ConstraintContext<'a> {
             return_type,
             loop_depth: 0,
             loop_break_stack: Vec::new(),
+            #[cfg(test)]
+            checked_depth: 0,
             scope_stack: Vec::new(),
         }
     }
@@ -293,6 +412,9 @@ pub struct ConstraintGenerator<'a> {
     comptime_values: Option<&'a HashMap<Spur, ConstValue>>,
     /// Type intern pool for creating pointer and array types during constraint generation.
     type_pool: &'a TypeInternPool,
+    /// Test-only exact dependency selections made before unification.
+    #[cfg(test)]
+    body_dependencies: Vec<InferenceBodyDependency>,
 }
 
 impl<'a> ConstraintGenerator<'a> {
@@ -367,6 +489,8 @@ impl<'a> ConstraintGenerator<'a> {
             const_function_aliases: None,
             comptime_values: None,
             type_pool,
+            #[cfg(test)]
+            body_dependencies: Vec::new(),
         }
     }
 
@@ -712,6 +836,11 @@ impl<'a> ConstraintGenerator<'a> {
         &self.expr_types
     }
 
+    #[cfg(test)]
+    pub(crate) fn body_dependencies(&self) -> &[InferenceBodyDependency] {
+        &self.body_dependencies
+    }
+
     /// Consume the constraint generator and return its generated constraints,
     /// literal variables, expression types, and allocated variable count.
     ///
@@ -938,6 +1067,9 @@ impl<'a> ConstraintGenerator<'a> {
                     .module_binding_types
                     .and_then(|bindings| bindings.get(&(span.file_id, *name)))
                 {
+                    #[cfg(test)]
+                    self.body_dependencies
+                        .push(InferenceBodyDependency::ModuleBinding(span.file_id, *name));
                     // Module binding declared in this file (`const m =
                     // @import(...)`): per-file scoped and distinct from the
                     // file's value-constant namespace (RUE-113).
@@ -946,6 +1078,14 @@ impl<'a> ConstraintGenerator<'a> {
                     .const_types
                     .and_then(|consts| consts.get(&(span.file_id, *name)))
                 {
+                    #[cfg(test)]
+                    self.body_dependencies
+                        .push(InferenceBodyDependency::ValueConst {
+                            file: span.file_id,
+                            name: *name,
+                            access_file: span.file_id,
+                            qualified: false,
+                        });
                     // File-level constant: its type was resolved during
                     // declaration gathering (i32/bool/unit literals, module
                     // types for `const m = @import(...)`). Yielding it here
@@ -1125,6 +1265,16 @@ impl<'a> ConstraintGenerator<'a> {
                         .copied()
                 });
                 let args = self.rir.call_args(args);
+                #[cfg(test)]
+                if alias_target.is_some() {
+                    self.body_dependencies
+                        .push(InferenceBodyDependency::ValueConst {
+                            file: span.file_id,
+                            name: *name,
+                            access_file: span.file_id,
+                            qualified: false,
+                        });
+                }
                 // `print(s)` / `println(s)` builtin free functions (RUE-1):
                 // generate the argument and yield unit. Semantic analysis
                 // validates the shared text family (`StrBuf`, `str`, `Str(N)`),
@@ -1140,6 +1290,19 @@ impl<'a> ConstraintGenerator<'a> {
                     }
                     InferType::Concrete(Type::UNIT)
                 } else if let Some(func) = function_key.and_then(|key| self.functions.get(&key)) {
+                    #[cfg(test)]
+                    if !func.is_generic && call_contract_matches(&args, &func.param_modes) {
+                        self.body_dependencies
+                            .push(InferenceBodyDependency::Function {
+                                function: function_key
+                                    .expect("resolved signature has a function key"),
+                                span,
+                                route: InferenceCallRoute::Unqualified {
+                                    alias: alias_target.map(|_| *name),
+                                },
+                                checked: ctx.checked_depth > 0,
+                            });
+                    }
                     // For generic functions, build the type substitution map from the
                     // comptime type arguments, then constrain each runtime argument
                     // against its (substituted) parameter type. When a type parameter
@@ -1178,6 +1341,21 @@ impl<'a> ConstraintGenerator<'a> {
                             } else if let Some(v) = self.extract_int_argument(arg.value) {
                                 value_subst.insert(func.param_names[i], v);
                             }
+                        }
+
+                        #[cfg(test)]
+                        if call_contract_matches(&args, &func.param_modes) {
+                            self.body_dependencies.push(generic_body_dependency(
+                                function_key.expect("resolved signature has a function key"),
+                                func,
+                                &type_subst,
+                                &value_subst,
+                                span,
+                                InferenceCallRoute::Unqualified {
+                                    alias: alias_target.map(|_| *name),
+                                },
+                                ctx.checked_depth > 0,
+                            ));
                         }
 
                         // Constrain each runtime argument to its parameter type, with
@@ -2216,7 +2394,7 @@ impl<'a> ConstraintGenerator<'a> {
                         // uses like `m.CONST + 1` are anchored (RUE-160).
                         // Resolved authoritatively in the receiver module's
                         // defining file (RUE-140, RUE-638).
-                        let member_const_ty = match &base_info.ty {
+                        let member_const = match &base_info.ty {
                             InferType::Concrete(ty) if ty.is_module() => ty
                                 .as_module()
                                 .and_then(|module_id| {
@@ -2228,9 +2406,21 @@ impl<'a> ConstraintGenerator<'a> {
                                     self.const_types
                                         .and_then(|consts| consts.get(&(file_id, *field)))
                                         .copied()
+                                        .map(|ty| (file_id, ty))
                                 }),
                             _ => None,
                         };
+                        #[cfg(test)]
+                        if let Some((file, _)) = member_const {
+                            self.body_dependencies
+                                .push(InferenceBodyDependency::ValueConst {
+                                    file,
+                                    name: *field,
+                                    access_file: span.file_id,
+                                    qualified: true,
+                                });
+                        }
+                        let member_const_ty = member_const.map(|(_, ty)| ty);
                         // A module member that is itself a (re-exported) module:
                         // `std.cmp` where std's file has `pub const cmp =
                         // @import("cmp.rue")`. Resolve it to the member module's
@@ -2458,7 +2648,7 @@ impl<'a> ConstraintGenerator<'a> {
                         .struct_type_for_module(module_ref, &type_name)
                         .or_else(|| self.enum_type_for_module(module_ref, &type_name))
                     && let Some(result) =
-                        self.generate_call_on_reduced_type(member_ty, *method, args, ctx)
+                        self.generate_call_on_reduced_type(member_ty, *method, args, span, ctx)
                 {
                     self.record_type(inst_ref, result.clone());
                     return ExprInfo::new(result, span);
@@ -2480,6 +2670,16 @@ impl<'a> ConstraintGenerator<'a> {
                     && let Some(string_id) = string_ty.as_struct()
                     && let Some(method_sig) = self.method_sig(&(string_id, *method))
                 {
+                    #[cfg(test)]
+                    if call_contract_matches(&call_args, &method_sig.param_modes) {
+                        self.body_dependencies
+                            .push(InferenceBodyDependency::Method {
+                                structure: string_id,
+                                method: *method,
+                                span,
+                                associated: false,
+                            });
+                    }
                     let shared_str_method = self.string_literal_default_is_str()
                         && self.interner.resolve(method) == "len";
                     if !shared_str_method {
@@ -2518,19 +2718,51 @@ impl<'a> ConstraintGenerator<'a> {
                     // the exact member's return type anchors uses like
                     // `m.go() + 1` to the member declaration (RUE-142).
                     InferType::Concrete(ty) if ty.is_module() => {
-                        let function_key = ty
-                            .as_module()
-                            .and_then(|module_id| {
-                                self.module_file_ids
-                                    .and_then(|ids| ids.get(&module_id))
-                                    .copied()
-                            })
-                            .and_then(|file_id| {
+                        let module_id = ty.as_module().expect("module type has a module id");
+                        let module_file = self
+                            .module_file_ids
+                            .and_then(|ids| ids.get(&module_id))
+                            .copied();
+                        let alias_target = module_file.and_then(|file_id| {
+                            self.const_function_aliases
+                                .and_then(|aliases| aliases.get(&(file_id, *method)))
+                                .copied()
+                        });
+                        let function_key = alias_target.or_else(|| {
+                            module_file.and_then(|file_id| {
                                 self.functions_by_file_name
                                     .and_then(|m| m.get(&(file_id, *method)))
                                     .copied()
-                            });
+                            })
+                        });
+                        #[cfg(test)]
+                        if let (Some(file), Some(_)) = (module_file, alias_target) {
+                            self.body_dependencies
+                                .push(InferenceBodyDependency::ValueConst {
+                                    file,
+                                    name: *method,
+                                    access_file: span.file_id,
+                                    qualified: true,
+                                });
+                        }
                         if let Some(func) = function_key.and_then(|key| self.functions.get(&key)) {
+                            #[cfg(test)]
+                            if !func.is_generic
+                                && call_contract_matches(&call_args, &func.param_modes)
+                            {
+                                self.body_dependencies
+                                    .push(InferenceBodyDependency::Function {
+                                        function: function_key
+                                            .expect("resolved module signature has a function key"),
+                                        span,
+                                        route: InferenceCallRoute::Module {
+                                            module: module_id,
+                                            member: *method,
+                                            via_alias: alias_target.is_some(),
+                                        },
+                                        checked: ctx.checked_depth > 0,
+                                    });
+                            }
                             if !func.is_generic && call_args.len() == func.param_types.len() {
                                 // Constrain each argument against its declared
                                 // parameter type (same as a direct Call).
@@ -2586,6 +2818,23 @@ impl<'a> ConstraintGenerator<'a> {
                                     } else if let Some(v) = self.extract_int_argument(arg.value) {
                                         value_subst.insert(func.param_names[i], v);
                                     }
+                                }
+                                #[cfg(test)]
+                                if call_contract_matches(&call_args, &func.param_modes) {
+                                    self.body_dependencies.push(generic_body_dependency(
+                                        function_key
+                                            .expect("resolved module signature has a function key"),
+                                        func,
+                                        &type_subst,
+                                        &value_subst,
+                                        span,
+                                        InferenceCallRoute::Module {
+                                            module: module_id,
+                                            member: *method,
+                                            via_alias: alias_target.is_some(),
+                                        },
+                                        ctx.checked_depth > 0,
+                                    ));
                                 }
                                 for (i, arg_info) in arg_infos.iter().enumerate() {
                                     if i >= func.param_types.len() || i >= func.param_comptime.len()
@@ -2678,11 +2927,14 @@ impl<'a> ConstraintGenerator<'a> {
                             .inline_ctor_head_types
                             .and_then(|heads| heads.get(receiver).copied())
                             .or(module_member_ty)
-                            && let Some(result) =
-                                self.generate_call_on_reduced_type(reduced, *method, args, ctx)
+                            && let Some(result) = self
+                                .generate_call_on_reduced_type(reduced, *method, args, span, ctx)
                         {
                             result
                         } else {
+                            #[cfg(test)]
+                            self.body_dependencies
+                                .push(InferenceBodyDependency::IncompleteCallable);
                             for arg in call_args.iter() {
                                 self.generate(arg.value, ctx);
                             }
@@ -2696,6 +2948,16 @@ impl<'a> ConstraintGenerator<'a> {
                             // signatures, RUE-164)
                             let method_key = (struct_id, *method);
                             if let Some(method_sig) = self.method_sig(&method_key) {
+                                #[cfg(test)]
+                                if call_contract_matches(&call_args, &method_sig.param_modes) {
+                                    self.body_dependencies
+                                        .push(InferenceBodyDependency::Method {
+                                            structure: struct_id,
+                                            method: *method,
+                                            span,
+                                            associated: false,
+                                        });
+                                }
                                 // Generate constraints for arguments
                                 for (arg, param_type) in
                                     call_args.iter().zip(method_sig.param_types.iter())
@@ -2757,11 +3019,14 @@ impl<'a> ConstraintGenerator<'a> {
                         if let Some(reduced) = self
                             .inline_ctor_head_types
                             .and_then(|heads| heads.get(receiver).copied())
-                            && let Some(result) =
-                                self.generate_call_on_reduced_type(reduced, *method, args, ctx)
+                            && let Some(result) = self
+                                .generate_call_on_reduced_type(reduced, *method, args, span, ctx)
                         {
                             result
                         } else {
+                            #[cfg(test)]
+                            self.body_dependencies
+                                .push(InferenceBodyDependency::IncompleteCallable);
                             for arg in call_args.iter() {
                                 self.generate(arg.value, ctx);
                             }
@@ -2796,7 +3061,15 @@ impl<'a> ConstraintGenerator<'a> {
             // The actual checking of unchecked operations happens in sema
             InstData::Checked { expr } => {
                 // Generate constraints for the inner expression
+                #[cfg(test)]
+                {
+                    ctx.checked_depth += 1;
+                }
                 let inner_info = self.generate(*expr, ctx);
+                #[cfg(test)]
+                {
+                    ctx.checked_depth -= 1;
+                }
                 inner_info.ty
             }
 
@@ -2974,7 +3247,8 @@ impl<'a> ConstraintGenerator<'a> {
         // Checked first so it takes precedence over the struct-method path
         // below.
         if let Some(enum_ty) = self.enum_type_for(&type_name, span.file_id)
-            && let Some(result) = self.generate_call_on_reduced_type(enum_ty, function, args, ctx)
+            && let Some(result) =
+                self.generate_call_on_reduced_type(enum_ty, function, args, span, ctx)
         {
             return result;
         }
@@ -2988,7 +3262,8 @@ impl<'a> ConstraintGenerator<'a> {
         if let Some(struct_ty) = self.struct_type_for(&type_name, span.file_id)
             && struct_ty.as_struct().is_some()
         {
-            if let Some(result) = self.generate_call_on_reduced_type(struct_ty, function, args, ctx)
+            if let Some(result) =
+                self.generate_call_on_reduced_type(struct_ty, function, args, span, ctx)
             {
                 return result;
             }
@@ -3024,6 +3299,7 @@ impl<'a> ConstraintGenerator<'a> {
         ty: Type,
         function: Spur,
         args: &rue_rir::RirCallArgsRange,
+        _span: Span,
         ctx: &mut ConstraintContext,
     ) -> Option<InferType> {
         if let Some(enum_id) = ty.as_enum() {
@@ -3048,6 +3324,16 @@ impl<'a> ConstraintGenerator<'a> {
         let struct_id = ty.as_struct()?;
         let method_sig = self.method_sig(&(struct_id, function))?;
         let args = self.rir.call_args(args);
+        #[cfg(test)]
+        if call_contract_matches(&args, &method_sig.param_modes) {
+            self.body_dependencies
+                .push(InferenceBodyDependency::Method {
+                    structure: struct_id,
+                    method: function,
+                    span: _span,
+                    associated: true,
+                });
+        }
         for (arg, param_type) in args.iter().zip(method_sig.param_types.iter()) {
             let defer_equality = self.is_slice_struct_type(param_type.clone());
             let arg_info = self.generate(arg.value, ctx);

--- a/crates/rue-air/src/inference/mod.rs
+++ b/crates/rue-air/src/inference/mod.rs
@@ -54,5 +54,7 @@ pub use generate::{
     ConstraintContext, ConstraintGenerator, ExprInfo, FunctionSig, LocalVarInfo, MethodSig,
     ParamVarInfo,
 };
+#[cfg(test)]
+pub(crate) use generate::{InferenceBodyDependency, InferenceCallRoute};
 pub use types::{InferType, TypeVarAllocator, TypeVarId};
 pub use unify::{UnificationError, Unifier, UnifyResult};

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -99,6 +99,8 @@ impl<'a> BodySema<'a> {
             ));
         }
         ctx.referenced_methods.insert((struct_id, method));
+        #[cfg(test)]
+        self.record_body_method_dependency((struct_id, method));
         let call_name =
             self.interner
                 .get_or_intern(&self.method_symbol(struct_id, "concat_borrowed", false));

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -350,20 +350,28 @@ impl<'a> BodySema<'a> {
         ctx.referenced_functions.insert(name);
 
         // Get parameter data from the arena
-        let param_types = self.param_arena.types(fn_info.params);
-        let param_modes = self.param_arena.modes(fn_info.params);
-        let param_comptime = self.param_arena.comptime(fn_info.params);
-        let param_names = self.param_arena.names(fn_info.params);
+        let param_types = self.param_arena.types(fn_info.params).to_vec();
+        let param_modes = self.param_arena.modes(fn_info.params).to_vec();
+        let param_comptime = self.param_arena.comptime(fn_info.params).to_vec();
+        let param_names = self.param_arena.names(fn_info.params).to_vec();
 
-        self.validate_call_contract(args_range, param_types, param_modes, span, true)?;
+        self.validate_call_contract(args_range, &param_types, &param_modes, span, true)?;
+        // The declaration, visibility, checked-call policy, and explicit call
+        // contract have all selected this exact callable. Record before
+        // operand analysis so a later argument diagnostic retains the edge.
+        #[cfg(test)]
+        {
+            self.record_body_named_dependency(NamedConstDependencyTargetEvent::FreeFunction {
+                file: fn_info.file_id.index(),
+                name: fn_name_str.clone(),
+            });
+            self.record_body_callable_dependency(name);
+        }
         let args = self.rir.call_args(args_range);
 
         // Extract info before any mutable borrow
         let is_generic = fn_info.is_generic;
-        let param_types = param_types.to_vec();
-        let param_comptime = param_comptime.to_vec();
         let param_comptime_type = self.comptime_type_param_flags(&fn_info);
-        let param_names = param_names.to_vec();
         let param_modes = param_modes.to_vec();
         let base_return_type = fn_info.return_type;
 
@@ -612,6 +620,15 @@ impl<'a> BodySema<'a> {
             // resolves back to COMPTIME_TYPE and is comptime-evaluated below).
             let return_type =
                 self.resolve_substituted_return_type(&fn_info, &type_subst, &value_subst)?;
+
+            #[cfg(test)]
+            if let Some(source) = self.body_dependency_observer.clone()
+                && let Ok(identity) =
+                    self.canonical_specialization_instance(name, &type_args, &value_args)
+            {
+                self.body_specialization_dependencies
+                    .push((source, identity));
+            }
 
             // Special case: functions that return `type` (not a type parameter) with only comptime args
             // can be fully evaluated at compile time to produce a concrete anonymous struct type.
@@ -890,7 +907,7 @@ impl<'a> BodySema<'a> {
 
         // Look up the method using StructId directly
         let method_key = (struct_id, method);
-        let method_info = self.method_info(method_key).ok_or_compile_error(
+        let method_info = self.method_info(method_key).copied().ok_or_compile_error(
             ErrorKind::UndefinedMethod {
                 type_name: struct_name_str.clone(),
                 method_name: method_name_str.clone(),
@@ -927,6 +944,8 @@ impl<'a> BodySema<'a> {
             span,
             false,
         )?;
+        #[cfg(test)]
+        self.record_body_method_dependency(method_key);
 
         // Clone data needed before mutable borrow
         let return_type = method_info.return_type;
@@ -1141,6 +1160,11 @@ impl<'a> BodySema<'a> {
                         span,
                     ));
                 }
+                #[cfg(test)]
+                self.record_body_named_dependency(NamedConstDependencyTargetEvent::ValueConst {
+                    file: mfile.index(),
+                    name: fn_name_str.clone(),
+                });
                 function_key = Some(fkey);
                 via_reexport = true;
             }
@@ -1204,6 +1228,8 @@ impl<'a> BodySema<'a> {
         }
 
         self.validate_call_contract(args_range, &param_types, &param_modes, span, true)?;
+        #[cfg(test)]
+        self.record_body_callable_dependency(function_key);
 
         // Analyze arguments (the per-pipeline recursion seam). Module-qualified
         // calls use the coercing path so slice and `borrow str` parameters
@@ -1316,7 +1342,7 @@ impl<'a> BodySema<'a> {
 
         // Look up the function using StructId
         let method_key = (struct_id, function);
-        let method_info = self.method_info(method_key).ok_or_compile_error(
+        let method_info = self.method_info(method_key).copied().ok_or_compile_error(
             ErrorKind::UndefinedAssocFn {
                 type_name: type_name_str.clone(),
                 function_name: function_name_str.clone(),
@@ -1347,6 +1373,8 @@ impl<'a> BodySema<'a> {
             span,
             true,
         )?;
+        #[cfg(test)]
+        self.record_body_method_dependency(method_key);
 
         // Clone data needed before mutable borrow
         let return_type = method_info.return_type;

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -6,7 +6,7 @@
 use super::*;
 
 impl<'a> BodySema<'a> {
-    pub(super) fn analyze_single_function<P>(
+    pub(in crate::sema) fn analyze_single_function<P>(
         &mut self,
         infer_ctx: &InferenceContext,
         fn_name: &str,
@@ -107,7 +107,7 @@ impl<'a> BodySema<'a> {
     /// The `infer_ctx` provides pre-computed type information for constraint generation.
     ///
     /// Returns the analyzed function, any warnings, and local strings collected during analysis.
-    pub(super) fn analyze_method_function<P>(
+    pub(in crate::sema) fn analyze_method_function<P>(
         &mut self,
         infer_ctx: &InferenceContext,
         full_name: &str,
@@ -230,7 +230,7 @@ impl<'a> BodySema<'a> {
     /// The `infer_ctx` provides pre-computed type information for constraint generation.
     ///
     /// Returns the analyzed function, any warnings, and local strings collected during analysis.
-    pub(super) fn analyze_destructor_function(
+    pub(in crate::sema) fn analyze_destructor_function(
         &mut self,
         infer_ctx: &InferenceContext,
         full_name: &str,
@@ -684,6 +684,11 @@ impl<'a> BodySema<'a> {
             for ty in observed_types {
                 self.record_resolved_declaration_type(ty);
             }
+        }
+
+        #[cfg(test)]
+        if self.one_body_error_recovery && !self.one_body_recovered_errors.is_empty() {
+            return Err(self.one_body_recovered_errors[0].clone());
         }
 
         Ok((

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -562,6 +562,8 @@ impl<'a> BodySema<'a> {
                 ));
             };
             ctx.referenced_methods.insert((struct_id, method));
+            #[cfg(test)]
+            self.record_body_method_dependency((struct_id, method));
             let (receiver, temp_scope) = self.materialize_borrow_argument(
                 air,
                 coll_result.air_ref,

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -394,6 +394,11 @@ impl<'a> BodySema<'a> {
         };
         ctx.referenced_methods.insert((struct_id, ptr_method));
         ctx.referenced_methods.insert((struct_id, len_method));
+        #[cfg(test)]
+        {
+            self.record_body_method_dependency((struct_id, ptr_method));
+            self.record_body_method_dependency((struct_id, len_method));
+        }
         let (receiver, prefix) = self.materialize_borrow_argument(air, value, ty, span, ctx)?;
         let ptr_call_name = self
             .interner
@@ -2628,6 +2633,8 @@ impl<'a> BodySema<'a> {
             ));
         }
         ctx.referenced_methods.insert((struct_id, method));
+        #[cfg(test)]
+        self.record_body_method_dependency((struct_id, method));
         let (receiver, temp_scope) =
             self.materialize_borrow_argument(air, base_result.air_ref, base_result.ty, span, ctx)?;
         let call_name =

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -6,6 +6,228 @@
 use super::*;
 
 impl<'a> BodySema<'a> {
+    #[cfg(test)]
+    fn inference_function_is_selected(
+        &self,
+        function: Spur,
+        span: Span,
+        route: &crate::inference::InferenceCallRoute,
+        checked: bool,
+    ) -> Option<bool> {
+        let info = self.function_info(function)?;
+        if (info.is_unchecked || info.is_extern) && !checked {
+            return Some(false);
+        }
+        match route {
+            crate::inference::InferenceCallRoute::Unqualified { alias } => {
+                if let Some(alias_name) = alias {
+                    let alias = self.value_const(&(span.file_id, *alias_name))?;
+                    if alias.value.as_function() != Some(function)
+                        || self
+                            .check_unqualified_visibility(
+                                "constant",
+                                self.interner.resolve(alias_name),
+                                alias.span.file_id,
+                                alias.is_pub,
+                                span,
+                            )
+                            .is_err()
+                    {
+                        return Some(false);
+                    }
+                } else if self
+                    .resolve_function_name_local(self.source_function_name(function), span.file_id)
+                    .is_none_or(|selected| selected != function)
+                {
+                    return Some(false);
+                }
+                Some(
+                    self.check_unqualified_visibility(
+                        "function",
+                        self.interner.resolve(&self.source_function_name(function)),
+                        info.file_id,
+                        info.is_pub,
+                        span,
+                    )
+                    .is_ok(),
+                )
+            }
+            crate::inference::InferenceCallRoute::Module {
+                module,
+                member,
+                via_alias,
+            } => {
+                let module_file = self.module_registry.get_def(*module).file_id;
+                if *via_alias {
+                    // The visible facade const is the module membership and
+                    // visibility grant. Its selected function may be private
+                    // or defined in another file, exactly as in the canonical
+                    // module-call path; do not reapply direct-member policy to
+                    // that hidden target.
+                    let alias = self.value_const(&(module_file, *member))?;
+                    return Some(
+                        alias.value.as_function() == Some(function)
+                            && self.is_accessible(span.file_id, module_file, alias.is_pub),
+                    );
+                }
+                let selected = self
+                    .resolve_function_name_local(*member, module_file)
+                    .is_some_and(|selected| selected == function);
+                Some(
+                    selected
+                        && info.file_id == module_file
+                        && self.is_accessible(span.file_id, info.file_id, info.is_pub),
+                )
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn record_inference_body_dependencies(
+        &mut self,
+        dependencies: &[crate::inference::InferenceBodyDependency],
+        expr_types: &HashMap<InstRef, InferType>,
+    ) -> bool {
+        if !self.one_body_error_recovery {
+            return false;
+        }
+
+        let mut incomplete = false;
+        for dependency in dependencies {
+            match dependency {
+                crate::inference::InferenceBodyDependency::Function {
+                    function,
+                    span,
+                    route,
+                    checked,
+                } => match self.inference_function_is_selected(*function, *span, route, *checked) {
+                    Some(true) => self.record_body_callable_dependency(*function),
+                    Some(false) => {}
+                    None => incomplete = true,
+                },
+                crate::inference::InferenceBodyDependency::Method {
+                    structure,
+                    method,
+                    span,
+                    associated,
+                } => {
+                    let Some(info) = self.method_info((*structure, *method)) else {
+                        incomplete = true;
+                        continue;
+                    };
+                    if info.has_self != *associated {
+                        if *associated {
+                            let def = self.type_pool.struct_def(*structure);
+                            if self
+                                .check_unqualified_visibility(
+                                    "struct",
+                                    &def.name,
+                                    def.file_id,
+                                    def.is_pub,
+                                    *span,
+                                )
+                                .is_err()
+                            {
+                                continue;
+                            }
+                        }
+                        self.record_body_method_dependency((*structure, *method));
+                    }
+                }
+                crate::inference::InferenceBodyDependency::ModuleBinding(file, name) => {
+                    self.record_body_named_dependency(
+                        crate::NamedConstDependencyTargetEvent::ModuleBinding {
+                            file: file.index(),
+                            name: self.interner.resolve(name).to_owned(),
+                        },
+                    );
+                }
+                crate::inference::InferenceBodyDependency::ValueConst {
+                    file,
+                    name,
+                    access_file,
+                    qualified,
+                } => {
+                    let Some(info) = self.value_const(&(*file, *name)) else {
+                        incomplete = true;
+                        continue;
+                    };
+                    if *qualified && !self.is_accessible(*access_file, *file, info.is_pub) {
+                        continue;
+                    }
+                    self.record_body_named_dependency(
+                        crate::NamedConstDependencyTargetEvent::ValueConst {
+                            file: file.index(),
+                            name: self.interner.resolve(name).to_owned(),
+                        },
+                    );
+                }
+                crate::inference::InferenceBodyDependency::Specialization {
+                    function,
+                    type_arguments,
+                    value_arguments,
+                    span,
+                    route,
+                    checked,
+                } => {
+                    match self.inference_function_is_selected(*function, *span, route, *checked) {
+                        Some(true) => {}
+                        Some(false) => continue,
+                        None => {
+                            incomplete = true;
+                            continue;
+                        }
+                    }
+                    let Some(source) = self.body_dependency_observer.clone() else {
+                        incomplete = true;
+                        continue;
+                    };
+                    match self.canonical_specialization_instance(
+                        *function,
+                        type_arguments,
+                        value_arguments,
+                    ) {
+                        Ok(identity) => self
+                            .body_specialization_dependencies
+                            .push((source, identity)),
+                        Err(_) => incomplete = true,
+                    }
+                }
+                crate::inference::InferenceBodyDependency::IncompleteCallable => {
+                    incomplete = true;
+                }
+            }
+        }
+
+        fn record_concrete(sema: &mut BodySema<'_>, ty: &InferType, access_file: FileId) -> bool {
+            match ty {
+                InferType::Concrete(ty) => {
+                    let accessible = match ty.kind() {
+                        TypeKind::Struct(id) => {
+                            let def = sema.type_pool.struct_def(id);
+                            sema.is_accessible(access_file, def.file_id, def.is_pub)
+                        }
+                        TypeKind::Enum(id) => {
+                            let def = sema.type_pool.enum_def(id);
+                            sema.is_accessible(access_file, def.file_id, def.is_pub)
+                        }
+                        _ => true,
+                    };
+                    if accessible {
+                        sema.record_resolved_declaration_type(*ty);
+                    }
+                    !accessible
+                }
+                InferType::Array { element, .. } => record_concrete(sema, element, access_file),
+                InferType::Var(_) | InferType::IntLiteral => false,
+            }
+        }
+        for (inst_ref, ty) in expr_types {
+            incomplete |= record_concrete(self, ty, self.rir.get(*inst_ref).span.file_id);
+        }
+        incomplete
+    }
+
     /// Run Hindley-Milner type inference on a function body.
     ///
     /// This is Phases 1-2 of the HM algorithm:
@@ -203,6 +425,9 @@ impl<'a> BodySema<'a> {
         // Phase 1: Generate constraints
         let body_info = cgen.generate(body, &mut cgen_ctx);
 
+        #[cfg(test)]
+        let inference_body_dependencies = cgen.body_dependencies().to_vec();
+
         // The function body's type must match the return type.
         // This handles implicit returns like `fn foo() -> i8 { 42 }`.
         // For arrays, we need to convert Type to InferType structurally.
@@ -260,6 +485,12 @@ impl<'a> BodySema<'a> {
         // For now, we collect the first error. In the future, we could
         // report multiple errors for better diagnostics.
         if let Some(err) = errors.first() {
+            #[cfg(test)]
+            {
+                let inference_dependency_incomplete = self
+                    .record_inference_body_dependencies(&inference_body_dependencies, &expr_types);
+                self.one_body_inference_failure_incomplete = inference_dependency_incomplete;
+            }
             // Map each UnifyResult variant to the appropriate ErrorKind
             let error_kind = match &err.kind {
                 UnifyResult::Ok => unreachable!("UnificationError should never contain Ok"),
@@ -309,6 +540,11 @@ impl<'a> BodySema<'a> {
             }
 
             return Err(compile_error);
+        }
+
+        #[cfg(test)]
+        {
+            self.one_body_inference_failure_incomplete = false;
         }
 
         // Default any unconstrained integer literals to i32

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -1962,6 +1962,50 @@ fn stable_module_files<D: super::DeclarationPhase>(sema: &super::Sema<'_, D>) ->
 }
 
 impl<'a> BoundSema<'a> {
+    /// RUE-1084 extraction seam.  This remains test-only until the compiler
+    /// body-query family replaces the whole-program production authority.
+    #[cfg(test)]
+    pub(crate) fn analyze_one_body_for_test(
+        self,
+        request: super::OneBodyRequest,
+        interruption: Option<super::OneBodyInterruption>,
+    ) -> super::OneBodyTransactionOutcome {
+        super::one_body::analyze_one_body(self.sema, request, interruption)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn remove_stable_definition_for_test(
+        mut self,
+        token: crate::SemanticDefinitionToken,
+    ) -> Self {
+        self.sema
+            .stable_definition_tokens
+            .retain(|_, candidate| *candidate != token);
+        self.sema.stable_definition_endpoints.remove(&token);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn reissue_stable_definition_for_test(
+        mut self,
+        token: crate::SemanticDefinitionToken,
+        issuer: u64,
+    ) -> Self {
+        let replacement = crate::SemanticDefinitionToken::new(issuer, token.slot());
+        for candidate in self.sema.stable_definition_tokens.values_mut() {
+            if *candidate == token {
+                *candidate = replacement;
+            }
+        }
+        if let Some(mut endpoint) = self.sema.stable_definition_endpoints.remove(&token) {
+            endpoint.token = replacement;
+            self.sema
+                .stable_definition_endpoints
+                .insert(replacement, endpoint);
+        }
+        self
+    }
+
     /// Install stable declaration dependency observations captured by the
     /// semantic query nucleus. These events describe the declaration payloads
     /// already installed in this epoch; AIR must not rediscover them by

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -334,6 +334,7 @@ impl CallLoanKind {
 ///
 /// Bundles together the mutable state that needs to be threaded through
 /// recursive `analyze_inst` calls.
+#[cfg_attr(test, derive(Clone))]
 pub(crate) struct AnalysisContext<'a> {
     /// RIR body root of the definition producing values in this analysis.
     /// Anonymous structural anchors are relative to this producer.

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -1790,11 +1790,39 @@ impl<'a> BodySema<'a> {
         let num_insts = inst_refs.len();
         for (i, inst_ref) in inst_refs.values().enumerate() {
             let is_last = i == num_insts - 1;
-            let result = if is_last {
-                self.analyze_inst(air, inst_ref, ctx)?
+            // Test-only statement recovery starts after body-wide inference has
+            // succeeded. Inference failures use the exact selections observed
+            // during constraint generation instead; substitution-dependent
+            // selections make that transaction non-terminal.
+            #[cfg(test)]
+            let recovery_checkpoint = self
+                .one_body_error_recovery
+                .then(|| (air.checkpoint(), ctx.clone()));
+            let outcome = if is_last {
+                self.analyze_inst(air, inst_ref, ctx)
             } else {
-                ctx.with_expected_type(None, |ctx| self.analyze_inst(air, inst_ref, ctx))?
+                ctx.with_expected_type(None, |ctx| self.analyze_inst(air, inst_ref, ctx))
             };
+            #[cfg(test)]
+            let result = match outcome {
+                Ok(result) => result,
+                Err(error) if self.one_body_error_recovery => {
+                    let (air_checkpoint, ctx_checkpoint) = recovery_checkpoint
+                        .expect("one-body recovery checkpoint must accompany recovery mode");
+                    air.rollback(air_checkpoint);
+                    *ctx = ctx_checkpoint;
+                    self.one_body_recovered_errors.push(error);
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::UnitConst,
+                        ty: Type::ERROR,
+                        span: self.rir.get(inst_ref).span,
+                    });
+                    AnalysisResult::new(air_ref, Type::ERROR)
+                }
+                Err(error) => return Err(error),
+            };
+            #[cfg(not(test))]
+            let result = outcome?;
 
             if is_last {
                 last_result = Some(result);

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -43,6 +43,8 @@ mod inference_ctx;
 mod info;
 mod known_symbols;
 mod metadata;
+#[cfg(test)]
+mod one_body;
 mod output;
 mod semantic_body_export;
 mod typeck;
@@ -66,6 +68,11 @@ use info::ConstResolution;
 pub use info::{AnonMethodSig, AnonMethodType, ConstInfo, FunctionInfo, MethodInfo};
 pub use known_symbols::KnownSymbols;
 pub use metadata::SemaMetadata;
+#[cfg(test)]
+pub(crate) use one_body::{
+    OneBodyCanonicalArtifact, OneBodyDependency, OneBodyInterruption, OneBodyNonTerminalReason,
+    OneBodyRequest, OneBodyTransactionOutcome,
+};
 pub use output::{
     AnalyzedBodyOwnerEvent, AnalyzedCallableKind, AnalyzedFunction, BodyAnalysisFailure,
     BodyAnalysisWork, BodyNamedDependencyEvent, BodyOwnerEndpoint, BodyOwnerKind, BodyOwnerToken,
@@ -335,6 +342,19 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
     pub(crate) body_owner_tokens:
         HashMap<(u32, String, Option<String>, BodyOwnerKind), BodyOwnerToken>,
     pub(crate) body_named_dependencies: Vec<BodyNamedDependencyEvent>,
+    #[cfg(test)]
+    pub(crate) one_body_error_recovery: bool,
+    #[cfg(test)]
+    pub(crate) one_body_recovered_errors: Vec<rue_error::CompileError>,
+    #[cfg(test)]
+    pub(crate) one_body_inference_failure_incomplete: bool,
+    #[cfg(test)]
+    pub(crate) body_callable_dependencies: Vec<(AnalyzedBodyOwnerEvent, Spur)>,
+    #[cfg(test)]
+    pub(crate) body_specialization_dependencies: Vec<(
+        AnalyzedBodyOwnerEvent,
+        crate::FunctionInstanceKey<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
+    )>,
     pub(crate) ordinary_free_function_dependencies: Vec<OrdinaryFreeFunctionDependencyEvent>,
     pub(crate) specialized_free_function_origins: Vec<SpecializedFreeFunctionOrigin>,
     pub(crate) specialized_free_function_dependencies: Vec<SpecializedFreeFunctionDependencyEvent>,
@@ -496,6 +516,16 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             body_dependency_observer,
             body_owner_tokens,
             body_named_dependencies,
+            #[cfg(test)]
+            one_body_error_recovery,
+            #[cfg(test)]
+            one_body_recovered_errors,
+            #[cfg(test)]
+            one_body_inference_failure_incomplete,
+            #[cfg(test)]
+            body_callable_dependencies,
+            #[cfg(test)]
+            body_specialization_dependencies,
             ordinary_free_function_dependencies,
             specialized_free_function_origins,
             specialized_free_function_dependencies,
@@ -568,6 +598,16 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             body_dependency_observer,
             body_owner_tokens,
             body_named_dependencies,
+            #[cfg(test)]
+            one_body_error_recovery,
+            #[cfg(test)]
+            one_body_recovered_errors,
+            #[cfg(test)]
+            one_body_inference_failure_incomplete,
+            #[cfg(test)]
+            body_callable_dependencies,
+            #[cfg(test)]
+            body_specialization_dependencies,
             ordinary_free_function_dependencies,
             specialized_free_function_origins,
             specialized_free_function_dependencies,
@@ -814,6 +854,24 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         self.body_analysis_work.named_const_dependency_events += 1;
     }
 
+    #[cfg(test)]
+    pub(crate) fn record_body_callable_dependency(&mut self, symbol: Spur) {
+        let Some(source) = self.body_dependency_observer.clone() else {
+            return;
+        };
+        self.body_callable_dependencies.push((source, symbol));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn record_body_method_dependency(&mut self, key: (StructId, Spur)) {
+        let Some(info) = self.method_info(key) else {
+            return;
+        };
+        let symbol = self.method_symbol(key.0, self.interner.resolve(&key.1), info.has_self);
+        let symbol = self.interner.get_or_intern(&symbol);
+        self.record_body_callable_dependency(symbol);
+    }
+
     pub(crate) fn validate_explicit_call_modes<A>(
         &self,
         args: A,
@@ -1052,6 +1110,16 @@ impl<'a> Sema<'a> {
             body_dependency_observer: None,
             body_owner_tokens: HashMap::new(),
             body_named_dependencies: Vec::new(),
+            #[cfg(test)]
+            one_body_error_recovery: false,
+            #[cfg(test)]
+            one_body_recovered_errors: Vec::new(),
+            #[cfg(test)]
+            one_body_inference_failure_incomplete: false,
+            #[cfg(test)]
+            body_callable_dependencies: Vec::new(),
+            #[cfg(test)]
+            body_specialization_dependencies: Vec::new(),
             ordinary_free_function_dependencies: Vec::new(),
             specialized_free_function_origins: Vec::new(),
             specialized_free_function_dependencies: Vec::new(),

--- a/crates/rue-air/src/sema/one_body.rs
+++ b/crates/rue-air/src/sema/one_body.rs
@@ -1,0 +1,987 @@
+//! Test-only extraction of an exact-one-body semantic transaction.
+//!
+//! Production continues to use the established whole-program driver.  This
+//! module exists to prove the transaction contract needed by the compiler's
+//! future body query without installing a second production authority.
+//!
+//! Module selections remain exact stable module-binding definition tokens:
+//! that is the canonical compiler join key and retains both the local binding
+//! and its module payload without guessing a target from a display path. Drop
+//! glue is not selected by semantic body analysis. Its named-destructor edges
+//! are emitted by CFG construction from the canonical type identities carried
+//! by a successful body; a deterministic semantic failure has no CFG artifact,
+//! while its type dependencies retain every input that can affect drop facts.
+
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::sync::Arc;
+
+use lasso::Spur;
+use rue_error::{CompileError, CompileErrors, ErrorKind};
+use rue_rir::InstData;
+use rue_span::{FileId, Span};
+
+use super::{AnalyzedBodyOwnerEvent, AnalyzedFunction, BodyOwnerKind, BodySema};
+use crate::{
+    FunctionInstanceKey, NominalInstanceKey, SemanticBodyExport, SemanticDefinitionToken,
+    SemanticModuleToken, SemanticSpecializationIdentity, SemanticSpecializedBodyExport,
+    StableDefinitionKind, Type, TypeInstanceKey,
+};
+
+#[derive(Debug, Clone)]
+pub(crate) enum OneBodyRequest {
+    Definition(SemanticDefinitionToken),
+    Specialization {
+        base: SemanticDefinitionToken,
+        type_arguments: Vec<Type>,
+        value_arguments: Vec<super::ConstValue>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OneBodyInterruption {
+    Canceled,
+    EngineAbort,
+}
+
+#[derive(Debug)]
+pub(crate) enum OneBodyCanonicalArtifact {
+    Ordinary(Box<SemanticBodyExport>),
+    Specialization(Box<SemanticSpecializedBodyExport>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum OneBodyDependency {
+    Callable(FunctionInstanceKey<SemanticDefinitionToken, SemanticModuleToken>),
+    Definition(SemanticDefinitionToken),
+    Type(TypeInstanceKey<SemanticDefinitionToken, SemanticModuleToken>),
+}
+
+#[derive(Debug)]
+pub(crate) enum OneBodyTransactionOutcome {
+    Success {
+        artifact: OneBodyCanonicalArtifact,
+        references: Arc<[OneBodyDependency]>,
+    },
+    DeterministicFailure {
+        errors: CompileErrors,
+        references: Arc<[OneBodyDependency]>,
+    },
+    NonTerminal {
+        reason: OneBodyNonTerminalReason,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum OneBodyNonTerminalReason {
+    Canceled,
+    EngineAbort,
+    TypedIncomplete(crate::SemanticBodyExportFailure),
+}
+
+impl OneBodyTransactionOutcome {
+    pub(crate) fn references(&self) -> Option<&[OneBodyDependency]> {
+        match self {
+            Self::Success { references, .. } | Self::DeterministicFailure { references, .. } => {
+                Some(references)
+            }
+            Self::NonTerminal { .. } => None,
+        }
+    }
+
+    pub(crate) fn artifact_instruction_count(&self) -> Option<usize> {
+        match self {
+            Self::Success {
+                artifact: OneBodyCanonicalArtifact::Ordinary(artifact),
+                ..
+            } => Some(artifact.body.instructions.len()),
+            Self::Success {
+                artifact: OneBodyCanonicalArtifact::Specialization(artifact),
+                ..
+            } => Some(artifact.body.instructions.len()),
+            Self::DeterministicFailure { .. } | Self::NonTerminal { .. } => None,
+        }
+    }
+
+    pub(crate) fn non_terminal_reason(&self) -> Option<&OneBodyNonTerminalReason> {
+        match self {
+            Self::NonTerminal { reason } => Some(reason),
+            Self::Success { .. } | Self::DeterministicFailure { .. } => None,
+        }
+    }
+}
+
+fn interruption_outcome(interruption: OneBodyInterruption) -> OneBodyTransactionOutcome {
+    OneBodyTransactionOutcome::NonTerminal {
+        reason: match interruption {
+            OneBodyInterruption::Canceled => OneBodyNonTerminalReason::Canceled,
+            OneBodyInterruption::EngineAbort => OneBodyNonTerminalReason::EngineAbort,
+        },
+    }
+}
+
+fn stable_token(
+    sema: &BodySema<'_>,
+    file: u32,
+    name: &str,
+    owner: Option<&str>,
+    kind: StableDefinitionKind,
+) -> Result<SemanticDefinitionToken, crate::SemanticBodyExportFailure> {
+    sema.stable_definition_token(file, name, owner, kind)
+}
+
+fn target_dependency(
+    sema: &BodySema<'_>,
+    target: &super::NamedConstDependencyTargetEvent,
+) -> Result<OneBodyDependency, crate::SemanticBodyExportFailure> {
+    use super::{DeclarationTypeDependencyTargetKind as TK, NamedConstDependencyTargetEvent as T};
+    match target {
+        T::ValueConst { file, name } => {
+            stable_token(sema, *file, name, None, StableDefinitionKind::ValueConst)
+                .map(OneBodyDependency::Definition)
+        }
+        T::FreeFunction { file, name } => {
+            stable_token(sema, *file, name, None, StableDefinitionKind::Function)
+                .map(|token| OneBodyDependency::Callable(FunctionInstanceKey::Definition(token)))
+        }
+        T::NamedType { file, name, kind } => {
+            let kind = match kind {
+                TK::Struct => StableDefinitionKind::Struct,
+                TK::Enum => StableDefinitionKind::Enum,
+                TK::ValueConst => StableDefinitionKind::ValueConst,
+            };
+            let token = stable_token(sema, *file, name, None, kind)?;
+            if matches!(
+                kind,
+                StableDefinitionKind::Struct | StableDefinitionKind::Enum
+            ) {
+                Ok(OneBodyDependency::Type(TypeInstanceKey::Nominal(
+                    NominalInstanceKey::Named(token),
+                )))
+            } else {
+                Ok(OneBodyDependency::Definition(token))
+            }
+        }
+        T::ModuleBinding { file, name } => {
+            stable_token(sema, *file, name, None, StableDefinitionKind::ModuleBinding)
+                .map(OneBodyDependency::Definition)
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ReferenceProjectionFailure {
+    TypedIncomplete(crate::SemanticBodyExportFailure),
+    EngineAbort,
+}
+
+impl From<crate::SemanticBodyExportFailure> for ReferenceProjectionFailure {
+    fn from(reason: crate::SemanticBodyExportFailure) -> Self {
+        Self::TypedIncomplete(reason)
+    }
+}
+
+fn projection_failure_outcome(failure: ReferenceProjectionFailure) -> OneBodyTransactionOutcome {
+    OneBodyTransactionOutcome::NonTerminal {
+        reason: match failure {
+            ReferenceProjectionFailure::TypedIncomplete(reason) => {
+                OneBodyNonTerminalReason::TypedIncomplete(reason)
+            }
+            ReferenceProjectionFailure::EngineAbort => OneBodyNonTerminalReason::EngineAbort,
+        },
+    }
+}
+
+fn arguments_have_issuer(
+    arguments: &crate::CanonicalArguments<SemanticDefinitionToken, SemanticModuleToken>,
+    issuer: u64,
+) -> bool {
+    arguments.types.iter().all(|ty| type_has_issuer(ty, issuer))
+        && arguments.values.iter().all(|value| match value {
+            crate::CanonicalArgumentValue::Type(ty) => type_has_issuer(ty, issuer),
+            crate::CanonicalArgumentValue::Function(function) => {
+                function_has_issuer(function, issuer)
+            }
+            crate::CanonicalArgumentValue::Integer(_)
+            | crate::CanonicalArgumentValue::Bool(_)
+            | crate::CanonicalArgumentValue::Unit
+            | crate::CanonicalArgumentValue::String(_) => true,
+        })
+}
+
+fn anonymous_nominal_has_issuer(
+    nominal: &crate::AnonymousNominalKey<SemanticDefinitionToken, SemanticModuleToken>,
+    issuer: u64,
+) -> bool {
+    let producer = match &nominal.producer {
+        crate::StableProducerId::Definition(definition) => definition.issuer() == issuer,
+        crate::StableProducerId::Function(function) => function_has_issuer(function, issuer),
+    };
+    producer && arguments_have_issuer(&nominal.arguments, issuer)
+}
+
+fn type_has_issuer(
+    ty: &TypeInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
+    issuer: u64,
+) -> bool {
+    match ty {
+        TypeInstanceKey::Nominal(NominalInstanceKey::Named(definition)) => {
+            definition.issuer() == issuer
+        }
+        TypeInstanceKey::Nominal(NominalInstanceKey::Anonymous(nominal)) => {
+            anonymous_nominal_has_issuer(nominal, issuer)
+        }
+        TypeInstanceKey::Array { element, .. }
+        | TypeInstanceKey::Slice { element, .. }
+        | TypeInstanceKey::PtrConst(element)
+        | TypeInstanceKey::PtrMut(element) => type_has_issuer(element, issuer),
+        TypeInstanceKey::Module(module) => module.issuer() == issuer,
+        TypeInstanceKey::I8
+        | TypeInstanceKey::I16
+        | TypeInstanceKey::I32
+        | TypeInstanceKey::I64
+        | TypeInstanceKey::U8
+        | TypeInstanceKey::U16
+        | TypeInstanceKey::U32
+        | TypeInstanceKey::U64
+        | TypeInstanceKey::Bool
+        | TypeInstanceKey::Unit
+        | TypeInstanceKey::Never
+        | TypeInstanceKey::ComptimeType
+        | TypeInstanceKey::BuiltinNominal { .. }
+        | TypeInstanceKey::GenericParameter(_) => true,
+    }
+}
+
+fn function_has_issuer(
+    function: &FunctionInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
+    issuer: u64,
+) -> bool {
+    match function {
+        FunctionInstanceKey::Definition(definition) => definition.issuer() == issuer,
+        FunctionInstanceKey::Specialization { base, arguments } => {
+            function_has_issuer(base, issuer) && arguments_have_issuer(arguments, issuer)
+        }
+        FunctionInstanceKey::AnonymousMember { owner, .. } => type_has_issuer(owner, issuer),
+        FunctionInstanceKey::DropGlue(ty) => type_has_issuer(ty, issuer),
+    }
+}
+
+fn dependency_has_issuer(dependency: &OneBodyDependency, issuer: u64) -> bool {
+    match dependency {
+        OneBodyDependency::Callable(function) => function_has_issuer(function, issuer),
+        OneBodyDependency::Definition(definition) => definition.issuer() == issuer,
+        OneBodyDependency::Type(ty) => type_has_issuer(ty, issuer),
+    }
+}
+
+fn body_references(
+    sema: &BodySema<'_>,
+    owner: Option<super::BodyOwnerToken>,
+    referenced_functions: &HashSet<Spur>,
+    referenced_methods: &HashSet<(crate::StructId, Spur)>,
+    specializations: &[(
+        Spur,
+        SemanticSpecializationIdentity<SemanticDefinitionToken, SemanticModuleToken>,
+    )],
+) -> Result<Arc<[OneBodyDependency]>, ReferenceProjectionFailure> {
+    let mut references = BTreeSet::new();
+    for function in referenced_functions {
+        let identity = sema.body_function_identity(*function)?;
+        references.insert(OneBodyDependency::Callable(identity));
+    }
+    for (structure, method) in referenced_methods {
+        let Some(info) = sema.method_info((*structure, *method)) else {
+            return Err(ReferenceProjectionFailure::EngineAbort);
+        };
+        let symbol = sema.method_symbol(*structure, sema.interner.resolve(method), info.has_self);
+        let Some(symbol) = sema.interner.get(&symbol) else {
+            return Err(ReferenceProjectionFailure::EngineAbort);
+        };
+        let identity = sema.body_function_identity(symbol)?;
+        references.insert(OneBodyDependency::Callable(identity));
+    }
+    for (source, identity) in &sema.body_specialization_dependencies {
+        if owner.is_some_and(|owner| source.token() != Some(owner)) {
+            continue;
+        }
+        references.insert(OneBodyDependency::Callable(identity.clone()));
+    }
+    for (source, symbol) in &sema.body_callable_dependencies {
+        if owner.is_some_and(|owner| source.token() != Some(owner)) {
+            continue;
+        }
+        let identity = sema.body_function_identity(*symbol)?;
+        references.insert(OneBodyDependency::Callable(identity));
+    }
+    for event in &sema.body_named_dependencies {
+        if owner.is_some_and(|owner| event.source.token() != Some(owner)) {
+            continue;
+        }
+        references.insert(target_dependency(sema, &event.target)?);
+    }
+    for event in &sema.declaration_type_dependencies {
+        if event.dependency_kind != super::DeclarationTypeDependencyKind::Body
+            || owner.is_some_and(|owner| event.source_token != Some(owner))
+        {
+            continue;
+        }
+        let kind = match event.target_kind {
+            super::DeclarationTypeDependencyTargetKind::Struct => StableDefinitionKind::Struct,
+            super::DeclarationTypeDependencyTargetKind::Enum => StableDefinitionKind::Enum,
+            super::DeclarationTypeDependencyTargetKind::ValueConst => {
+                StableDefinitionKind::ValueConst
+            }
+        };
+        let token = stable_token(sema, event.target_file, &event.target_name, None, kind)?;
+        if matches!(
+            kind,
+            StableDefinitionKind::Struct | StableDefinitionKind::Enum
+        ) {
+            references.insert(OneBodyDependency::Type(TypeInstanceKey::Nominal(
+                NominalInstanceKey::Named(token),
+            )));
+        } else {
+            references.insert(OneBodyDependency::Definition(token));
+        }
+    }
+    for event in &sema.declaration_type_call_head_dependencies {
+        if event.dependency_kind != super::DeclarationTypeDependencyKind::Body
+            || owner.is_some_and(|owner| event.source_token != Some(owner))
+        {
+            continue;
+        }
+        let token = stable_token(
+            sema,
+            event.callable_file,
+            &event.callable_name,
+            None,
+            StableDefinitionKind::Function,
+        )?;
+        references.insert(OneBodyDependency::Callable(
+            FunctionInstanceKey::Definition(token),
+        ));
+    }
+    for (_, identity) in specializations {
+        references.remove(&OneBodyDependency::Callable(
+            FunctionInstanceKey::Definition(identity.base),
+        ));
+    }
+    for (source, identity) in &sema.body_specialization_dependencies {
+        if owner.is_some_and(|owner| source.token() != Some(owner)) {
+            continue;
+        }
+        if let FunctionInstanceKey::Specialization { base, .. } = identity {
+            references.remove(&OneBodyDependency::Callable((**base).clone()));
+        }
+    }
+    let references: Arc<[OneBodyDependency]> = references.into_iter().collect::<Vec<_>>().into();
+    if let Some(owner) = owner
+        && references
+            .iter()
+            .any(|dependency| !dependency_has_issuer(dependency, owner.issuer()))
+    {
+        return Err(ReferenceProjectionFailure::TypedIncomplete(
+            crate::SemanticBodyExportFailure::ForeignStableIdentityIssuer,
+        ));
+    }
+    Ok(references)
+}
+
+fn fail(
+    sema: &BodySema<'_>,
+    owner: Option<super::BodyOwnerToken>,
+    error: CompileError,
+) -> OneBodyTransactionOutcome {
+    if sema.one_body_inference_failure_incomplete {
+        return OneBodyTransactionOutcome::NonTerminal {
+            reason: OneBodyNonTerminalReason::TypedIncomplete(
+                crate::SemanticBodyExportFailure::MissingStableIdentity,
+            ),
+        };
+    }
+    if matches!(
+        error.kind,
+        ErrorKind::InvalidCompilerInput(_)
+            | ErrorKind::CompilerProducerInvariant(_)
+            | ErrorKind::CompilerResourceLimit(_)
+            | ErrorKind::CompilerResourceExhaustion(_)
+            | ErrorKind::OutputPublication(_)
+            | ErrorKind::InternalError(_)
+            | ErrorKind::InternalCodegenError(_)
+    ) {
+        return OneBodyTransactionOutcome::NonTerminal {
+            reason: OneBodyNonTerminalReason::EngineAbort,
+        };
+    }
+    let errors = if sema.one_body_recovered_errors.is_empty() {
+        CompileErrors::from(error)
+    } else {
+        let mut errors = CompileErrors::new();
+        for error in &sema.one_body_recovered_errors {
+            errors.push(error.clone());
+        }
+        errors
+    };
+    match body_references(sema, owner, &HashSet::new(), &HashSet::new(), &[]) {
+        Ok(references) => OneBodyTransactionOutcome::DeterministicFailure { errors, references },
+        Err(failure) => projection_failure_outcome(failure),
+    }
+}
+
+fn finalize_ordinary(
+    sema: &BodySema<'_>,
+    owner: super::BodyOwnerToken,
+    body_span: Span,
+    function: AnalyzedFunction,
+    warnings: Vec<rue_error::CompileWarning>,
+    strings: Vec<String>,
+    referenced_functions: HashSet<Spur>,
+    referenced_methods: HashSet<(crate::StructId, Spur)>,
+    interruption: Option<OneBodyInterruption>,
+) -> OneBodyTransactionOutcome {
+    let (function, specializations) =
+        match crate::specialize::select_one_body_specializations(sema, function) {
+            Ok(selected) => selected,
+            Err(error) => return fail(sema, Some(owner), error),
+        };
+    let references = match body_references(
+        sema,
+        Some(owner),
+        &referenced_functions,
+        &referenced_methods,
+        &specializations,
+    ) {
+        Ok(references) => references,
+        Err(failure) => return projection_failure_outcome(failure),
+    };
+    if let Some(interruption) = interruption {
+        return interruption_outcome(interruption);
+    }
+    let specialized_calls = specializations.iter().cloned().collect::<HashMap<_, _>>();
+    match sema.export_one_body_with_specializations(
+        owner,
+        body_span,
+        &function,
+        &strings,
+        &warnings,
+        &specialized_calls,
+    ) {
+        Ok(artifact) => OneBodyTransactionOutcome::Success {
+            artifact: OneBodyCanonicalArtifact::Ordinary(Box::new(artifact)),
+            references,
+        },
+        Err(reason) => OneBodyTransactionOutcome::NonTerminal {
+            reason: OneBodyNonTerminalReason::TypedIncomplete(reason),
+        },
+    }
+}
+
+pub(super) fn analyze_one_body(
+    mut sema: BodySema<'_>,
+    request: OneBodyRequest,
+    interruption: Option<OneBodyInterruption>,
+) -> OneBodyTransactionOutcome {
+    // The request control state is authoritative and dominates setup,
+    // semantic diagnostics, canonicalization, and publication alike.
+    if let Some(interruption) = interruption {
+        return interruption_outcome(interruption);
+    }
+    sema.one_body_error_recovery = true;
+    sema.one_body_recovered_errors.clear();
+    sema.one_body_inference_failure_incomplete = false;
+    if let Err(error) = sema.get_or_create_str_struct(Span::default()) {
+        return fail(&sema, None, error);
+    }
+    let infer_ctx = sema.build_inference_context();
+    match request {
+        OneBodyRequest::Specialization {
+            base,
+            type_arguments,
+            value_arguments,
+        } => {
+            let Some(endpoint) = sema.stable_definition_endpoints.get(&base) else {
+                return fail(
+                    &sema,
+                    None,
+                    CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                        "specialization base has no current stable endpoint".into(),
+                    )),
+                );
+            };
+            let Some(source_name) = sema.interner.get(endpoint.name.as_ref()) else {
+                return fail(
+                    &sema,
+                    None,
+                    CompileError::without_span(ErrorKind::UndefinedFunction(
+                        endpoint.name.to_string(),
+                    )),
+                );
+            };
+            let Some(&base_name) = sema
+                .functions_by_file_name
+                .get(&(FileId::new(endpoint.file), source_name))
+            else {
+                return fail(
+                    &sema,
+                    None,
+                    CompileError::without_span(ErrorKind::UndefinedFunction(
+                        endpoint.name.to_string(),
+                    )),
+                );
+            };
+            let key = crate::specialize::SpecializationKey {
+                base_name,
+                type_args: type_arguments,
+                value_args: value_arguments,
+            };
+            let base_name = key.base_name;
+            let base_info = sema.function_info(base_name).cloned();
+            let owner = base_info.as_ref().map(|info| {
+                sema.body_owner_token(
+                    info.file_id,
+                    sema.interner.resolve(&sema.source_function_name(base_name)),
+                    None,
+                    BodyOwnerKind::FreeFunction,
+                )
+            });
+            let specialized =
+                match crate::specialize::analyze_one_specialization(&mut sema, &infer_ctx, key) {
+                    Ok(body) => body,
+                    Err(error) => return fail(&sema, owner, error),
+                };
+            let (function, nested) = match crate::specialize::select_one_body_specializations(
+                &sema,
+                specialized.function,
+            ) {
+                Ok(value) => value,
+                Err(error) => return fail(&sema, owner, error),
+            };
+            let references = match body_references(
+                &sema,
+                owner,
+                &specialized.referenced_functions,
+                &specialized.referenced_methods,
+                &nested,
+            ) {
+                Ok(references) => references,
+                Err(failure) => return projection_failure_outcome(failure),
+            };
+            let Some(base_info) = base_info else {
+                return fail(
+                    &sema,
+                    owner,
+                    CompileError::without_span(ErrorKind::UndefinedFunction(
+                        sema.interner.resolve(&base_name).to_owned(),
+                    )),
+                );
+            };
+            let specialized_calls = nested.iter().cloned().collect::<HashMap<_, _>>();
+            match sema.export_specialized_body(
+                base_name,
+                &base_info,
+                &specialized.key.type_args,
+                &specialized.key.value_args,
+                &function,
+                &specialized.local_strings,
+                &specialized.warnings,
+                &specialized_calls,
+                &specialized.dependencies,
+                specialized.dependency_boundary_complete,
+            ) {
+                Ok(artifact) if artifact.identity == specialized.identity => {
+                    OneBodyTransactionOutcome::Success {
+                        artifact: OneBodyCanonicalArtifact::Specialization(Box::new(artifact)),
+                        references,
+                    }
+                }
+                Ok(_) => OneBodyTransactionOutcome::NonTerminal {
+                    reason: OneBodyNonTerminalReason::TypedIncomplete(
+                        crate::SemanticBodyExportFailure::MissingStableIdentity,
+                    ),
+                },
+                Err(reason) => OneBodyTransactionOutcome::NonTerminal {
+                    reason: OneBodyNonTerminalReason::TypedIncomplete(reason),
+                },
+            }
+        }
+        OneBodyRequest::Definition(token) => {
+            analyze_definition(&mut sema, &infer_ctx, token, interruption)
+        }
+    }
+}
+
+fn analyze_definition(
+    sema: &mut BodySema<'_>,
+    infer_ctx: &super::InferenceContext,
+    token: SemanticDefinitionToken,
+    interruption: Option<OneBodyInterruption>,
+) -> OneBodyTransactionOutcome {
+    let Some(endpoint) = sema.stable_definition_endpoints.get(&token).cloned() else {
+        return fail(
+            sema,
+            None,
+            CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "one-body request has no current stable endpoint".into(),
+            )),
+        );
+    };
+    match endpoint.kind {
+        StableDefinitionKind::Function => {
+            let Some(source_name) = sema.interner.get(endpoint.name.as_ref()) else {
+                return fail(
+                    sema,
+                    None,
+                    CompileError::without_span(ErrorKind::UndefinedFunction(
+                        endpoint.name.to_string(),
+                    )),
+                );
+            };
+            let Some(&name) = sema
+                .functions_by_file_name
+                .get(&(FileId::new(endpoint.file), source_name))
+            else {
+                return fail(
+                    sema,
+                    None,
+                    CompileError::without_span(ErrorKind::UndefinedFunction(
+                        endpoint.name.to_string(),
+                    )),
+                );
+            };
+            let info = sema.functions[&name];
+            if info.is_generic || info.is_extern {
+                return OneBodyTransactionOutcome::NonTerminal {
+                    reason: OneBodyNonTerminalReason::TypedIncomplete(
+                        crate::SemanticBodyExportFailure::UnsupportedGenericCall,
+                    ),
+                };
+            }
+            let source = sema.source_function_name(name);
+            let Some(declaration) = sema
+                .declaration_index
+                .first_free_function(source, Some(info.file_id))
+            else {
+                return fail(
+                    sema,
+                    None,
+                    CompileError::without_span(ErrorKind::UndefinedFunction(
+                        endpoint.name.to_string(),
+                    )),
+                );
+            };
+            let InstData::FnDecl {
+                params,
+                return_type,
+                body,
+                ..
+            } = &sema.rir.get(declaration).data
+            else {
+                unreachable!()
+            };
+            let owner = sema.body_owner_token(
+                info.file_id,
+                endpoint.name.as_ref(),
+                None,
+                BodyOwnerKind::FreeFunction,
+            );
+            let previous_body =
+                sema.body_dependency_observer
+                    .replace(AnalyzedBodyOwnerEvent::FreeFunction {
+                        token: owner,
+                        file: endpoint.file,
+                        name: endpoint.name.to_string(),
+                    });
+            let previous_type = sema.declaration_type_observer.replace((
+                info.file_id,
+                endpoint.name.to_string(),
+                None,
+                super::DeclarationTypeDependencySourceKind::Function,
+                super::DeclarationTypeDependencyKind::Body,
+            ));
+            let result = sema.analyze_single_function(
+                infer_ctx,
+                sema.interner.resolve(&name),
+                *return_type,
+                sema.rir.params(params).values(),
+                *body,
+                info.span,
+                info.allow_unused_variable,
+                info.allow_unreachable_code,
+            );
+            sema.body_dependency_observer = previous_body;
+            sema.declaration_type_observer = previous_type;
+            match result {
+                Ok((mut function, warnings, strings, functions, methods)) => {
+                    function.ordinary_owner = Some(owner);
+                    finalize_ordinary(
+                        sema,
+                        owner,
+                        sema.rir.get(*body).span,
+                        function,
+                        warnings,
+                        strings,
+                        functions,
+                        methods,
+                        interruption,
+                    )
+                }
+                Err(error) => fail(sema, Some(owner), error),
+            }
+        }
+        StableDefinitionKind::Method | StableDefinitionKind::AssociatedFunction => {
+            analyze_named_method(sema, infer_ctx, &endpoint, interruption)
+        }
+        StableDefinitionKind::Destructor => {
+            analyze_named_destructor(sema, infer_ctx, &endpoint, interruption)
+        }
+        _ => fail(
+            sema,
+            None,
+            CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "one-body request does not identify a callable body".into(),
+            )),
+        ),
+    }
+}
+
+fn analyze_named_method(
+    sema: &mut BodySema<'_>,
+    infer_ctx: &super::InferenceContext,
+    endpoint: &crate::SemanticDefinitionEndpoint,
+    interruption: Option<OneBodyInterruption>,
+) -> OneBodyTransactionOutcome {
+    let Some(owner_name) = endpoint.owner.as_deref() else {
+        return fail(
+            sema,
+            None,
+            CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "method endpoint has no owner".into(),
+            )),
+        );
+    };
+    let Some(owner_symbol) = sema.interner.get(owner_name) else {
+        return fail(
+            sema,
+            None,
+            CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "method owner is absent".into(),
+            )),
+        );
+    };
+    let Some(&struct_id) = sema
+        .structs_by_file_name
+        .get(&(FileId::new(endpoint.file), owner_symbol))
+    else {
+        return fail(
+            sema,
+            None,
+            CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "method owner is absent".into(),
+            )),
+        );
+    };
+    let Some(method_name) = sema.interner.get(endpoint.name.as_ref()) else {
+        return fail(
+            sema,
+            None,
+            CompileError::without_span(ErrorKind::UndefinedFunction(endpoint.name.to_string())),
+        );
+    };
+    let Some(info) = sema.method_info((struct_id, method_name)).cloned() else {
+        return fail(
+            sema,
+            None,
+            CompileError::without_span(ErrorKind::UndefinedFunction(endpoint.name.to_string())),
+        );
+    };
+    let Some(&declaration) = sema
+        .named_method_declarations
+        .get(&(struct_id, method_name))
+    else {
+        return fail(
+            sema,
+            None,
+            CompileError::without_span(ErrorKind::UndefinedFunction(endpoint.name.to_string())),
+        );
+    };
+    let InstData::FnDecl {
+        params,
+        return_type,
+        body,
+        has_self,
+        self_mode,
+        self_is_mut,
+        ..
+    } = &sema.rir.get(declaration).data
+    else {
+        unreachable!()
+    };
+    let kind = if *has_self {
+        BodyOwnerKind::Method
+    } else {
+        BodyOwnerKind::AssociatedFunction
+    };
+    let owner = sema.body_owner_token(
+        info.span.file_id,
+        endpoint.name.as_ref(),
+        Some(owner_name),
+        kind,
+    );
+    let generic = sema
+        .param_arena
+        .comptime(info.params)
+        .iter()
+        .any(|value| *value);
+    let owner_event = AnalyzedBodyOwnerEvent::NamedMethod {
+        token: owner,
+        file: endpoint.file,
+        owner_name: owner_name.to_owned(),
+        method_name: endpoint.name.to_string(),
+        generic,
+    };
+    let previous_body = sema.body_dependency_observer.replace(owner_event);
+    let previous_type = sema.declaration_type_observer.replace((
+        info.span.file_id,
+        endpoint.name.to_string(),
+        Some(owner_name.to_owned()),
+        if *has_self {
+            super::DeclarationTypeDependencySourceKind::Method
+        } else {
+            super::DeclarationTypeDependencySourceKind::AssociatedFunction
+        },
+        super::DeclarationTypeDependencyKind::Body,
+    ));
+    let full_name = sema.method_symbol(struct_id, endpoint.name.as_ref(), *has_self);
+    let result = sema.analyze_method_function(
+        infer_ctx,
+        &full_name,
+        *return_type,
+        sema.rir.params(params).values(),
+        *body,
+        info.span,
+        info.struct_type,
+        *has_self,
+        *self_mode,
+        *self_is_mut,
+    );
+    sema.body_dependency_observer = previous_body;
+    sema.declaration_type_observer = previous_type;
+    match result {
+        Ok((mut function, warnings, strings, functions, methods)) => {
+            function.ordinary_owner = Some(owner);
+            finalize_ordinary(
+                sema,
+                owner,
+                sema.rir.get(*body).span,
+                function,
+                warnings,
+                strings,
+                functions,
+                methods,
+                interruption,
+            )
+        }
+        Err(error) => fail(sema, Some(owner), error),
+    }
+}
+
+fn analyze_named_destructor(
+    sema: &mut BodySema<'_>,
+    infer_ctx: &super::InferenceContext,
+    endpoint: &crate::SemanticDefinitionEndpoint,
+    interruption: Option<OneBodyInterruption>,
+) -> OneBodyTransactionOutcome {
+    let Some(owner_name) = endpoint.owner.as_deref() else {
+        return fail(
+            sema,
+            None,
+            CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "destructor endpoint has no owner".into(),
+            )),
+        );
+    };
+    let Some(owner_symbol) = sema.interner.get(owner_name) else {
+        return fail(
+            sema,
+            None,
+            CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "destructor owner is absent".into(),
+            )),
+        );
+    };
+    let Some(&struct_id) = sema
+        .structs_by_file_name
+        .get(&(FileId::new(endpoint.file), owner_symbol))
+    else {
+        return fail(
+            sema,
+            None,
+            CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "destructor owner is absent".into(),
+            )),
+        );
+    };
+    let Some(record) = sema
+        .declaration_index
+        .destructors()
+        .iter()
+        .find(|record| {
+            record.span.file_id.index() == endpoint.file && record.type_name == owner_symbol
+        })
+        .cloned()
+    else {
+        return fail(
+            sema,
+            None,
+            CompileError::without_span(ErrorKind::UndefinedFunction(format!(
+                "{owner_name}.__drop"
+            ))),
+        );
+    };
+    let owner = sema.body_owner_token(
+        record.span.file_id,
+        owner_name,
+        Some(owner_name),
+        BodyOwnerKind::Destructor,
+    );
+    let previous_body =
+        sema.body_dependency_observer
+            .replace(AnalyzedBodyOwnerEvent::NamedDestructor {
+                token: owner,
+                file: endpoint.file,
+                owner_name: owner_name.to_owned(),
+            });
+    let previous_type = sema.declaration_type_observer.replace((
+        record.span.file_id,
+        owner_name.to_owned(),
+        Some(owner_name.to_owned()),
+        super::DeclarationTypeDependencySourceKind::Destructor,
+        super::DeclarationTypeDependencyKind::Body,
+    ));
+    let result = sema.analyze_destructor_function(
+        infer_ctx,
+        &sema.destructor_symbol(struct_id),
+        record.body,
+        record.span,
+        Type::new_struct(struct_id),
+    );
+    sema.body_dependency_observer = previous_body;
+    sema.declaration_type_observer = previous_type;
+    match result {
+        Ok((mut function, warnings, strings, functions, methods)) => {
+            function.ordinary_owner = Some(owner);
+            finalize_ordinary(
+                sema,
+                owner,
+                sema.rir.get(record.body).span,
+                function,
+                warnings,
+                strings,
+                functions,
+                methods,
+                interruption,
+            )
+        }
+        Err(error) => fail(sema, Some(owner), error),
+    }
+}

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -98,6 +98,32 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         self.export_body(owner, body_span, analyzed, strings, warnings, None)
     }
 
+    /// Test-only exact-body export after generic-call selection has rewritten
+    /// the caller.  Production keeps its established pre-specialization export
+    /// ordering until the compiler body-query cutover.
+    #[cfg(test)]
+    pub(in crate::sema) fn export_one_body_with_specializations(
+        &self,
+        owner: BodyOwnerToken,
+        body_span: Span,
+        analyzed: &AnalyzedFunction,
+        strings: &[String],
+        warnings: &[CompileWarning],
+        specialized_calls: &HashMap<
+            Spur,
+            SemanticSpecializationIdentity<SemanticDefinitionToken, SemanticModuleToken>,
+        >,
+    ) -> Result<SemanticBodyExport, F> {
+        self.export_body(
+            owner,
+            body_span,
+            analyzed,
+            strings,
+            warnings,
+            Some(specialized_calls),
+        )
+    }
+
     fn export_body(
         &self,
         owner: BodyOwnerToken,
@@ -560,7 +586,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         )
     }
 
-    fn body_function_identity(
+    pub(in crate::sema) fn body_function_identity(
         &self,
         symbol: Spur,
     ) -> Result<crate::FunctionInstanceKey<SemanticDefinitionToken, SemanticModuleToken>, F> {

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -4259,4 +4259,946 @@ fn main() -> i32 {
             .is_some()
         );
     }
+
+    fn one_body_fixture(
+        source: &str,
+    ) -> (
+        crate::sema::BoundSema<'static>,
+        Vec<crate::SemanticDefinitionEndpoint>,
+    ) {
+        let (rir, interner) = lower_files(&[(source, FileId::DEFAULT)]);
+        let rir = Box::leak(Box::new(rir));
+        let interner = Box::leak(Box::new(interner));
+        let shells = Sema::new_synthetic(rir, interner, PreviewFeatures::new())
+            .predeclare_declaration_shells_for_test()
+            .unwrap();
+        let records = shells.declaration_shells().cloned().collect::<Vec<_>>();
+        let (definitions, owners) = authoritative_test_endpoints(&records);
+        let initial_definitions = definitions
+            .iter()
+            .filter(|definition| definition.kind != crate::StableDefinitionKind::ValueConst)
+            .cloned()
+            .collect::<Vec<_>>();
+        let resolved = shells
+            .install_stable_identity_endpoints(&initial_definitions, &[])
+            .unwrap()
+            .resolve_declarations()
+            .unwrap();
+        let definitions = resolved
+            .binding_manifest()
+            .bindings()
+            .iter()
+            .enumerate()
+            .map(|(slot, binding)| crate::SemanticDefinitionEndpoint {
+                token: crate::SemanticDefinitionToken::new(91, slot as u32),
+                file: binding.file_id.index(),
+                name: binding.name.clone(),
+                kind: binding.kind,
+                owner: binding.owner.clone(),
+            })
+            .collect::<Vec<_>>();
+        let bound = resolved
+            .install_stable_identity_endpoints(&definitions, &[])
+            .unwrap()
+            .install_body_owner_tokens(&owners)
+            .unwrap();
+        (bound, definitions)
+    }
+
+    fn one_body_two_file_fixture(
+        main: &str,
+        dependency: &str,
+    ) -> (
+        crate::sema::BoundSema<'static>,
+        Vec<crate::SemanticDefinitionEndpoint>,
+    ) {
+        let dependency_file = FileId::new(1);
+        let (rir, interner) =
+            lower_files(&[(main, FileId::DEFAULT), (dependency, dependency_file)]);
+        let import = rir
+            .iter()
+            .find_map(|(_, inst)| {
+                let InstData::Intrinsic { name, args } = &inst.data else {
+                    return None;
+                };
+                (interner.resolve(name) == "import").then_some((inst.span.start, args))
+            })
+            .expect("one-body two-file fixture must import its dependency");
+        let view = TestCanonicalImportView {
+            modules: vec![
+                TestModule {
+                    id: "main.rue".to_owned(),
+                    file_id: FileId::DEFAULT,
+                    path: "/main.rue".to_owned(),
+                },
+                TestModule {
+                    id: "dep.rue".to_owned(),
+                    file_id: dependency_file,
+                    path: "/dependency/dep.rue".to_owned(),
+                },
+            ],
+            sites: vec![TestSite {
+                importer: "main.rue".to_owned(),
+                offset: import.0,
+                specifier: "dep.rue".to_owned(),
+                target: "dep.rue".to_owned(),
+            }],
+        };
+        let rir = Box::leak(Box::new(rir));
+        let interner = Box::leak(Box::new(interner));
+        let mut sema = Sema::new_synthetic(rir, interner, PreviewFeatures::new());
+        sema.set_root_file_id(FileId::DEFAULT);
+        sema.set_file_paths(HashMap::from([
+            (FileId::DEFAULT, "/main.rue".to_owned()),
+            (dependency_file, "/dependency/dep.rue".to_owned()),
+        ]));
+        sema.set_canonical_imports(&view).unwrap();
+        let shells = sema.predeclare_declaration_shells_for_test().unwrap();
+        let records = shells.declaration_shells().cloned().collect::<Vec<_>>();
+        let (definitions, owners) = authoritative_test_endpoints(&records);
+        let initial_definitions = definitions
+            .iter()
+            .filter(|definition| definition.kind != crate::StableDefinitionKind::ValueConst)
+            .cloned()
+            .collect::<Vec<_>>();
+        let modules = [FileId::DEFAULT, dependency_file]
+            .into_iter()
+            .enumerate()
+            .map(|(slot, file)| crate::SemanticModuleEndpoint {
+                token: crate::SemanticModuleToken::new(91, slot as u32),
+                file: file.index(),
+            })
+            .collect::<Vec<_>>();
+        let resolved = shells
+            .install_stable_identity_endpoints(&initial_definitions, &modules)
+            .unwrap()
+            .resolve_declarations()
+            .unwrap();
+        let definitions = resolved
+            .binding_manifest()
+            .bindings()
+            .iter()
+            .enumerate()
+            .map(|(slot, binding)| crate::SemanticDefinitionEndpoint {
+                token: crate::SemanticDefinitionToken::new(91, slot as u32),
+                file: binding.file_id.index(),
+                name: binding.name.clone(),
+                kind: binding.kind,
+                owner: binding.owner.clone(),
+            })
+            .collect::<Vec<_>>();
+        let bound = resolved
+            .install_stable_identity_endpoints(&definitions, &modules)
+            .unwrap()
+            .install_body_owner_tokens(&owners)
+            .unwrap();
+        (bound, definitions)
+    }
+
+    fn endpoint(
+        definitions: &[crate::SemanticDefinitionEndpoint],
+        name: &str,
+        kind: crate::StableDefinitionKind,
+        owner: Option<&str>,
+    ) -> crate::SemanticDefinitionToken {
+        definitions
+            .iter()
+            .find(|endpoint| {
+                endpoint.name.as_ref() == name
+                    && endpoint.kind == kind
+                    && endpoint.owner.as_deref() == owner
+            })
+            .unwrap_or_else(|| panic!("missing endpoint {owner:?}.{name}:{kind:?}"))
+            .token
+    }
+
+    #[test]
+    fn one_body_transaction_covers_free_method_destructor_and_specialization() {
+        use crate::sema::{
+            OneBodyCanonicalArtifact as A, OneBodyRequest as R, OneBodyTransactionOutcome as O,
+        };
+
+        let source = r#"
+            struct Box { value: i32, fn get(borrow self) -> i32 { self.value } }
+            drop fn Box(self) {}
+            fn identity(comptime T: type, value: T) -> T { value }
+            fn helper() -> i32 { 7 }
+            fn main() -> i32 { helper() }
+        "#;
+
+        for (name, kind, owner) in [
+            ("helper", crate::StableDefinitionKind::Function, None),
+            ("get", crate::StableDefinitionKind::Method, Some("Box")),
+            ("Box", crate::StableDefinitionKind::Destructor, Some("Box")),
+        ] {
+            let (bound, definitions) = one_body_fixture(source);
+            let token = endpoint(&definitions, name, kind, owner);
+            let outcome = bound.analyze_one_body_for_test(R::Definition(token), None);
+            assert!(
+                matches!(
+                    &outcome,
+                    O::Success {
+                        artifact: A::Ordinary(_),
+                        ..
+                    }
+                ),
+                "{kind:?} transaction failed: {outcome:?}"
+            );
+            assert!(outcome.artifact_instruction_count().is_some());
+        }
+
+        let (bound, definitions) = one_body_fixture(source);
+        let base = endpoint(
+            &definitions,
+            "identity",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let outcome = bound.analyze_one_body_for_test(
+            R::Specialization {
+                base,
+                type_arguments: vec![Type::I32],
+                value_arguments: Vec::new(),
+            },
+            None,
+        );
+        assert!(
+            matches!(
+                &outcome,
+                O::Success {
+                    artifact: A::Specialization(_),
+                    ..
+                }
+            ),
+            "specialization transaction failed: {outcome:?}"
+        );
+        assert!(outcome.artifact_instruction_count().is_some());
+    }
+
+    #[test]
+    fn one_body_recursion_is_a_reference_not_nested_analysis() {
+        use crate::sema::{
+            OneBodyDependency as D, OneBodyRequest as R, OneBodyTransactionOutcome as O,
+        };
+        let source = r#"
+            fn recurse(n: i32) -> i32 {
+                if n == 0 { 0 } else { recurse(n - 1) }
+            }
+            fn unreachable_bad() -> i32 { missing() }
+            fn main() -> i32 { recurse(2) }
+        "#;
+        let (bound, definitions) = one_body_fixture(source);
+        let recurse = endpoint(
+            &definitions,
+            "recurse",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let outcome = bound.analyze_one_body_for_test(R::Definition(recurse), None);
+        let O::Success { references, .. } = outcome else {
+            panic!("recursive one-body transaction failed: {outcome:?}")
+        };
+        assert_eq!(
+            references
+                .iter()
+                .filter(|reference| matches!(reference, D::Callable(crate::FunctionInstanceKey::Definition(token)) if *token == recurse))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn one_body_generic_call_selects_specialization_without_expanding_its_body() {
+        use crate::sema::{
+            OneBodyDependency as D, OneBodyRequest as R, OneBodyTransactionOutcome as O,
+        };
+        let source = r#"
+            fn generic(comptime T: type, value: T) -> T { missing() }
+            fn caller() -> i32 { generic(i32, 1) }
+            fn main() -> i32 { caller() }
+        "#;
+        let (bound, definitions) = one_body_fixture(source);
+        let caller = endpoint(
+            &definitions,
+            "caller",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let generic = endpoint(
+            &definitions,
+            "generic",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let outcome = bound.analyze_one_body_for_test(R::Definition(caller), None);
+        let O::Success { references, .. } = outcome else {
+            panic!("generic caller transaction expanded its invalid callee: {outcome:?}")
+        };
+        assert!(references.iter().any(|reference| {
+            matches!(reference, D::Callable(crate::FunctionInstanceKey::Specialization { base, .. }) if **base == crate::FunctionInstanceKey::Definition(generic))
+        }));
+    }
+
+    #[test]
+    fn one_body_specialization_excludes_comptime_dead_branch_references() {
+        use crate::sema::{
+            OneBodyDependency as D, OneBodyRequest as R, OneBodyTransactionOutcome as O,
+        };
+        let source = r#"
+            fn live() -> i32 { 1 }
+            fn dead() -> i32 { 2 }
+            fn choose(comptime flag: bool) -> i32 {
+                if flag { live() } else { dead() }
+            }
+            fn main() -> i32 { choose(true) }
+        "#;
+        let (bound, definitions) = one_body_fixture(source);
+        let choose = endpoint(
+            &definitions,
+            "choose",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let live = endpoint(
+            &definitions,
+            "live",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let dead = endpoint(
+            &definitions,
+            "dead",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let outcome = bound.analyze_one_body_for_test(
+            R::Specialization {
+                base: choose,
+                type_arguments: Vec::new(),
+                value_arguments: vec![crate::sema::ConstValue::Bool(true)],
+            },
+            None,
+        );
+        let O::Success { references, .. } = outcome else {
+            panic!("comptime-selected specialization failed: {outcome:?}")
+        };
+        assert!(references.contains(&D::Callable(crate::FunctionInstanceKey::Definition(live))));
+        assert!(!references.contains(&D::Callable(crate::FunctionInstanceKey::Definition(dead))));
+    }
+
+    #[test]
+    fn failed_one_body_keeps_later_positive_refs_without_inventing_edges() {
+        use crate::sema::{
+            OneBodyDependency as D, OneBodyRequest as R, OneBodyTransactionOutcome as O,
+        };
+        let source = r#"
+            struct Box {
+                value: i32,
+                fn get(borrow self) -> i32 { self.value }
+            }
+            drop fn Box(self) {}
+            fn good() -> i32 { 1 }
+            fn bad() -> i32 {
+                missing();
+                good();
+                let b = Box { value: 2 };
+                let result = b.get();
+                @drop(b);
+                result
+            }
+            fn main() -> i32 { 0 }
+        "#;
+        let (bound, definitions) = one_body_fixture(source);
+        let good = endpoint(
+            &definitions,
+            "good",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let bad = endpoint(
+            &definitions,
+            "bad",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let get = endpoint(
+            &definitions,
+            "get",
+            crate::StableDefinitionKind::Method,
+            Some("Box"),
+        );
+        let box_type = endpoint(
+            &definitions,
+            "Box",
+            crate::StableDefinitionKind::Struct,
+            None,
+        );
+        let outcome = bound.analyze_one_body_for_test(R::Definition(bad), None);
+        let O::DeterministicFailure { errors, references } = outcome else {
+            panic!("bad body did not publish a deterministic failure: {outcome:?}")
+        };
+        assert!(!errors.is_empty());
+        assert_eq!(
+            references.len(),
+            3,
+            "unexpected recovered references: {references:?}"
+        );
+        for expected in [good, get] {
+            assert!(
+                references.contains(&D::Callable(crate::FunctionInstanceKey::Definition(
+                    expected
+                )))
+            );
+        }
+        assert!(
+            references.contains(&D::Type(crate::TypeInstanceKey::Nominal(
+                crate::NominalInstanceKey::Named(box_type)
+            )))
+        );
+    }
+
+    #[test]
+    fn failed_one_body_inference_keeps_later_sibling_callable_and_type_refs() {
+        use crate::sema::{
+            OneBodyDependency as D, OneBodyRequest as R, OneBodyTransactionOutcome as O,
+        };
+        let source = r#"
+            struct Box { value: i32 }
+            fn generic(comptime T: type, value: T) -> T { value }
+            fn after() -> i32 { 1 }
+            fn sibling() -> i32 { 2 }
+            fn bad(flag: bool) -> i32 {
+                let wrong: bool = 1;
+                let boxed = Box { value: 3 };
+                generic(i32, 4);
+                after();
+                if flag { 0 } else { sibling() }
+            }
+            fn main() -> i32 { 0 }
+        "#;
+        let (bound, definitions) = one_body_fixture(source);
+        let bad = endpoint(
+            &definitions,
+            "bad",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let expected_callables = ["after", "sibling"].map(|name| {
+            endpoint(
+                &definitions,
+                name,
+                crate::StableDefinitionKind::Function,
+                None,
+            )
+        });
+        let box_type = endpoint(
+            &definitions,
+            "Box",
+            crate::StableDefinitionKind::Struct,
+            None,
+        );
+        let generic = endpoint(
+            &definitions,
+            "generic",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let outcome = bound.analyze_one_body_for_test(R::Definition(bad), None);
+        let O::DeterministicFailure { references, .. } = outcome else {
+            panic!("inference failure did not publish a deterministic terminal: {outcome:?}")
+        };
+        assert_eq!(
+            references.len(),
+            expected_callables.len() + 2,
+            "{references:?}"
+        );
+        for expected in expected_callables {
+            assert!(
+                references.contains(&D::Callable(crate::FunctionInstanceKey::Definition(
+                    expected
+                )))
+            );
+        }
+        assert!(
+            references.contains(&D::Type(crate::TypeInstanceKey::Nominal(
+                crate::NominalInstanceKey::Named(box_type)
+            )))
+        );
+        assert!(references.iter().any(|reference| {
+            matches!(reference, D::Callable(crate::FunctionInstanceKey::Specialization { base, .. }) if **base == crate::FunctionInstanceKey::Definition(generic))
+        }));
+    }
+
+    #[test]
+    fn failed_one_body_inference_with_unresolved_generic_identity_is_non_terminal() {
+        use crate::sema::{OneBodyRequest as R, OneBodyTransactionOutcome as O};
+        let source = r#"
+            fn generic(comptime T: type, value: T) -> T { value }
+            fn bad() -> i32 {
+                let wrong: bool = 1;
+                generic(missing_type(), 1)
+            }
+            fn main() -> i32 { 0 }
+        "#;
+        let (bound, definitions) = one_body_fixture(source);
+        let bad = endpoint(
+            &definitions,
+            "bad",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let outcome = bound.analyze_one_body_for_test(R::Definition(bad), None);
+        assert!(matches!(outcome, O::NonTerminal { .. }), "{outcome:?}");
+        assert_eq!(outcome.references(), None);
+    }
+
+    #[test]
+    fn failed_one_body_keeps_selected_specialization_reference() {
+        use crate::sema::{
+            OneBodyDependency as D, OneBodyRequest as R, OneBodyTransactionOutcome as O,
+        };
+        let source = r#"
+            fn generic(comptime T: type, value: T) -> T { value }
+            fn bad() -> i32 { missing(); generic(i32, 1) }
+            fn main() -> i32 { 0 }
+        "#;
+        let (bound, definitions) = one_body_fixture(source);
+        let generic = endpoint(
+            &definitions,
+            "generic",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let bad = endpoint(
+            &definitions,
+            "bad",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let outcome = bound.analyze_one_body_for_test(R::Definition(bad), None);
+        let O::DeterministicFailure { references, .. } = outcome else {
+            panic!("bad generic caller was not deterministic: {outcome:?}")
+        };
+        assert!(references.iter().any(|reference| {
+            matches!(reference, D::Callable(crate::FunctionInstanceKey::Specialization { base, .. }) if **base == crate::FunctionInstanceKey::Definition(generic))
+        }));
+        assert!(!references.iter().any(|reference| {
+            matches!(reference, D::Callable(crate::FunctionInstanceKey::Definition(token)) if *token == generic)
+        }));
+    }
+
+    #[test]
+    fn failed_one_body_keeps_later_module_binding_and_qualified_callable() {
+        use crate::sema::{
+            OneBodyDependency as D, OneBodyRequest as R, OneBodyTransactionOutcome as O,
+        };
+        let (bound, definitions) = one_body_two_file_fixture(
+            r#"
+                const dep = @import("dep.rue");
+                fn bad() -> i32 { missing(); dep.good() }
+                fn main() -> i32 { 0 }
+            "#,
+            "pub fn good() -> i32 { 1 }",
+        );
+        let bad = endpoint(
+            &definitions,
+            "bad",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let module = endpoint(
+            &definitions,
+            "dep",
+            crate::StableDefinitionKind::ModuleBinding,
+            None,
+        );
+        let good = definitions
+            .iter()
+            .find(|definition| {
+                definition.file == 1
+                    && definition.name.as_ref() == "good"
+                    && definition.kind == crate::StableDefinitionKind::Function
+            })
+            .expect("dependency function endpoint")
+            .token;
+        let outcome = bound.analyze_one_body_for_test(R::Definition(bad), None);
+        let O::DeterministicFailure { references, .. } = outcome else {
+            panic!("bad qualified caller was not deterministic: {outcome:?}")
+        };
+        assert!(references.contains(&D::Definition(module)));
+        assert!(references.contains(&D::Callable(crate::FunctionInstanceKey::Definition(good))));
+    }
+
+    #[test]
+    fn failed_one_body_inference_keeps_unqualified_and_qualified_value_constants() {
+        use crate::sema::{
+            OneBodyDependency as D, OneBodyRequest as R, OneBodyTransactionOutcome as O,
+        };
+        let source = r#"
+            const N: i32 = 1;
+            fn bad() -> i32 { let wrong: bool = 1; N }
+            fn main() -> i32 { 0 }
+        "#;
+        let (bound, definitions) = one_body_fixture(source);
+        let bad = endpoint(
+            &definitions,
+            "bad",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let n = endpoint(
+            &definitions,
+            "N",
+            crate::StableDefinitionKind::ValueConst,
+            None,
+        );
+        let outcome = bound.analyze_one_body_for_test(R::Definition(bad), None);
+        let O::DeterministicFailure { references, .. } = outcome else {
+            panic!("constant inference failure was not deterministic: {outcome:?}")
+        };
+        assert!(references.contains(&D::Definition(n)), "{references:?}");
+
+        let (bound, definitions) = one_body_two_file_fixture(
+            r#"
+                const dep = @import("dep.rue");
+                fn bad() -> i32 { let wrong: bool = 1; dep.N }
+                fn main() -> i32 { 0 }
+            "#,
+            "pub const N: i32 = 1;",
+        );
+        let bad = endpoint(
+            &definitions,
+            "bad",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let module = endpoint(
+            &definitions,
+            "dep",
+            crate::StableDefinitionKind::ModuleBinding,
+            None,
+        );
+        let n = definitions
+            .iter()
+            .find(|definition| {
+                definition.file == 1
+                    && definition.name.as_ref() == "N"
+                    && definition.kind == crate::StableDefinitionKind::ValueConst
+            })
+            .expect("qualified constant endpoint")
+            .token;
+        let outcome = bound.analyze_one_body_for_test(R::Definition(bad), None);
+        let O::DeterministicFailure { references, .. } = outcome else {
+            panic!("qualified constant inference failure was not deterministic: {outcome:?}")
+        };
+        assert!(
+            references.contains(&D::Definition(module)),
+            "{references:?}"
+        );
+        assert!(references.contains(&D::Definition(n)), "{references:?}");
+    }
+
+    #[test]
+    fn failed_one_body_inference_keeps_unqualified_and_qualified_callable_aliases() {
+        use crate::sema::{
+            OneBodyDependency as D, OneBodyRequest as R, OneBodyTransactionOutcome as O,
+        };
+        let source = r#"
+            fn helper() -> i32 { 1 }
+            const alias = helper;
+            fn bad() -> i32 { let wrong: bool = 1; alias() }
+            fn main() -> i32 { 0 }
+        "#;
+        let (bound, definitions) = one_body_fixture(source);
+        let bad = endpoint(
+            &definitions,
+            "bad",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let helper = endpoint(
+            &definitions,
+            "helper",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let alias = endpoint(
+            &definitions,
+            "alias",
+            crate::StableDefinitionKind::ValueConst,
+            None,
+        );
+        let outcome = bound.analyze_one_body_for_test(R::Definition(bad), None);
+        let O::DeterministicFailure { references, .. } = outcome else {
+            panic!("callable-alias inference failure was not deterministic: {outcome:?}")
+        };
+        assert!(references.contains(&D::Definition(alias)), "{references:?}");
+        assert!(references.contains(&D::Callable(crate::FunctionInstanceKey::Definition(helper))));
+
+        let (bound, definitions) = one_body_two_file_fixture(
+            r#"
+                const dep = @import("dep.rue");
+                fn bad() -> i32 { let wrong: bool = 1; dep.alias() }
+                fn main() -> i32 { 0 }
+            "#,
+            "fn helper() -> i32 { 1 } pub const alias = helper;",
+        );
+        let bad = endpoint(
+            &definitions,
+            "bad",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let module = endpoint(
+            &definitions,
+            "dep",
+            crate::StableDefinitionKind::ModuleBinding,
+            None,
+        );
+        let helper = endpoint(
+            &definitions,
+            "helper",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let alias = endpoint(
+            &definitions,
+            "alias",
+            crate::StableDefinitionKind::ValueConst,
+            None,
+        );
+        let outcome = bound.analyze_one_body_for_test(R::Definition(bad), None);
+        let O::DeterministicFailure { references, .. } = outcome else {
+            panic!("qualified callable-alias failure was not deterministic: {outcome:?}")
+        };
+        assert!(
+            references.contains(&D::Definition(module)),
+            "{references:?}"
+        );
+        assert!(references.contains(&D::Definition(alias)), "{references:?}");
+        assert!(references.contains(&D::Callable(crate::FunctionInstanceKey::Definition(helper))));
+    }
+
+    #[test]
+    fn rejected_one_body_callable_forms_publish_no_callable_edge() {
+        use crate::sema::{OneBodyDependency as D, OneBodyRequest as R};
+
+        let (bound, definitions) = one_body_two_file_fixture(
+            r#"
+                const dep = @import("dep.rue");
+                fn bad() -> i32 { dep.secret() }
+                fn main() -> i32 { 0 }
+            "#,
+            "fn secret() -> i32 { 1 }",
+        );
+        let bad = endpoint(
+            &definitions,
+            "bad",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let outcome = bound.analyze_one_body_for_test(R::Definition(bad), None);
+        let references = outcome.references().expect("privacy is deterministic");
+        assert!(
+            !references
+                .iter()
+                .any(|reference| matches!(reference, D::Callable(_))),
+            "private member invented a callable edge: {references:?}"
+        );
+
+        let source = r#"
+            struct S {
+                fn associated() -> i32 { 1 }
+                fn method(borrow self) -> i32 { 2 }
+            }
+            fn bad() -> i32 {
+                let s = S {};
+                s.associated();
+                S.method()
+            }
+            fn main() -> i32 { 0 }
+        "#;
+        let (bound, definitions) = one_body_fixture(source);
+        let bad = endpoint(
+            &definitions,
+            "bad",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let associated = endpoint(
+            &definitions,
+            "associated",
+            crate::StableDefinitionKind::AssociatedFunction,
+            Some("S"),
+        );
+        let method = endpoint(
+            &definitions,
+            "method",
+            crate::StableDefinitionKind::Method,
+            Some("S"),
+        );
+        let outcome = bound.analyze_one_body_for_test(R::Definition(bad), None);
+        let references = outcome
+            .references()
+            .expect("wrong call forms are deterministic");
+        for rejected in [associated, method] {
+            assert!(
+                !references.contains(&D::Callable(crate::FunctionInstanceKey::Definition(
+                    rejected
+                ))),
+                "wrong call form invented an edge: {references:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unmappable_one_body_references_are_non_terminal_without_partial_edges() {
+        use crate::sema::{OneBodyRequest as R, OneBodyTransactionOutcome as O};
+        let source = r#"
+            struct Box {
+                value: i32,
+                fn get(borrow self) -> i32 { self.value }
+            }
+            fn generic(comptime T: type, value: T) -> T { value }
+            fn good() -> i32 { 1 }
+            fn bad() -> i32 {
+                missing();
+                good();
+                let b = Box { value: 2 };
+                b.get();
+                generic(i32, 3)
+            }
+            fn main() -> i32 { 0 }
+        "#;
+        for (name, kind, owner) in [
+            ("good", crate::StableDefinitionKind::Function, None),
+            ("get", crate::StableDefinitionKind::Method, Some("Box")),
+            ("Box", crate::StableDefinitionKind::Struct, None),
+            ("generic", crate::StableDefinitionKind::Function, None),
+        ] {
+            let (bound, definitions) = one_body_fixture(source);
+            let bad = endpoint(
+                &definitions,
+                "bad",
+                crate::StableDefinitionKind::Function,
+                None,
+            );
+            let missing = endpoint(&definitions, name, kind, owner);
+            let outcome = bound
+                .remove_stable_definition_for_test(missing)
+                .analyze_one_body_for_test(R::Definition(bad), None);
+            assert!(
+                matches!(outcome, O::NonTerminal { .. }),
+                "{name}: {outcome:?}"
+            );
+            assert_eq!(
+                outcome.references(),
+                None,
+                "{name}: partial references leaked"
+            );
+        }
+
+        for (name, kind, owner) in [
+            ("good", crate::StableDefinitionKind::Function, None),
+            ("get", crate::StableDefinitionKind::Method, Some("Box")),
+            ("Box", crate::StableDefinitionKind::Struct, None),
+            ("generic", crate::StableDefinitionKind::Function, None),
+        ] {
+            let (bound, definitions) = one_body_fixture(source);
+            let bad = endpoint(
+                &definitions,
+                "bad",
+                crate::StableDefinitionKind::Function,
+                None,
+            );
+            let foreign = endpoint(&definitions, name, kind, owner);
+            let outcome = bound
+                .reissue_stable_definition_for_test(foreign, 92)
+                .analyze_one_body_for_test(R::Definition(bad), None);
+            assert!(
+                matches!(outcome, O::NonTerminal { .. }),
+                "{name}: {outcome:?}"
+            );
+            assert_eq!(
+                outcome.references(),
+                None,
+                "{name}: foreign issuer leaked partial refs"
+            );
+        }
+    }
+
+    #[test]
+    fn interrupted_and_incomplete_one_body_transactions_publish_no_references() {
+        use crate::sema::{
+            OneBodyInterruption as I, OneBodyNonTerminalReason as N, OneBodyRequest as R,
+            OneBodyTransactionOutcome as O,
+        };
+        let source = r#"
+            fn callee() -> i32 { 1 }
+            fn caller() -> i32 { callee() }
+            fn bad() -> i32 { missing() }
+            fn generic(comptime T: type, value: T) -> T { missing() }
+            fn warned() -> i32 { let unused = 1; 0 }
+            fn main() -> i32 { 0 }
+        "#;
+        for interruption in [I::Canceled, I::EngineAbort] {
+            for scenario in 0..4 {
+                let (bound, definitions) = one_body_fixture(source);
+                let request = match scenario {
+                    0 => R::Definition(endpoint(
+                        &definitions,
+                        "bad",
+                        crate::StableDefinitionKind::Function,
+                        None,
+                    )),
+                    1 => R::Definition(crate::SemanticDefinitionToken::new(91, u32::MAX)),
+                    2 => R::Specialization {
+                        base: endpoint(
+                            &definitions,
+                            "generic",
+                            crate::StableDefinitionKind::Function,
+                            None,
+                        ),
+                        type_arguments: vec![Type::I32],
+                        value_arguments: Vec::new(),
+                    },
+                    _ => R::Specialization {
+                        base: crate::SemanticDefinitionToken::new(91, u32::MAX),
+                        type_arguments: vec![Type::I32],
+                        value_arguments: Vec::new(),
+                    },
+                };
+                let outcome = bound.analyze_one_body_for_test(request, Some(interruption));
+                assert_eq!(outcome.references(), None);
+                assert!(matches!(
+                    (&outcome, interruption),
+                    (
+                        O::NonTerminal {
+                            reason: N::Canceled
+                        },
+                        I::Canceled
+                    ) | (
+                        O::NonTerminal {
+                            reason: N::EngineAbort
+                        },
+                        I::EngineAbort
+                    )
+                ));
+            }
+        }
+        let (bound, definitions) = one_body_fixture(source);
+        let warned = endpoint(
+            &definitions,
+            "warned",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let outcome = bound.analyze_one_body_for_test(R::Definition(warned), None);
+        assert_eq!(
+            outcome.references(),
+            None,
+            "typed incompleteness leaked refs"
+        );
+        assert!(outcome.non_terminal_reason().is_some());
+    }
 }

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -611,6 +611,130 @@ fn rewrite_call_generic(
     }
 }
 
+/// Select and rewrite the concrete generic calls in one completed body without
+/// expanding any selected specialization body.
+///
+/// This is the extraction seam for the test-only one-body transaction work in
+/// RUE-1084.  The production fixed-point driver deliberately continues to own
+/// its existing expansion policy until the compiler query cutover.  Keeping
+/// selection here ensures the transaction does not guess specialization edges
+/// by rescanning RIR syntax.
+#[cfg(test)]
+pub(crate) fn select_one_body_specializations(
+    sema: &crate::sema::BodySema<'_>,
+    mut function: AnalyzedFunction,
+) -> CompileResult<(
+    AnalyzedFunction,
+    Vec<(
+        Spur,
+        crate::SemanticSpecializationIdentity<
+            crate::SemanticDefinitionToken,
+            crate::SemanticModuleToken,
+        >,
+    )>,
+)> {
+    let mut specializations = HashMap::new();
+    let mut pending = Vec::new();
+    let mut work = crate::BodyAnalysisWork::default();
+    if collect_specializations(
+        &function.air,
+        sema.interner,
+        &mut specializations,
+        &mut pending,
+        &mut work,
+    ) {
+        let mut editor = function.air.into_editor();
+        rewrite_call_generic(&mut editor, &specializations, &mut work);
+        function.air = editor.finish(crate::AirValidationContext::SemanticWithSymbols(
+            &sema.type_pool,
+            sema.interner,
+        ))?;
+    }
+    let mut selected = pending
+        .iter()
+        .map(|key| {
+            Ok((
+                specializations[key].mangled_name,
+                Specializer::stable_identity(key, sema).map_err(|failure| {
+                    CompileError::new(
+                        ErrorKind::InternalError(format!(
+                            "failed to select a canonical specialization reference: {failure:?}"
+                        )),
+                        specializations[key].call_site_span,
+                    )
+                })?,
+            ))
+        })
+        .collect::<CompileResult<Vec<_>>>()?;
+    selected.sort_by(|left, right| left.1.cmp(&right.1));
+    selected.dedup_by(|left, right| left.1 == right.1);
+    Ok((function, selected))
+}
+
+#[cfg(test)]
+pub(crate) struct OneSpecializedBody {
+    pub(crate) key: SpecializationKey,
+    pub(crate) function: AnalyzedFunction,
+    pub(crate) warnings: Vec<CompileWarning>,
+    pub(crate) local_strings: Vec<String>,
+    pub(crate) referenced_functions: HashSet<Spur>,
+    pub(crate) referenced_methods: HashSet<(StructId, Spur)>,
+    pub(crate) dependencies: Vec<crate::SemanticDefinitionToken>,
+    pub(crate) dependency_boundary_complete: bool,
+    pub(crate) identity: crate::SemanticSpecializationIdentity<
+        crate::SemanticDefinitionToken,
+        crate::SemanticModuleToken,
+    >,
+}
+
+/// Analyze exactly one concrete specialization.  No call-site scan or
+/// specialization fixed point is performed here; the caller supplies the
+/// already-selected local key and receives references for later scheduling.
+#[cfg(test)]
+pub(crate) fn analyze_one_specialization(
+    sema: &mut crate::sema::BodySema<'_>,
+    infer_ctx: &InferenceContext,
+    key: SpecializationKey,
+) -> CompileResult<OneSpecializedBody> {
+    let base_info = sema.function_info(key.base_name).cloned().ok_or_else(|| {
+        CompileError::without_span(ErrorKind::UndefinedFunction(
+            sema.interner.resolve(&key.base_name).to_owned(),
+        ))
+    })?;
+    let specialized_name = sema.interner.get_or_intern(&mangle_specialized_name(
+        sema.interner.resolve(&key.base_name),
+        &key.type_args,
+        &key.value_args,
+    ));
+    let identity = Specializer::stable_identity(&key, sema).map_err(|failure| {
+        CompileError::new(
+            ErrorKind::InternalError(format!(
+                "failed to issue one-body specialization identity: {failure:?}"
+            )),
+            base_info.span,
+        )
+    })?;
+    let body = create_specialized_function(
+        sema,
+        infer_ctx,
+        &key,
+        specialized_name,
+        &base_info,
+        sema.interner,
+    )?;
+    Ok(OneSpecializedBody {
+        key,
+        function: body.function,
+        warnings: body.warnings,
+        local_strings: body.local_strings,
+        referenced_functions: body.referenced_functions,
+        referenced_methods: body.referenced_methods,
+        dependencies: body.dependencies,
+        dependency_boundary_complete: body.dependency_boundary_complete,
+        identity,
+    })
+}
+
 /// Separator between mangled segments in a specialized symbol name.
 ///
 /// A `.` is deliberately *illegal* in a Rue identifier (which is


### PR DESCRIPTION
## Summary

- extract a test-only exact-one-body AIR transaction for ordinary functions, methods, destructors, and specializations
- retain sorted, fail-closed semantic dependency references across deterministic failures while withholding terminals for cancellation, engine abort, and typed incompleteness
- separate generic-call selection from specialization expansion and add repository-wide production-authority inventory coverage

This is the non-production prerequisite for the atomic RUE-1027 body-query cutover. The existing whole-program body driver remains the sole production authority in this change.

## Validation

- focused one-body tests: 15/15
- rue-air unit tests: 574/574
- `scripts/rue quick`: 35 targets
- full suite: CLI 1705 passed / 11 ignored, Caldera, oracle 64/64, reproducibility, spec 2153 passed / 18 ignored, UI 204/204
- independent adversarial review: accepted after three rounds

Fixes RUE-1084