### PR TITLE
RUE-1010: materialize StrBuf as real memory in the oracle; close the text-gap ledger

### DIFF
--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -2,8 +2,8 @@
 
 use super::{InventoryScope, ModelGapAudit, ModelGapRegistration};
 use rue_oracle::{
-    ExternalDependencyKind, ImplementationDefinedKind, ModelGapKind, SemanticGapKind,
-    UnsupportedIntrinsicKind, UnsupportedRuntimeCallKind,
+    ExternalDependencyKind, ModelGapKind, SemanticGapKind, UnsupportedIntrinsicKind,
+    UnsupportedRuntimeCallKind,
 };
 use std::fmt;
 
@@ -72,39 +72,9 @@ impl Entry {
 /// values moved, which the RUE-987 sweep re-verified.
 const ENTRIES: &[Entry] = &[
     Entry::new(
-        "cli.abi",
-        "string_return_by_value",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.abi",
-        "string_return_with_args",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.aggregate_slots",
-        "dbg_string_from_field",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.aggregate_slots",
-        "store_string_from_field",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.aggregate_slots",
-        "string_array_pass_by_value",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
         "cli.arraybuf_library",
         "arraybuf_strbuf_elements",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
@@ -114,87 +84,21 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
-        "cli.borrow_sibling_moves",
-        "byref_method_receiver_stays_usable_control",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.builtin_method_infer",
-        "capacity_compare_literal_compiles",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
-        &[],
-    ),
-    Entry::new(
-        "cli.byref_params",
-        "inout_whole_string_reassign",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
         "cli.const_init",
         "string_const_prints_and_measures",
         runtime_call(UnsupportedRuntimeCallKind::Println),
         &[],
     ),
     Entry::new(
-        "cli.differential_opt",
-        "fixed_string_inout_forwarding_and_projected_lvalues_across_opt_levels",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.divergence",
-        "break_mid_block_no_double_drop",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.divergence",
-        "return_mid_block_in_untaken_branch",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
         "cli.enum_payloads",
         "returned_nested_json_drops_safely",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.field_type_inference",
-        "string_field_method_receiver_anchors_literal",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.for_loops",
-        "for_chars_invalid_utf8_traps",
-        semantic(SemanticGapKind::TextProjectionRead),
+        runtime_call(UnsupportedRuntimeCallKind::Println),
         &[],
     ),
     Entry::new(
         "cli.for_loops",
         "for_chars_lossy_replaces_raw_invalid_bytes",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
-        &[],
-    ),
-    Entry::new(
-        "cli.for_loops",
-        "for_chars_lossy_valid_dbg",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.for_loops",
-        "for_chars_scalars_dbg",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.for_loops",
-        "for_string_bytes_dbg",
-        semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
     // std.fs File IO v0 (RUE-712, ADR-0057): pure-Rue fs over @syscall. The
@@ -206,55 +110,55 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.fs_file_io",
         "fs_roundtrip",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_append",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_drop_close_reopen",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_close_then_reopen_safe",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_read_full_buffer_invalid",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_read_whole_file_loop",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_reserve_then_read_fills",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_open_missing_not_found",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_write_to_readonly",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     // std.fs v1 follow-ups (ADR-0057 "Future Work"): seek/tell, fstat/newfstatat
@@ -266,50 +170,44 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.fs_file_io",
         "fs_seek_set_read_back",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &["aarch64-linux", "x86-64-linux"],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_seek_cur_end_relative",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &["aarch64-linux", "x86-64-linux"],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_stat_size_and_is_file",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &["aarch64-linux", "x86-64-linux"],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_metadata_by_path_size",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &["aarch64-linux", "x86-64-linux"],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_rename_old_gone_new_present",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &["aarch64-linux", "x86-64-linux"],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_remove_file_then_open_notfound",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &["aarch64-linux", "x86-64-linux"],
     ),
     Entry::new(
         "cli.fs_file_io",
         "fs_mkdir_stat_is_dir_then_rmdir",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &["aarch64-linux", "x86-64-linux"],
-    ),
-    Entry::new(
-        "cli.ice_regressions",
-        "struct_field_string_eq_rue94",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
     ),
     // ADR-0052 phase 3 (RUE-974): the compact-layout CLI cases reach a field
     // through `@field_ptr`, which the oracle model does not model (same gap as
@@ -358,18 +256,6 @@ const ENTRIES: &[Entry] = &[
     // RUE-978: the byte-surface behavior cases allocate through @alloc_bytes,
     // which the oracle model does not model.
     Entry::new(
-        "cli.partial_move_depth",
-        "disjoint_sibling_after_subfield_move_ok",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.partial_move_depth",
-        "disjoint_sibling_element_move_ok",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
         "cli.pointers",
         "ptr_offset_forward_on_mmap_pointer",
         external(ExternalDependencyKind::SystemCall),
@@ -378,7 +264,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.print",
         "print_borrows_string_reusable_after_call",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
@@ -408,31 +294,31 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.print",
         "println_composed_with_to_string_and_concat",
-        semantic(SemanticGapKind::TextProjectionRead),
+        runtime_call(UnsupportedRuntimeCallKind::Println),
         &[],
     ),
     Entry::new(
         "cli.programs",
         "dbg_string_then_use",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.programs",
         "string_builder_push_str",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.raw_ptr_and_method_name",
         "string_push_str_on_mut_ok",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.reserved_names",
         "builtin_method_name_allowed",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
@@ -496,12 +382,6 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
-        "cli.std_byte_bridges",
-        "all_three_representations_round_trip_without_consuming_sources",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
         "cli.std_m3",
         "std_sort_m3",
         intrinsic(UnsupportedIntrinsicKind::ByteRead),
@@ -510,19 +390,13 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.std_m3",
         "std_strbuf_chars_share_core_decoder",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_m3",
-        "std_strbuf_chars_strict_invalid_utf8_traps",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.std_m3",
         "std_strbuf_compiler_cutover",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
@@ -540,7 +414,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.std_m3",
         "std_strings_m3",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
@@ -557,152 +431,38 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "cli.std_strbuf",
-        "canonical_identity_drives_string_semantics",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_strbuf",
-        "generic_inout_accepts_literal_initialized_strbuf",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_strbuf",
         "mem_swap_exchanges_move_only_strbufs",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.std_strbuf",
-        "source_byte_range_out_of_bounds",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_strbuf",
-        "source_literal_promotion_self_append_and_adjacent_bytes",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_strbuf",
         "source_owned_algorithms_use_packed_bytes",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.std_strbuf",
-        "source_zero_capacity_empty_ranges_and_early_free",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.std_strmap",
         "std_strmap_smoke",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.str_fixed_type",
-        "str_fixed_exact_borrow_is_by_reference",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.str_fixed_type",
-        "str_fixed_exact_inout_is_by_reference",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.str_fixed_type",
-        "str_fixed_len_and_first_byte",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.str_fixed_type",
-        "str_fixed_len_independent_of_capacity",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.str_fixed_type",
-        "str_fixed_packed_byte_indexing",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.str_fixed_type",
-        "str_fixed_param_roundtrip",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.str_type",
-        "str_preserves_explicit_strbuf_literal_context",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.str_type",
-        "strbuf_field_borrow_str_view",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.str_type",
-        "strbuf_read_through_borrow_str_view_values",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.strbuf_library",
         "strbuf_new_push_str_len_print",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.strbuf_library",
         "strbuf_with_capacity_concat",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.string_byte_access",
-        "borrow_rooted_strbuf_byte_reads",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.string_byte_access",
-        "substring_byte_range",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.string_byte_access",
-        "substring_out_of_range_traps",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.string_byte_access",
-        "substring_result_is_mutable",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.string_growth",
-        "growth_does_not_corrupt_neighbor",
-        semantic(SemanticGapKind::TextProjectionRead),
+        runtime_call(UnsupportedRuntimeCallKind::Println),
         &[],
     ),
     Entry::new(
         "cli.string_growth",
         "interleaved_repeated_growth_stress",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
@@ -720,73 +480,49 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.string_mutation_receivers",
         "field_receiver_push_str",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.string_mutation_receivers",
         "inout_param_receiver_push_str",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.string_mutation_receivers",
         "self_field_receiver_via_method",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.string_mutation_value_position",
         "statement_position_mutation_still_runs",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.string_phase1",
-        "concat_chained_and_mutable_result",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.string_phase1",
-        "concat_is_concatenation_not_addition",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.string_phase1",
-        "contains_and_starts_with",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.string_phase1",
         "to_string_all_integer_widths",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "cli.string_phase1",
-        "to_string_demo",
-        semantic(SemanticGapKind::TextProjectionRead),
+        runtime_call(UnsupportedRuntimeCallKind::Println),
         &[],
     ),
     Entry::new(
         "cli.string_phase1",
         "to_string_i32_no_cast_needed",
-        semantic(SemanticGapKind::TextProjectionRead),
+        runtime_call(UnsupportedRuntimeCallKind::Println),
         &[],
     ),
     Entry::new(
         "cli.try_operator",
         "try_string_payload",
-        semantic(SemanticGapKind::TextProjectionRead),
+        runtime_call(UnsupportedRuntimeCallKind::Println),
         &[],
     ),
     Entry::new(
         "cli.try_operator",
         "try_unwrap_and_short_circuit",
-        semantic(SemanticGapKind::TextProjectionRead),
+        runtime_call(UnsupportedRuntimeCallKind::Println),
         &[],
     ),
     Entry::new(
@@ -798,43 +534,25 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.wildcard_payload_binding",
         "discarded_non_copy_payload_drops_once",
-        semantic(SemanticGapKind::TextProjectionRead),
+        runtime_call(UnsupportedRuntimeCallKind::Println),
         &[],
     ),
     Entry::new(
         "cli.zst_drop_glue",
         "enum_payload_fields_keep_drop_offsets",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.zst_drop_glue",
         "nested_struct_array_keeps_drop_offsets_and_stride",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "cli.zst_drop_glue",
         "struct_fields_keep_drop_offsets",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "string_field",
-        "string_field_rebound_then_eq",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "string_field",
-        "string_struct_field_eq_false",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "string_field",
-        "string_struct_field_eq_true",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
 ];
@@ -904,16 +622,8 @@ const fn runtime_call(kind: UnsupportedRuntimeCallKind) -> ModelGapKind {
     ModelGapKind::Semantic(SemanticGapKind::RuntimeCall(kind))
 }
 
-const fn semantic(kind: SemanticGapKind) -> ModelGapKind {
-    ModelGapKind::Semantic(kind)
-}
-
 const fn external(kind: ExternalDependencyKind) -> ModelGapKind {
     ModelGapKind::ExternalDependency(kind)
-}
-
-const fn implementation_defined(kind: ImplementationDefinedKind) -> ModelGapKind {
-    ModelGapKind::ImplementationDefined(kind)
 }
 
 #[cfg(test)]

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -2,8 +2,8 @@
 
 use super::{InventoryScope, ModelGapAudit, ModelGapRegistration};
 use rue_oracle::{
-    ExternalDependencyKind, ImplementationDefinedKind, ModelGapKind, SemanticGapKind,
-    UnsupportedIntrinsicKind, UnsupportedRuntimeCallKind,
+    ExternalDependencyKind, ModelGapKind, SemanticGapKind, UnsupportedIntrinsicKind,
+    UnsupportedRuntimeCallKind,
 };
 use std::fmt;
 
@@ -68,123 +68,51 @@ const ENTRIES: &[Entry] = &[
     // Source-defined StrBuf methods expose their first unmodeled ordinary
     // projection, allocation, pointer, or inout operation to the oracle.
     Entry::new(
-        "expressions.for",
-        "for_chars_lossy_valid",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "expressions.for",
-        "for_chars_scalars",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "expressions.for",
-        "for_string_borrows_not_consumes",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "expressions.for",
-        "for_string_bytes_count",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "expressions.for",
-        "for_string_bytes_multibyte",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
         "expressions.intrinsics",
         "dbg_string_borrows_not_consumed",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "expressions.intrinsics",
         "dbg_string_dropped_exactly_once",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "items.general",
         "fn_builtin_method_name_allowed",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "types.destructors",
         "codegen_nontrivial_drop_call",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "types.destructors",
         "struct_with_destructor_field",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "types.destructors",
         "struct_with_string_fields_dropped",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "types.destructors",
         "type_with_destructor",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.destructors",
-        "type_with_destructor_literal_promoted",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.move-semantics",
-        "borrow_method_receiver_still_usable_after",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "types.mutable_strings",
         "string_building_message",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_byte_at_empty_none",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_byte_at_in_bounds",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_byte_at_last_byte_boundary",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_byte_at_loop_sum",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_byte_at_out_of_bounds_none",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
@@ -195,152 +123,26 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "types.mutable_strings",
-        "string_clone_basic",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_clone_borrow",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_clone_independent",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_destructor_heap",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_destructor_literal",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
         "string_equality_after_mutation",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_is_empty_false",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_is_empty_true",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_len_empty",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_len_literal",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "types.mutable_strings",
         "string_push_byte",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "types.mutable_strings",
         "string_push_str_basic",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "types.mutable_strings",
         "string_push_str_multiple",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_query_borrows_borrow_and_inout_rooted_places",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.str_type",
-        "str_literal_explicit_strbuf_context",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "string_new_equality_with_empty",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "string_with_capacity_equality_with_empty",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "to_string_i32_default_literal",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "to_string_i64_extremes",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "to_string_negative_and_zero",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "to_string_positive",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "to_string_signed_widths",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "to_string_unsigned_widths_high_bit",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "expressions.for",
-        "for_chars_invalid_utf8_traps",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "expressions.for",
-        "for_chars_lossy_replaces_invalid",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
@@ -526,12 +328,6 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::ParseI64),
         &[],
     ),
-    Entry::new(
-        "items.impl-blocks",
-        "method_and_assoc_string_view_coercions",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
     // ADR-0052 phase 7 (RUE-978): the unaligned-access round trip allocates
     // through @alloc, which the oracle model does not model.
     Entry::new(
@@ -584,86 +380,14 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "types.mutable_strings",
-        "string_capacity_literal",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_clear",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
         "string_growth_on_append",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_heap_promotion",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_literal_no_capacity",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_literal_read_only",
-        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_query_borrow_valid",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.mutable_strings",
-        "string_representation_len_cap",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
         "types.mutable_strings",
         "string_reserve",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.str_fixed_type",
-        "str_fixed_exact_capacity_ok",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.str_fixed_type",
-        "str_fixed_in_struct_field",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.str_fixed_type",
-        "str_fixed_len_is_current_not_capacity",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.str_fixed_type",
-        "str_fixed_returnable",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.str_type",
-        "borrow_str_view_of_strbuf_reads_values",
-        semantic(SemanticGapKind::TextProjectionRead),
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),
     Entry::new(
@@ -693,85 +417,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "types.strings",
         "println_composes_with_to_string_and_concat",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "string_concat_borrows_operands",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "string_concat_is_not_integer_add",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "string_concat_literals",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "string_contains_byte_level",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "string_dropped_implicitly",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "string_heap_freed_once",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "string_search_does_not_consume",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "string_starts_with_byte_level",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "string_substring_bytes",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "string_substring_does_not_consume",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "string_substring_empty",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "string_substring_len",
-        semantic(SemanticGapKind::TextProjectionRead),
-        &[],
-    ),
-    Entry::new(
-        "types.strings",
-        "string_substring_out_of_bounds_traps",
-        semantic(SemanticGapKind::TextProjectionRead),
+        runtime_call(UnsupportedRuntimeCallKind::Println),
         &[],
     ),
 ];
@@ -841,16 +487,8 @@ const fn runtime_call(kind: UnsupportedRuntimeCallKind) -> ModelGapKind {
     ModelGapKind::Semantic(SemanticGapKind::RuntimeCall(kind))
 }
 
-const fn semantic(kind: SemanticGapKind) -> ModelGapKind {
-    ModelGapKind::Semantic(kind)
-}
-
 const fn external(kind: ExternalDependencyKind) -> ModelGapKind {
     ModelGapKind::ExternalDependency(kind)
-}
-
-const fn implementation_defined(kind: ImplementationDefinedKind) -> ModelGapKind {
-    ModelGapKind::ImplementationDefined(kind)
 }
 
 #[cfg(test)]

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -628,20 +628,6 @@ enum Value {
     /// variant's payload fields in declaration order (RUE-285). A
     /// discriminant-only enum (or C-like enum) stays a bare `Int` tag.
     Aggregate(Vec<Value>),
-    /// String-like data, modeled as raw byte content plus ABI slot width.
-    ///
-    /// `String`/`StrBuf` occupies three slots (`ptr`, `len`, `cap`), while
-    /// `str`/`Str(N)` occupies two (`ptr`, `len`). Keeping the width on
-    /// the value prevents a `str` parameter from shifting later parameters as if
-    /// it were a growable string. Every width here is the compiler's
-    /// `abi_slot_count` for the corresponding text type; `string_literal_value`
-    /// and `text_struct_slots` derive it from that authority, and the type-free
-    /// constructors below carry the same values for the
-    /// sites that have no type in hand.
-    Str {
-        bytes: Vec<u8>,
-        slots: usize,
-    },
     /// A raw pointer into the abstract heap (RUE model-gap closure). `None` is
     /// the null pointer (`@int_to_ptr(0)`, a failed `@alloc`/`@realloc`); `Some`
     /// names a live cell inside an [`Allocation`]. Heap allocations
@@ -695,54 +681,32 @@ struct Allocation {
 }
 
 impl Value {
-    fn string(text: impl Into<String>) -> Self {
-        Self::string_bytes(text.into().into_bytes())
-    }
-
-    /// The owned-`StrBuf` width `abi_slot_count(StrBuf) == 3`
-    /// ({ptr, len, cap}). Used by the type-free sites (the `@to_string` result,
-    /// which is always a `StrBuf`, and test fixtures); the type-aware paths
-    /// derive the same value from the compiler authority.
-    fn string_bytes(bytes: impl Into<Vec<u8>>) -> Self {
-        Self::Str {
-            bytes: bytes.into(),
-            slots: 3,
-        }
-    }
-
+    /// A detached two-slot `str` view header (`{null, len}`) for shape/
+    /// classification fixtures that never read the bytes.
     #[cfg(test)]
-    fn str_view(text: impl Into<String>) -> Self {
-        Self::str_view_bytes(text.into().into_bytes())
-    }
-
-    /// The `str`/`Str(N)` view width
-    /// `abi_slot_count(str) == 2` ({ptr, len}). The interpreter's live path
-    /// (`string_literal_value`) now derives the width from the compiler
-    /// authority, so this explicit two-slot constructor is a test fixture only.
-    #[cfg(test)]
-    fn str_view_bytes(bytes: impl Into<Vec<u8>>) -> Self {
-        Self::Str {
-            bytes: bytes.into(),
-            slots: 2,
-        }
+    fn str_view(text: impl AsRef<str>) -> Self {
+        Value::Aggregate(vec![
+            Value::Ptr(None),
+            Value::Int(text.as_ref().len() as i128),
+        ])
     }
 
     fn as_int(&self) -> i128 {
         match self {
             Value::Int(n) => *n,
             Value::Bool(b) => *b as i128,
-            // Unreachable for a well-typed program (aggregates/strings/pointers
-            // never reach a bare scalar context; a pointer becomes an integer
-            // only through `@ptr_to_int`, which computes its address explicitly);
+            // Unreachable for a well-typed program (aggregates/pointers never
+            // reach a bare scalar context; a pointer becomes an integer only
+            // through `@ptr_to_int`, which computes its address explicitly);
             // defined so callers need not thread an error.
-            Value::Unit | Value::Aggregate(_) | Value::Str { .. } | Value::Ptr(_) => 0,
+            Value::Unit | Value::Aggregate(_) | Value::Ptr(_) => 0,
         }
     }
     fn as_bool(&self) -> bool {
         match self {
             Value::Bool(b) => *b,
             Value::Int(n) => *n != 0,
-            Value::Unit | Value::Aggregate(_) | Value::Str { .. } | Value::Ptr(_) => false,
+            Value::Unit | Value::Aggregate(_) | Value::Ptr(_) => false,
         }
     }
 }
@@ -947,17 +911,15 @@ enum WritebackPlace<'a> {
 }
 
 impl<'a> Interp<'a> {
-    fn string_literal_value(&self, text: String, ty: Type) -> Value {
-        // Derive the text value's ABI slot width from the
-        // compiler's `abi_slot_count` authority instead of hardcoding
-        // str/Str(N) = 2 and StrBuf = 3. A str/Str(N) view is two slots
-        // ({ptr, len}); an owned StrBuf is three ({ptr, len, cap}). The
-        // value-slot decomposition is preserved across the ADR-0052 migration
-        // (only the physical byte layout compacts), so these widths are stable.
-        Value::Str {
-            bytes: text.into_bytes(),
-            slots: self.text_value_slot_width(ty),
-        }
+    fn string_literal_value(&mut self, text: String, ty: Type) -> Value {
+        // A source string literal materializes as a real text header over an
+        // (immortal) heap byte allocation (RUE-1010 §6.13.2). The ABI slot width
+        // comes from the compiler's `abi_slot_count` authority: a str/Str(N)
+        // view is two slots ({ptr, len}); an owned StrBuf is three
+        // ({buf, cap, len}). A literal is non-owning/static-backed, so its
+        // capacity word is 0 (matching the compiler's `cap = 0` literal state).
+        let slots = self.text_value_slot_width(ty);
+        self.materialize_text(text.into_bytes(), slots, 0)
     }
 
     /// ABI value-slot width the interpreter carries for a text value of type
@@ -1001,124 +963,6 @@ impl<'a> Interp<'a> {
         }
     }
 
-    /// Return the ABI width certified by a real text-field projection.
-    ///
-    /// The oracle stores text as an opaque byte vector instead of exposing its
-    /// compiler ABI fields. Only a field projection whose struct metadata and
-    /// field index match that ABI may therefore become a registrable model
-    /// gap. In particular, an arbitrary `Index` projection or an out-of-range
-    /// field must remain a compiler/oracle contract violation even if a broken
-    /// frame happens to contain a `Value::Str` at runtime.
-    fn text_projection_slots(&self, projection: Projection) -> Option<usize> {
-        let Projection::Field {
-            struct_id,
-            field_index,
-        } = projection
-        else {
-            return None;
-        };
-        // The nested RawBuf core's buffer pointer (`core.buf`, field 0) is the
-        // text pointer of a three-slot owned StrBuf (RUE-1066). The base value
-        // is the two-slot core view left by the `.core` passthrough, so it
-        // certifies the owned width via the `expected == 3` reconciliation in
-        // `is_matching_text_projection`.
-        if self.is_strbuf_core_struct(struct_id) {
-            return (field_index == 0).then_some(3);
-        }
-        let slots = self.text_struct_slots(struct_id)?;
-        let def = self.state.type_pool.struct_def(struct_id);
-        // Flat text struct: str/Str(N) (2 fields) or a legacy flat StrBuf
-        // (3 fields, `{ptr, len, cap}`); its `{ptr, len}` prefix is fields 0/1.
-        if def.field_count() == slots && (field_index as usize) < 2 {
-            return Some(slots);
-        }
-        // Nested StrBuf (RUE-1066): `{core, len}` is two fields but three ABI
-        // slots. Its length header is field 1; the buffer pointer lives in the
-        // core (matched above).
-        if self.is_owned_string_struct(struct_id) && def.field_count() == 2 && field_index == 1 {
-            return Some(slots);
-        }
-        None
-    }
-
-    /// Whether `struct_id` is the nested `RawBuf(u8)` core of an owned StrBuf
-    /// (RUE-1066): a two-field `{buf: ptr, cap: u64}` aggregate that is neither
-    /// a `str`/`Str(N)` view nor the StrBuf wrapper itself. It is only ever
-    /// consulted while projecting an opaque `Value::Str`, where the base is
-    /// already known to be text, so this shape check cannot misfire on an
-    /// unrelated user struct.
-    fn is_strbuf_core_struct(&self, struct_id: rue_air::StructId) -> bool {
-        if self.is_str_like_struct(struct_id) || self.is_owned_string_struct(struct_id) {
-            return false;
-        }
-        let def = self.state.type_pool.struct_def(struct_id);
-        def.field_count() == 2 && def.fields[0].ty.is_ptr() && def.fields[1].ty == Type::U64
-    }
-
-    /// The `.core` step of a nested StrBuf (`{core: RawBuf(u8), len}`, field 0).
-    /// Projecting it leaves the opaque text value in place, narrowed to the
-    /// two-slot core view so the buffer-pointer and capacity projections that
-    /// follow resolve against the RawBuf core.
-    fn is_strbuf_core_projection(&self, projection: Projection) -> bool {
-        let Projection::Field {
-            struct_id,
-            field_index,
-        } = projection
-        else {
-            return false;
-        };
-        field_index == 0
-            && self.is_owned_string_struct(struct_id)
-            && self.state.type_pool.struct_def(struct_id).field_count() == 2
-    }
-
-    fn is_matching_text_projection(&self, projection: Projection, actual_slots: usize) -> bool {
-        matches!(
-            (self.text_projection_slots(projection), actual_slots),
-            (Some(expected), actual) if expected == actual
-                // A literal contextualized as source StrBuf is still carried
-                // as its two-slot static view until the unmodeled projection
-                // materializes the three-slot header.
-                || (expected == 3 && actual == 2)
-        )
-    }
-
-    /// The canonical core `str` length field is part of the stable language
-    /// model, so the oracle can derive it directly from its byte-vector
-    /// representation. Other text-header projections remain explicit model
-    /// gaps: in particular, source `StrBuf` storage and raw pointers are not
-    /// materialized by the interpreter.
-    fn is_core_str_length_projection(&self, projection: Projection, actual_slots: usize) -> bool {
-        let Projection::Field {
-            struct_id,
-            field_index,
-        } = projection
-        else {
-            return false;
-        };
-        let def = self.state.type_pool.struct_def(struct_id);
-        actual_slots == 2 && def.name == "str" && def.field_count() == 2 && field_index == 1
-    }
-
-    fn is_owned_string_capacity_projection(&self, projection: Projection) -> bool {
-        let Projection::Field {
-            struct_id,
-            field_index,
-        } = projection
-        else {
-            return false;
-        };
-        // Legacy flat StrBuf `{ptr, len, cap}`: capacity is field 2.
-        if self.is_owned_string_struct(struct_id)
-            && self.state.type_pool.struct_def(struct_id).field_count() == 3
-            && field_index == 2
-        {
-            return true;
-        }
-        // Nested RawBuf core `{buf, cap}` (RUE-1066): capacity is field 1.
-        self.is_strbuf_core_struct(struct_id) && field_index == 1
-    }
-
     fn is_owned_string_type(&self, ty: Type) -> bool {
         if let TypeKind::Struct(struct_id) = ty.kind() {
             self.is_owned_string_struct(struct_id)
@@ -1129,6 +973,115 @@ impl<'a> Interp<'a> {
 
     fn is_owned_string_struct(&self, struct_id: rue_air::StructId) -> bool {
         self.state.type_pool.is_strbuf(struct_id)
+    }
+
+    /// Whether `ty` is a text type — a `str`/`Str(N)` view or an owned `StrBuf`.
+    /// Text values are ordinary `Value::Aggregate` headers over a real byte
+    /// allocation (RUE-1010 §6.13); this predicate lets a consumer that holds a
+    /// value's static type read its bytes through [`Self::text_bytes`] rather
+    /// than depending on any layout detail.
+    fn is_text_type(&self, ty: Type) -> bool {
+        self.is_str_like_type(ty) || self.is_owned_string_type(ty)
+    }
+
+    /// Extract the `(buffer pointer, length)` pair from a materialized text
+    /// header value. A `str`/`Str(N)` view is a two-slot `{ptr, len}` aggregate;
+    /// an owned `StrBuf` is `{core: {buf, cap}, len}`, so its pointer lives one
+    /// level down in the nested `RawBuf` core (RUE-1066). Returns `None` for a
+    /// value that is not shaped like either header.
+    fn text_ptr_len(val: &Value) -> Option<(Option<PtrTarget>, i128)> {
+        let Value::Aggregate(cells) = val else {
+            return None;
+        };
+        if cells.len() != 2 {
+            return None;
+        }
+        let len = match &cells[1] {
+            Value::Int(n) => *n,
+            _ => return None,
+        };
+        match &cells[0] {
+            // `str`/`Str(N)` view: `{ptr, len}`.
+            Value::Ptr(target) => Some((target.clone(), len)),
+            // Owned `StrBuf`: `{core: {buf, cap}, len}` — the pointer is the
+            // core's field 0.
+            Value::Aggregate(core) => match core.first() {
+                Some(Value::Ptr(target)) => Some((target.clone(), len)),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Read the byte content of a materialized text value out of the heap. The
+    /// `len` bytes starting at the header's buffer pointer are read cell by cell
+    /// through the same `byte_at` path the runtime's byte helpers model, so a
+    /// text read rides entirely on the modeled allocation store.
+    fn text_bytes(&self, val: &Value) -> Step<Vec<u8>> {
+        let gap = unsupported_intrinsic_kind("byte_read");
+        let Some((target, len)) = Self::text_ptr_len(val) else {
+            return Err(unsupported(gap, "text value is not a materialized header"));
+        };
+        if len <= 0 {
+            return Ok(Vec::new());
+        }
+        let Some(target) = target else {
+            // A non-null length over a null buffer is a malformed header.
+            return Err(unsupported(
+                gap,
+                "text header has a null buffer with nonzero length",
+            ));
+        };
+        let mut bytes = Vec::with_capacity(len as usize);
+        for i in 0..len {
+            bytes.push(self.byte_at(&target, i, gap)?);
+        }
+        Ok(bytes)
+    }
+
+    /// Materialize a text value: mint a heap byte allocation holding `bytes` and
+    /// build the ABI-shaped header over it. A two-slot `slots` yields a
+    /// `str`/`Str(N)` view `{ptr, len}`; a three-slot `slots` yields an owned
+    /// `StrBuf` `{core: {buf, cap}, len}` (RUE-1066 nested layout). An empty
+    /// value keeps a null buffer (no allocation), matching the source's empty
+    /// state. `cap` is the capacity word stored in an owned header.
+    fn materialize_text(&mut self, bytes: Vec<u8>, slots: usize, cap: i128) -> Value {
+        let len = bytes.len() as i128;
+        let ptr = if bytes.is_empty() {
+            Value::Ptr(None)
+        } else {
+            let cells = bytes.into_iter().map(|b| Value::Int(b as i128)).collect();
+            let alloc = self.heap_alloc(Value::Aggregate(cells), 1, false);
+            Value::Ptr(Some(PtrTarget {
+                alloc,
+                path: Vec::new(),
+                index: 0,
+            }))
+        };
+        if slots >= 3 {
+            // Owned `StrBuf`: `{core: {buf, cap}, len}`.
+            Value::Aggregate(vec![
+                Value::Aggregate(vec![ptr, Value::Int(cap)]),
+                Value::Int(len),
+            ])
+        } else {
+            // `str`/`Str(N)` view: `{ptr, len}`.
+            Value::Aggregate(vec![ptr, Value::Int(len)])
+        }
+    }
+
+    /// Allocate `bytes` into the heap and return a raw pointer to cell 0, for
+    /// tests that drive the projected-char builtins (which take a `ptr`/`len`
+    /// pair) directly.
+    #[cfg(test)]
+    fn test_alloc_str_ptr(&mut self, bytes: &[u8]) -> Value {
+        let cells = bytes.iter().map(|b| Value::Int(*b as i128)).collect();
+        let alloc = self.heap_alloc(Value::Aggregate(cells), 1, false);
+        Value::Ptr(Some(PtrTarget {
+            alloc,
+            path: Vec::new(),
+            index: 0,
+        }))
     }
 
     fn classify_unsupported_runtime_call_static(
@@ -1198,9 +1151,11 @@ impl<'a> Interp<'a> {
                     kind,
                     RuntimeCallKind::StrPrintProjected | RuntimeCallKind::StrPrintlnProjected
                 ) {
-                    matches!(args[0], Value::Str { .. }) && is_int_value(1)
+                    // The projected print path passes a raw text pointer + len.
+                    matches!(args[0], Value::Ptr(_)) && is_int_value(1)
                 } else {
-                    matches!(args[0], Value::Str { .. })
+                    // The aggregate print path passes a materialized text header.
+                    Self::text_ptr_len(&args[0]).is_some()
                 }
             }
         };
@@ -1711,13 +1666,12 @@ impl<'a> Interp<'a> {
         match intrinsic {
             AbortIntrinsic::Panic => match values.as_slice() {
                 [] => self.abort_with_stderr(TrapKind::UserPanic, &[b"panic\n"]),
-                [
-                    Value::Str {
-                        bytes,
-                        slots: 2 | 3,
-                    },
-                ] => self
-                    .abort_with_stderr(TrapKind::UserPanic, &[b"panic: ", bytes.as_slice(), b"\n"]),
+                [message] if Self::text_ptr_len(message).is_some() => {
+                    // The message is a materialized `str` view; read its bytes
+                    // from the heap before aborting (RUE-1010 §6.13).
+                    let bytes = self.text_bytes(message)?;
+                    self.abort_with_stderr(TrapKind::UserPanic, &[b"panic: ", &bytes, b"\n"])
+                }
                 [_] => Err(unsupported(
                     UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
                     "intrinsic @panic runtime value shape",
@@ -1727,13 +1681,9 @@ impl<'a> Interp<'a> {
             AbortIntrinsic::Assert => {
                 let (condition, message) = match values.as_slice() {
                     [Value::Bool(condition)] => (*condition, None),
-                    [
-                        Value::Bool(condition),
-                        Value::Str {
-                            bytes,
-                            slots: 2 | 3,
-                        },
-                    ] => (*condition, Some(bytes.as_slice())),
+                    [Value::Bool(condition), message] if Self::text_ptr_len(message).is_some() => {
+                        (*condition, Some(self.text_bytes(message)?))
+                    }
                     _ => {
                         return Err(unsupported(
                             UnsupportedKind::ContractViolation(
@@ -1748,7 +1698,7 @@ impl<'a> Interp<'a> {
                 } else if let Some(message) = message {
                     // The message-carrying assertion uses the same runtime path
                     // and trap category as `@panic(message)`.
-                    self.abort_with_stderr(TrapKind::UserPanic, &[b"panic: ", message, b"\n"])
+                    self.abort_with_stderr(TrapKind::UserPanic, &[b"panic: ", &message, b"\n"])
                 } else {
                     self.abort_with_stderr(TrapKind::AssertionFailure, &[b"assertion failed\n"])
                 }
@@ -1759,28 +1709,30 @@ impl<'a> Interp<'a> {
     fn write_dbg(&mut self, val: &Value, ty: Type) -> Step<()> {
         let remaining = self.stdout_cap.saturating_sub(self.stdout_bytes);
 
-        // Formatting a String normally clones its complete contents. Reject an
-        // oversized value before formatting so the output limit also bounds
-        // that temporary allocation.
-        if let Value::Str { bytes, .. } = val
-            && bytes.len() >= remaining
-        {
-            return Err(unsupported(
-                UnsupportedKind::ResourceLimit(ResourceLimitKind::StdoutBytes),
-                format!(
-                    "stdout byte limit exceeded ({}-byte limit)",
-                    self.stdout_cap
-                ),
-            ));
-        }
-
-        let formatted = format_dbg(val, ty)?;
-        let emitted_len = match val {
-            Value::Str { bytes, .. } => bytes.len(),
-            _ => formatted.len(),
+        // `@dbg` of a text value prints its byte content (matches
+        // __rue_dbg_str), read from the heap through the materialized header
+        // (RUE-1010 §6.13); every other value uses the scalar `format_dbg`.
+        // Reserve one byte for the trailing newline; the comparison form avoids
+        // overflowing while computing `len + 1`, and rejecting an oversized
+        // value before decoding also bounds that temporary allocation.
+        let (formatted, emitted_len) = if self.is_text_type(ty) {
+            let bytes = self.text_bytes(val)?;
+            if bytes.len() >= remaining {
+                return Err(unsupported(
+                    UnsupportedKind::ResourceLimit(ResourceLimitKind::StdoutBytes),
+                    format!(
+                        "stdout byte limit exceeded ({}-byte limit)",
+                        self.stdout_cap
+                    ),
+                ));
+            }
+            let len = bytes.len();
+            (String::from_utf8_lossy(&bytes).into_owned(), len)
+        } else {
+            let formatted = format_dbg(val, ty)?;
+            let len = formatted.len();
+            (formatted.into_owned(), len)
         };
-        // Reserve one byte for the newline emitted by this `@dbg` call. Using
-        // the comparison form avoids overflowing while computing `len + 1`.
         if emitted_len >= remaining {
             return Err(unsupported(
                 UnsupportedKind::ResourceLimit(ResourceLimitKind::StdoutBytes),
@@ -2212,7 +2164,7 @@ impl<'a> Interp<'a> {
     /// Dispatch a runtime text builtin. Returns `Ok(None)` when `name` is an
     /// ordinary source-defined function with a CFG body.
     fn string_builtin(
-        &self,
+        &mut self,
         kind: RuntimeCallKind,
         args: &[Value],
         arg_types: &[Type],
@@ -2234,13 +2186,17 @@ impl<'a> Interp<'a> {
                 matches!(args[0], Value::Int(_))
             }
             RuntimeCallKind::StrByteAt => {
-                matches!(args[0], Value::Str { slots: 2, .. }) && matches!(args[1], Value::Int(_))
+                // The receiver is a materialized `str` view `{ptr, len}`
+                // (RUE-1010 §6.13); the index is a scalar.
+                Self::text_ptr_len(&args[0]).is_some() && matches!(args[1], Value::Int(_))
             }
             RuntimeCallKind::StrCharScalar
             | RuntimeCallKind::StrCharScalarLossy
             | RuntimeCallKind::StrCharNext
             | RuntimeCallKind::StrCharNextLossy => {
-                matches!(args[0], Value::Str { .. })
+                // The projected-char path passes a raw text pointer, a length,
+                // and a byte offset.
+                matches!(args[0], Value::Ptr(_))
                     && matches!(args[1], Value::Int(_))
                     && matches!(args[2], Value::Int(_))
             }
@@ -2252,33 +2208,19 @@ impl<'a> Interp<'a> {
                 format!("builtin '{name}' runtime argument shape drift"),
             ));
         }
-        let string_bytes = |value: &Value| -> Result<Vec<u8>, Flow> {
-            match value {
-                Value::Str { bytes, .. } => Ok(bytes.clone()),
-                _ => Err(unsupported(
-                    UnsupportedKind::ContractViolation(ContractViolationKind::BuiltinArgumentType),
-                    format!("builtin '{name}' received a non-string argument"),
-                )),
-            }
-        };
-        let str_bytes = |ptr: &Value, len: &Value| -> Result<Vec<u8>, Flow> {
-            let bytes = string_bytes(ptr)?;
-            let len = len.as_int();
-            if len < 0 || len as u128 > bytes.len() as u128 {
-                return Err(unsupported(
-                    UnsupportedKind::ContractViolation(ContractViolationKind::BuiltinArgumentType),
-                    format!("builtin '{name}' received an invalid str pointer/length pair"),
-                ));
-            }
-            Ok(bytes[..len as usize].to_vec())
-        };
         let out = match kind {
-            RuntimeCallKind::ToString => Value::string((args[0].as_int() as i64).to_string()),
+            RuntimeCallKind::ToString => {
+                let digits = (args[0].as_int() as i64).to_string().into_bytes();
+                let cap = digits.len() as i128;
+                self.materialize_text(digits, self.text_value_slot_width(result_ty), cap)
+            }
             RuntimeCallKind::ToStringUnsigned => {
-                Value::string((args[0].as_int() as u64).to_string())
+                let digits = (args[0].as_int() as u64).to_string().into_bytes();
+                let cap = digits.len() as i128;
+                self.materialize_text(digits, self.text_value_slot_width(result_ty), cap)
             }
             RuntimeCallKind::StrByteAt => {
-                let bytes = string_bytes(&args[0])?;
+                let bytes = self.text_bytes(&args[0])?;
                 let index = args[1].as_int();
                 if index < 0 || index as u128 >= bytes.len() as u128 {
                     return Err(Flow::Panic(Panic::runtime(TrapKind::IndexOutOfBounds)));
@@ -2286,14 +2228,14 @@ impl<'a> Interp<'a> {
                 Value::Int(bytes[index as usize] as i128)
             }
             RuntimeCallKind::StrCharScalar => {
-                let bytes = str_bytes(&args[0], &args[1])?;
+                let bytes = self.bytes_from_ptr(&args[0], args[1].as_int())?;
                 match char_at(&bytes, args[2].as_int()) {
                     Some((scalar, _)) => Value::Int(scalar as i128),
                     None => return Err(Flow::Panic(Panic::runtime(TrapKind::InvalidUtf8))),
                 }
             }
             RuntimeCallKind::StrCharNext => {
-                let bytes = str_bytes(&args[0], &args[1])?;
+                let bytes = self.bytes_from_ptr(&args[0], args[1].as_int())?;
                 let offset = args[2].as_int();
                 match char_at(&bytes, offset) {
                     Some((_, width)) => Value::Int(offset + width as i128),
@@ -2301,17 +2243,37 @@ impl<'a> Interp<'a> {
                 }
             }
             RuntimeCallKind::StrCharScalarLossy => {
-                let bytes = str_bytes(&args[0], &args[1])?;
+                let bytes = self.bytes_from_ptr(&args[0], args[1].as_int())?;
                 Value::Int(char_at_lossy(&bytes, args[2].as_int()).0 as i128)
             }
             RuntimeCallKind::StrCharNextLossy => {
-                let bytes = str_bytes(&args[0], &args[1])?;
+                let bytes = self.bytes_from_ptr(&args[0], args[1].as_int())?;
                 let offset = args[2].as_int();
                 Value::Int(offset + char_at_lossy(&bytes, offset).1 as i128)
             }
             _ => return Ok(None),
         };
         Ok(Some(out))
+    }
+
+    /// Read `len` bytes starting at a raw text pointer (the projected-char
+    /// path's `ptr`/`len` pair), through the modeled allocation store.
+    fn bytes_from_ptr(&self, ptr: &Value, len: i128) -> Step<Vec<u8>> {
+        let gap = unsupported_intrinsic_kind("byte_read");
+        if len <= 0 {
+            return Ok(Vec::new());
+        }
+        let Value::Ptr(Some(target)) = ptr else {
+            return Err(unsupported(
+                gap,
+                "text pointer is not a live buffer pointer",
+            ));
+        };
+        let mut bytes = Vec::with_capacity(len as usize);
+        for i in 0..len {
+            bytes.push(self.byte_at(target, i, gap)?);
+        }
+        Ok(bytes)
     }
 
     /// Run the drop of a value of type `ty`, in the spec-3.9 order: the type's
@@ -2916,6 +2878,80 @@ impl<'a> Interp<'a> {
         range_check(r, ty)
     }
 
+    /// Type-directed structural equality (`==`/`!=`). A text field/element/
+    /// payload compares by byte content (read from the heap), so two equal
+    /// strings held in distinct buffer allocations are equal; everything else
+    /// compares by value, recursing into struct fields, array elements, and the
+    /// active enum variant's payload (mirroring `run_drop`'s aggregate layout).
+    fn values_equal_typed(&self, x: &Value, y: &Value, ty: Type) -> Step<bool> {
+        if self.is_text_type(ty) {
+            return Ok(self.text_bytes(x)? == self.text_bytes(y)?);
+        }
+        match ty.kind() {
+            TypeKind::Struct(sid) => {
+                let (Value::Aggregate(xs), Value::Aggregate(ys)) = (x, y) else {
+                    return Ok(x == y);
+                };
+                let def = self.state.type_pool.struct_def(sid);
+                if xs.len() != ys.len() || xs.len() != def.fields.len() {
+                    return Ok(x == y);
+                }
+                for (i, field) in def.fields.iter().enumerate() {
+                    if !self.values_equal_typed(&xs[i], &ys[i], field.ty)? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
+            TypeKind::Array(aid) => {
+                let (elem_ty, _len) = self.state.type_pool.array_def(aid);
+                let (Value::Aggregate(xs), Value::Aggregate(ys)) = (x, y) else {
+                    return Ok(x == y);
+                };
+                if xs.len() != ys.len() {
+                    return Ok(false);
+                }
+                for (xe, ye) in xs.iter().zip(ys.iter()) {
+                    if !self.values_equal_typed(xe, ye, elem_ty)? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
+            TypeKind::Enum(eid) => {
+                // A discriminant-only variant is a bare `Int` tag; a payload
+                // variant is `[tag, payload...]`. Compare the active variant,
+                // then its payload fields by their declared types.
+                match (x, y) {
+                    (Value::Aggregate(xs), Value::Aggregate(ys)) => {
+                        if xs.is_empty() || ys.is_empty() || xs[0] != ys[0] {
+                            return Ok(false);
+                        }
+                        let tag = xs[0].as_int() as usize;
+                        let payload_tys = self.state.type_pool.enum_def(eid).variant_payload(tag);
+                        if xs.len() != ys.len() {
+                            return Ok(false);
+                        }
+                        for (i, pty) in payload_tys.iter().enumerate() {
+                            match (xs.get(i + 1), ys.get(i + 1)) {
+                                (Some(xe), Some(ye)) => {
+                                    if !self.values_equal_typed(xe, ye, *pty)? {
+                                        return Ok(false);
+                                    }
+                                }
+                                _ => return Ok(false),
+                            }
+                        }
+                        Ok(true)
+                    }
+                    // Same-variant discriminant-only enums (or a mixed shape).
+                    _ => Ok(x == y),
+                }
+            }
+            _ => Ok(x == y),
+        }
+    }
+
     fn cmp(
         &mut self,
         cfg: &'a Cfg,
@@ -2926,24 +2962,36 @@ impl<'a> Interp<'a> {
     ) -> Step<Value> {
         let x = self.eval(cfg, frame, a)?;
         let y = self.eval(cfg, frame, b)?;
-        // Strings compare by content (String ==/!=). Aggregates (structs,
-        // arrays, payload enums) compare STRUCTURALLY, field-by-field /
-        // element-by-element / same-variant-and-equal-payload, via `Value`'s
-        // derived `PartialEq` which recurses into nested aggregates (RUE-285).
-        // Only `==` / `!=` reach an aggregate here (ordering `< > <= >=` is a
-        // type error on aggregates), so we report `Equal` iff structurally
-        // equal and an arbitrary non-`Equal` ordering otherwise — enough for
-        // `pick` to decide `==`/`!=`. Everything else compares by integer value.
-        let ord = match (&x, &y) {
-            (Value::Str { bytes: sx, .. }, Value::Str { bytes: sy, .. }) => sx.cmp(sy),
-            (Value::Aggregate(_), _) | (_, Value::Aggregate(_)) => {
-                if x == y {
-                    std::cmp::Ordering::Equal
-                } else {
-                    std::cmp::Ordering::Less
+        // Strings compare by byte content (str/StrBuf ==/!=/ordering), read from
+        // the heap through the materialized headers (RUE-1010 §6.13). Other
+        // aggregates (structs, arrays, payload enums) compare STRUCTURALLY,
+        // field-by-field / element-by-element / same-variant-and-equal-payload,
+        // via `Value`'s derived `PartialEq` which recurses into nested
+        // aggregates (RUE-285). Only `==` / `!=` reach a non-text aggregate here
+        // (ordering `< > <= >=` is a type error on those), so we report `Equal`
+        // iff structurally equal and an arbitrary non-`Equal` ordering
+        // otherwise — enough for `pick` to decide `==`/`!=`. Everything else
+        // compares by integer value.
+        let ty = cfg.get_inst(a).ty;
+        let ord = if self.is_text_type(ty) {
+            let bx = self.text_bytes(&x)?;
+            let by = self.text_bytes(&y)?;
+            bx.cmp(&by)
+        } else {
+            match (&x, &y) {
+                (Value::Aggregate(_), _) | (_, Value::Aggregate(_)) => {
+                    // Only `==`/`!=` reach an aggregate; compare with text
+                    // awareness so a text field/element/payload is judged by its
+                    // byte content, not by the identity of its heap buffer
+                    // pointer (RUE-1010 §6.13).
+                    if self.values_equal_typed(&x, &y, ty)? {
+                        std::cmp::Ordering::Equal
+                    } else {
+                        std::cmp::Ordering::Less
+                    }
                 }
+                _ => x.as_int().cmp(&y.as_int()),
             }
-            _ => x.as_int().cmp(&y.as_int()),
         };
         Ok(Value::Bool(pick(ord)))
     }
@@ -3064,38 +3112,16 @@ impl<'a> Interp<'a> {
     fn place_read(&mut self, cfg: &'a Cfg, frame: &mut Frame, place: &Place) -> Step<Value> {
         let (base, path) = self.resolve_path(cfg, frame, place)?;
         let mut cur = self.base_value_of(frame, base)?;
-        for (idx, projection) in path {
+        for (idx, _projection) in path {
             cur = match cur {
                 Value::Aggregate(mut v) if idx < v.len() => v.swap_remove(idx),
                 Value::Aggregate(_) => {
                     return Err(Flow::Panic(Panic::runtime(TrapKind::IndexOutOfBounds)));
                 }
-                Value::Str { .. } if self.is_owned_string_capacity_projection(projection) => {
-                    return Err(unsupported(
-                        UnsupportedKind::ImplementationDefined(
-                            ImplementationDefinedKind::StringCapacityValue,
-                        ),
-                        "source StrBuf capacity value",
-                    ));
-                }
-                Value::Str { bytes, slots }
-                    if self.is_core_str_length_projection(projection, slots) =>
-                {
-                    Value::Int(bytes.len() as i128)
-                }
-                Value::Str { slots, .. } if self.is_matching_text_projection(projection, slots) => {
-                    return Err(unsupported(
-                        UnsupportedKind::SemanticGap(SemanticGapKind::TextProjectionRead),
-                        "projection of non-aggregate",
-                    ));
-                }
-                // The `.core` step of a nested StrBuf (RUE-1066) is transparent:
-                // keep the opaque bytes and narrow to the two-slot RawBuf core
-                // so the `core.buf` / `core.cap` projections that follow resolve
-                // to the text-pointer / capacity model gaps.
-                Value::Str { bytes, .. } if self.is_strbuf_core_projection(projection) => {
-                    Value::Str { bytes, slots: 2 }
-                }
+                // Text values (str/StrBuf) are now ordinary aggregate headers
+                // over a real byte allocation (RUE-1010 §6.13), so their
+                // `{ptr, len}` / `{core: {buf, cap}, len}` fields project through
+                // the aggregate arm above — no special text-projection handling.
                 _ => {
                     return Err(unsupported(
                         UnsupportedKind::ContractViolation(
@@ -3275,9 +3301,16 @@ impl<'a> Interp<'a> {
             TypeKind::PtrConst(_) | TypeKind::PtrMut(_) => Value::Ptr(None),
             TypeKind::Struct(sid) => {
                 if self.is_str_like_struct(sid) || self.is_owned_string_struct(sid) {
-                    Value::Str {
-                        bytes: Vec::new(),
-                        slots: self.text_value_slot_width(ty),
+                    // Empty text header: a null buffer with zero length and
+                    // capacity (RUE-1010 §6.13). A str/Str(N) view is
+                    // `{ptr, len}`; an owned StrBuf is `{core: {buf, cap}, len}`.
+                    if self.text_value_slot_width(ty) >= 3 {
+                        Value::Aggregate(vec![
+                            Value::Aggregate(vec![Value::Ptr(None), Value::Int(0)]),
+                            Value::Int(0),
+                        ])
+                    } else {
+                        Value::Aggregate(vec![Value::Ptr(None), Value::Int(0)])
                     }
                 } else {
                     let sd = self.state.type_pool.struct_def(sid);
@@ -4035,10 +4068,8 @@ fn from_bits(bits_val: u128, bits: u32, signed: bool) -> i128 {
 /// Format a value exactly as the `@dbg` runtime intrinsic prints it (decimal for
 /// integers respecting signedness, `true`/`false` for bool), sans the newline.
 fn format_dbg(val: &Value, ty: Type) -> Result<Cow<'_, str>, Flow> {
-    // `@dbg` of a String prints its content (matches __rue_dbg_str).
-    if let Value::Str { bytes, .. } = val {
-        return Ok(String::from_utf8_lossy(bytes));
-    }
+    // Text values (`@dbg` of a str/StrBuf) are decoded from the heap by the
+    // caller (`write_dbg`); this scalar formatter only sees non-text values.
     Ok(match ty.kind() {
         TypeKind::Bool => Cow::Owned(val.as_bool().to_string()),
         k if kind_signed(k) => Cow::Owned(val.as_int().to_string()),

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -207,7 +207,7 @@ fn find_intrinsic_in_function<'a>(
 fn shared_str_character_builtins_require_and_model_ptr_len_offset() {
     let state = query_cfg_state("struct Probe { pointer: ptr mut u8 } fn main() -> i32 { 0 }")
         .expect("probe must compile");
-    let interp = Interp {
+    let mut interp = Interp {
         state: &state,
         stdout: String::new(),
         stdout_bytes: 0,
@@ -227,8 +227,10 @@ fn shared_str_character_builtins_require_and_model_ptr_len_offset() {
     );
     let types = [ptr, Type::U64, Type::U64];
     let modes = [CfgArgMode::Normal; 3];
-    let bytes = Value::str_view("hé");
-    let args = [bytes.clone(), Value::Int(3), Value::Int(1)];
+    // The projected-char builtins take a raw text pointer + length; back it with
+    // a real heap allocation ("hé" is 3 bytes).
+    let text_ptr = interp.test_alloc_str_ptr("hé".as_bytes());
+    let args = [text_ptr, Value::Int(3), Value::Int(1)];
 
     assert_eq!(
         expect_modeled_value(interp.string_builtin(
@@ -251,11 +253,8 @@ fn shared_str_character_builtins_require_and_model_ptr_len_offset() {
         Some(Value::Int(3))
     );
 
-    let invalid = [
-        Value::str_view_bytes([b'a', 0xff, b'b']),
-        Value::Int(3),
-        Value::Int(1),
-    ];
+    let invalid_ptr = interp.test_alloc_str_ptr(&[b'a', 0xff, b'b']);
+    let invalid = [invalid_ptr, Value::Int(3), Value::Int(1)];
     assert_eq!(
         expect_modeled_value(interp.string_builtin(
             RuntimeCallKind::StrCharScalarLossy,

--- a/crates/rue-oracle/src/tests/place_contracts.rs
+++ b/crates/rue-oracle/src/tests/place_contracts.rs
@@ -126,10 +126,10 @@ fn matching_cfg_metadata_is_required_before_a_runtime_symptom_is_registrable() {
         heap: Vec::new(),
     };
     let mut frame = Frame {
-        // Deliberately inject the oracle's text runtime representation under
-        // non-text Pair projection metadata. Value shape alone must not turn
-        // this broken state into a registrable TextProjection gap.
-        params: vec![Some(Value::string("not a Pair")), None],
+        // Deliberately inject a non-aggregate value under Pair projection
+        // metadata. A field projection of a non-aggregate must be a contract
+        // violation, not a silently-read cell.
+        params: vec![Some(Value::Ptr(None)), None],
         locals: vec![None; cfg.num_locals() as usize],
         cache: HashMap::new(),
         promoted: HashMap::new(),
@@ -357,7 +357,9 @@ fn validated_cfg_rejects_invalid_owned_text_projection_metadata() {
         cache: HashMap::new(),
         promoted: HashMap::new(),
     };
-    view_frame.locals[view_slot as usize] = Some(Value::string("wrong three-slot value"));
+    // A non-aggregate value under str projection metadata: reading a field of
+    // it must be a contract violation, not a silent success.
+    view_frame.locals[view_slot as usize] = Some(Value::Ptr(None));
     let mut view_interp = Interp {
         state: &view_state,
         stdout: String::new(),


### PR DESCRIPTION
## Summary

PR C of the StrBuf→RawBuf sequence — the oracle-coverage half of RUE-1010. Follows PR B (#1880, merged).

The oracle modeled every text value as an opaque `Value::Str { bytes }` — a byte vector with no heap pointer — so a StrBuf's `{ptr, cap, len}` header was never physically laid out. Reading the header (`as_ptr`/`len`/capacity) or byte-copying its buffer therefore hit `TextProjectionRead` / `StringCapacityValue` model gaps: ~104 corpus cases were accepted debt.

Text values now ride the **modeled allocation store** (§6.13), exactly like ArrayBuf: a string literal and `@to_string` materialize a real header `Value::Aggregate` over a heap byte allocation (one `Int` cell per byte). A `str`/`Str(N)` view is `{ptr, len}`; an owned StrBuf is `{core: {buf, cap}, len}` (the RUE-1066 nested layout). Header-field projections then resolve through the ordinary aggregate path — no text-projection special cases — and the byte intrinsics operate on real cells, so StrBuf byte reads/writes/copies are modeled end to end.

## Changes

- **Producers**: `string_literal_value` (immortal, `cap = 0` non-owning literal) and `@to_string`/`@to_string_unsigned` (owned, `cap = len`) mint a real header; `zeroed_value` yields an empty header.
- **Consumers** read bytes from the heap via a shared `text_bytes` helper: `@dbg`/print, `@panic`/`@assert` messages, string equality/ordering, byte indexing, and the projected-char builtins (which take a raw `ptr`/`len`).
- **`cmp`** gains a type-directed `values_equal_typed`: a text field/element/enum-payload compares by byte content, so two equal strings held in distinct buffers are equal (structural `Value` equality would otherwise compare buffer-pointer identity — this was the one differential disagreement, now fixed).
- The opaque `Value::Str` variant, its constructors, and the `TextProjectionRead`/`StringCapacityValue` projection classifiers are removed.

## Ledger

- **47 CLI + 57 spec** StrBuf entries **retired** (the oracle now agrees with the compiled binary).
- **44 CLI + 15 spec** entries **reclassified** to the operation that legitimately still gaps — file-buffer `@byte_copy`, or the unmodeled print I/O runtime call — because the string handling now runs, so the gap simply surfaces later.

## Scope note

Only the oracle crate and the model-gap ledger are touched (no compiler/std/codegen changes). Container-scoped retire / use-after-free (§6.13.1) is already modeled on trunk (the recycling-allocator work), so this PR is the remaining StrBuf-coverage half of RUE-1010.

## Validation

- Both oracle-diff corpora (CLI + spec): **0 disagreements, 0 harness failures**
- Oracle unit tests (103), oracle-diff unit tests (88), differential-oracle (4): green
- `scripts/rue fmt`, `./clippy.sh` (63 targets) clean

Refs RUE-1010

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLsiAQKJ41esde9Ya8Up8V

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLsiAQKJ41esde9Ya8Up8V)_