### PR TITLE
RUE-1115: shard CLI/spec corpora off the Linux test lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,11 +196,14 @@ jobs:
         run: scripts/ci-timed "${{ matrix.name }} build" -- ./buck2 build //crates/...
 
       - name: Run tests
-        # Every platform runs Caldera on an explicit parallel shard below;
-        # macOS also shards its ordinary CLI and spec corpora. Local full suites
-        # still own every discovered target in one invocation.
+        # Every platform now shards its Caldera, ordinary CLI, and spec corpora
+        # onto explicit parallel jobs below (RUE-1115); the main lane keeps the
+        # broad discovery pass plus the smaller heavy suites. The deferral set is
+        # identical across platforms, so it is a constant rather than a
+        # per-matrix expression. Local full suites still own every discovered
+        # target in one invocation.
         env:
-          RUE_CI_DEFER_HEAVY_SUITES: ${{ matrix.name == 'macos' && '//:cli-tests //:cli-tests-caldera //:spec-tests' || '//:cli-tests-caldera' }}
+          RUE_CI_DEFER_HEAVY_SUITES: '//:cli-tests //:cli-tests-caldera //:spec-tests'
         run: scripts/ci-timed "${{ matrix.name }} tests" -- ./test.sh
 
   # RUE-617/RUE-1019: keep the byte-reproducibility proof independent of the
@@ -279,10 +282,12 @@ jobs:
         # by `--cfg=scaling_matrix`, not the whole compiler unit suite.
         run: scripts/ci-timed "scaling-matrix run" -- ./buck2 run //crates/rue-compiler:scaling-matrix-test -- scaling_matrix --nocapture
 
-  # The macOS CLI and spec corpora dominate that platform's wall clock, and
-  # Caldera intentionally stresses compiler resources on every architecture.
-  # Run them on separate machines while each main platform lane retains broad
-  # discovery, the smaller corpora, and omission-audit coverage.
+  # The CLI and spec corpora dominate each platform's wall clock, and Caldera
+  # intentionally stresses compiler resources on every architecture. Run them on
+  # separate machines (RUE-1115) while each main platform lane retains broad
+  # discovery, the smaller corpora, and omission-audit coverage. Every platform
+  # defers the same three heavy corpora (see RUE_CI_DEFER_HEAVY_SUITES on the
+  # `test` job), so each architecture gets a cli / cli-caldera / spec shard here.
   platform-corpus:
     strategy:
       matrix:
@@ -304,14 +309,34 @@ jobs:
             check_name: macos-spec
           - os: ubuntu-latest
             cache_name: linux-x64
+            target: //:cli-tests
+            name: cli
+            check_name: linux-x64-cli
+          - os: ubuntu-latest
+            cache_name: linux-x64
             target: //:cli-tests-caldera
             name: cli-caldera
             check_name: linux-x64-cli-caldera
+          - os: ubuntu-latest
+            cache_name: linux-x64
+            target: //:spec-tests
+            name: spec
+            check_name: linux-x64-spec
+          - os: ubuntu-24.04-arm
+            cache_name: linux-arm64
+            target: //:cli-tests
+            name: cli
+            check_name: linux-arm64-cli
           - os: ubuntu-24.04-arm
             cache_name: linux-arm64
             target: //:cli-tests-caldera
             name: cli-caldera
             check_name: linux-arm64-cli-caldera
+          - os: ubuntu-24.04-arm
+            cache_name: linux-arm64
+            target: //:spec-tests
+            name: spec
+            check_name: linux-arm64-spec
     runs-on: ${{ matrix.os }}
     name: test (${{ matrix.check_name }})
     steps:

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -20,12 +20,16 @@ compiler-reproducibility job is the deliberate exception: its two independently
 materialized compiler builds stay local and cache-free, while the ordinary
 linux-x64 test lane may use BuildBuddy.
 
-The platform test lanes all retain broad target discovery. On macOS, the main
-lane defers the two longest heavy targets (`//:cli-tests` and `//:spec-tests`)
-to explicit required jobs so those corpora overlap. `test.sh` accepts that
-deferral only under `CI=true`, validates each target against Buck's live
-`rue_heavy_suite` query, and continues to audit every corpus target it owns.
-Local full suites never defer coverage.
+The platform test lanes all retain broad target discovery. Every platform
+(linux-x64, linux-arm64, macOS) defers its three heaviest corpora —
+`//:cli-tests`, `//:cli-tests-caldera`, and `//:spec-tests` — to explicit
+`platform-corpus` jobs so those corpora overlap the main lane instead of
+serializing behind it (RUE-1115). Each architecture therefore has a matching
+`cli`, `cli-caldera`, and `spec` shard in the `platform-corpus` matrix, and
+those checks must be marked required in branch protection (a maintainer
+action). `test.sh` accepts that deferral only under `CI=true`, validates each
+target against Buck's live `rue_heavy_suite` query, and continues to audit
+every corpus target it owns. Local full suites never defer coverage.
 
 Major Buck commands run through `scripts/ci-timed`, which preserves output and
 the exact command exit status while appending wall time and aggregate


### PR DESCRIPTION
## What

Defer the three heaviest corpora — `//:cli-tests`, `//:cli-tests-caldera`, and `//:spec-tests` — to parallel `platform-corpus` jobs on **every** platform, not just macOS. Adds `cli` and `spec` shards to the `platform-corpus` matrix for `linux-x64` and `linux-arm64` (each already had a `cli-caldera` shard), and collapses `RUE_CI_DEFER_HEAVY_SUITES` from a per-matrix expression to a constant now that all platforms defer the same set.

## Why

On a cache-warm merge-queue run, `test (linux-arm64)` was the workflow's **~21-minute critical path** (`test (linux-x64)` ~15.6 min). In those jobs the build step is a fast cache hit — the time is almost entirely **test execution run serially on one runner**. The arm64 lane breaks down as:

- Broad unit pass (`//... --exclude rue_heavy_suite`): ~6.5 min
- `//:cli-tests`: **~12:21** (1,680 cases) — inline, single biggest chunk
- `spec-tests` 1:14, `reproducible-programs` 0:44, rest <5s

macOS already fanned its CLI/spec corpora out to parallel jobs; the Linux lanes deferred only `caldera` (currently a stub, RUE-1083), so they ran the whole corpus end-to-end on one machine. This change mirrors the macOS sharding on Linux.

## Validated impact ✅

Measured on this PR's CI run ([`29934284597`](https://github.com/rue-language/rue/actions/runs/29934284597), commit `cd4ba48`, all green) versus the pre-change cache-warm merge-queue baseline ([`29926036161`](https://github.com/rue-language/rue/actions/runs/29926036161)):

| Lane | Before | After | Δ |
| --- | ---: | ---: | ---: |
| **Overall workflow critical path** | ~21:26 | **~12:31** | **−8:55 (~42%)** |
| `test (linux-arm64)` main lane | 21:23 | **7:54** | −13:29 (~63%) |
| `test (linux-x64)` main lane | 15:37 | **9:18** | −6:19 (~40%) |

The Linux main lanes now run just the broad discovery pass plus the smaller heavy suites. The relocated corpora run concurrently on their own runners:

- `test (linux-arm64-cli)` **12:29**, `test (linux-x64-cli)` **11:36** (new)
- `test (linux-arm64-spec)` 1:33, `test (linux-x64-spec)` 2:34 (new)
- `test (macos-cli)` 12:01 (pre-existing; macOS was already sharded, so its critical path is unchanged — the win is entirely on Linux)

This matches the pre-merge estimate (arm64 main → ~8 min, overall → ~13 min). As expected, the change **relocates** the long pole rather than shrinking it: the workflow is now bounded at ~12:30 by the `cli` corpus running on its own runner. Shrinking that pole via internal sharding of `cli-tests` is tracked separately in **RUE-1116**.

Note on comparability: baseline is a `merge_group` run and this is a `pull_request` run, but both are on in-repo (non-fork) branches with the BuildBuddy cache available and run the identical workload, so the comparison is apples-to-apples. The post-merge `merge_group` run will reconfirm.

## Correctness

`test.sh` already supports deferral: it accepts `RUE_CI_DEFER_HEAVY_SUITES` only under `CI=true` and validates each deferred target against Buck's live `attrfilter(labels, rue_heavy_suite, //...)` query (the RUE-924 corpus-omission audit skips deferred suites but still requires them to be real heavy-suite targets). All three deferred targets are labeled `rue_heavy_suite` in `BUCK`, so no harness change is needed. All nine `platform-corpus` shards (cli / cli-caldera / spec × 3 platforms) passed on this run.

## Follow-up required (maintainer)

The new per-architecture checks — `test (linux-x64-cli)`, `test (linux-x64-spec)`, `test (linux-arm64-cli)`, `test (linux-arm64-spec)` — must be **marked required in branch protection** for the deferred coverage to gate merges. Until then the corpora still run (just non-required) on Linux.

Closes RUE-1115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)