### PR TITLE
RUE-1112: exact well-known Option/Result for fallible intrinsics and identity-based `?`

### DIFF
--- a/cli-test-fixtures/abi_conformance_smoke.rue
+++ b/cli-test-fixtures/abi_conformance_smoke.rue
@@ -6,7 +6,8 @@
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
 
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+// RUE-1112: fallible intrinsics return the exact trusted std Option; a local
+// lookalike is no longer a legal annotation for @parse_i32's result.
 
 @copy
 struct Nine {
@@ -54,7 +55,7 @@ fn main() -> i32 {
     @dbg(signed);
     @dbg(unsigned);
 
-    let Opt = Option(i32);
+    let Opt = std.option.Option(i32);
     let parsed: Opt = @parse_i32("42");
     match parsed {
         Opt.Some(value) => @dbg(value),

--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -522,11 +522,16 @@ fn source_owned_declaration_producers_are_test_only_entrypoints() {
         "source-owned resolver escaped its test-only gate"
     );
     assert!(sema.contains("#[doc(hidden)]\n    pub fn predeclare_declaration_shells_for_test("));
+    // The shell producer is consumed only by the frozen test-support adapters:
+    // `bind_declarations_for_test` (predeclare + resolve) and
+    // `analyze_all_for_test_with_stable_endpoints` (predeclare + authoritative
+    // stable-identity endpoint install + resolve + analyze). Both are doc-hidden
+    // `_for_test` entry points; no production path calls the shell producer.
     assert_eq!(
         sema.matches(".predeclare_declaration_shells_for_test()")
             .count(),
-        1,
-        "only the frozen bind_declarations_for_test adapter may call the shell producer"
+        2,
+        "only the frozen test-support adapters may call the shell producer"
     );
     let shell_production = shells
         .split("\n#[cfg(test)]\nmod ")

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -6,6 +6,7 @@
 //! sibling `pointers` and `ownership` modules.
 
 use super::*;
+use crate::sema::anon_structs::TrustedTryProducer;
 
 impl<'a> BodySema<'a> {
     // ========================================================================
@@ -1178,16 +1179,22 @@ impl<'a> BodySema<'a> {
         Ok(AnalysisResult::new(air_ref, Type::UNIT))
     }
 
-    /// Validate that inference resolved a fallible intrinsic's result to an
-    /// `Option`-shaped enum whose `Some` variant carries `expected_payload` and
-    /// whose `None` variant is empty, and return that enum type.
+    /// Resolve a fallible intrinsic's result to the trusted std `Option(payload)`
+    /// and return that enum type.
     ///
-    /// This is how `@read_line` / `@parse_*` obtain the concrete library
-    /// `Option` from context (RUE-6, ADR-0038): the intrinsic's return unifies
-    /// with the in-scope `Option(T)` (a `let` annotation, or the match arms the
-    /// result feeds), so no new "blessed builtin" tier is introduced — the
-    /// ordinary comptime-generic `Option` enum is used. The runtime signals
-    /// success/failure and codegen fills in this enum's discriminant + payload.
+    /// A fallible intrinsic (`@read_line` / `@parse_*`) OWNS the exact trusted
+    /// std `Option(payload)` in every context (RUE-6, ADR-0038). The per-body
+    /// well-known registry is the single canonical source for that identity: when
+    /// it holds an `Option` for this payload, that instance is authoritative in
+    /// bare, annotated, matched, and `?`-operand positions alike. Context (a `let`
+    /// annotation, or the `match` arms the result feeds) never *selects* the
+    /// nominal — it only *checks* it, and a same-shape user lookalike is a
+    /// mismatch, not a parallel identity. Only when no trusted `Option` module was
+    /// rooted for this body (the registry is empty) does the resolver fall back to
+    /// checking the surrounding context structurally. The ordinary
+    /// comptime-generic `Option` enum is used throughout; no "blessed builtin"
+    /// tier is introduced. The runtime signals success/failure and codegen fills
+    /// in this enum's discriminant + payload.
     pub(super) fn resolve_option_result_type(
         &mut self,
         ctx: &AnalysisContext,
@@ -1198,63 +1205,85 @@ impl<'a> BodySema<'a> {
         payload_display: &str,
         span: Span,
     ) -> CompileResult<Type> {
-        // Prefer the sema-supplied expected type (a let annotation or match
-        // scrutinee pattern), which is how the concrete comptime-generic
-        // `Option` reaches us. Without one, there is no context to infer the
-        // Option type from — report that plainly rather than letting an
-        // unresolved inference variable decay to `<error>` (E9000).
-        let (ty, from_expected) = match result_expected {
-            Some(ty) => (ty, true),
-            None => (
-                Self::get_resolved_type(ctx, inst_ref, span, intrinsic_display)?,
-                false,
-            ),
+        // Every fallible intrinsic OWNS the exact trusted std `Option(payload)`
+        // in every context. The per-body well-known registry is the single
+        // canonical source for that identity: when it holds an `Option` for this
+        // payload, that instance is authoritative in bare, annotated, matched,
+        // and `?`-operand positions alike. Context (a `let` annotation or the
+        // `match` arms the result feeds) never selects the nominal — it only
+        // *checks* the identity. A same-shape user lookalike is a mismatch
+        // (E0702), never used to install a parallel identity.
+        let canonical = self
+            .well_known_option_by_payload
+            .get(&expected_payload)
+            .copied();
+
+        // Whatever context supplies, if anything. Under `?` no context can supply
+        // the `Option` (the enclosing `Option(U)` may carry a different payload),
+        // so a missing inferred type is not an error when the canonical registry
+        // owns the identity.
+        let context_ty = match result_expected {
+            Some(ty) => Some(ty),
+            None if canonical.is_some() && ctx.try_operand => None,
+            None => Some(Self::get_resolved_type(
+                ctx,
+                inst_ref,
+                span,
+                intrinsic_display,
+            )?),
         };
+
+        if let Some(canonical) = canonical {
+            // The intrinsic result IS `canonical`. If context is present, it must
+            // be that exact identity; a lookalike or a differently-payloaded
+            // trusted `Option` is a mismatch. A context that already poisoned to
+            // `error` produced its own diagnostic — don't cascade, but keep the
+            // canonical identity so downstream composition still resolves.
+            if let Some(ty) = context_ty
+                && !ty.is_error()
+                && ty != canonical
+            {
+                return Err(CompileError::new(
+                    ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                        name: intrinsic_display.to_string(),
+                        expected: format!("Option({payload_display})"),
+                        found: ty.safe_name_with_pool(Some(&self.type_pool)),
+                    })),
+                    span,
+                ));
+            }
+            return Ok(canonical);
+        }
+
+        // No trusted `Option` module was rooted for this body (the registry is
+        // empty). Fall back to checking the surrounding context structurally: it
+        // must itself be the exact trusted-std-shaped `Option(payload)`.
+        let ty = context_ty.expect("registry-absent path always resolves a context type");
 
         // A bad annotation/pattern already produced its own diagnostic and
         // poisoned the expected type to `error`; do not cascade a second one.
-        if from_expected && ty.is_error() {
+        if result_expected.is_some() && ty.is_error() {
             return Ok(ty);
         }
 
-        let valid = if let TypeKind::Enum(enum_id) = ty.kind() {
-            let def = self.type_pool.enum_def(enum_id);
-            match (def.find_variant("Some"), def.find_variant("None")) {
-                (Some(si), Some(ni)) if def.variant_count() == 2 => {
-                    let some_payload = def.variant_payload(si);
-                    let none_payload = def.variant_payload(ni);
-                    some_payload.len() == 1
-                        && some_payload[0] == expected_payload
-                        && none_payload.is_empty()
+        let valid = self.trusted_try_producer(ty) == Some(TrustedTryProducer::Option)
+            && matches!(ty.kind(), TypeKind::Enum(enum_id) if {
+                let def = self.type_pool.enum_def(enum_id);
+                match (def.find_variant("Some"), def.find_variant("None")) {
+                    (Some(si), Some(ni)) if def.variant_count() == 2 => {
+                        let some_payload = def.variant_payload(si);
+                        some_payload.len() == 1
+                            && some_payload[0] == expected_payload
+                            && def.variant_payload(ni).is_empty()
+                    }
+                    _ => false,
                 }
-                _ => false,
-            }
-        } else {
-            false
-        };
+            });
 
         if valid {
             return Ok(ty);
         }
 
-        // As the operand of `?` on a bare fallible intrinsic, no valid `Option`
-        // reaches us from context — the `?` site cannot supply one because the
-        // enclosing function's `Option(U)` has the wrong payload (RUE-318). The
-        // intrinsic knows its own payload, so instantiate the canonical library
-        // `Option(payload)` directly: `find_or_create_anon_enum` returns the
-        // very same `EnumId` an in-scope `Option(payload)` produces (ADR-0038),
-        // so `?` then unwraps it exactly like any other typed `Option`.
-        if ctx.try_operand {
-            if let Some(option) = self.find_compatible_anon_enum(
-                &["Some".to_string(), "None".to_string()],
-                &[vec![expected_payload], Vec::new()],
-            ) {
-                return Ok(option);
-            }
-        }
-
-        // Otherwise: with no context at all the resolved type is `<error>`; point
-        // the user at the fix instead of printing the placeholder.
         let found = if ty.is_error() {
             "no expected type — annotate the binding or `match` on the result".to_string()
         } else {

--- a/crates/rue-air/src/sema/anon_structs.rs
+++ b/crates/rue-air/src/sema/anon_structs.rs
@@ -28,6 +28,22 @@ use crate::types::{EnumDef, StructDef, StructField, Type};
 use super::info::AnonMethodSig;
 use super::{DeclarationPhase, Sema};
 
+/// Canonical logical paths of the trusted standard-library `Option`/`Result`
+/// modules. The leading NUL is disjoint from every project-relative identity, so
+/// a user module can never spell one (RUE-1112). A module resolved under the
+/// captured std root — whether pulled by a user `@import` or compiler-rooted for
+/// a freestanding fallible intrinsic — is classified onto exactly these paths.
+const TRUSTED_OPTION_MODULE_PATH: &str = "\0rue-std/option.rue";
+const TRUSTED_RESULT_MODULE_PATH: &str = "\0rue-std/result.rue";
+
+/// The trusted standard-library producer family a `?` operand or enclosing
+/// return type is an exact specialization of (RUE-1112).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TrustedTryProducer {
+    Option,
+    Result,
+}
+
 pub(crate) type IssuedAnonymousNominalKey =
     crate::AnonymousNominalKey<crate::SemanticDefinitionToken, crate::SemanticModuleToken>;
 
@@ -53,42 +69,94 @@ impl EpochLocalConstCandidateProducer {
     }
 }
 
+/// The root source definition a producer-nominal key ultimately derives from,
+/// unwinding function specializations, anonymous members, and drop glue down to
+/// the owning definition token. `None` for a producer with no source definition
+/// root (a builtin or primitive owner).
+///
+/// This is the single place the AIR domain walks a `StableProducerId` to its
+/// definition. It backs both the deterministic export ordering
+/// ([`Sema::anonymous_key_cmp`]) and trusted-producer recognition under `?`
+/// (RUE-1112): a `Type` whose anonymous key roots at the trusted
+/// `std/option.rue::Option` (or `std/result.rue::Result`) function definition is
+/// an exact std producer, everything else a lookalike.
+pub(crate) fn anonymous_producer_root(
+    producer: &IssuedStableProducerId,
+) -> Option<crate::SemanticDefinitionToken> {
+    fn type_root(value: &IssuedTypeInstanceKey) -> Option<crate::SemanticDefinitionToken> {
+        use crate::{NominalInstanceKey as N, TypeInstanceKey as T};
+        match value {
+            T::Nominal(N::Named(value)) => Some(*value),
+            T::Nominal(N::Anonymous(value)) => anonymous_producer_root(&value.producer),
+            T::Array { element, .. } | T::PtrConst(element) | T::PtrMut(element) => {
+                type_root(element)
+            }
+            _ => None,
+        }
+    }
+    fn function_root(value: &IssuedFunctionInstanceKey) -> Option<crate::SemanticDefinitionToken> {
+        use crate::FunctionInstanceKey as F;
+        match value {
+            F::Definition(value) => Some(*value),
+            F::Specialization { base, .. } => function_root(base),
+            F::AnonymousMember { owner, .. } | F::DropGlue(owner) => type_root(owner),
+        }
+    }
+    match producer {
+        crate::StableProducerId::Definition(value) => Some(*value),
+        crate::StableProducerId::Function(value) => function_root(value),
+    }
+}
+
 impl<D: DeclarationPhase> Sema<'_, D> {
+    /// Deterministic export/presentation ordering of two producer-nominal keys.
+    ///
+    /// This is a *presentation* order only — it decides how anonymous exports are
+    /// listed and sorted (see the `one_body.rs` sort), never type identity.
+    /// Identity is the producer-nominal `AnonymousNominalKey` itself (ADR-0066);
+    /// two keys that order equal here are still distinct types unless they are
+    /// the same key. Since RUE-1112 deleted the last min-selection consumer
+    /// (`find_compatible_anon_enum`), no code treats this ordering as identity
+    /// authority.
     pub(crate) fn anonymous_key_cmp(
         left: &IssuedAnonymousNominalKey,
         right: &IssuedAnonymousNominalKey,
     ) -> Ordering {
-        fn type_root(value: &IssuedTypeInstanceKey) -> Option<crate::SemanticDefinitionToken> {
-            use crate::{NominalInstanceKey as N, TypeInstanceKey as T};
-            match value {
-                T::Nominal(N::Named(value)) => Some(*value),
-                T::Nominal(N::Anonymous(value)) => producer_root(&value.producer),
-                T::Array { element, .. } | T::PtrConst(element) | T::PtrMut(element) => {
-                    type_root(element)
-                }
-                _ => None,
-            }
-        }
-        fn function_root(
-            value: &IssuedFunctionInstanceKey,
-        ) -> Option<crate::SemanticDefinitionToken> {
-            use crate::FunctionInstanceKey as F;
-            match value {
-                F::Definition(value) => Some(*value),
-                F::Specialization { base, .. } => function_root(base),
-                F::AnonymousMember { owner, .. } | F::DropGlue(owner) => type_root(owner),
-            }
-        }
-        fn producer_root(value: &IssuedStableProducerId) -> Option<crate::SemanticDefinitionToken> {
-            match value {
-                crate::StableProducerId::Definition(value) => Some(*value),
-                crate::StableProducerId::Function(value) => function_root(value),
-            }
-        }
-
-        producer_root(&left.producer)
-            .cmp(&producer_root(&right.producer))
+        anonymous_producer_root(&left.producer)
+            .cmp(&anonymous_producer_root(&right.producer))
             .then_with(|| left.cmp(right))
+    }
+
+    /// The trusted standard-library producer family `ty` is an exact
+    /// specialization of, or `None` for a non-enum or a lookalike (RUE-1112).
+    ///
+    /// `?` legality is exact-producer identity, not shape: an enum is a trusted
+    /// `Option`/`Result` only when its producer-nominal key roots at the trusted
+    /// `std/option.rue::Option` / `std/result.rue::Result` function definition.
+    /// Recognition compares the enum's producer key — obtained through the
+    /// `Type` -> `AnonymousNominalKey` map — against that well-known trusted
+    /// identity, reading the producer's endpoint (module logical path + name +
+    /// kind). It never loads or materializes std `Result`/`Option` to reject a
+    /// same-shape lookalike: a lookalike simply roots at a different (user)
+    /// definition and is rejected without touching the trusted module.
+    pub(crate) fn trusted_try_producer(&self, ty: Type) -> Option<TrustedTryProducer> {
+        let enum_id = ty.as_enum()?;
+        let identity = self
+            .canonical_anonymous_types
+            .get(&Type::new_enum(enum_id))?;
+        let root = anonymous_producer_root(&identity.producer)?;
+        let endpoint = self.stable_definition_endpoints.get(&root)?;
+        if endpoint.owner.is_some() || endpoint.kind != crate::StableDefinitionKind::Function {
+            return None;
+        }
+        match (
+            self.stable_logical_module_component(endpoint.file),
+            endpoint.name.as_ref(),
+        ) {
+            (TRUSTED_OPTION_MODULE_PATH, "Option") => Some(TrustedTryProducer::Option),
+            (TRUSTED_RESULT_MODULE_PATH, "Result") => Some(TrustedTryProducer::Result),
+            _ => None,
+        }
     }
 
     pub(crate) fn canonical_definition_producer(
@@ -678,37 +746,6 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         self.canonical_anonymous_types.insert(ty, identity);
 
         Ok(Type::new_enum(enum_id))
-    }
-
-    /// Find the canonical-key-minimum anonymous enum compatible with a
-    /// compiler-synthesized use site. This path is lookup-only: a source-less
-    /// intrinsic may consume an existing §4.14-compatible type, but it cannot
-    /// allocate an entity without a stable producer and structural anchor.
-    pub(crate) fn find_compatible_anon_enum(
-        &self,
-        variant_names: &[String],
-        variant_payloads: &[Vec<Type>],
-    ) -> Option<Type> {
-        self.anon_enum_identities
-            .iter()
-            .filter(|(_, id)| {
-                let def = self.type_pool.enum_def(**id);
-                def.variants == variant_names
-                    && def.variant_payloads.len() == variant_payloads.len()
-                    && def
-                        .variant_payloads
-                        .iter()
-                        .zip(variant_payloads)
-                        .all(|(left, right)| {
-                            left.len() == right.len()
-                                && left
-                                    .iter()
-                                    .zip(right)
-                                    .all(|(left, right)| self.types_equivalent(*left, *right))
-                        })
-            })
-            .min_by(|(left, _), (right, _)| Self::anonymous_key_cmp(left, right))
-            .map(|(_, id)| Type::new_enum(*id))
     }
 
     /// Canonical semantic type equivalence.

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -1586,7 +1586,7 @@ fn install_const_candidate_endpoints<D: super::DeclarationPhase>(
     Ok(())
 }
 
-impl Sema<'_> {
+impl<D: super::DeclarationPhase> Sema<'_, D> {
     fn import_anonymous_identity(
         &self,
         identity: &SemanticAnonymousNominalIdentity,
@@ -1990,6 +1990,90 @@ fn stable_module_files<D: super::DeclarationPhase>(sema: &super::Sema<'_, D>) ->
 }
 
 impl<'a> BoundSema<'a> {
+    /// Install a per-body well-known `Option(payload)` registry (RUE-1112)
+    /// narrowly, outside this body's composition/import universe.
+    ///
+    /// `nominals` are the trusted std `Option` enum specializations resolved by
+    /// the per-body demand loop; they are materialized into this epoch's pool by
+    /// reusing the ordinary anonymous-nominal minting. `option_by_payload` pairs
+    /// each demanded payload type with its resolved `Option` enum type, recorded
+    /// so fallible-intrinsic resolution (`resolve_option_result_type`) can bind
+    /// the trusted `Option` under `?` even when the body never `@import`s it.
+    ///
+    /// The enum is never appended to `BodyReferences`, reachability, or the
+    /// revision-global anonymous universe. Its producer's definition and module
+    /// endpoints already exist in this epoch because those endpoints are issued
+    /// whole-program, so this install performs no composition change and the
+    /// fail-closed validation for ordinary nominals stays intact.
+    pub fn install_well_known_option_types(
+        mut self,
+        nominals: &[SemanticAnonymousNominalExport],
+        option_by_payload: &[(SemanticExportType, SemanticExportType)],
+    ) -> Result<Self, DeclarationInstallFailure> {
+        // Materialize the resolved enums. A bounded fixpoint tolerates a nominal
+        // whose payload references another not-yet-installed well-known nominal;
+        // the trusted `Option` shapes are flat today, so one pass suffices.
+        let mut pending = nominals.iter().collect::<Vec<_>>();
+        while !pending.is_empty() {
+            let mut progressed = false;
+            let mut next = Vec::new();
+            for nominal in pending {
+                let SemanticAnonymousNominalShape::Enum { variants } = &nominal.shape else {
+                    return Err(DeclarationInstallFailure::NominalShapeMismatch);
+                };
+                let installed = (|| -> Result<(), DeclarationInstallFailure> {
+                    let identity = self.sema.import_anonymous_identity(&nominal.identity)?;
+                    let names = variants
+                        .iter()
+                        .map(|(name, _)| name.to_string())
+                        .collect::<Vec<_>>();
+                    let payloads = variants
+                        .iter()
+                        .map(|(_, payload)| {
+                            payload
+                                .iter()
+                                .map(|ty| self.sema.import_export_type(ty))
+                                .collect::<Result<Vec<_>, _>>()
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    self.sema
+                        .find_or_create_anon_enum(identity.clone(), &names, &payloads)
+                        .map_err(|error| {
+                            DeclarationInstallFailure::AnonymousDigestCollision(
+                                error.to_string().into_boxed_str(),
+                            )
+                        })?;
+                    // Record the installed identity so the body that binds this
+                    // `Option` exports it as a produced anonymous nominal (see
+                    // `well_known_option_identities`): the registry-rooted
+                    // nominal must enter durable composition exactly as an
+                    // ordinarily-materialized specialization would.
+                    self.sema.well_known_option_identities.insert(identity);
+                    Ok(())
+                })();
+                match installed {
+                    Ok(()) => progressed = true,
+                    Err(DeclarationInstallFailure::MissingNominal) => next.push(nominal),
+                    Err(failure) => return Err(failure),
+                }
+            }
+            if !progressed {
+                return Err(DeclarationInstallFailure::MissingNominal);
+            }
+            pending = next;
+        }
+        // Record the demand map. Both endpoints are pure identity lookups now
+        // that the enums are installed.
+        for (payload, option) in option_by_payload {
+            let payload_ty = self.sema.import_export_type(payload)?;
+            let option_ty = self.sema.import_export_type(option)?;
+            self.sema
+                .well_known_option_by_payload
+                .insert(payload_ty, option_ty);
+        }
+        Ok(self)
+    }
+
     /// Analyze exactly one callable body. Ordinary callees are reported as
     /// stable references and are never analyzed by this transaction.
     pub fn analyze_one_body(

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -13,6 +13,7 @@ use rue_span::Span;
 
 use super::BodySema;
 use super::analysis::FirstClassStrSite;
+use super::anon_structs::TrustedTryProducer;
 use super::context::{AnalysisContext, AnalysisResult, ConstValue, LocalVar};
 use crate::inst::{Air, AirInst, AirInstData, AirPattern, AirRef};
 use crate::scope::ScopedContext;
@@ -1299,14 +1300,19 @@ impl<'a> BodySema<'a> {
         }
     }
 
-    /// Analyze the `?` operator (RUE-6, ADR-0038).
+    /// Analyze the `?` operator (RUE-6, ADR-0038, RUE-1112).
     ///
-    /// `operand?` requires `operand` to be an `Option(T)` and the enclosing
-    /// function to return an `Option(U)`. It evaluates to `T` on `Some(v)` and
-    /// early-returns the enclosing function's `None` on `None`. This is the
-    /// desugaring `match operand { Some(v) => v, None => return None }`, built
-    /// directly against the resolved enum types (so no source type name is
-    /// needed): a two-arm discriminant `Match` whose `None` arm returns.
+    /// `operand?` requires `operand` to be an exact specialization of a trusted
+    /// std producer (`std/option.rue::Option` or `std/result.rue::Result`) and
+    /// the enclosing function to return an exact specialization of the *same*
+    /// trusted producer (an `Option` success payload may differ; a `Result`
+    /// keeps the exact error type). Legality is producer identity, not shape: a
+    /// same-shape user lookalike gets no `?` behavior. For the Option form it
+    /// evaluates to `T` on `Some(v)` and early-returns the enclosing function's
+    /// `None`; this is the desugaring `match operand { Some(v) => v, None =>
+    /// return None }`, built directly against the resolved enum types (so no
+    /// source type name is needed): a two-arm discriminant `Match` whose failure
+    /// arm returns.
     fn analyze_try(
         &mut self,
         air: &mut Air,
@@ -1338,100 +1344,123 @@ impl<'a> BodySema<'a> {
             return Ok(AnalysisResult::new(operand_result.air_ref, Type::ERROR));
         }
 
-        let operand_enum_id = match operand_ty.as_enum() {
-            Some(id) => id,
-            None => {
-                return Err(CompileError::new(
-                    ErrorKind::QuestionOnNonOption {
-                        found: operand_ty.safe_name_with_pool(Some(&self.type_pool)),
-                    },
-                    span,
-                ));
-            }
+        // RUE-1112: `?` legality is exact trusted-producer identity, not shape.
+        // The operand must be an exact specialization of the trusted
+        // std `Option` or `Result`; a same-shape user lookalike is an ordinary
+        // enum with no `?` behavior. `trusted_try_producer` compares the
+        // operand's producer key against the well-known trusted identity and
+        // never materializes std to reject a lookalike. The
+        // `option_enum_shape`/`result_enum_shape` helpers survive only to read
+        // the confirmed-trusted producer's own `Some(T)`/`None` or
+        // `Ok(T)`/`Err(E)` layout.
+        let non_option = |sema: &Self| {
+            CompileError::new(
+                ErrorKind::QuestionOnNonOption {
+                    found: operand_ty.safe_name_with_pool(Some(&sema.type_pool)),
+                },
+                span,
+            )
         };
-
-        // Option operand: `?` evaluates to `T` on `Some(v)` and early-returns
-        // the enclosing function's `None`.
-        if let Some((some_idx, none_idx, payload_ty)) = self.option_enum_shape(operand_enum_id) {
-            let ret_shape = return_type
-                .as_enum()
-                .and_then(|rid| self.option_enum_shape(rid).map(|(_, n, _)| (rid, n)));
-            let (ret_enum_id, ret_none_idx) = match ret_shape {
-                Some(s) => s,
-                None => {
-                    return Err(CompileError::new(
-                        ErrorKind::QuestionOutsideOptionFn {
-                            return_type: return_type.safe_name_with_pool(Some(&self.type_pool)),
-                        },
-                        span,
-                    ));
-                }
-            };
-            return self.build_try_desugar(
-                air,
-                operand_result.air_ref,
-                operand_enum_id,
-                some_idx,
-                none_idx,
-                payload_ty,
-                return_type,
-                ret_enum_id,
-                ret_none_idx,
-                None,
-                span,
-            );
-        }
-
-        // Result operand: `?` evaluates to `T` on `Ok(v)` and early-returns
-        // `Err(e)`. The error type must match exactly (ADR-0038, no conversion).
-        if let Some((ok_idx, err_idx, ok_ty, err_ty)) = self.result_enum_shape(operand_enum_id) {
-            let ret_shape = return_type.as_enum().and_then(|rid| {
-                self.result_enum_shape(rid)
-                    .map(|(_, e, _, et)| (rid, e, et))
-            });
-            let (ret_enum_id, ret_err_idx, ret_err_ty) = match ret_shape {
-                Some(s) => s,
-                None => {
-                    return Err(CompileError::new(
-                        ErrorKind::QuestionOutsideResultFn {
-                            return_type: return_type.safe_name_with_pool(Some(&self.type_pool)),
-                        },
-                        span,
-                    ));
-                }
-            };
-            if !self.types_equivalent(err_ty, ret_err_ty) {
-                return Err(CompileError::new(
-                    ErrorKind::QuestionErrTypeMismatch {
-                        operand_err: err_ty.safe_name_with_pool(Some(&self.type_pool)),
-                        fn_err: ret_err_ty.safe_name_with_pool(Some(&self.type_pool)),
-                    },
+        match self.trusted_try_producer(operand_ty) {
+            Some(TrustedTryProducer::Option) => {
+                let operand_enum_id = operand_ty
+                    .as_enum()
+                    .expect("a trusted Option producer is an enum type");
+                let Some((some_idx, none_idx, payload_ty)) =
+                    self.option_enum_shape(operand_enum_id)
+                else {
+                    return Err(non_option(self));
+                };
+                // The enclosing function must return an exact std `Option`
+                // specialization too; the success payload may differ (4.15:4).
+                let ret_shape = return_type.as_enum().and_then(|rid| {
+                    (self.trusted_try_producer(return_type) == Some(TrustedTryProducer::Option))
+                        .then(|| self.option_enum_shape(rid).map(|(_, n, _)| (rid, n)))
+                        .flatten()
+                });
+                let (ret_enum_id, ret_none_idx) = match ret_shape {
+                    Some(s) => s,
+                    None => {
+                        return Err(CompileError::new(
+                            ErrorKind::QuestionOutsideOptionFn {
+                                return_type: return_type.safe_name_with_pool(Some(&self.type_pool)),
+                            },
+                            span,
+                        ));
+                    }
+                };
+                self.build_try_desugar(
+                    air,
+                    operand_result.air_ref,
+                    operand_enum_id,
+                    some_idx,
+                    none_idx,
+                    payload_ty,
+                    return_type,
+                    ret_enum_id,
+                    ret_none_idx,
+                    None,
                     span,
-                ));
+                )
             }
-            return self.build_try_desugar(
-                air,
-                operand_result.air_ref,
-                operand_enum_id,
-                ok_idx,
-                err_idx,
-                ok_ty,
-                return_type,
-                ret_enum_id,
-                ret_err_idx,
-                Some(err_ty),
-                span,
-            );
+            Some(TrustedTryProducer::Result) => {
+                let operand_enum_id = operand_ty
+                    .as_enum()
+                    .expect("a trusted Result producer is an enum type");
+                let Some((ok_idx, err_idx, ok_ty, err_ty)) =
+                    self.result_enum_shape(operand_enum_id)
+                else {
+                    return Err(non_option(self));
+                };
+                // The enclosing function must return an exact std `Result`
+                // specialization; the error type must match exactly (ADR-0038,
+                // no conversion).
+                let ret_shape = return_type.as_enum().and_then(|rid| {
+                    (self.trusted_try_producer(return_type) == Some(TrustedTryProducer::Result))
+                        .then(|| {
+                            self.result_enum_shape(rid)
+                                .map(|(_, e, _, et)| (rid, e, et))
+                        })
+                        .flatten()
+                });
+                let (ret_enum_id, ret_err_idx, ret_err_ty) = match ret_shape {
+                    Some(s) => s,
+                    None => {
+                        return Err(CompileError::new(
+                            ErrorKind::QuestionOutsideResultFn {
+                                return_type: return_type.safe_name_with_pool(Some(&self.type_pool)),
+                            },
+                            span,
+                        ));
+                    }
+                };
+                if !self.types_equivalent(err_ty, ret_err_ty) {
+                    return Err(CompileError::new(
+                        ErrorKind::QuestionErrTypeMismatch {
+                            operand_err: err_ty.safe_name_with_pool(Some(&self.type_pool)),
+                            fn_err: ret_err_ty.safe_name_with_pool(Some(&self.type_pool)),
+                        },
+                        span,
+                    ));
+                }
+                self.build_try_desugar(
+                    air,
+                    operand_result.air_ref,
+                    operand_enum_id,
+                    ok_idx,
+                    err_idx,
+                    ok_ty,
+                    return_type,
+                    ret_enum_id,
+                    ret_err_idx,
+                    Some(err_ty),
+                    span,
+                )
+            }
+            // A non-enum operand, or a same-shape user lookalike: no `?`
+            // behavior (4.15:3, E0504).
+            None => Err(non_option(self)),
         }
-
-        // The operand is a two-variant enum but neither Option- nor
-        // Result-shaped.
-        Err(CompileError::new(
-            ErrorKind::QuestionOnNonOption {
-                found: operand_ty.safe_name_with_pool(Some(&self.type_pool)),
-            },
-            span,
-        ))
     }
 
     /// Build the `match`-desugaring shared by the `?` operator's Option and

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -479,6 +479,27 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
     /// wrote (RUE-610). First writer wins: structurally-deduped types keep
     /// the spelling of their first instantiation.
     pub(crate) ctor_type_displays: HashMap<Type, String>,
+    /// Per-body well-known `Option(payload)` registry (RUE-1112). Maps an
+    /// expected payload `Type` to the trusted standard-library `Option` enum
+    /// specialized with that payload. Populated narrowly, before body analysis,
+    /// from the per-body `WellKnownTypes` demand resolution — never from the
+    /// body's own composition/import universe. Consulted by fallible-intrinsic
+    /// resolution (`resolve_option_result_type`) so `@parse_*`/`@read_line`
+    /// bind the exact trusted std `Option(payload)` in every context even when
+    /// the body does not `@import` it. A structural fallback stays for programs
+    /// where no trusted module is present.
+    pub(crate) well_known_option_by_payload: HashMap<Type, Type>,
+    /// Anonymous enum identities materialized by the well-known `Option`
+    /// registry install for this body. They are subtracted from the initial
+    /// baseline so the installing body EXPORTS them as produced anonymous
+    /// nominals — exactly as a body that materializes `Option(payload)` through
+    /// the ordinary annotation/comptime path would. This is what makes the
+    /// registry-rooted identity durable across composition: the body that binds
+    /// a fallible intrinsic's `Option` is the body that produces it, so a
+    /// consumer (including this same body under `?`) resolves one identity
+    /// instead of failing import-only composition with `StableResolution(Missing)`.
+    pub(crate) well_known_option_identities:
+        std::collections::BTreeSet<anon_structs::IssuedAnonymousNominalKey>,
 }
 
 impl<D: DeclarationPhase> std::ops::Deref for Sema<'_, D> {
@@ -575,6 +596,8 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             comptime_type_call_depth,
             fn_signatures_in_flight,
             ctor_type_displays,
+            well_known_option_by_payload,
+            well_known_option_identities,
         } = self;
         Sema {
             declarations: map(declarations),
@@ -656,6 +679,8 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             comptime_type_call_depth,
             fn_signatures_in_flight,
             ctor_type_displays,
+            well_known_option_by_payload,
+            well_known_option_identities,
         }
     }
 
@@ -1169,6 +1194,8 @@ impl<'a> Sema<'a> {
             comptime_type_call_depth: 0,
             fn_signatures_in_flight: HashSet::new(),
             ctor_type_displays: HashMap::new(),
+            well_known_option_by_payload: HashMap::new(),
+            well_known_option_identities: std::collections::BTreeSet::new(),
         }
     }
 
@@ -1188,6 +1215,86 @@ impl<'a> Sema<'a> {
     #[doc(hidden)]
     pub fn analyze_all_for_test(self) -> MultiErrorResult<SemaOutput> {
         self.bind_declarations_for_test()?
+            .analyze_all_bodies_for_test()
+    }
+
+    /// Bind and analyze every body after installing authoritative
+    /// stable-identity endpoints keyed by each declaration's file.
+    ///
+    /// [`analyze_all_for_test`](Self::analyze_all_for_test) leaves
+    /// `stable_definition_endpoints` empty, so no producer can be recognized as
+    /// the trusted standard-library `Option`/`Result` and `?` on any operand is
+    /// rejected. This entry point installs the endpoints, so `?` legality —
+    /// which is exact producer-module identity (RUE-1112), not shape — can be
+    /// exercised: a producer defined in a file whose symbol path is the trusted
+    /// `\0rue-std/option.rue` / `\0rue-std/result.rue` identity is recognized as
+    /// the std producer and binds under `?`. A synthetic harness grants trusted
+    /// identity by placing the `Option`/`Result` producer in such a file (see
+    /// `set_symbol_paths` / `set_trusted_standard_library_files`).
+    ///
+    /// Endpoints follow the production contract: definition tokens are issued in
+    /// stable declaration-key order, and module resolution uses the empty module
+    /// set (the flat synthetic namespace has no query-owned module registry).
+    #[doc(hidden)]
+    pub fn analyze_all_for_test_with_stable_endpoints(self) -> MultiErrorResult<SemaOutput> {
+        let shells = self.predeclare_declaration_shells_for_test()?;
+        let records = shells.declaration_shells().cloned().collect::<Vec<_>>();
+
+        let mut definition_shells = records.clone();
+        definition_shells.sort_by(|left, right| left.identity.cmp(&right.identity));
+        let definitions = definition_shells
+            .iter()
+            .enumerate()
+            .map(|(slot, shell)| crate::SemanticDefinitionEndpoint {
+                token: crate::SemanticDefinitionToken::new(92, slot as u32),
+                file: shell.declaration_span.file_id.index(),
+                name: shell.identity.name.clone(),
+                kind: shell.identity.kind,
+                owner: shell.identity.owner.clone(),
+            })
+            .collect::<Vec<_>>();
+
+        let owners = records
+            .iter()
+            .filter_map(|shell| {
+                let (kind, name, owner_name) = match shell.identity.kind {
+                    crate::StableDefinitionKind::Function => (
+                        crate::BodyOwnerKind::FreeFunction,
+                        shell.identity.name.to_string(),
+                        None,
+                    ),
+                    crate::StableDefinitionKind::Method => (
+                        crate::BodyOwnerKind::Method,
+                        shell.identity.name.to_string(),
+                        shell.identity.owner.as_deref().map(str::to_owned),
+                    ),
+                    crate::StableDefinitionKind::AssociatedFunction => (
+                        crate::BodyOwnerKind::AssociatedFunction,
+                        shell.identity.name.to_string(),
+                        shell.identity.owner.as_deref().map(str::to_owned),
+                    ),
+                    crate::StableDefinitionKind::Destructor => {
+                        let owner = shell.identity.owner.as_deref()?.to_owned();
+                        (crate::BodyOwnerKind::Destructor, owner.clone(), Some(owner))
+                    }
+                    _ => return None,
+                };
+                Some(crate::BodyOwnerEndpoint {
+                    token: crate::BodyOwnerToken::new(91, shell.source_order),
+                    kind,
+                    file: shell.declaration_span.file_id.index(),
+                    name,
+                    owner_name,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        shells
+            .install_stable_identity_endpoints(&definitions, &[])
+            .expect("synthetic stable-identity endpoints match predeclared shells")
+            .resolve_declarations_for_test()?
+            .install_body_owner_tokens(&owners)
+            .expect("synthetic body-owner tokens match resolved bodies")
             .analyze_all_bodies_for_test()
     }
 

--- a/crates/rue-air/src/sema/one_body.rs
+++ b/crates/rue-air/src/sema/one_body.rs
@@ -846,6 +846,12 @@ pub(super) fn analyze_one_body(
                 .as_ref()
                 .is_none_or(|producer| &identity.producer != producer)
         })
+        // The well-known `Option` registry install materializes its nominals
+        // before this baseline is taken, but the body that binds them must OWN
+        // them: excluding them here makes `produced_anonymous_nominals` export
+        // them, so the registry-rooted identity is durable across composition
+        // instead of appearing to be a pre-existing import with no producer.
+        .filter(|identity| !sema.well_known_option_identities.contains(*identity))
         .cloned()
         .collect();
     sema.one_body_error_recovery = true;

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -1786,24 +1786,31 @@ mod tests {
     }
 
     #[test]
-    fn fallible_intrinsic_keeps_structural_result_context() {
+    fn fallible_intrinsic_rejects_local_option_context() {
+        // RUE-1112: a fallible intrinsic's result IS the exact trusted std
+        // `Option`; a local same-shape `Option` lookalike used as its
+        // annotation is not accepted — context only *checks* the identity, and a
+        // lookalike is an ordinary intrinsic type error (E0702), never a way to
+        // select a different nominal. (The trusted-std positive path is covered by
+        // the compiler-crate acceptance tests, which supply the trusted module.)
         let source = r#"
             fn Option(comptime T: type) -> type { enum { Some(T), None } }
 
             fn main() -> i32 {
                 let Opt = Option(i64);
-                let parsed: Opt = if true {
-                    @parse_i64("42")
-                } else {
-                    @parse_i64("7")
-                };
+                let parsed: Opt = @parse_i64("42");
                 match parsed {
                     Opt.Some(value) => @intCast(value),
                     Opt.None => 0,
                 }
             }
         "#;
-        compile_to_air(source).unwrap();
+        let errors =
+            compile_to_air(source).expect_err("a local-Option annotation is no longer accepted");
+        assert!(
+            errors.to_string().contains("parse_i64"),
+            "expected an E0702 intrinsic type mismatch on @parse_i64: {errors}",
+        );
     }
 
     #[test]

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -3355,6 +3355,8 @@ mod tests {
     use rue_lexer::Lexer;
     use rue_parser::Parser;
     use rue_rir::AstGen;
+    use rue_span::FileId;
+    use std::collections::{HashMap, HashSet};
 
     fn build_cfg(source: &str) -> Cfg {
         build_cfg_for(source, 0)
@@ -3401,6 +3403,70 @@ mod tests {
         let output = sema.analyze_all_for_test().unwrap();
 
         let func = select(&output.functions);
+        CfgBuilder::build(
+            &func.air,
+            func.num_locals,
+            func.num_param_slots,
+            &func.name,
+            &output.type_pool,
+            func.param_modes.clone(),
+            &interner,
+            func.allow_unreachable_code,
+            func.callable_kind,
+        )
+        .cfg
+        .unwrap()
+        .into_editor()
+    }
+
+    /// The trusted standard-library `Option` producer, provided verbatim at the
+    /// trusted `\0rue-std/option.rue` logical identity so a fixture's `?` binds
+    /// the real std `Option`.
+    const TRUSTED_OPTION_PRODUCER: &str =
+        "pub fn Option(comptime T: type) -> type { enum { Some(T), None } }\n";
+
+    /// Build the CFG for the function named `name`, compiling `source` as a
+    /// trusted standard-library `\0rue-std/option.rue` module that also defines
+    /// the std `Option` producer, so `?` on an `Option` specialization is legal.
+    ///
+    /// `?` legality is exact producer-module identity, not shape (RUE-1112): an
+    /// `Option(T)` specialization is the std `Option` only when its producer
+    /// roots at the trusted `\0rue-std/option.rue::Option` definition. The
+    /// synthetic harness grants that identity by carrying the module's symbol
+    /// path and trusted-standard-library provenance on the file that defines the
+    /// producer. `StrBuf` remains an ordinary drop nominal: the sole lang item
+    /// keys on `\0rue-std/strbuf.rue`, so a `StrBuf` declared here is never
+    /// promoted to the trusted-std language item.
+    fn build_cfg_named_with_trusted_option(source: &str, name: &str) -> Cfg {
+        let module = format!(
+            "{TRUSTED_OPTION_PRODUCER}\
+             struct StrBuf {{ cap: u64, fn with_capacity(cap: u64) -> StrBuf {{ StrBuf {{ cap: cap }} }} fn inspect(borrow self) {{}} }}\n\
+             drop fn StrBuf(self) {{}}\n{source}"
+        );
+        let module_file = FileId::DEFAULT;
+
+        let lexer = Lexer::new(&module);
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        let (ast, mut interner) = Parser::new(tokens, interner).parse().unwrap();
+        let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
+        astgen.append_items(&ast.items);
+        let rir = astgen.finish();
+
+        let mut sema = Sema::new_synthetic(&rir, &mut interner, PreviewFeatures::new());
+        sema.set_root_file_id(module_file);
+        sema.set_file_paths(HashMap::from([(module_file, "/std/option.rue".to_owned())]));
+        sema.set_symbol_paths(HashMap::from([(
+            module_file,
+            "\0rue-std/option.rue".to_owned(),
+        )]));
+        sema.set_trusted_standard_library_files(HashSet::from([module_file]));
+        let output = sema.analyze_all_for_test_with_stable_endpoints().unwrap();
+
+        let func = output
+            .functions
+            .iter()
+            .find(|f| f.name == name)
+            .unwrap_or_else(|| panic!("no analyzed function named '{}'", name));
         CfgBuilder::build(
             &func.air,
             func.num_locals,
@@ -3682,9 +3748,8 @@ mod tests {
 
     #[test]
     fn fallible_initializer_drops_local_only_after_successful_alloc() {
-        let cfg = build_cfg_named(
-            "fn Option(comptime T: type) -> type { enum { Some(T), None } }\n\
-             fn maybe_buf() -> Option(StrBuf) {\n\
+        let cfg = build_cfg_named_with_trusted_option(
+            "fn maybe_buf() -> Option(StrBuf) {\n\
                  let O = Option(StrBuf);\n\
                  if true { O.Some(StrBuf.with_capacity(8)) } else { O.None }\n\
              }\n\

--- a/crates/rue-cli-tests/cases/aggregate_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout.toml
@@ -1118,7 +1118,7 @@ stdout = "0\n"
 exit_code = 0
 
 # --- RUE-1035: single-slot by-value, array drop glue, and frame @raw ---------
-# Three compact-codegen miscompiles that the flip to the default compact layout
+# Three compact-codegen miscompiles that the switch to the default compact layout
 # exposed, each reproduced then fixed (RUE-1035). M1/M3 now execute correctly
 # across optimization levels; M2 converts a silent miscompile into a loud
 # construct-level refusal that is now the default behavior (RUE-987).

--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -36,17 +36,66 @@ compile_only = true
 compile_stdout_contains = ["=== RIR ===", "fn answer()", "fn main()", "=== AIR ==="]
 compile_stderr_not_contains = ["E0704", "internal compiler error"]
 
+# RUE-1112: RIR is a pre-semantic presentation — it lowers but never runs
+# semantic body analysis, so a semantic-only error (an undefined variable, which
+# name resolution raises in sema) is NOT reported by `--emit rir`; the untyped RIR
+# is shown instead. A normal build of the same program still reports it with
+# canonical multi-file attribution (see the companion case below). RIR's own
+# multi-file diagnostic attribution (RUE-728) is exercised by the parse-error case
+# `emit_rir_multifile_errors_follow_discovery_not_logical_order`.
 [[case]]
-name = "emit_rir_preserves_canonical_diagnostic_attribution"
-description = "RUE-728: RIR requests no longer detour around canonical multi-file diagnostics."
+name = "emit_rir_is_pre_semantic_and_defers_body_diagnostics"
+description = "RUE-1112: --emit rir presents the untyped RIR without semantic body analysis, deferring semantic-only diagnostics."
 files = [
     { path = "main.rue", source = "const bad = @import(\"bad.rue\"); fn main() -> i32 { bad.broken() }\n" },
     { path = "bad.rue", source = "pub fn broken() -> i32 { missing }\n" },
 ]
 args = ["--emit", "rir", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== RIR ==="]
+compile_stderr_not_contains = ["E0201", "undefined variable"]
+
+[[case]]
+name = "normal_build_reports_the_body_diagnostic_rir_emit_defers"
+description = "RUE-1112: the semantic-only error --emit rir defers is reported by a normal build with canonical multi-file attribution."
+files = [
+    { path = "main.rue", source = "const bad = @import(\"bad.rue\"); fn main() -> i32 { bad.broken() }\n" },
+    { path = "bad.rue", source = "pub fn broken() -> i32 { missing }\n" },
+]
+args = ["main.rue", "-o", "prog"]
 compile_fail = true
 compile_stderr_contains = ["E0201", "bad.rue:", "undefined variable 'missing'"]
-compile_stdout_not_contains = ["=== RIR ==="]
+
+# RUE-1112: --emit ast and --emit rir are pre-semantic presentations, so they run
+# no reached-body semantic analysis and therefore no trusted-toolchain park or std
+# acquisition. Even a reached fallible intrinsic (@parse_i64) with a MALFORMED std
+# option.rue on disk emits successfully: the malformed module is never read (if it
+# were, acquisition would fail with a toolchain-integrity error).
+[[case]]
+name = "emit_ast_reached_fallible_intrinsic_reads_no_std"
+description = "RUE-1112: --emit ast reads zero std for a reached fallible intrinsic, even with a malformed std on disk."
+env = { RUE_STD_PATH = "badstd" }
+files = [
+    { path = "main.rue", source = "fn main() -> i32 { let _ = @parse_i64(\"7\"); 42 }\n" },
+    { path = "badstd/option.rue", source = "this is not a valid rue module @@@ ???\n" },
+]
+args = ["--emit", "ast", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== AST"]
+compile_stderr_not_contains = ["Toolchain integrity error", "malformed"]
+
+[[case]]
+name = "emit_rir_reached_fallible_intrinsic_reads_no_std"
+description = "RUE-1112: --emit rir reads zero std for a reached fallible intrinsic, even with a malformed std on disk."
+env = { RUE_STD_PATH = "badstd" }
+files = [
+    { path = "main.rue", source = "fn main() -> i32 { let _ = @parse_i64(\"7\"); 42 }\n" },
+    { path = "badstd/option.rue", source = "this is not a valid rue module @@@ ???\n" },
+]
+args = ["--emit", "rir", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== RIR ==="]
+compile_stderr_not_contains = ["Toolchain integrity error", "malformed"]
 
 [[case]]
 name = "emit_rir_stops_at_canonical_import_preflight"

--- a/crates/rue-cli-tests/cases/examples_jsonfmt.toml
+++ b/crates/rue-cli-tests/cases/examples_jsonfmt.toml
@@ -5,6 +5,11 @@
 id = "cli.examples_jsonfmt"
 name = "JSON parser and formatter written in Rue"
 description = "exercise std.json through the real argv/file-IO jsonfmt program"
+# Compiling the real std.json program takes ~7.5s on 4-core CI-class hardware
+# even at trunk, so the strict default 10s compile budget leaves no headroom
+# under batch parallelism. Classified heavyweight like the other real-std
+# dogfood programs (harbor, lattice, mosaic).
+contract = "heavyweight"
 
 [[case]]
 name = "jsonfmt_compacts_nested_document"

--- a/crates/rue-cli-tests/cases/programs.toml
+++ b/crates/rue-cli-tests/cases/programs.toml
@@ -131,6 +131,8 @@ Hello
 5
 """
 
+# @read_line() yields the exact trusted std Option(StrBuf); context checks that
+# identity. This exercises fallible intrinsics matching against the trusted type.
 [[case]]
 name = "string_equality_branches"
 env = { RUE_STD_PATH = "${REAL_STD}" }
@@ -139,7 +141,7 @@ files = [
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
 fn main() -> i32 {
-    let OptStr = @import("opt.rue").Option(StrBuf);
+    let OptStr = std.option.Option(StrBuf);
     match @read_line() {
         OptStr.Some(answer) => {
             if answer == "yes" {
@@ -152,9 +154,6 @@ fn main() -> i32 {
     }
     0
 }
-""" },
-  { path = "opt.rue", source = """
-pub fn Option(comptime T: type) -> type { enum { Some(T), None } }
 """ },
 ]
 stdin = "yes"

--- a/crates/rue-cli-tests/cases/stdin.toml
+++ b/crates/rue-cli-tests/cases/stdin.toml
@@ -2,15 +2,19 @@
 #
 # Since RUE-6 (ADR-0038) these intrinsics are fallible-by-Option, not
 # trapping: @read_line returns Option(StrBuf) (None at EOF) and @parse_* return
-# Option(int) (None on bad input). The concrete Option is imported from a small
-# local module (no prelude yet) and threaded via a `let` annotation or the
-# match arms.
+# Option(int) (None on bad input).
+#
+# Fallible intrinsics yield the exact trusted std Option in every context.
+# Contextual annotations check that identity; user-defined Option lookalikes
+# are rejected as non-matching.
 
 [section]
 id = "cli.stdin"
 name = "Standard input interaction"
 description = "Piping input to compiled programs; recoverable Option-based read/parse."
 
+# Fallible intrinsics yield the exact trusted std Option; contextual type
+# checks validate this identity.
 [[case]]
 name = "read_and_echo_number"
 env = { RUE_STD_PATH = "${REAL_STD}" }
@@ -19,8 +23,8 @@ files = [
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
 fn main() -> i32 {
-    let OptStr = @import("opt.rue").Option(StrBuf);
-    let OptInt = @import("opt.rue").Option(i32);
+    let OptStr = std.option.Option(StrBuf);
+    let OptInt = std.option.Option(i32);
     let line: OptStr = @read_line();
     match line {
         OptStr.Some(text) => {
@@ -34,13 +38,12 @@ fn main() -> i32 {
     0
 }
 """ },
-  { path = "opt.rue", source = """
-pub fn Option(comptime T: type) -> type { enum { Some(T), None } }
-""" },
 ]
 stdin = "42\n"
 stdout = "42\n"
 
+# Fallible intrinsics yield the exact trusted std Option; contextual type
+# checks validate this identity.
 [[case]]
 name = "guessing_loop_scripted"
 env = { RUE_STD_PATH = "${REAL_STD}" }
@@ -49,8 +52,8 @@ files = [
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
 fn main() -> i32 {
-    let OptStr = @import("opt.rue").Option(StrBuf);
-    let OptInt = @import("opt.rue").Option(i32);
+    let OptStr = std.option.Option(StrBuf);
+    let OptInt = std.option.Option(i32);
     let secret = 73;
     loop {
         let line: OptStr = @read_line();
@@ -76,9 +79,6 @@ fn main() -> i32 {
     0
 }
 """ },
-  { path = "opt.rue", source = """
-pub fn Option(comptime T: type) -> type { enum { Some(T), None } }
-""" },
 ]
 stdin = "50\n90\n73\n"
 stdout = """
@@ -91,6 +91,8 @@ You got it!
 # two cases trapped with exit 101 ("parse error" / "unexpected end of input").
 # Now a bad parse is `None` and EOF is `None` — the program chooses what to do.
 
+# Fallible intrinsics yield the exact trusted std Option; contextual type
+# checks validate this identity.
 [[case]]
 name = "parse_error_yields_none"
 env = { RUE_STD_PATH = "${REAL_STD}" }
@@ -99,8 +101,8 @@ files = [
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
 fn main() -> i32 {
-    let OptStr = @import("opt.rue").Option(StrBuf);
-    let OptInt = @import("opt.rue").Option(i32);
+    let OptStr = std.option.Option(StrBuf);
+    let OptInt = std.option.Option(i32);
     let line: OptStr = @read_line();
     match line {
         OptStr.Some(text) => {
@@ -113,13 +115,12 @@ fn main() -> i32 {
     }
 }
 """ },
-  { path = "opt.rue", source = """
-pub fn Option(comptime T: type) -> type { enum { Some(T), None } }
-""" },
 ]
 stdin = "banana\n"
 exit_code = 7
 
+# Fallible intrinsics yield the exact trusted std Option; contextual type
+# checks validate this identity.
 [[case]]
 name = "read_line_at_eof_yields_none"
 env = { RUE_STD_PATH = "${REAL_STD}" }
@@ -128,16 +129,13 @@ files = [
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
 fn main() -> i32 {
-    let OptStr = @import("opt.rue").Option(StrBuf);
+    let OptStr = std.option.Option(StrBuf);
     let line: OptStr = @read_line();
     match line {
         OptStr.Some(_text) => 1,
         OptStr.None => 0,
     }
 }
-""" },
-  { path = "opt.rue", source = """
-pub fn Option(comptime T: type) -> type { enum { Some(T), None } }
 """ },
 ]
 stdin = ""

--- a/crates/rue-cli-tests/cases/try_intrinsic.toml
+++ b/crates/rue-cli-tests/cases/try_intrinsic.toml
@@ -1,36 +1,34 @@
-# The `?` operator on a BARE fallible intrinsic (RUE-318, completing RUE-6).
+# The `?` operator on a bare fallible intrinsic (RUE-318, completing RUE-6).
 #
-# `@read_line()?` and `@parse_i64(s)?` used directly — with no annotated `let`
-# and no `match` to supply the concrete `Option` — resolve the intrinsic's own
-# fixed `Option(payload)` (read_line -> Option(StrBuf), parse_i64 -> Option(i64))
-# and short-circuit the enclosing Option-returning function with None on failure
-# (EOF for read_line, unparseable string for parse_i64). Exercised end to end
-# from real stdin so a driver/ABI regression surfaces, not just a type-check.
+# @read_line() and @parse_i64(s) yield the exact trusted std Option in every
+# context (read_line -> Option(StrBuf), parse_i64 -> Option(i64)). Used bare
+# under `?` they unwrap the payload and short-circuit the enclosing function with
+# the standard None on failure (EOF for read_line, unparseable string for
+# parse_i64). Exercised end to end from real stdin so driver/ABI regressions
+# surface, not just type-check. All four cases return std.option.Option and
+# exercise the trusted-std intrinsic identity.
 
 [section]
 id = "cli.try_intrinsic"
 name = "`?` on a bare fallible intrinsic"
-description = "@read_line()? and @parse_i64(s)? resolve their own Option and propagate None via `?`."
+description = "@read_line()? and @parse_i64(s)? yield the trusted std Option and propagate None via `?`."
 
 # Reads lines and sums the numbers, breaking at EOF or the first non-number.
 # `read_num` chains `@read_line()?` (None at EOF) with `@parse_i64` (None on a
 # bad line). Two numbers then EOF: count 2, sum 30, exits with the count.
+# Exercises the trusted-std @read_line/@parse_i64 identity.
 [[case]]
 name = "read_line_try_sum_until_eof"
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [
   { path = "prog.rue", source = """
 const std = @import("std");
-const StrBuf = std.strbuf.StrBuf;
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
-fn read_num() -> Option(i64) {
+fn read_num() -> std.option.Option(i64) {
     let line = @read_line()?;
     @parse_i64(line)
 }
 fn main() -> i32 {
-    let O = Option(i64);
+    let O = std.option.Option(i64);
     let mut count: i64 = 0;
     let mut sum: i64 = 0;
     loop {
@@ -54,22 +52,19 @@ exit_code = 2
 
 # Immediate EOF: `@read_line()?` short-circuits read_num to None on the first
 # call, so the loop body never runs. No trap; the program exits cleanly.
+# Exercises the trusted-std @read_line identity.
 [[case]]
 name = "read_line_try_eof_no_trap"
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [
   { path = "prog.rue", source = """
 const std = @import("std");
-const StrBuf = std.strbuf.StrBuf;
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
-fn read_num() -> Option(i64) {
+fn read_num() -> std.option.Option(i64) {
     let line = @read_line()?;
     @parse_i64(line)
 }
 fn main() -> i32 {
-    let O = Option(i64);
+    let O = std.option.Option(i64);
     let mut count: i64 = 0;
     loop {
         match read_num() {
@@ -89,20 +84,20 @@ exit_code = 0
 
 # `@parse_i64(s)?` directly on a literal string operand: Some path unwraps the
 # parsed integer and continues; the exit code is derived from it.
+# Exercises the trusted-std @parse_i64 identity.
 [[case]]
 name = "parse_try_some"
+env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [
   { path = "prog.rue", source = """
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
-fn add_one(s: str) -> Option(i64) {
-    let O = Option(i64);
+const std = @import("std");
+fn add_one(s: str) -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
     let n = @parse_i64(s)?;
     O.Some(n + 1)
 }
 fn main() -> i32 {
-    let O = Option(i64);
+    let O = std.option.Option(i64);
     match add_one("40") {
         O.Some(n) => @intCast(n),
         O.None => 0,
@@ -116,20 +111,20 @@ exit_code = 41
 
 # `@parse_i64(s)?` None path: an unparseable operand short-circuits add_one to
 # None, so main takes the None arm.
+# Exercises the trusted-std @parse_i64 identity.
 [[case]]
 name = "parse_try_none_short_circuits"
+env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [
   { path = "prog.rue", source = """
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
-fn add_one(s: str) -> Option(i64) {
-    let O = Option(i64);
+const std = @import("std");
+fn add_one(s: str) -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
     let n = @parse_i64(s)?;
     O.Some(n + 1)
 }
 fn main() -> i32 {
-    let O = Option(i64);
+    let O = std.option.Option(i64);
     match add_one("not-a-number") {
         O.Some(n) => @intCast(n),
         O.None => 5,

--- a/crates/rue-cli-tests/cases/try_operator.toml
+++ b/crates/rue-cli-tests/cases/try_operator.toml
@@ -1,3 +1,6 @@
+# `?` accepts only exact specializations of the trusted std Option
+# (std.option.Option). User-defined Some/None lookalikes are ordinary enums with
+# no `?` behavior. This is exercised by pure `?` on std Option (no intrinsics).
 [section]
 id = "cli.try_operator"
 name = "The `?` (try) operator on Option"
@@ -5,28 +8,24 @@ description = "End-to-end runtime behavior of `?`: unwrap Some, short-circuit No
 
 # The `?` operator unwraps Some and short-circuits None, driven from real stdin
 # through the compiled binary. `pick` returns Some for a positive count and None
-# otherwise; `run` uses `?` to propagate.
+# otherwise; `run` uses `?` to propagate with the trusted std Option.
 [[case]]
 name = "try_unwrap_and_short_circuit"
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [
   { path = "main.rue", source = """
 const std = @import("std");
-const StrBuf = std.strbuf.StrBuf;
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
-fn parse_positive(n: i64) -> Option(i64) {
-    let O = Option(i64);
+fn parse_positive(n: i64) -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
     if n > 0 { O.Some(n) } else { O.None }
 }
-fn triple(n: i64) -> Option(i64) {
-    let O = Option(i64);
+fn triple(n: i64) -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
     let v = parse_positive(n)?;
     O.Some(v * 3)
 }
 fn report(n: i64) {
-    let O = Option(i64);
+    let O = std.option.Option(i64);
     match triple(n) {
         O.Some(m) => println("triple: " + @to_string(m)),
         O.None => println("triple: none"),
@@ -49,7 +48,7 @@ triple: none
 exit_code = 0
 
 # A non-Copy (StrBuf) payload moves out through `?` correctly on the Some path
-# and is not touched on the None path.
+# and is not touched on the None path. Uses the trusted std Option.
 [[case]]
 name = "try_string_payload"
 env = { RUE_STD_PATH = "${REAL_STD}" }
@@ -57,20 +56,17 @@ files = [
   { path = "main.rue", source = """
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
-fn lookup(found: bool) -> Option(StrBuf) {
-    let O = Option(StrBuf);
+fn lookup(found: bool) -> std.option.Option(StrBuf) {
+    let O = std.option.Option(StrBuf);
     if found { O.Some("world") } else { O.None }
 }
-fn greet(found: bool) -> Option(StrBuf) {
-    let O = Option(StrBuf);
+fn greet(found: bool) -> std.option.Option(StrBuf) {
+    let O = std.option.Option(StrBuf);
     let name = lookup(found)?;
     O.Some("hello " + name)
 }
 fn show(found: bool) {
-    let O = Option(StrBuf);
+    let O = std.option.Option(StrBuf);
     match greet(found) {
         O.Some(s) => println(s),
         O.None => println("(nothing)"),
@@ -90,16 +86,16 @@ hello world
 """
 exit_code = 0
 
-# `?` in a function that does not return Option is E0503.
+# `?` in a function that does not return Option is E0503. Main returns i32,
+# so using `?` on the trusted std Option is an error.
 [[case]]
 name = "try_outside_option_fn_is_e0503"
+env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [
   { path = "main.rue", source = """
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
-fn some_val() -> Option(i64) {
-    let O = Option(i64);
+const std = @import("std");
+fn some_val() -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
     O.Some(1)
 }
 fn main() -> i32 {
@@ -112,18 +108,17 @@ args = ["main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["E0503", "returns an `Option`"]
 
-# `?` applied to a non-Option value is E0504.
+# `?` applied to a non-Option value is E0504. The operand is i32, not an Option.
 [[case]]
 name = "try_on_non_option_is_e0504"
+env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [
   { path = "main.rue", source = """
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
-fn f() -> Option(i64) {
+const std = @import("std");
+fn f() -> std.option.Option(i64) {
     let x = 5;
     let y = x?;
-    let O = Option(i64);
+    let O = std.option.Option(i64);
     O.Some(y)
 }
 fn main() -> i32 { f(); 0 }

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -12,7 +12,7 @@ use rue_compiler::unstable::{
     prepare_stable_definitions, query_merge, semantic_parity_snapshot,
 };
 use rue_compiler::{
-    AcceptedReadManifestEntry, CompileOptions, CompilerSession, FileMetadataFingerprint,
+    AcceptedReadManifest, CompileOptions, CompilerSession, FileMetadataFingerprint,
     FrontendDiagnosticSnapshot, ImportDiscoveryContext, ImportObservationLedger, OptLevel,
     PhysicalFileIdentity, SemanticView, SourceMetadata, SourceSnapshot,
 };
@@ -309,14 +309,10 @@ fn single_root_snapshot(source: String) -> SourceSnapshot {
 
 fn completion_discovery(
     source: Arc<String>,
-) -> (
-    SourceSnapshot,
-    ImportDiscoveryContext,
-    Arc<[AcceptedReadManifestEntry]>,
-) {
+) -> (SourceSnapshot, ImportDiscoveryContext, AcceptedReadManifest) {
     let context = ImportDiscoveryContext::new(1, "/bench", None, "rue-888-benchmark").unwrap();
     let source_len = source.len() as u64;
-    let assembler = DiscoverySourceAssembler::new(
+    let mut assembler = DiscoverySourceAssembler::new(
         context.clone(),
         "/bench/main.rue",
         "/bench/main.rue",
@@ -341,7 +337,7 @@ fn close_completion_discovery(session: &mut CompilerSession, source: &SourceSnap
         .stage_import_discovery(
             &discovered,
             context,
-            accepted_reads,
+            accepted_reads.shared_slice(),
             ImportObservationLedger::default(),
         )
         .unwrap();

--- a/crates/rue-compiler-session-bench/src/representative.rs
+++ b/crates/rue-compiler-session-bench/src/representative.rs
@@ -12,7 +12,7 @@ use rue_compiler::unstable::{
     publish_import_observation_batch,
 };
 use rue_compiler::{
-    AcceptedImportSource, AcceptedReadManifestEntry, CompileOptions, CompilerSession,
+    AcceptedImportSource, AcceptedReadManifest, CompileOptions, CompilerSession,
     FileMetadataFingerprint, ImportDiscoveryContext, ImportObservation, PhysicalFileIdentity,
     SemanticView, SourceSnapshot,
 };
@@ -74,11 +74,7 @@ fn variant_sources(variant: Variant) -> BTreeMap<String, Arc<String>> {
 
 fn assemble(
     sources: &BTreeMap<String, Arc<String>>,
-) -> (
-    SourceSnapshot,
-    ImportDiscoveryContext,
-    Arc<[AcceptedReadManifestEntry]>,
-) {
+) -> (SourceSnapshot, ImportDiscoveryContext, AcceptedReadManifest) {
     let context =
         ImportDiscoveryContext::new(1, "/bench", Some("/bench/std"), "rue-901-scenario").unwrap();
     let root = sources.get(ROOT).unwrap().clone();
@@ -157,7 +153,7 @@ fn close_discovery(session: &mut CompilerSession, source: &SourceSnapshot) {
             .stage_import_discovery(
                 &discovered,
                 context.clone(),
-                accepted_reads.clone(),
+                accepted_reads.shared_slice(),
                 ledger.clone(),
             )
             .unwrap();

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -52,12 +52,18 @@ const PRODUCTION_MODULES: &[(&str, &str)] = &[
     ("semantic_symbols", include_str!("semantic_symbols.rs")),
     ("semantic_identity", include_str!("semantic_identity.rs")),
     ("session", include_str!("session.rs")),
+    ("shared_segments", include_str!("shared_segments.rs")),
     ("source_identity", include_str!("source_identity.rs")),
     ("source_metadata", include_str!("source_metadata.rs")),
     ("source_snapshot", include_str!("source_snapshot.rs")),
     ("syntax", include_str!("syntax.rs")),
+    (
+        "toolchain_module_demand",
+        include_str!("toolchain_module_demand.rs"),
+    ),
     ("typed_query_store", include_str!("typed_query_store.rs")),
     ("unstable", include_str!("unstable.rs")),
+    ("well_known_option", include_str!("well_known_option.rs")),
 ];
 
 const RUE_868_RAW_FACADE_VOCABULARY: &[&str] = &[
@@ -738,7 +744,8 @@ fn root_export_metadata(owner: &str, symbol: &str) -> (&'static str, &'static st
             | "ImportObservation"
             | "ImportObservationLedger"
             | "ImportObservationStatus" => ("compatibility-boundary", "legacy-embedders"),
-            "AcceptedReadManifestEntry"
+            "AcceptedReadManifest"
+            | "AcceptedReadManifestEntry"
             | "FileMetadataFingerprint"
             | "ImportCandidateRole"
             | "ImportDiscoveryContext"
@@ -777,6 +784,15 @@ fn root_export_metadata(owner: &str, symbol: &str) -> (&'static str, &'static st
         "source_identity" | "source_metadata" | "source_snapshot" | "rue_span" => {
             ("source-input", "cli+embedders")
         }
+        "toolchain_module_demand" => match symbol {
+            "OPTION_MODULE_LOGICAL_PATH"
+            | "ParkedToolchainModules"
+            | "STRBUF_MODULE_LOGICAL_PATH"
+            | "TrustedToolchainModuleDemand" => {
+                ("toolchain-module-demand", "source-loaders+embedders")
+            }
+            _ => panic!("unclassified toolchain-module-demand facade export: {symbol}"),
+        },
         "rue_cfg" | "rue_target" => ("compilation-config", "cli+embedders"),
         _ => panic!("unclassified facade export owner: {owner}::{symbol}"),
     }
@@ -1395,6 +1411,7 @@ fn unstable_views_do_not_alias_query_engine_records() {
         [
             "pubusecrate::diagnostic::{ColorChoice,DiagnosticFormatter,JsonDiagnostic,JsonDiagnosticFormatter,JsonSpan,JsonSuggestion,MultiFileFormatter,MultiFileJsonFormatter,SourceInfo,};",
             "pubusecrate::import_discovery::{DiscoverySourceAssembler,ImportDemandFrontier,ImportDemandMode,ImportDemandRoots,ImportInputRevision,};",
+            "pubusecrate::session::{ClosedDiscoveryContinuation,SemanticParkOutcome,TrustedSuccessorDelta};",
         ],
         "unstable may reexport only reviewed presentation, source-assembly, and Phase-2 demand helpers"
     );

--- a/crates/rue-compiler/src/body_query.rs
+++ b/crates/rue-compiler/src/body_query.rs
@@ -42,6 +42,41 @@ pub(crate) enum BodyReference {
     Type(crate::TypeInstanceKey),
 }
 
+/// One trusted-standard-library `Option(payload)` demanded by a body's
+/// fallible-intrinsic use. The `call` is rooted under the requesting body's
+/// lease so the specialization is memoized across bodies that share a payload;
+/// `payload` is the demanded `Some`-variant type. `kind` is the fallible-payload
+/// tag used to select exactly the demands a body's own raw source requires, so a
+/// body roots no specialization it does not use.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WellKnownOptionDemand {
+    pub(crate) kind: crate::well_known_option::FalliblePayload,
+    pub(crate) payload: crate::durable_semantics::DurableType,
+    pub(crate) call: crate::semantic_query_nucleus::ComptimeCallQueryKey,
+}
+
+/// The per-body resolution of the well-known `Option` demands: the resolved
+/// enum for each demanded payload, plus every anonymous nominal to materialize
+/// narrowly. Empty whenever a body demands nothing (no fallible intrinsics or
+/// no trusted `Option` module present), so freestanding programs keep the
+/// structural `find_compatible_anon_enum` fallback.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct WellKnownOptionResolution {
+    pub(crate) option_by_payload: Arc<
+        [(
+            crate::durable_semantics::DurableType,
+            crate::durable_semantics::DurableType,
+        )],
+    >,
+    pub(crate) anonymous_nominals: Arc<[crate::durable_semantics::DurableAnonymousNominal]>,
+}
+
+impl WellKnownOptionResolution {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.option_by_payload.is_empty()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BodyReferences(pub(crate) Arc<[BodyReference]>);
 

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -1665,6 +1665,7 @@ pub(crate) fn analyze_body_query(
     query_shells: &[rue_air::SemanticDeclarationShell],
     query_declarations: &[DurableDeclarationSemantic],
     query_anonymous_nominals: &[crate::durable_semantics::DurableAnonymousNominal],
+    well_known: &crate::body_query::WellKnownOptionResolution,
     key: &crate::body_query::BodyQueryKey,
     cancellation: &rue_query::CancellationToken,
     // Per-body declaration-context work is accrued here, at the stage sources,
@@ -1857,6 +1858,42 @@ pub(crate) fn analyze_body_query(
     work.endpoints_installed += body_owner_endpoints_installed
         + semantic_definition_endpoints.len()
         + semantic_module_endpoints_installed;
+    // Install the per-body well-known `Option(payload)` registry (RUE-1112)
+    // narrowly, now that whole-program definition/module endpoints exist. The
+    // resolved trusted-std `Option` enums are materialized into this epoch and
+    // recorded so fallible-intrinsic resolution binds them under `?`; they are
+    // never appended to composition, `BodyReferences`, or reachability, so the
+    // fail-closed validation for ordinary nominals stays intact. A body that
+    // demanded nothing installs nothing.
+    let bound = if well_known.is_empty() {
+        bound
+    } else {
+        let (well_known_nominals, well_known_option_by_payload) =
+            match crate::durable_semantics::project_durable_option_registry(
+                merged,
+                &definitions,
+                well_known,
+            ) {
+                Ok(projected) => projected,
+                Err(failure) => {
+                    return Ok(deterministic_failure(
+                        "project_durable_option_registry",
+                        format!("{failure:?}"),
+                    ));
+                }
+            };
+        match bound
+            .install_well_known_option_types(&well_known_nominals, &well_known_option_by_payload)
+        {
+            Ok(bound) => bound,
+            Err(failure) => {
+                return Ok(deterministic_failure(
+                    "install_well_known_option_types",
+                    format!("{failure:?}"),
+                ));
+            }
+        }
+    };
     drop(install_span);
     let analyze_span = info_span!("body_analyze").entered();
     let outcome = bound.analyze_one_body_instance(

--- a/crates/rue-compiler/src/dependency_envelope.rs
+++ b/crates/rue-compiler/src/dependency_envelope.rs
@@ -411,7 +411,7 @@ mod tests {
             .stage_import_discovery(
                 &snapshot,
                 context(1),
-                assembler.accepted_read_manifest(),
+                assembler.accepted_read_manifest().shared_slice(),
                 ImportObservationLedger::default(),
             )
             .unwrap();
@@ -468,14 +468,14 @@ mod tests {
 
     #[test]
     fn missing_envelope_is_revision_labeled_and_incomplete() {
-        let assembler = assembler("const x = @import(\"missing\"); fn main() -> i32 { 0 }");
+        let mut assembler = assembler("const x = @import(\"missing\"); fn main() -> i32 { 0 }");
         let snapshot = assembler.snapshot().unwrap();
         let mut session = CompilerSession::new();
         let plan = session
             .stage_import_discovery(
                 &snapshot,
                 context(1),
-                assembler.accepted_read_manifest(),
+                assembler.accepted_read_manifest().shared_slice(),
                 ImportObservationLedger::default(),
             )
             .unwrap();
@@ -519,14 +519,14 @@ mod tests {
 
     #[test]
     fn malformed_import_shape_is_not_an_incomplete_envelope() {
-        let assembler = assembler("fn main() -> i32 { @import(); 0 }");
+        let mut assembler = assembler("fn main() -> i32 { @import(); 0 }");
         let snapshot = assembler.snapshot().unwrap();
         let mut session = CompilerSession::new();
         let plan = session
             .stage_import_discovery(
                 &snapshot,
                 context(1),
-                assembler.accepted_read_manifest(),
+                assembler.accepted_read_manifest().shared_slice(),
                 ImportObservationLedger::default(),
             )
             .unwrap();

--- a/crates/rue-compiler/src/diagnostic_attempt_store.rs
+++ b/crates/rue-compiler/src/diagnostic_attempt_store.rs
@@ -62,7 +62,7 @@ pub(crate) struct ImportDiagnosticInputDescriptor {
     pub(crate) context: Option<ImportDiscoveryContext>,
     pub(crate) plan: Option<ImportDiscoveryPlan>,
     pub(crate) ledger: ImportObservationLedger,
-    pub(crate) accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
+    pub(crate) accepted_reads: crate::AcceptedReadManifest,
 }
 
 impl ImportDiagnosticInputDescriptor {
@@ -82,7 +82,7 @@ impl ImportDiagnosticInputDescriptor {
         &self.ledger
     }
     #[cfg(test)]
-    pub(crate) fn accepted_read_manifest(&self) -> &[crate::AcceptedReadManifestEntry] {
+    pub(crate) fn accepted_read_manifest(&self) -> &crate::AcceptedReadManifest {
         &self.accepted_reads
     }
 }
@@ -102,7 +102,7 @@ pub struct FrontendDiagnosticSnapshot {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum DiagnosticAttemptProvenance {
     Canonical,
-    Presentation(Arc<[ModuleId]>),
+    Presentation(crate::shared_segments::SharedList<ModuleId>),
 }
 
 impl FrontendDiagnosticSnapshot {
@@ -594,14 +594,18 @@ mod tests {
         .unwrap();
         let reverse =
             SourceSnapshot::new(metadata, vec![(other, other_text), (root, root_text)]).unwrap();
-        let forward_order: Arc<[ModuleId]> = forward
-            .files()
-            .map(|file| forward.module_id(file.file_id).unwrap().clone())
-            .collect();
-        let reverse_order: Arc<[ModuleId]> = reverse
-            .files()
-            .map(|file| reverse.module_id(file.file_id).unwrap().clone())
-            .collect();
+        let forward_order = crate::shared_segments::SharedList::flat(
+            forward
+                .files()
+                .map(|file| forward.module_id(file.file_id).unwrap().clone())
+                .collect(),
+        );
+        let reverse_order = crate::shared_segments::SharedList::flat(
+            reverse
+                .files()
+                .map(|file| reverse.module_id(file.file_id).unwrap().clone())
+                .collect(),
+        );
         let attempt = |source: &SourceSnapshot, provenance| {
             Arc::new(FrontendDiagnosticSnapshot {
                 source: source.clone(),

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -869,6 +869,43 @@ pub(crate) fn project_durable_anonymous_nominals(
     Ok(projected.into())
 }
 
+/// Project a per-body well-known `Option` resolution (RUE-1112) into the AIR
+/// export algebra: the anonymous enum nominals to materialize narrowly, plus
+/// each `(payload, option_enum)` type pair for the demand registry. Projection
+/// runs against the same bound definition set as the ordinary anonymous
+/// nominals, so the trusted `Option` producer/module identities resolve exactly.
+pub(crate) fn project_durable_option_registry(
+    merged: &CanonicalMergedProgram,
+    definitions: &BoundDefinitionSet,
+    resolution: &crate::body_query::WellKnownOptionResolution,
+) -> Result<
+    (
+        Arc<[rue_air::SemanticAnonymousNominalExport]>,
+        Vec<(rue_air::SemanticExportType, rue_air::SemanticExportType)>,
+    ),
+    DurableSemanticProjectionFailure,
+> {
+    let module_files = merged
+        .ast()
+        .modules()
+        .iter()
+        .map(|module| (module.module_id().clone(), module.file_id()))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let nominals =
+        project_durable_anonymous_nominals(merged, definitions, &resolution.anonymous_nominals)?;
+    let option_by_payload = resolution
+        .option_by_payload
+        .iter()
+        .map(|(payload, option)| {
+            Ok((
+                project_type(payload, definitions, &module_files)?,
+                project_type(option, definitions, &module_files)?,
+            ))
+        })
+        .collect::<Result<Vec<_>, DurableSemanticProjectionFailure>>()?;
+    Ok((nominals, option_by_payload))
+}
+
 fn project_payload(
     value: &DurableDeclarationPayload,
     definitions: &BoundDefinitionSet,

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -429,8 +429,27 @@ impl ImportObservation {
 /// Public `Default` construction and mutation are retained only for the
 /// RUE-1033 legacy compatibility boundary. A freely constructed ledger is not
 /// freshness- or speculation-safe and must not seed a new canonical request.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
-pub struct ImportObservationLedger(BTreeMap<ImportDiscoveryRequest, ImportObservation>);
+///
+/// The ledger is a persistent structure (RUE-1112): frozen segments are shared
+/// by `Arc` across clones, and entries recorded since the value was cloned live
+/// in a private head. Cloning therefore costs O(entries recorded since the
+/// parent value was itself cloned) — the delta — never the whole ledger, and
+/// the head IS the exact recorded delta of the current step, which the
+/// successor publication consumes directly instead of re-deriving additions by
+/// diffing complete values. Equality and hashing are over the logical merged
+/// sequence, so a flat and a segmented ledger with identical content are
+/// indistinguishable to query memoization.
+#[derive(Debug, Default)]
+pub struct ImportObservationLedger {
+    /// Frozen shared segments, oldest first; mutually disjoint by request.
+    frozen: Vec<Arc<BTreeMap<ImportDiscoveryRequest, ImportObservation>>>,
+    /// Entries recorded since this value was cloned from its parent.
+    head: BTreeMap<ImportDiscoveryRequest, ImportObservation>,
+}
+
+/// Segment chains longer than this are compacted on clone so lookup depth stays
+/// bounded under long frontier-round chains.
+const LEDGER_COMPACTION_DEPTH: usize = 16;
 
 impl ImportObservationLedger {
     /// Record legacy host evidence.
@@ -440,7 +459,7 @@ impl ImportObservationLedger {
     /// canonical protocol instead.
     pub fn record(&mut self, observation: ImportObservation) -> CompileResult<()> {
         let request = observation.request.clone();
-        if let Some(previous) = self.0.get(&request) {
+        if let Some(previous) = self.get(&request) {
             if previous == &observation {
                 return Ok(());
             }
@@ -448,22 +467,135 @@ impl ImportObservationLedger {
                 "one discovery request received conflicting observations",
             ));
         }
-        self.0.insert(request, observation);
+        self.head.insert(request, observation);
         Ok(())
     }
     pub fn get(&self, request: &ImportDiscoveryRequest) -> Option<&ImportObservation> {
-        self.0.get(request)
+        if let Some(observation) = self.head.get(request) {
+            return Some(observation);
+        }
+        self.frozen
+            .iter()
+            .rev()
+            .find_map(|segment| segment.get(request))
     }
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = &ImportObservation> {
-        self.0.values()
+    pub fn iter(&self) -> LedgerIter<'_> {
+        let mut cursors: Vec<std::collections::btree_map::Iter<'_, _, _>> =
+            self.frozen.iter().map(|segment| segment.iter()).collect();
+        cursors.push(self.head.iter());
+        LedgerIter {
+            remaining: self.len(),
+            heads: cursors.iter_mut().map(Iterator::next).collect(),
+            cursors,
+        }
     }
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.frozen
+            .iter()
+            .map(|segment| segment.len())
+            .sum::<usize>()
+            + self.head.len()
     }
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.head.is_empty() && self.frozen.iter().all(|segment| segment.is_empty())
+    }
+
+    /// The exact observations recorded into THIS value since it was cloned from
+    /// its parent — the current step's delta, in canonical request order
+    /// (RUE-1112). The successor publication consumes this recorded delta
+    /// directly rather than re-deriving it by diffing complete ledgers.
+    pub(crate) fn recorded_delta(
+        &self,
+    ) -> impl ExactSizeIterator<Item = &ImportObservation> + Clone {
+        self.head.values()
     }
 }
+
+impl Clone for ImportObservationLedger {
+    fn clone(&self) -> Self {
+        // Freeze the head into a shared segment so the clone starts with an
+        // empty recorded delta; only the head (the parent's own delta) is
+        // copied, never the frozen predecessor segments.
+        let mut frozen = self.frozen.clone();
+        if !self.head.is_empty() {
+            frozen.push(Arc::new(self.head.clone()));
+        }
+        if frozen.len() >= LEDGER_COMPACTION_DEPTH {
+            // Compact a long chain into one segment; the merged map is the same
+            // logical value.
+            let mut merged = BTreeMap::new();
+            for segment in &frozen {
+                for (request, observation) in segment.iter() {
+                    merged.insert(request.clone(), observation.clone());
+                }
+            }
+            frozen = vec![Arc::new(merged)];
+        }
+        Self {
+            frozen,
+            head: BTreeMap::new(),
+        }
+    }
+}
+
+impl PartialEq for ImportObservationLedger {
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len() && self.iter().eq(other.iter())
+    }
+}
+
+impl Eq for ImportObservationLedger {}
+
+impl std::hash::Hash for ImportObservationLedger {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // Logical hash over the merged sequence: length then each observation in
+        // canonical request order, so representation never affects identity.
+        self.len().hash(state);
+        for observation in self.iter() {
+            observation.hash(state);
+        }
+    }
+}
+
+/// K-way merge over the ledger's disjoint sorted segments, yielding
+/// observations in canonical request order.
+pub struct LedgerIter<'a> {
+    cursors: Vec<std::collections::btree_map::Iter<'a, ImportDiscoveryRequest, ImportObservation>>,
+    heads: Vec<Option<(&'a ImportDiscoveryRequest, &'a ImportObservation)>>,
+    remaining: usize,
+}
+
+impl<'a> Iterator for LedgerIter<'a> {
+    type Item = &'a ImportObservation;
+
+    fn next(&mut self) -> Option<&'a ImportObservation> {
+        let mut best: Option<usize> = None;
+        for (index, head) in self.heads.iter().enumerate() {
+            if let Some((request, _)) = head {
+                match best {
+                    None => best = Some(index),
+                    Some(current) => {
+                        let (best_request, _) = self.heads[current].as_ref().unwrap();
+                        if request < best_request {
+                            best = Some(index);
+                        }
+                    }
+                }
+            }
+        }
+        let chosen = best?;
+        let (_, observation) = self.heads[chosen].take().unwrap();
+        self.heads[chosen] = self.cursors[chosen].next();
+        self.remaining -= 1;
+        Some(observation)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl<'a> ExactSizeIterator for LedgerIter<'a> {}
 
 /// Authority allowed to expose missing external-input requests.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -553,11 +685,19 @@ impl ImportDemandRoots {
     }
 }
 
+/// Canonical order for request groups: by the first request of each group.
+fn group_order(
+    a: &Arc<[ImportDiscoveryRequest]>,
+    b: &Arc<[ImportDiscoveryRequest]>,
+) -> std::cmp::Ordering {
+    a[0].cmp(&b[0])
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ImportDiscoveryPlan {
     source_revision: SourceRevision,
     context: ImportDiscoveryContext,
-    groups: Arc<[Arc<[ImportDiscoveryRequest]>]>,
+    groups: crate::shared_segments::SharedSegments<Arc<[ImportDiscoveryRequest]>>,
 }
 
 impl ImportDiscoveryPlan {
@@ -602,12 +742,54 @@ impl ImportDiscoveryPlan {
                 &importer_path,
             )?);
         }
-        groups.sort_by(|left: &Arc<[ImportDiscoveryRequest]>, right| left[0].cmp(&right[0]));
+        groups.sort_by(group_order);
         Ok(Self {
             source_revision: program.source_revision().clone(),
             context,
-            groups: groups.into(),
+            groups: crate::shared_segments::SharedSegments::flat(groups.into(), group_order),
         })
+    }
+
+    /// Build a strictly-additive successor plan by carrying a predecessor plan's
+    /// request groups verbatim and constructing groups ONLY for the newly
+    /// appended modules' import occurrences (RUE-1112). The predecessor modules'
+    /// sources are byte-identical in the successor, so their groups are reused
+    /// rather than reconstructed; `discovery_groups_for_occurrence` runs only for
+    /// occurrences owned by `new_modules`. Returns the successor plan and the
+    /// number of groups actually constructed (the new ones), so the caller can
+    /// prove plan construction is O(new leaves), independent of the predecessor
+    /// import topology.
+    pub(crate) fn extend_trusted_successor(
+        predecessor: &ImportDiscoveryPlan,
+        program: &ParsedProgram,
+        context: ImportDiscoveryContext,
+        new_modules: &[ModuleId],
+    ) -> CompileResult<(Self, u64)> {
+        // Construct groups ONLY for the newly appended modules' occurrences; the
+        // predecessor plan's groups are carried by reference through
+        // `SharedSegments::extend`, never copied or re-sorted.
+        let mut delta = Vec::new();
+        let mut constructed = 0u64;
+        for module_id in new_modules {
+            let Some(module) = program.module(module_id) else {
+                continue;
+            };
+            for site in module.imports() {
+                let occurrence = ImportOccurrenceKey::from_directive(site);
+                let importer_path = requested_path_for_module(&context, site.importer())?;
+                let built = discovery_groups_for_occurrence(&context, &occurrence, &importer_path)?;
+                constructed += built.len() as u64;
+                delta.extend(built);
+            }
+        }
+        Ok((
+            Self {
+                source_revision: program.source_revision().clone(),
+                context,
+                groups: crate::shared_segments::SharedSegments::extend(&predecessor.groups, delta),
+            },
+            constructed,
+        ))
     }
 
     pub fn source_revision(&self) -> &SourceRevision {
@@ -616,13 +798,39 @@ impl ImportDiscoveryPlan {
     pub fn context(&self) -> &ImportDiscoveryContext {
         &self.context
     }
+    /// The successor delta groups: request groups owned only by modules added
+    /// since the predecessor close (empty for a full plan). Iterating these
+    /// avoids materializing or filtering the full merged plan on the acquisition
+    /// path (RUE-1112).
+    pub(crate) fn delta_groups(&self) -> &[Arc<[ImportDiscoveryRequest]>] {
+        self.groups.delta_segment()
+    }
+
+    /// The shared request-group representation (RUE-1112 successor sharing).
+    pub(crate) fn group_segments(
+        &self,
+    ) -> &crate::shared_segments::SharedSegments<Arc<[ImportDiscoveryRequest]>> {
+        &self.groups
+    }
+
+    /// The demand roots for the successor delta occurrences alone — the frontier
+    /// and close-time projection for a trusted-toolchain successor root only in
+    /// these, never in the predecessor topology (RUE-1112). Derived directly from
+    /// the delta segment, never by filtering the merged plan.
+    pub(crate) fn delta_roots(&self) -> ImportDemandRoots {
+        ImportDemandRoots::new(
+            self.delta_groups()
+                .iter()
+                .map(|group| group[0].occurrence().clone()),
+        )
+    }
     /// Expose legacy host-driven candidate groups.
     ///
     /// This bypass is retained only for the RUE-1033 compatibility boundary.
     /// It is not freshness- or speculation-safe; new consumers must request a
     /// compiler-produced frontier through the unstable canonical protocol.
     pub fn groups(&self) -> &[Arc<[ImportDiscoveryRequest]>] {
-        &self.groups
+        self.groups.as_slice()
     }
 
     /// Return exactly the next operations allowed by candidate precedence.
@@ -688,42 +896,61 @@ impl ImportDiscoveryPlan {
         &'a self,
         ledger: &'a ImportObservationLedger,
     ) -> Vec<&'a AcceptedImportSource> {
-        let mut by_site: BTreeMap<&ImportOccurrenceKey, Vec<&Arc<[ImportDiscoveryRequest]>>> =
-            BTreeMap::new();
-        for group in self.groups.iter() {
-            by_site.entry(&group[0].occurrence).or_default().push(group);
-        }
-        let mut accepted = Vec::new();
-        for groups in by_site.values() {
-            for group in groups {
-                if group
-                    .iter()
-                    .any(|request| ledger.get(request).is_some_and(|o| o.status.is_failure()))
-                {
-                    break;
-                }
-                let present = group
-                    .iter()
-                    .filter_map(|request| ledger.get(request))
-                    .filter_map(ImportObservation::accepted_source)
-                    .collect::<Vec<_>>();
-                if !present.is_empty() {
-                    accepted.extend(present);
-                    break;
-                }
+        accepted_sources_for(self.groups.iter(), ledger)
+    }
+
+    /// The accepted sources of a trusted-toolchain successor plan's delta groups
+    /// alone — those owned by modules added since the predecessor close (RUE-1112).
+    /// The predecessor leaves are already assembled, so a successor add only needs
+    /// these; the merged plan is never scanned.
+    pub(crate) fn delta_accepted_sources<'a>(
+        &'a self,
+        ledger: &'a ImportObservationLedger,
+    ) -> Vec<&'a AcceptedImportSource> {
+        accepted_sources_for(self.groups.delta_segment().iter(), ledger)
+    }
+}
+
+/// The winning accepted sources across a set of candidate request groups.
+fn accepted_sources_for<'a>(
+    groups: impl Iterator<Item = &'a Arc<[ImportDiscoveryRequest]>>,
+    ledger: &'a ImportObservationLedger,
+) -> Vec<&'a AcceptedImportSource> {
+    let mut by_site: BTreeMap<&ImportOccurrenceKey, Vec<&Arc<[ImportDiscoveryRequest]>>> =
+        BTreeMap::new();
+    for group in groups {
+        by_site.entry(&group[0].occurrence).or_default().push(group);
+    }
+    let mut accepted = Vec::new();
+    for groups in by_site.values() {
+        for group in groups {
+            if group
+                .iter()
+                .any(|request| ledger.get(request).is_some_and(|o| o.status.is_failure()))
+            {
+                break;
+            }
+            let present = group
+                .iter()
+                .filter_map(|request| ledger.get(request))
+                .filter_map(ImportObservation::accepted_source)
+                .collect::<Vec<_>>();
+            if !present.is_empty() {
+                accepted.extend(present);
+                break;
             }
         }
-        accepted.sort_by(|left, right| {
-            left.requested_path
-                .cmp(&right.requested_path)
-                .then(left.canonical_path.cmp(&right.canonical_path))
-        });
-        accepted.dedup_by(|left, right| {
-            left.canonical_path == right.canonical_path
-                && left.content_fingerprint == right.content_fingerprint
-        });
-        accepted
     }
+    accepted.sort_by(|left, right| {
+        left.requested_path
+            .cmp(&right.requested_path)
+            .then(left.canonical_path.cmp(&right.canonical_path))
+    });
+    accepted.dedup_by(|left, right| {
+        left.canonical_path == right.canonical_path
+            && left.content_fingerprint == right.content_fingerprint
+    });
+    accepted
 }
 
 /// Compute candidate precedence for one exact indexed occurrence from captured
@@ -958,7 +1185,7 @@ pub(crate) fn reduce_exact_import_graph(
     root: ModuleId,
     groups: &[Arc<[ImportDiscoveryRequest]>],
     ledger: &ImportObservationLedger,
-    accepted_reads: &[AcceptedReadManifestEntry],
+    accepted_reads: &AcceptedReadManifest,
 ) -> CompileResult<crate::CanonicalImportGraph> {
     validate_exact_import_ledger(groups, ledger)?;
     let manifest = accepted_import_manifest(accepted_reads)?;
@@ -1024,13 +1251,13 @@ pub(crate) fn validate_exact_import_occurrence(
 }
 
 pub(crate) fn validate_accepted_import_manifest(
-    accepted_reads: &[AcceptedReadManifestEntry],
+    accepted_reads: &AcceptedReadManifest,
 ) -> CompileResult<()> {
     accepted_import_manifest(accepted_reads).map(drop)
 }
 
 fn accepted_import_manifest(
-    accepted_reads: &[AcceptedReadManifestEntry],
+    accepted_reads: &AcceptedReadManifest,
 ) -> CompileResult<BTreeMap<PhysicalFileIdentity, &AcceptedReadManifestEntry>> {
     let manifest = accepted_reads
         .iter()
@@ -1109,7 +1336,7 @@ fn module_for_accepted_source(
 
 pub(crate) fn accepted_import_module(
     source: &AcceptedImportSource,
-    accepted_reads: &[AcceptedReadManifestEntry],
+    accepted_reads: &AcceptedReadManifest,
 ) -> CompileResult<ModuleId> {
     let mut matches = accepted_reads
         .iter()
@@ -1148,6 +1375,33 @@ pub struct DiscoverySourceAssembler {
     physical: BTreeMap<PhysicalFileIdentity, PhysicalSourceOwner>,
     canonical_identities: BTreeMap<Arc<str>, PhysicalFileIdentity>,
     accepted_reads: BTreeMap<ModuleId, AcceptedReadManifestEntry>,
+    /// The last produced snapshot; the next [`Self::snapshot`] extends it with
+    /// only the modules added since, sharing every predecessor segment
+    /// (RUE-1112). Predecessor `FileId`s stay stable across extensions.
+    cached_snapshot: Option<SourceSnapshot>,
+    /// Modules added since `cached_snapshot` was produced, in insertion order.
+    appended_since_snapshot: Vec<ModuleId>,
+    /// Cumulative sources materialized by full snapshot builds (the first
+    /// snapshot of a lineage); never incremented on the extension path.
+    snapshot_sources_rebuilt: u64,
+    /// Cumulative sources appended by extension builds — the only per-round
+    /// snapshot work once a lineage's first snapshot exists.
+    snapshot_sources_appended: u64,
+    /// The last produced provenance manifest; the next
+    /// [`Self::accepted_read_manifest`] extends it with only the entries added
+    /// since, sharing every predecessor segment (RUE-1112). Invalidated when a
+    /// retained entry is rewritten (a canonical-path improvement), which falls
+    /// back to a counted full rebuild.
+    cached_manifest: Option<AcceptedReadManifest>,
+    /// Modules whose provenance entries were added since `cached_manifest` was
+    /// produced, in insertion order.
+    appended_since_manifest: Vec<ModuleId>,
+    /// Cumulative provenance entries materialized by full manifest builds;
+    /// never incremented on the extension path.
+    manifest_entries_rebuilt: u64,
+    /// Cumulative provenance entries appended by extension manifest builds —
+    /// the only per-round manifest work once a lineage's first manifest exists.
+    manifest_entries_appended: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -1161,6 +1415,140 @@ struct AssembledSource {
     requested_path: Arc<str>,
     canonical_path: Arc<str>,
     source: Arc<String>,
+}
+
+/// The accepted-read provenance manifest as a persistent segmented sequence
+/// (RUE-1112): `Arc`-shared predecessor segments plus an appended delta, sorted
+/// by module identity within and across segments. A strictly-additive successor
+/// shares every predecessor segment by reference, so extending the manifest
+/// never copies or re-validates a predecessor entry; the merged contiguous
+/// slice materializes lazily, off the acquisition path. Equality and hashing
+/// are logical over the merged sequence.
+#[derive(Clone)]
+pub struct AcceptedReadManifest {
+    entries: crate::shared_segments::SharedSegments<AcceptedReadManifestEntry>,
+    /// Lazily materialized merged slice for consumers that need `Arc<[T]>`
+    /// (the RUE-1033 stable staging boundary and retained artifacts).
+    merged: std::sync::OnceLock<Arc<[AcceptedReadManifestEntry]>>,
+}
+
+fn accepted_read_order(
+    a: &AcceptedReadManifestEntry,
+    b: &AcceptedReadManifestEntry,
+) -> std::cmp::Ordering {
+    a.module.cmp(&b.module)
+}
+
+/// Logical rendering over the merged entry sequence: the lazily materialized
+/// merged cache is derived state and never participates.
+impl std::fmt::Debug for AcceptedReadManifest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
+/// Logical equality over the merged entry sequence: the lazily materialized
+/// merged cache is derived state and never participates.
+impl PartialEq for AcceptedReadManifest {
+    fn eq(&self, other: &Self) -> bool {
+        self.entries == other.entries
+    }
+}
+
+impl Eq for AcceptedReadManifest {}
+
+impl std::hash::Hash for AcceptedReadManifest {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.entries.hash(state);
+    }
+}
+
+impl AcceptedReadManifest {
+    /// A complete manifest built in one piece (fresh discovery). Entries are
+    /// canonicalized to module order here; duplicate modules are preserved for
+    /// the publication validation to reject.
+    pub(crate) fn from_entries(mut entries: Vec<AcceptedReadManifestEntry>) -> Self {
+        entries.sort_by(accepted_read_order);
+        Self {
+            entries: crate::shared_segments::SharedSegments::flat(
+                entries.into(),
+                accepted_read_order,
+            ),
+            merged: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// Wrap a complete shared slice, sharing it without copying when it is
+    /// already in canonical module order (the compatibility boundary makes no
+    /// ordering promise, so an unordered slice is canonicalized by copy).
+    pub(crate) fn from_shared(entries: Arc<[AcceptedReadManifestEntry]>) -> Self {
+        if !entries.is_sorted_by(|a, b| accepted_read_order(a, b) != std::cmp::Ordering::Greater) {
+            return Self::from_entries(entries.to_vec());
+        }
+        let merged = std::sync::OnceLock::new();
+        let _ = merged.set(entries.clone());
+        Self {
+            entries: crate::shared_segments::SharedSegments::flat(entries, accepted_read_order),
+            merged,
+        }
+    }
+
+    /// A strictly-additive successor sharing every segment of `base` by
+    /// reference and appending only `appended` (sorted here; must be new
+    /// modules).
+    pub(crate) fn extend_with_appended(
+        base: &AcceptedReadManifest,
+        appended: Vec<AcceptedReadManifestEntry>,
+    ) -> Self {
+        Self {
+            entries: crate::shared_segments::SharedSegments::extend(&base.entries, appended),
+            merged: std::sync::OnceLock::new(),
+        }
+    }
+
+    pub(crate) fn segments(
+        &self,
+    ) -> &crate::shared_segments::SharedSegments<AcceptedReadManifestEntry> {
+        &self.entries
+    }
+
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &AcceptedReadManifestEntry> {
+        self.entries.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.len() == 0
+    }
+
+    /// The provenance entry for `module`, by per-segment binary search.
+    pub(crate) fn find_module(&self, module: &ModuleId) -> Option<&AcceptedReadManifestEntry> {
+        self.entries.find_by(|entry| entry.module.cmp(module))
+    }
+
+    /// Whether `entry` appears byte-identical in this manifest.
+    pub(crate) fn contains_entry(&self, entry: &AcceptedReadManifestEntry) -> bool {
+        self.find_module(&entry.module) == Some(entry)
+    }
+
+    /// The merged contiguous manifest, materialized lazily at most once per
+    /// value; a flat manifest shares its single segment without copying. The
+    /// acquisition path's publication never calls this.
+    pub fn shared_slice(&self) -> Arc<[AcceptedReadManifestEntry]> {
+        self.merged
+            .get_or_init(|| {
+                let segments = self.entries.segments();
+                if segments.len() == 1 {
+                    segments[0].clone()
+                } else {
+                    self.entries.iter().cloned().collect::<Vec<_>>().into()
+                }
+            })
+            .clone()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1241,6 +1629,14 @@ impl DiscoverySourceAssembler {
             physical,
             canonical_identities,
             accepted_reads,
+            cached_snapshot: None,
+            appended_since_snapshot: Vec::new(),
+            snapshot_sources_rebuilt: 0,
+            snapshot_sources_appended: 0,
+            cached_manifest: None,
+            appended_since_manifest: Vec::new(),
+            manifest_entries_rebuilt: 0,
+            manifest_entries_appended: 0,
         })
     }
 
@@ -1273,6 +1669,26 @@ impl DiscoverySourceAssembler {
         }
         let mut added = 0;
         for source in plan.accepted_sources(ledger) {
+            added += usize::from(self.add_source(source)?);
+        }
+        Ok(added)
+    }
+
+    /// Add only the accepted reads of a trusted-toolchain successor plan's delta
+    /// groups (RUE-1112). The predecessor leaves are already assembled, so the
+    /// merged plan and its winner map are never rebuilt.
+    pub fn add_successor_plan_reads(
+        &mut self,
+        plan: &ImportDiscoveryPlan,
+        ledger: &ImportObservationLedger,
+    ) -> CompileResult<usize> {
+        if plan.context != self.context {
+            return Err(invalid_input(
+                "discovery plan belongs to a different epoch or captured context",
+            ));
+        }
+        let mut added = 0;
+        for source in plan.delta_accepted_sources(ledger) {
             added += usize::from(self.add_source(source)?);
         }
         Ok(added)
@@ -1324,16 +1740,31 @@ impl DiscoverySourceAssembler {
                 )));
             }
             if source.canonical_path() < owner.canonical_path.as_ref() {
-                self.entries.get_mut(&owner.module).unwrap().canonical_path =
-                    source.canonical_path.clone();
-                self.accepted_reads
-                    .get_mut(&owner.module)
-                    .unwrap()
-                    .canonical_path = source.canonical_path.clone();
-                self.physical
-                    .get_mut(&source.metadata_identity)
-                    .unwrap()
-                    .canonical_path = source.canonical_path.clone();
+                // The canonical representative may improve only while this
+                // entry is PENDING — not yet carried by any produced snapshot
+                // or manifest. Once produced, the representative is frozen:
+                // rewriting it would diverge the cached shared snapshot from
+                // the provenance manifest and mutate published predecessor
+                // state, which the strictly-additive publication rejects. A
+                // later alias still registers below and joins by physical
+                // identity; only the retained display/provenance path keeps
+                // its published spelling.
+                let snapshot_pending = self.cached_snapshot.is_none()
+                    || self.appended_since_snapshot.contains(&owner.module);
+                let manifest_pending = self.cached_manifest.is_none()
+                    || self.appended_since_manifest.contains(&owner.module);
+                if snapshot_pending && manifest_pending {
+                    self.entries.get_mut(&owner.module).unwrap().canonical_path =
+                        source.canonical_path.clone();
+                    self.accepted_reads
+                        .get_mut(&owner.module)
+                        .unwrap()
+                        .canonical_path = source.canonical_path.clone();
+                    self.physical
+                        .get_mut(&source.metadata_identity)
+                        .unwrap()
+                        .canonical_path = source.canonical_path.clone();
+                }
             }
             self.canonical_identities
                 .insert(source.canonical_path.clone(), source.metadata_identity);
@@ -1364,6 +1795,8 @@ impl DiscoverySourceAssembler {
                 source: source.source.clone(),
             },
         );
+        self.appended_since_snapshot.push(module.clone());
+        self.appended_since_manifest.push(module.clone());
         self.accepted_reads.insert(
             module.clone(),
             AcceptedReadManifestEntry {
@@ -1378,7 +1811,42 @@ impl DiscoverySourceAssembler {
         Ok(true)
     }
 
-    pub fn snapshot(&self) -> CompileResult<SourceSnapshot> {
+    pub fn snapshot(&mut self) -> CompileResult<SourceSnapshot> {
+        // Extension route: once a lineage's first snapshot exists, each
+        // successor snapshot appends only the modules added since, sharing every
+        // predecessor segment by reference — no predecessor source is copied,
+        // re-hashed, or re-validated, and predecessor FileIds stay stable.
+        if let Some(cached) = self.cached_snapshot.clone() {
+            if self.appended_since_snapshot.is_empty() {
+                return Ok(cached);
+            }
+            let next_index = cached.len() as u32;
+            let appended: Vec<crate::source_snapshot::AppendedSource> = self
+                .appended_since_snapshot
+                .iter()
+                .enumerate()
+                .map(|(offset, module)| {
+                    let entry = self
+                        .entries
+                        .get(module)
+                        .expect("appended modules retain their assembled entries");
+                    crate::source_snapshot::AppendedSource {
+                        file_id: FileId::new(next_index + offset as u32 + 1),
+                        physical_path: display_path_for_module(module, entry),
+                        logical_path: module.as_str().to_owned(),
+                        trusted_standard_library: module.is_trusted_standard_library(),
+                        text: entry.source.clone(),
+                    }
+                })
+                .collect();
+            self.snapshot_sources_appended = self
+                .snapshot_sources_appended
+                .saturating_add(appended.len() as u64);
+            let snapshot = SourceSnapshot::extend_with_appended(&cached, appended)?;
+            self.cached_snapshot = Some(snapshot.clone());
+            self.appended_since_snapshot.clear();
+            return Ok(snapshot);
+        }
         let root_module = &self.root_module;
         let ordered = std::iter::once((root_module, self.entries.get(root_module).unwrap())).chain(
             self.entries
@@ -1423,11 +1891,72 @@ impl DiscoverySourceAssembler {
             .enumerate()
             .map(|(index, (_, entry))| (FileId::new((index + 1) as u32), entry.source.clone()))
             .collect();
-        SourceSnapshot::new(metadata, contents)
+        self.snapshot_sources_rebuilt = self
+            .snapshot_sources_rebuilt
+            .saturating_add(self.entries.len() as u64);
+        let snapshot = SourceSnapshot::new(metadata, contents)?;
+        self.cached_snapshot = Some(snapshot.clone());
+        self.appended_since_snapshot.clear();
+        Ok(snapshot)
     }
 
-    pub fn accepted_read_manifest(&self) -> Arc<[AcceptedReadManifestEntry]> {
-        self.accepted_reads.values().cloned().collect()
+    /// Cumulative sources materialized by full snapshot builds; the extension
+    /// path never increments this.
+    pub fn snapshot_sources_rebuilt(&self) -> u64 {
+        self.snapshot_sources_rebuilt
+    }
+
+    /// Cumulative sources appended by extension snapshot builds.
+    pub fn snapshot_sources_appended(&self) -> u64 {
+        self.snapshot_sources_appended
+    }
+
+    /// The accepted-read provenance manifest. Once a lineage's first manifest
+    /// exists, each successor manifest appends only the entries added since,
+    /// sharing every predecessor segment by reference — no predecessor entry is
+    /// copied, re-validated, or re-compared (RUE-1112).
+    pub fn accepted_read_manifest(&mut self) -> AcceptedReadManifest {
+        if let Some(cached) = self.cached_manifest.clone() {
+            if self.appended_since_manifest.is_empty() {
+                return cached;
+            }
+            let appended: Vec<AcceptedReadManifestEntry> = self
+                .appended_since_manifest
+                .iter()
+                .map(|module| {
+                    self.accepted_reads
+                        .get(module)
+                        .expect("appended modules retain their provenance entries")
+                        .clone()
+                })
+                .collect();
+            self.manifest_entries_appended = self
+                .manifest_entries_appended
+                .saturating_add(appended.len() as u64);
+            let manifest = AcceptedReadManifest::extend_with_appended(&cached, appended);
+            self.cached_manifest = Some(manifest.clone());
+            self.appended_since_manifest.clear();
+            return manifest;
+        }
+        self.manifest_entries_rebuilt = self
+            .manifest_entries_rebuilt
+            .saturating_add(self.accepted_reads.len() as u64);
+        let manifest =
+            AcceptedReadManifest::from_entries(self.accepted_reads.values().cloned().collect());
+        self.cached_manifest = Some(manifest.clone());
+        self.appended_since_manifest.clear();
+        manifest
+    }
+
+    /// Cumulative provenance entries materialized by full manifest builds; the
+    /// extension path never increments this.
+    pub fn manifest_entries_rebuilt(&self) -> u64 {
+        self.manifest_entries_rebuilt
+    }
+
+    /// Cumulative provenance entries appended by extension manifest builds.
+    pub fn manifest_entries_appended(&self) -> u64 {
+        self.manifest_entries_appended
     }
 }
 

--- a/crates/rue-compiler/src/import_graph.rs
+++ b/crates/rue-compiler/src/import_graph.rs
@@ -52,18 +52,40 @@ impl ImportDirective {
     }
 }
 
-/// Canonically ordered import sites from one lowered source snapshot.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
-pub struct ImportDirectives(Arc<[ImportDirective]>);
+/// Canonically ordered import sites from one lowered source snapshot, held as
+/// `Arc`-shared sorted segments: a strictly-additive successor program shares
+/// every predecessor segment by reference and appends only its new modules'
+/// sites (RUE-1112). Equality, hashing, and debug rendering are logical over
+/// the merged order; the contiguous slice materializes lazily, at most once
+/// per value, off the successor staging path.
+#[derive(Clone)]
+pub struct ImportDirectives(crate::shared_segments::SharedSegments<ImportDirective>);
+
+fn import_directive_order(a: &ImportDirective, b: &ImportDirective) -> std::cmp::Ordering {
+    a.cmp(b)
+}
 
 impl ImportDirectives {
     pub(crate) fn from_records(mut records: Vec<ImportDirective>) -> Self {
         records.sort();
-        Self(records.into())
+        Self(crate::shared_segments::SharedSegments::flat(
+            records.into(),
+            import_directive_order,
+        ))
     }
+
+    /// A strictly-additive successor sharing every segment of `base` by
+    /// reference and appending only `delta` (sorted here; must be disjoint —
+    /// sites of modules `base` does not carry).
+    pub(crate) fn extend(base: &ImportDirectives, delta: Vec<ImportDirective>) -> Self {
+        Self(crate::shared_segments::SharedSegments::extend(
+            &base.0, delta,
+        ))
+    }
+
     /// Import sites ordered by logical module, source offset, then specifier.
     pub fn as_slice(&self) -> &[ImportDirective] {
-        &self.0
+        self.0.as_slice()
     }
 
     pub fn len(&self) -> usize {
@@ -71,11 +93,37 @@ impl ImportDirectives {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.0.len() == 0
     }
 
     pub fn iter(&self) -> std::slice::Iter<'_, ImportDirective> {
-        self.0.iter()
+        self.as_slice().iter()
+    }
+}
+
+impl Default for ImportDirectives {
+    fn default() -> Self {
+        Self::from_records(Vec::new())
+    }
+}
+
+impl PartialEq for ImportDirectives {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Eq for ImportDirectives {}
+
+impl std::hash::Hash for ImportDirectives {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl std::fmt::Debug for ImportDirectives {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("ImportDirectives").field(&self.0).finish()
     }
 }
 
@@ -125,11 +173,22 @@ impl CanonicalImportRecord {
     }
 }
 
+/// Canonical order for the record sequence: importer, normalized spelling, then
+/// outcome (the record's derived total order).
+fn record_order(a: &CanonicalImportRecord, b: &CanonicalImportRecord) -> std::cmp::Ordering {
+    a.cmp(b)
+}
+
 /// Canonical resolved topology, independent of import-site occurrences.
+///
+/// The record sequence is a [`SharedSegments`], so a strictly-additive
+/// trusted-toolchain successor (RUE-1112) reuses the predecessor's record `Arc`
+/// by reference and stores only its sorted delta — no predecessor record is
+/// copied, re-sorted, or reallocated when the successor graph is built.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CanonicalImportGraph {
     root: ModuleId,
-    records: Arc<[CanonicalImportRecord]>,
+    records: crate::shared_segments::SharedSegments<CanonicalImportRecord>,
 }
 
 impl CanonicalImportGraph {
@@ -141,8 +200,29 @@ impl CanonicalImportGraph {
         records.dedup();
         Self {
             root,
-            records: records.into(),
+            records: crate::shared_segments::SharedSegments::flat(records.into(), record_order),
         }
+    }
+
+    /// Build a strictly-additive successor graph that shares `base`'s record
+    /// sequence by reference and appends `delta` (RUE-1112). `delta`'s importers
+    /// must be disjoint from `base`'s.
+    pub(crate) fn from_additive_successor(
+        root: ModuleId,
+        base: &CanonicalImportGraph,
+        delta: Vec<CanonicalImportRecord>,
+    ) -> Self {
+        Self {
+            root,
+            records: crate::shared_segments::SharedSegments::extend(&base.records, delta),
+        }
+    }
+
+    /// The shared record-segment representation (RUE-1112 successor sharing).
+    pub(crate) fn record_segments(
+        &self,
+    ) -> &crate::shared_segments::SharedSegments<CanonicalImportRecord> {
+        &self.records
     }
 
     pub fn root(&self) -> &ModuleId {
@@ -151,7 +231,7 @@ impl CanonicalImportGraph {
 
     /// Records sorted by importer, normalized spelling, then outcome.
     pub fn records(&self) -> &[CanonicalImportRecord] {
-        &self.records
+        self.records.as_slice()
     }
 
     /// Validate and canonicalize an explicitly supplied graph, failing closed.
@@ -172,7 +252,7 @@ impl CanonicalImportGraph {
         records.dedup();
         Ok(Self {
             root,
-            records: records.into(),
+            records: crate::shared_segments::SharedSegments::flat(records.into(), record_order),
         })
     }
 }
@@ -414,6 +494,130 @@ fn validate_records(
     }
 }
 
+/// Validate a strictly-additive trusted-toolchain successor graph incrementally
+/// (RUE-1112).
+///
+/// The predecessor graph closed valid, and the newly appended modules have no
+/// incoming edges from predecessor modules (nothing already in the compilation
+/// imports a freshly demanded trusted leaf). Therefore:
+///
+/// * predecessor records were already validated and carry no problems, so they
+///   are not re-examined;
+/// * a new record can only introduce a problem of its own — a foreign importer
+///   or target, a missing/ambiguous resolution, or a duplicate/conflict among the
+///   new records themselves (new importers are disjoint from predecessor
+///   importers, so no new record can conflict with a predecessor record);
+/// * any cycle involving a new module consists entirely of new modules, because a
+///   cycle edge into a new module can only originate from another new module.
+///
+/// This validates only `new_records` and detects cycles only within the
+/// new-module-induced subgraph, unioning the result with the carried predecessor
+/// validation — never re-walking the predecessor topology. `inputs` supplies the
+/// merged module set for membership checks only.
+pub(crate) fn validate_additive_successor(
+    predecessor: &CanonicalImportGraphValidation,
+    new_records: &[CanonicalImportRecord],
+    inputs: &ModuleResolutionInputs,
+    new_modules: &BTreeSet<ModuleId>,
+) -> CanonicalImportGraphValidation {
+    // Membership is checked by binary search over the shared, structurally
+    // extended resolution inputs, so the predecessor module table is never
+    // materialized into a set on the acquisition path (RUE-1112).
+    let mut problems = predecessor.problems().to_vec();
+    let mut by_key: BTreeMap<(ModuleId, Arc<str>), BTreeSet<CanonicalImportResolution>> =
+        BTreeMap::new();
+    // Cycle adjacency confined to new-module → new-module edges; every key and
+    // target is a new module, so `cycle_components` is well formed.
+    let mut new_adjacency: BTreeMap<ModuleId, BTreeSet<ModuleId>> = new_modules
+        .iter()
+        .cloned()
+        .map(|module| (module, BTreeSet::new()))
+        .collect();
+    let mut sorted = new_records.to_vec();
+    sorted.sort();
+    for pair in sorted.windows(2) {
+        if pair[0] == pair[1] {
+            problems.push(CanonicalImportGraphProblem::DuplicateRecord(
+                pair[0].clone(),
+            ));
+        }
+    }
+    for record in &sorted {
+        let key = (record.importer.clone(), record.normalized_specifier.clone());
+        by_key
+            .entry(key.clone())
+            .or_default()
+            .insert(record.resolution.clone());
+        if !inputs.contains(&record.importer) {
+            problems.push(CanonicalImportGraphProblem::ForeignImporter {
+                importer: key.0,
+                normalized_specifier: key.1,
+            });
+        }
+        match &record.resolution {
+            CanonicalImportResolution::Resolved(target) => {
+                if !inputs.contains(target) {
+                    problems.push(CanonicalImportGraphProblem::ForeignResolvedTarget {
+                        importer: record.importer.clone(),
+                        normalized_specifier: record.normalized_specifier.clone(),
+                        target: target.clone(),
+                    });
+                } else if inputs.contains(&record.importer)
+                    && new_modules.contains(target)
+                    && let Some(edges) = new_adjacency.get_mut(&record.importer)
+                {
+                    edges.insert(target.clone());
+                }
+            }
+            CanonicalImportResolution::Missing => {
+                problems.push(CanonicalImportGraphProblem::MissingResolution {
+                    importer: record.importer.clone(),
+                    normalized_specifier: record.normalized_specifier.clone(),
+                });
+            }
+            CanonicalImportResolution::Ambiguous {
+                file_module,
+                directory_module,
+            } => {
+                for target in [file_module, directory_module] {
+                    if !inputs.contains(target) {
+                        problems.push(CanonicalImportGraphProblem::ForeignResolvedTarget {
+                            importer: record.importer.clone(),
+                            normalized_specifier: record.normalized_specifier.clone(),
+                            target: target.clone(),
+                        });
+                    }
+                }
+                problems.push(CanonicalImportGraphProblem::AmbiguousResolution {
+                    importer: record.importer.clone(),
+                    normalized_specifier: record.normalized_specifier.clone(),
+                    file_module: file_module.clone(),
+                    directory_module: directory_module.clone(),
+                });
+            }
+        }
+    }
+    for ((importer, normalized_specifier), resolutions) in by_key {
+        if resolutions.len() > 1 {
+            problems.push(CanonicalImportGraphProblem::ConflictingCanonicalKey {
+                importer,
+                normalized_specifier,
+                resolutions: resolutions.into_iter().collect::<Vec<_>>().into(),
+            });
+        }
+    }
+    problems.sort();
+    problems.dedup();
+    let mut cycles = predecessor.cycles().to_vec();
+    cycles.extend(cycle_components(&new_adjacency));
+    cycles.sort();
+    cycles.dedup();
+    CanonicalImportGraphValidation {
+        problems: problems.into(),
+        cycles: cycles.into(),
+    }
+}
+
 fn cycle_components(
     adjacency: &BTreeMap<ModuleId, BTreeSet<ModuleId>>,
 ) -> Vec<CanonicalImportCycle> {
@@ -507,6 +711,92 @@ mod tests {
             specifier,
             CanonicalImportResolution::Resolved(ModuleId::from_logical_path(target).unwrap()),
         )
+    }
+
+    fn missing(importer: &str, specifier: &str) -> CanonicalImportRecord {
+        CanonicalImportRecord::new(
+            ModuleId::from_logical_path(importer).unwrap(),
+            specifier,
+            CanonicalImportResolution::Missing,
+        )
+    }
+
+    /// The incremental additive-successor validation must be identical to a full
+    /// validation of the merged graph, so production can carry the predecessor
+    /// validation and validate only the delta. This exercises the same code path
+    /// the trusted-toolchain successor close uses, across a clean additive delta
+    /// and deltas that introduce a new-module self-cycle, a new-module two-cycle,
+    /// a new-to-predecessor edge, and a missing resolution.
+    #[test]
+    fn additive_successor_validation_equals_full_validation() {
+        // A valid predecessor graph: root a imports b, b imports c.
+        let predecessor_records = vec![
+            resolved("a.rue", "b.rue", "b.rue"),
+            resolved("b.rue", "c.rue", "c.rue"),
+        ];
+        let predecessor_inputs = inputs(&["a.rue", "b.rue", "c.rue"], "a.rue");
+        let predecessor_graph = CanonicalImportGraph::from_discovery_records(
+            ModuleId::from_logical_path("a.rue").unwrap(),
+            predecessor_records.clone(),
+        );
+        let predecessor_validation =
+            validate_canonical_import_graph(&predecessor_graph, &predecessor_inputs);
+        assert!(predecessor_validation.is_valid());
+
+        let new_module = |name: &str| ModuleId::from_logical_path(name).unwrap();
+
+        // Each case: (added module names, delta records).
+        let cases: Vec<(Vec<&str>, Vec<CanonicalImportRecord>)> = vec![
+            // Clean additive: new x imports the existing c and a fresh y.
+            (
+                vec!["x.rue", "y.rue"],
+                vec![
+                    resolved("x.rue", "c.rue", "c.rue"),
+                    resolved("x.rue", "y.rue", "y.rue"),
+                ],
+            ),
+            // New-module self-cycle.
+            (vec!["x.rue"], vec![resolved("x.rue", "x.rue", "x.rue")]),
+            // New-module two-cycle among the delta.
+            (
+                vec!["x.rue", "y.rue"],
+                vec![
+                    resolved("x.rue", "y.rue", "y.rue"),
+                    resolved("y.rue", "x.rue", "x.rue"),
+                ],
+            ),
+            // New-to-predecessor edge (cannot create a cycle back into the delta).
+            (vec!["x.rue"], vec![resolved("x.rue", "b.rue", "b.rue")]),
+            // Delta with a missing resolution.
+            (vec!["x.rue"], vec![missing("x.rue", "nope.rue")]),
+        ];
+
+        for (added, delta_records) in cases {
+            let mut all_names = vec!["a.rue", "b.rue", "c.rue"];
+            all_names.extend(added.iter().copied());
+            let merged_inputs = inputs(&all_names, "a.rue");
+            let new_modules: BTreeSet<ModuleId> =
+                added.iter().map(|name| new_module(name)).collect();
+
+            let mut merged_records = predecessor_records.clone();
+            merged_records.extend(delta_records.iter().cloned());
+            let merged_graph = CanonicalImportGraph::from_discovery_records(
+                ModuleId::from_logical_path("a.rue").unwrap(),
+                merged_records,
+            );
+
+            let full = validate_canonical_import_graph(&merged_graph, &merged_inputs);
+            let incremental = validate_additive_successor(
+                &predecessor_validation,
+                &delta_records,
+                &merged_inputs,
+                &new_modules,
+            );
+            assert_eq!(
+                incremental, full,
+                "incremental successor validation must equal full validation for added={added:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -60,12 +60,15 @@ mod semantic_identity;
 mod semantic_query_nucleus;
 mod semantic_symbols;
 mod session;
+mod shared_segments;
 mod source_identity;
 mod source_metadata;
 mod source_snapshot;
 mod syntax;
+mod toolchain_module_demand;
 mod typed_query_store;
 pub mod unstable;
+mod well_known_option;
 
 #[cfg(test)]
 mod test_support;
@@ -103,9 +106,10 @@ pub use dependency_envelope::{
 pub(crate) use diagnostic_attempt_store::FrontendDiagnosticIdentity;
 pub use diagnostic_attempt_store::{DiagnosticStage, FrontendDiagnosticSnapshot};
 pub use import_discovery::{
-    AcceptedImportSource, AcceptedReadManifestEntry, FileMetadataFingerprint, ImportCandidateRole,
-    ImportDiscoveryContext, ImportDiscoveryPlan, ImportDiscoveryRequest, ImportObservation,
-    ImportObservationLedger, ImportObservationStatus, ImportOccurrenceKey, PhysicalFileIdentity,
+    AcceptedImportSource, AcceptedReadManifest, AcceptedReadManifestEntry, FileMetadataFingerprint,
+    ImportCandidateRole, ImportDiscoveryContext, ImportDiscoveryPlan, ImportDiscoveryRequest,
+    ImportObservation, ImportObservationLedger, ImportObservationStatus, ImportOccurrenceKey,
+    PhysicalFileIdentity,
 };
 pub(crate) use import_discovery::{
     ImportDemandFrontier, ImportDemandMode, ImportDemandRoots, ImportInputRevision,
@@ -130,6 +134,12 @@ pub use session::{CanonicalImportGraphOutput, CompilerSession, CompilerSessionUp
 pub use source_identity::{ModuleId, ModuleRevision, SourceId, SourceIdVersion, SourceRevision};
 pub use source_metadata::SourceMetadata;
 pub use source_snapshot::{MAX_SOURCE_BYTES, SourceSnapshot};
+pub use toolchain_module_demand::{
+    OPTION_MODULE_LOGICAL_PATH, ParkedToolchainModules, STRBUF_MODULE_LOGICAL_PATH,
+    TrustedToolchainModuleDemand,
+};
+// Internal registered-query payload — never crosses the crate boundary.
+pub(crate) use toolchain_module_demand::BodyToolchainDemand;
 
 // Query keys, invalidation records, dependency manifests, fingerprints, and
 // work records are compiler implementation. Keep crate-local paths available
@@ -235,7 +245,7 @@ pub(crate) use durable_body::{convert_semantic_body_exports, finalize_durable_or
 pub(crate) use durable_semantics::{
     import_durable_declaration_semantics, project_durable_declaration_semantics,
 };
-pub(crate) use import_graph::validate_canonical_import_graph;
+pub(crate) use import_graph::{validate_additive_successor, validate_canonical_import_graph};
 #[cfg(test)]
 pub(crate) use linking::{parse_runtime_archive, validate_runtime};
 pub(crate) use queries::build_functions_and_cfgs;

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -787,13 +787,31 @@ impl ParsedModulesWork {
     }
 }
 
-/// Deterministically ordered collection of independently parsed modules.
+/// Deterministically ordered collection of independently parsed modules. The
+/// module table is held as `Arc`-shared sorted segments: a strictly-additive
+/// successor shares every predecessor segment by reference and appends only its
+/// newly parsed modules (RUE-1112). The whole-program merged views — the
+/// contiguous module slice and the merged import directives — are projections
+/// that materialize lazily, never on the successor staging path.
 #[derive(Debug, Clone)]
 pub struct ParsedProgram {
     source_revision: SourceRevision,
-    modules: Arc<[Arc<ParsedModule>]>,
+    modules: crate::shared_segments::SharedSegments<Arc<ParsedModule>>,
     imports: ImportDirectives,
     invalid_imports: Arc<[ParsedInvalidImport]>,
+}
+
+fn parsed_module_order(a: &Arc<ParsedModule>, b: &Arc<ParsedModule>) -> std::cmp::Ordering {
+    a.module_id().cmp(b.module_id())
+}
+
+fn sort_invalid_imports(invalid_imports: &mut [ParsedInvalidImport]) {
+    invalid_imports.sort_by(|left, right| {
+        left.importer
+            .cmp(&right.importer)
+            .then(left.span.file_id.index().cmp(&right.span.file_id.index()))
+            .then(left.span.start.cmp(&right.span.start))
+    });
 }
 
 impl ParsedProgram {
@@ -830,15 +848,76 @@ impl ParsedProgram {
             .iter()
             .flat_map(|module| module.invalid_imports().iter().cloned())
             .collect::<Vec<_>>();
-        invalid_imports.sort_by(|left, right| {
-            left.importer
-                .cmp(&right.importer)
-                .then(left.span.file_id.index().cmp(&right.span.file_id.index()))
-                .then(left.span.start.cmp(&right.span.start))
-        });
+        sort_invalid_imports(&mut invalid_imports);
         Ok(Self {
             source_revision,
-            modules: modules.into(),
+            modules: crate::shared_segments::SharedSegments::flat(
+                modules.into(),
+                parsed_module_order,
+            ),
+            imports,
+            invalid_imports: invalid_imports.into(),
+        })
+    }
+
+    /// A strictly-additive successor program: every predecessor module, import
+    /// directive, and source-revision segment is shared by reference; only the
+    /// newly appended modules are added. `source_revision` is the successor
+    /// snapshot's already-extended revision — the identity the appended leaves
+    /// were published under — never re-derived by enumerating modules.
+    pub(crate) fn extend_successor(
+        predecessor: &ParsedProgram,
+        source_revision: SourceRevision,
+        mut delta: Vec<Arc<ParsedModule>>,
+    ) -> CompileResult<Self> {
+        delta.sort_by(parsed_module_order);
+        let predecessor_len = predecessor.modules.len();
+        for module in &delta {
+            if predecessor.module(module.module_id()).is_some() {
+                return Err(invalid_input(format!(
+                    "successor parse delta re-declares retained module {}",
+                    module.module_id()
+                )));
+            }
+            // Appended sources extend the predecessor's dense file table, so a
+            // delta file ID inside the retained range is a construction error.
+            if (module.file_id().index() as usize) <= predecessor_len {
+                return Err(invalid_input(format!(
+                    "successor parse delta reuses retained file ID {} for module {}",
+                    module.file_id().index(),
+                    module.module_id()
+                )));
+            }
+        }
+        if source_revision.module_segments().len() != predecessor_len + delta.len() {
+            return Err(invalid_input(
+                "successor parse delta does not reconcile with its extended source revision",
+            ));
+        }
+        let imports = ImportDirectives::extend(
+            &predecessor.imports,
+            delta
+                .iter()
+                .flat_map(|module| module.imports().iter())
+                .cloned()
+                .collect(),
+        );
+        // A committed predecessor parsed cleanly, so this concatenation copies
+        // only diagnostics-bearing records (empty in the additive flow).
+        let mut invalid_imports = predecessor
+            .invalid_imports
+            .iter()
+            .cloned()
+            .chain(
+                delta
+                    .iter()
+                    .flat_map(|module| module.invalid_imports().iter().cloned()),
+            )
+            .collect::<Vec<_>>();
+        sort_invalid_imports(&mut invalid_imports);
+        Ok(Self {
+            source_revision,
+            modules: crate::shared_segments::SharedSegments::extend(&predecessor.modules, delta),
             imports,
             invalid_imports: invalid_imports.into(),
         })
@@ -850,16 +929,28 @@ impl ParsedProgram {
     pub fn source_revision(&self) -> &SourceRevision {
         &self.source_revision
     }
+
+    /// The contiguous merged module table — a lazily materialized projection
+    /// (at most once per value). Paths that only iterate or look up single
+    /// modules use [`Self::modules_iter`] / [`Self::module`] instead.
     pub fn modules(&self) -> &[Arc<ParsedModule>] {
-        &self.modules
+        self.modules.as_slice()
     }
 
-    /// Look up a module by its stable logical identity.
+    /// Stream the modules in canonical logical order without materializing the
+    /// merged table.
+    pub(crate) fn modules_iter(&self) -> impl ExactSizeIterator<Item = &Arc<ParsedModule>> {
+        self.modules.iter()
+    }
+
+    pub(crate) fn modules_len(&self) -> usize {
+        self.modules.len()
+    }
+
+    /// Look up a module by its stable logical identity (per-segment binary
+    /// search; never materializes the merged table).
     pub fn module(&self, id: &ModuleId) -> Option<&Arc<ParsedModule>> {
-        self.modules
-            .binary_search_by(|module| module.module_id().cmp(id))
-            .ok()
-            .map(|index| &self.modules[index])
+        self.modules.find_by(|module| module.module_id().cmp(id))
     }
 
     /// Traverse module-qualified ASTs in canonical logical-module order.
@@ -898,7 +989,7 @@ impl ParsedProgram {
 
     #[cfg(test)]
     pub(crate) fn shared_symbol_strings(&self) -> Option<Vec<&str>> {
-        let first = self.modules.first()?;
+        let first = self.modules.iter().next()?;
         if self.modules.iter().all(|module| {
             Arc::ptr_eq(
                 &module.payload.resolver.resolver,
@@ -1026,6 +1117,19 @@ pub(crate) fn reset_parse_operation_entries() {
 #[cfg(test)]
 pub(crate) fn parse_operation_entries() -> usize {
     PARSE_OPERATION_ENTRIES.with(Cell::get)
+}
+
+/// Invalidation classification for a strictly-additive trusted successor
+/// (RUE-1112): relative to its committed predecessor exactly the appended
+/// modules are added — nothing is removed, rebound, or reparsed — so only the
+/// delta is examined; retained modules are never enumerated or compared.
+pub(crate) fn classify_successor_invalidation(delta: &[ModuleId]) -> ParseInvalidationSummary {
+    let mut added = delta.to_vec();
+    added.sort();
+    ParseInvalidationSummary {
+        added,
+        ..Default::default()
+    }
 }
 
 pub(crate) fn classify_invalidation(

--- a/crates/rue-compiler/src/producer_nominal_acceptance_tests.rs
+++ b/crates/rue-compiler/src/producer_nominal_acceptance_tests.rs
@@ -17,9 +17,881 @@
 
 use crate::*;
 use std::collections::BTreeSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use rue_target::Target;
+
+// ===========================================================================
+// RUE-1112 — per-body well-known `Option(payload)` demand, projection, and AIR
+// try-operand consumption.
+//
+// Every fallible intrinsic (`@read_line`, `@parse_i32/i64/u32/u64`) returns the
+// exact trusted standard-library `Option(payload)`. When the trusted `Option`
+// module is present, the per-body demand loop roots the matching
+// `Option(payload)` comptime specialization under the requesting body's lease,
+// projects it through a narrow per-body `WellKnownTypes` input, and AIR's
+// `resolve_option_result_type` binds it under `?` — winning over any same-shape
+// local lookalike the legacy structural scan would otherwise pick. When the
+// module is absent, the plan is empty and the legacy `find_compatible_anon_enum`
+// scan stays in force (freestanding programs are unchanged).
+// ===========================================================================
+
+/// The trusted standard-library `Option` module source, verbatim from
+/// `std/option.rue`. Provided at the trusted logical path so the demand planner
+/// and projection resolve the real std producer identity.
+const TRUSTED_OPTION_SOURCE: &str = r#"
+pub fn Option(comptime T: type) -> type {
+    enum {
+        Some(T),
+        None,
+    }
+}
+"#;
+
+/// The `FileId` the helpers assign to the root module.
+const ROOT_FILE: FileId = FileId::new(1);
+/// The `FileId` the helpers assign to the trusted `\0rue-std/option.rue` module.
+/// Because the test controls this assignment, an enum whose `EnumDef.file_id`
+/// equals it was produced by the trusted std `Option`, not a local lookalike —
+/// the provenance signal the acceptance criteria demand.
+const TRUSTED_OPTION_FILE: FileId = FileId::new(2);
+
+/// Build a snapshot whose root module is `root_source`, with the trusted std
+/// `Option` module provided at `\0rue-std/option.rue`. The root reaches it with
+/// `@import("std/option.rue")` (physical-path suffix match). The trusted flag is
+/// what makes `plan_well_known_option_demands` treat the module as present.
+fn trusted_option_snapshot(root_source: &str) -> SourceSnapshot {
+    let metadata = SourceMetadata::new_with_trusted_standard_library(
+        ROOT_FILE,
+        HashMap::from([
+            (ROOT_FILE, "/project/main.rue".to_owned()),
+            (TRUSTED_OPTION_FILE, "/project/std/option.rue".to_owned()),
+        ]),
+        HashMap::from([
+            (ROOT_FILE, "main.rue".to_owned()),
+            (TRUSTED_OPTION_FILE, "\0rue-std/option.rue".to_owned()),
+        ]),
+        HashSet::from([TRUSTED_OPTION_FILE]),
+    )
+    .expect("trusted-std metadata is valid");
+    SourceSnapshot::new(
+        metadata,
+        vec![
+            (ROOT_FILE, Arc::new(root_source.to_owned())),
+            (
+                TRUSTED_OPTION_FILE,
+                Arc::new(TRUSTED_OPTION_SOURCE.to_owned()),
+            ),
+        ],
+    )
+    .expect("trusted-option snapshot is valid")
+}
+
+/// Publish `root_source` alongside the trusted std `Option` module and return
+/// the semantic output. Import resolution is the test-fixture graph, exactly as
+/// the other multi-module frontend tests use.
+fn semantic_with_trusted_option(
+    root_source: &str,
+    options: &CompileOptions,
+) -> Result<Arc<CanonicalSemanticOutput>, CompileErrors> {
+    let snapshot = trusted_option_snapshot(root_source);
+    let (_, semantic, _) = crate::test_frontend_snapshot(&snapshot, options)?;
+    Ok(semantic)
+}
+
+/// Compile and link `root_source` with the trusted std `Option` module present,
+/// producing a runnable ELF.
+fn compile_with_trusted_option(
+    root_source: &str,
+    options: &CompileOptions,
+) -> Result<CompileOutput, CompileErrors> {
+    let snapshot = trusted_option_snapshot(root_source);
+    crate::test_compile_snapshot(&snapshot, options)
+}
+
+/// The result Option enum types bound to each fallible parse/read intrinsic in
+/// a semantic output — the exact type `resolve_option_result_type` chose. Each
+/// entry is the intrinsic's runtime kind paired with the `EnumId` of its
+/// `Option` result. Reading the AIR instruction's `ty` directly gives the
+/// binding the `?` site consumed, not merely what exists in the pool.
+fn fallible_intrinsic_option_enums(
+    semantic: &CanonicalSemanticOutput,
+) -> Vec<(rue_air::RuntimeCallKind, rue_air::EnumId)> {
+    let mut found = Vec::new();
+    for function in semantic.functions() {
+        for (_, inst) in function.analyzed.air.iter() {
+            if let rue_air::AirInstData::Intrinsic {
+                runtime: Some(runtime),
+                ..
+            } = &inst.data
+                && matches!(
+                    runtime,
+                    rue_air::RuntimeCallKind::ParseI32
+                        | rue_air::RuntimeCallKind::ParseI64
+                        | rue_air::RuntimeCallKind::ParseU32
+                        | rue_air::RuntimeCallKind::ParseU64
+                        | rue_air::RuntimeCallKind::ReadLine
+                )
+                && let rue_air::TypeKind::Enum(enum_id) = inst.ty.kind()
+            {
+                found.push((*runtime, enum_id));
+            }
+        }
+    }
+    found
+}
+
+/// The stable producer digest (`__anon_enum_<hash>`) of the single `Option`
+/// enum bound to a `@parse_i64(...)?` site. Panics unless there is exactly one.
+/// Because the digest hashes the producer's LOGICAL module identity plus a
+/// definition-relative anchor (RUE-1089, allocation-order-independent), the same
+/// producer yields the same digest across programs — so a digest computed from a
+/// std-only reference program identifies the trusted std `Option(i64)` anywhere.
+fn bound_parse_i64_digest(semantic: &CanonicalSemanticOutput) -> String {
+    let parse = fallible_intrinsic_option_enums(semantic)
+        .into_iter()
+        .filter(|(runtime, _)| *runtime == rue_air::RuntimeCallKind::ParseI64)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        parse.len(),
+        1,
+        "expected exactly one @parse_i64 binding, got {} ({parse:?})",
+        parse.len(),
+    );
+    let def = semantic.type_pool().enum_def(parse[0].1);
+    assert_eq!(
+        def.variants,
+        vec!["Some".to_string(), "None".to_string()],
+        "the ?-bound type must be Option-shaped",
+    );
+    assert_eq!(
+        def.variant_payload(0),
+        &[rue_air::Type::I64],
+        "the ?-bound Option must carry the i64 payload",
+    );
+    def.name.clone()
+}
+
+/// The producer digests of every `Some(i64)/None`-shaped anonymous enum in a
+/// pool. Distinct producers of the same shape (a std `Option` and a local
+/// lookalike) appear as distinct digests, so the size of this set counts how
+/// many independent `Option(i64)` identities the program materialized.
+fn option_i64_pool_digests(semantic: &CanonicalSemanticOutput) -> BTreeSet<String> {
+    let pool = semantic.type_pool();
+    pool.all_enum_ids()
+        .into_iter()
+        .map(|id| pool.enum_def(id))
+        .filter(|def| {
+            def.variants == vec!["Some".to_string(), "None".to_string()]
+                && def.variant_payload(0) == [rue_air::Type::I64]
+        })
+        .map(|def| def.name.clone())
+        .collect()
+}
+
+/// The stable digest that identifies the trusted std `Option(i64)`: computed
+/// from a std-only reference program whose sole `Option(i64)` is unambiguously
+/// the trusted producer.
+fn std_option_i64_reference_digest(options: &CompileOptions) -> String {
+    let reference = r#"
+const opt = @import("std/option.rue");
+fn probe(s: str) -> opt.Option(i64) {
+    let O = opt.Option(i64);
+    O.Some(@parse_i64(s)?)
+}
+fn main() -> i32 {
+    let O = opt.Option(i64);
+    match probe("1") { O.Some(v) => @intCast(v), O.None => 0 }
+}
+"#;
+    let semantic =
+        semantic_with_trusted_option(reference, options).expect("std reference program compiles");
+    bound_parse_i64_digest(&semantic)
+}
+
+/// t-win. With the trusted std `Option` module present, a bare `@parse_i64(s)?`
+/// binds the STD `Option(i64)`. Asserted by provenance: the intrinsic's result
+/// enum carries the trusted producer's stable digest (distinct from the digest a
+/// local `Option` producer yields), and the program links and executes to 42.
+#[test]
+fn well_known_parse_binds_trusted_std_option() {
+    let options = CompileOptions::default();
+    let source = r#"
+const opt = @import("std/option.rue");
+fn read_num(s: str) -> opt.Option(i64) {
+    let O = opt.Option(i64);
+    O.Some(@parse_i64(s)?)
+}
+fn main() -> i32 {
+    let O = opt.Option(i64);
+    match read_num("42") {
+        O.Some(v) => @intCast(v),
+        O.None => 0,
+    }
+}
+"#;
+    let semantic = semantic_with_trusted_option(source, &options)
+        .expect("trusted-option parse program compiles");
+    let bound = bound_parse_i64_digest(&semantic);
+    assert_eq!(
+        bound,
+        std_option_i64_reference_digest(&options),
+        "the ?-bound Option(i64) must carry the trusted std producer's digest",
+    );
+
+    // The digest is provenance-sensitive rather than shape-only: RUE-1112's
+    // `well_known_registry_wins_over_local_lookalike` proves the std producer is
+    // bound even when a same-shape local `Option(i64)` lookalike is materialized
+    // in the very same body. A same-shape local lookalike is not a valid `?`
+    // operand — only the trusted std producer is — so that control lives in the
+    // registry-wins test above.
+
+    // End to end: the trusted-option program links and runs to the payload 42.
+    #[cfg(unix)]
+    {
+        let output = compile_with_trusted_option(source, &options).expect("t-win links");
+        if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+            let execution = execute_wrap(&output, "twin");
+            assert_eq!(
+                execution.status.code(),
+                Some(42),
+                "t-win must execute to 42: {execution:?}",
+            );
+        } else {
+            let _ = output;
+        }
+    }
+}
+
+/// t-win (registry wins over a materialized local lookalike). The requesting
+/// body materializes a LOCAL same-shape `Option(i64)` in its own universe — the
+/// exact enum the legacy structural scan would pick — yet `@parse_i64(s)?` still
+/// binds the TRUSTED std `Option(i64)`. The narrow well-known registry is
+/// consulted before the scan, so provenance is the trusted producer even though
+/// a compatible local enum is in scope.
+#[test]
+fn well_known_registry_wins_over_local_lookalike() {
+    let options = CompileOptions::default();
+    let source = r#"
+const opt = @import("std/option.rue");
+fn Local(comptime T: type) -> type { enum { Some(T), None } }
+fn read_num(s: str) -> opt.Option(i64) {
+    // A local Option(i64) lookalike, materialized in THIS body's universe so the
+    // legacy `find_compatible_anon_enum` scan would find and bind it.
+    let L = Local(i64);
+    let _decoy: L = L.None;
+    let O = opt.Option(i64);
+    O.Some(@parse_i64(s)?)
+}
+fn main() -> i32 {
+    let O = opt.Option(i64);
+    match read_num("42") {
+        O.Some(v) => @intCast(v),
+        O.None => 0,
+    }
+}
+"#;
+    let semantic =
+        semantic_with_trusted_option(source, &options).expect("lookalike program compiles");
+
+    // Both a std and a local Option(i64) identity were materialized.
+    let pool_digests = option_i64_pool_digests(&semantic);
+    let std_digest = std_option_i64_reference_digest(&options);
+    assert!(
+        pool_digests.contains(&std_digest),
+        "the std Option(i64) must be present in the pool: {pool_digests:?}",
+    );
+    assert!(
+        pool_digests.iter().any(|d| *d != std_digest),
+        "a distinct local Option(i64) lookalike must also be present: {pool_digests:?}",
+    );
+
+    // The `?` site bound the trusted std producer, NOT the local lookalike.
+    assert_eq!(
+        bound_parse_i64_digest(&semantic),
+        std_digest,
+        "the registry must win: `?` binds the trusted std Option, not the local lookalike",
+    );
+}
+
+/// Freestanding `?` legality by producer identity (RUE-1112). There is no
+/// structural-shape fallback: `?` legality is exact trusted-producer identity in
+/// every context — even freestanding.
+///
+/// 1. A freestanding program whose `?` operand is a LOCAL (non-std) `Option`
+///    lookalike is rejected (E0504, `QuestionOnNonOption`): the local producer
+///    is not the trusted std `Option`, and no fallback resolves it anymore.
+/// 2. A program with the trusted std `Option` acquired resolves `?` on a bare
+///    `@parse_i64` against that std producer and compiles — the std-acquired
+///    path is the only one that works now.
+#[test]
+fn freestanding_local_option_try_is_now_rejected_without_std() {
+    let options = CompileOptions::default();
+
+    // (1) Freestanding local-Option `?` — no trusted std, no fallible intrinsic.
+    // The operand of `?` is the local `Option(i64)` lookalike; its producer is
+    // the user's own `Option` function, not the trusted std one, so `?` is
+    // rejected: no structural-shape fallback resolves a lookalike.
+    let local_lookalike = r#"
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn make() -> Option(i64) {
+    let O = Option(i64);
+    O.Some(1)
+}
+fn use_it() -> Option(i64) {
+    let v = make()?;
+    let O = Option(i64);
+    O.Some(v)
+}
+fn main() -> i32 {
+    let O = Option(i64);
+    match use_it() {
+        O.Some(v) => @intCast(v),
+        O.None => 0,
+    }
+}
+"#;
+    let errors = fresh_semantic(local_lookalike, &options)
+        .expect_err("a local-Option `?` operand is no longer accepted (fallback deleted)");
+    let rendered = errors.to_string();
+    assert!(
+        rendered.contains("the `?` operator can only be applied to an `Option`"),
+        "expected E0504 QuestionOnNonOption for a lookalike `?` operand: {rendered}",
+    );
+
+    // (2) With the trusted std `Option` acquired, `?` on a bare `@parse_i64`
+    // binds the std producer and the program compiles. This is the freestanding
+    // fallible-intrinsic case's real, std-acquired resolution path.
+    let std_acquired = r#"
+const opt = @import("std/option.rue");
+fn read_num(s: str) -> opt.Option(i64) {
+    let O = opt.Option(i64);
+    O.Some(@parse_i64(s)?)
+}
+fn main() -> i32 {
+    let O = opt.Option(i64);
+    match read_num("42") {
+        O.Some(v) => @intCast(v),
+        O.None => 0,
+    }
+}
+"#;
+    let semantic = semantic_with_trusted_option(std_acquired, &options)
+        .expect("std-acquired `@parse_i64(s)?` compiles");
+    // The `?` bound the trusted std Option(i64).
+    assert_eq!(
+        bound_parse_i64_digest(&semantic),
+        std_option_i64_reference_digest(&options),
+        "std-acquired `?` binds the trusted std Option",
+    );
+}
+
+/// The number of well-known `Option` demands the planner roots for a snapshot.
+/// Built through the same lower path the session uses (`merge_parsed_modules`
+/// then `lower_canonical_rir`), then `plan_well_known_option_demands` directly —
+/// the exact function the session calls once per semantic request.
+fn planned_demand_count(snapshot: &SourceSnapshot, options: &CompileOptions) -> usize {
+    planned_demands(snapshot, options).len()
+}
+
+/// The `FileId` the StrBuf helper assigns to the trusted `\0rue-std/strbuf.rue`
+/// module.
+const TRUSTED_STRBUF_FILE: FileId = FileId::new(3);
+
+/// A minimal trusted `\0rue-std/strbuf.rue` carrying just the `StrBuf` struct in
+/// the canonical `{buf, len, cap}` shape (RUE-1066). The planner only needs the
+/// module present to spell the `StrBuf` nominal `DurableType`; this is enough.
+const TRUSTED_STRBUF_SOURCE: &str = r#"
+pub struct StrBuf {
+    buf: ptr mut u8,
+    len: u64,
+    cap: u64,
+}
+"#;
+
+/// Build a snapshot whose root is `root_source`, with BOTH the trusted std
+/// `Option` and `StrBuf` modules provided at their trusted logical paths.
+fn trusted_option_and_strbuf_snapshot(root_source: &str) -> SourceSnapshot {
+    let metadata = SourceMetadata::new_with_trusted_standard_library(
+        ROOT_FILE,
+        HashMap::from([
+            (ROOT_FILE, "/project/main.rue".to_owned()),
+            (TRUSTED_OPTION_FILE, "/project/std/option.rue".to_owned()),
+            (TRUSTED_STRBUF_FILE, "/project/std/strbuf.rue".to_owned()),
+        ]),
+        HashMap::from([
+            (ROOT_FILE, "main.rue".to_owned()),
+            (TRUSTED_OPTION_FILE, "\0rue-std/option.rue".to_owned()),
+            (TRUSTED_STRBUF_FILE, "\0rue-std/strbuf.rue".to_owned()),
+        ]),
+        HashSet::from([TRUSTED_OPTION_FILE, TRUSTED_STRBUF_FILE]),
+    )
+    .expect("trusted-std metadata is valid");
+    SourceSnapshot::new(
+        metadata,
+        vec![
+            (ROOT_FILE, Arc::new(root_source.to_owned())),
+            (
+                TRUSTED_OPTION_FILE,
+                Arc::new(TRUSTED_OPTION_SOURCE.to_owned()),
+            ),
+            (
+                TRUSTED_STRBUF_FILE,
+                Arc::new(TRUSTED_STRBUF_SOURCE.to_owned()),
+            ),
+        ],
+    )
+    .expect("trusted-option+strbuf snapshot is valid")
+}
+
+/// StrBuf-payload encoding (RUE-1112). `@read_line`'s `Option(StrBuf)` carries a
+/// NOMINAL payload, unlike the scalar `@parse_*` intrinsics. When both trusted
+/// `Option` and `StrBuf` modules are present, the planner roots a demand whose
+/// `ComptimeCallQueryKey` type-argument is the canonical trusted `StrBuf`
+/// `DurableType::Nominal` — the exact spelling `durable_semantics` blesses. Drop
+/// the `StrBuf` module and the read_line demand is skipped (its payload cannot be
+/// spelled), leaving only the scalar demand; the program falls through the scan.
+#[test]
+fn read_line_plans_a_strbuf_nominal_option_demand() {
+    let options = CompileOptions::default();
+    // The demand planner roots an `Option(payload)` only for a fallible
+    // intrinsic that is the operand of `?` (RUE-1112): that is the sole context
+    // where the registry, not the surrounding annotation/`match`, supplies the
+    // intrinsic's trusted std `Option`. So the probe uses `@read_line()?` /
+    // `@parse_i64(s)?` to exercise the StrBuf and i64 demands.
+    let root = r#"
+fn probe(s: str) {
+    let _ = @read_line()?;
+    let _ = @parse_i64(s)?;
+}
+fn main() -> i32 { 0 }
+"#;
+
+    // Expected canonical StrBuf nominal DurableType, spelled exactly as the
+    // planner (and durable_semantics) do.
+    let strbuf_module =
+        crate::ModuleId::from_trusted_standard_library_path("\0rue-std/strbuf.rue").unwrap();
+    let strbuf_nominal = crate::durable_semantics::DurableType::Nominal(
+        crate::StableDefinitionKey::from_stable_parts(
+            strbuf_module,
+            crate::StableDefinitionNamespace::Type,
+            crate::StableDefinitionKind::Struct,
+            "StrBuf",
+            None,
+        ),
+    );
+
+    // Both modules present: read_line's StrBuf demand is rooted.
+    let with_strbuf = trusted_option_and_strbuf_snapshot(root);
+    let demands = planned_demands(&with_strbuf, &options);
+    assert!(
+        demands.iter().any(|d| d.payload == strbuf_nominal),
+        "the read_line demand must carry the trusted StrBuf nominal payload; got {:?}",
+        demands.iter().map(|d| &d.payload).collect::<Vec<_>>(),
+    );
+    assert!(
+        demands
+            .iter()
+            .any(|d| d.payload == crate::durable_semantics::DurableType::I64),
+        "the parse_i64 demand must also be planned",
+    );
+    // And that StrBuf demand's ComptimeCall type-argument is the same nominal.
+    let strbuf_demand = demands
+        .iter()
+        .find(|d| d.payload == strbuf_nominal)
+        .expect("StrBuf demand present");
+    assert!(
+        strbuf_demand
+            .call
+            .type_arguments
+            .iter()
+            .any(|(name, ty)| name.as_ref() == "T" && *ty == strbuf_nominal),
+        "the ComptimeCallQueryKey must bind T = the trusted StrBuf nominal",
+    );
+
+    // Without the StrBuf module the read_line demand is dropped; only i64 remains.
+    let option_only = trusted_option_snapshot(root);
+    let scalar_only = planned_demands(&option_only, &options);
+    assert!(
+        scalar_only.iter().all(|d| d.payload != strbuf_nominal),
+        "without the StrBuf module no StrBuf demand may be planned",
+    );
+    assert!(
+        scalar_only
+            .iter()
+            .any(|d| d.payload == crate::durable_semantics::DurableType::I64),
+        "the scalar i64 demand must still be planned without StrBuf",
+    );
+}
+
+/// The well-known `Option` demands the planner roots for a snapshot — the exact
+/// `WellKnownOptionDemand` list the session builds once per semantic request.
+fn planned_demands(
+    snapshot: &SourceSnapshot,
+    options: &CompileOptions,
+) -> Arc<[crate::body_query::WellKnownOptionDemand]> {
+    let parsed =
+        crate::parsed_modules::parse_source_snapshot_modules(snapshot).expect("snapshot parses");
+    let merged = crate::merge_parsed_modules(&parsed).expect("modules merge");
+    let rir = crate::canonical_lower::lower_canonical_rir(&merged).expect("rir lowers");
+    let configuration = crate::semantic_query_nucleus::SemanticQueryConfiguration {
+        target: options.target,
+        preview_features: crate::StablePreviewFeatures::new(&options.preview_features),
+    };
+    crate::well_known_option::plan_well_known_option_demands(&merged, &rir, &configuration)
+}
+
+/// t1. A body with NO fallible intrinsic plans ZERO `Option` demands even with
+/// the trusted std module present; a body that DOES use one plans a demand;
+/// and a fallible intrinsic with NO trusted module present plans zero (the gate
+/// keeps freestanding programs on the legacy scan). This is the assertable
+/// "zero demands" signal: the count of demands the session roots per request.
+#[test]
+fn no_fallible_intrinsic_plans_zero_option_demands() {
+    let options = CompileOptions::default();
+
+    // Std present, no fallible intrinsic → zero demands.
+    let quiet = trusted_option_snapshot(
+        r#"
+const opt = @import("std/option.rue");
+fn main() -> i32 {
+    let O = opt.Option(i64);
+    match O.Some(41) { O.Some(v) => @intCast(v) + 1, O.None => 0 }
+}
+"#,
+    );
+    assert_eq!(
+        planned_demand_count(&quiet, &options),
+        0,
+        "a std-present program with no fallible intrinsic must plan zero demands",
+    );
+
+    // Std present, a fallible intrinsic → a demand is planned.
+    let loud = trusted_option_snapshot(
+        r#"
+const opt = @import("std/option.rue");
+fn read_num(s: str) -> opt.Option(i64) {
+    let O = opt.Option(i64);
+    O.Some(@parse_i64(s)?)
+}
+fn main() -> i32 { 0 }
+"#,
+    );
+    assert_eq!(
+        planned_demand_count(&loud, &options),
+        1,
+        "a std-present program using @parse_i64 must plan exactly one (i64) demand",
+    );
+
+    // Fallible intrinsic but NO trusted module → gate keeps the plan empty.
+    let freestanding = SourceSnapshot::single(
+        "<freestanding>",
+        r#"
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn read_num(s: str) -> Option(i64) {
+    let O = Option(i64);
+    O.Some(@parse_i64(s)?)
+}
+fn main() -> i32 { 0 }
+"#,
+    )
+    .expect("snapshot");
+    assert_eq!(
+        planned_demand_count(&freestanding, &options),
+        0,
+        "without a trusted std module the plan must be empty (legacy scan stays in force)",
+    );
+}
+
+/// t2. Two distinct bodies each demanding the SAME payload (`i64`) share ONE
+/// materialized `Option(i64)` specialization: the nucleus memoizes the
+/// `ComptimeCall` rooted under each body's lease, so both `?` sites bind the
+/// identical `EnumId` and the pool holds exactly one std `Option(i64)` identity.
+/// (The nucleus's Computed-then-Reused execution is internal to the body-request
+/// loop; the shared identity is its observable, request-stable consequence.)
+#[test]
+fn two_bodies_same_payload_share_one_specialization() {
+    let options = CompileOptions::default();
+    let source = r#"
+const opt = @import("std/option.rue");
+fn first(s: str) -> opt.Option(i64) {
+    let O = opt.Option(i64);
+    O.Some(@parse_i64(s)?)
+}
+fn second(s: str) -> opt.Option(i64) {
+    let O = opt.Option(i64);
+    O.Some(@parse_i64(s)?)
+}
+fn main() -> i32 {
+    let O = opt.Option(i64);
+    match first("1") { O.Some(_a) => match second("2") { O.Some(_b) => 0, O.None => 1 }, O.None => 2 }
+}
+"#;
+    let semantic =
+        semantic_with_trusted_option(source, &options).expect("two-body program compiles");
+    let parse_enums = fallible_intrinsic_option_enums(&semantic)
+        .into_iter()
+        .filter(|(runtime, _)| *runtime == rue_air::RuntimeCallKind::ParseI64)
+        .map(|(_, id)| id)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        parse_enums.len(),
+        2,
+        "both bodies must contribute a @parse_i64 binding, got {parse_enums:?}",
+    );
+    assert_eq!(
+        parse_enums[0], parse_enums[1],
+        "both bodies must bind the one shared std Option(i64) specialization",
+    );
+    let std_digest = std_option_i64_reference_digest(&options);
+    let pool = option_i64_pool_digests(&semantic);
+    assert_eq!(
+        pool,
+        BTreeSet::from([std_digest]),
+        "exactly one std Option(i64) identity must exist across both bodies: {pool:?}",
+    );
+}
+
+/// Publish `root_source` (trusted std `Option` present) into `session`, adopting
+/// the test import graph, and return the semantic output.
+fn publish_trusted_semantic(
+    session: &mut CompilerSession,
+    root_source: &str,
+    options: &CompileOptions,
+) -> Result<Arc<CanonicalSemanticOutput>, CompileErrors> {
+    let snapshot = trusted_option_snapshot(root_source);
+    let program = session
+        .update_for_presentation(&snapshot)
+        .into_owner_result()?;
+    if !program.import_directives().is_empty() {
+        let graph = crate::test_fixture_import_graph(&program)?;
+        session.adopt_test_import_graph(graph);
+    }
+    session.canonical_semantic(options)
+}
+
+/// Warm/fresh parity on t-win. A WARM incremental compile (reached after the
+/// session already compiled an unrelated prior revision that also carried the
+/// trusted std module) produces semantic output identical to a FRESH compile:
+/// the per-body demand, projection, and narrow install are deterministic and
+/// session-issuer-independent, so the well-known `Option(i64)` binding and every
+/// symbol agree exactly.
+#[test]
+fn well_known_parse_warm_and_fresh_agree() {
+    let options = CompileOptions::default();
+    let target = r#"
+const opt = @import("std/option.rue");
+fn read_num(s: str) -> opt.Option(i64) {
+    let O = opt.Option(i64);
+    O.Some(@parse_i64(s)?)
+}
+fn main() -> i32 {
+    let O = opt.Option(i64);
+    match read_num("42") { O.Some(v) => @intCast(v), O.None => 0 }
+}
+"#;
+
+    let mut warm_session = CompilerSession::new();
+    // An unrelated prior revision (still trusted-std-bearing) warms the session.
+    publish_trusted_semantic(
+        &mut warm_session,
+        r#"
+const opt = @import("std/option.rue");
+fn main() -> i32 { 0 }
+"#,
+        &options,
+    )
+    .ok();
+    let warm = publish_trusted_semantic(&mut warm_session, target, &options)
+        .expect("warm compile of t-win");
+
+    let fresh = semantic_with_trusted_option(target, &options).expect("fresh compile of t-win");
+
+    assert_eq!(
+        warm.unstable_parity_snapshot(),
+        fresh.unstable_parity_snapshot(),
+        "warm/fresh semantic parity snapshot diverged for t-win",
+    );
+    assert_eq!(
+        bound_parse_i64_digest(&warm),
+        bound_parse_i64_digest(&fresh),
+        "warm/fresh disagreed on the well-known Option(i64) binding",
+    );
+}
+
+/// The per-site `Option(i64)` `EnumId` bound at every `@parse_i64` instruction in
+/// a semantic output, in AIR order. Reading `inst.ty` gives the identity each
+/// site actually consumed, so mixed `?`-operand and plain uses can be compared
+/// directly for shared identity.
+fn parse_i64_bound_enums(semantic: &CanonicalSemanticOutput) -> Vec<rue_air::EnumId> {
+    fallible_intrinsic_option_enums(semantic)
+        .into_iter()
+        .filter(|(runtime, _)| *runtime == rue_air::RuntimeCallKind::ParseI64)
+        .map(|(_, id)| id)
+        .collect()
+}
+
+/// B1(a). A plain, unannotated `let _ = @parse_i64("1")` — no `?`, no type
+/// annotation, no surrounding `match` — compiles, and the intrinsic result type
+/// IS the trusted std `Option(i64)`. The fallible intrinsic OWNS its exact
+/// trusted `Option` identity in every context: context does not select the
+/// nominal, the per-body well-known registry does. Provenance is asserted by the
+/// bound producer's stable digest matching the std-only reference program's.
+#[test]
+fn plain_unannotated_parse_owns_trusted_std_option() {
+    let options = CompileOptions::default();
+    let source = r#"
+const opt = @import("std/option.rue");
+fn main() -> i32 {
+    let _ = @parse_i64("1");
+    0
+}
+"#;
+    let semantic = semantic_with_trusted_option(source, &options)
+        .expect("a plain unannotated @parse_i64 compiles");
+    assert_eq!(
+        bound_parse_i64_digest(&semantic),
+        std_option_i64_reference_digest(&options),
+        "a bare `let _ = @parse_i64(..)` result carries the trusted std producer's digest",
+    );
+}
+
+/// B1(b), one body. A single body mixing a plain `@parse_i64` use and a
+/// `@parse_i64(..)?` operand of the SAME payload compiles with no fail-closed
+/// E9000, both sites bind the identical `EnumId`, and the whole-program pool
+/// holds exactly ONE `Option(i64)` identity (the trusted std producer). The
+/// per-body registry memoizes the one specialization; a plain use and a `?`
+/// operand cannot fork it into two identities.
+#[test]
+fn mixed_plain_and_try_in_one_body_share_one_identity() {
+    let options = CompileOptions::default();
+    let source = r#"
+const opt = @import("std/option.rue");
+fn read_num(s: str) -> opt.Option(i64) {
+    let O = opt.Option(i64);
+    let _plain = @parse_i64(s);
+    O.Some(@parse_i64(s)?)
+}
+fn main() -> i32 {
+    let O = opt.Option(i64);
+    match read_num("42") { O.Some(v) => @intCast(v), O.None => 0 }
+}
+"#;
+    let semantic = semantic_with_trusted_option(source, &options)
+        .expect("mixed plain + `?` in one body compiles with no E9000");
+    let bound = parse_i64_bound_enums(&semantic);
+    assert_eq!(
+        bound.len(),
+        2,
+        "both the plain and the `?` @parse_i64 site must bind, got {bound:?}",
+    );
+    assert!(
+        bound.iter().all(|id| *id == bound[0]),
+        "the plain and `?` sites must bind ONE shared Option(i64) EnumId: {bound:?}",
+    );
+    assert_eq!(
+        option_i64_pool_digests(&semantic),
+        BTreeSet::from([std_option_i64_reference_digest(&options)]),
+        "exactly one std Option(i64) identity must exist for the mixed body",
+    );
+}
+
+/// B1(b), across two bodies. A plain `@parse_i64` in one body and a
+/// `@parse_i64(..)?` operand in another (same payload) compile with no E9000,
+/// every site binds the identical `EnumId`, and the pool holds exactly ONE
+/// `Option(i64)` identity shared across both bodies.
+#[test]
+fn mixed_plain_and_try_across_two_bodies_share_one_identity() {
+    let options = CompileOptions::default();
+    let source = r#"
+const opt = @import("std/option.rue");
+fn plainly(s: str) -> i32 {
+    let _ = @parse_i64(s);
+    0
+}
+fn fallibly(s: str) -> opt.Option(i64) {
+    let O = opt.Option(i64);
+    O.Some(@parse_i64(s)?)
+}
+fn main() -> i32 {
+    let O = opt.Option(i64);
+    match fallibly("42") { O.Some(v) => @intCast(v) + plainly("1"), O.None => 0 }
+}
+"#;
+    let semantic = semantic_with_trusted_option(source, &options)
+        .expect("mixed plain + `?` across two bodies compiles with no E9000");
+    let bound = parse_i64_bound_enums(&semantic);
+    assert_eq!(
+        bound.len(),
+        2,
+        "the plain body and the `?` body must each bind a @parse_i64 site: {bound:?}",
+    );
+    assert!(
+        bound.iter().all(|id| *id == bound[0]),
+        "sites in distinct bodies must bind ONE shared Option(i64) EnumId: {bound:?}",
+    );
+    assert_eq!(
+        option_i64_pool_digests(&semantic),
+        BTreeSet::from([std_option_i64_reference_digest(&options)]),
+        "exactly one std Option(i64) identity must exist across the two bodies",
+    );
+}
+
+/// B1(c). Warm/fresh parity on the mixed (plain + `?`) program: a warm
+/// incremental compile and a fresh compile agree on the full semantic parity
+/// snapshot and on the shared well-known `Option(i64)` binding. The per-body
+/// demand, projection, and narrow install are deterministic and
+/// session-issuer-independent even when a body mixes plain and `?` uses.
+#[test]
+fn mixed_plain_and_try_warm_and_fresh_agree() {
+    let options = CompileOptions::default();
+    let target = r#"
+const opt = @import("std/option.rue");
+fn read_num(s: str) -> opt.Option(i64) {
+    let O = opt.Option(i64);
+    let _plain = @parse_i64(s);
+    O.Some(@parse_i64(s)?)
+}
+fn main() -> i32 {
+    let O = opt.Option(i64);
+    match read_num("42") { O.Some(v) => @intCast(v), O.None => 0 }
+}
+"#;
+
+    let mut warm_session = CompilerSession::new();
+    publish_trusted_semantic(
+        &mut warm_session,
+        r#"
+const opt = @import("std/option.rue");
+fn main() -> i32 { 0 }
+"#,
+        &options,
+    )
+    .ok();
+    let warm = publish_trusted_semantic(&mut warm_session, target, &options)
+        .expect("warm compile of the mixed program");
+    let fresh =
+        semantic_with_trusted_option(target, &options).expect("fresh compile of the mixed program");
+
+    assert_eq!(
+        warm.unstable_parity_snapshot(),
+        fresh.unstable_parity_snapshot(),
+        "warm/fresh semantic parity snapshot diverged for the mixed program",
+    );
+    let warm_bound = parse_i64_bound_enums(&warm);
+    let fresh_bound = parse_i64_bound_enums(&fresh);
+    assert!(
+        warm_bound.iter().all(|id| *id == warm_bound[0])
+            && fresh_bound.iter().all(|id| *id == fresh_bound[0]),
+        "each of warm and fresh must bind one shared identity: {warm_bound:?} / {fresh_bound:?}",
+    );
+    assert_eq!(
+        option_i64_pool_digests(&warm),
+        option_i64_pool_digests(&fresh),
+        "warm/fresh disagreed on the Option(i64) identity set for the mixed program",
+    );
+}
 
 /// The canonical RUE-1089 Wrap repro: a GENERIC struct producer whose method
 /// reaches an anonymous-enum MEMBER (`self.inner`, of type `Option(T)`) under

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -22,11 +22,11 @@ type SemanticNucleusFamily = QueryFamily<
 >;
 
 use crate::{
-    AcceptedReadManifestEntry, CompileError, CompileResult, DefinitionKind, DefinitionNamespace,
-    ErrorKind, ImportDemandFrontier, ImportDemandMode, ImportDemandRoots, ImportDiscoveryContext,
-    ImportDiscoveryPlan, ImportDiscoveryRequest, ImportInputRevision, ImportObservation,
-    ImportObservationLedger, ModuleId, ModuleRevision, SourceSnapshot, Span, StableDefinitionKey,
-    SyntaxWork,
+    AcceptedReadManifest, AcceptedReadManifestEntry, CompileError, CompileResult, DefinitionKind,
+    DefinitionNamespace, ErrorKind, ImportDemandFrontier, ImportDemandMode, ImportDemandRoots,
+    ImportDiscoveryContext, ImportDiscoveryPlan, ImportDiscoveryRequest, ImportInputRevision,
+    ImportObservation, ImportObservationLedger, ModuleId, ModuleRevision, SourceRevision,
+    SourceSnapshot, Span, StableDefinitionKey, SyntaxWork,
 };
 
 use crate::canonical_lower::{ModuleRirOutput, lower_module_rir_with_work};
@@ -132,6 +132,7 @@ where
     F::Key: 'static,
     F::Record: 'static,
 {
+    #[cfg(test)]
     pub(crate) fn new(runtime: &QueryRuntime, name: &'static str) -> Self {
         let family = runtime
             .family_with_equality(name, F::MAX_TERMINALS, record_equal::<F>)
@@ -144,8 +145,47 @@ where
         }
     }
 
+    /// A family registered CONTENT-ADDRESSED (RUE-1112): its records are pure
+    /// functions of their keys alone, which is the sole minting authority for
+    /// the exact-terminal adoption capability
+    /// ([`rue_query::QueryFamily::adoptable_terminal`]). The parse family
+    /// qualifies: an ordinary key is the exact source content, table order,
+    /// and presentation; a successor key pins the published immutable lineage
+    /// plus its exact appended segment.
+    pub(crate) fn new_content_addressed(runtime: &QueryRuntime, name: &'static str) -> Self {
+        let family = runtime
+            .content_addressed_family_with_equality(name, F::MAX_TERMINALS, record_equal::<F>)
+            .expect("compiler query families have unique stable names");
+        let selection = family.selection();
+        Self {
+            runtime: runtime.clone(),
+            family,
+            selection,
+        }
+    }
+
     fn key(&mut self, key: F::Key) -> CompatibilityKey<F::Key> {
         CompatibilityKey { key }
+    }
+
+    /// The runtime family handle, for a computing query that declares a
+    /// dependency on one of this family's terminals (RUE-1112): requesting a
+    /// key through it records a real dependency edge, so red/green validation
+    /// and leases flow through the terminal.
+    pub(crate) fn family_handle(&self) -> QueryFamily<CompatibilityKey<F::Key>, F::Record> {
+        self.family.clone()
+    }
+
+    /// The currently selected terminal, for identity assertions.
+    #[cfg(test)]
+    pub(crate) fn selected_terminal(&self) -> Option<Arc<rue_query::QueryTerminal<F::Record>>> {
+        self.selection.current().cloned()
+    }
+
+    /// The last good terminal itself — the exact capability a successor
+    /// computation records as its predecessor dependency (RUE-1112).
+    pub(crate) fn last_good_terminal(&self) -> Option<&Arc<rue_query::QueryTerminal<F::Record>>> {
+        self.selection.last_good()
     }
 
     pub(crate) fn prepare(&mut self, key: F::Key) -> PreparedRevisionedQuery<F> {
@@ -438,6 +478,17 @@ pub(crate) struct RevisionedQueryDatabase {
     raw_declaration_signatures:
         QueryFamily<RawDeclarationSignatureQueryKey, RawDeclarationSignatureQueryValue>,
     raw_declaration_bodies: QueryFamily<RawDeclarationBodyQueryKey, RawDeclarationBodyQueryValue>,
+    // The registered `body-toolchain-demands` node (RUE-1112). It projects one
+    // reached body's exact raw declaration body to the sorted, deduplicated set
+    // of trusted toolchain modules its fallible intrinsics demand plus the
+    // demanding body's stable requester anchor. It is pure (its only input is the
+    // raw-body query, so the dependency edge is honest for invalidation, metrics,
+    // and future parallel scheduling), does no presence check, and does no I/O.
+    // The rooted semantic attempt queries it BEFORE each body transaction, checks
+    // the demanded modules against the satisfied catalogue, and parks the absent
+    // ones without entering the transaction.
+    body_toolchain_demands:
+        QueryFamily<crate::body_query::BodyQueryKey, crate::BodyToolchainDemand>,
     body_transactions:
         QueryFamily<crate::body_query::BodyQueryKey, crate::body_query::BodyTransaction>,
     canonical_bodies:
@@ -460,6 +511,45 @@ pub(crate) struct RevisionedQueryDatabase {
     current_import_revision: Option<ImportInputRevision>,
     #[cfg(test)]
     current_test_import_revision: Option<Revision>,
+    /// Cumulative count of import occurrences the demand frontier has rooted
+    /// through [`Self::import_frontier`] (RUE-1112). One `ResolveImport`
+    /// projection is dispatched per rooted occurrence, so this measures the
+    /// per-round discovery-frontier breadth. The trusted-toolchain re-close roots
+    /// only in the newly appended leaves and modules newly discovered from them,
+    /// so a predecessor occurrence contributes to this counter exactly once — at
+    /// the initial close — and never again during acquisition.
+    import_frontier_roots_requested: u64,
+    /// Cumulative count of occurrences the close-time exact-import projection has
+    /// dispatched a `ResolveImport` query for through [`Self::exact_import_groups`]
+    /// (RUE-1112). A trusted-toolchain successor close projects only the newly
+    /// appended occurrences, so a predecessor occurrence contributes here exactly
+    /// once — at the initial close — and never again during acquisition.
+    exact_import_groups_dispatched: u64,
+    /// Cumulative leaves published through the complete publication path.
+    import_view_full_leaves_published: u64,
+    /// Cumulative delta leaves published through the successor overlay path.
+    import_view_overlay_leaves_published: u64,
+    /// Cumulative ledger observations DEEP-COPIED while cloning a view's
+    /// carried ledger (the cloned value's recorded head — its own delta). The
+    /// persistent ledger shares frozen predecessor segments by `Arc`, so this
+    /// counts only per-step delta entries and stays flat across predecessor
+    /// topologies. Atomic because shared-state accessors count from `&self`.
+    import_view_ledger_entries_cloned: std::sync::atomic::AtomicU64,
+    /// Predecessor source entries element-compared by the overlay publication's
+    /// FALLBACK diff (a host-rebuilt snapshot); the structural-authority path
+    /// never increments this, so the acquisition profile can require it zero.
+    import_view_source_entries_compared: std::sync::atomic::AtomicU64,
+    /// Predecessor accepted-read entries element-compared by the overlay
+    /// publication's FALLBACK provenance diff (a host-rebuilt manifest); the
+    /// structural-authority path never increments this, so the acquisition
+    /// profile can require it zero.
+    import_view_read_entries_compared: std::sync::atomic::AtomicU64,
+    /// The module revisions appended by overlay publications since the last
+    /// committed close (RUE-1112): the session-owned recorded-additions lineage.
+    /// The successor stage/close derive their module delta from THIS record —
+    /// each exact issued batch and the trusted publish append here at
+    /// publication — instead of re-deriving it by scanning complete views.
+    lineage_additions: Vec<ModuleRevision>,
     pub(crate) parse: RevisionedFamily<super::session::ParseQuery>,
 }
 
@@ -774,8 +864,8 @@ struct ImportInputView {
     revision: Revision,
     generation: u64,
     context: ImportDiscoveryContext,
-    sources: Arc<[ModuleRevision]>,
-    accepted_reads: Arc<[AcceptedReadManifestEntry]>,
+    sources: SourceRevision,
+    accepted_reads: AcceptedReadManifest,
     ledger: ImportObservationLedger,
 }
 
@@ -1053,6 +1143,98 @@ fn module_input_view(
         .find(|view| view.revision == revision)
         .cloned()
         .ok_or(QueryAbort::UnpublishedRevision(revision))
+}
+
+/// What authorizes a successor overlay's added modules (RUE-1112): a frontier
+/// batch admits exactly the modules its own accepted observations resolve; a
+/// trusted successor admits exactly the capability-verified leaf set.
+pub(crate) enum OverlayJustification<'a> {
+    BatchAccepted,
+    TrustedLeaves(&'a std::collections::BTreeSet<ModuleId>),
+}
+
+/// Two-pointer walk over two sequences sorted by `order`: returns the entries of
+/// `successor` absent from `parent`, and rejects any parent entry that does not
+/// reappear byte-identical (an additive lineage can only append).
+fn additive_diff<'a, T: Clone + PartialEq + 'a>(
+    parent: impl Iterator<Item = &'a T>,
+    successor: impl Iterator<Item = &'a T>,
+    order: impl Fn(&T, &T) -> std::cmp::Ordering,
+    what: &str,
+) -> CompileResult<Vec<T>> {
+    let mut added = Vec::new();
+    let mut parent = parent.peekable();
+    let mut successor = successor.peekable();
+    loop {
+        match (parent.peek(), successor.peek()) {
+            (Some(old), Some(new)) => match order(old, new) {
+                std::cmp::Ordering::Equal => {
+                    if old != new {
+                        return Err(import_input_error(format!(
+                            "successor overlay mutates a predecessor {what} (the lineage is strictly additive)"
+                        )));
+                    }
+                    parent.next();
+                    successor.next();
+                }
+                std::cmp::Ordering::Greater => {
+                    added.push((*new).clone());
+                    successor.next();
+                }
+                std::cmp::Ordering::Less => {
+                    return Err(import_input_error(format!(
+                        "successor overlay drops a predecessor {what} (the lineage is strictly additive)"
+                    )));
+                }
+            },
+            (Some(_), None) => {
+                return Err(import_input_error(format!(
+                    "successor overlay drops a predecessor {what} (the lineage is strictly additive)"
+                )));
+            }
+            (None, Some(new)) => {
+                added.push((*new).clone());
+                successor.next();
+            }
+            (None, None) => return Ok(added),
+        }
+    }
+}
+
+/// Publish module-source leaves for ONLY the newly added modules of a successor
+/// overlay; inherited modules keep their leaves through the overlay's parent.
+/// The retained module view still records the complete successor snapshot (an
+/// `Arc`-backed clone).
+fn publish_module_inputs_delta(
+    store: &Mutex<ModuleInputStore>,
+    revision: Revision,
+    snapshot: &SourceSnapshot,
+    new_sources: &[ModuleRevision],
+) -> Vec<(InputIdentity, u64)> {
+    let mut store = store
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mut leaves = Vec::new();
+    for source in new_sources {
+        let leaf = ModuleInputLeaf {
+            revision: source.clone(),
+        };
+        let ModuleInputStore {
+            next_stamp, stamps, ..
+        } = &mut *store;
+        leaves.push((
+            module_source_input(&source.module),
+            exact_value_stamp(next_stamp, stamps, &leaf),
+        ));
+    }
+    store.revisions.push_back(Arc::new(ModuleInputView {
+        revision,
+        snapshot: snapshot.clone(),
+    }));
+    while store.revisions.len() > MODULE_INPUT_REVISION_RETENTION {
+        store.revisions.pop_front();
+    }
+    leaves
 }
 
 fn publish_module_inputs(
@@ -6503,8 +6685,7 @@ impl RevisionedQueryDatabase {
                     context.input(accepted_read_input(key.occurrence.importer()))?;
                     let importer = view
                         .accepted_reads
-                        .iter()
-                        .find(|entry| entry.module() == key.occurrence.importer())
+                        .find_module(key.occurrence.importer())
                         .expect("indexed importer retains accepted-read provenance");
                     let occurrence = crate::ImportOccurrenceKey::from_directive(site);
                     let groups = crate::import_discovery::discovery_groups_for_occurrence(
@@ -6851,6 +7032,65 @@ impl RevisionedQueryDatabase {
                 crate::body_query::transaction_equal,
             )
             .expect("the BodyTransaction family has one canonical name");
+        // The registered `body-toolchain-demands` node (RUE-1112). Its only
+        // input is the exact raw declaration body, so the raw-body dependency
+        // edge is recorded honestly; the projection itself is a pure lexical
+        // scan of that body's fallible intrinsics. It performs no presence check
+        // and no I/O, so the rooted attempt may evaluate it before deciding to
+        // park. A body with no source declaration, an unavailable raw body, or no
+        // fallible intrinsic projects the empty demand set.
+        let bodies_for_toolchain_demands = raw_declaration_bodies.clone();
+        let body_toolchain_demands = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.body-toolchain-demands",
+                BODY_QUERY_MEMO_RETENTION,
+                |left: &crate::BodyToolchainDemand, right: &crate::BodyToolchainDemand| {
+                    left == right
+                },
+                move |context, _, key: &crate::body_query::BodyQueryKey| {
+                    let Some(definition) = body_source_definition_key(&key.instance).cloned()
+                    else {
+                        return Ok(QueryOutput::success(
+                            crate::BodyToolchainDemand::from_payload_kinds([], None),
+                        ));
+                    };
+                    let Some(candidate) = declaration_candidate_for_stable_key(&definition) else {
+                        return Ok(QueryOutput::success(
+                            crate::BodyToolchainDemand::from_payload_kinds([], Some(definition)),
+                        ));
+                    };
+                    let raw = context.query_registered(
+                        &bodies_for_toolchain_demands,
+                        RawDeclarationBodyQueryKey(candidate),
+                    )?;
+                    let rue_query::QueryOutcome::Success(RawDeclarationBodyQueryValue::Available(
+                        raw_body,
+                    )) = raw.outcome()
+                    else {
+                        // No scannable body text (absent, ambiguous, or an
+                        // occurrence failure): nothing is demanded. The body
+                        // transaction, which runs only on a satisfied prerequisite,
+                        // surfaces that failure through its ordinary path.
+                        return Ok(QueryOutput::success(
+                            crate::BodyToolchainDemand::from_payload_kinds([], Some(definition)),
+                        ));
+                    };
+                    // The single canonical per-body fallible-intrinsic scan
+                    // (RUE-1112 C1). This node is the one authority for a body's
+                    // payload kinds AND the trusted-module demands they imply; the
+                    // body transaction observes this terminal instead of rescanning
+                    // the raw text.
+                    let payload_kinds =
+                        crate::well_known_option::scan_body_payload_kinds(&raw_body.body);
+                    Ok(QueryOutput::success(
+                        crate::BodyToolchainDemand::from_payload_kinds(
+                            payload_kinds,
+                            Some(definition),
+                        ),
+                    ))
+                },
+            )
+            .expect("the BodyToolchainDemands family has one canonical name");
         let transactions_for_produced_anonymous = body_transactions.clone();
         let semantic_nucleus_for_produced_anonymous =
             Arc::new(std::sync::OnceLock::<SemanticNucleusFamily>::new());
@@ -8210,7 +8450,7 @@ impl RevisionedQueryDatabase {
             "SemanticNucleus producer projection is installed once"
         );
         Self {
-            parse: RevisionedFamily::new(&runtime, "compiler.parse"),
+            parse: RevisionedFamily::new_content_addressed(&runtime, "compiler.parse"),
             runtime: runtime.clone(),
             next_revision: 1,
             next_source_stamp: 1,
@@ -8229,6 +8469,7 @@ impl RevisionedQueryDatabase {
             #[cfg(test)]
             raw_declaration_signatures,
             raw_declaration_bodies,
+            body_toolchain_demands,
             body_transactions,
             canonical_bodies: runtime
                 .family_with_equality(
@@ -8257,6 +8498,14 @@ impl RevisionedQueryDatabase {
             current_import_revision: None,
             #[cfg(test)]
             current_test_import_revision: None,
+            import_frontier_roots_requested: 0,
+            exact_import_groups_dispatched: 0,
+            import_view_full_leaves_published: 0,
+            import_view_overlay_leaves_published: 0,
+            import_view_ledger_entries_cloned: std::sync::atomic::AtomicU64::new(0),
+            import_view_source_entries_compared: std::sync::atomic::AtomicU64::new(0),
+            import_view_read_entries_compared: std::sync::atomic::AtomicU64::new(0),
+            lineage_additions: Vec::new(),
         }
     }
 }
@@ -8474,9 +8723,11 @@ impl RevisionedQueryDatabase {
         >,
         declaration_modules: Arc<[ModuleId]>,
         producer_body_terminal_required: bool,
+        well_known_demands: Arc<[crate::body_query::WellKnownOptionDemand]>,
         cancellation: CancellationToken,
         compute: impl FnOnce(
             Arc<[crate::durable_semantics::DurableAnonymousNominal]>,
+            crate::body_query::WellKnownOptionResolution,
         ) -> Result<crate::body_query::BodyTransaction, QueryAbort>,
     ) -> Result<
         Arc<rue_query::QueryTerminal<crate::body_query::BodyTransaction>>,
@@ -8511,6 +8762,19 @@ impl RevisionedQueryDatabase {
                 else {
                     return Err(QueryAbort::Canceled);
                 };
+                // Observe THIS body's exact fallible-intrinsic payload set from the
+                // registered `body-toolchain-demands` node — the ONE canonical
+                // per-body scan (RUE-1112 C1) — instead of rescanning the raw text.
+                // A body roots only the payloads it uses, so an unrelated body gains
+                // no query edge to payloads it does not use.
+                let toolchain_demand =
+                    context.query_registered(&self.body_toolchain_demands, key.clone())?;
+                let rue_query::QueryOutcome::Success(toolchain_demand) =
+                    toolchain_demand.outcome()
+                else {
+                    unreachable!("BodyToolchainDemands publishes typed values")
+                };
+                let body_payload_kinds = toolchain_demand.payload_kinds();
                 // The one-body resolver consumes declaration-set selection,
                 // including negative and qualified lookups that do not become
                 // positive BodyReferences. Until it publishes those exact
@@ -8604,11 +8868,56 @@ impl RevisionedQueryDatabase {
                         );
                     }
                 }
+                // Root the trusted-std `Option(payload)` demands under THIS
+                // body's lease (RUE-1112). Each `ComptimeCall` resolves the real
+                // materialized `Option` specialization with std provenance; the
+                // nucleus memoizes it so bodies sharing a payload share one
+                // terminal while keeping their own per-body edge. The resolved
+                // enums reach AIR through the narrow per-body `WellKnownTypes`
+                // input, never this body's composition universe. A demand that
+                // fails to project (e.g. an absent payload type) is skipped so
+                // the body simply falls through to the legacy structural scan.
+                let well_known = {
+                    let mut option_by_payload = Vec::new();
+                    let mut nominals = BTreeMap::new();
+                    for demand in well_known_demands
+                        .iter()
+                        .filter(|demand| body_payload_kinds.contains(&demand.kind))
+                    {
+                        let projected = context.query_registered(
+                            &self.semantic_nucleus,
+                            crate::semantic_query_nucleus::SemanticNucleusKey::ComptimeCall(
+                                demand.call.clone(),
+                            ),
+                        )?;
+                        if let rue_query::QueryOutcome::Success(
+                            crate::semantic_query_nucleus::SemanticNucleusValue::ComptimeCall(
+                                projection,
+                            ),
+                        ) = projected.outcome()
+                            && let crate::semantic_query_nucleus::ComptimeCallResultProjection::Type(
+                                option_type,
+                            ) = &projection.result
+                        {
+                            option_by_payload.push((demand.payload.clone(), option_type.clone()));
+                            for nominal in projection.anonymous_nominals.iter() {
+                                nominals.insert(nominal.identity.clone(), nominal.clone());
+                            }
+                        }
+                    }
+                    crate::body_query::WellKnownOptionResolution {
+                        option_by_payload: Arc::from(option_by_payload),
+                        anonymous_nominals: Arc::from(
+                            nominals.into_values().collect::<Vec<_>>(),
+                        ),
+                    }
+                };
                 let transaction = compute(
                     selected_anonymous
                         .into_values()
                         .collect::<Vec<_>>()
                         .into(),
+                    well_known,
                 )?;
                 let mut semantic_dependencies = BTreeSet::from([definition]);
                 let mut anonymous_dependencies = BTreeSet::new();
@@ -8858,6 +9167,30 @@ impl RevisionedQueryDatabase {
             .into_result()
     }
 
+    /// Project one reached body's trusted-toolchain-module demand set (RUE-1112)
+    /// from the registered `body-toolchain-demands` node. This is the rooted
+    /// semantic attempt's park prerequisite: it observes the body's exact raw
+    /// body, is pure and I/O-free, and never itself parks. The rooted attempt
+    /// checks the projected modules against the satisfied catalogue and decides
+    /// whether to park BEFORE the body transaction runs.
+    pub(crate) fn body_toolchain_demands(
+        &self,
+        revision: Revision,
+        key: crate::body_query::BodyQueryKey,
+        cancellation: CancellationToken,
+    ) -> Result<Arc<rue_query::QueryTerminal<crate::BodyToolchainDemand>>, QueryAbort> {
+        self.runtime
+            .request_registered(&self.body_toolchain_demands, revision, key, cancellation)
+            .into_result()
+    }
+
+    /// Whether the body-transaction family has published any terminal. Used by
+    /// the RUE-1112 park test to prove a park precedes any body transaction.
+    #[cfg(test)]
+    pub(crate) fn any_body_transaction_terminal(&self) -> bool {
+        self.body_transactions.any_retained_key(|_| true)
+    }
+
     pub(crate) fn projected_declaration_semantics(
         &self,
         revision: Revision,
@@ -9076,11 +9409,12 @@ impl RevisionedQueryDatabase {
         &mut self,
         snapshot: &SourceSnapshot,
         context: ImportDiscoveryContext,
-        accepted_reads: Arc<[AcceptedReadManifestEntry]>,
+        accepted_reads: AcceptedReadManifest,
     ) -> CompileResult<ImportInputRevision> {
         self.next_import_request += 1;
         let generation = self.next_import_request;
         self.current_import_revision = None;
+        self.lineage_additions.clear();
         // A new request generation is a fresh filesystem observation epoch.
         // Reuse requires a future explicit watch/read-policy proof token. The
         // API deliberately has no carried-ledger input that could be mistaken
@@ -9117,9 +9451,7 @@ impl RevisionedQueryDatabase {
                 .cloned()
         }
         .ok_or_else(|| import_input_error("import input revision is no longer retained"))?;
-        if plan.context() != &view.context
-            || plan.source_revision().modules() != view.sources.as_ref()
-        {
+        if plan.context() != &view.context || plan.source_revision() != &view.sources {
             return Err(import_input_error(
                 "import plan does not match its pinned granular input revision",
             ));
@@ -9138,6 +9470,9 @@ impl RevisionedQueryDatabase {
         let mut fanout = Vec::<Vec<ImportDiscoveryRequest>>::new();
         let mut operation_indices = BTreeMap::<ImportHostOperationKey, usize>::new();
         let mut speculative_blocked = false;
+        self.import_frontier_roots_requested = self
+            .import_frontier_roots_requested
+            .saturating_add(roots.occurrences().len() as u64);
         for occurrence in roots.occurrences() {
             let key = ResolveImportKey {
                 occurrence: occurrence.clone(),
@@ -9193,8 +9528,71 @@ impl RevisionedQueryDatabase {
         self.current_import_revision
     }
 
+    /// Cumulative import-occurrence roots dispatched by [`Self::import_frontier`].
+    /// See the field docs on `import_frontier_roots_requested`.
+    pub(crate) fn import_frontier_roots_requested(&self) -> u64 {
+        self.import_frontier_roots_requested
+    }
+
+    /// Cumulative close-time `ResolveImport` projections dispatched by
+    /// [`Self::exact_import_groups`]. See the field docs on
+    /// `exact_import_groups_dispatched`.
+    pub(crate) fn exact_import_groups_dispatched(&self) -> u64 {
+        self.exact_import_groups_dispatched
+    }
+
+    /// Cumulative leaves published through the complete
+    /// [`Self::publish_import_view`] path (fresh generations). Scales with the
+    /// program; never used on the successor overlay path.
+    pub(crate) fn import_view_full_leaves_published(&self) -> u64 {
+        self.import_view_full_leaves_published
+    }
+
+    /// Cumulative leaves published through the sparse successor overlay path
+    /// ([`Self::publish_import_view_overlay`]): delta leaves plus the one
+    /// re-stamped aggregate topology leaf. Predecessor leaves are structurally
+    /// inherited and never counted here, so the acquisition delta is O(new
+    /// leaves), independent of the predecessor topology.
+    pub(crate) fn import_view_overlay_leaves_published(&self) -> u64 {
+        self.import_view_overlay_leaves_published
+    }
+
+    /// Cumulative ledger observations deep-copied while cloning view ledgers
+    /// (each clone copies only the cloned value's recorded delta; frozen
+    /// predecessor segments are shared by `Arc`).
+    pub(crate) fn import_view_ledger_entries_cloned(&self) -> u64 {
+        self.import_view_ledger_entries_cloned
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Predecessor source entries compared by the overlay publication's fallback
+    /// diff; zero whenever the structural-authority path ran.
+    pub(crate) fn import_view_source_entries_compared(&self) -> u64 {
+        self.import_view_source_entries_compared
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Predecessor accepted-read entries compared by the overlay publication's
+    /// fallback provenance diff; zero whenever the structural-authority path
+    /// ran.
+    pub(crate) fn import_view_read_entries_compared(&self) -> u64 {
+        self.import_view_read_entries_compared
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// The module revisions appended by overlay publications since the last
+    /// committed close — the recorded-additions lineage (RUE-1112).
+    pub(crate) fn lineage_additions(&self) -> &[ModuleRevision] {
+        &self.lineage_additions
+    }
+
+    /// Reset the recorded-additions lineage at a committed close boundary.
+    pub(crate) fn clear_lineage_additions(&mut self) {
+        self.lineage_additions.clear();
+    }
+
     pub(crate) fn exact_import_groups(
-        &self,
+        &mut self,
         revision: ImportInputRevision,
         roots: &ImportDemandRoots,
     ) -> CompileResult<Vec<Arc<[ImportDiscoveryRequest]>>> {
@@ -9203,6 +9601,9 @@ impl RevisionedQueryDatabase {
                 "exact import projection requested from a non-current revision",
             ));
         }
+        self.exact_import_groups_dispatched = self
+            .exact_import_groups_dispatched
+            .saturating_add(roots.occurrences().len() as u64);
         let runtime_revision = Revision::new(revision.revision_id, revision.request_generation);
         let mut groups = Vec::new();
         for occurrence in roots.occurrences() {
@@ -9239,7 +9640,7 @@ impl RevisionedQueryDatabase {
         &mut self,
         frontier: &ImportDemandFrontier,
         snapshot: &SourceSnapshot,
-        accepted_reads: Arc<[AcceptedReadManifestEntry]>,
+        accepted_reads: AcceptedReadManifest,
         observations: Vec<ImportObservation>,
     ) -> CompileResult<ImportInputRevision> {
         if frontier.mode != ImportDemandMode::Rooted {
@@ -9262,27 +9663,66 @@ impl RevisionedQueryDatabase {
                 "host import results must exactly preserve the compiler-produced batch order",
             ));
         }
-        let (context, mut ledger) = {
+        let mut ledger = {
             let store = lock_import_store(&self.import_store);
             let view = store
                 .revisions
                 .iter()
                 .find(|view| view.revision.id() == frontier.revision.revision_id)
                 .ok_or_else(|| import_input_error("import input revision is no longer retained"))?;
-            (view.context.clone(), view.ledger.clone())
+            // The persistent ledger clone deep-copies only the parent value's
+            // recorded delta; frozen predecessor segments are shared by `Arc`.
+            self.import_view_ledger_entries_cloned.fetch_add(
+                view.ledger.recorded_delta().len() as u64,
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            view.ledger.clone()
         };
         for (observation, fanout) in observations.into_iter().zip(frontier.fanout.iter()) {
             for request in fanout.iter().cloned() {
                 ledger.record(observation.fanout_to(request)?)?;
             }
         }
-        self.publish_import_view(
+        // Publish the successor as a sparse overlay over the current view: only
+        // the batch's own additions become leaves, the aggregate topology is
+        // re-stamped, and every predecessor leaf is structurally inherited. The
+        // additions are re-derived and justified against the batch's accepted
+        // observations inside the overlay publication, so an unrelated module in
+        // the supplied snapshot or manifest is rejected there.
+        self.publish_import_view_overlay(
+            frontier.revision,
             snapshot,
-            context,
             accepted_reads,
             ledger,
-            frontier.revision.request_generation,
+            OverlayJustification::BatchAccepted,
             frontier.revision.frontier_round + 1,
+        )
+    }
+
+    /// Publish a strictly-additive trusted-toolchain successor input revision
+    /// (RUE-1112) as a sparse overlay over the current published view. Unlike
+    /// [`Self::publish_import_batch`] this carries no new import observation: the
+    /// appended leaves' own `@import` edges are not yet observed here (the
+    /// driver's subsequent re-close discovers them), so the carried ledger and the
+    /// aggregate topology are inherited unchanged and only the appended leaves'
+    /// source/provenance leaves are published. The additions are re-derived from
+    /// the parent view and must equal the capability-verified `added` set exactly.
+    pub(crate) fn publish_trusted_successor_view(
+        &mut self,
+        parent: ImportInputRevision,
+        snapshot: &SourceSnapshot,
+        accepted_reads: AcceptedReadManifest,
+        ledger: ImportObservationLedger,
+        added: &std::collections::BTreeSet<ModuleId>,
+        frontier_round: u64,
+    ) -> CompileResult<ImportInputRevision> {
+        self.publish_import_view_overlay(
+            parent,
+            snapshot,
+            accepted_reads,
+            ledger,
+            OverlayJustification::TrustedLeaves(added),
+            frontier_round,
         )
     }
 
@@ -9302,16 +9742,66 @@ impl RevisionedQueryDatabase {
             .ok_or_else(|| import_input_error("import input revision is no longer retained"))
     }
 
+    /// The complete published state of the current import-input revision: its
+    /// snapshot, context, accepted-read provenance, and carried ledger
+    /// (RUE-1112). The trusted-toolchain successor stage/close consume THIS
+    /// state rather than any host-supplied replacement, so a caller cannot
+    /// substitute a snapshot, context, provenance manifest, or ledger that
+    /// diverges from what the compiler published.
+    pub(crate) fn current_import_view_state(
+        &self,
+    ) -> Option<(
+        ImportInputRevision,
+        SourceSnapshot,
+        ImportDiscoveryContext,
+        AcceptedReadManifest,
+        ImportObservationLedger,
+    )> {
+        let current = self.current_import_revision?;
+        let runtime = Revision::new(current.revision_id, current.request_generation);
+        let view = {
+            let store = lock_import_store(&self.import_store);
+            store
+                .revisions
+                .iter()
+                .find(|view| view.revision == runtime)
+                .cloned()
+        }?;
+        let snapshot = {
+            let store = self
+                .module_store
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            store
+                .revisions
+                .iter()
+                .find(|module_view| module_view.revision == runtime)
+                .map(|module_view| module_view.snapshot.clone())
+        }?;
+        self.import_view_ledger_entries_cloned.fetch_add(
+            view.ledger.recorded_delta().len() as u64,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        Some((
+            current,
+            snapshot,
+            view.context.clone(),
+            view.accepted_reads.clone(),
+            view.ledger.clone(),
+        ))
+    }
+
     fn publish_import_view(
         &mut self,
         snapshot: &SourceSnapshot,
         context: ImportDiscoveryContext,
-        accepted_reads: Arc<[AcceptedReadManifestEntry]>,
+        accepted_reads: AcceptedReadManifest,
         ledger: ImportObservationLedger,
         generation: u64,
         frontier_round: u64,
     ) -> CompileResult<ImportInputRevision> {
-        let sources: Arc<[ModuleRevision]> = snapshot.source_revision().modules().to_vec().into();
+        let source_revision = snapshot.source_revision().clone();
+        let sources = source_revision.modules();
         let provenance = accepted_reads
             .iter()
             .map(|entry| (entry.module(), entry))
@@ -9423,6 +9913,9 @@ impl RevisionedQueryDatabase {
             revision,
             snapshot,
         ));
+        self.import_view_full_leaves_published = self
+            .import_view_full_leaves_published
+            .saturating_add(leaves.len() as u64);
         self.runtime
             .publish_revision(revision, leaves)
             .map_err(|error| {
@@ -9432,7 +9925,7 @@ impl RevisionedQueryDatabase {
             revision,
             generation,
             context,
-            sources,
+            sources: source_revision,
             accepted_reads,
             ledger,
         });
@@ -9448,7 +9941,7 @@ impl RevisionedQueryDatabase {
         store.provenance_stamps.retain(|(candidate, _)| {
             retained
                 .iter()
-                .any(|view| view.accepted_reads.contains(candidate))
+                .any(|view| view.accepted_reads.contains_entry(candidate))
         });
         store.observation_stamps.retain(|(candidate, _)| {
             retained
@@ -9458,6 +9951,267 @@ impl RevisionedQueryDatabase {
         let published = ImportInputRevision {
             revision_id: revision.id(),
             request_generation: generation,
+            frontier_round,
+        };
+        self.current_import_revision = Some(published);
+        Ok(published)
+    }
+
+    /// Publish a same-generation successor input view as a sparse immutable
+    /// overlay over the CURRENT published view (RUE-1112).
+    ///
+    /// The successor's leaves are derived here, never supplied: sorted
+    /// two-pointer diffs against the parent view yield exactly the added module
+    /// sources, accepted reads, and observations, and every parent entry must
+    /// reappear byte-identical (a mutated or dropped predecessor source, read, or
+    /// observation rejects the publication — the lineage is strictly additive at
+    /// this boundary, closing the batch-injection route). Only those delta leaves
+    /// plus, when observations grew, the one re-stamped aggregate topology leaf
+    /// are published through the runtime's sparse overlay; predecessor leaves are
+    /// structurally inherited and never rehashed, revalidated, or republished.
+    fn publish_import_view_overlay(
+        &mut self,
+        parent: ImportInputRevision,
+        snapshot: &SourceSnapshot,
+        accepted_reads: AcceptedReadManifest,
+        ledger: ImportObservationLedger,
+        justification: OverlayJustification<'_>,
+        frontier_round: u64,
+    ) -> CompileResult<ImportInputRevision> {
+        if self.current_import_revision != Some(parent) {
+            return Err(import_input_error(
+                "a successor overlay must extend the current published revision",
+            ));
+        }
+        let parent_runtime = Revision::new(parent.revision_id, parent.request_generation);
+        let parent_view = {
+            let store = lock_import_store(&self.import_store);
+            store
+                .revisions
+                .iter()
+                .find(|view| view.revision == parent_runtime)
+                .cloned()
+        }
+        .ok_or_else(|| import_input_error("import input revision is no longer retained"))?;
+
+        // Source additions come from STRUCTURAL AUTHORITY: when the successor
+        // snapshot's module segments share every parent segment by `Arc`
+        // identity, the shared segments ARE the parent view by construction —
+        // no predecessor comparison — and the appended segments are the exact
+        // source delta. A host handing a rebuilt (non-shared) snapshot instead
+        // falls back to the explicit byte-identical two-pointer diff, whose
+        // element comparisons are counted so the acquisition profile proves the
+        // structural path ran. The observation delta is likewise never
+        // re-derived: the persistent ledger's recorded head IS this step's
+        // delta.
+        let successor_segments = snapshot.source_revision().module_segments();
+        let parent_segments = parent_view.sources.module_segments();
+        let structural_sources = {
+            let parent_count = parent_segments.segments().len();
+            let shared_prefix = successor_segments.segments().len() >= parent_count
+                && successor_segments
+                    .segments()
+                    .iter()
+                    .zip(parent_segments.segments().iter())
+                    .all(|(a, b)| Arc::ptr_eq(a, b));
+            shared_prefix.then(|| {
+                successor_segments.segments()[parent_count..]
+                    .iter()
+                    .flat_map(|segment| segment.iter())
+                    .cloned()
+                    .collect::<Vec<_>>()
+            })
+        };
+        let new_sources = match structural_sources {
+            Some(appended) => appended,
+            None => {
+                self.import_view_source_entries_compared.fetch_add(
+                    parent_view.sources.modules().len() as u64,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+                additive_diff(
+                    parent_view.sources.modules().iter(),
+                    snapshot.source_revision().modules().iter(),
+                    |a, b| a.module.cmp(&b.module),
+                    "module source",
+                )?
+            }
+        };
+        // Accepted-read provenance additions come from the SAME structural
+        // authority: a successor manifest sharing every parent segment by `Arc`
+        // identity IS the parent manifest plus its appended segments, so the
+        // appended segments are the exact provenance delta with no predecessor
+        // comparison. A rebuilt (non-shared) manifest falls back to the counted
+        // byte-identical two-pointer diff.
+        let structural_reads = {
+            let parent_segments = parent_view.accepted_reads.segments();
+            let successor_segments = accepted_reads.segments();
+            let parent_count = parent_segments.segments().len();
+            let shared_prefix = successor_segments.segments().len() >= parent_count
+                && successor_segments
+                    .segments()
+                    .iter()
+                    .zip(parent_segments.segments().iter())
+                    .all(|(a, b)| Arc::ptr_eq(a, b));
+            shared_prefix.then(|| {
+                successor_segments.segments()[parent_count..]
+                    .iter()
+                    .flat_map(|segment| segment.iter())
+                    .cloned()
+                    .collect::<Vec<_>>()
+            })
+        };
+        let new_reads = match structural_reads {
+            Some(appended) => appended,
+            None => {
+                self.import_view_read_entries_compared.fetch_add(
+                    parent_view.accepted_reads.len() as u64,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+                additive_diff(
+                    parent_view.accepted_reads.iter(),
+                    accepted_reads.iter(),
+                    |a, b| a.module().cmp(b.module()),
+                    "accepted-read provenance",
+                )?
+            }
+        };
+        let new_observations: Vec<ImportObservation> = ledger.recorded_delta().cloned().collect();
+
+        // The additions must be EXACTLY what this step's justification derives —
+        // set equality in both directions, not membership. A frontier batch's
+        // accepted observations authorize exactly the newly resolved modules: an
+        // unrelated module riding along in the snapshot/manifest is an
+        // injection, and an authorized module missing from the snapshot or
+        // manifest is an omission (topology would claim "resolved" with no
+        // source leaf behind it); both reject. A trusted successor admits only
+        // the capability-verified leaf set with no observations.
+        let authorized: std::collections::BTreeSet<ModuleId> = match justification {
+            OverlayJustification::BatchAccepted => new_observations
+                .iter()
+                .filter_map(|observation| observation.accepted_source())
+                .map(|source| {
+                    crate::import_discovery::accepted_import_module(source, &accepted_reads)
+                })
+                .collect::<Result<_, _>>()?,
+            OverlayJustification::TrustedLeaves(added) => {
+                if !new_observations.is_empty() {
+                    return Err(import_input_error(
+                        "a trusted successor carries no new import observations",
+                    ));
+                }
+                added.clone()
+            }
+        };
+        // Modules the authorization introduces that the parent does not already
+        // carry (an accepted observation may re-resolve an existing module).
+        let parent_has = |module: &ModuleId| {
+            parent_view
+                .sources
+                .module_segments()
+                .contains_by(|source| source.module.cmp(module))
+        };
+        let required_new: std::collections::BTreeSet<&ModuleId> = authorized
+            .iter()
+            .filter(|module| !parent_has(module))
+            .collect();
+        let new_source_ids: std::collections::BTreeSet<&ModuleId> =
+            new_sources.iter().map(|source| &source.module).collect();
+        let new_read_ids: std::collections::BTreeSet<&ModuleId> =
+            new_reads.iter().map(|read| read.module()).collect();
+        if new_source_ids != required_new {
+            return Err(import_input_error(
+                "successor overlay module sources must equal this step's authorized additions exactly",
+            ));
+        }
+        if new_read_ids != required_new {
+            return Err(import_input_error(
+                "successor overlay accepted-read provenance must equal this step's authorized additions exactly",
+            ));
+        }
+        for observation in &new_observations {
+            if observation.request().context() != &parent_view.context {
+                return Err(import_input_error(
+                    "import observation belongs to a different discovery epoch",
+                ));
+            }
+        }
+
+        let revision = Revision::new(self.next_revision, parent.request_generation);
+        self.next_revision += 1;
+        let mut leaves = Vec::new();
+        {
+            let mut store = lock_import_store(&self.import_store);
+            let ImportInputStore {
+                next_stamp,
+                provenance_stamps,
+                observation_stamps,
+                ..
+            } = &mut *store;
+            if !new_observations.is_empty() {
+                // The observation set strictly grew, so the aggregate topology is
+                // a genuinely new value: re-stamp the SAME stable identity with a
+                // fresh stamp. Observers of the topology dirty through ordinary
+                // red/green validation; every other inherited leaf stays green.
+                let stamp = *next_stamp;
+                *next_stamp += 1;
+                leaves.push((accepted_import_topology_input(), stamp));
+            }
+            for source in &new_sources {
+                let accepted = accepted_reads
+                    .find_module(&source.module)
+                    .expect("delta provenance validated above");
+                leaves.push((
+                    accepted_read_input(&source.module),
+                    exact_value_stamp(next_stamp, provenance_stamps, accepted),
+                ));
+            }
+            for read in &new_reads {
+                leaves.push((
+                    accepted_import_provenance_input(read.metadata_identity()),
+                    exact_value_stamp(next_stamp, provenance_stamps, read),
+                ));
+            }
+            for observation in &new_observations {
+                leaves.push((
+                    import_observation_input(observation.request()),
+                    exact_value_stamp(next_stamp, observation_stamps, observation),
+                ));
+            }
+        }
+        leaves.extend(publish_module_inputs_delta(
+            &self.module_store,
+            revision,
+            snapshot,
+            &new_sources,
+        ));
+        self.import_view_overlay_leaves_published = self
+            .import_view_overlay_leaves_published
+            .saturating_add(leaves.len() as u64);
+        self.runtime
+            .publish_revision_overlay(revision, parent_runtime, leaves)
+            .map_err(|error| {
+                import_input_error(format!("cannot publish successor overlay: {error:?}"))
+            })?;
+        // Record this step's exact additions on the session-owned lineage; the
+        // successor stage/close derive their module delta from this record.
+        self.lineage_additions.extend(new_sources.iter().cloned());
+        let view = Arc::new(ImportInputView {
+            revision,
+            generation: parent.request_generation,
+            context: parent_view.context.clone(),
+            sources: snapshot.source_revision().clone(),
+            accepted_reads,
+            ledger,
+        });
+        let mut store = lock_import_store(&self.import_store);
+        store.revisions.push_back(view);
+        while store.revisions.len() > IMPORT_INPUT_REVISION_RETENTION {
+            store.revisions.pop_front();
+        }
+        let published = ImportInputRevision {
+            revision_id: revision.id(),
+            request_generation: parent.request_generation,
             frontier_round,
         };
         self.current_import_revision = Some(published);
@@ -9498,6 +10252,100 @@ impl RevisionedQueryDatabase {
             .publish_revision(revision, leaves)
             .expect("compiler input revisions are immutable and uniquely numbered");
         revision
+    }
+
+    /// The input-leaf identity of one module's source content, for records
+    /// that depend on exactly an appended segment's leaves (RUE-1112).
+    pub(crate) fn module_source_input(module: &ModuleId) -> InputIdentity {
+        module_source_input(module)
+    }
+
+    /// Parse ONLY a trusted successor's appended modules at the published
+    /// overlay revision and structurally extend the retained predecessor
+    /// program (RUE-1112). Predecessor modules are never re-dispatched,
+    /// re-parsed, or re-enumerated; their leaves and parse terminals are
+    /// inherited through the overlay lineage.
+    pub(crate) fn parse_program_extension(
+        &self,
+        revision: Revision,
+        predecessor: &Arc<ParsedProgram>,
+        appended: &[(ModuleId, crate::FileId)],
+    ) -> (
+        Result<Arc<ParsedProgram>, crate::CompileErrors>,
+        ParsedModulesWork,
+    ) {
+        let snapshot = self
+            .module_store
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .revisions
+            .iter()
+            .find(|view| view.revision == revision)
+            .expect("parse projection retains its module input revision")
+            .snapshot
+            .clone();
+        let mut parsed = Vec::with_capacity(appended.len());
+        let mut errors = crate::CompileErrors::new();
+        let mut work = ParsedModulesWork::default();
+        for (module, file_id) in appended {
+            work.modules_considered += 1;
+            work.previous_module_lookups += 1;
+            let attempt = self.runtime.request_registered(
+                &self.parse_modules,
+                revision,
+                ModuleQueryKey(module.clone()),
+                CancellationToken::new(),
+            );
+            let Some(terminal) = attempt.terminal() else {
+                errors.push(import_input_error(format!(
+                    "ParseModule({module}) aborted: {:?}",
+                    attempt.abort()
+                )));
+                continue;
+            };
+            let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+                unreachable!("ParseModule publishes typed values")
+            };
+            let computed = matches!(attempt.execution(), RequestExecution::Computed);
+            if computed {
+                work.modules_reparsed += 1;
+                work.syntax.lexer_invocations += value.work.lexer_invocations;
+                work.syntax.parser_invocations += value.work.parser_invocations;
+                work.syntax.lexed_bytes += value.work.lexed_bytes;
+                work.syntax.tokens += value.work.tokens;
+            }
+            match &value.result {
+                Ok(module) => {
+                    let projected = crate::parsed_modules::rebind_parsed_module(&snapshot, module);
+                    if !computed {
+                        if Arc::ptr_eq(&projected, module) {
+                            work.modules_reused += 1;
+                        } else {
+                            work.modules_rebound += 1;
+                        }
+                    }
+                    parsed.push(projected);
+                }
+                Err(module_errors) => {
+                    if !computed {
+                        work.modules_reused += 1;
+                    }
+                    errors.extend(
+                        module_errors
+                            .clone()
+                            .map_spans(|span| Span::with_file(*file_id, span.start, span.end)),
+                    )
+                }
+            }
+        }
+        let result = if errors.is_empty() {
+            ParsedProgram::extend_successor(predecessor, snapshot.source_revision().clone(), parsed)
+                .map(Arc::new)
+                .map_err(crate::CompileErrors::from)
+        } else {
+            Err(errors)
+        };
+        (result, work)
     }
 
     pub(crate) fn parse_program(
@@ -9817,8 +10665,10 @@ impl RevisionedQueryDatabase {
         // Exact source stamps live exactly as long as a parse memo key (or the
         // current request before selection). They are never independently FIFO
         // evicted while a terminal can still observe the stamp.
-        self.source_stamps
-            .retain(|(source, _)| self.parse.any_retained_key(|key| key.source() == source));
+        self.source_stamps.retain(|(source, _)| {
+            self.parse
+                .any_retained_key(|key| key.pinned_source() == Some(source))
+        });
         debug_assert!(self.source_stamps.len() <= self.parse.retention().memo_nodes);
     }
 
@@ -10524,6 +11374,131 @@ mod tests {
             panic!("direct target-selected const failed: {keyed:?}")
         };
         assert_eq!(i128::from(retired), keyed);
+    }
+
+    /// RUE-1112 demand-resolves proof. Once the trusted `\0rue-std/option.rue`
+    /// module is present in the snapshot's module set — exactly as the host
+    /// publishes it on the successor after satisfying a
+    /// `TrustedToolchainModuleDemand` — a directly-rooted `ComptimeCall` for
+    /// `\0rue-std/option.rue::Option(i64)` resolves the real materialized
+    /// nominal with std provenance. This is the proven key shape:
+    ///
+    /// `DeclarationCandidateKey { module: from_trusted_standard_library_path(..),
+    ///  Function, "Option", None }` -> `DeclarationSemanticQueryKey` ->
+    /// `ComptimeCallQueryKey { type_arguments: [("T", DurableType::I64)] }`.
+    ///
+    /// The consumption track wires this into AIR; here we only prove
+    /// resolvability against a present trusted module.
+    #[test]
+    fn trusted_std_option_comptime_call_resolves_for_i64() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+        use crate::durable_semantics::{DurableAnonymousNominalShape as Shape, DurableType};
+        use crate::semantic_query_nucleus::{
+            ComptimeCallQueryKey, ComptimeCallResultProjection as ResultProjection,
+            SemanticNucleusKey as Key, SemanticNucleusValue as V,
+        };
+        use std::collections::HashSet;
+
+        // The freestanding fallible-intrinsic program plus the trusted Option
+        // module the host published on the successor. `main.rue` names a bare
+        // `@parse_i64`, which is the reason the demand was emitted upstream.
+        let root = FileId::new(1);
+        let option = FileId::new(2);
+        let physical = HashMap::from([
+            (root, "/project/main.rue".to_owned()),
+            (option, "/sdk/option.rue".to_owned()),
+        ]);
+        let logical = HashMap::from([
+            (root, "main.rue".to_owned()),
+            (option, crate::OPTION_MODULE_LOGICAL_PATH.to_owned()),
+        ]);
+        let metadata = SourceMetadata::new_with_trusted_standard_library(
+            root,
+            physical,
+            logical,
+            HashSet::from([option]),
+        )
+        .unwrap();
+        let source = SourceSnapshot::new(
+            metadata,
+            vec![
+                (
+                    root,
+                    Arc::new("fn main() -> i32 { let x: i32 = 0; x }".to_owned()),
+                ),
+                (
+                    option,
+                    Arc::new(
+                        "pub fn Option(comptime T: type) -> type { enum { Some(T), None } }"
+                            .to_owned(),
+                    ),
+                ),
+            ],
+        )
+        .unwrap();
+
+        let module =
+            ModuleId::from_trusted_standard_library_path(crate::OPTION_MODULE_LOGICAL_PATH)
+                .unwrap();
+        assert!(
+            module.is_trusted_standard_library(),
+            "the demand resolves against a trusted std module"
+        );
+
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&source),
+            &source,
+        );
+        let value = request_semantic_nucleus(
+            &database,
+            revision,
+            Key::ComptimeCall(ComptimeCallQueryKey {
+                declaration: crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                    declaration: declaration_candidate(
+                        &database,
+                        revision,
+                        &module,
+                        Category::Function,
+                        "Option",
+                    ),
+                    configuration: semantic_configuration(),
+                },
+                type_arguments: Arc::from([(Arc::from("T"), DurableType::I64)]),
+                value_arguments: Arc::from([]),
+            }),
+        );
+
+        let V::ComptimeCall(projection) = value else {
+            panic!("trusted Option(i64) comptime call did not resolve: {value:?}");
+        };
+        assert!(
+            matches!(projection.result, ResultProjection::Type(_)),
+            "Option(i64) must resolve to a materialized type, got {:?}",
+            projection.result
+        );
+        // The real materialized nominal: an Option enum whose `Some` carries the
+        // requested `i64` payload and whose `None` is empty.
+        let materialized_option = projection.anonymous_nominals.iter().any(|nominal| {
+            matches!(
+                &nominal.shape,
+                Shape::Enum { variants }
+                    if variants.len() == 2
+                        && variants.iter().any(|(name, payload)| {
+                            name.as_ref() == "Some"
+                                && payload.len() == 1
+                                && payload[0] == DurableType::I64
+                        })
+                        && variants.iter().any(|(name, payload)| {
+                            name.as_ref() == "None" && payload.is_empty()
+                        })
+            )
+        });
+        assert!(
+            materialized_option,
+            "Option(i64) must materialize a real Some(i64)/None nominal: {:?}",
+            projection.anonymous_nominals
+        );
     }
 
     /// RUE-1089 Theme 5 (fail-before-terminal). A divergent (wrong-but-present)
@@ -13531,7 +14506,7 @@ mod tests {
 
     fn begin_and_plan(
         session: &mut CompilerSession,
-        assembler: &DiscoverySourceAssembler,
+        assembler: &mut DiscoverySourceAssembler,
         context: ImportDiscoveryContext,
     ) -> (ImportInputRevision, ImportDiscoveryPlan) {
         let snapshot = assembler.snapshot().unwrap();
@@ -13543,7 +14518,7 @@ mod tests {
             .stage_import_discovery(
                 &snapshot,
                 context,
-                reads,
+                reads.shared_slice(),
                 ImportObservationLedger::default(),
             )
             .unwrap();
@@ -13552,11 +14527,11 @@ mod tests {
 
     fn begin_database_plan(
         database: &mut RevisionedQueryDatabase,
-        assembler: &DiscoverySourceAssembler,
+        assembler: &mut DiscoverySourceAssembler,
         context: ImportDiscoveryContext,
     ) -> (
         SourceSnapshot,
-        Arc<[crate::AcceptedReadManifestEntry]>,
+        AcceptedReadManifest,
         ImportInputRevision,
         ImportDiscoveryPlan,
     ) {
@@ -13581,7 +14556,7 @@ mod tests {
     fn publish_manifest_observations(
         database: &mut RevisionedQueryDatabase,
         snapshot: &SourceSnapshot,
-        reads: Arc<[crate::AcceptedReadManifestEntry]>,
+        reads: AcceptedReadManifest,
         plan: &ImportDiscoveryPlan,
         mut revision: ImportInputRevision,
     ) -> ImportInputRevision {
@@ -13629,7 +14604,7 @@ mod tests {
     fn publish_remapped_observations(
         database: &mut RevisionedQueryDatabase,
         snapshot: &SourceSnapshot,
-        reads: Arc<[crate::AcceptedReadManifestEntry]>,
+        reads: AcceptedReadManifest,
         plan: &ImportDiscoveryPlan,
         mut revision: ImportInputRevision,
         remaps: &[(&str, PhysicalFileIdentity)],
@@ -13705,10 +14680,10 @@ mod tests {
         use crate::declaration_candidate::DeclarationCandidateCategory as Category;
 
         let source = "const selected = if true { @import(\"same\") } else { @import(\"same\") }; const untouched = @import(\"other\"); fn main() {}";
-        let (_, assembler, context) = import_fixture(301, source);
+        let (_, mut assembler, context) = import_fixture(301, source);
         let mut database = RevisionedQueryDatabase::default();
         let (snapshot, reads, revision, plan) =
-            begin_database_plan(&mut database, &assembler, context);
+            begin_database_plan(&mut database, &mut assembler, context);
         let revision =
             publish_manifest_observations(&mut database, &snapshot, reads, &plan, revision);
         let runtime_revision = Revision::new(revision.revision_id, revision.request_generation);
@@ -13843,10 +14818,10 @@ mod tests {
         use crate::declaration_candidate::DeclarationCandidateCategory as Category;
 
         let first_source = "const selected = @import(\"missing\"); fn main() {}";
-        let (_, first_assembler, first_context) = import_fixture(302, first_source);
+        let (_, mut first_assembler, first_context) = import_fixture(302, first_source);
         let mut database = RevisionedQueryDatabase::default();
         let (first_snapshot, first_reads, first_revision, first_plan) =
-            begin_database_plan(&mut database, &first_assembler, first_context);
+            begin_database_plan(&mut database, &mut first_assembler, first_context);
         let old_occurrence = first_plan.groups()[0][0].occurrence().clone();
         assert_ne!(
             ResolveImportKey {
@@ -13890,9 +14865,9 @@ mod tests {
 
         let shifted_source =
             "// position-only relocation\n\nconst selected = @import(\"missing\"); fn main() {}";
-        let (_, shifted_assembler, shifted_context) = import_fixture(303, shifted_source);
+        let (_, mut shifted_assembler, shifted_context) = import_fixture(303, shifted_source);
         let (shifted_snapshot, shifted_reads, shifted_revision, shifted_plan) =
-            begin_database_plan(&mut database, &shifted_assembler, shifted_context);
+            begin_database_plan(&mut database, &mut shifted_assembler, shifted_context);
         let shifted_revision = publish_manifest_observations(
             &mut database,
             &shifted_snapshot,
@@ -13938,11 +14913,11 @@ mod tests {
     fn declaration_import_recovers_when_resolution_observations_arrive() {
         use crate::declaration_candidate::DeclarationCandidateCategory as Category;
 
-        let (_, assembler, context) =
+        let (_, mut assembler, context) =
             import_fixture(306, "const selected = @import(\"missing\"); fn main() {}");
         let mut database = RevisionedQueryDatabase::default();
         let (snapshot, reads, revision, plan) =
-            begin_database_plan(&mut database, &assembler, context);
+            begin_database_plan(&mut database, &mut assembler, context);
         let module = ModuleId::from_logical_path("main.rue").unwrap();
         let key = declaration_import_key(
             &module,
@@ -13990,11 +14965,11 @@ mod tests {
             SemanticNucleusValue as Value,
         };
 
-        let (_, assembler, context) =
+        let (_, mut assembler, context) =
             import_fixture(307, "const selected = @import(\"missing\"); fn main() {}");
         let mut database = RevisionedQueryDatabase::default();
         let (snapshot, reads, revision, plan) =
-            begin_database_plan(&mut database, &assembler, context);
+            begin_database_plan(&mut database, &mut assembler, context);
         let runtime_revision = Revision::new(revision.revision_id, revision.request_generation);
         let module = ModuleId::from_logical_path("main.rue").unwrap();
         let query =
@@ -14061,7 +15036,7 @@ mod tests {
             .unwrap();
         let mut database = RevisionedQueryDatabase::default();
         let (snapshot, reads, revision, plan) =
-            begin_database_plan(&mut database, &assembler, context);
+            begin_database_plan(&mut database, &mut assembler, context);
         let revision =
             publish_manifest_observations(&mut database, &snapshot, reads, &plan, revision);
         let runtime_revision = Revision::new(revision.revision_id, revision.request_generation);
@@ -14160,7 +15135,7 @@ mod tests {
             .unwrap();
         let mut database = RevisionedQueryDatabase::default();
         let (first_snapshot, first_reads, first_revision, first_plan) =
-            begin_database_plan(&mut database, &first_assembler, first_context);
+            begin_database_plan(&mut database, &mut first_assembler, first_context);
         let first_revision = publish_manifest_observations(
             &mut database,
             &first_snapshot,
@@ -14205,7 +15180,7 @@ mod tests {
             )
             .unwrap();
         let (remapped_snapshot, remapped_reads, remapped_revision, remapped_plan) =
-            begin_database_plan(&mut database, &remapped_assembler, remapped_context);
+            begin_database_plan(&mut database, &mut remapped_assembler, remapped_context);
         let remapped_revision = publish_remapped_observations(
             &mut database,
             &remapped_snapshot,
@@ -14246,7 +15221,7 @@ mod tests {
         let green_context =
             ImportDiscoveryContext::new(307, "/project", Some("/sdk"), "test-policy").unwrap();
         let (green_snapshot, green_reads, green_revision, green_plan) =
-            begin_database_plan(&mut database, &green_assembler, green_context);
+            begin_database_plan(&mut database, &mut green_assembler, green_context);
         let green_revision = publish_remapped_observations(
             &mut database,
             &green_snapshot,
@@ -14299,7 +15274,7 @@ mod tests {
         }
         let mut database = RevisionedQueryDatabase::default();
         let (first_snapshot, first_reads, first_revision, first_plan) =
-            begin_database_plan(&mut database, &first_assembler, first_context);
+            begin_database_plan(&mut database, &mut first_assembler, first_context);
         let first_revision = publish_manifest_observations(
             &mut database,
             &first_snapshot,
@@ -14363,7 +15338,7 @@ mod tests {
                 .unwrap();
         }
         let (remapped_snapshot, remapped_reads, remapped_revision, remapped_plan) =
-            begin_database_plan(&mut database, &remapped_assembler, remapped_context);
+            begin_database_plan(&mut database, &mut remapped_assembler, remapped_context);
         let remaps = [
             ("/project/dep.rue", PhysicalFileIdentity::new(2, 1)),
             ("/project/dep/_dep.rue", PhysicalFileIdentity::new(3, 1)),
@@ -14412,7 +15387,7 @@ mod tests {
         let green_context =
             ImportDiscoveryContext::new(308, "/project", Some("/sdk"), "test-policy").unwrap();
         let (green_snapshot, green_reads, green_revision, green_plan) =
-            begin_database_plan(&mut database, &green_assembler, green_context);
+            begin_database_plan(&mut database, &mut green_assembler, green_context);
         let green_revision = publish_remapped_observations(
             &mut database,
             &green_snapshot,
@@ -14433,27 +15408,96 @@ mod tests {
         assert_eq!(green.terminal().unwrap().stamp(), remapped_stamp);
     }
 
+    /// A hard-link alias with a lexicographically smaller canonical path that is
+    /// observed only AFTER the entry was carried by a produced snapshot/manifest
+    /// must not rewrite the retained representative: the published state is
+    /// immutable, so the assembler keeps reproducing exactly the snapshot,
+    /// manifest, and published view it already handed out. (Observed before the
+    /// first production, the smaller alias still wins — see the hard-link
+    /// order-independence tests.)
+    #[test]
+    fn alias_observed_after_publication_keeps_snapshot_manifest_and_view_in_agreement() {
+        let (_, mut assembler, context) = import_fixture(311, "fn main() {}");
+        assembler
+            .add_explicit(
+                "/project/a.rue",
+                "/real/z-hard-a",
+                PhysicalFileIdentity::new(9, 9),
+                FileMetadataFingerprint::new(1, 2, 3),
+                Arc::new("same inode".into()),
+            )
+            .unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let snapshot = assembler.snapshot().unwrap();
+        let manifest = assembler.accepted_read_manifest();
+        let revision = database
+            .begin_import_inputs(&snapshot, context, manifest.clone())
+            .unwrap();
+
+        // The smaller alias of the SAME physical identity arrives only now.
+        assembler
+            .add_explicit(
+                "/project/a.rue",
+                "/real/a-hard-a",
+                PhysicalFileIdentity::new(9, 9),
+                FileMetadataFingerprint::new(1, 2, 3),
+                Arc::new("same inode".into()),
+            )
+            .unwrap();
+        let successor_snapshot = assembler.snapshot().unwrap();
+        let successor_manifest = assembler.accepted_read_manifest();
+
+        // The retained representative is frozen, so snapshot and manifest stay
+        // in exact agreement with each other...
+        assert_eq!(successor_snapshot.metadata(), snapshot.metadata());
+        assert_eq!(
+            successor_snapshot.source_revision(),
+            snapshot.source_revision()
+        );
+        assert_eq!(successor_manifest, manifest);
+        assert!(
+            successor_manifest
+                .iter()
+                .any(|entry| entry.canonical_path() == "/real/z-hard-a")
+        );
+
+        // ...and with the published view, byte for byte, so a later successor
+        // publication extends this state rather than rejecting it as mutated.
+        let (current, view_snapshot, _, view_manifest, _) =
+            database.current_import_view_state().unwrap();
+        assert_eq!(current, revision);
+        assert_eq!(
+            view_snapshot.source_revision(),
+            successor_snapshot.source_revision()
+        );
+        assert_eq!(view_manifest, successor_manifest);
+    }
+
     #[test]
     fn import_publication_rejects_duplicate_and_unmatched_physical_provenance() {
         let source = "const selected = @import(\"dep\"); fn main() {}";
-        let (_, assembler, context) = import_fixture(309, source);
+        let (_, mut assembler, context) = import_fixture(309, source);
         let snapshot = assembler.snapshot().unwrap();
         let reads = assembler.accepted_read_manifest();
         let duplicated = reads
             .iter()
             .cloned()
-            .chain(std::iter::once(reads[0].clone()))
+            .chain(std::iter::once(reads.iter().next().unwrap().clone()))
             .collect::<Vec<_>>();
         let mut database = RevisionedQueryDatabase::default();
         assert!(
             database
-                .begin_import_inputs(&snapshot, context.clone(), duplicated.into())
+                .begin_import_inputs(
+                    &snapshot,
+                    context.clone(),
+                    AcceptedReadManifest::from_entries(duplicated),
+                )
                 .is_err(),
             "duplicate physical provenance must fail before revision publication"
         );
 
         let (snapshot, reads, revision, plan) =
-            begin_database_plan(&mut database, &assembler, context);
+            begin_database_plan(&mut database, &mut assembler, context);
         let roots = ImportDemandRoots::whole_plan(&plan);
         let frontier = database
             .import_frontier(revision, &plan, ImportDemandMode::Rooted, &roots)
@@ -14496,7 +15540,7 @@ mod tests {
             .map(|index| format!("const c{index} = @import(\"x{index}\");"))
             .collect::<Vec<_>>()
             .join("\n");
-        let (_, assembler, context) = import_fixture(305, &source_text);
+        let (_, mut assembler, context) = import_fixture(305, &source_text);
         let snapshot = assembler.snapshot().unwrap();
         let reads = assembler.accepted_read_manifest();
         let mut database =
@@ -14610,8 +15654,8 @@ mod tests {
             const d = @import("d");
             fn main() -> i32 { 0 }
         "#;
-        let (mut session, assembler, context) = import_fixture(1, source);
-        let (revision, plan) = begin_and_plan(&mut session, &assembler, context);
+        let (mut session, mut assembler, context) = import_fixture(1, source);
+        let (revision, plan) = begin_and_plan(&mut session, &mut assembler, context);
         let frontier = session
             .import_demand_frontier_for_roots(
                 revision,
@@ -14681,11 +15725,11 @@ mod tests {
 
     #[test]
     fn speculative_frontiers_are_effect_free_and_cannot_publish_host_results() {
-        let (mut session, assembler, context) = import_fixture(
+        let (mut session, mut assembler, context) = import_fixture(
             2,
             r#"const helper = @import("helper"); fn main() -> i32 { 0 }"#,
         );
-        let (revision, plan) = begin_and_plan(&mut session, &assembler, context);
+        let (revision, plan) = begin_and_plan(&mut session, &mut assembler, context);
         let speculative = session
             .import_demand_frontier_for_roots(
                 revision,
@@ -14731,12 +15775,12 @@ mod tests {
 
     #[test]
     fn resolve_import_recomputes_when_only_discovery_context_changes() {
-        let (mut session, assembler, first_context) = import_fixture(
+        let (mut session, mut assembler, first_context) = import_fixture(
             24,
             r#"const standard = @import("std"); fn main() -> i32 { 0 }"#,
         );
         let (first_revision, first_plan) =
-            begin_and_plan(&mut session, &assembler, first_context.clone());
+            begin_and_plan(&mut session, &mut assembler, first_context.clone());
         let first = session
             .import_demand_frontier_for_roots(
                 first_revision,
@@ -14764,7 +15808,7 @@ mod tests {
             .stage_import_discovery(
                 &snapshot,
                 second_context.clone(),
-                reads,
+                reads.shared_slice(),
                 ImportObservationLedger::default(),
             )
             .unwrap();
@@ -14805,8 +15849,8 @@ mod tests {
             ));
         }
         source.push_str("fn main() -> i32 { 0 }\n");
-        let (mut session, assembler, context) = import_fixture(21, &source);
-        let (revision, plan) = begin_and_plan(&mut session, &assembler, context);
+        let (mut session, mut assembler, context) = import_fixture(21, &source);
+        let (revision, plan) = begin_and_plan(&mut session, &mut assembler, context);
         let selected = plan
             .groups()
             .iter()
@@ -14847,12 +15891,12 @@ mod tests {
 
     #[test]
     fn new_request_generation_has_no_carried_ledger_authority() {
-        let (mut session, assembler, context) = import_fixture(
+        let (mut session, mut assembler, context) = import_fixture(
             22,
             r#"const missing = @import("missing.rue"); fn main() -> i32 { 0 }"#,
         );
         let (first_revision, first_plan) =
-            begin_and_plan(&mut session, &assembler, context.clone());
+            begin_and_plan(&mut session, &mut assembler, context.clone());
         let first = session
             .import_demand_frontier_for_roots(
                 first_revision,
@@ -14885,7 +15929,7 @@ mod tests {
         let fresh_ledger = session.import_observation_ledger(fresh_revision).unwrap();
         assert!(fresh_ledger.is_empty());
         let fresh_plan = session
-            .stage_import_discovery(&snapshot, context, reads, fresh_ledger)
+            .stage_import_discovery(&snapshot, context, reads.shared_slice(), fresh_ledger)
             .unwrap();
         let reread = session
             .import_demand_frontier_for_roots(
@@ -14911,7 +15955,7 @@ mod tests {
 
     #[test]
     fn duplicate_occurrences_share_one_host_operation_and_fan_out_typed_results() {
-        let (mut session, assembler, context) = import_fixture(
+        let (mut session, mut assembler, context) = import_fixture(
             23,
             r#"
                 const first = @import("shared.rue");
@@ -14919,7 +15963,7 @@ mod tests {
                 fn main() -> i32 { 0 }
             "#,
         );
-        let (revision, plan) = begin_and_plan(&mut session, &assembler, context);
+        let (revision, plan) = begin_and_plan(&mut session, &mut assembler, context);
         let frontier = session
             .import_demand_frontier_for_roots(
                 revision,
@@ -14957,8 +16001,8 @@ mod tests {
     #[test]
     fn successor_revisions_carry_observations_but_new_epochs_reread() {
         let source = r#"const helper = @import("helper"); fn main() -> i32 { 0 }"#;
-        let (mut session, assembler, context) = import_fixture(3, source);
-        let (revision, plan) = begin_and_plan(&mut session, &assembler, context);
+        let (mut session, mut assembler, context) = import_fixture(3, source);
+        let (revision, plan) = begin_and_plan(&mut session, &mut assembler, context);
         let first = session
             .import_demand_frontier_for_roots(
                 revision,
@@ -14991,7 +16035,7 @@ mod tests {
             .stage_import_discovery(
                 &assembler.snapshot().unwrap(),
                 plan.context().clone(),
-                assembler.accepted_read_manifest(),
+                assembler.accepted_read_manifest().shared_slice(),
                 carried,
             )
             .unwrap();
@@ -15023,7 +16067,7 @@ mod tests {
             .stage_import_discovery(
                 &new_snapshot,
                 new_context,
-                assembler.accepted_read_manifest(),
+                assembler.accepted_read_manifest().shared_slice(),
                 ImportObservationLedger::default(),
             )
             .unwrap();

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1196,10 +1196,15 @@ pub(crate) struct ImportDiscoveryRevisionArtifact {
     parse_work: ParsedModulesWork,
     plan: Option<crate::ImportDiscoveryPlan>,
     ledger: crate::ImportObservationLedger,
-    accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
+    accepted_reads: crate::AcceptedReadManifest,
     graph: Option<Arc<CanonicalImportGraphOutput>>,
     diagnostics: CompileErrors,
     diagnostic_snapshot: Option<Arc<FrontendDiagnosticSnapshot>>,
+    /// The exact successor parse record this stage computed (RUE-1112). The
+    /// successor close adopts by re-selecting THIS terminal — same key, same
+    /// revision — never by re-deriving an extension against the now-selected
+    /// successor state.
+    successor_parse: Option<ParseQueryRecord>,
 }
 
 impl ImportDiscoveryRevisionArtifact {
@@ -1232,7 +1237,7 @@ impl ImportDiscoveryRevisionArtifact {
     pub(crate) fn ledger(&self) -> &crate::ImportObservationLedger {
         &self.ledger
     }
-    pub(crate) fn accepted_read_manifest(&self) -> &[crate::AcceptedReadManifestEntry] {
+    pub(crate) fn accepted_read_manifest(&self) -> &crate::AcceptedReadManifest {
         &self.accepted_reads
     }
     pub(crate) fn graph(&self) -> Option<&Arc<CanonicalImportGraphOutput>> {
@@ -1292,6 +1297,52 @@ pub struct CompilerSession {
     /// Protocol context only while the typed import-closure query is open.
     /// Closed attempts live exclusively in their plan or closure terminal.
     open_discovery: Option<Arc<ImportDiscoveryRevisionArtifact>>,
+    /// Trusted-toolchain continuation state (RUE-1112). Set only at a
+    /// successful import-discovery close and single-use: consumed by a
+    /// successful `publish_trusted_toolchain_successor`, and cleared on any new
+    /// import-input request or source update so a stale token cannot continue.
+    continuation: Option<ContinuationState>,
+    /// Nonce of the outstanding trusted-toolchain successor delta authority
+    /// (RUE-1112), set by a successful `publish_trusted_toolchain_successor` and
+    /// cleared by the successor close it authorizes (or by any new import-input
+    /// request/source update, so a stale delta can neither stage nor close).
+    successor_delta_nonce: Option<u64>,
+    /// Monotonic nonce source for continuation tokens; a token is valid only
+    /// while its nonce matches the outstanding state.
+    next_continuation_nonce: u64,
+    /// Cumulative request groups constructed during import-plan staging
+    /// (RUE-1112). A full plan build constructs one per program occurrence; a
+    /// trusted-toolchain successor stage reuses the predecessor plan's groups and
+    /// constructs only the newly appended occurrences', so a predecessor
+    /// occurrence contributes here exactly once — at the initial close.
+    import_plan_groups_constructed: u64,
+    /// Cumulative canonical import records reduced and validated during
+    /// close (RUE-1112). A full close reduces/validates one per program
+    /// occurrence; a trusted-toolchain successor close carries the predecessor's
+    /// closed graph and reduces/validates only the newly appended occurrences', so
+    /// a predecessor occurrence contributes here exactly once — at the initial
+    /// close.
+    import_close_records_reduced: u64,
+    /// Cumulative source entries materialized into whole-program parse
+    /// projections (RUE-1112): the presentation order, demanded module set, and
+    /// merged program construction a FULL parse build enumerates. A
+    /// trusted-toolchain successor stage extends the retained predecessor
+    /// artifact instead, so a predecessor entry contributes here exactly once —
+    /// at the initial close.
+    parse_sources_materialized: u64,
+    /// Cumulative source entries embedded in parse query keys (RUE-1112): an
+    /// ordinary key carries every file's exact content identity; a successor
+    /// key carries only the published lineage identity plus its appended
+    /// segment, so key hashing and equality never touch a predecessor entry.
+    parse_key_entries_compared: u64,
+    /// Cumulative module parse queries dispatched by the parse projection
+    /// (RUE-1112). A full build dispatches one per module; a successor stage
+    /// dispatches only the appended modules'.
+    parse_modules_dispatched: u64,
+    /// Cumulative entries examined by parse invalidation classification
+    /// (RUE-1112). A full classification examines every current module; a
+    /// successor classifies only its appended delta.
+    parse_invalidation_entries_compared: u64,
     queries: FrontendQueryDatabase,
     #[cfg(test)]
     supplied_test_import_graph: Option<CanonicalImportGraph>,
@@ -1303,7 +1354,7 @@ pub struct CompilerSession {
     cancel_semantic_before_publication: bool,
     published: Option<Arc<ParsedProgram>>,
     published_snapshot: Option<SourceSnapshot>,
-    batch_diagnostic_order: Option<Vec<crate::ModuleId>>,
+    batch_diagnostic_order: Option<crate::shared_segments::SharedList<crate::ModuleId>>,
     definition_shard_baseline: Option<crate::DefinitionSnapshot>,
     metrics: CompilerSessionMetrics,
     diagnostics: DiagnosticAttemptStore,
@@ -1600,6 +1651,132 @@ fn enqueue_owned_destructor_closure(
 enum SemanticRequestControl {
     Compile(CompileErrors),
     Abort(rue_query::QueryAbort),
+    /// A reached body demanded a trusted toolchain module absent from the current
+    /// revision (RUE-1112). The rooted attempt recorded the park before
+    /// entering the body transaction; the host driver acquires the demanded
+    /// modules and retries on a successor, while stable no-filesystem entries
+    /// convert the park to an error/absence result at their outer boundary.
+    Parked(Box<crate::ParkedToolchainModules>),
+}
+
+/// The outcome of the rooted, park-aware semantic entry
+/// [`CompilerSession::semantic_or_toolchain_park`] (RUE-1112), consumed by the
+/// host source-loading driver through the unstable facade.
+pub enum SemanticParkOutcome {
+    /// Analysis completed against a revision that satisfied every reached body's
+    /// trusted-toolchain-module demand.
+    Ready(Arc<crate::SemanticView>),
+    /// Analysis produced deterministic program diagnostics.
+    Errors(CompileErrors),
+    /// A reached body demanded a trusted toolchain module absent from the current
+    /// revision. The host driver must acquire the demanded modules, publish a
+    /// successor, and retry.
+    Parked(Box<crate::ParkedToolchainModules>),
+}
+
+/// An opaque, single-use continuation issued ONLY from a successful close of
+/// import discovery (RUE-1112).
+///
+/// It authorizes exactly one strictly-additive trusted-toolchain successor on
+/// the closed revision, in the same request generation. It is bound to the
+/// issuing session (`session`) and to the outstanding close (`nonce` +
+/// `revision`); a token from a different session, a stale token (superseded by a
+/// newer close or a new request), or a reused token (after a successful publish)
+/// is rejected. The fields are private: the host holds the token and hands it
+/// back, never inspecting or constructing it.
+#[derive(Debug, Clone)]
+pub struct ClosedDiscoveryContinuation {
+    session: Arc<()>,
+    nonce: u64,
+    revision: crate::ImportInputRevision,
+}
+
+/// Opaque, compiler-derived authority for the modules a trusted-toolchain
+/// successor may stage, project, reduce, and commit (RUE-1112).
+///
+/// It is minted ONLY by [`CompilerSession::publish_trusted_toolchain_successor`]
+/// from the verified `added == demanded` set — never from host input — and is
+/// bound to the issuing session and successor revision. Its fields are private,
+/// so the host cannot construct, inspect, or edit the module set: it carries the
+/// value opaquely between the successor stage and close. The successor stage and
+/// close derive the exact module delta from the committed predecessor and the
+/// current snapshot and verify the carried `appended` roots are present, so a
+/// caller can neither omit an authorized module (committing a graph that lacks
+/// imports for modules actually in the snapshot) nor admit an unauthorized one.
+#[derive(Debug, Clone)]
+pub struct TrustedSuccessorDelta {
+    session: Arc<()>,
+    nonce: u64,
+    revision: crate::ImportInputRevision,
+    appended: Arc<[crate::ModuleId]>,
+}
+
+impl TrustedSuccessorDelta {
+    /// The successor input revision this delta was minted on. Exposing the
+    /// revision does not expose the authorized module set; the host needs it only
+    /// to continue discovery in the same request generation.
+    pub fn revision(&self) -> crate::ImportInputRevision {
+        self.revision
+    }
+}
+
+/// Session-held authority backing an outstanding [`ClosedDiscoveryContinuation`].
+/// Retains the predecessor snapshot, context, accepted-read provenance, and the
+/// carried ledger so `publish_trusted_toolchain_successor` can verify a strictly
+/// additive successor entirely from records, without any filesystem access.
+///
+/// A close alone leaves the state NON-AUTHORIZING (`attached_demands` is `None`):
+/// no token can be minted and no successor authorized. Authority is granted
+/// only when a rooted semantic park atomically attaches that park's exact sorted
+/// missing-demand set to this same state. Demand authority therefore lives here,
+/// bound to one closed revision and one park — never in an ambient session field
+/// a later, non-parking close could inherit.
+/// The CURRENT compiler-published view state a verified successor stage/close
+/// consumes, with the derived module delta (RUE-1112). Everything here comes
+/// from the published lineage; none of it is host-suppliable.
+struct SuccessorState {
+    snapshot: SourceSnapshot,
+    context: crate::ImportDiscoveryContext,
+    accepted_reads: crate::AcceptedReadManifest,
+    ledger: crate::ImportObservationLedger,
+    /// The published lineage identity this state was read from.
+    revision: crate::ImportInputRevision,
+    /// The appended module revisions (view sources minus the committed
+    /// predecessor), in canonical module order.
+    delta: Arc<[crate::ModuleRevision]>,
+}
+
+#[derive(Debug, Clone)]
+struct ContinuationState {
+    nonce: u64,
+    revision: crate::ImportInputRevision,
+    snapshot: SourceSnapshot,
+    accepted_reads: crate::AcceptedReadManifest,
+    ledger: crate::ImportObservationLedger,
+    /// The exact sorted missing-demand set the rooted park attached, or `None`
+    /// while the closed state is non-authorizing (no park has arrived for it).
+    attached_demands: Option<Arc<[crate::TrustedToolchainModuleDemand]>>,
+}
+
+/// Convert an unsatisfied trusted-toolchain park to the error a stable
+/// no-filesystem semantic entry returns at its outer boundary (RUE-1112).
+///
+/// This is a deterministic contract failure, never an ICE: the source is
+/// otherwise valid, but a guaranteed toolchain input the reached bodies demand
+/// was not supplied. The park-aware host driver acquires and retries; a stable
+/// embedder that omits the input gets this distinguishable classification.
+fn unresolved_toolchain_park_errors(park: &crate::ParkedToolchainModules) -> CompileErrors {
+    let modules = park
+        .demands()
+        .iter()
+        .map(|demand| demand.logical_path().to_owned())
+        .collect::<Vec<_>>()
+        .join(", ");
+    CompileErrors::from(crate::CompileError::without_span(
+        rue_error::ErrorKind::UnsatisfiedTrustedToolchainInput(format!(
+            "reached bodies demand trusted standard-library module(s) [{modules}] that are not present in this compilation; supply them (a std root the host can acquire from) before semantic analysis"
+        )),
+    ))
 }
 
 impl From<CompileErrors> for SemanticRequestControl {
@@ -1677,6 +1854,17 @@ impl FrontendQueryDatabase {
         previous.is_some_and(|previous| previous != current)
     }
 
+    /// Select `source` as the current exact source WITHOUT disappearing the
+    /// predecessor leaf (RUE-1112). A strictly-additive successor adoption
+    /// leaves the predecessor's immutable leaf live, so every retained
+    /// terminal that correctly depends on it stays valid — nothing is
+    /// invalidated or re-walked; new publications simply observe the new
+    /// leaf. Ordinary updates keep the disappearing [`Self::publish_source`],
+    /// whose invalidation is the real contract for replaced sources.
+    fn publish_source_additive(&mut self, source: ExactSourceInput) {
+        self.source_inputs.publish_retained(&mut self.graph, source);
+    }
+
     fn publish_import_graph(&mut self, imports: CanonicalImportGraph) {
         self.import_inputs.publish(&mut self.graph, imports);
     }
@@ -1738,7 +1926,57 @@ struct DependencyManifestCacheEntry {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct ParseQueryKey {
+pub(crate) enum ParseQueryKey {
+    /// Ordinary content-addressed parsing: keyed on the exact source content,
+    /// table order, and presentation, so any equal re-request reuses the
+    /// terminal.
+    Ordinary(Box<OrdinaryParseKey>),
+    /// A trusted-toolchain successor parse projection (RUE-1112): keyed on the
+    /// published predecessor lineage identity plus the exact appended source
+    /// segment. Content is pinned by the published revision, so key hashing and
+    /// equality never touch a predecessor entry.
+    Successor {
+        revision: crate::ImportInputRevision,
+        delta: Arc<[crate::ModuleRevision]>,
+        /// The exact retained predecessor parse terminal this successor
+        /// extends, verified by structural source ancestry at preparation.
+        predecessor: rue_query::Revision,
+    },
+}
+
+impl ParseQueryKey {
+    /// The exact source identity an Ordinary key pins (and whose stamp it
+    /// retains); a Successor key pins its sources through the published
+    /// lineage identity instead and allocates no stamp.
+    pub(crate) fn pinned_source(&self) -> Option<&ExactSourceInput> {
+        match self {
+            Self::Ordinary(key) => Some(&key.source),
+            Self::Successor { .. } => None,
+        }
+    }
+}
+
+/// The reconciled inputs of one successor parse extension (RUE-1112), prepared
+/// without side effects so both the staging and adoption paths verify the
+/// predecessor binding before starting a metrics attempt.
+struct PreparedSuccessorParse {
+    predecessor_program: Arc<ParsedProgram>,
+    predecessor_order: crate::shared_segments::SharedList<crate::ModuleId>,
+    /// The retained predecessor parse terminal's exact runtime identity; the
+    /// successor key embeds it, so the successor terminal is bound to THIS
+    /// predecessor artifact, never an ambient "latest".
+    predecessor_revision: rue_query::Revision,
+    /// The predecessor parse terminal ITSELF, minted into the exact-terminal
+    /// adoption capability by the parse family's content-addressed
+    /// registration. The successor computation records it as a runtime
+    /// dependency, so the graph carries a real successor-after-predecessor
+    /// edge with the captured terminal's exact node, incarnation, and stamp.
+    predecessor_terminal: rue_query::AdoptableTerminal<ParseQueryRecord>,
+    appended: Vec<(crate::ModuleId, crate::FileId)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct OrdinaryParseKey {
     source: ExactSourceInput,
     /// Caller-owned source table order. This is presentation state rather than
     /// module identity, but a selected parse record retains the exact snapshot
@@ -1746,12 +1984,6 @@ pub(crate) struct ParseQueryKey {
     /// record while granular module terminals remain reusable.
     file_order: Arc<[crate::FileId]>,
     presentation: DiagnosticAttemptProvenance,
-}
-
-impl ParseQueryKey {
-    pub(crate) fn source(&self) -> &ExactSourceInput {
-        &self.source
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -1811,30 +2043,76 @@ impl TypedQueryFamily for ParseQuery {
     }
 
     fn record_is_consistent(record: &Self::Record) -> bool {
-        record.snapshot.source_revision() == &record.key.source.revision
-            && record.snapshot.metadata() == &record.key.source.metadata
-            && record
-                .snapshot
-                .files()
-                .map(|source| source.file_id)
-                .eq(record.key.file_order.iter().copied())
-            && match &record.result {
-                Ok(program) => program.source_revision() == &record.key.source.revision,
-                Err(_) => true,
+        match &record.key {
+            ParseQueryKey::Ordinary(key) => {
+                record.snapshot.source_revision() == &key.source.revision
+                    && record.snapshot.metadata() == &key.source.metadata
+                    && record
+                        .snapshot
+                        .files()
+                        .map(|source| source.file_id)
+                        .eq(key.file_order.iter().copied())
+                    && match &record.result {
+                        Ok(program) => program.source_revision() == &key.source.revision,
+                        Err(_) => true,
+                    }
+                    && record.diagnostics.source_revision() == &key.source.revision
+                    && record.diagnostics.identity() == &FrontendDiagnosticIdentity::Syntax
+                    && record.diagnostics.provenance == key.presentation
             }
-            && record.diagnostics.source_revision() == &record.key.source.revision
-            && record.diagnostics.identity() == &FrontendDiagnosticIdentity::Syntax
-            && record.diagnostics.provenance == record.key.presentation
+            ParseQueryKey::Successor { delta, .. } => {
+                // Content identity is pinned by the published lineage in the
+                // key; consistency stays O(delta) — a predecessor entry is
+                // never re-enumerated here.
+                record.snapshot.len() >= delta.len()
+                    && match &record.result {
+                        Ok(program) => program.modules_len() == record.snapshot.len(),
+                        Err(_) => true,
+                    }
+                    && record.diagnostics.identity() == &FrontendDiagnosticIdentity::Syntax
+            }
+        }
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ImportPlanQueryKey {
+enum ImportPlanQueryKey {
+    /// Ordinary content-addressed staging: keyed on the exact inputs, so an
+    /// unchanged program recompiled in a fresh session hits the same memoized
+    /// terminal it does today.
+    Ordinary(Box<OrdinaryImportPlanKey>),
+    /// Trusted-toolchain successor staging (RUE-1112): keyed on the published
+    /// lineage identity being staged plus the exact successor delta. The
+    /// published revision identity is session-unique and immutably bound to its
+    /// leaf view, so it stands in for the full predecessor content without
+    /// hashing or comparing predecessor entries; the delta names the appended
+    /// module revisions exactly. Identities are never fingerprints (ADR-0066):
+    /// a revision id is a published immutable identity, not a content digest.
+    Successor {
+        revision: crate::ImportInputRevision,
+        delta: Arc<[crate::ModuleRevision]>,
+        policy_version: u32,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct OrdinaryImportPlanKey {
     source: ExactSourceInput,
     context: crate::ImportDiscoveryContext,
     policy_version: u32,
-    accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
+    accepted_reads: crate::AcceptedReadManifest,
     carried_ledger: crate::ImportObservationLedger,
+}
+
+impl ImportPlanQueryKey {
+    /// The exact source revision an Ordinary key pins; a Successor key pins its
+    /// sources through the published revision identity instead.
+    fn pinned_source_revision(&self) -> Option<&crate::SourceRevision> {
+        match self {
+            Self::Ordinary(key) => Some(&key.source.revision),
+            Self::Successor { .. } => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1878,18 +2156,44 @@ impl TypedQueryFamily for ImportPlanQuery {
     }
 
     fn record_is_consistent(record: &Self::Record) -> bool {
-        record.diagnostics.source_revision() == &record.key.source.revision
+        match record.key.pinned_source_revision() {
+            Some(revision) => record.diagnostics.source_revision() == revision,
+            None => true,
+        }
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ImportClosureQueryKey {
+enum ImportClosureQueryKey {
+    /// Ordinary content-addressed closure (unchanged warm-reuse semantics).
+    Ordinary(Box<OrdinaryImportClosureKey>),
+    /// Trusted-toolchain successor closure (RUE-1112): keyed on the published
+    /// lineage identity being closed plus the exact successor delta (see the
+    /// plan key's Successor variant for the identity discipline).
+    Successor {
+        revision: crate::ImportInputRevision,
+        delta: Arc<[crate::ModuleRevision]>,
+        policy_version: u32,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct OrdinaryImportClosureKey {
     source: ExactSourceInput,
     context: crate::ImportDiscoveryContext,
     policy_version: u32,
-    accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
+    accepted_reads: crate::AcceptedReadManifest,
     plan: crate::ImportDiscoveryPlan,
     ledger: crate::ImportObservationLedger,
+}
+
+impl ImportClosureQueryKey {
+    fn pinned_source_revision(&self) -> Option<&crate::SourceRevision> {
+        match self {
+            Self::Ordinary(key) => Some(&key.source.revision),
+            Self::Successor { .. } => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1937,12 +2241,27 @@ impl TypedQueryFamily for ImportClosureQuery {
     }
 
     fn record_is_consistent(record: &Self::Record) -> bool {
-        record.artifact.snapshot().source_revision() == &record.key.source.revision
-            && record.diagnostics.source_revision() == &record.key.source.revision
-            && match &record.result {
-                Ok(graph) => graph.input().sources == record.key.source.revision,
-                Err(_) => true,
+        let mutual =
+            record.artifact.snapshot().source_revision() == record.diagnostics.source_revision();
+        match record.key.pinned_source_revision() {
+            Some(revision) => {
+                record.artifact.snapshot().source_revision() == revision
+                    && record.diagnostics.source_revision() == revision
+                    && match &record.result {
+                        Ok(graph) => &graph.input().sources == revision,
+                        Err(_) => true,
+                    }
             }
+            None => {
+                mutual
+                    && match &record.result {
+                        Ok(graph) => {
+                            &graph.input().sources == record.artifact.snapshot().source_revision()
+                        }
+                        Err(_) => true,
+                    }
+            }
+        }
     }
 }
 
@@ -2778,8 +3097,12 @@ impl CompilerSession {
         &mut self,
         snapshot: &SourceSnapshot,
         context: crate::ImportDiscoveryContext,
-        accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
+        accepted_reads: crate::AcceptedReadManifest,
     ) -> crate::CompileResult<crate::ImportInputRevision> {
+        // A fresh observation generation invalidates any outstanding
+        // trusted-toolchain continuation and successor-delta authority (RUE-1112).
+        self.continuation = None;
+        self.successor_delta_nonce = None;
         self.queries
             .revisioned
             .begin_import_inputs(snapshot, context, accepted_reads)
@@ -2803,7 +3126,7 @@ impl CompilerSession {
         &mut self,
         frontier: &crate::ImportDemandFrontier,
         snapshot: &SourceSnapshot,
-        accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
+        accepted_reads: crate::AcceptedReadManifest,
         observations: Vec<crate::ImportObservation>,
     ) -> crate::CompileResult<crate::ImportInputRevision> {
         self.queries.revisioned.publish_import_batch(
@@ -2820,6 +3143,144 @@ impl CompilerSession {
         revision: crate::ImportInputRevision,
     ) -> crate::CompileResult<crate::ImportObservationLedger> {
         self.queries.revisioned.import_ledger(revision)
+    }
+
+    /// Cumulative import occurrences the demand frontier has rooted (RUE-1112).
+    /// One `ResolveImport` projection is dispatched per rooted occurrence, so the
+    /// delta across a trusted-toolchain re-close counts only the newly appended
+    /// leaves and modules newly discovered from them — never a predecessor
+    /// occurrence. The host driver reads this to prove the re-close does not
+    /// re-root the predecessor import topology.
+    pub(crate) fn import_frontier_roots_requested(&self) -> u64 {
+        self.queries.revisioned.import_frontier_roots_requested()
+    }
+
+    /// Cumulative import-plan request groups constructed during staging
+    /// (RUE-1112). See the field docs on `import_plan_groups_constructed`.
+    pub(crate) fn import_plan_groups_constructed(&self) -> u64 {
+        self.import_plan_groups_constructed
+    }
+
+    /// See the field docs on `parse_sources_materialized`.
+    pub(crate) fn parse_sources_materialized(&self) -> u64 {
+        self.parse_sources_materialized
+    }
+
+    /// See the field docs on `parse_key_entries_compared`.
+    pub(crate) fn parse_key_entries_compared(&self) -> u64 {
+        self.parse_key_entries_compared
+    }
+
+    /// See the field docs on `parse_modules_dispatched`.
+    pub(crate) fn parse_modules_dispatched(&self) -> u64 {
+        self.parse_modules_dispatched
+    }
+
+    /// See the field docs on `parse_invalidation_entries_compared`.
+    pub(crate) fn parse_invalidation_entries_compared(&self) -> u64 {
+        self.parse_invalidation_entries_compared
+    }
+
+    /// The currently selected parse terminal, for identity assertions.
+    #[cfg(test)]
+    pub(crate) fn selected_parse_terminal(
+        &self,
+    ) -> Option<Arc<rue_query::QueryTerminal<ParseQueryRecord>>> {
+        self.queries.revisioned.parse.selected_terminal()
+    }
+
+    /// Cumulative dependency-graph invalidation events across the retained
+    /// frontend query families (merge, import diagnostics, RIR, semantic,
+    /// definitions, dependency manifests). A strictly-additive successor
+    /// adoption keeps the predecessor's immutable source leaf live, so it
+    /// contributes ZERO here regardless of how many variants are retained;
+    /// only a genuine replacement (an ordinary update) invalidates dependents.
+    pub(crate) fn frontend_query_invalidations(&self) -> u64 {
+        let graph = &self.queries.graph;
+        (graph.invalidation_count::<MergeQuery>()
+            + graph.invalidation_count::<ImportDiagnosticQuery>()
+            + graph.invalidation_count::<RirQuery>()
+            + graph.invalidation_count::<SemanticQuery>()
+            + graph.invalidation_count::<DefinitionQuery>()
+            + graph.invalidation_count::<DependencyManifestQuery>()) as u64
+    }
+
+    /// Cumulative close-time `ResolveImport` projections dispatched (RUE-1112).
+    pub(crate) fn exact_import_groups_dispatched(&self) -> u64 {
+        self.queries.revisioned.exact_import_groups_dispatched()
+    }
+
+    /// Cumulative canonical import records reduced and validated during close
+    /// (RUE-1112). See the field docs on `import_close_records_reduced`.
+    pub(crate) fn import_close_records_reduced(&self) -> u64 {
+        self.import_close_records_reduced
+    }
+
+    /// Cumulative leaves published through the complete publication path
+    /// (fresh generations); scales with the program (RUE-1112).
+    pub(crate) fn import_view_full_leaves_published(&self) -> u64 {
+        self.queries.revisioned.import_view_full_leaves_published()
+    }
+
+    /// Cumulative delta leaves published through the sparse successor overlay
+    /// path; predecessor leaves are structurally inherited and never counted
+    /// (RUE-1112).
+    pub(crate) fn import_view_overlay_leaves_published(&self) -> u64 {
+        self.queries
+            .revisioned
+            .import_view_overlay_leaves_published()
+    }
+
+    /// Cumulative predecessor ledger observations deep-cloned into successor
+    /// view ledgers (visible remaining cost; RUE-1112).
+    pub(crate) fn import_view_ledger_entries_cloned(&self) -> u64 {
+        self.queries.revisioned.import_view_ledger_entries_cloned()
+    }
+
+    /// Predecessor source entries compared by the overlay publication's fallback
+    /// diff; zero whenever the structural-authority path ran (RUE-1112).
+    pub(crate) fn import_view_source_entries_compared(&self) -> u64 {
+        self.queries
+            .revisioned
+            .import_view_source_entries_compared()
+    }
+
+    /// Predecessor accepted-read entries compared by the overlay publication's
+    /// provenance diff (RUE-1112).
+    pub(crate) fn import_view_read_entries_compared(&self) -> u64 {
+        self.queries.revisioned.import_view_read_entries_compared()
+    }
+
+    /// Structural-sharing witness for the committed import discovery's three
+    /// additively shared artifacts (RUE-1112): for each of the canonical graph
+    /// records, the plan's request groups, and the module-resolution table, the
+    /// identity address of its shared predecessor segment and its delta length. A
+    /// trusted-toolchain successor carries each predecessor segment `Arc` by
+    /// reference, so every address equals the predecessor close's — proving no
+    /// predecessor entry was copied, re-sorted, or reallocated.
+    pub(crate) fn committed_successor_sharing(&self) -> Option<[(usize, usize); 3]> {
+        let artifact = self.committed_import_discovery_artifact()?;
+        let graph = artifact.graph.as_ref()?;
+        let plan = artifact.plan.as_ref()?;
+        let record_segments = graph.graph().record_segments();
+        let group_segments = plan.group_segments();
+        let module_segments = graph.input().resolution.module_segments();
+        let witness =
+            |predecessor_ptr: *const (), delta_len: usize| (predecessor_ptr as usize, delta_len);
+        Some([
+            witness(
+                Arc::as_ptr(record_segments.predecessor_segment()) as *const (),
+                record_segments.delta_segment().len(),
+            ),
+            witness(
+                Arc::as_ptr(group_segments.predecessor_segment()) as *const (),
+                group_segments.delta_segment().len(),
+            ),
+            witness(
+                Arc::as_ptr(module_segments.predecessor_segment()) as *const (),
+                module_segments.delta_segment().len(),
+            ),
+        ])
     }
     #[cfg(test)]
     pub(crate) fn discovery_attempt(&self) -> Option<&Arc<ImportDiscoveryRevisionArtifact>> {
@@ -2932,7 +3393,7 @@ impl CompilerSession {
                 context: None,
                 plan: None,
                 ledger: crate::ImportObservationLedger::default(),
-                accepted_reads: Arc::from([]),
+                accepted_reads: crate::AcceptedReadManifest::from_entries(Vec::new()),
             };
             if let Some((cached, handle)) = self
                 .queries
@@ -3006,6 +3467,124 @@ impl CompilerSession {
         accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
         carried_ledger: crate::ImportObservationLedger,
     ) -> Result<crate::ImportDiscoveryPlan, CompileErrors> {
+        self.stage_import_discovery_inner(
+            snapshot,
+            context,
+            crate::AcceptedReadManifest::from_shared(accepted_reads),
+            carried_ledger,
+            None,
+        )
+    }
+
+    /// Verify a [`TrustedSuccessorDelta`] against this session and the CURRENT
+    /// compiler-published import-input view, returning that view's exact state
+    /// together with the derived module delta (RUE-1112). The successor stage and
+    /// close consume ONLY this published state — snapshot, context, provenance,
+    /// and ledger — so a caller cannot substitute any replacement; the view
+    /// itself is only extendable through justified overlay publications, so the
+    /// derived delta always equals the accumulated compiler-authorized additions.
+    fn derive_successor_state(
+        &self,
+        delta: &TrustedSuccessorDelta,
+    ) -> Result<SuccessorState, CompileErrors> {
+        let reject = |message: &str| {
+            CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                format!("trusted-toolchain successor delta rejected: {message}"),
+            )))
+        };
+        if !Arc::ptr_eq(&delta.session, &self.identity) {
+            return Err(reject("the successor delta belongs to a different session"));
+        }
+        let Some(outstanding) = self.successor_delta_nonce else {
+            return Err(reject(
+                "no outstanding successor-delta authority; it was already consumed or invalidated",
+            ));
+        };
+        if outstanding != delta.nonce {
+            return Err(reject(
+                "the successor delta is stale (superseded by a newer publish, request, or close)",
+            ));
+        }
+        let Some((current, snapshot, context, accepted_reads, ledger)) =
+            self.queries.revisioned.current_import_view_state()
+        else {
+            return Err(reject(
+                "no current import-input view backs the successor delta",
+            ));
+        };
+        if current.request_generation != delta.revision.request_generation {
+            return Err(reject(
+                "the successor delta belongs to a different request generation than the current view",
+            ));
+        }
+        // The module delta is the session-owned recorded-additions lineage: the
+        // exact additions each overlay publication recorded since the committed
+        // close. Predecessor byte-identity is enforced where state changes — at
+        // every overlay publication — so nothing is re-derived by scanning
+        // complete views here; this read is O(delta).
+        let mut new_modules: Vec<crate::ModuleRevision> =
+            self.queries.revisioned.lineage_additions().to_vec();
+        new_modules.sort_by(|a, b| a.module.cmp(&b.module));
+        new_modules.dedup();
+        // Every authorized appended module must be present, so the successor can
+        // never omit a demanded trusted module.
+        let new_set: std::collections::BTreeSet<&crate::ModuleId> = new_modules
+            .iter()
+            .map(|revision| &revision.module)
+            .collect();
+        for module in delta.appended.iter() {
+            if !new_set.contains(module) {
+                return Err(reject(
+                    "the successor omits an authorized appended module; it must contain every demanded trusted module",
+                ));
+            }
+        }
+        Ok(SuccessorState {
+            snapshot,
+            context,
+            accepted_reads,
+            ledger,
+            revision: current,
+            delta: new_modules.into(),
+        })
+    }
+
+    /// Stage a strictly-additive trusted-toolchain successor (RUE-1112). The
+    /// staged snapshot, context, provenance, and carried ledger are the CURRENT
+    /// compiler-published view's own state, and the module delta is derived and
+    /// verified from the opaque `delta` capability — the caller supplies nothing
+    /// but the capability. The plan reuses the committed predecessor plan's
+    /// request groups and constructs groups only for the delta's import
+    /// occurrences, so predecessor occurrences are never re-staged.
+    pub(crate) fn stage_import_discovery_successor(
+        &mut self,
+        delta: &TrustedSuccessorDelta,
+    ) -> Result<crate::ImportDiscoveryPlan, CompileErrors> {
+        let state = self.derive_successor_state(delta)?;
+        self.stage_import_discovery_inner(
+            &state.snapshot,
+            state.context,
+            state.accepted_reads,
+            state.ledger,
+            Some((state.revision, state.delta)),
+        )
+    }
+
+    fn stage_import_discovery_inner(
+        &mut self,
+        snapshot: &SourceSnapshot,
+        context: crate::ImportDiscoveryContext,
+        accepted_reads: crate::AcceptedReadManifest,
+        carried_ledger: crate::ImportObservationLedger,
+        successor: Option<(crate::ImportInputRevision, Arc<[crate::ModuleRevision]>)>,
+    ) -> Result<crate::ImportDiscoveryPlan, CompileErrors> {
+        let new_module_ids: Option<Vec<crate::ModuleId>> = successor.as_ref().map(|(_, delta)| {
+            delta
+                .iter()
+                .map(|revision| revision.module.clone())
+                .collect()
+        });
+        let new_modules: Option<&[crate::ModuleId]> = new_module_ids.as_deref();
         let continuation = self.open_discovery.as_deref().filter(|attempt| {
             continues_discovery_lifecycle(
                 attempt,
@@ -3021,12 +3600,22 @@ impl CompilerSession {
         // failure. Reinstall protocol context only if staging reaches Open.
         self.open_discovery = None;
         let source_revision = snapshot.source_revision().clone();
-        let plan_key = ImportPlanQueryKey {
-            source: ExactSourceInput::new(snapshot),
-            context: context.clone(),
-            policy_version: crate::IMPORT_DISCOVERY_POLICY_VERSION,
-            accepted_reads: accepted_reads.clone(),
-            carried_ledger: carried_ledger.clone(),
+        // A successor stage keys on {published lineage identity, exact delta}
+        // rather than re-hashing the full content; the ordinary path keeps its
+        // exact content key and therefore its warm reuse.
+        let plan_key = match &successor {
+            Some((revision, delta)) => ImportPlanQueryKey::Successor {
+                revision: *revision,
+                delta: delta.clone(),
+                policy_version: crate::IMPORT_DISCOVERY_POLICY_VERSION,
+            },
+            None => ImportPlanQueryKey::Ordinary(Box::new(OrdinaryImportPlanKey {
+                source: ExactSourceInput::new(snapshot),
+                context: context.clone(),
+                policy_version: crate::IMPORT_DISCOVERY_POLICY_VERSION,
+                accepted_reads: accepted_reads.clone(),
+                carried_ledger: carried_ledger.clone(),
+            })),
         };
         let (plan_dependency, publish_plan) = self.select_import_plan_query(plan_key.clone());
         if let Err(errors) = validate_accepted_read_manifest(snapshot, &accepted_reads) {
@@ -3051,6 +3640,7 @@ impl CompilerSession {
                 graph: None,
                 diagnostics: errors.clone(),
                 diagnostic_snapshot: Some(diagnostic_snapshot),
+                successor_parse: None,
             });
             self.publish_import_plan_query(
                 plan_key,
@@ -3066,7 +3656,12 @@ impl CompilerSession {
             );
             return Err(errors);
         }
-        let (parse_result, staged_work) = self.parse_staging_snapshot(snapshot);
+        let (parse_result, staged_work, staged_successor_parse) = self.parse_staging_snapshot(
+            snapshot,
+            successor
+                .as_ref()
+                .map(|(revision, delta)| (*revision, delta)),
+        );
         parse_work.accumulate(staged_work);
         let program = match parse_result {
             Ok(program) => program,
@@ -3092,6 +3687,7 @@ impl CompilerSession {
                     graph: None,
                     diagnostics: errors.clone(),
                     diagnostic_snapshot: Some(diagnostic_snapshot),
+                    successor_parse: None,
                 });
                 self.publish_import_plan_query(
                     plan_key,
@@ -3108,7 +3704,37 @@ impl CompilerSession {
                 return Err(errors);
             }
         };
-        let plan = match crate::ImportDiscoveryPlan::new(&program, context.clone()) {
+        // A trusted-toolchain successor stage reuses the committed predecessor
+        // plan's request groups and constructs groups only for the newly appended
+        // modules' occurrences; predecessor occurrences are never re-staged. When
+        // no predecessor plan is retained (an unexpected legacy state) it falls
+        // back to a full build so the plan is always complete.
+        let predecessor_plan = new_modules.and_then(|_| {
+            self.last_good_discovery_artifact()
+                .and_then(|artifact| artifact.plan.clone())
+        });
+        let plan_build = match (new_modules, predecessor_plan) {
+            (Some(new_modules), Some(predecessor)) => {
+                crate::ImportDiscoveryPlan::extend_trusted_successor(
+                    &predecessor,
+                    &program,
+                    context.clone(),
+                    new_modules,
+                )
+                .map(|(plan, constructed)| {
+                    self.import_plan_groups_constructed = self
+                        .import_plan_groups_constructed
+                        .saturating_add(constructed);
+                    plan
+                })
+            }
+            _ => crate::ImportDiscoveryPlan::new(&program, context.clone()).inspect(|plan| {
+                self.import_plan_groups_constructed = self
+                    .import_plan_groups_constructed
+                    .saturating_add(plan.groups().len() as u64);
+            }),
+        };
+        let plan = match plan_build {
             Ok(plan) => plan,
             Err(error) => {
                 let errors = CompileErrors::from(error);
@@ -3133,6 +3759,7 @@ impl CompilerSession {
                     graph: None,
                     diagnostics: errors.clone(),
                     diagnostic_snapshot: Some(diagnostic_snapshot),
+                    successor_parse: None,
                 });
                 self.publish_import_plan_query(
                     plan_key,
@@ -3191,6 +3818,7 @@ impl CompilerSession {
             graph: None,
             diagnostics: CompileErrors::new(),
             diagnostic_snapshot: None,
+            successor_parse: staged_successor_parse,
         }));
         Ok(plan)
     }
@@ -3207,7 +3835,7 @@ impl CompilerSession {
         &mut self,
         ledger: crate::ImportObservationLedger,
     ) -> Result<Arc<crate::ImportDiscoveryView>, CompileErrors> {
-        self.close_import_discovery_artifact(ledger)
+        self.close_import_discovery_artifact(ledger, None)
             .map(|artifact| Arc::new(crate::ImportDiscoveryView::new(artifact)))
     }
 
@@ -3216,13 +3844,40 @@ impl CompilerSession {
         &mut self,
         ledger: crate::ImportObservationLedger,
     ) -> Result<Arc<ImportDiscoveryRevisionArtifact>, CompileErrors> {
-        self.close_import_discovery_artifact(ledger)
+        self.close_import_discovery_artifact(ledger, None)
+    }
+
+    /// Close a strictly-additive trusted-toolchain successor (RUE-1112). The
+    /// closing ledger is the CURRENT compiler-published view's own carried
+    /// ledger and the module delta is derived from the opaque capability — the
+    /// caller supplies nothing but the capability, so no replacement ledger or
+    /// module set can be substituted. The close projects and reduces only the
+    /// delta occurrences and merges them into the committed predecessor's closed
+    /// graph, never re-projecting or re-reducing predecessor occurrences.
+    pub(crate) fn close_import_discovery_successor(
+        &mut self,
+        delta: &TrustedSuccessorDelta,
+    ) -> Result<Arc<ImportDiscoveryRevisionArtifact>, CompileErrors> {
+        let state = self.derive_successor_state(delta)?;
+        let closed = self
+            .close_import_discovery_artifact(state.ledger, Some((state.revision, state.delta)))?;
+        // Consume the single-use delta authority only on a successful close.
+        self.successor_delta_nonce = None;
+        Ok(closed)
     }
 
     fn close_import_discovery_artifact(
         &mut self,
         ledger: crate::ImportObservationLedger,
+        successor: Option<(crate::ImportInputRevision, Arc<[crate::ModuleRevision]>)>,
     ) -> Result<Arc<ImportDiscoveryRevisionArtifact>, CompileErrors> {
+        let new_module_ids: Option<Vec<crate::ModuleId>> = successor.as_ref().map(|(_, delta)| {
+            delta
+                .iter()
+                .map(|revision| revision.module.clone())
+                .collect()
+        });
+        let new_modules: Option<&[crate::ModuleId]> = new_module_ids.as_deref();
         let open = self
             .open_discovery
             .as_deref()
@@ -3239,7 +3894,26 @@ impl CompilerSession {
             .as_ref()
             .expect("open discovery attempt retains its program")
             .clone();
-        let roots = crate::ImportDemandRoots::whole_plan(&plan);
+        // A trusted-toolchain successor close carries the committed predecessor's
+        // closed graph and projects/reduces only the newly appended modules'
+        // occurrences. When no predecessor graph is retained it falls back to a
+        // full close so the committed graph is always complete.
+        let new_module_set: Option<std::collections::BTreeSet<crate::ModuleId>> =
+            new_modules.map(|modules| modules.iter().cloned().collect());
+        let predecessor_graph = new_modules.and_then(|_| {
+            self.last_good_discovery_artifact()
+                .and_then(|artifact| artifact.graph.clone())
+        });
+        let narrow = match (new_module_set, predecessor_graph) {
+            (Some(set), Some(graph)) => Some((set, graph)),
+            _ => None,
+        };
+        // A successor projects only the delta occurrences, derived directly from
+        // the plan's delta segment — never by filtering the merged plan.
+        let roots = match &narrow {
+            Some(_) => plan.delta_roots(),
+            None => crate::ImportDemandRoots::whole_plan(&plan),
+        };
         let exact_groups = match self.queries.revisioned.current_import_revision() {
             Some(revision) => match self
                 .queries
@@ -3253,6 +3927,7 @@ impl CompilerSession {
                         open,
                         plan,
                         ledger,
+                        successor.as_ref(),
                         ImportDiscoveryRevisionStatus::ClosedAttempted,
                         None,
                         &errors,
@@ -3265,21 +3940,61 @@ impl CompilerSession {
             // groups until that entire public boundary is removed together.
             None => plan.groups().to_vec(),
         };
+        // The predecessor ledger portion was validated at the predecessor close;
+        // a successor close validates and reduces only the newly appended
+        // occurrences' observations. Those observations are gathered directly from
+        // the plan's delta groups (O(delta)), never by scanning the full carried
+        // ledger. The full `ledger` is still what the committed artifact carries.
+        let narrow_ledger = match &narrow {
+            Some(_) => {
+                let new_observations = plan
+                    .delta_groups()
+                    .iter()
+                    .flat_map(|group| group.iter())
+                    .filter_map(|request| ledger.get(request).cloned())
+                    .collect::<Vec<_>>();
+                let mut filtered = crate::ImportObservationLedger::default();
+                let mut record_error = None;
+                for observation in new_observations {
+                    if let Err(error) = filtered.record(observation) {
+                        record_error = Some(error);
+                        break;
+                    }
+                }
+                if let Some(error) = record_error {
+                    let errors = CompileErrors::from(error);
+                    self.publish_failed_import_attempt(
+                        open,
+                        plan,
+                        ledger,
+                        successor.as_ref(),
+                        ImportDiscoveryRevisionStatus::ClosedAttempted,
+                        None,
+                        &errors,
+                    );
+                    return Err(errors);
+                }
+                Some(filtered)
+            }
+            None => None,
+        };
+        let check_ledger = narrow_ledger.as_ref().unwrap_or(&ledger);
         if let Err(error) =
-            crate::import_discovery::validate_exact_import_ledger(&exact_groups, &ledger)
+            crate::import_discovery::validate_exact_import_ledger(&exact_groups, check_ledger)
         {
             let errors = CompileErrors::from(error);
             self.publish_failed_import_attempt(
                 open,
                 plan,
                 ledger,
+                successor.as_ref(),
                 ImportDiscoveryRevisionStatus::ClosedAttempted,
                 None,
                 &errors,
             );
             return Err(errors);
         }
-        if !crate::import_discovery::exact_import_pending_requests(&exact_groups, &ledger)
+        if !crate::import_discovery::exact_import_pending_requests(&exact_groups, check_ledger)
             .is_empty()
         {
             let errors =
@@ -3291,19 +4006,24 @@ impl CompilerSession {
                 open,
                 plan,
                 ledger,
+                successor.as_ref(),
                 ImportDiscoveryRevisionStatus::ClosedAttempted,
                 None,
                 &errors,
             );
             return Err(errors);
         }
-        let diagnostics =
-            crate::import_discovery::exact_import_diagnostics(&program, &exact_groups, &ledger);
-        if crate::import_discovery::exact_import_has_failures(&exact_groups, &ledger) {
+        let diagnostics = crate::import_discovery::exact_import_diagnostics(
+            &program,
+            &exact_groups,
+            check_ledger,
+        );
+        if crate::import_discovery::exact_import_has_failures(&exact_groups, check_ledger) {
             self.publish_failed_import_attempt(
                 open,
                 plan,
                 ledger,
+                successor.as_ref(),
                 ImportDiscoveryRevisionStatus::ClosedAttempted,
                 None,
                 &diagnostics,
@@ -3311,17 +4031,38 @@ impl CompilerSession {
             return Err(diagnostics);
         }
 
-        let resolution = match ModuleResolutionInputs::new(
-            program.root().clone(),
-            program
-                .modules()
-                .iter()
-                .map(|module| crate::ModuleResolutionInput {
-                    module: module.module_id().clone(),
-                    physical_path: Arc::from(module.physical_path()),
-                })
-                .collect(),
-        ) {
+        // A successor shares the committed predecessor's module-resolution table
+        // by reference and appends only the delta modules (looked up by identity),
+        // so the complete table is never reconstructed or re-sorted. A full close
+        // builds the whole table.
+        let resolution_build = match &narrow {
+            Some((set, predecessor)) => {
+                let delta: Vec<crate::ModuleResolutionInput> = set
+                    .iter()
+                    .filter_map(|module_id| program.module(module_id))
+                    .map(|module| crate::ModuleResolutionInput {
+                        module: module.module_id().clone(),
+                        physical_path: Arc::from(module.physical_path()),
+                    })
+                    .collect();
+                crate::ModuleResolutionInputs::extend_successor(
+                    &predecessor.input().resolution,
+                    delta,
+                )
+            }
+            None => crate::ModuleResolutionInputs::new(
+                program.root().clone(),
+                program
+                    .modules()
+                    .iter()
+                    .map(|module| crate::ModuleResolutionInput {
+                        module: module.module_id().clone(),
+                        physical_path: Arc::from(module.physical_path()),
+                    })
+                    .collect(),
+            ),
+        };
+        let resolution = match resolution_build {
             Ok(resolution) => resolution,
             Err(error) => {
                 let errors = CompileErrors::from(error);
@@ -3329,6 +4070,7 @@ impl CompilerSession {
                     open,
                     plan,
                     ledger,
+                    successor.as_ref(),
                     ImportDiscoveryRevisionStatus::ClosedAttempted,
                     None,
                     &errors,
@@ -3341,10 +4083,13 @@ impl CompilerSession {
             resolution,
             std_dir: open.context.std_root().map(Arc::from),
         };
+        // Reduce only the projected occurrences: the whole plan for a full close,
+        // or exactly the newly appended modules' occurrences for a trusted-toolchain
+        // successor. `reduced` therefore holds the new records in successor mode.
         let reduced = match crate::import_discovery::reduce_exact_import_graph(
             program.root().clone(),
             &exact_groups,
-            &ledger,
+            check_ledger,
             &open.accepted_reads,
         ) {
             Ok(graph) => graph,
@@ -3354,6 +4099,7 @@ impl CompilerSession {
                     open,
                     plan,
                     ledger,
+                    successor.as_ref(),
                     ImportDiscoveryRevisionStatus::ClosedAttempted,
                     None,
                     &errors,
@@ -3361,7 +4107,38 @@ impl CompilerSession {
                 return Err(errors);
             }
         };
-        let validation = validate_canonical_import_graph(&reduced, &input.resolution);
+        self.import_close_records_reduced = self
+            .import_close_records_reduced
+            .saturating_add(reduced.records().len() as u64);
+        // In successor mode, merge the new records into the committed predecessor's
+        // closed graph and validate incrementally (the predecessor topology is
+        // carried, never re-walked). A full close reduces and validates the whole
+        // graph directly.
+        let (reduced, validation) = match &narrow {
+            Some((set, predecessor)) => {
+                // The reduction produced only the delta records; build the
+                // successor graph by structurally sharing the predecessor's record
+                // segment (no predecessor record is copied or re-sorted) and
+                // validate only the delta against the carried predecessor result.
+                let new_records = reduced.records().to_vec();
+                let merged = crate::CanonicalImportGraph::from_additive_successor(
+                    program.root().clone(),
+                    predecessor.graph(),
+                    new_records.clone(),
+                );
+                let validation = crate::validate_additive_successor(
+                    predecessor.validation(),
+                    &new_records,
+                    &input.resolution,
+                    set,
+                );
+                (merged, validation)
+            }
+            None => {
+                let validation = validate_canonical_import_graph(&reduced, &input.resolution);
+                (reduced, validation)
+            }
+        };
         let graph = Arc::new(CanonicalImportGraphOutput {
             input: input.clone(),
             graph: reduced,
@@ -3383,6 +4160,7 @@ impl CompilerSession {
                 open,
                 plan,
                 ledger,
+                successor.as_ref(),
                 ImportDiscoveryRevisionStatus::ClosedAttempted,
                 None,
                 &errors,
@@ -3394,6 +4172,7 @@ impl CompilerSession {
                 open,
                 plan,
                 ledger,
+                successor.as_ref(),
                 ImportDiscoveryRevisionStatus::ClosedAttempted,
                 Some(graph),
                 &diagnostics,
@@ -3405,12 +4184,15 @@ impl CompilerSession {
             &open.snapshot,
             program.clone(),
             open.parse_work,
+            successor.is_some(),
+            open.successor_parse.clone(),
         );
         if let Err(errors) = adoption.into_result() {
             self.publish_failed_import_attempt(
                 open,
                 plan,
                 ledger,
+                successor.as_ref(),
                 ImportDiscoveryRevisionStatus::ClosedAttempted,
                 None,
                 &errors,
@@ -3418,7 +4200,7 @@ impl CompilerSession {
             return Err(errors);
         }
         let (closure_key, closure_dependencies, publish_closure) =
-            self.select_import_closure_query(&open, &plan, &ledger);
+            self.select_import_closure_query(&open, &plan, &ledger, successor.as_ref());
         let diagnostic_snapshot = self.publish_import_diagnostics(
             &open.snapshot,
             Some(open.context.clone()),
@@ -3443,7 +4225,250 @@ impl CompilerSession {
             publish_closure,
         );
         self.open_discovery = None;
+        // A committed close is a lineage boundary: additions recorded before it
+        // belong to the closed graph, so the recorded-additions lineage resets.
+        self.queries.revisioned.clear_lineage_additions();
+        // Record the closed state for a possible trusted-toolchain continuation
+        // (RUE-1112), but only when the canonical begin/frontier/publish
+        // protocol produced a current import-input revision — legacy embedders
+        // that bypass it get no continuation. The state retains everything the
+        // successor verification needs (predecessor snapshot, context, accepted
+        // reads, carried ledger) so the check is record-only, never filesystem.
+        //
+        // The closed state is deliberately NON-AUTHORIZING here (`attached_demands`
+        // is `None`): a close by itself mints no token and authorizes no successor.
+        // Only a subsequent rooted semantic park attaches its exact missing-demand
+        // set to this same state, so a later close whose attempt never parks can
+        // never inherit an earlier park's authority.
+        self.continuation = self
+            .queries
+            .revisioned
+            .current_import_revision()
+            .map(|revision| {
+                self.next_continuation_nonce += 1;
+                ContinuationState {
+                    nonce: self.next_continuation_nonce,
+                    revision,
+                    snapshot: artifact.snapshot().clone(),
+                    accepted_reads: artifact.accepted_read_manifest().clone(),
+                    ledger: artifact.ledger().clone(),
+                    attached_demands: None,
+                }
+            });
         Ok(artifact)
+    }
+
+    /// Mint the trusted-toolchain continuation token for the current successful
+    /// import-discovery close, if one is outstanding AND authorizing (RUE-1112).
+    /// A closed state becomes authorizing only once a rooted semantic park
+    /// has attached its exact missing-demand set; a close whose attempt is ready
+    /// (or never parked) mints no token. The token is opaque and single-use; the
+    /// host hands it back to [`Self::publish_trusted_toolchain_successor`].
+    pub(crate) fn closed_discovery_continuation(&self) -> Option<ClosedDiscoveryContinuation> {
+        self.continuation
+            .as_ref()
+            .filter(|state| state.attached_demands.is_some())
+            .map(|state| ClosedDiscoveryContinuation {
+                session: self.identity.clone(),
+                nonce: state.nonce,
+                revision: state.revision,
+            })
+    }
+
+    /// Publish exactly one strictly-additive trusted-toolchain successor on the
+    /// continuation's closed revision (RUE-1112).
+    ///
+    /// The host has already done all filesystem work through the B4-hardened
+    /// path — read each demanded module, checked containment/manifest/stable-read
+    /// provenance, assembled the successor snapshot and accepted-read records.
+    /// This verifies that work purely from records (no filesystem access) by
+    /// diffing the successor against the continuation's predecessor, then
+    /// publishes in the SAME request generation carrying the predecessor ledger
+    /// unchanged. The added leaves carry no observation in the predecessor
+    /// ledger yet; discovery of the `@import` edges they introduce (a trusted
+    /// leaf such as `strbuf.rue` imports `option.rue`/`arraybuf.rue`/`rawbuf.rue`)
+    /// is the driver's subsequent re-close, which roots its frontier only in
+    /// these new leaves.
+    ///
+    /// Returns the successor revision together with the exact set of module IDs
+    /// it appended (the verified `added == demanded` set). The re-close uses that
+    /// set as the sole discovery frontier roots, so the predecessor import
+    /// topology is never re-rooted or re-resolved.
+    pub(crate) fn publish_trusted_toolchain_successor(
+        &mut self,
+        token: ClosedDiscoveryContinuation,
+        issued_frontier: &crate::ImportDemandFrontier,
+        successor: &SourceSnapshot,
+        accepted_reads: crate::AcceptedReadManifest,
+    ) -> Result<TrustedSuccessorDelta, CompileErrors> {
+        let reject = |message: &str| {
+            CompileErrors::from(crate::CompileError::without_span(
+                rue_error::ErrorKind::InvalidCompilerInput(format!(
+                    "trusted-toolchain successor rejected: {message}"
+                )),
+            ))
+        };
+
+        // Same session.
+        if !Arc::ptr_eq(&token.session, &self.identity) {
+            return Err(reject("continuation token belongs to a different session"));
+        }
+        // Token current + unused. Peek without consuming so a rejected batch
+        // leaves the token valid for a corrected retry; only a successful publish
+        // consumes it (a reused token then finds no outstanding state).
+        let state = match self.continuation.as_ref() {
+            Some(state) if token.nonce == state.nonce && token.revision == state.revision => {
+                state.clone()
+            }
+            Some(_) => {
+                return Err(reject(
+                    "continuation token is stale (superseded by a newer close or request)",
+                ));
+            }
+            None => {
+                return Err(reject(
+                    "no outstanding closed-discovery continuation; the token was already used or invalidated",
+                ));
+            }
+        };
+
+        // The closure witness: the empty rooted frontier of the token's closed
+        // revision. Only a genuinely-closed predecessor may continue.
+        if issued_frontier.mode() != crate::ImportDemandMode::Rooted {
+            return Err(reject("the closure witness frontier must be rooted"));
+        }
+        if issued_frontier.revision() != state.revision {
+            return Err(reject(
+                "the closure witness frontier does not belong to the continuation's revision",
+            ));
+        }
+        if !issued_frontier.requests().is_empty() {
+            return Err(reject(
+                "the closure witness frontier is not empty; the predecessor did not close",
+            ));
+        }
+
+        // Same compilation root (the context/read policy is carried unchanged
+        // into the successor below).
+        if successor.source_revision().root() != state.snapshot.source_revision().root() {
+            return Err(reject("the successor changed the compilation root"));
+        }
+
+        // Strict additive source evolution: every predecessor module revision
+        // must appear byte-identical in the successor; the additions are exactly
+        // the new leaves.
+        let old_modules: std::collections::BTreeSet<&crate::ModuleRevision> =
+            state.snapshot.source_revision().modules().iter().collect();
+        let new_modules: std::collections::BTreeSet<&crate::ModuleRevision> =
+            successor.source_revision().modules().iter().collect();
+        if !old_modules.is_subset(&new_modules) {
+            return Err(reject(
+                "a predecessor module revision was mutated or removed (source evolution must be strictly additive)",
+            ));
+        }
+        let additions: Vec<&crate::ModuleRevision> =
+            new_modules.difference(&old_modules).copied().collect();
+        if additions.is_empty() {
+            return Err(reject(
+                "a trusted-toolchain successor must add at least one leaf",
+            ));
+        }
+
+        // Every predecessor accepted-read entry must appear byte-identical in the
+        // successor manifest (altered old provenance rejected).
+        let new_reads: std::collections::HashSet<&crate::AcceptedReadManifestEntry> =
+            accepted_reads.iter().collect();
+        for old in state.accepted_reads.iter() {
+            if !new_reads.contains(old) {
+                return Err(reject(
+                    "a predecessor accepted-read provenance entry was altered or removed",
+                ));
+            }
+        }
+
+        // Demand authority lives only in the attached park set. A close whose
+        // rooted attempt never parked is non-authorizing: it may not consume the
+        // token or admit any leaf, so a later ready close can never reuse an
+        // earlier park's demands.
+        let Some(attached_demands) = state.attached_demands.as_ref() else {
+            return Err(reject(
+                "the closed continuation is not authorizing; no rooted semantic park has attached a demanded-module set",
+            ));
+        };
+
+        // Every addition is a trusted standard-library leaf with well-formed
+        // accepted-read provenance in the successor manifest.
+        for addition in &additions {
+            if !addition.module.is_trusted_standard_library() {
+                return Err(reject(
+                    "an added leaf is not a trusted standard-library module",
+                ));
+            }
+            if !accepted_reads
+                .iter()
+                .any(|entry| entry.module() == &addition.module)
+            {
+                return Err(reject(
+                    "an added trusted leaf has no accepted-read provenance",
+                ));
+            }
+        }
+
+        // The successor's added module-ID set must EQUAL the park's demanded
+        // missing set — set equality, not per-member membership. This enforces
+        // the one-park/one-batched-successor contract in both directions: an
+        // arbitrary or uninvited module (added ⊄ demanded) is rejected, and a
+        // partial batch that omits a demanded member (demanded ⊄ added) is
+        // rejected WITHOUT consuming the single-use token (the peek above only
+        // consumes on the successful publish below).
+        let demanded: std::collections::BTreeSet<crate::ModuleId> = attached_demands
+            .iter()
+            .map(|demand| demand.trusted_module_id())
+            .collect::<Result<_, _>>()
+            .map_err(CompileErrors::from)?;
+        let added: std::collections::BTreeSet<crate::ModuleId> = additions
+            .iter()
+            .map(|addition| addition.module.clone())
+            .collect();
+        if added != demanded {
+            return Err(reject(
+                "the successor's added trusted modules must equal the rooted park's demanded missing set exactly (one park, one batched successor)",
+            ));
+        }
+
+        // Publish the strictly-additive successor in the SAME request generation
+        // as a sparse overlay over the predecessor view: the carried ledger and
+        // topology are inherited unchanged, only the verified added leaves'
+        // source/provenance leaves are published, and the overlay re-derives the
+        // additions from the published parent view (they must equal `added`).
+        let published = self
+            .queries
+            .revisioned
+            .publish_trusted_successor_view(
+                state.revision,
+                successor,
+                accepted_reads,
+                state.ledger.clone(),
+                &added,
+                state.revision.frontier_round + 1,
+            )
+            .map_err(CompileErrors::from)?;
+        // Consume the single-use continuation only on success.
+        self.continuation = None;
+        // Mint the opaque successor-delta authority from the VERIFIED `added`
+        // set (equal to the park's demanded missing set). `BTreeSet` iteration is
+        // sorted, so the appended roots are deterministic. The host receives only
+        // this opaque value; it cannot inspect or edit the module identities.
+        let appended: Arc<[crate::ModuleId]> = added.into_iter().collect::<Vec<_>>().into();
+        self.next_continuation_nonce += 1;
+        let nonce = self.next_continuation_nonce;
+        self.successor_delta_nonce = Some(nonce);
+        Ok(TrustedSuccessorDelta {
+            session: self.identity.clone(),
+            nonce,
+            revision: published,
+            appended,
+        })
     }
 
     fn publish_failed_import_attempt(
@@ -3451,13 +4476,14 @@ impl CompilerSession {
         open: ImportDiscoveryRevisionArtifact,
         plan: crate::ImportDiscoveryPlan,
         ledger: crate::ImportObservationLedger,
+        successor: Option<&(crate::ImportInputRevision, Arc<[crate::ModuleRevision]>)>,
         status: ImportDiscoveryRevisionStatus,
         graph: Option<Arc<CanonicalImportGraphOutput>>,
         errors: &CompileErrors,
     ) -> Arc<ImportDiscoveryRevisionArtifact> {
         debug_assert_ne!(status, ImportDiscoveryRevisionStatus::ClosedValid);
         let (closure_key, closure_dependencies, publish_closure) =
-            self.select_import_closure_query(&open, &plan, &ledger);
+            self.select_import_closure_query(&open, &plan, &ledger, successor);
         let diagnostic_snapshot = self.publish_import_diagnostics(
             &open.snapshot,
             Some(open.context.clone()),
@@ -3568,13 +4594,13 @@ impl CompilerSession {
                 .batch_diagnostic_order
                 .as_ref()
                 .map_or(DiagnosticAttemptProvenance::Canonical, |order| {
-                    DiagnosticAttemptProvenance::Presentation(order.clone().into())
+                    DiagnosticAttemptProvenance::Presentation(order.clone())
                 }),
             FrontendDiagnosticIdentity::Merge if errors.is_some() => self
                 .batch_diagnostic_order
                 .as_ref()
                 .map_or(DiagnosticAttemptProvenance::Canonical, |order| {
-                    DiagnosticAttemptProvenance::Presentation(order.clone().into())
+                    DiagnosticAttemptProvenance::Presentation(order.clone())
                 }),
             FrontendDiagnosticIdentity::Merge => DiagnosticAttemptProvenance::Canonical,
             FrontendDiagnosticIdentity::Import(_)
@@ -3619,7 +4645,7 @@ impl CompilerSession {
         context: Option<crate::ImportDiscoveryContext>,
         plan: Option<crate::ImportDiscoveryPlan>,
         ledger: crate::ImportObservationLedger,
-        accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
+        accepted_reads: crate::AcceptedReadManifest,
         errors: &CompileErrors,
     ) -> Arc<FrontendDiagnosticSnapshot> {
         let input = ImportDiagnosticInputDescriptor {
@@ -3716,6 +4742,12 @@ impl CompilerSession {
         {
             self.supplied_test_import_graph = None;
         }
+        // A source update supersedes the predecessor any outstanding
+        // trusted-toolchain continuation or successor-delta authority was
+        // issued against (RUE-1112): a stale capability can neither stage nor
+        // close over an artifact the update replaced.
+        self.continuation = None;
+        self.successor_delta_nonce = None;
         self.select_diagnostic_presentation(None);
         let provenance = self.syntax_diagnostic_provenance();
         self.run_parse_update(snapshot, provenance)
@@ -3734,12 +4766,18 @@ impl CompilerSession {
         {
             self.supplied_test_import_graph = None;
         }
-        self.select_diagnostic_presentation(Some(
+        // A presentation update replaces the retained parse artifact exactly
+        // like a source update, so it likewise supersedes any outstanding
+        // trusted-toolchain continuation or successor-delta authority
+        // (RUE-1112).
+        self.continuation = None;
+        self.successor_delta_nonce = None;
+        self.select_diagnostic_presentation(Some(crate::shared_segments::SharedList::flat(
             snapshot
                 .files()
                 .map(|source| snapshot.module_id(source.file_id).unwrap().clone())
                 .collect(),
-        ));
+        )));
         let provenance = self.syntax_diagnostic_provenance();
         self.run_parse_update(snapshot, provenance)
     }
@@ -3749,17 +4787,52 @@ impl CompilerSession {
         snapshot: &SourceSnapshot,
         _program: Arc<ParsedProgram>,
         _work: ParsedModulesWork,
+        successor: bool,
+        retained_successor_parse: Option<ParseQueryRecord>,
     ) -> CompilerSessionUpdate {
         #[cfg(test)]
         {
             self.supplied_test_import_graph = None;
         }
-        self.select_diagnostic_presentation(Some(
+        // A trusted-successor close adopts by RE-SELECTING the exact successor
+        // parse terminal its stage computed and retained on the open artifact
+        // — same key, same revision — never by re-deriving an extension
+        // against the now-selected successor state (which would mint a second
+        // empty-extension terminal). A missing retained terminal rejects the
+        // close.
+        if successor {
+            return match retained_successor_parse {
+                Some(record) => self.run_parse_update_successor(snapshot, record),
+                None => {
+                    let errors = CompileErrors::from(CompileError::without_span(
+                        ErrorKind::InvalidCompilerInput(
+                            "trusted-toolchain successor close rejected: the staged successor parse terminal is not retained".into(),
+                        ),
+                    ));
+                    let diagnostics = Arc::new(FrontendDiagnosticSnapshot {
+                        source: snapshot.clone(),
+                        stage: FrontendDiagnosticIdentity::Syntax,
+                        provenance: DiagnosticAttemptProvenance::Canonical,
+                        errors: errors.as_slice().to_vec().into(),
+                        warnings: Arc::from([]),
+                    });
+                    CompilerSessionUpdate {
+                        result: Err(errors),
+                        work: ParsedModulesWork::default(),
+                        #[cfg(test)]
+                        invalidation: ParseInvalidationSummary::default(),
+                        downstream_invalidated: false,
+                        diagnostics,
+                    }
+                }
+            };
+        }
+        self.select_diagnostic_presentation(Some(crate::shared_segments::SharedList::flat(
             snapshot
                 .files()
                 .map(|source| snapshot.module_id(source.file_id).unwrap().clone())
                 .collect(),
-        ));
+        )));
         let provenance = self.syntax_diagnostic_provenance();
         self.run_parse_update(snapshot, provenance)
     }
@@ -3782,11 +4855,14 @@ impl CompilerSession {
         self.batch_diagnostic_order
             .as_ref()
             .map_or(DiagnosticAttemptProvenance::Canonical, |order| {
-                DiagnosticAttemptProvenance::Presentation(order.clone().into())
+                DiagnosticAttemptProvenance::Presentation(order.clone())
             })
     }
 
-    fn select_diagnostic_presentation(&mut self, order: Option<Vec<crate::ModuleId>>) {
+    fn select_diagnostic_presentation(
+        &mut self,
+        order: Option<crate::shared_segments::SharedList<crate::ModuleId>>,
+    ) {
         self.batch_diagnostic_order = order;
     }
 
@@ -3803,7 +4879,12 @@ impl CompilerSession {
         ParseInvalidationSummary,
     ) {
         let source = ExactSourceInput::new(snapshot);
-        let key = ParseQueryKey {
+        // An ordinary key carries every file's exact content identity, so the
+        // typed store hashes and compares each of them.
+        self.parse_key_entries_compared = self
+            .parse_key_entries_compared
+            .saturating_add(snapshot.len() as u64);
+        let key = ParseQueryKey::Ordinary(Box::new(OrdinaryParseKey {
             source: source.clone(),
             file_order: snapshot
                 .files()
@@ -3811,7 +4892,7 @@ impl CompilerSession {
                 .collect::<Vec<_>>()
                 .into(),
             presentation: presentation.clone(),
-        };
+        }));
         let revision = self.queries.revisioned.source_revision(&source, snapshot);
         let demanded_modules = match &presentation {
             DiagnosticAttemptProvenance::Canonical => snapshot
@@ -3820,13 +4901,22 @@ impl CompilerSession {
                 .iter()
                 .map(|source| source.module.clone())
                 .collect::<Vec<_>>(),
-            DiagnosticAttemptProvenance::Presentation(order) => order.to_vec(),
+            DiagnosticAttemptProvenance::Presentation(order) => order.iter().cloned().collect(),
         };
+        self.parse_sources_materialized = self
+            .parse_sources_materialized
+            .saturating_add(demanded_modules.len() as u64);
+        self.parse_modules_dispatched = self
+            .parse_modules_dispatched
+            .saturating_add(demanded_modules.len() as u64);
         let (modular_result, modular_work) = self.queries.revisioned.parse_program(
             revision,
             snapshot.source_revision().root(),
             demanded_modules,
         );
+        self.parse_invalidation_entries_compared = self
+            .parse_invalidation_entries_compared
+            .saturating_add(snapshot.len() as u64);
         let prepared = self.queries.revisioned.parse.prepare(key.clone());
         let baseline = self.parse_baseline();
         let attempt = prepared.execute(revision, attempt_id, |context| {
@@ -3842,7 +4932,7 @@ impl CompilerSession {
             let diagnostics = Arc::new(FrontendDiagnosticSnapshot {
                 source: snapshot.clone(),
                 stage: FrontendDiagnosticIdentity::Syntax,
-                provenance: key.presentation.clone(),
+                provenance: presentation.clone(),
                 errors: result
                     .as_ref()
                     .err()
@@ -3898,27 +4988,330 @@ impl CompilerSession {
         (record, view, execution, work, invalidation)
     }
 
+    /// Reconcile one successor parse extension without side effects: the
+    /// retained parse artifact this stage extends (within one trusted re-close,
+    /// the committed predecessor for the first stage and the prior successor
+    /// stage after a frontier batch), its presentation order, and the appended
+    /// (module, file) pairs. The retained artifact must PROVE it is the
+    /// successor snapshot's structural ancestor — every one of its source
+    /// segments carried by `Arc` identity, same root, and its exact
+    /// presentation order — so a parse record from any other snapshot (an
+    /// intervening source or presentation update) can never be extended; the
+    /// capability is rejected instead. Everything here is O(appended); content
+    /// identity is pinned by the published revision, never re-hashed or
+    /// re-compared.
+    fn prepare_successor_parse(
+        &self,
+        snapshot: &SourceSnapshot,
+        delta: &Arc<[crate::ModuleRevision]>,
+    ) -> Result<PreparedSuccessorParse, CompileErrors> {
+        let reject = |message: &str| {
+            CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                format!("trusted-toolchain successor parse rejected: {message}"),
+            )))
+        };
+        let Some(terminal) = self.queries.revisioned.parse.last_good_terminal() else {
+            return Err(reject("no predecessor parse artifact is retained"));
+        };
+        let Ok(predecessor_terminal) = self
+            .queries
+            .revisioned
+            .parse
+            .family_handle()
+            .adoptable_terminal(terminal)
+        else {
+            return Err(reject(
+                "the retained predecessor parse terminal is not adoptable",
+            ));
+        };
+        let rue_query::QueryOutcome::Success(record) = predecessor_terminal.terminal().outcome()
+        else {
+            return Err(reject("the retained predecessor parse artifact failed"));
+        };
+        let Ok(predecessor_program) = record.result.as_ref().cloned() else {
+            return Err(reject("the retained predecessor parse artifact failed"));
+        };
+        let DiagnosticAttemptProvenance::Presentation(predecessor_order) =
+            &record.diagnostics.provenance
+        else {
+            return Err(reject(
+                "the retained parse artifact carries no staging presentation order",
+            ));
+        };
+        let predecessor_order = predecessor_order.clone();
+        let predecessor_revision = record.runtime_revision;
+        // STRUCTURAL ANCESTRY: the successor snapshot must carry every source
+        // segment of the retained artifact's snapshot by `Arc` identity, with
+        // the same root. An artifact retained by an intervening update over a
+        // different or reordered snapshot cannot share this lineage and is
+        // rejected here rather than silently extended.
+        let predecessor_snapshot = record.snapshot.clone();
+        {
+            let successor_segments = snapshot.source_revision().module_segments().segments();
+            let predecessor_segments = predecessor_snapshot
+                .source_revision()
+                .module_segments()
+                .segments();
+            let shared_prefix = successor_segments.len() >= predecessor_segments.len()
+                && successor_segments
+                    .iter()
+                    .zip(predecessor_segments.iter())
+                    .all(|(a, b)| Arc::ptr_eq(a, b));
+            if !shared_prefix
+                || snapshot.source_revision().root()
+                    != predecessor_snapshot.source_revision().root()
+            {
+                return Err(reject(
+                    "the retained parse artifact is not the successor snapshot's structural ancestor",
+                ));
+            }
+        }
+        let predecessor_len = predecessor_program.modules_len();
+        if predecessor_len != predecessor_snapshot.len()
+            || predecessor_order.len() != predecessor_len
+        {
+            return Err(reject(
+                "the retained parse artifact does not cover its own snapshot",
+            ));
+        }
+        // A re-stage whose snapshot appended nothing since the retained parse
+        // (a frontier round that only grew observations) extends with an empty
+        // delta and reuses every retained module.
+        if predecessor_len > snapshot.len() || snapshot.len() - predecessor_len > delta.len() {
+            return Err(reject(
+                "the successor snapshot does not extend the retained parse artifact by the authorized delta",
+            ));
+        }
+        // The appended sources extend the predecessor's dense file table, so
+        // the appended (module, file) pairs are exactly the tail file IDs.
+        let mut appended = Vec::with_capacity(snapshot.len() - predecessor_len);
+        for index in predecessor_len as u32 + 1..=snapshot.len() as u32 {
+            let file_id = crate::FileId::new(index);
+            let Some(module) = snapshot.module_id(file_id) else {
+                return Err(reject("an appended source has no logical module"));
+            };
+            appended.push((module.clone(), file_id));
+        }
+        // Every appended module must be one of the capability-verified delta
+        // modules (the delta is cumulative since the committed close, so a
+        // later stage of one re-close appends a suffix of it).
+        for (module, _) in &appended {
+            if delta
+                .binary_search_by(|revision| revision.module.cmp(module))
+                .is_err()
+            {
+                return Err(reject(
+                    "an appended module is outside the capability-verified delta",
+                ));
+            }
+        }
+        Ok(PreparedSuccessorParse {
+            predecessor_program,
+            predecessor_order,
+            predecessor_revision,
+            predecessor_terminal,
+            appended,
+        })
+    }
+
+    /// The successor parse projection (RUE-1112): keyed on the published
+    /// lineage identity plus the exact appended segment, parsing ONLY the
+    /// appended modules and structurally extending the retained predecessor
+    /// parsed program and presentation order.
+    #[allow(clippy::type_complexity)]
+    fn execute_parse_query_successor(
+        &mut self,
+        snapshot: &SourceSnapshot,
+        revision: crate::ImportInputRevision,
+        delta: &Arc<[crate::ModuleRevision]>,
+        prepared: PreparedSuccessorParse,
+        attempt_id: AttemptId,
+    ) -> (
+        ParseQueryRecord,
+        Arc<dyn AttemptView>,
+        QueryAttemptExecution,
+        ParsedModulesWork,
+        ParseInvalidationSummary,
+    ) {
+        let PreparedSuccessorParse {
+            predecessor_program,
+            predecessor_order,
+            predecessor_revision,
+            predecessor_terminal,
+            appended,
+        } = prepared;
+        let successor_order = crate::shared_segments::SharedList::extend(
+            &predecessor_order,
+            appended.iter().map(|(module, _)| module.clone()).collect(),
+        );
+        self.select_diagnostic_presentation(Some(successor_order.clone()));
+        let presentation = DiagnosticAttemptProvenance::Presentation(successor_order);
+
+        // A successor key embeds only the published lineage identity and its
+        // appended segment.
+        self.parse_key_entries_compared = self
+            .parse_key_entries_compared
+            .saturating_add(delta.len() as u64);
+        let key = ParseQueryKey::Successor {
+            revision,
+            delta: delta.clone(),
+            predecessor: predecessor_revision,
+        };
+        let runtime_revision =
+            rue_query::Revision::new(revision.revision_id, revision.request_generation);
+        self.parse_modules_dispatched = self
+            .parse_modules_dispatched
+            .saturating_add(appended.len() as u64);
+        let (modular_result, modular_work) = self.queries.revisioned.parse_program_extension(
+            runtime_revision,
+            &predecessor_program,
+            &appended,
+        );
+        self.parse_invalidation_entries_compared = self
+            .parse_invalidation_entries_compared
+            .saturating_add(appended.len() as u64);
+        let appended_modules: Vec<crate::ModuleId> =
+            appended.iter().map(|(module, _)| module.clone()).collect();
+        let parse_family = self.queries.revisioned.parse.family_handle();
+        let prepared = self.queries.revisioned.parse.prepare(key.clone());
+        let attempt = prepared.execute(runtime_revision, attempt_id, |context| {
+            // The record adopts the CAPTURED predecessor parse terminal as a
+            // runtime dependency — the exact terminal held by preparation,
+            // observed by node, incarnation, and stamp with no key hash or
+            // content comparison — so successor-after-predecessor is a real
+            // query edge: red/green validation and leases flow through it,
+            // and the node's endorsement at this revision carries the exact
+            // stamp to every compatible descendant. Adoption is sound here
+            // because parse keys are content-addressed: the key alone pins
+            // the terminal's value. A stale or evicted terminal aborts the
+            // attempt rather than being silently re-derived.
+            if parse_family
+                .observe_adopted_terminal(context, &predecessor_terminal)
+                .is_err()
+            {
+                return Err(rue_query::QueryAbort::Canceled);
+            }
+            // Plus exactly the appended modules' input leaves; the remaining
+            // predecessor content is pinned by the dependency above and the
+            // published lineage identity in the key.
+            for (module, _) in &appended {
+                context.input(
+                    crate::revisioned_query_database::RevisionedQueryDatabase::module_source_input(
+                        module,
+                    ),
+                )?;
+            }
+            let work = modular_work;
+            let invalidation =
+                crate::parsed_modules::classify_successor_invalidation(&appended_modules);
+            let result = modular_result;
+            // Freeze diagnostics privately with the query output. Session
+            // selection and metrics happen only after atomic publication.
+            let diagnostics = Arc::new(FrontendDiagnosticSnapshot {
+                source: snapshot.clone(),
+                stage: FrontendDiagnosticIdentity::Syntax,
+                provenance: presentation.clone(),
+                errors: result
+                    .as_ref()
+                    .err()
+                    .map_or_else(|| Arc::from([]), |errors| errors.as_slice().to_vec().into()),
+                warnings: Arc::from([]),
+            });
+            Ok(ParseQueryRecord {
+                key,
+                runtime_revision,
+                snapshot: snapshot.clone(),
+                result,
+                diagnostics,
+                work,
+                invalidation,
+            })
+        });
+        self.queries.revisioned.select_parse(&attempt);
+        let terminal = attempt
+            .terminal()
+            .unwrap_or_else(|| panic!("parse query aborted: {:?}", attempt.abort()));
+        let record = match terminal.outcome() {
+            rue_query::QueryOutcome::Success(record) => record.clone(),
+            rue_query::QueryOutcome::Failure(_) => unreachable!("parse retains typed records"),
+        };
+        let execution = match attempt.execution() {
+            rue_query::RequestExecution::Computed => {
+                self.metrics
+                    .diagnostic_publication(self.diagnostics.latest().is_some());
+                QueryAttemptExecution::Computed
+            }
+            rue_query::RequestExecution::Reused | rue_query::RequestExecution::Joined => {
+                self.reuse_diagnostics(record.diagnostics.clone());
+                QueryAttemptExecution::Reused
+            }
+            rue_query::RequestExecution::Aborted => unreachable!(),
+        };
+        let work = if execution == QueryAttemptExecution::Computed {
+            record.work
+        } else {
+            ParsedModulesWork::default()
+        };
+        // A successor record's classification is relative to the retained
+        // predecessor its key pins, so the reused branch reuses it verbatim.
+        let invalidation = record.invalidation.clone();
+        let view = self.queries.revisioned.parse.attempt_view(
+            attempt_id,
+            attempt,
+            QueryStructuralWork::Parse(work),
+        );
+        self.diagnostics.select(view.clone());
+        (record, view, execution, work, invalidation)
+    }
+
     fn parse_staging_snapshot(
         &mut self,
         snapshot: &SourceSnapshot,
-    ) -> (Result<Arc<ParsedProgram>, CompileErrors>, ParsedModulesWork) {
+        successor: Option<(crate::ImportInputRevision, &Arc<[crate::ModuleRevision]>)>,
+    ) -> (
+        Result<Arc<ParsedProgram>, CompileErrors>,
+        ParsedModulesWork,
+        Option<ParseQueryRecord>,
+    ) {
+        // A successor stage MUST extend its verified predecessor: a failed
+        // predecessor binding rejects the stage rather than silently falling
+        // back to a full content-keyed build under successor authority.
+        let prepared_successor = match successor {
+            Some((revision, delta)) => match self.prepare_successor_parse(snapshot, delta) {
+                Ok(prepared) => Some((revision, delta.clone(), prepared)),
+                Err(errors) => return (Err(errors), ParsedModulesWork::default(), None),
+            },
+            None => None,
+        };
+        let staged_successor = prepared_successor.is_some();
         let mut guard = self.metrics.begin_unprojected("parse");
-        let order = snapshot
-            .files()
-            .map(|source| snapshot.module_id(source.file_id).unwrap().clone())
-            .collect::<Vec<_>>();
-        self.select_diagnostic_presentation(Some(order.clone()));
-        let presentation = DiagnosticAttemptProvenance::Presentation(order.into());
         let attempt_id = guard.id;
-        let (record, view, execution, work, _invalidation) =
-            self.execute_parse_query(snapshot, presentation, attempt_id);
+        let (record, view, execution, work, _invalidation) = match prepared_successor {
+            Some((revision, delta, prepared)) => {
+                self.execute_parse_query_successor(snapshot, revision, &delta, prepared, attempt_id)
+            }
+            None => {
+                let order = snapshot
+                    .files()
+                    .map(|source| snapshot.module_id(source.file_id).unwrap().clone())
+                    .collect::<Vec<_>>();
+                self.parse_sources_materialized = self
+                    .parse_sources_materialized
+                    .saturating_add(order.len() as u64);
+                let order = crate::shared_segments::SharedList::flat(order.into());
+                self.select_diagnostic_presentation(Some(order.clone()));
+                let presentation = DiagnosticAttemptProvenance::Presentation(order);
+                self.execute_parse_query(snapshot, presentation, attempt_id)
+            }
+        };
         guard.started();
         let result = record.result.clone();
         guard.attach_diagnostics(record.diagnostics.clone());
         guard.bind(view);
         guard.finish(execution, None, &result, QueryStructuralWork::None);
         self.metrics.synchronize();
-        (result, work)
+        let retained = staged_successor.then(|| record.clone());
+        (result, work, retained)
     }
 
     fn select_import_plan_query(
@@ -3975,17 +5368,28 @@ impl CompilerSession {
         open: &ImportDiscoveryRevisionArtifact,
         plan: &crate::ImportDiscoveryPlan,
         ledger: &crate::ImportObservationLedger,
+        successor: Option<&(crate::ImportInputRevision, Arc<[crate::ModuleRevision]>)>,
     ) -> (
         ImportClosureQueryKey,
         Vec<crate::query_graph::ObservedDependency>,
         bool,
     ) {
-        let plan_key = ImportPlanQueryKey {
-            source: ExactSourceInput::new(&open.snapshot),
-            context: open.context.clone(),
-            policy_version: crate::IMPORT_DISCOVERY_POLICY_VERSION,
-            accepted_reads: open.accepted_reads.clone(),
-            carried_ledger: open.ledger.clone(),
+        // Reconstruct the exact key the stage published its plan terminal under:
+        // the successor identity key for a successor close, the content key
+        // otherwise.
+        let plan_key = match successor {
+            Some((revision, delta)) => ImportPlanQueryKey::Successor {
+                revision: *revision,
+                delta: delta.clone(),
+                policy_version: crate::IMPORT_DISCOVERY_POLICY_VERSION,
+            },
+            None => ImportPlanQueryKey::Ordinary(Box::new(OrdinaryImportPlanKey {
+                source: ExactSourceInput::new(&open.snapshot),
+                context: open.context.clone(),
+                policy_version: crate::IMPORT_DISCOVERY_POLICY_VERSION,
+                accepted_reads: open.accepted_reads.clone(),
+                carried_ledger: open.ledger.clone(),
+            })),
         };
         let plan_dependency = self
             .queries
@@ -3993,13 +5397,20 @@ impl CompilerSession {
             .handle(&plan_key)
             .expect("an open discovery revision retains its typed plan terminal")
             .observed();
-        let key = ImportClosureQueryKey {
-            source: plan_key.source,
-            context: open.context.clone(),
-            policy_version: crate::IMPORT_DISCOVERY_POLICY_VERSION,
-            accepted_reads: open.accepted_reads.clone(),
-            plan: plan.clone(),
-            ledger: ledger.clone(),
+        let key = match successor {
+            Some((revision, delta)) => ImportClosureQueryKey::Successor {
+                revision: *revision,
+                delta: delta.clone(),
+                policy_version: crate::IMPORT_DISCOVERY_POLICY_VERSION,
+            },
+            None => ImportClosureQueryKey::Ordinary(Box::new(OrdinaryImportClosureKey {
+                source: ExactSourceInput::new(&open.snapshot),
+                context: open.context.clone(),
+                policy_version: crate::IMPORT_DISCOVERY_POLICY_VERSION,
+                accepted_reads: open.accepted_reads.clone(),
+                plan: plan.clone(),
+                ledger: ledger.clone(),
+            })),
         };
         let input_dependency = self
             .queries
@@ -4107,6 +5518,114 @@ impl CompilerSession {
                         downstream_invalidated,
                         diagnostics,
                     }
+                }
+            }
+            Err(errors) => CompilerSessionUpdate {
+                result: Err(errors),
+                work: parse_work,
+                #[cfg(test)]
+                invalidation,
+                downstream_invalidated: false,
+                diagnostics,
+            },
+        }
+    }
+
+    /// The successor-close counterpart of [`Self::run_parse_update`]: adopts
+    /// the successor parse terminal for semantic queries with the same
+    /// publication bookkeeping, without re-running the whole-program
+    /// content-keyed projection (RUE-1112). The candidate extends the retained
+    /// predecessor by construction, so downstream invalidation follows from an
+    /// existing publication rather than a module-table comparison.
+    fn run_parse_update_successor(
+        &mut self,
+        snapshot: &SourceSnapshot,
+        retained: ParseQueryRecord,
+    ) -> CompilerSessionUpdate {
+        let mut guard = self.metrics.begin_unprojected("parse");
+        let attempt_id = guard.id;
+        // Re-request the exact staged terminal: same key, same revision. The
+        // stage's selection protects that terminal, so this reuses it without
+        // publishing anything new; the recompute body republishes the retained
+        // record verbatim only if the terminal were ever evicted.
+        if let ParseQueryKey::Successor { delta, .. } = &retained.key {
+            self.parse_key_entries_compared = self
+                .parse_key_entries_compared
+                .saturating_add(delta.len() as u64);
+        }
+        let key = retained.key.clone();
+        let runtime_revision = retained.runtime_revision;
+        let recompute = retained.clone();
+        let prepared = self.queries.revisioned.parse.prepare(key);
+        let attempt = prepared.execute(runtime_revision, attempt_id, |context| {
+            for module in &recompute.invalidation.added {
+                context.input(
+                    crate::revisioned_query_database::RevisionedQueryDatabase::module_source_input(
+                        module,
+                    ),
+                )?;
+            }
+            Ok(recompute.clone())
+        });
+        self.queries.revisioned.select_parse(&attempt);
+        let terminal = attempt
+            .terminal()
+            .unwrap_or_else(|| panic!("parse query aborted: {:?}", attempt.abort()));
+        let record = match terminal.outcome() {
+            rue_query::QueryOutcome::Success(record) => record.clone(),
+            rue_query::QueryOutcome::Failure(_) => unreachable!("parse retains typed records"),
+        };
+        let execution = match attempt.execution() {
+            rue_query::RequestExecution::Computed => QueryAttemptExecution::Computed,
+            rue_query::RequestExecution::Reused | rue_query::RequestExecution::Joined => {
+                self.reuse_diagnostics(record.diagnostics.clone());
+                QueryAttemptExecution::Reused
+            }
+            rue_query::RequestExecution::Aborted => unreachable!(),
+        };
+        // The stage already accounted this terminal's parse work; re-selecting
+        // it at close performs none.
+        let parse_work = ParsedModulesWork::default();
+        let invalidation = record.invalidation.clone();
+        let view = self.queries.revisioned.parse.attempt_view(
+            attempt_id,
+            attempt,
+            QueryStructuralWork::Parse(parse_work),
+        );
+        self.diagnostics.select(view.clone());
+        guard.started();
+        self.metrics.update(parse_work, invalidation.clone());
+        let result = record.result.clone();
+        let diagnostics = record.diagnostics.clone();
+        guard.attach_diagnostics(diagnostics.clone());
+        guard.bind(view);
+        guard.finish(execution, None, &result, QueryStructuralWork::None);
+        self.metrics.synchronize();
+        match result {
+            Ok(candidate) => {
+                if self.open_discovery.as_deref().is_some_and(|artifact| {
+                    artifact.source_revision != *candidate.source_revision()
+                }) {
+                    self.open_discovery = None;
+                }
+                let downstream_invalidated = self.published.is_some();
+                // The predecessor source leaf stays live: additive adoption
+                // must not disappear it and transitively invalidate every
+                // retained terminal that still correctly depends on it.
+                self.queries
+                    .publish_source_additive(ExactSourceInput::new(snapshot));
+                self.metrics
+                    .project_dependency_invalidations(&self.queries.graph, downstream_invalidated);
+                self.published = Some(candidate.clone());
+                self.published_snapshot = Some(snapshot.clone());
+                self.refresh_retention_metrics();
+                CompilerSessionUpdate {
+                    result: Ok(candidate),
+                    work: parse_work,
+                    #[cfg(test)]
+                    invalidation,
+                    downstream_invalidated,
+                    diagnostics,
                 }
             }
             Err(errors) => CompilerSessionUpdate {
@@ -4301,7 +5820,10 @@ impl CompilerSession {
                     .as_ref()
                     .expect("a published parsed program retains its exact source snapshot"),
             ),
-            presentation: self.batch_diagnostic_order.clone().map(Arc::from),
+            presentation: self
+                .batch_diagnostic_order
+                .as_ref()
+                .map(crate::shared_segments::SharedList::as_arc),
         };
         if let Some((entry, handle)) = self
             .queries
@@ -4389,13 +5911,17 @@ impl CompilerSession {
         guard.accrue(QueryStructuralWork::Merge(
             attempt_work.expect("merge prefix just installed"),
         ));
+        let batch_order = self
+            .batch_diagnostic_order
+            .as_ref()
+            .map(crate::shared_segments::SharedList::as_arc);
         let merged = projected_indexes
             .and_then(|indexes| {
                 merge_parsed_modules_reusing_indexes(
                     &parsed,
                     &indexes,
                     self.definition_shard_baseline.as_ref(),
-                    self.batch_diagnostic_order.as_deref(),
+                    batch_order.as_deref(),
                 )
             })
             .map(Arc::new);
@@ -4635,6 +6161,54 @@ impl CompilerSession {
         {
             Ok(output) => Ok(output),
             Err(SemanticRequestControl::Compile(errors)) => Err(errors),
+            // `canonical_semantic` is a stable no-filesystem entry: it cannot
+            // acquire trusted toolchain modules, so it converts an unsatisfied
+            // park to its own error result at this outer boundary (RUE-1112).
+            // The park-aware host driver uses `semantic_or_toolchain_park`, which
+            // surfaces the park distinctly and retries after acquisition.
+            Err(SemanticRequestControl::Parked(park)) => {
+                Err(unresolved_toolchain_park_errors(&park))
+            }
+            Err(SemanticRequestControl::Abort(abort)) => {
+                panic!("uncanceled semantic request aborted: {abort:?}")
+            }
+        }
+    }
+
+    /// Analyze the current revision, surfacing an unsatisfied trusted-toolchain
+    /// park distinctly instead of converting it to an error (RUE-1112). This
+    /// is the rooted, park-aware entry the host compile driver retries: on
+    /// [`SemanticParkOutcome::Parked`] it acquires exactly the demanded modules,
+    /// publishes a successor, and calls this again.
+    pub(crate) fn semantic_or_toolchain_park(
+        &mut self,
+        options: &CompileOptions,
+    ) -> SemanticParkOutcome {
+        match self
+            .canonical_semantic_with_cancellation(options, rue_query::CancellationToken::new())
+        {
+            Ok(owner) => {
+                let rir = self
+                    .selected_semantic_rir_owner()
+                    .expect("successful semantic query retains its exact RIR terminal");
+                SemanticParkOutcome::Ready(Arc::new(crate::SemanticView::new(owner, rir)))
+            }
+            Err(SemanticRequestControl::Compile(errors)) => SemanticParkOutcome::Errors(errors),
+            Err(SemanticRequestControl::Parked(park)) => {
+                // Atomically attach this rooted park's exact sorted missing-demand
+                // set to the outstanding closed continuation, making it authorizing
+                // (RUE-1112). Demand authority lives only here — bound to this
+                // closed revision and this park — so a later, non-parking close can
+                // never inherit it, and `publish_trusted_toolchain_successor` can
+                // require the successor's added set to EQUAL exactly this set.
+                if let Some(state) = self.continuation.as_mut() {
+                    let mut demands = park.demands().to_vec();
+                    demands.sort();
+                    demands.dedup();
+                    state.attached_demands = Some(Arc::from(demands));
+                }
+                SemanticParkOutcome::Parked(park)
+            }
             Err(SemanticRequestControl::Abort(abort)) => {
                 panic!("uncanceled semantic request aborted: {abort:?}")
             }
@@ -4666,7 +6240,16 @@ impl CompilerSession {
             Ok(result) => result,
             Err(payload) => self.resume_canceled_query(&mut guard, payload),
         };
-        if matches!(result, Err(SemanticRequestControl::Abort(_))) {
+        // A trusted-toolchain park exits the attempt before the body transaction
+        // publishes a terminal, leaving the semantic query in-flight. Clear that
+        // in-flight attempt exactly as an abort would, so the host driver's retry
+        // (after acquiring the demanded module and re-closing on a new revision)
+        // begins a fresh selection instead of colliding with a stale computing
+        // key (RUE-1112).
+        if matches!(
+            result,
+            Err(SemanticRequestControl::Abort(_)) | Err(SemanticRequestControl::Parked(_))
+        ) {
             guard.request_cancel();
         }
         let structural = attempt_record
@@ -5080,6 +6663,16 @@ impl CompilerSession {
                 target: options.target,
                 preview_features: StablePreviewFeatures::new(&options.preview_features),
             };
+            // Plan the trusted-std `Option(payload)` demands once for this
+            // semantic request (RUE-1112). The plan is empty — leaving the
+            // legacy AIR structural scan in force — unless the trusted `Option`
+            // module is present AND the program uses a fallible intrinsic. Each
+            // reached body roots these demands under its own lease below.
+            let well_known_demands = crate::well_known_option::plan_well_known_option_demands(
+                &merged,
+                &rir,
+                &configuration,
+            );
             let mut pending = std::collections::BTreeSet::new();
             for record in prepared_definitions.definitions().definitions() {
                 let stable = record.stable_key();
@@ -5271,6 +6864,25 @@ impl CompilerSession {
                 };
                 body_produced_anonymous.clear();
                 body_query_errors.clear();
+                // RUE-1112: the satisfied trusted-module catalogue for this
+                // revision — the trusted standard-library logical paths already
+                // present in the canonical program. The rooted attempt checks
+                // each reached body's projected toolchain-module demand against
+                // this set and parks the absent ones before running the body.
+                let present_trusted_modules: std::collections::BTreeSet<Arc<str>> = merged
+                    .ast()
+                    .modules()
+                    .iter()
+                    .map(|module| module.module_id())
+                    .filter(|module| module.is_trusted_standard_library())
+                    .map(|module| Arc::<str>::from(module.as_str()))
+                    .collect();
+                // Set when a reached body demands a trusted toolchain module
+                // absent from `present_trusted_modules`. The park is recorded here
+                // (the rooted attempt), carried out of band, and surfaced to the
+                // host driver after the worklist; the demanding body's transaction
+                // never runs on an unsatisfied prerequisite.
+                let mut parked_toolchain: Option<crate::ParkedToolchainModules> = None;
                 while let Some(instance) = priority_pending.pop().or_else(|| pending.pop_first()) {
                     let popped_depth = instance_depth.get(&instance).copied().unwrap_or(0);
                     // Producer-nominal identity is exact: a reached anonymous
@@ -5367,6 +6979,120 @@ impl CompilerSession {
                         instance: instance.clone(),
                         configuration: configuration.clone(),
                     };
+                    // RUE-1112: query THIS reached body's trusted-toolchain
+                    // demand projection (the registered `body-toolchain-demands`
+                    // node over its exact raw body) FIRST, and check the demanded
+                    // modules against the satisfied catalogue. If any demanded
+                    // module is absent from the current revision, record the park
+                    // out of band and stop WITHOUT entering the body transaction:
+                    // only a satisfied prerequisite permits the transaction to run.
+                    // The projection is pure and I/O-free, so this never itself
+                    // reads the filesystem; the host driver acquires the absent
+                    // modules and retries on a successor.
+                    match self.queries.revisioned.body_toolchain_demands(
+                        runtime_revision,
+                        key.clone(),
+                        cancellation.clone(),
+                    ) {
+                        Ok(terminal) => {
+                            let rue_query::QueryOutcome::Success(demand) = terminal.outcome()
+                            else {
+                                unreachable!("BodyToolchainDemands publishes typed values")
+                            };
+                            let mut batch_modules: std::collections::BTreeSet<
+                                crate::TrustedToolchainModuleDemand,
+                            > = demand
+                                .modules()
+                                .iter()
+                                .filter(|module| {
+                                    !present_trusted_modules.contains(module.logical_path())
+                                })
+                                .cloned()
+                                .collect();
+                            if !batch_modules.is_empty() {
+                                // RUE-1112 C2: batch EVERY already-reached body's
+                                // unsatisfied trusted-module demand into ONE park, so
+                                // a single successor acquisition satisfies all of
+                                // them (a parse body needing Option and a read_line
+                                // body needing StrBuf never produce two successors).
+                                // Project the remaining already-reached pending
+                                // bodies WITHOUT entering any transaction, in stable
+                                // order, and union absent modules + requester
+                                // anchors. Bodies not yet discoverable are naturally
+                                // outside this batch — a later park round (the
+                                // driver's retry loop) handles them.
+                                let mut batch_requesters: std::collections::BTreeSet<
+                                    crate::StableDefinitionKey,
+                                > = demand.requester().cloned().into_iter().collect();
+                                let mut remaining: std::collections::BTreeSet<
+                                    crate::FunctionInstanceKey,
+                                > = pending.iter().cloned().collect();
+                                remaining.extend(priority_pending.iter().cloned());
+                                for pending_instance in remaining {
+                                    if visited.contains(&pending_instance) {
+                                        continue;
+                                    }
+                                    let pending_key = crate::body_query::BodyQueryKey {
+                                        instance: pending_instance,
+                                        configuration: configuration.clone(),
+                                    };
+                                    match self.queries.revisioned.body_toolchain_demands(
+                                        runtime_revision,
+                                        pending_key,
+                                        cancellation.clone(),
+                                    ) {
+                                        Ok(pending_terminal) => {
+                                            let rue_query::QueryOutcome::Success(pending_demand) =
+                                                pending_terminal.outcome()
+                                            else {
+                                                unreachable!(
+                                                    "BodyToolchainDemands publishes typed values"
+                                                )
+                                            };
+                                            let mut any_absent = false;
+                                            for module in pending_demand.modules() {
+                                                if !present_trusted_modules
+                                                    .contains(module.logical_path())
+                                                {
+                                                    batch_modules.insert(module.clone());
+                                                    any_absent = true;
+                                                }
+                                            }
+                                            if any_absent
+                                                && let Some(anchor) = pending_demand.requester()
+                                            {
+                                                batch_requesters.insert(anchor.clone());
+                                            }
+                                        }
+                                        // A pending body whose projection cannot yet
+                                        // publish is left for a later park round.
+                                        Err(rue_query::QueryAbort::Canceled)
+                                            if !cancellation.is_canceled() => {}
+                                        Err(abort) => {
+                                            return Err(SemanticRequestControl::Abort(abort));
+                                        }
+                                    }
+                                }
+                                parked_toolchain = Some(crate::ParkedToolchainModules::new(
+                                    batch_modules,
+                                    batch_requesters,
+                                ));
+                                break;
+                            }
+                        }
+                        Err(rue_query::QueryAbort::Canceled) if !cancellation.is_canceled() => {
+                            body_query_errors.insert(
+                                instance.clone(),
+                                crate::CompileErrors::from(crate::CompileError::without_span(
+                                    rue_error::ErrorKind::InternalError(format!(
+                                        "reached body toolchain-demand projection {instance:?} did not publish a terminal"
+                                    )),
+                                )),
+                            );
+                            break;
+                        }
+                        Err(abort) => return Err(SemanticRequestControl::Abort(abort)),
+                    }
                     let producer_body_terminal_required = match &instance {
                         crate::FunctionInstanceKey::AnonymousMember { owner, .. } => {
                             if let crate::TypeInstanceKey::Nominal(
@@ -5394,8 +7120,9 @@ impl CompilerSession {
                         declaration_candidates.clone(),
                         declaration_modules.clone(),
                         producer_body_terminal_required,
+                        well_known_demands.clone(),
                         cancellation.clone(),
-                        |selected_anonymous| {
+                        |selected_anonymous, well_known| {
                             queried_body_work.bodies_attempted += 1;
                             // Every cold reached-body analysis re-prepares,
                             // re-projects, and re-installs the entire declaration
@@ -5441,6 +7168,7 @@ impl CompilerSession {
                                     "body traversal follows a successful declaration projection",
                                 ),
                                 &body_anonymous,
+                                &well_known,
                                 &key,
                                 cancellation,
                                 &mut stage_context,
@@ -5913,6 +7641,15 @@ impl CompilerSession {
                             }
                         }
                     }
+                }
+                // RUE-1112: a reached body demanded an absent trusted
+                // toolchain module. Surface the park to the rooted attempt's
+                // caller WITHOUT publishing a semantic terminal, so the host
+                // driver can acquire the modules and retry on a successor. This
+                // return precedes candidate assembly because the worklist broke
+                // early with an unsatisfied prerequisite.
+                if let Some(park) = parked_toolchain {
+                    return Err(SemanticRequestControl::Parked(Box::new(park)));
                 }
                 durable_body_candidates = queried_ordinary;
                 durable_specialized_body_candidates = queried_specialized;
@@ -8391,7 +10128,7 @@ fn programs_are_pointer_equivalent(left: &ParsedProgram, right: &ParsedProgram) 
 
 fn validate_accepted_read_manifest(
     snapshot: &SourceSnapshot,
-    accepted_reads: &[crate::AcceptedReadManifestEntry],
+    accepted_reads: &crate::AcceptedReadManifest,
 ) -> Result<(), CompileErrors> {
     if accepted_reads.len() != snapshot.len() {
         return Err(CompileErrors::from(CompileError::without_span(
@@ -8447,7 +10184,7 @@ fn continues_discovery_lifecycle(
     previous: &ImportDiscoveryRevisionArtifact,
     snapshot: &SourceSnapshot,
     context: &crate::ImportDiscoveryContext,
-    accepted_reads: &[crate::AcceptedReadManifestEntry],
+    accepted_reads: &crate::AcceptedReadManifest,
     carried_ledger: &crate::ImportObservationLedger,
 ) -> bool {
     if previous.status != ImportDiscoveryRevisionStatus::Open || previous.context != *context {
@@ -8457,7 +10194,7 @@ fn continues_discovery_lifecycle(
         return false;
     };
     if program.root() != snapshot.source_revision().root()
-        || !program.modules().iter().all(|module| {
+        || !program.modules_iter().all(|module| {
             let file_id = module.file_id();
             snapshot.module_id(file_id) == Some(module.module_id())
                 && snapshot.source_id(file_id) == Some(module.source_id())
@@ -8469,7 +10206,7 @@ fn continues_discovery_lifecycle(
     if !previous
         .accepted_reads
         .iter()
-        .all(|entry| accepted_reads.iter().any(|candidate| candidate == entry))
+        .all(|entry| accepted_reads.contains_entry(entry))
     {
         return false;
     }
@@ -8575,7 +10312,7 @@ mod tests {
             ),
             (
                 "ImportObservationLedger::default",
-                "derive(Debug, Clone, Default, PartialEq, Eq, Hash)",
+                "derive(Debug, Default)]\npub struct ImportObservationLedger",
             ),
             (
                 "ImportObservationLedger::record",
@@ -8653,6 +10390,991 @@ mod tests {
             ],
             7,
         )
+    }
+
+    #[test]
+    fn absent_trusted_option_parks_the_rooted_attempt_with_exact_demand_and_anchor() {
+        // RUE-1112: a freestanding program whose reached `main` body uses a
+        // fallible intrinsic while NO trusted std module is present. The
+        // rooted attempt must park with exactly the `option.rue` demand, anchored
+        // on the demanding body (`main`), and must NOT run or publish any body
+        // transaction — the unsatisfied prerequisite stops the worklist before it
+        // enters `body_transaction`.
+        let source = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn main() -> i32 { let _ = @parse_i64(\"1\"); 0 }",
+            )],
+            1,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+
+        let park = match session.semantic_or_toolchain_park(&CompileOptions::default()) {
+            SemanticParkOutcome::Parked(park) => park,
+            SemanticParkOutcome::Ready(_) => {
+                panic!("expected a trusted-toolchain park, got successful analysis")
+            }
+            SemanticParkOutcome::Errors(errors) => {
+                panic!("expected a trusted-toolchain park, got errors: {errors:?}")
+            }
+        };
+
+        // Exact demand set: exactly the trusted std `Option` module.
+        let demands: Vec<&str> = park
+            .demands()
+            .iter()
+            .map(crate::TrustedToolchainModuleDemand::logical_path)
+            .collect();
+        assert_eq!(demands, vec![crate::OPTION_MODULE_LOGICAL_PATH]);
+
+        // Exact requester anchor: the demanding body's stable key (`main`).
+        assert_eq!(park.requesters().len(), 1);
+        let anchor = &park.requesters()[0];
+        assert_eq!(anchor.name(), "main");
+        assert_eq!(anchor.kind(), crate::StableDefinitionKind::Function);
+
+        // No body transaction ran or published a terminal.
+        assert!(
+            !session.queries.revisioned.any_body_transaction_terminal(),
+            "the park must precede any body transaction",
+        );
+    }
+
+    #[test]
+    fn already_reached_parks_batch_into_one_park_with_unioned_demands_and_anchors() {
+        // RUE-1112 C2: two reached helper bodies demand different trusted modules
+        // (a: parse -> Option; b: read_line -> Option+StrBuf) while no trusted std
+        // is present. `main` reaches both, then the first to park must batch the
+        // remaining already-reached body: ONE park carrying the UNION of absent
+        // modules ([Option, StrBuf]) and BOTH requester anchors, so a single
+        // successor acquisition satisfies everything.
+        let source = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn a() -> i32 { let _ = @parse_i64(\"1\"); 0 }\n\
+                 fn b() -> i32 { let _ = @read_line(); 0 }\n\
+                 fn main() -> i32 { a() + b() }",
+            )],
+            1,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+
+        let park = match session.semantic_or_toolchain_park(&CompileOptions::default()) {
+            SemanticParkOutcome::Parked(park) => park,
+            SemanticParkOutcome::Ready(_) => panic!("expected a batched park, got ready analysis"),
+            SemanticParkOutcome::Errors(errors) => {
+                panic!("expected a batched park, got errors: {errors:?}")
+            }
+        };
+
+        // Union of absent modules across both already-reached bodies, sorted.
+        let demands: Vec<&str> = park
+            .demands()
+            .iter()
+            .map(crate::TrustedToolchainModuleDemand::logical_path)
+            .collect();
+        assert_eq!(
+            demands,
+            vec![
+                crate::OPTION_MODULE_LOGICAL_PATH,
+                crate::STRBUF_MODULE_LOGICAL_PATH
+            ]
+        );
+
+        // Both demanding bodies contribute a requester anchor. That both `a` and
+        // `b` appear proves neither transacted before the park — each was still
+        // pending and got projected into the one batch (`main`, which has no
+        // fallible intrinsic, does run its transaction first, as expected).
+        let anchors: std::collections::BTreeSet<&str> =
+            park.requesters().iter().map(|key| key.name()).collect();
+        assert_eq!(anchors, std::collections::BTreeSet::from(["a", "b"]));
+    }
+
+    // ---- RUE-1112: trusted-toolchain continuation + successor publication ----
+
+    fn continuation_std_context() -> crate::ImportDiscoveryContext {
+        crate::ImportDiscoveryContext::new(1, "/project", Some("/sdk"), "test-policy").unwrap()
+    }
+
+    fn continuation_metadata() -> crate::FileMetadataFingerprint {
+        crate::FileMetadataFingerprint::new(10, 20, 30)
+    }
+
+    /// Drive `root_source` to a canonical import-discovery close, then run the
+    /// rooted semantic attempt so its park atomically attaches the demanded-missing
+    /// set to the closed continuation. Returns the session (now holding an
+    /// AUTHORIZING continuation), its token, the empty closure-witness frontier, the
+    /// predecessor snapshot, its accepted reads, and the assembler ready to add
+    /// trusted leaves. Panics unless the attempt parked — the caller supplies a
+    /// reached-fallible-intrinsic root whose demand set is the acquisition batch.
+    ///
+    /// This exercises the real protocol (close → park → attach → mint): demand
+    /// authority is never seeded by direct field assignment, so a close whose
+    /// attempt never parks yields no token.
+    fn closed_continuation_for(
+        root_source: &str,
+    ) -> (
+        CompilerSession,
+        ClosedDiscoveryContinuation,
+        crate::ImportDemandFrontier,
+        SourceSnapshot,
+        crate::AcceptedReadManifest,
+        crate::DiscoverySourceAssembler,
+    ) {
+        let ctx = continuation_std_context();
+        let mut assembler = crate::DiscoverySourceAssembler::new(
+            ctx.clone(),
+            "/project/main.rue",
+            "/project/main.rue",
+            crate::PhysicalFileIdentity::new(1, 1),
+            continuation_metadata(),
+            Arc::new(root_source.to_owned()),
+        )
+        .unwrap();
+        let snapshot = assembler.snapshot().unwrap();
+        let reads = assembler.accepted_read_manifest();
+        let mut session = CompilerSession::new();
+        let revision = session
+            .begin_import_input_request(&snapshot, ctx.clone(), reads.clone())
+            .unwrap();
+        let plan = session
+            .stage_import_discovery(
+                &snapshot,
+                ctx.clone(),
+                reads.shared_slice(),
+                crate::ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let roots = plan.demand_roots();
+        let frontier = session
+            .import_demand_frontier_for_roots(
+                revision,
+                &plan,
+                crate::ImportDemandMode::Rooted,
+                &roots,
+            )
+            .unwrap();
+        assert!(
+            frontier.requests().is_empty(),
+            "a freestanding root closes with an empty frontier",
+        );
+        let ledger = session.import_observation_ledger(revision).unwrap();
+        session.close_import_discovery(ledger).unwrap();
+        // A bare close is non-authorizing: no demand set has been attached yet.
+        assert!(
+            session.closed_discovery_continuation().is_none(),
+            "a close mints no token until a rooted park attaches a demanded set",
+        );
+        // The rooted attempt parks; the park attaches its exact demanded-missing
+        // set to this closed state, making the continuation authorizing.
+        match session.semantic_or_toolchain_park(&CompileOptions::default()) {
+            SemanticParkOutcome::Parked(_) => {}
+            SemanticParkOutcome::Ready(_) => {
+                panic!("expected the reached fallible intrinsic to park the rooted attempt")
+            }
+            SemanticParkOutcome::Errors(errors) => {
+                panic!("expected a trusted-toolchain park, got errors: {errors:?}")
+            }
+        }
+        let token = session
+            .closed_discovery_continuation()
+            .expect("an attached rooted park makes the closed continuation authorizing");
+        (session, token, frontier, snapshot, reads, assembler)
+    }
+
+    /// The common single-module case: a reached `@parse_i64` parks on exactly the
+    /// trusted std `Option` module.
+    fn closed_continuation() -> (
+        CompilerSession,
+        ClosedDiscoveryContinuation,
+        crate::ImportDemandFrontier,
+        SourceSnapshot,
+        crate::AcceptedReadManifest,
+        crate::DiscoverySourceAssembler,
+    ) {
+        closed_continuation_for("fn main() -> i32 { let _ = @parse_i64(\"1\"); 0 }")
+    }
+
+    fn add_trusted_option(assembler: &mut crate::DiscoverySourceAssembler) {
+        assembler
+            .add_explicit(
+                "/sdk/option.rue",
+                "/sdk/option.rue",
+                crate::PhysicalFileIdentity::new(2, 2),
+                continuation_metadata(),
+                Arc::new(
+                    "pub fn Option(comptime T: type) -> type { enum { Some(T), None } }".to_owned(),
+                ),
+            )
+            .unwrap();
+    }
+
+    fn add_trusted_strbuf(assembler: &mut crate::DiscoverySourceAssembler) {
+        assembler
+            .add_explicit(
+                "/sdk/strbuf.rue",
+                "/sdk/strbuf.rue",
+                crate::PhysicalFileIdentity::new(3, 3),
+                continuation_metadata(),
+                Arc::new("pub struct StrBuf { len: i64 }".to_owned()),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn trusted_successor_publishes_additive_leaf_in_same_generation() {
+        let (mut session, token, frontier, predecessor, _reads, mut assembler) =
+            closed_continuation();
+        let predecessor_modules = predecessor.source_revision().modules().to_vec();
+        add_trusted_option(&mut assembler);
+        let successor = assembler.snapshot().unwrap();
+        let successor_reads = assembler.accepted_read_manifest();
+
+        let delta = session
+            .publish_trusted_toolchain_successor(token, &frontier, &successor, successor_reads)
+            .expect("a strictly-additive trusted successor publishes");
+        // The publish mints an opaque delta authority bound to the appended set.
+        // Its module identities are private; the successor stage/close derive and
+        // verify them from the snapshot, so the host cannot edit them here.
+        let published = delta.revision();
+
+        // Same request generation as the predecessor close; the frontier round
+        // advances by one (a successor of that same observation epoch).
+        assert_eq!(
+            published.request_generation,
+            frontier.revision().request_generation
+        );
+        assert_eq!(
+            published.frontier_round,
+            frontier.revision().frontier_round + 1
+        );
+
+        // Every pre-existing module leaf is preserved byte-identical. Its exact
+        // ModuleRevision — and therefore its SourceId, the parse key — reappears in
+        // the successor, so no pre-existing module is re-read or reparsed across
+        // acquisition; only the trusted Option leaf is appended.
+        for old in &predecessor_modules {
+            assert!(
+                successor.source_revision().modules().contains(old),
+                "pre-existing module {old:?} must be preserved byte-identical",
+            );
+        }
+        assert_eq!(
+            successor.source_revision().modules().len(),
+            predecessor_modules.len() + 1,
+        );
+    }
+
+    #[test]
+    fn trusted_successor_reused_token_is_rejected() {
+        let (mut session, token, frontier, _pred, _reads, mut assembler) = closed_continuation();
+        add_trusted_option(&mut assembler);
+        let successor = assembler.snapshot().unwrap();
+        let reads = assembler.accepted_read_manifest();
+        // The first publish consumes the single-use token.
+        session
+            .publish_trusted_toolchain_successor(
+                token.clone(),
+                &frontier,
+                &successor,
+                reads.clone(),
+            )
+            .unwrap();
+        // Reusing it finds no outstanding continuation.
+        let err = session
+            .publish_trusted_toolchain_successor(token, &frontier, &successor, reads)
+            .unwrap_err();
+        assert!(
+            err.first().unwrap().to_string().contains("already used"),
+            "{err:?}",
+        );
+    }
+
+    #[test]
+    fn trusted_successor_stale_token_is_rejected() {
+        let (mut session, token, frontier, _pred, _reads, mut assembler) = closed_continuation();
+        // Simulate a newer close superseding this token: advance the outstanding
+        // state's nonce so the presented token no longer matches (stale).
+        session.next_continuation_nonce += 7;
+        session.continuation.as_mut().unwrap().nonce = session.next_continuation_nonce;
+        add_trusted_option(&mut assembler);
+        let successor = assembler.snapshot().unwrap();
+        let reads = assembler.accepted_read_manifest();
+        let err = session
+            .publish_trusted_toolchain_successor(token, &frontier, &successor, reads)
+            .unwrap_err();
+        assert!(
+            err.first().unwrap().to_string().contains("stale"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn trusted_successor_new_request_invalidates_the_token() {
+        let (mut session, token, frontier, predecessor, reads, mut assembler) =
+            closed_continuation();
+        // A fresh import-input request invalidates any outstanding continuation.
+        session
+            .begin_import_input_request(&predecessor, continuation_std_context(), reads)
+            .unwrap();
+        add_trusted_option(&mut assembler);
+        let successor = assembler.snapshot().unwrap();
+        let successor_reads = assembler.accepted_read_manifest();
+        let err = session
+            .publish_trusted_toolchain_successor(token, &frontier, &successor, successor_reads)
+            .unwrap_err();
+        assert!(
+            err.first().unwrap().to_string().contains("already used"),
+            "{err:?}",
+        );
+    }
+
+    #[test]
+    fn trusted_successor_mutated_predecessor_is_rejected() {
+        let (mut session, token, frontier, _pred, _reads, _assembler) = closed_continuation();
+        // A successor whose pre-existing root content differs is a mutated
+        // predecessor: source evolution must be strictly additive.
+        let ctx = continuation_std_context();
+        let mut other = crate::DiscoverySourceAssembler::new(
+            ctx,
+            "/project/main.rue",
+            "/project/main.rue",
+            crate::PhysicalFileIdentity::new(1, 1),
+            continuation_metadata(),
+            Arc::new("fn main() -> i32 { 1 }".to_owned()),
+        )
+        .unwrap();
+        add_trusted_option(&mut other);
+        let successor = other.snapshot().unwrap();
+        let reads = other.accepted_read_manifest();
+        let err = session
+            .publish_trusted_toolchain_successor(token, &frontier, &successor, reads)
+            .unwrap_err();
+        assert!(
+            err.first()
+                .unwrap()
+                .to_string()
+                .contains("strictly additive"),
+            "{err:?}",
+        );
+    }
+
+    #[test]
+    fn trusted_successor_arbitrary_module_is_rejected() {
+        let (mut session, token, frontier, _pred, _reads, mut assembler) = closed_continuation();
+        // StrBuf is a trusted module the park did NOT demand here (the reached
+        // `@parse_i64` parks on Option only), so the added set {StrBuf} does not
+        // equal the demanded set {Option} and may not ride in on this continuation.
+        add_trusted_strbuf(&mut assembler);
+        let successor = assembler.snapshot().unwrap();
+        let reads = assembler.accepted_read_manifest();
+        let err = session
+            .publish_trusted_toolchain_successor(token, &frontier, &successor, reads)
+            .unwrap_err();
+        assert!(
+            err.first()
+                .unwrap()
+                .to_string()
+                .contains("must equal the rooted park's demanded missing set"),
+            "{err:?}",
+        );
+    }
+
+    #[test]
+    fn trusted_successor_ready_close_is_non_authorizing() {
+        // A close whose rooted semantic attempt is READY (no fallible intrinsic,
+        // no park) attaches no demanded set, so the closed continuation mints no
+        // token. Demand authority lives only in an attached park, so a ready close
+        // can never inherit an earlier park's demand set and admit an uninvited
+        // trusted leaf.
+        let ctx = continuation_std_context();
+        let mut assembler = crate::DiscoverySourceAssembler::new(
+            ctx.clone(),
+            "/project/main.rue",
+            "/project/main.rue",
+            crate::PhysicalFileIdentity::new(1, 1),
+            continuation_metadata(),
+            Arc::new("fn main() -> i32 { 0 }".to_owned()),
+        )
+        .unwrap();
+        let snapshot = assembler.snapshot().unwrap();
+        let reads = assembler.accepted_read_manifest();
+        let mut session = CompilerSession::new();
+        let revision = session
+            .begin_import_input_request(&snapshot, ctx.clone(), reads.clone())
+            .unwrap();
+        let plan = session
+            .stage_import_discovery(
+                &snapshot,
+                ctx.clone(),
+                reads.shared_slice(),
+                crate::ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let roots = plan.demand_roots();
+        let _frontier = session
+            .import_demand_frontier_for_roots(
+                revision,
+                &plan,
+                crate::ImportDemandMode::Rooted,
+                &roots,
+            )
+            .unwrap();
+        let ledger = session.import_observation_ledger(revision).unwrap();
+        session.close_import_discovery(ledger).unwrap();
+        // The rooted attempt is ready: no park, so no demanded set is attached.
+        assert!(matches!(
+            session.semantic_or_toolchain_park(&CompileOptions::default()),
+            SemanticParkOutcome::Ready(_)
+        ));
+        assert!(
+            session.closed_discovery_continuation().is_none(),
+            "a ready close is non-authorizing and mints no continuation token",
+        );
+    }
+
+    #[test]
+    fn trusted_successor_partial_batch_is_rejected_without_consuming_token() {
+        // A reached `@read_line` parks on BOTH Option and StrBuf. A successor that
+        // adds only Option is a partial batch — added {Option} does not equal the
+        // demanded {Option, StrBuf} — so it is rejected. A rejection never consumes
+        // the single-use token, so completing the batch and retrying with the same
+        // token then publishes.
+        let (mut session, token, frontier, _pred, _reads, mut assembler) =
+            closed_continuation_for("fn main() -> i32 { let _ = @read_line(); 0 }");
+        add_trusted_option(&mut assembler);
+        let partial = assembler.snapshot().unwrap();
+        let partial_reads = assembler.accepted_read_manifest();
+        let err = session
+            .publish_trusted_toolchain_successor(token.clone(), &frontier, &partial, partial_reads)
+            .unwrap_err();
+        assert!(
+            err.first()
+                .unwrap()
+                .to_string()
+                .contains("must equal the rooted park's demanded missing set"),
+            "{err:?}",
+        );
+        // The token survived the rejection; completing the two-module batch and
+        // retrying publishes with the SAME token.
+        add_trusted_strbuf(&mut assembler);
+        let full = assembler.snapshot().unwrap();
+        let full_reads = assembler.accepted_read_manifest();
+        session
+            .publish_trusted_toolchain_successor(token, &frontier, &full, full_reads)
+            .expect("the completed two-module batch publishes with the un-consumed token");
+    }
+
+    #[test]
+    fn trusted_successor_altered_predecessor_provenance_is_rejected() {
+        let (mut session, token, frontier, _pred, _reads, mut assembler) = closed_continuation();
+        add_trusted_option(&mut assembler);
+        let successor = assembler.snapshot().unwrap();
+        let full_reads = assembler.accepted_read_manifest();
+        // Drop the predecessor root's accepted-read provenance, keeping only the
+        // added leaf's: the old provenance is no longer byte-identical.
+        let tampered: Vec<_> = full_reads
+            .iter()
+            .filter(|entry| entry.module().is_trusted_standard_library())
+            .cloned()
+            .collect();
+        let err = session
+            .publish_trusted_toolchain_successor(
+                token,
+                &frontier,
+                &successor,
+                crate::AcceptedReadManifest::from_entries(tampered),
+            )
+            .unwrap_err();
+        assert!(
+            err.first()
+                .unwrap()
+                .to_string()
+                .contains("altered or removed"),
+            "{err:?}",
+        );
+    }
+
+    /// A successor-delta capability minted by one session cannot authorize a
+    /// successor stage on a different session: the delta is bound to its issuing
+    /// session, so a cross-session value is rejected without staging anything.
+    #[test]
+    fn successor_delta_from_another_session_is_rejected() {
+        let (mut issuer, token, frontier, _pred, _reads, mut assembler) = closed_continuation();
+        add_trusted_option(&mut assembler);
+        let successor = assembler.snapshot().unwrap();
+        let reads = assembler.accepted_read_manifest();
+        let delta = issuer
+            .publish_trusted_toolchain_successor(token, &frontier, &successor, reads.clone())
+            .expect("a strictly-additive successor publishes");
+
+        let mut other = CompilerSession::new();
+        let err = other.stage_import_discovery_successor(&delta).unwrap_err();
+        assert!(
+            err.first()
+                .unwrap()
+                .to_string()
+                .contains("different session"),
+            "{err:?}",
+        );
+    }
+
+    /// A successor-delta capability is single-generation: a new import-input
+    /// request invalidates it, so a stale delta can neither stage nor close.
+    #[test]
+    fn stale_successor_delta_cannot_stage() {
+        let (mut session, token, frontier, _pred, _reads, mut assembler) = closed_continuation();
+        add_trusted_option(&mut assembler);
+        let successor = assembler.snapshot().unwrap();
+        let reads = assembler.accepted_read_manifest();
+        let delta = session
+            .publish_trusted_toolchain_successor(token, &frontier, &successor, reads.clone())
+            .expect("a strictly-additive successor publishes");
+
+        // A fresh observation generation invalidates the outstanding delta.
+        session
+            .begin_import_input_request(&successor, continuation_std_context(), reads.clone())
+            .unwrap();
+        let err = session
+            .stage_import_discovery_successor(&delta)
+            .unwrap_err();
+        assert!(
+            err.first()
+                .unwrap()
+                .to_string()
+                .contains("no outstanding successor-delta authority"),
+            "{err:?}",
+        );
+    }
+
+    /// The successor parse terminal is a REAL runtime query dependent of the
+    /// exact predecessor parse terminal — the graph carries the
+    /// successor-after-predecessor edge — and the successor close re-selects
+    /// the staged terminal itself: same terminal identity, no second parse
+    /// dispatch, and no second empty-extension publication.
+    #[test]
+    fn successor_close_reuses_the_staged_terminal_with_a_predecessor_edge() {
+        let (mut session, token, frontier, _pred, _reads, mut assembler) = closed_continuation();
+        let predecessor_terminal = session
+            .selected_parse_terminal()
+            .expect("the committed close selects its staged parse terminal");
+        add_trusted_option(&mut assembler);
+        let successor = assembler.snapshot().unwrap();
+        let reads = assembler.accepted_read_manifest();
+        let delta = session
+            .publish_trusted_toolchain_successor(token, &frontier, &successor, reads)
+            .expect("a strictly-additive successor publishes");
+        session
+            .stage_import_discovery_successor(&delta)
+            .expect("the successor stages");
+        let staged_terminal = session
+            .selected_parse_terminal()
+            .expect("the successor stage selects its parse terminal");
+        assert!(
+            !Arc::ptr_eq(&predecessor_terminal, &staged_terminal),
+            "the successor stage computes its own terminal"
+        );
+        // (a) The successor terminal observes the exact predecessor parse
+        // terminal as a runtime query dependency — the FULL captured identity
+        // (node, incarnation, AND stamp), not an equivalent replacement under
+        // the same display node — so red/green validation and leases flow
+        // successor-after-predecessor through the graph.
+        let observation = staged_terminal
+            .dependencies()
+            .iter()
+            .find(|dependency| dependency.node == *predecessor_terminal.node())
+            .unwrap_or_else(|| {
+                panic!(
+                    "the successor terminal must depend on the exact predecessor parse terminal: {:?}",
+                    staged_terminal.dependencies(),
+                )
+            });
+        assert_eq!(
+            observation.incarnation,
+            predecessor_terminal.node_incarnation(),
+            "the dependency must carry the captured terminal's exact node incarnation"
+        );
+        assert_eq!(
+            observation.stamp,
+            predecessor_terminal.stamp(),
+            "the dependency must carry the captured terminal's exact stamp"
+        );
+        // That the adoption touched no predecessor content-key Hash/Eq is
+        // proven mechanically by the rue-query frozen-key regression
+        // (`adoption_never_hashes_or_compares_the_predecessor_key`).
+        // (b) The close re-selects the staged terminal itself: identical
+        // terminal identity, no parse dispatch, and no second publication.
+        let dispatched = session.parse_modules_dispatched();
+        let materialized = session.parse_sources_materialized();
+        session
+            .close_import_discovery_successor(&delta)
+            .expect("the successor closes");
+        let adopted_terminal = session
+            .selected_parse_terminal()
+            .expect("the successor close selects the staged parse terminal");
+        assert!(
+            Arc::ptr_eq(&staged_terminal, &adopted_terminal),
+            "the successor close must re-select the exact staged parse terminal"
+        );
+        assert_eq!(
+            session.parse_modules_dispatched(),
+            dispatched,
+            "the successor close dispatches no parse work"
+        );
+        assert_eq!(
+            session.parse_sources_materialized(),
+            materialized,
+            "the successor close materializes no whole-program projection"
+        );
+    }
+
+    /// A strictly-additive successor adoption must leave the predecessor's
+    /// immutable source leaf live: retained frontend terminals that correctly
+    /// depend on it (however many variants are prewarmed) stay valid, and the
+    /// acquisition contributes ZERO dependency-graph invalidation events —
+    /// the successor becomes current without walking or invalidating the
+    /// predecessor's retained downstream.
+    #[test]
+    fn successor_adoption_invalidates_no_retained_frontend_variants() {
+        let acquisition_invalidations = |prewarm_retained_downstream: bool| -> u64 {
+            let (mut session, token, frontier, _pred, _reads, mut assembler) =
+                closed_continuation();
+            if prewarm_retained_downstream {
+                // Retain additional terminals depending on the predecessor's
+                // source leaf. Semantic — and the definition/manifest variants
+                // that observe it — cannot complete on this predecessor (the
+                // reached fallible intrinsic parks semantic until
+                // acquisition), so the retained downstream of the leaf is the
+                // pre-semantic tier: merged RIR and canonical import
+                // diagnostics.
+                session
+                    .rir()
+                    .expect("pre-semantic RIR completes on the parked predecessor");
+                session
+                    .import_diagnostics()
+                    .expect("import diagnostics retain on the closed predecessor");
+            }
+            add_trusted_option(&mut assembler);
+            let successor = assembler.snapshot().unwrap();
+            let reads = assembler.accepted_read_manifest();
+            let delta = session
+                .publish_trusted_toolchain_successor(token, &frontier, &successor, reads)
+                .expect("a strictly-additive successor publishes");
+            let before = session.frontend_query_invalidations();
+            session
+                .stage_import_discovery_successor(&delta)
+                .expect("the successor stages");
+            session
+                .close_import_discovery_successor(&delta)
+                .expect("the successor closes");
+            session.frontend_query_invalidations() - before
+        };
+        let bare = acquisition_invalidations(false);
+        let prewarmed = acquisition_invalidations(true);
+        assert_eq!(
+            bare, 0,
+            "additive successor adoption must not invalidate retained frontend terminals"
+        );
+        assert_eq!(
+            prewarmed, 0,
+            "additive successor adoption must not invalidate retained frontend terminals regardless of how much retained downstream depends on the predecessor leaf"
+        );
+    }
+
+    /// A successor-delta capability outstanding across an intervening source or
+    /// presentation update is invalidated: the update replaced the retained
+    /// parse artifact the successor would extend, so the stale capability can
+    /// neither stage nor close — a mixed parsed program (foreign retained
+    /// modules under the successor's claimed source revision) is never
+    /// produced.
+    #[test]
+    fn intervening_presentation_update_invalidates_successor_delta() {
+        let (mut session, token, frontier, _pred, _reads, mut assembler) = closed_continuation();
+        add_trusted_option(&mut assembler);
+        let successor = assembler.snapshot().unwrap();
+        let reads = assembler.accepted_read_manifest();
+        let delta = session
+            .publish_trusted_toolchain_successor(token, &frontier, &successor, reads)
+            .expect("a strictly-additive successor publishes");
+
+        // An intervening presentation update installs a successful parse of a
+        // DIFFERENT snapshot (unrelated content and file order).
+        let foreign = snapshot(
+            &[
+                (2, "/q/aux.rue", "aux.rue", "pub fn v() -> i32 { 2 }"),
+                (1, "/q/main.rue", "main.rue", "fn main() -> i32 { 0 }"),
+            ],
+            1,
+        );
+        session
+            .update_for_presentation(&foreign)
+            .into_result()
+            .expect("the foreign presentation update parses");
+
+        let stage_err = session
+            .stage_import_discovery_successor(&delta)
+            .unwrap_err();
+        assert!(
+            stage_err
+                .first()
+                .unwrap()
+                .to_string()
+                .contains("no outstanding successor-delta authority"),
+            "{stage_err:?}",
+        );
+        let close_err = session
+            .close_import_discovery_successor(&delta)
+            .unwrap_err();
+        assert!(
+            close_err
+                .first()
+                .unwrap()
+                .to_string()
+                .contains("no outstanding successor-delta authority"),
+            "{close_err:?}",
+        );
+    }
+
+    /// Substituted snapshots, contexts, provenance manifests, and ledgers are
+    /// INEXPRESSIBLE at the successor stage/close: those APIs consume only the
+    /// compiler-published view and the opaque capability. The one remaining host
+    /// input surface on a same-generation lineage is the observation-batch
+    /// publication, so the tampering regressions below attack through it; the
+    /// overlay publication re-derives and justifies every addition, rejecting
+    /// each attack before anything is published.
+    ///
+    /// Run one tampered batch publication against a closed lineage whose rooted
+    /// frontier witness is empty, returning the rejection text.
+    fn tampered_batch_error(
+        build: impl FnOnce(&crate::ImportDiscoveryContext) -> crate::DiscoverySourceAssembler,
+    ) -> String {
+        let (mut session, _token, frontier, _pred, _reads, _assembler) = closed_continuation();
+        let ctx = continuation_std_context();
+        let mut tampered = build(&ctx);
+        let snapshot = tampered.snapshot().unwrap();
+        let reads = tampered.accepted_read_manifest();
+        session
+            .publish_import_observation_batch(&frontier, &snapshot, reads, Vec::new())
+            .unwrap_err()
+            .to_string()
+    }
+
+    /// A batch cannot INJECT a module: a snapshot carrying a module no accepted
+    /// observation of that batch resolves is rejected at publication, so an
+    /// unrelated module can never enter the published lineage (and therefore can
+    /// never reach a successor stage/close, which read only the published view).
+    #[test]
+    fn observation_batch_rejects_an_injected_module() {
+        let error = tampered_batch_error(|ctx| {
+            let mut assembler = crate::DiscoverySourceAssembler::new(
+                ctx.clone(),
+                "/project/main.rue",
+                "/project/main.rue",
+                crate::PhysicalFileIdentity::new(1, 1),
+                continuation_metadata(),
+                Arc::new("fn main() -> i32 { let _ = @parse_i64(\"1\"); 0 }".to_owned()),
+            )
+            .unwrap();
+            // An extra module with provenance but NO justifying observation.
+            add_trusted_option(&mut assembler);
+            assembler
+        });
+        assert!(
+            error.contains("must equal this step's authorized additions exactly"),
+            "{error}",
+        );
+    }
+
+    /// A batch cannot MUTATE a predecessor module under its ID: a snapshot whose
+    /// root module has the same identity but different content is rejected at
+    /// publication (the lineage is strictly additive at that boundary).
+    #[test]
+    fn observation_batch_rejects_a_mutated_predecessor_source() {
+        let error = tampered_batch_error(|ctx| {
+            crate::DiscoverySourceAssembler::new(
+                ctx.clone(),
+                "/project/main.rue",
+                "/project/main.rue",
+                crate::PhysicalFileIdentity::new(1, 1),
+                continuation_metadata(),
+                // Same root identity, DIFFERENT body.
+                Arc::new("fn main() -> i32 { let _ = @parse_i64(\"1\"); 42 }".to_owned()),
+            )
+            .unwrap()
+        });
+        assert!(
+            error.contains("mutates a predecessor module source"),
+            "{error}",
+        );
+    }
+
+    /// A batch cannot OMIT an accepted module: publishing the exact
+    /// compiler-issued accepted observation for a newly resolved module while
+    /// omitting that module from the successor snapshot is rejected — the
+    /// additions must EQUAL the batch's accepted resolutions in both
+    /// directions, so topology can never claim "resolved" without the module's
+    /// source leaf behind it.
+    #[test]
+    fn observation_batch_rejects_omitting_an_accepted_module() {
+        let ctx = continuation_std_context();
+        let root_source = "const a = @import(\"a.rue\"); fn main() -> i32 { 0 }";
+        let mut assembler = crate::DiscoverySourceAssembler::new(
+            ctx.clone(),
+            "/project/main.rue",
+            "/project/main.rue",
+            crate::PhysicalFileIdentity::new(1, 1),
+            continuation_metadata(),
+            Arc::new(root_source.to_owned()),
+        )
+        .unwrap();
+        let snapshot = assembler.snapshot().unwrap();
+        let reads = assembler.accepted_read_manifest();
+        let mut session = CompilerSession::new();
+        let revision = session
+            .begin_import_input_request(&snapshot, ctx.clone(), reads.clone())
+            .unwrap();
+        let plan = session
+            .stage_import_discovery(
+                &snapshot,
+                ctx.clone(),
+                reads.shared_slice(),
+                crate::ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let roots = plan.demand_roots();
+        let frontier = session
+            .import_demand_frontier_for_roots(
+                revision,
+                &plan,
+                crate::ImportDemandMode::Rooted,
+                &roots,
+            )
+            .unwrap();
+        assert!(
+            !frontier.requests().is_empty(),
+            "an unresolved import demands host reads",
+        );
+
+        // Answer the frontier honestly for a.rue: the exact compiler-issued
+        // accepted observation, absent elsewhere.
+        let module_source = "pub fn value() -> i32 { 1 }";
+        let observations: Vec<crate::ImportObservation> = frontier
+            .requests()
+            .iter()
+            .map(|request| {
+                if request.requested_path() == "/project/a.rue" {
+                    crate::ImportObservation::accepted(
+                        request.clone(),
+                        crate::AcceptedImportSource::new(
+                            Arc::from("/project/a.rue"),
+                            Arc::from("/project/a.rue"),
+                            crate::PhysicalFileIdentity::new(5, 5),
+                            continuation_metadata(),
+                            Arc::new(module_source.to_owned()),
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap()
+                } else {
+                    crate::ImportObservation::absent(request.clone())
+                }
+            })
+            .collect();
+
+        // A manifest carrying the resolved module's provenance, but a snapshot
+        // OMITTING the module itself.
+        let mut with_module = crate::DiscoverySourceAssembler::new(
+            ctx.clone(),
+            "/project/main.rue",
+            "/project/main.rue",
+            crate::PhysicalFileIdentity::new(1, 1),
+            continuation_metadata(),
+            Arc::new(root_source.to_owned()),
+        )
+        .unwrap();
+        with_module
+            .add_explicit(
+                "/project/a.rue",
+                "/project/a.rue",
+                crate::PhysicalFileIdentity::new(5, 5),
+                continuation_metadata(),
+                Arc::new(module_source.to_owned()),
+            )
+            .unwrap();
+        let reads_with_module = with_module.accepted_read_manifest();
+        let err = session
+            .publish_import_observation_batch(&frontier, &snapshot, reads_with_module, observations)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("must equal this step's authorized additions exactly"),
+            "{err}",
+        );
+    }
+
+    /// A batch cannot SUBSTITUTE predecessor provenance: an accepted-read entry
+    /// for an existing module with altered physical identity is rejected at
+    /// publication.
+    #[test]
+    fn observation_batch_rejects_substituted_provenance() {
+        let error = tampered_batch_error(|ctx| {
+            crate::DiscoverySourceAssembler::new(
+                ctx.clone(),
+                "/project/main.rue",
+                "/project/main.rue",
+                // Same content, DIFFERENT physical identity: the module revision
+                // matches but its provenance record does not.
+                crate::PhysicalFileIdentity::new(7, 7),
+                continuation_metadata(),
+                Arc::new("fn main() -> i32 { let _ = @parse_i64(\"1\"); 0 }".to_owned()),
+            )
+            .unwrap()
+        });
+        assert!(
+            error.contains("mutates a predecessor accepted-read provenance"),
+            "{error}",
+        );
+    }
+
+    #[test]
+    fn stable_no_filesystem_boundary_classifies_unsatisfied_toolchain_input_not_ice() {
+        // RUE-1112 C3: the stable no-filesystem `canonical_semantic` entry cannot
+        // acquire, so an unsatisfied trusted-toolchain demand for otherwise-valid
+        // source is a deterministic CONTRACT failure, never an ICE (E9000).
+        let source = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn main() -> i32 { let _ = @parse_i64(\"1\"); 0 }",
+            )],
+            1,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        let errors = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap_err();
+        let error = errors.first().expect("unsatisfied toolchain input error");
+        assert!(
+            matches!(
+                error.kind,
+                rue_error::ErrorKind::UnsatisfiedTrustedToolchainInput(_)
+            ),
+            "expected an unsatisfied-trusted-toolchain-input classification, got {:?}",
+            error.kind
+        );
+        assert_ne!(error.kind.code(), rue_error::ErrorCode::INTERNAL_ERROR);
+        assert_eq!(
+            error.kind.code(),
+            rue_error::ErrorCode::UNSATISFIED_TRUSTED_TOOLCHAIN_INPUT
+        );
     }
 
     #[test]
@@ -14743,8 +17465,9 @@ fn main() -> i32 { selected.value() }"#,
                 Arc::new(BTreeMap::new()),
                 Arc::from([]),
                 false,
+                Arc::from([]),
                 cancellation.clone(),
-                |_| panic!("semantic request must have materialized this body terminal"),
+                |_, _| panic!("semantic request must have materialized this body terminal"),
             )
             .unwrap();
         let body = session
@@ -14792,8 +17515,9 @@ fn main() -> i32 { selected.value() }"#,
                 Arc::new(BTreeMap::new()),
                 Arc::from([]),
                 false,
+                Arc::from([]),
                 rue_query::CancellationToken::new(),
-                |_| panic!("semantic request must have materialized this body terminal"),
+                |_, _| panic!("semantic request must have materialized this body terminal"),
             )
             .unwrap();
         let rue_query::QueryOutcome::Success(transaction) = terminal.outcome() else {
@@ -14820,14 +17544,169 @@ fn main() -> i32 { selected.value() }"#,
                 Arc::new(BTreeMap::new()),
                 Arc::from([]),
                 false,
+                Arc::from([]),
                 rue_query::CancellationToken::new(),
-                |_| panic!("semantic request must have materialized this body terminal"),
+                |_, _| panic!("semantic request must have materialized this body terminal"),
             )
             .unwrap()
             .dependencies()
             .iter()
             .map(|dependency| format!("{:?}", dependency.node))
             .collect()
+    }
+
+    /// A trusted-std `Option` snapshot for the well-known query-edge isolation
+    /// regression: the root is `root_source`, and the trusted std `Option` module
+    /// is provided at `\0rue-std/option.rue`, reached with
+    /// `@import("std/option.rue")` (physical-suffix match).
+    fn well_known_option_isolation_snapshot(root_source: &str) -> SourceSnapshot {
+        let root = FileId::new(1);
+        let option = FileId::new(2);
+        let metadata = SourceMetadata::new_with_trusted_standard_library(
+            root,
+            HashMap::from([
+                (root, "/project/main.rue".to_owned()),
+                (option, "/project/std/option.rue".to_owned()),
+            ]),
+            HashMap::from([
+                (root, "main.rue".to_owned()),
+                (option, "\0rue-std/option.rue".to_owned()),
+            ]),
+            HashSet::from([option]),
+        )
+        .unwrap();
+        SourceSnapshot::new(
+            metadata,
+            vec![
+                (root, Arc::new(root_source.to_owned())),
+                (
+                    option,
+                    Arc::new(
+                        "pub fn Option(comptime T: type) -> type { enum { Some(T), None } }"
+                            .to_owned(),
+                    ),
+                ),
+            ],
+        )
+        .unwrap()
+    }
+
+    /// Query-edge isolation. Two reached bodies demand DIFFERENT well-known
+    /// `Option` payloads: `left` uses `@parse_i32` (payload i32), `right` uses
+    /// `@parse_i64` (payload i64). Each body derives its OWN exact payload set from
+    /// its canonical raw body and roots only that payload's `Option`
+    /// specialization, so:
+    ///
+    /// 1. `left`'s dependency edges reach the i32 `Option` specialization and NOT
+    ///    the i64 one; `right`'s reach the i64 specialization and NOT the i32 one.
+    ///    A body therefore cannot inherit failure or cancellation from an
+    ///    unrelated body's specialization — it has no edge to it.
+    /// 2. Invalidating the i64 specialization's owning body (editing `right`)
+    ///    leaves `left`'s terminal identity (its published stamp) unchanged: with
+    ///    no edge to the churned specialization, `left` is reused, not recomputed.
+    #[test]
+    fn sibling_body_retains_no_edge_to_a_distinct_payload_specialization() {
+        let options = CompileOptions::default();
+
+        // Locate the ComptimeCall specialization edges by the payload spelled in
+        // the dependency node's Debug rendering. The two bodies demand distinct
+        // payloads, so distinct nodes carry the i32 and i64 type arguments.
+        let has_i32_option_edge = |nodes: &[String]| {
+            nodes.iter().any(|node| {
+                node.contains("comptime:") && node.contains("Option") && node.contains("I32)")
+            })
+        };
+        let has_i64_option_edge = |nodes: &[String]| {
+            nodes.iter().any(|node| {
+                node.contains("comptime:") && node.contains("Option") && node.contains("I64)")
+            })
+        };
+
+        let program_v1 = r#"
+const opt = @import("std/option.rue");
+fn left(s: str) -> opt.Option(i32) {
+    let O = opt.Option(i32);
+    O.Some(@parse_i32(s)?)
+}
+fn right(s: str) -> opt.Option(i64) {
+    let O = opt.Option(i64);
+    O.Some(@parse_i64(s)?)
+}
+fn main() -> i32 {
+    let OA = opt.Option(i32);
+    let OB = opt.Option(i64);
+    let a = match left("1") { OA.Some(v) => v, OA.None => 0 };
+    let b = match right("2") { OB.Some(v) => @intCast(v), OB.None => 0 };
+    a + b
+}
+"#;
+
+        let source_v1 = well_known_option_isolation_snapshot(program_v1);
+        let mut session = CompilerSession::new();
+        publish_with_test_imports(&mut session, &source_v1);
+        session.canonical_semantic(&options).unwrap();
+
+        let left_key = body_query_key(&mut session, &options, "left");
+        let right_key = body_query_key(&mut session, &options, "right");
+
+        let left_nodes = retained_body_dependency_nodes(&session, &left_key);
+        let right_nodes = retained_body_dependency_nodes(&session, &right_key);
+
+        assert!(
+            has_i32_option_edge(&left_nodes),
+            "left (i32) must have an edge to the Option(i32) specialization: {left_nodes:?}",
+        );
+        assert!(
+            !has_i64_option_edge(&left_nodes),
+            "left (i32) must have NO edge to the sibling's Option(i64) specialization: {left_nodes:?}",
+        );
+        assert!(
+            has_i64_option_edge(&right_nodes),
+            "right (i64) must have an edge to the Option(i64) specialization: {right_nodes:?}",
+        );
+        assert!(
+            !has_i32_option_edge(&right_nodes),
+            "right (i64) must have NO edge to the sibling's Option(i32) specialization: {right_nodes:?}",
+        );
+
+        // `left`'s terminal identity before the sibling churns.
+        let left_stamp_v1 = retained_body_transaction(&session, &left_key).0;
+
+        // Invalidate the i64 specialization's owning body: edit ONLY `right`,
+        // keeping its i64 payload demand. `left`'s raw body and its i32 demand are
+        // untouched, and it has no edge to the i64 specialization, so its terminal
+        // must be reused with an unchanged stamp.
+        let program_v2 = r#"
+const opt = @import("std/option.rue");
+fn left(s: str) -> opt.Option(i32) {
+    let O = opt.Option(i32);
+    O.Some(@parse_i32(s)?)
+}
+fn right(s: str) -> opt.Option(i64) {
+    let O = opt.Option(i64);
+    let _churn = 7 + 8;
+    O.Some(@parse_i64(s)?)
+}
+fn main() -> i32 {
+    let OA = opt.Option(i32);
+    let OB = opt.Option(i64);
+    let a = match left("1") { OA.Some(v) => v, OA.None => 0 };
+    let b = match right("2") { OB.Some(v) => @intCast(v), OB.None => 0 };
+    a + b
+}
+"#;
+        let source_v2 = well_known_option_isolation_snapshot(program_v2);
+        publish_with_test_imports(&mut session, &source_v2);
+        session.canonical_semantic(&options).unwrap();
+
+        let left_key_v2 = body_query_key(&mut session, &options, "left");
+        let left_stamp_v2 = retained_body_transaction(&session, &left_key_v2).0;
+
+        assert_eq!(
+            left_stamp_v1, left_stamp_v2,
+            "editing the i64-owning sibling must not disturb left's terminal identity: \
+             left has no edge to the i64 specialization",
+        );
     }
 
     fn projected_anonymous_nominals(
@@ -15370,8 +18249,9 @@ fn main() -> i32 { selected.value() }"#,
             Arc::new(BTreeMap::new()),
             Arc::from([]),
             false,
+            Arc::from([]),
             rue_query::CancellationToken::new(),
-            |_| {
+            |_, _| {
                 compute_called.set(true);
                 Err(rue_query::QueryAbort::Canceled)
             },

--- a/crates/rue-compiler/src/shared_segments.rs
+++ b/crates/rue-compiler/src/shared_segments.rs
@@ -1,0 +1,472 @@
+//! Structurally shared, additively extended sorted sequences (RUE-1112).
+//!
+//! A [`SharedSegments`] holds a canonical sorted sequence as an ordered list of
+//! `Arc`-shared, mutually-disjoint sorted segments. A strictly-additive successor
+//! appends exactly one new segment and shares every predecessor segment by `Arc`
+//! clone — no predecessor element is copied, sorted, or reallocated, and a chain
+//! of successors accumulates one segment per acquisition round (bounded by the
+//! driver's round bound) rather than flattening. The merged flat slice is
+//! materialized at most once, lazily, and only when a consumer needs a contiguous
+//! `&[T]`; the acquisition path reads the newest delta segment directly and never
+//! triggers it.
+//!
+//! Equality and hashing are over the LOGICAL merged sequence, computed by a
+//! streaming k-way merge with no allocation of the merged buffer, so a flat value
+//! and a segmented value with identical content compare and hash identically —
+//! the representation is invisible to query memoization.
+
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, OnceLock};
+
+/// A canonical sorted sequence represented as an ordered list of `Arc`-shared,
+/// mutually-disjoint sorted segments. `cmp` is the canonical total order every
+/// segment is sorted by; the segments partition the logical sequence, so their
+/// k-way merge is the sorted union.
+pub(crate) struct SharedSegments<T> {
+    segments: Arc<[Arc<[T]>]>,
+    cmp: fn(&T, &T) -> Ordering,
+    merged: OnceLock<Arc<[T]>>,
+}
+
+impl<T> SharedSegments<T> {
+    /// A flat sequence: one segment. `items` must already be canonical (sorted by
+    /// `cmp`, deduplicated).
+    pub(crate) fn flat(items: Arc<[T]>, cmp: fn(&T, &T) -> Ordering) -> Self {
+        Self {
+            segments: Arc::from([items]),
+            cmp,
+            merged: OnceLock::new(),
+        }
+    }
+
+    /// The first (oldest) segment: the original base carried through every
+    /// successor by reference. Two successors of the same base return
+    /// `Arc`-pointer-equal first segments, proving the base was never copied.
+    pub(crate) fn predecessor_segment(&self) -> &Arc<[T]> {
+        &self.segments[0]
+    }
+
+    /// The newest delta segment (empty for a flat value). Iterating this avoids
+    /// materializing the merged sequence on the acquisition path.
+    pub(crate) fn delta_segment(&self) -> &[T] {
+        if self.segments.len() > 1 {
+            &self.segments[self.segments.len() - 1]
+        } else {
+            &[]
+        }
+    }
+
+    /// Every `Arc`-shared segment, oldest first. Two successors of a common
+    /// ancestor share every ancestor segment by pointer; consumers use this to
+    /// witness structural inheritance without walking predecessor entries.
+    pub(crate) fn segments(&self) -> &[Arc<[T]>] {
+        &self.segments
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.segments.iter().map(|segment| segment.len()).sum()
+    }
+
+    /// Whether any element compares `Equal` under `f`, by binary search over each
+    /// sorted segment — O(segments · log n) with no materialization. `f` must be
+    /// consistent with the canonical order.
+    pub(crate) fn contains_by(&self, mut f: impl FnMut(&T) -> Ordering) -> bool {
+        self.segments
+            .iter()
+            .any(|segment| segment.binary_search_by(&mut f).is_ok())
+    }
+
+    /// The element comparing `Equal` under `f`, by binary search over each sorted
+    /// segment — with no materialization.
+    pub(crate) fn find_by(&self, mut f: impl FnMut(&T) -> Ordering) -> Option<&T> {
+        for segment in self.segments.iter() {
+            if let Ok(index) = segment.binary_search_by(&mut f) {
+                return Some(&segment[index]);
+            }
+        }
+        None
+    }
+
+    /// Iterate the logical merged sequence in canonical order without allocating
+    /// the merged buffer (a small per-segment cursor vector aside).
+    pub(crate) fn iter(&self) -> MergeIter<'_, T> {
+        MergeIter {
+            cursors: self
+                .segments
+                .iter()
+                .map(|segment| (&**segment, 0))
+                .collect(),
+            cmp: self.cmp,
+        }
+    }
+}
+
+impl<T: Clone> SharedSegments<T> {
+    /// Build a strictly-additive successor that carries every segment of `base`
+    /// by `Arc` clone and appends `delta` as one new segment. `delta` must be
+    /// disjoint from `base` and is sorted here (only `delta`, never `base`). No
+    /// base segment is copied or re-sorted, and the base is NOT flattened, so a
+    /// chain of successors stays O(round) segments.
+    pub(crate) fn extend(base: &SharedSegments<T>, mut delta: Vec<T>) -> Self {
+        delta.sort_by(base.cmp);
+        delta.dedup_by(|a, b| (base.cmp)(a, b) == Ordering::Equal);
+        let mut segments: Vec<Arc<[T]>> = base.segments.to_vec();
+        segments.push(delta.into());
+        Self {
+            segments: segments.into(),
+            cmp: base.cmp,
+            merged: OnceLock::new(),
+        }
+    }
+
+    /// The logical merged sequence as one contiguous slice. A flat value borrows
+    /// its single stored `Arc` directly; a segmented value materializes the k-way
+    /// merge once into a cached `Arc`. This is the only place a successor ever
+    /// allocates a predecessor-sized buffer, and the acquisition path never calls
+    /// it (it reads `delta_segment` instead).
+    pub(crate) fn as_slice(&self) -> &[T] {
+        if self.segments.len() == 1 {
+            return &self.segments[0];
+        }
+        self.merged
+            .get_or_init(|| self.iter().cloned().collect::<Vec<_>>().into())
+    }
+}
+
+/// Streaming k-way merge over the segments (each sorted, mutually disjoint).
+pub(crate) struct MergeIter<'a, T> {
+    cursors: Vec<(&'a [T], usize)>,
+    cmp: fn(&T, &T) -> Ordering,
+}
+
+impl<'a, T> Iterator for MergeIter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<&'a T> {
+        let mut best: Option<usize> = None;
+        for (index, (segment, position)) in self.cursors.iter().enumerate() {
+            if let Some(candidate) = segment.get(*position) {
+                match best {
+                    None => best = Some(index),
+                    Some(current) => {
+                        let (best_segment, best_position) = self.cursors[current];
+                        if (self.cmp)(candidate, &best_segment[best_position]) == Ordering::Less {
+                            best = Some(index);
+                        }
+                    }
+                }
+            }
+        }
+        let chosen = best?;
+        let segment = self.cursors[chosen].0;
+        let position = self.cursors[chosen].1;
+        self.cursors[chosen].1 = position + 1;
+        Some(&segment[position])
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining: usize = self
+            .cursors
+            .iter()
+            .map(|(segment, position)| segment.len() - position)
+            .sum();
+        (remaining, Some(remaining))
+    }
+}
+
+impl<'a, T> ExactSizeIterator for MergeIter<'a, T> {}
+
+impl<T: Clone> Clone for SharedSegments<T> {
+    fn clone(&self) -> Self {
+        // Share all segments by `Arc` clone; the materialized cache is not carried
+        // so a clone holds no predecessor-sized buffer.
+        Self {
+            segments: Arc::clone(&self.segments),
+            cmp: self.cmp,
+            merged: OnceLock::new(),
+        }
+    }
+}
+
+impl<T: PartialEq> PartialEq for SharedSegments<T> {
+    fn eq(&self, other: &Self) -> bool {
+        // Fast path: identical segment lists by pointer.
+        if self.segments.len() == other.segments.len()
+            && self
+                .segments
+                .iter()
+                .zip(other.segments.iter())
+                .all(|(a, b)| Arc::ptr_eq(a, b))
+        {
+            return true;
+        }
+        self.len() == other.len() && self.iter().eq(other.iter())
+    }
+}
+
+impl<T: Eq> Eq for SharedSegments<T> {}
+
+impl<T: Hash> Hash for SharedSegments<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Match `<[T] as Hash>`: length then each element in canonical order, so a
+        // flat value and a segmented value with identical content hash identically.
+        self.len().hash(state);
+        for item in self.iter() {
+            item.hash(state);
+        }
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for SharedSegments<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
+/// An append-only ORDERED sequence (no sort relation) represented as `Arc`-shared
+/// concatenated segments. A strictly-additive successor appends exactly one new
+/// segment and shares every predecessor segment by `Arc` clone; the logical
+/// sequence is the segments in order, back to back. Equality, hashing, and debug
+/// rendering are over the logical concatenation, so representation is invisible
+/// to memoization. The contiguous slice materializes lazily, at most once per
+/// value, and never on a path that only iterates.
+pub(crate) struct SharedList<T> {
+    segments: Arc<[Arc<[T]>]>,
+    merged: OnceLock<Arc<[T]>>,
+}
+
+impl<T> SharedList<T> {
+    /// A flat sequence: one segment holding the items in order.
+    pub(crate) fn flat(items: Arc<[T]>) -> Self {
+        Self {
+            segments: Arc::from([items]),
+            merged: OnceLock::new(),
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.segments.iter().map(|segment| segment.len()).sum()
+    }
+
+    /// The logical sequence in order, streaming across segments.
+    pub(crate) fn iter(&self) -> impl ExactSizeIterator<Item = &T> {
+        ListIter {
+            segments: &self.segments,
+            segment: 0,
+            position: 0,
+            remaining: self.len(),
+        }
+    }
+}
+
+struct ListIter<'a, T> {
+    segments: &'a [Arc<[T]>],
+    segment: usize,
+    position: usize,
+    remaining: usize,
+}
+
+impl<'a, T> Iterator for ListIter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<&'a T> {
+        loop {
+            let segment = self.segments.get(self.segment)?;
+            if let Some(item) = segment.get(self.position) {
+                self.position += 1;
+                self.remaining -= 1;
+                return Some(item);
+            }
+            self.segment += 1;
+            self.position = 0;
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl<'a, T> ExactSizeIterator for ListIter<'a, T> {}
+
+impl<T: Clone> SharedList<T> {
+    /// Build a strictly-additive successor that carries every segment of `base`
+    /// by `Arc` clone and appends `delta` in order as one new segment. No base
+    /// segment is copied and the base is never flattened.
+    pub(crate) fn extend(base: &SharedList<T>, delta: Vec<T>) -> Self {
+        let mut segments: Vec<Arc<[T]>> = base.segments.to_vec();
+        segments.push(delta.into());
+        Self {
+            segments: segments.into(),
+            merged: OnceLock::new(),
+        }
+    }
+
+    /// The logical sequence as one contiguous shared slice, materialized lazily
+    /// at most once per value; a flat value shares its single segment directly.
+    pub(crate) fn as_arc(&self) -> Arc<[T]> {
+        self.merged
+            .get_or_init(|| {
+                if self.segments.len() == 1 {
+                    self.segments[0].clone()
+                } else {
+                    self.iter().cloned().collect::<Vec<_>>().into()
+                }
+            })
+            .clone()
+    }
+}
+
+impl<T: Clone> Clone for SharedList<T> {
+    fn clone(&self) -> Self {
+        // Share all segments by `Arc` clone; the materialized cache is not
+        // carried so a clone holds no predecessor-sized buffer.
+        Self {
+            segments: Arc::clone(&self.segments),
+            merged: OnceLock::new(),
+        }
+    }
+}
+
+impl<T: PartialEq> PartialEq for SharedList<T> {
+    fn eq(&self, other: &Self) -> bool {
+        // Fast path: identical segment lists by pointer.
+        if self.segments.len() == other.segments.len()
+            && self
+                .segments
+                .iter()
+                .zip(other.segments.iter())
+                .all(|(a, b)| Arc::ptr_eq(a, b))
+        {
+            return true;
+        }
+        self.len() == other.len() && self.iter().eq(other.iter())
+    }
+}
+
+impl<T: Eq> Eq for SharedList<T> {}
+
+impl<T: Hash> Hash for SharedList<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Match `<[T] as Hash>`: length then each element in logical order, so a
+        // flat value and a segmented value with identical content hash
+        // identically.
+        self.len().hash(state);
+        for item in self.iter() {
+            item.hash(state);
+        }
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for SharedList<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+
+    fn cmp(a: &i32, b: &i32) -> Ordering {
+        a.cmp(b)
+    }
+
+    fn hash_of(segments: &SharedSegments<i32>) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        segments.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    #[test]
+    fn successor_merges_disjoint_sorted_segments_and_matches_flat() {
+        let predecessor: Arc<[i32]> = Arc::from([1, 3, 5, 7]);
+        let base = SharedSegments::flat(Arc::clone(&predecessor), cmp);
+        let successor = SharedSegments::extend(&base, vec![8, 2, 6]);
+        assert_eq!(successor.as_slice(), &[1, 2, 3, 5, 6, 7, 8]);
+        assert_eq!(
+            successor.iter().copied().collect::<Vec<_>>(),
+            vec![1, 2, 3, 5, 6, 7, 8]
+        );
+        assert_eq!(successor.len(), 7);
+        assert_eq!(successor.delta_segment(), &[2, 6, 8]);
+
+        let flat = SharedSegments::flat(Arc::from([1, 2, 3, 5, 6, 7, 8]), cmp);
+        assert_eq!(successor, flat);
+        assert_eq!(hash_of(&successor), hash_of(&flat));
+    }
+
+    #[test]
+    fn chained_successors_stay_multi_segment_and_share_every_ancestor() {
+        let base = SharedSegments::flat(Arc::from([10, 20, 30]), cmp);
+        let first = SharedSegments::extend(&base, vec![15, 25]);
+        let second = SharedSegments::extend(&first, vec![5, 35]);
+
+        // The second successor is three segments (no flattening of `first`).
+        assert_eq!(second.segments().len(), 3);
+        // Every ancestor segment is shared by pointer with `first`.
+        assert!(Arc::ptr_eq(&second.segments()[0], &first.segments()[0]));
+        assert!(Arc::ptr_eq(&second.segments()[1], &first.segments()[1]));
+        assert!(Arc::ptr_eq(
+            second.predecessor_segment(),
+            base.predecessor_segment()
+        ));
+
+        // Logical content and equivalence with a flat value are preserved.
+        assert_eq!(
+            second.iter().copied().collect::<Vec<_>>(),
+            vec![5, 10, 15, 20, 25, 30, 35]
+        );
+        let flat = SharedSegments::flat(Arc::from([5, 10, 15, 20, 25, 30, 35]), cmp);
+        assert_eq!(second, flat);
+        assert_eq!(hash_of(&second), hash_of(&flat));
+        assert!(second.contains_by(|value| value.cmp(&25)));
+        assert!(!second.contains_by(|value| value.cmp(&26)));
+        assert_eq!(second.find_by(|value| value.cmp(&35)), Some(&35));
+    }
+
+    #[test]
+    fn flat_borrows_without_materializing() {
+        let items: Arc<[i32]> = Arc::from([1, 2, 3]);
+        let flat = SharedSegments::flat(Arc::clone(&items), cmp);
+        assert!(std::ptr::eq(flat.as_slice().as_ptr(), items.as_ptr()));
+        assert_eq!(flat.delta_segment(), &[] as &[i32]);
+    }
+
+    #[test]
+    fn shared_list_extends_in_order_sharing_ancestors() {
+        let base = SharedList::flat(Arc::from([30, 10, 20]));
+        let first = SharedList::extend(&base, vec![5, 25]);
+        let second = SharedList::extend(&first, vec![15]);
+
+        // Order is concatenation order, never sorted; ancestors are shared by
+        // pointer and never flattened.
+        assert_eq!(
+            second.iter().copied().collect::<Vec<_>>(),
+            vec![30, 10, 20, 5, 25, 15]
+        );
+        assert_eq!(second.len(), 6);
+        assert!(Arc::ptr_eq(&second.segments[0], &first.segments[0]));
+        assert!(Arc::ptr_eq(&second.segments[1], &first.segments[1]));
+
+        // Logical equality/hash match a flat value with identical content.
+        let flat = SharedList::flat(Arc::from([30, 10, 20, 5, 25, 15]));
+        assert_eq!(second, flat);
+        assert_eq!(hash_of_list(&second), hash_of_list(&flat));
+        assert_eq!(second.as_arc().as_ref(), flat.as_arc().as_ref());
+
+        // A flat value's contiguous form shares its single segment directly.
+        let items: Arc<[i32]> = Arc::from([1, 2]);
+        let single = SharedList::flat(Arc::clone(&items));
+        assert!(std::ptr::eq(single.as_arc().as_ptr(), items.as_ptr()));
+    }
+
+    fn hash_of_list(value: &SharedList<i32>) -> u64 {
+        use std::hash::{DefaultHasher, Hasher as _};
+        let mut hasher = DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+}

--- a/crates/rue-compiler/src/source_identity.rs
+++ b/crates/rue-compiler/src/source_identity.rs
@@ -117,7 +117,9 @@ impl From<&SourceId> for SourceBucketKey {
 /// remain distinct entries.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceStore {
-    buckets: Arc<BTreeMap<SourceBucketKey, Arc<[SourceId]>>>,
+    /// `Arc`-shared bucket segments, oldest first; a strictly-additive
+    /// successor appends one segment and shares the rest (RUE-1112).
+    buckets: Vec<Arc<BTreeMap<SourceBucketKey, Arc<[SourceId]>>>>,
     len: usize,
 }
 
@@ -151,14 +153,49 @@ impl SourceStore {
                 .push(source);
         }
         Self {
-            buckets: Arc::new(
+            buckets: vec![Arc::new(
                 buckets
                     .into_iter()
                     .map(|(key, bucket)| (key, bucket.into()))
                     .collect(),
-            ),
+            )],
             len,
         }
+    }
+
+    /// Build a strictly-additive successor store that shares every bucket
+    /// segment of `base` by reference and appends one segment holding only the
+    /// genuinely new identities (RUE-1112). No base identity is copied or
+    /// re-bucketed.
+    pub(crate) fn extend_with_ids(
+        base: &SourceStore,
+        appended: impl IntoIterator<Item = SourceId>,
+    ) -> Self {
+        let mut appended: Vec<_> = appended
+            .into_iter()
+            .filter(|source| base.get(source).is_none())
+            .collect();
+        appended.sort();
+        appended.dedup();
+        if appended.is_empty() {
+            return base.clone();
+        }
+        let len = base.len + appended.len();
+        let mut new_bucket = BTreeMap::<_, Vec<_>>::new();
+        for source in appended {
+            new_bucket
+                .entry(SourceBucketKey::from(&source))
+                .or_default()
+                .push(source);
+        }
+        let mut buckets = base.buckets.clone();
+        buckets.push(Arc::new(
+            new_bucket
+                .into_iter()
+                .map(|(key, bucket)| (key, bucket.into()))
+                .collect(),
+        ));
+        Self { buckets, len }
     }
 
     /// Number of distinct exact source byte strings.
@@ -173,11 +210,14 @@ impl SourceStore {
 
     /// Return this store's canonical exact identity for `source`.
     pub fn get(&self, source: &SourceId) -> Option<&SourceId> {
-        let bucket = self.buckets.get(&SourceBucketKey::from(source))?;
-        bucket
-            .binary_search(source)
-            .ok()
-            .map(|index| &bucket[index])
+        let key = SourceBucketKey::from(source);
+        self.buckets.iter().find_map(|segment| {
+            let bucket = segment.get(&key)?;
+            bucket
+                .binary_search(source)
+                .ok()
+                .map(|index| &bucket[index])
+        })
     }
 
     /// Share the exact retained source allocation identified by `source`.
@@ -185,9 +225,12 @@ impl SourceStore {
         self.get(source).map(|source| source.0.text.clone())
     }
 
-    /// Iterate exact identities in version, digest, then byte order.
+    /// Iterate exact identities, segment by segment; within each segment the
+    /// order is version, digest, then byte order.
     pub fn iter(&self) -> impl Iterator<Item = &SourceId> + '_ {
-        self.buckets.values().flat_map(|bucket| bucket.iter())
+        self.buckets
+            .iter()
+            .flat_map(|segment| segment.values().flat_map(|bucket| bucket.iter()))
     }
 }
 
@@ -321,18 +364,30 @@ pub struct ModuleRevision {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SourceRevision {
     root: ModuleId,
-    modules: Arc<[ModuleRevision]>,
+    modules: crate::shared_segments::SharedSegments<ModuleRevision>,
 }
+
+/// Canonical order for the module/source mapping: by module identity.
+fn module_revision_order(a: &ModuleRevision, b: &ModuleRevision) -> std::cmp::Ordering {
+    a.module.cmp(&b.module)
+}
+
 impl SourceRevision {
     pub fn root(&self) -> &ModuleId {
         &self.root
     }
     pub fn modules(&self) -> &[ModuleRevision] {
+        self.modules.as_slice()
+    }
+    /// The shared segmented representation (RUE-1112 successor sharing).
+    pub(crate) fn module_segments(
+        &self,
+    ) -> &crate::shared_segments::SharedSegments<ModuleRevision> {
         &self.modules
     }
     /// Build a complete, canonical module/source mapping.
     pub fn new(root: ModuleId, mut modules: Vec<ModuleRevision>) -> CompileResult<Self> {
-        modules.sort_by(|a, b| a.module.cmp(&b.module));
+        modules.sort_by(module_revision_order);
         if let Some(duplicate) = modules
             .windows(2)
             .find(|pair| pair[0].module == pair[1].module)
@@ -352,7 +407,48 @@ impl SourceRevision {
         }
         Ok(Self {
             root,
-            modules: modules.into(),
+            modules: crate::shared_segments::SharedSegments::flat(
+                modules.into(),
+                module_revision_order,
+            ),
+        })
+    }
+
+    /// Build a strictly-additive successor mapping that shares `base`'s module
+    /// segments by reference and appends only `appended` (RUE-1112). Validates
+    /// the appended entries alone: they must be new module identities. No base
+    /// entry is copied, re-sorted, or re-validated.
+    pub(crate) fn extend_with_appended(
+        base: &SourceRevision,
+        appended: Vec<ModuleRevision>,
+    ) -> CompileResult<Self> {
+        for entry in &appended {
+            if base
+                .modules
+                .contains_by(|candidate| candidate.module.cmp(&entry.module))
+            {
+                return Err(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                    format!(
+                        "source revision successor re-adds existing module ID {:?}",
+                        entry.module
+                    ),
+                )));
+            }
+        }
+        let mut sorted = appended;
+        sorted.sort_by(module_revision_order);
+        if let Some(duplicate) = sorted
+            .windows(2)
+            .find(|pair| pair[0].module == pair[1].module)
+            .map(|pair| &pair[0].module)
+        {
+            return Err(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                format!("source revision contains duplicate module ID {duplicate:?}"),
+            )));
+        }
+        Ok(Self {
+            root: base.root.clone(),
+            modules: crate::shared_segments::SharedSegments::extend(&base.modules, sorted),
         })
     }
 }
@@ -362,17 +458,69 @@ pub struct ModuleResolutionInput {
     pub module: ModuleId,
     pub physical_path: Arc<str>,
 }
+/// Canonical order for module-resolution inputs: by module identity.
+fn module_input_order(a: &ModuleResolutionInput, b: &ModuleResolutionInput) -> std::cmp::Ordering {
+    a.module.cmp(&b.module)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ModuleResolutionInputs {
     root: ModuleId,
-    modules: Arc<[ModuleResolutionInput]>,
+    modules: crate::shared_segments::SharedSegments<ModuleResolutionInput>,
 }
 impl ModuleResolutionInputs {
     pub fn root(&self) -> &ModuleId {
         &self.root
     }
     pub fn modules(&self) -> &[ModuleResolutionInput] {
+        self.modules.as_slice()
+    }
+
+    /// Whether `module` is in the resolution set, by binary search over the
+    /// shared segments — O(log n) with no materialization (RUE-1112).
+    pub(crate) fn contains(&self, module: &ModuleId) -> bool {
+        self.modules.contains_by(|entry| entry.module.cmp(module))
+    }
+
+    /// The shared module-table representation (RUE-1112 successor sharing).
+    pub(crate) fn module_segments(
+        &self,
+    ) -> &crate::shared_segments::SharedSegments<ModuleResolutionInput> {
         &self.modules
+    }
+
+    /// Build a strictly-additive successor by structurally sharing `base`'s
+    /// module table and appending `delta` (RUE-1112). Only `delta` is validated
+    /// and sorted; `base`'s table is carried by reference. `delta` must be
+    /// disjoint from `base` (the modules added since the predecessor close).
+    pub(crate) fn extend_successor(
+        base: &ModuleResolutionInputs,
+        delta: Vec<ModuleResolutionInput>,
+    ) -> CompileResult<Self> {
+        if let Some(module) = delta
+            .iter()
+            .find(|entry| entry.physical_path.is_empty())
+            .map(|entry| &entry.module)
+        {
+            return Err(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                format!("module resolution input {module:?} has an empty physical path"),
+            )));
+        }
+        let mut sorted = delta.clone();
+        sorted.sort_by(module_input_order);
+        if let Some(duplicate) = sorted
+            .windows(2)
+            .find(|pair| pair[0].module == pair[1].module)
+            .map(|pair| &pair[0].module)
+        {
+            return Err(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                format!("module resolution inputs contain duplicate module ID {duplicate:?}"),
+            )));
+        }
+        Ok(Self {
+            root: base.root.clone(),
+            modules: crate::shared_segments::SharedSegments::extend(&base.modules, delta),
+        })
     }
     /// Build canonical explicit module-resolution inputs.
     pub fn new(root: ModuleId, mut modules: Vec<ModuleResolutionInput>) -> CompileResult<Self> {
@@ -419,15 +567,17 @@ impl ModuleResolutionInputs {
         }
         Ok(Self {
             root,
-            modules: modules.into(),
+            modules: crate::shared_segments::SharedSegments::flat(
+                modules.into(),
+                module_input_order,
+            ),
         })
     }
 
     pub fn physical_path(&self, module: &ModuleId) -> Option<&str> {
         self.modules
-            .binary_search_by(|entry| entry.module.cmp(module))
-            .ok()
-            .map(|index| self.modules[index].physical_path.as_ref())
+            .find_by(|entry| entry.module.cmp(module))
+            .map(|entry| entry.physical_path.as_ref())
     }
 
     pub fn from_metadata(metadata: &SourceMetadata) -> Self {

--- a/crates/rue-compiler/src/source_metadata.rs
+++ b/crates/rue-compiler/src/source_metadata.rs
@@ -18,27 +18,90 @@ use crate::SourceView;
 
 /// Immutable, validated identities for every source in a compilation.
 ///
-/// The descriptor owns its path maps and keeps a separate ascending `FileId`
-/// index. Callers therefore retain constant-time lookup while deterministic
-/// iterators never depend on `HashMap` iteration order.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// The descriptor is a persistent structure (RUE-1112): it holds one or more
+/// `Arc`-shared segments, each owning its path maps and ascending `FileId`
+/// index. A strictly-additive successor appends one validated segment and
+/// shares every predecessor segment by reference, so extending the descriptor
+/// never copies, re-normalizes, or re-validates a predecessor entry; the merged
+/// ascending id index is materialized lazily, off the extension path. Callers
+/// retain constant-time lookup while deterministic iterators never depend on
+/// `HashMap` iteration order.
+#[derive(Debug)]
 pub struct SourceMetadata {
     root_file_id: FileId,
+    segments: Vec<std::sync::Arc<MetadataSegment>>,
+    len: usize,
+    merged_ids: std::sync::OnceLock<Vec<FileId>>,
+}
+
+/// One validated, immutable slice of the descriptor. Segment ids are ascending
+/// and every later segment's ids are strictly greater than every earlier
+/// segment's, so chaining segments preserves ascending order.
+#[derive(Debug)]
+struct MetadataSegment {
     sorted_ids: Vec<FileId>,
     physical_paths: HashMap<FileId, String>,
     logical_paths: HashMap<FileId, String>,
     trusted_standard_library_files: HashSet<FileId>,
+    /// Normalized path identities, retained so an appended segment can check
+    /// cross-segment collisions without re-normalizing predecessor entries.
+    normalized_physical: HashSet<String>,
+    normalized_logical: HashSet<String>,
 }
+
+impl Clone for SourceMetadata {
+    fn clone(&self) -> Self {
+        Self {
+            root_file_id: self.root_file_id,
+            segments: self.segments.clone(),
+            len: self.len,
+            merged_ids: std::sync::OnceLock::new(),
+        }
+    }
+}
+
+impl PartialEq for SourceMetadata {
+    fn eq(&self, other: &Self) -> bool {
+        // Logical equality over the merged descriptor, so a flat value and a
+        // segmented value with identical content are indistinguishable.
+        if self.root_file_id != other.root_file_id || self.len != other.len {
+            return false;
+        }
+        // Fast path: identical segment lists by pointer.
+        if self.segments.len() == other.segments.len()
+            && self
+                .segments
+                .iter()
+                .zip(other.segments.iter())
+                .all(|(a, b)| std::sync::Arc::ptr_eq(a, b))
+        {
+            return true;
+        }
+        self.file_ids().zip(other.file_ids()).all(|(a, b)| {
+            a == b
+                && self.physical_path(a) == other.physical_path(b)
+                && self.logical_path(a) == other.logical_path(b)
+                && self.is_trusted_standard_library_file(a)
+                    == other.is_trusted_standard_library_file(b)
+        })
+    }
+}
+
+impl Eq for SourceMetadata {}
 
 impl std::hash::Hash for SourceMetadata {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         // This type owns unordered `HashMap`/`HashSet` fields, so `Hash` cannot
-        // be derived. Hashing the root plus the deterministic ascending id index
-        // is consistent with the structural `Eq`: equal metadata necessarily
-        // agree on both, and any collision between distinct metadata is resolved
-        // by exact `Eq` when the typed key indexes the memo map.
+        // be derived. Hashing the root plus the deterministic ascending id
+        // sequence is consistent with the logical `Eq`: equal metadata
+        // necessarily agree on both, and any collision between distinct
+        // metadata is resolved by exact `Eq` when the typed key indexes the
+        // memo map. The id sequence is representation-independent.
         std::hash::Hash::hash(&self.root_file_id, state);
-        std::hash::Hash::hash(&self.sorted_ids, state);
+        std::hash::Hash::hash(&self.len, state);
+        for file_id in self.file_ids() {
+            std::hash::Hash::hash(&file_id, state);
+        }
     }
 }
 
@@ -56,58 +119,20 @@ impl SourceMetadata {
         if physical_paths.is_empty() {
             return Err(invalid_input("source metadata contains no files"));
         }
-
-        let mut file_ids: Vec<_> = physical_paths.keys().copied().collect();
-        file_ids.sort_by_key(|file_id| file_id.index());
-
         if !physical_paths.contains_key(&root_file_id) {
             return Err(invalid_input(format!(
                 "root file ID {} is absent from source metadata",
                 display_file_id(root_file_id)
             )));
         }
-
-        let missing_logical_ids: Vec<_> = file_ids
-            .iter()
-            .copied()
-            .filter(|file_id| !logical_paths.contains_key(file_id))
-            .collect();
-        if !missing_logical_ids.is_empty() {
-            return Err(invalid_input(format!(
-                "logical path map is missing file IDs: {}",
-                display_file_ids(&missing_logical_ids)
-            )));
-        }
-
-        let mut unknown_logical_ids: Vec<_> = logical_paths
-            .keys()
-            .copied()
-            .filter(|file_id| !physical_paths.contains_key(file_id))
-            .collect();
-        unknown_logical_ids.sort_by_key(|file_id| file_id.index());
-        if !unknown_logical_ids.is_empty() {
-            return Err(invalid_input(format!(
-                "logical path map contains unknown file IDs: {}",
-                display_file_ids(&unknown_logical_ids)
-            )));
-        }
-
-        let logical_paths: HashMap<_, _> = logical_paths
-            .into_iter()
-            .map(|(file_id, path)| (file_id, normalize_module_path(&path)))
-            .collect();
-
-        validate_nonempty_paths("physical", &file_ids, &physical_paths)?;
-        validate_nonempty_paths("logical", &file_ids, &logical_paths)?;
-        validate_normalized_collisions("physical", &file_ids, &physical_paths)?;
-        validate_normalized_collisions("logical", &file_ids, &logical_paths)?;
-
+        let segment =
+            MetadataSegment::validated(physical_paths, logical_paths, HashSet::new(), None)?;
+        let len = segment.sorted_ids.len();
         Ok(Self {
             root_file_id,
-            sorted_ids: file_ids,
-            physical_paths,
-            logical_paths,
-            trusted_standard_library_files: HashSet::new(),
+            segments: vec![std::sync::Arc::new(segment)],
+            len,
+            merged_ids: std::sync::OnceLock::new(),
         })
     }
 
@@ -117,21 +142,105 @@ impl SourceMetadata {
         logical_paths: HashMap<FileId, String>,
         trusted_standard_library_files: HashSet<FileId>,
     ) -> CompileResult<Self> {
-        let mut metadata = Self::new(root_file_id, physical_paths, logical_paths)?;
-        for file_id in &trusted_standard_library_files {
-            let Some(path) = metadata.logical_path(*file_id) else {
-                return Err(invalid_input(
-                    "trusted standard-library file is absent from metadata",
-                ));
-            };
-            if !path.starts_with("\0rue-std/") {
-                return Err(invalid_input(
-                    "trusted standard-library file has a non-standard logical path",
-                ));
+        if physical_paths.is_empty() {
+            return Err(invalid_input("source metadata contains no files"));
+        }
+        if !physical_paths.contains_key(&root_file_id) {
+            return Err(invalid_input(format!(
+                "root file ID {} is absent from source metadata",
+                display_file_id(root_file_id)
+            )));
+        }
+        let segment = MetadataSegment::validated(
+            physical_paths,
+            logical_paths,
+            trusted_standard_library_files,
+            None,
+        )?;
+        let len = segment.sorted_ids.len();
+        Ok(Self {
+            root_file_id,
+            segments: vec![std::sync::Arc::new(segment)],
+            len,
+            merged_ids: std::sync::OnceLock::new(),
+        })
+    }
+
+    /// Build a strictly-additive successor descriptor that shares every segment
+    /// of `self` by reference and appends one validated segment (RUE-1112).
+    ///
+    /// Only the appended entries are normalized and validated — nonempty
+    /// identities, normalized-collision checks within the appended set and
+    /// against the shared base's retained normalized identities, id
+    /// disjointness, and the trusted-namespace invariant — exactly the
+    /// invariants full construction enforces, applied incrementally. Appended
+    /// ids must be strictly greater than every existing id so chained segments
+    /// stay ascending.
+    pub(crate) fn extend_with_appended(
+        &self,
+        physical_paths: HashMap<FileId, String>,
+        logical_paths: HashMap<FileId, String>,
+        trusted_standard_library_files: HashSet<FileId>,
+    ) -> CompileResult<Self> {
+        if physical_paths.is_empty() {
+            return Err(invalid_input("source metadata extension appends no files"));
+        }
+        let max_existing = self
+            .segments
+            .last()
+            .and_then(|segment| segment.sorted_ids.last())
+            .expect("validated descriptors are never empty")
+            .index();
+        for file_id in physical_paths.keys() {
+            if self.contains_file(*file_id) || file_id.index() <= max_existing {
+                return Err(invalid_input(format!(
+                    "source metadata extension re-uses file ID {}",
+                    display_file_id(*file_id)
+                )));
             }
         }
-        metadata.trusted_standard_library_files = trusted_standard_library_files;
-        Ok(metadata)
+        let segment = MetadataSegment::validated(
+            physical_paths,
+            logical_paths,
+            trusted_standard_library_files,
+            Some(&self.segments),
+        )?;
+        let len = self.len + segment.sorted_ids.len();
+        let mut segments = self.segments.clone();
+        segments.push(std::sync::Arc::new(segment));
+        Ok(Self {
+            root_file_id: self.root_file_id,
+            segments,
+            len,
+            merged_ids: std::sync::OnceLock::new(),
+        })
+    }
+
+    /// The merged ascending id index, materialized lazily off the extension
+    /// path; a single-segment descriptor borrows its segment directly.
+    fn ids(&self) -> &[FileId] {
+        if self.segments.len() == 1 {
+            return &self.segments[0].sorted_ids;
+        }
+        self.merged_ids.get_or_init(|| {
+            self.segments
+                .iter()
+                .flat_map(|segment| segment.sorted_ids.iter().copied())
+                .collect()
+        })
+    }
+
+    fn segment_for(&self, file_id: FileId) -> Option<&MetadataSegment> {
+        self.segments
+            .iter()
+            .map(std::sync::Arc::as_ref)
+            .find(|segment| segment.physical_paths.contains_key(&file_id))
+    }
+
+    pub(crate) fn is_trusted_standard_library_file(&self, file_id: FileId) -> bool {
+        self.segments
+            .iter()
+            .any(|segment| segment.trusted_standard_library_files.contains(&file_id))
     }
 
     #[cfg(test)]
@@ -201,7 +310,7 @@ impl SourceMetadata {
     /// Number of files described by this metadata.
     #[inline]
     pub fn len(&self) -> usize {
-        self.sorted_ids.len()
+        self.len
     }
 
     /// Whether this descriptor contains no files.
@@ -210,23 +319,26 @@ impl SourceMetadata {
     /// [`Self::len`] therefore always returns `false`.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.sorted_ids.is_empty()
+        self.len == 0
     }
 
     /// Whether this descriptor contains `file_id`.
     #[inline]
     pub fn contains_file(&self, file_id: FileId) -> bool {
-        self.physical_paths.contains_key(&file_id)
+        self.segment_for(file_id).is_some()
     }
 
     /// File IDs in ascending numeric order.
     pub fn file_ids(&self) -> impl DoubleEndedIterator<Item = FileId> + ExactSizeIterator + '_ {
-        self.sorted_ids.iter().copied()
+        self.ids().iter().copied()
     }
 
     /// The physical diagnostic/module path for `file_id`.
     pub fn physical_path(&self, file_id: FileId) -> Option<&str> {
-        self.physical_paths.get(&file_id).map(String::as_str)
+        self.segment_for(file_id)?
+            .physical_paths
+            .get(&file_id)
+            .map(String::as_str)
     }
 
     /// The canonical logical semantic identity for `file_id`.
@@ -236,13 +348,16 @@ impl SourceMetadata {
     /// contents, snapshots, or interner epochs and are not standalone cache
     /// keys.
     pub fn logical_path(&self, file_id: FileId) -> Option<&str> {
-        self.logical_paths.get(&file_id).map(String::as_str)
+        self.segment_for(file_id)?
+            .logical_paths
+            .get(&file_id)
+            .map(String::as_str)
     }
 
     /// Canonical logical module identity for a request-local file ID.
     pub fn module_id(&self, file_id: FileId) -> Option<ModuleId> {
         let path = self.logical_path(file_id)?;
-        Some(if self.trusted_standard_library_files.contains(&file_id) {
+        Some(if self.is_trusted_standard_library_file(file_id) {
             ModuleId::from_trusted_validated_canonical(path)
         } else {
             ModuleId::from_validated_canonical(path)
@@ -259,12 +374,11 @@ impl SourceMetadata {
     pub fn physical_paths(
         &self,
     ) -> impl DoubleEndedIterator<Item = (FileId, &str)> + ExactSizeIterator + '_ {
-        self.sorted_ids.iter().map(|&file_id| {
+        self.ids().iter().map(|&file_id| {
             let path = self
-                .physical_paths
-                .get(&file_id)
+                .physical_path(file_id)
                 .expect("validated physical path key");
-            (file_id, path.as_str())
+            (file_id, path)
         })
     }
 
@@ -272,29 +386,12 @@ impl SourceMetadata {
     pub fn logical_paths(
         &self,
     ) -> impl DoubleEndedIterator<Item = (FileId, &str)> + ExactSizeIterator + '_ {
-        self.sorted_ids.iter().map(|&file_id| {
+        self.ids().iter().map(|&file_id| {
             let path = self
-                .logical_paths
-                .get(&file_id)
+                .logical_path(file_id)
                 .expect("validated logical path key");
-            (file_id, path.as_str())
+            (file_id, path)
         })
-    }
-
-    /// The complete physical path map.
-    ///
-    /// The map is immutable but its iteration order is unspecified. Use
-    /// [`Self::physical_paths`] when deterministic iteration matters.
-    pub fn physical_path_map(&self) -> &HashMap<FileId, String> {
-        &self.physical_paths
-    }
-
-    /// The complete logical path map.
-    ///
-    /// The map is immutable but its iteration order is unspecified. Use
-    /// [`Self::logical_paths`] when deterministic iteration matters.
-    pub fn logical_path_map(&self) -> &HashMap<FileId, String> {
-        &self.logical_paths
     }
 
     #[cfg(test)]
@@ -365,6 +462,105 @@ impl SourceMetadata {
         }
 
         Ok(())
+    }
+}
+
+impl MetadataSegment {
+    /// Validate one segment's complete path maps: exactly the invariants full
+    /// construction has always enforced (key agreement, nonempty normalized
+    /// identities, normalized-collision freedom, trusted-namespace membership),
+    /// applied to this segment's entries alone — plus, for an appended segment,
+    /// collision freedom against the shared base's RETAINED normalized
+    /// identities (no base entry is re-normalized or re-walked).
+    fn validated(
+        physical_paths: HashMap<FileId, String>,
+        logical_paths: HashMap<FileId, String>,
+        trusted_standard_library_files: HashSet<FileId>,
+        base: Option<&[std::sync::Arc<MetadataSegment>]>,
+    ) -> CompileResult<Self> {
+        let mut file_ids: Vec<_> = physical_paths.keys().copied().collect();
+        file_ids.sort_by_key(|file_id| file_id.index());
+
+        let missing_logical_ids: Vec<_> = file_ids
+            .iter()
+            .copied()
+            .filter(|file_id| !logical_paths.contains_key(file_id))
+            .collect();
+        if !missing_logical_ids.is_empty() {
+            return Err(invalid_input(format!(
+                "logical path map is missing file IDs: {}",
+                display_file_ids(&missing_logical_ids)
+            )));
+        }
+
+        let mut unknown_logical_ids: Vec<_> = logical_paths
+            .keys()
+            .copied()
+            .filter(|file_id| !physical_paths.contains_key(file_id))
+            .collect();
+        unknown_logical_ids.sort_by_key(|file_id| file_id.index());
+        if !unknown_logical_ids.is_empty() {
+            return Err(invalid_input(format!(
+                "logical path map contains unknown file IDs: {}",
+                display_file_ids(&unknown_logical_ids)
+            )));
+        }
+
+        let logical_paths: HashMap<_, _> = logical_paths
+            .into_iter()
+            .map(|(file_id, path)| (file_id, normalize_module_path(&path)))
+            .collect();
+
+        validate_nonempty_paths("physical", &file_ids, &physical_paths)?;
+        validate_nonempty_paths("logical", &file_ids, &logical_paths)?;
+        validate_normalized_collisions("physical", &file_ids, &physical_paths)?;
+        validate_normalized_collisions("logical", &file_ids, &logical_paths)?;
+
+        for file_id in &trusted_standard_library_files {
+            let Some(path) = logical_paths.get(file_id) else {
+                return Err(invalid_input(
+                    "trusted standard-library file is absent from metadata",
+                ));
+            };
+            if !path.starts_with("\0rue-std/") {
+                return Err(invalid_input(
+                    "trusted standard-library file has a non-standard logical path",
+                ));
+            }
+        }
+
+        let normalized_physical: HashSet<String> = file_ids
+            .iter()
+            .map(|file_id| normalize_module_path(&physical_paths[file_id]))
+            .collect();
+        let normalized_logical: HashSet<String> = logical_paths.values().cloned().collect();
+        if let Some(base) = base {
+            for segment in base {
+                for path in &normalized_physical {
+                    if segment.normalized_physical.contains(path) {
+                        return Err(invalid_input(format!(
+                            "physical path {path:?} collides with an existing source identity"
+                        )));
+                    }
+                }
+                for path in &normalized_logical {
+                    if segment.normalized_logical.contains(path) {
+                        return Err(invalid_input(format!(
+                            "logical path {path:?} collides with an existing source identity"
+                        )));
+                    }
+                }
+            }
+        }
+
+        Ok(Self {
+            sorted_ids: file_ids,
+            physical_paths,
+            logical_paths,
+            trusted_standard_library_files,
+            normalized_physical,
+            normalized_logical,
+        })
     }
 }
 
@@ -473,8 +669,8 @@ mod tests {
             Some("stable/util.rue")
         );
         assert_eq!(metadata.logical_path(FileId::new(20)), Some("src/root.rue"));
-        assert_eq!(metadata.physical_path_map().len(), 2);
-        assert_eq!(metadata.logical_path_map().len(), 2);
+        assert_eq!(metadata.physical_paths().len(), 2);
+        assert_eq!(metadata.logical_paths().len(), 2);
     }
 
     #[test]

--- a/crates/rue-compiler/src/source_snapshot.rs
+++ b/crates/rue-compiler/src/source_snapshot.rs
@@ -33,10 +33,34 @@ pub struct SourceSnapshot {
 #[derive(Debug)]
 struct SourceSnapshotData {
     metadata: SourceMetadata,
-    contents: Vec<SourceRecord>,
-    index: HashMap<FileId, usize>,
+    /// `Arc`-shared record segments, oldest first (RUE-1112): a strictly
+    /// additive successor appends one segment and shares the rest, so extending
+    /// a snapshot never copies, re-hashes, or re-validates a predecessor
+    /// record.
+    segments: Vec<Arc<SnapshotSegment>>,
+    /// Global start index of each segment, aligned with `segments`.
+    segment_offsets: Vec<usize>,
+    len: usize,
     revision: SourceRevision,
     source_store: SourceStore,
+}
+
+#[derive(Debug)]
+struct SnapshotSegment {
+    contents: Vec<SourceRecord>,
+    /// Position within THIS segment for each of its file ids.
+    index: HashMap<FileId, usize>,
+}
+
+impl SnapshotSegment {
+    fn from_records(contents: Vec<SourceRecord>) -> Self {
+        let index = contents
+            .iter()
+            .enumerate()
+            .map(|(index, record)| (record.file_id, index))
+            .collect();
+        Self { contents, index }
+    }
 }
 
 #[derive(Debug)]
@@ -144,8 +168,9 @@ impl SourceSnapshot {
         Ok(Self {
             data: Arc::new(SourceSnapshotData {
                 metadata,
-                contents,
-                index,
+                len: contents.len(),
+                segments: vec![Arc::new(SnapshotSegment { contents, index })],
+                segment_offsets: vec![0],
                 revision,
                 source_store,
             }),
@@ -267,8 +292,9 @@ impl SourceSnapshot {
         Ok(Self {
             data: Arc::new(SourceSnapshotData {
                 metadata,
-                contents,
-                index,
+                len: contents.len(),
+                segments: vec![Arc::new(SnapshotSegment { contents, index })],
+                segment_offsets: vec![0],
                 revision,
                 source_store,
             }),
@@ -303,7 +329,7 @@ impl SourceSnapshot {
     /// Number of source files in this snapshot.
     #[inline]
     pub fn len(&self) -> usize {
-        self.data.contents.len()
+        self.data.len
     }
 
     /// Whether this snapshot contains no source files.
@@ -312,7 +338,7 @@ impl SourceSnapshot {
     /// returns `false`.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.data.contents.is_empty()
+        self.data.len == 0
     }
 
     /// Borrow the source text for `file_id`.
@@ -347,15 +373,20 @@ impl SourceSnapshot {
 
     /// Borrow one supported source record view without copying its text.
     pub fn source(&self, file_id: FileId) -> Option<SourceView<'_>> {
-        let index = *self.data.index.get(&file_id)?;
-        Some(self.file_at(index))
+        let record = self.record(file_id)?;
+        let path = self
+            .data
+            .metadata
+            .physical_path(file_id)
+            .expect("snapshot contents validated against metadata");
+        Some(SourceView::new(path, record.text.as_str(), file_id))
     }
 
     /// Borrow supported source record views in caller-supplied order.
     pub fn files(
         &self,
     ) -> impl DoubleEndedIterator<Item = SourceView<'_>> + ExactSizeIterator + '_ {
-        (0..self.data.contents.len()).map(|index| self.file_at(index))
+        (0..self.data.len).map(|index| self.file_at(index))
     }
 
     fn content(&self, file_id: FileId) -> Option<&Arc<String>> {
@@ -363,13 +394,31 @@ impl SourceSnapshot {
     }
 
     fn record(&self, file_id: FileId) -> Option<&SourceRecord> {
-        let record = &self.data.contents[*self.data.index.get(&file_id)?];
+        let record = self.data.segments.iter().find_map(|segment| {
+            segment
+                .index
+                .get(&file_id)
+                .map(|&position| &segment.contents[position])
+        })?;
         debug_assert_eq!(record.file_id, file_id);
         Some(record)
     }
 
+    fn record_at(&self, index: usize) -> &SourceRecord {
+        // Few segments (one per acquisition step, compacted publication-side),
+        // so a linear offset walk stays cheap.
+        let segment_position = self
+            .data
+            .segment_offsets
+            .iter()
+            .rposition(|&start| start <= index)
+            .expect("segment offsets begin at zero");
+        let segment = &self.data.segments[segment_position];
+        &segment.contents[index - self.data.segment_offsets[segment_position]]
+    }
+
     fn file_at(&self, index: usize) -> SourceView<'_> {
-        let record = &self.data.contents[index];
+        let record = self.record_at(index);
         let file_id = record.file_id;
         let path = self
             .data
@@ -378,6 +427,109 @@ impl SourceSnapshot {
             .expect("snapshot contents validated against metadata");
         SourceView::new(path, record.text.as_str(), file_id)
     }
+
+    /// Build a strictly-additive successor snapshot that shares every record
+    /// segment, metadata segment, store bucket segment, and module-revision
+    /// segment of `base` by reference, appending one validated segment holding
+    /// only `appended` (RUE-1112). Only the appended sources are hashed and
+    /// validated; no predecessor record is copied, re-hashed, or re-validated.
+    /// Appended file ids are assigned after the base's, so predecessor ids stay
+    /// stable across the extension.
+    pub(crate) fn extend_with_appended(
+        base: &SourceSnapshot,
+        appended: Vec<AppendedSource>,
+    ) -> CompileResult<SourceSnapshot> {
+        if appended.is_empty() {
+            return Ok(base.clone());
+        }
+        let mut physical_paths = HashMap::new();
+        let mut logical_paths = HashMap::new();
+        let mut trusted = HashSet::new();
+        for entry in &appended {
+            physical_paths.insert(entry.file_id, entry.physical_path.clone());
+            logical_paths.insert(entry.file_id, entry.logical_path.clone());
+            if entry.trusted_standard_library {
+                trusted.insert(entry.file_id);
+            }
+        }
+        let metadata =
+            base.data
+                .metadata
+                .extend_with_appended(physical_paths, logical_paths, trusted)?;
+        validate_source_lengths(
+            appended
+                .iter()
+                .map(|entry| (entry.file_id, entry.text.len())),
+            &metadata,
+        )?;
+        // Hash ONLY the appended sources.
+        let candidates: Vec<_> = appended
+            .into_iter()
+            .map(|entry| {
+                let module_id = metadata
+                    .module_id(entry.file_id)
+                    .expect("appended entries were just validated into the metadata");
+                let source_id = SourceId::from_shared_text(entry.text);
+                (entry.file_id, module_id, source_id)
+            })
+            .collect();
+        let source_store = SourceStore::extend_with_ids(
+            &base.data.source_store,
+            candidates.iter().map(|(_, _, source_id)| source_id.clone()),
+        );
+        let records: Vec<_> = candidates
+            .into_iter()
+            .map(|(file_id, module_id, requested_id)| {
+                let source_id = source_store
+                    .get(&requested_id)
+                    .expect("store was extended with every appended source")
+                    .clone();
+                let text = source_store
+                    .shared_text(&source_id)
+                    .expect("canonical store identity retains exact source text");
+                SourceRecord {
+                    file_id,
+                    module_id,
+                    source_id,
+                    text,
+                }
+            })
+            .collect();
+        let revision = SourceRevision::extend_with_appended(
+            &base.data.revision,
+            records
+                .iter()
+                .map(|record| ModuleRevision {
+                    module: record.module_id.clone(),
+                    source: record.source_id.clone(),
+                })
+                .collect(),
+        )?;
+        let mut segments = base.data.segments.clone();
+        let mut segment_offsets = base.data.segment_offsets.clone();
+        segment_offsets.push(base.data.len);
+        let len = base.data.len + records.len();
+        segments.push(Arc::new(SnapshotSegment::from_records(records)));
+        Ok(SourceSnapshot {
+            data: Arc::new(SourceSnapshotData {
+                metadata,
+                segments,
+                segment_offsets,
+                len,
+                revision,
+                source_store,
+            }),
+        })
+    }
+}
+
+/// One source appended by a strictly-additive snapshot extension (RUE-1112).
+pub(crate) struct AppendedSource {
+    pub(crate) file_id: FileId,
+    pub(crate) physical_path: String,
+    pub(crate) logical_path: String,
+    pub(crate) trusted_standard_library: bool,
+    pub(crate) text: Arc<String>,
 }
 
 fn validate_source_len(file_id: FileId, path: &str, len: usize) -> CompileResult<()> {

--- a/crates/rue-compiler/src/supported_api_inventory.rs
+++ b/crates/rue-compiler/src/supported_api_inventory.rs
@@ -55,6 +55,7 @@ stable|import_discovery|compatibility-boundary|legacy-embedders|ImportDiscoveryR
 stable|import_discovery|compatibility-boundary|legacy-embedders|ImportObservation|pub use import_discovery::ImportObservation
 stable|import_discovery|compatibility-boundary|legacy-embedders|ImportObservationLedger|pub use import_discovery::ImportObservationLedger
 stable|import_discovery|compatibility-boundary|legacy-embedders|ImportObservationStatus|pub use import_discovery::ImportObservationStatus
+stable|import_discovery|dependency-artifact|source-loaders+embedders|AcceptedReadManifest|pub use import_discovery::AcceptedReadManifest
 stable|import_discovery|dependency-artifact|source-loaders+embedders|AcceptedReadManifestEntry|pub use import_discovery::AcceptedReadManifestEntry
 stable|import_discovery|dependency-artifact|source-loaders+embedders|FileMetadataFingerprint|pub use import_discovery::FileMetadataFingerprint
 stable|import_discovery|dependency-artifact|source-loaders+embedders|ImportCandidateRole|pub use import_discovery::ImportCandidateRole
@@ -96,6 +97,10 @@ stable|source_identity|source-input|cli+embedders|SourceRevision|pub use source_
 stable|source_metadata|source-input|cli+embedders|SourceMetadata|pub use source_metadata::SourceMetadata
 stable|source_snapshot|source-input|cli+embedders|MAX_SOURCE_BYTES|pub use source_snapshot::MAX_SOURCE_BYTES
 stable|source_snapshot|source-input|cli+embedders|SourceSnapshot|pub use source_snapshot::SourceSnapshot
+stable|toolchain_module_demand|toolchain-module-demand|source-loaders+embedders|OPTION_MODULE_LOGICAL_PATH|pub use toolchain_module_demand::OPTION_MODULE_LOGICAL_PATH
+stable|toolchain_module_demand|toolchain-module-demand|source-loaders+embedders|ParkedToolchainModules|pub use toolchain_module_demand::ParkedToolchainModules
+stable|toolchain_module_demand|toolchain-module-demand|source-loaders+embedders|STRBUF_MODULE_LOGICAL_PATH|pub use toolchain_module_demand::STRBUF_MODULE_LOGICAL_PATH
+stable|toolchain_module_demand|toolchain-module-demand|source-loaders+embedders|TrustedToolchainModuleDemand|pub use toolchain_module_demand::TrustedToolchainModuleDemand
 unstable|CompilerSession|debug-tooling|in-tree-tooling|unstable_dependency_baseline|pub fn unstable_dependency_baseline(&mut self,options:&CompileOptions,std_dir:Option<&str>,)->Result<Arc<crate::unstable::DependencyBaseline>,CompileErrors>
 unstable|CompilerSession|debug-tooling|in-tree-tooling|unstable_invalidation_metrics|pub fn unstable_invalidation_metrics(&mut self,previous:&crate::unstable::DependencyBaseline,current:&crate::unstable::DependencyBaseline,)->Result<crate::unstable::InvalidationMetrics,CompileErrors>
 unstable|CompilerSession|debug-tooling|in-tree-tooling|unstable_metrics|pub fn unstable_metrics(&self)->crate::unstable::MetricsSnapshot

--- a/crates/rue-compiler/src/toolchain_module_demand.rs
+++ b/crates/rue-compiler/src/toolchain_module_demand.rs
@@ -1,0 +1,225 @@
+//! Typed trusted-toolchain-module demands (RUE-1112).
+//!
+//! # Why this is a distinct mechanism from import discovery
+//!
+//! A freestanding Rue program (zero `@import`s) whose reached body contains a
+//! fallible intrinsic (`@read_line`, `@parse_i32/i64/u32/u64`) must still be
+//! able to obtain the trusted standard-library `Option` type: sema resolves the
+//! intrinsic's `Option(payload)` result against the canonical comptime-generic
+//! `Option` enum (RUE-6, ADR-0038). For an import-free program nothing ever
+//! pulls `\0rue-std/option.rue` into the compilation, so the module is absent
+//! and the demand cannot resolve.
+//!
+//! Import discovery cannot supply it: it drives parser-owned `ImportDemandRoots`
+//! to a fixed point and *closes* before any semantic/body request runs, and
+//! trusted-std classification happens only through real import resolution. A
+//! foreign demand type threaded through the import frontier was rejected by
+//! review.
+//!
+//! Instead the demand is a *distinct typed* [`TrustedToolchainModuleDemand`],
+//! raised by the rooted semantic attempt (not by any import occurrence) when a
+//! reached body needs a trusted module absent from the current revision, and
+//! satisfied by the host source-loading layer that owns filesystem access. The
+//! demand:
+//!
+//! * is **not** an `ImportOccurrenceKey` and never enters accepted import
+//!   topology or the accepted-read ledger's import plan;
+//! * is raised **only** for a body the semantic worklist actually reaches, so an
+//!   unreachable helper that mentions a fallible intrinsic forces no std read;
+//! * is satisfied by the host, which performs one policy-checked read, classifies
+//!   the module trusted through the existing classification, and publishes it on
+//!   a strictly-additive successor snapshot via the assembler.
+//!
+//! A program whose reached bodies use no fallible intrinsic raises **zero**
+//! demands and performs **zero** std reads, so unrelated programs never observe
+//! the trusted module even when it is malformed on disk.
+
+use std::sync::Arc;
+
+use rue_error::CompileResult;
+
+use crate::well_known_option::FalliblePayload;
+use crate::{ModuleId, StableDefinitionKey};
+
+/// Canonical logical path of the trusted standard-library `Option` module.
+///
+/// The leading NUL cannot occur in a filesystem path, so this namespace is
+/// provably disjoint from every project-relative identity.
+pub const OPTION_MODULE_LOGICAL_PATH: &str = "\0rue-std/option.rue";
+
+/// Canonical logical path of the trusted standard-library `StrBuf` module.
+///
+/// `@read_line`'s result is the exact trusted std `Option(StrBuf)` (spec
+/// 4.13:35). Naming that payload requires the trusted `StrBuf` nominal, so a
+/// reached `@read_line` in a program that has not otherwise pulled `StrBuf`
+/// demands this module in addition to the `Option` module.
+pub const STRBUF_MODULE_LOGICAL_PATH: &str = "\0rue-std/strbuf.rue";
+
+/// A typed demand for a trusted toolchain-provided module.
+///
+/// This is deliberately **not** an `ImportOccurrenceKey`: it carries no importer
+/// occurrence, participates in no import candidate ordering, and never enters
+/// the `ImportObservationLedger`. It only names the trusted logical module the
+/// reached bodies require.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TrustedToolchainModuleDemand {
+    logical_path: Arc<str>,
+}
+
+impl TrustedToolchainModuleDemand {
+    /// The demand for the trusted standard-library `Option` module.
+    pub fn option() -> Self {
+        Self {
+            logical_path: Arc::from(OPTION_MODULE_LOGICAL_PATH),
+        }
+    }
+
+    /// The demand for the trusted standard-library `StrBuf` module, required to
+    /// spell `@read_line`'s `Option(StrBuf)` payload.
+    pub fn strbuf() -> Self {
+        Self {
+            logical_path: Arc::from(STRBUF_MODULE_LOGICAL_PATH),
+        }
+    }
+
+    /// The trusted logical module path this demand names.
+    pub fn logical_path(&self) -> &str {
+        &self.logical_path
+    }
+
+    /// The trusted `ModuleId` this demand resolves to once the host satisfies it.
+    ///
+    /// The returned identity carries the standard-library origin, so a snapshot
+    /// that contains it reports the module as trusted.
+    pub fn trusted_module_id(&self) -> CompileResult<ModuleId> {
+        ModuleId::from_trusted_standard_library_path(self.logical_path.as_ref())
+    }
+
+    /// The path fragment relative to the standard-library root (drops the
+    /// `\0rue-std/` namespace prefix), used by the host to resolve the module
+    /// against the toolchain's std path.
+    pub fn std_relative_path(&self) -> &str {
+        self.logical_path
+            .strip_prefix("\0rue-std/")
+            .unwrap_or(&self.logical_path)
+    }
+}
+
+/// The trusted-toolchain-module demand projected from ONE reached body's exact
+/// raw declaration body (RUE-1112).
+///
+/// This is the deterministic output of the registered `body-toolchain-demands`
+/// query node: it names, sorted and deduplicated, the trusted modules the body's
+/// fallible intrinsics require, together with the stable key of the demanding
+/// body (its requester anchor). It is **pure**: it derives solely from the raw
+/// body text, performs no filesystem I/O, and does no presence check. The rooted
+/// semantic attempt separately checks these names against the satisfied
+/// trusted-module catalogue and parks the absent ones before entering the body
+/// transaction, so speculative evaluation of this projection is always safe.
+///
+/// This is internal registered-query payload — it never crosses the crate
+/// boundary. Only the host-boundary park/continuation types are public; the
+/// loader consumes those, not this.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BodyToolchainDemand {
+    modules: Arc<[TrustedToolchainModuleDemand]>,
+    payload_kinds: Arc<[FalliblePayload]>,
+    requester: Option<StableDefinitionKey>,
+}
+
+impl BodyToolchainDemand {
+    /// Build a demand projection for `requester` from the body's fallible-intrinsic
+    /// payload kinds, deriving the trusted-module demands and carrying the payload
+    /// kinds themselves so the body transaction observes ONE canonical scan rather
+    /// than rescanning the raw text (RUE-1112 C1). Sorts/deduplicates both sets so
+    /// the node's output is canonical. `requester` is `None` only for a reached
+    /// instance with no source declaration key, which always projects the empty
+    /// demand set; whenever a module is demanded the requester anchor is present.
+    pub(crate) fn from_payload_kinds(
+        payload_kinds: impl IntoIterator<Item = FalliblePayload>,
+        requester: Option<StableDefinitionKey>,
+    ) -> Self {
+        let mut payload_kinds: Vec<_> = payload_kinds.into_iter().collect();
+        payload_kinds.sort();
+        payload_kinds.dedup();
+        let mut modules = Vec::new();
+        if !payload_kinds.is_empty() {
+            modules.push(TrustedToolchainModuleDemand::option());
+        }
+        if payload_kinds.contains(&FalliblePayload::StrBuf) {
+            modules.push(TrustedToolchainModuleDemand::strbuf());
+        }
+        modules.sort();
+        modules.dedup();
+        Self {
+            modules: Arc::from(modules),
+            payload_kinds: Arc::from(payload_kinds),
+            requester,
+        }
+    }
+
+    /// The trusted modules this body demands (sorted, deduplicated).
+    pub(crate) fn modules(&self) -> &[TrustedToolchainModuleDemand] {
+        &self.modules
+    }
+
+    /// The fallible-intrinsic payload kinds this body uses (sorted, deduplicated).
+    /// The single canonical per-body scan; the body transaction observes this
+    /// instead of rescanning the raw body text.
+    pub(crate) fn payload_kinds(&self) -> &[FalliblePayload] {
+        &self.payload_kinds
+    }
+
+    /// The stable key of the body that demands these modules (its anchor),
+    /// present whenever any module is demanded.
+    pub(crate) fn requester(&self) -> Option<&StableDefinitionKey> {
+        self.requester.as_ref()
+    }
+}
+
+/// The park raised by the rooted semantic attempt when a reached body demands a
+/// trusted toolchain module absent from the current revision (RUE-1112).
+///
+/// It carries the sorted, deduplicated absent modules and the stable requester
+/// anchors of the bodies that demanded them. It is carried out of band from the
+/// rooted attempt to its outer host boundary — the transport-failure pattern
+/// (`producer_transport_failure`) — and is never originated inside a body
+/// transaction: only the rooted attempt, having checked the satisfied catalogue,
+/// records it, and only the host driver acts on it by acquiring the modules and
+/// retrying on a successor. Stable no-filesystem APIs convert an unsatisfied
+/// park to their own error/absence result at their outer boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParkedToolchainModules {
+    demands: Arc<[TrustedToolchainModuleDemand]>,
+    requesters: Arc<[StableDefinitionKey]>,
+}
+
+impl ParkedToolchainModules {
+    /// Build a park from the absent demands and their requester anchors, sorting
+    /// and deduplicating both so the surfaced state is canonical.
+    pub fn new(
+        demands: impl IntoIterator<Item = TrustedToolchainModuleDemand>,
+        requesters: impl IntoIterator<Item = StableDefinitionKey>,
+    ) -> Self {
+        let mut demands: Vec<_> = demands.into_iter().collect();
+        demands.sort();
+        demands.dedup();
+        let mut requesters: Vec<_> = requesters.into_iter().collect();
+        requesters.sort();
+        requesters.dedup();
+        Self {
+            demands: Arc::from(demands),
+            requesters: Arc::from(requesters),
+        }
+    }
+
+    /// The absent trusted modules the reached bodies demand (sorted, deduped).
+    pub fn demands(&self) -> &[TrustedToolchainModuleDemand] {
+        &self.demands
+    }
+
+    /// The stable keys of the bodies that demanded the absent modules.
+    pub fn requesters(&self) -> &[StableDefinitionKey] {
+        &self.requesters
+    }
+}

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -28,7 +28,7 @@ pub fn begin_import_input_request(
     session: &mut crate::CompilerSession,
     snapshot: &crate::SourceSnapshot,
     context: crate::ImportDiscoveryContext,
-    accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
+    accepted_reads: crate::AcceptedReadManifest,
 ) -> crate::CompileResult<ImportInputRevision> {
     session.begin_import_input_request(snapshot, context, accepted_reads)
 }
@@ -43,11 +43,19 @@ pub fn import_demand_frontier_for_roots(
     session.import_demand_frontier_for_roots(revision, plan, mode, roots)
 }
 
+/// The demand roots for a trusted-toolchain successor plan's delta occurrences
+/// alone (RUE-1112). Derived directly from the plan's delta segment, so the host
+/// roots its re-close frontier without materializing or filtering the merged
+/// predecessor plan.
+pub fn plan_delta_roots(plan: &crate::ImportDiscoveryPlan) -> ImportDemandRoots {
+    plan.delta_roots()
+}
+
 pub fn publish_import_observation_batch(
     session: &mut crate::CompilerSession,
     frontier: &ImportDemandFrontier,
     snapshot: &crate::SourceSnapshot,
-    accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
+    accepted_reads: crate::AcceptedReadManifest,
     observations: Vec<crate::ImportObservation>,
 ) -> crate::CompileResult<ImportInputRevision> {
     session.publish_import_observation_batch(frontier, snapshot, accepted_reads, observations)
@@ -58,6 +66,205 @@ pub fn import_observation_ledger(
     revision: ImportInputRevision,
 ) -> crate::CompileResult<crate::ImportObservationLedger> {
     session.import_observation_ledger(revision)
+}
+
+/// Stage a strictly-additive trusted-toolchain successor (RUE-1112). The staged
+/// snapshot, context, provenance, and carried ledger are the CURRENT
+/// compiler-published view's own state and the module delta is derived from the
+/// opaque `delta` capability — the host supplies nothing but the capability, so
+/// no replacement state can be substituted. Predecessor occurrences are never
+/// re-staged.
+pub fn stage_import_discovery_successor(
+    session: &mut crate::CompilerSession,
+    delta: &TrustedSuccessorDelta,
+) -> Result<crate::ImportDiscoveryPlan, crate::CompileErrors> {
+    session.stage_import_discovery_successor(delta)
+}
+
+/// Close a strictly-additive trusted-toolchain successor (RUE-1112). The closing
+/// ledger is the CURRENT compiler-published view's own carried ledger and the
+/// module delta is derived from the opaque `delta` capability — the host
+/// supplies nothing but the capability. Predecessor occurrences are never
+/// re-projected or re-reduced.
+pub fn close_import_discovery_successor(
+    session: &mut crate::CompilerSession,
+    delta: &TrustedSuccessorDelta,
+) -> Result<Arc<crate::ImportDiscoveryView>, crate::CompileErrors> {
+    session
+        .close_import_discovery_successor(delta)
+        .map(|artifact| Arc::new(crate::ImportDiscoveryView::new(artifact)))
+}
+
+/// Cumulative import occurrences the demand frontier has rooted (RUE-1112).
+///
+/// One `ResolveImport` projection is dispatched per rooted occurrence. The delta
+/// across a trusted-toolchain re-close counts only occurrences owned by the newly
+/// appended leaves and modules newly discovered from them; a predecessor
+/// occurrence is rooted once at the initial close and never re-rooted during
+/// acquisition. Host source-loading reads this to prove the re-close is O(new
+/// leaves), independent of the predecessor import topology.
+pub fn import_frontier_roots_requested(session: &crate::CompilerSession) -> u64 {
+    session.import_frontier_roots_requested()
+}
+
+/// Cumulative import-plan request groups constructed during staging (RUE-1112).
+///
+/// A full plan build constructs one group per program import occurrence; a
+/// trusted-toolchain successor stage reuses the committed predecessor plan's
+/// groups and constructs only the newly appended occurrences'. The delta across a
+/// re-close is O(new leaves), independent of the predecessor topology.
+pub fn import_plan_groups_constructed(session: &crate::CompilerSession) -> u64 {
+    session.import_plan_groups_constructed()
+}
+
+/// Cumulative close-time `ResolveImport` projections dispatched (RUE-1112).
+///
+/// A full close projects one per program occurrence; a trusted-toolchain
+/// successor close projects only the newly appended occurrences'. The delta
+/// across a re-close is O(new leaves).
+pub fn exact_import_groups_dispatched(session: &crate::CompilerSession) -> u64 {
+    session.exact_import_groups_dispatched()
+}
+
+/// Cumulative canonical import records reduced and validated during close
+/// (RUE-1112).
+///
+/// A full close reduces/validates one per program occurrence; a trusted-toolchain
+/// successor close carries the predecessor's closed graph and reduces/validates
+/// only the newly appended occurrences'. The delta across a re-close is O(new
+/// leaves).
+pub fn import_close_records_reduced(session: &crate::CompilerSession) -> u64 {
+    session.import_close_records_reduced()
+}
+
+/// Cumulative leaves published through the complete input-publication path
+/// (fresh generations only). Scales with the program (RUE-1112).
+pub fn import_view_full_leaves_published(session: &crate::CompilerSession) -> u64 {
+    session.import_view_full_leaves_published()
+}
+
+/// Cumulative delta leaves published through the sparse successor overlay path
+/// (RUE-1112). Each same-generation successor publishes only its own additions
+/// plus at most one re-stamped aggregate topology leaf; predecessor leaves are
+/// structurally inherited and never republished, so the acquisition delta is
+/// O(new leaves), independent of the predecessor topology.
+pub fn import_view_overlay_leaves_published(session: &crate::CompilerSession) -> u64 {
+    session.import_view_overlay_leaves_published()
+}
+
+/// Cumulative predecessor ledger observations deep-cloned into successor view
+/// ledgers (RUE-1112). The successor view still carries a complete ledger value,
+/// so this cost remains predecessor-scale and is surfaced rather than hidden.
+pub fn import_view_ledger_entries_cloned(session: &crate::CompilerSession) -> u64 {
+    session.import_view_ledger_entries_cloned()
+}
+
+/// Predecessor source entries element-compared by the overlay publication's
+/// fallback diff (RUE-1112). The structural-authority path — a successor
+/// snapshot whose segments share the parent view by `Arc` identity — never
+/// compares a predecessor entry, so acquisition keeps this at zero.
+pub fn import_view_source_entries_compared(session: &crate::CompilerSession) -> u64 {
+    session.import_view_source_entries_compared()
+}
+
+/// Predecessor accepted-read entries element-compared by the overlay
+/// publication's fallback provenance diff (RUE-1112) — a host-rebuilt manifest
+/// that cannot prove itself by segment identity. The structural-authority path
+/// never increments this.
+pub fn import_view_read_entries_compared(session: &crate::CompilerSession) -> u64 {
+    session.import_view_read_entries_compared()
+}
+
+/// Source entries materialized into whole-program parse projections
+/// (RUE-1112): the presentation order, demanded module set, and merged program
+/// a FULL parse build enumerates. A trusted-toolchain successor stage extends
+/// the retained predecessor artifact and never increments this.
+pub fn parse_sources_materialized(session: &crate::CompilerSession) -> u64 {
+    session.parse_sources_materialized()
+}
+
+/// Source entries embedded in parse query keys (RUE-1112): an ordinary key
+/// carries every file's exact content identity; a successor key carries only
+/// the published lineage identity plus its appended segment.
+pub fn parse_key_entries_compared(session: &crate::CompilerSession) -> u64 {
+    session.parse_key_entries_compared()
+}
+
+/// Module parse queries dispatched by the parse projection (RUE-1112). A full
+/// build dispatches one per module; a successor stage dispatches only the
+/// appended modules'.
+pub fn parse_modules_dispatched(session: &crate::CompilerSession) -> u64 {
+    session.parse_modules_dispatched()
+}
+
+/// Entries examined by parse invalidation classification (RUE-1112). A full
+/// classification examines every current module; a successor classifies only
+/// its appended delta.
+pub fn parse_invalidation_entries_compared(session: &crate::CompilerSession) -> u64 {
+    session.parse_invalidation_entries_compared()
+}
+
+/// Cumulative dependency-graph invalidation events across the retained
+/// frontend query families (RUE-1112). A strictly-additive successor adoption
+/// keeps the predecessor's immutable source leaf live and contributes zero
+/// here; only a genuine replacement invalidates retained dependents.
+pub fn frontend_query_invalidations(session: &crate::CompilerSession) -> u64 {
+    session.frontend_query_invalidations()
+}
+
+/// Structural-sharing witnesses for the committed import discovery's three
+/// additively shared artifacts (RUE-1112): `[graph_records, plan_groups,
+/// resolution_modules]`, each `(predecessor_segment_address, delta_len)`. A
+/// trusted-toolchain successor shares each predecessor segment `Arc` by
+/// reference, so every address is identical to the predecessor close's — proving
+/// no predecessor entry was copied when the successor artifacts were built.
+pub fn committed_successor_sharing(
+    session: &crate::CompilerSession,
+) -> Option<[(usize, usize); 3]> {
+    session.committed_successor_sharing()
+}
+
+pub use crate::session::{ClosedDiscoveryContinuation, SemanticParkOutcome, TrustedSuccessorDelta};
+
+/// Run rooted, park-aware semantic analysis on the current committed revision,
+/// surfacing an unsatisfied trusted-toolchain park distinctly (RUE-1112).
+///
+/// This is the host source-loading driver's retry entry: on
+/// [`SemanticParkOutcome::Parked`] the park atomically attaches its exact
+/// missing-demand set to the outstanding closed continuation, so a subsequent
+/// [`closed_discovery_continuation`] mints an authorizing token; the driver
+/// acquires exactly those modules, publishes a successor, re-closes, and calls
+/// this again.
+pub fn semantic_or_toolchain_park(
+    session: &mut crate::CompilerSession,
+    options: &crate::CompileOptions,
+) -> SemanticParkOutcome {
+    session.semantic_or_toolchain_park(options)
+}
+
+/// Mint the single-use trusted-toolchain continuation for the current successful
+/// import-discovery close, if one is outstanding (RUE-1112).
+pub fn closed_discovery_continuation(
+    session: &crate::CompilerSession,
+) -> Option<ClosedDiscoveryContinuation> {
+    session.closed_discovery_continuation()
+}
+
+/// Publish one strictly-additive trusted-toolchain successor on the
+/// continuation's closed revision, verified entirely from records (RUE-1112).
+///
+/// Returns an opaque [`TrustedSuccessorDelta`] capability derived from the
+/// compiler-verified appended module set. The host carries it to the successor
+/// stage and close, which derive the module delta from it; the host cannot
+/// inspect or edit the module identities.
+pub fn publish_trusted_toolchain_successor(
+    session: &mut crate::CompilerSession,
+    token: ClosedDiscoveryContinuation,
+    issued_frontier: &ImportDemandFrontier,
+    successor: &crate::SourceSnapshot,
+    accepted_reads: crate::AcceptedReadManifest,
+) -> Result<TrustedSuccessorDelta, crate::CompileErrors> {
+    session.publish_trusted_toolchain_successor(token, issued_frontier, successor, accepted_reads)
 }
 
 /// Unstable human-readable compiler stages. These are projections of the

--- a/crates/rue-compiler/src/well_known_option.rs
+++ b/crates/rue-compiler/src/well_known_option.rs
@@ -1,0 +1,233 @@
+//! Per-body well-known `Option(payload)` demand planning.
+//!
+//! Every fallible intrinsic (`@read_line`, `@parse_i32/i64/u32/u64`) yields the
+//! exact trusted standard-library `Option(payload)`. When a trusted `Option`
+//! module is present in the program, this planner computes the set of payloads
+//! the program demands and roots the matching comptime-`Option` specializations
+//! under each requesting body's lease (see `revisioned_query_database.rs`). The
+//! resolved enums reach AIR through a narrow per-body `WellKnownTypes` input,
+//! never the body's composition/import universe.
+//!
+//! Planning is two-staged. This module builds the whole-program *catalogue* of
+//! demandable `Option(payload)` specializations (one per payload the program
+//! uses anywhere), each tagged with its [`FalliblePayload`] kind. Each reached
+//! body then derives its OWN exact payload set from its canonical raw body
+//! ([`scan_body_payload_kinds`]) and roots only the catalogue entries that set
+//! selects, so a body gains a query edge to a specialization only for a payload
+//! it actually uses and cannot inherit failure or cancellation from an unrelated
+//! body's specialization. The semantic nucleus memoizes each specialization, so
+//! bodies sharing a payload share one terminal. A program with no fallible
+//! intrinsic demands nothing at all.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use crate::body_query::WellKnownOptionDemand;
+use crate::canonical_lower::CanonicalRirOutput;
+use crate::canonical_merge::CanonicalMergedProgram;
+use crate::declaration_candidate::{DeclarationCandidateCategory, DeclarationCandidateKey};
+use crate::durable_semantics::DurableType;
+use crate::semantic_query_nucleus::{
+    ComptimeCallQueryKey, DeclarationSemanticQueryKey, SemanticQueryConfiguration,
+};
+use crate::{ModuleId, StableDefinitionKey, StableDefinitionKind, StableDefinitionNamespace};
+
+const TRUSTED_OPTION_MODULE_PATH: &str = "\0rue-std/option.rue";
+const TRUSTED_STRBUF_MODULE_PATH: &str = "\0rue-std/strbuf.rue";
+
+/// One fallible-intrinsic payload demanded by a body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum FalliblePayload {
+    I32,
+    I64,
+    U32,
+    U64,
+    StrBuf,
+}
+
+impl FalliblePayload {
+    /// Map a fallible-intrinsic name (as spelled after `@`) to the payload of
+    /// the `Option` it returns. Non-fallible intrinsics return `None`.
+    fn from_intrinsic_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "read_line" => Self::StrBuf,
+            "parse_i32" => Self::I32,
+            "parse_i64" => Self::I64,
+            "parse_u32" => Self::U32,
+            "parse_u64" => Self::U64,
+            _ => return None,
+        })
+    }
+}
+
+/// The fallible-intrinsic payload kinds one body's raw source text demands.
+///
+/// Each reached body derives its own exact payload set from its canonical raw
+/// body BEFORE its per-body query roots any well-known `Option` specialization,
+/// so a body roots only the payloads it actually uses and gains no query edge to
+/// payloads owned by unrelated bodies. The scan is lexical (an `At` token
+/// followed by the intrinsic identifier), so an intrinsic named only in a
+/// comment or string literal demands nothing.
+pub(crate) fn scan_body_payload_kinds(body: &str) -> BTreeSet<FalliblePayload> {
+    let mut payloads = BTreeSet::new();
+    let Ok((tokens, interner)) = rue_lexer::Lexer::new(body).tokenize() else {
+        return payloads;
+    };
+    for pair in tokens.windows(2) {
+        if !matches!(pair[0].kind, rue_lexer::TokenKind::At) {
+            continue;
+        }
+        if let rue_lexer::TokenKind::Ident(symbol) = pair[1].kind
+            && let Some(payload) = FalliblePayload::from_intrinsic_name(interner.resolve(&symbol))
+        {
+            payloads.insert(payload);
+        }
+    }
+    payloads
+}
+
+/// Whether `module` is present among the program's canonical modules.
+fn module_present(merged: &CanonicalMergedProgram, module: &ModuleId) -> bool {
+    merged
+        .ast()
+        .modules()
+        .iter()
+        .any(|candidate| candidate.module_id() == module)
+}
+
+/// Scan the whole-program RIR for every fallible-intrinsic call, returning the
+/// sorted, deduplicated set of demanded payloads.
+///
+/// Every fallible intrinsic yields the exact trusted std `Option(payload)` in
+/// every context, so every use — bare, contextually annotated, matched, or the
+/// operand of a `?` — demands the canonical `Option(payload)`. The registry is
+/// the single durable source for that identity; context only checks it. Scanning
+/// all uses (not only `?`-operands) is what lets a plain `let x = @parse_i64(…)`
+/// or `match @parse_i32(…)` resolve to the canonical trusted `Option` rather
+/// than depending on a surrounding annotation to supply the nominal.
+fn scan_fallible_payloads(rir: &CanonicalRirOutput) -> BTreeSet<FalliblePayload> {
+    let interner = rir.semantic_symbols().interner();
+    let mut payloads = BTreeSet::new();
+    for (_, inst) in rir.rir().iter() {
+        if let rue_rir::InstData::Intrinsic { name, .. } = &inst.data
+            && let Some(payload) = FalliblePayload::from_intrinsic_name(interner.resolve(name))
+        {
+            payloads.insert(payload);
+        }
+    }
+    payloads
+}
+
+/// The trusted `StrBuf` nominal `DurableType`, when the trusted `StrBuf` module
+/// is present. `@read_line`'s `Option(StrBuf)` cannot be demanded without it.
+fn trusted_strbuf_type(merged: &CanonicalMergedProgram) -> Option<DurableType> {
+    let module = ModuleId::from_trusted_standard_library_path(TRUSTED_STRBUF_MODULE_PATH).ok()?;
+    module_present(merged, &module).then(|| {
+        DurableType::Nominal(StableDefinitionKey::from_stable_parts(
+            module,
+            StableDefinitionNamespace::Type,
+            StableDefinitionKind::Struct,
+            "StrBuf",
+            None,
+        ))
+    })
+}
+
+/// Plan the well-known `Option` demand catalogue for a semantic request.
+///
+/// Returns an empty catalogue whenever the trusted `Option` module is absent or
+/// the program uses no fallible intrinsic; otherwise it holds one entry per
+/// payload the program uses anywhere, each carrying the exact `ComptimeCall` to
+/// root under a body's lease and the payload it satisfies. Per-body selection
+/// from this catalogue happens in `body_transaction`.
+pub(crate) fn plan_well_known_option_demands(
+    merged: &CanonicalMergedProgram,
+    rir: &CanonicalRirOutput,
+    configuration: &SemanticQueryConfiguration,
+) -> Arc<[WellKnownOptionDemand]> {
+    let Ok(option_module) =
+        ModuleId::from_trusted_standard_library_path(TRUSTED_OPTION_MODULE_PATH)
+    else {
+        return Arc::from(Vec::new());
+    };
+    // The trusted `Option` module must be present to name any specialization.
+    // When it is absent the catalogue is empty and fallible-intrinsic resolution
+    // uses its structural context check instead.
+    if !module_present(merged, &option_module) {
+        return Arc::from(Vec::new());
+    }
+    let payloads = scan_fallible_payloads(rir);
+    if payloads.is_empty() {
+        return Arc::from(Vec::new());
+    }
+    let option_candidate = DeclarationCandidateKey {
+        module: option_module,
+        category: DeclarationCandidateCategory::Function,
+        name: Arc::from("Option"),
+        owner: None,
+        duplicate_discriminator: 0,
+    };
+    let strbuf = trusted_strbuf_type(merged);
+    let mut demands = Vec::new();
+    for payload in payloads {
+        let payload_type = match payload {
+            FalliblePayload::I32 => DurableType::I32,
+            FalliblePayload::I64 => DurableType::I64,
+            FalliblePayload::U32 => DurableType::U32,
+            FalliblePayload::U64 => DurableType::U64,
+            // Without the trusted StrBuf module the payload cannot be spelled;
+            // the read_line demand is simply not rooted and falls through.
+            FalliblePayload::StrBuf => match &strbuf {
+                Some(strbuf) => strbuf.clone(),
+                None => continue,
+            },
+        };
+        let call = ComptimeCallQueryKey {
+            declaration: DeclarationSemanticQueryKey {
+                declaration: option_candidate.clone(),
+                configuration: configuration.clone(),
+            },
+            type_arguments: Arc::from(vec![(Arc::<str>::from("T"), payload_type.clone())]),
+            value_arguments: Arc::from(Vec::new()),
+        };
+        demands.push(WellKnownOptionDemand {
+            kind: payload,
+            payload: payload_type,
+            call,
+        });
+    }
+    Arc::from(demands)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn per_body_scan_derives_only_the_body_s_own_payloads() {
+        // A body that uses `@parse_i32` demands exactly `I32` — not the payloads
+        // of intrinsics that appear only in sibling bodies.
+        assert_eq!(
+            scan_body_payload_kinds("{ let x: i32 = @parse_i32(s)?; x }"),
+            BTreeSet::from([FalliblePayload::I32]),
+        );
+        // Multiple distinct fallible intrinsics in one body accumulate.
+        assert_eq!(
+            scan_body_payload_kinds("{ let a = @parse_u64(s); let b = @read_line(); 0 }"),
+            BTreeSet::from([FalliblePayload::U64, FalliblePayload::StrBuf]),
+        );
+    }
+
+    #[test]
+    fn per_body_scan_ignores_non_lexical_mentions_and_non_fallible_intrinsics() {
+        // A fallible-intrinsic name in a comment or string literal is not a use.
+        assert!(
+            scan_body_payload_kinds("{ // @parse_i64 here\n let s = \"@parse_i32\"; 0 }")
+                .is_empty()
+        );
+        // A non-fallible intrinsic demands nothing.
+        assert!(scan_body_payload_kinds("{ let s = @to_string(1); 0 }").is_empty());
+        // A body with no intrinsics at all demands nothing.
+        assert!(scan_body_payload_kinds("{ let x = 1 + 2; x }").is_empty());
+    }
+}

--- a/crates/rue-compiler/tests/differential_oracle.rs
+++ b/crates/rue-compiler/tests/differential_oracle.rs
@@ -20,9 +20,9 @@ use rue_compiler::unstable::{
     publish_import_observation_batch, semantic_input_debug,
 };
 use rue_compiler::{
-    AcceptedImportSource, AcceptedReadManifestEntry, CompileOptions, CompilerSession,
-    FileMetadataFingerprint, FrontendDiagnosticSnapshot, ImportDiscoveryContext, ImportObservation,
-    PhysicalFileIdentity, PreviewFeature, PreviewFeatures, SourceMetadata, SourceSnapshot,
+    AcceptedImportSource, CompileOptions, CompilerSession, FileMetadataFingerprint,
+    FrontendDiagnosticSnapshot, ImportDiscoveryContext, ImportObservation, PhysicalFileIdentity,
+    PreviewFeature, PreviewFeatures, SourceMetadata, SourceSnapshot,
 };
 use rue_span::FileId;
 use rue_target::Target;
@@ -39,7 +39,7 @@ struct Step {
 #[derive(Clone)]
 struct DiscoveryInput {
     context: ImportDiscoveryContext,
-    accepted_reads: Arc<[AcceptedReadManifestEntry]>,
+    accepted_reads: rue_compiler::AcceptedReadManifest,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -149,7 +149,7 @@ fn close_discovery(session: &mut CompilerSession, step: &Step) -> String {
         let plan = match session.stage_import_discovery(
             &step.snapshot,
             discovery.context.clone(),
-            discovery.accepted_reads.clone(),
+            discovery.accepted_reads.shared_slice(),
             ledger.clone(),
         ) {
             Ok(plan) => plan,

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -405,6 +405,7 @@ impl ErrorCode {
     pub const COMPILER_RESOURCE_LIMIT: Self = Self(1401);
     pub const COMPILER_RESOURCE_EXHAUSTION: Self = Self(1402);
     pub const OUTPUT_PUBLICATION: Self = Self(1403);
+    pub const UNSATISFIED_TRUSTED_TOOLCHAIN_INPUT: Self = Self(1404);
 
     // ========================================================================
     // Internal compiler errors (E9000-E9999)
@@ -1733,6 +1734,17 @@ pub enum ErrorKind {
     #[error("output publication failed: {0}")]
     OutputPublication(String),
 
+    /// A required trusted toolchain input — a standard-library module the
+    /// program's reached bodies demand (RUE-1112) — was absent from the
+    /// compilation and the caller did not supply it. The standard library is a
+    /// toolchain guarantee, so a stable no-filesystem entry that observes an
+    /// unsatisfied demand reports this deterministic contract failure at its
+    /// boundary rather than an ICE: the CLI host acquires the module and retries,
+    /// while an embedder that omits a guaranteed toolchain input gets a clear,
+    /// distinguishable contract error.
+    #[error("unsatisfied trusted toolchain input: {0}")]
+    UnsatisfiedTrustedToolchainInput(String),
+
     // Internal compiler errors (bugs in the compiler itself)
     #[error("internal compiler producer invariant: {0}")]
     CompilerProducerInvariant(String),
@@ -1937,6 +1949,9 @@ impl ErrorKind {
             ErrorKind::CompilerResourceLimit(_) => ErrorCode::COMPILER_RESOURCE_LIMIT,
             ErrorKind::CompilerResourceExhaustion(_) => ErrorCode::COMPILER_RESOURCE_EXHAUSTION,
             ErrorKind::OutputPublication(_) => ErrorCode::OUTPUT_PUBLICATION,
+            ErrorKind::UnsatisfiedTrustedToolchainInput(_) => {
+                ErrorCode::UNSATISFIED_TRUSTED_TOOLCHAIN_INPUT
+            }
 
             // Internal compiler errors (E9000-E9999)
             ErrorKind::CompilerProducerInvariant(_) | ErrorKind::InternalError(_) => {

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -710,7 +710,7 @@ fn run_source_with_real_std(
             .stage_import_discovery(
                 &snapshot,
                 context.clone(),
-                assembler.accepted_read_manifest(),
+                assembler.accepted_read_manifest().shared_slice(),
                 ledger.clone(),
             )
             .map_err(|errors| format!("{errors:#?}"))?;

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -318,6 +318,12 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "expressions.try",
+        "try_parse_freestanding_no_imports",
+        intrinsic(UnsupportedIntrinsicKind::ParseI64),
+        &[],
+    ),
+    Entry::new(
+        "expressions.try",
         "try_parse_intrinsic_none_short_circuits",
         intrinsic(UnsupportedIntrinsicKind::ParseI64),
         &[],

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -1094,10 +1094,144 @@ fn validated_cfg_rejects_out_of_bounds_field_pointer_projection_metadata() {
     ));
 }
 
+/// Compile `root` with the given trusted standard-library modules present,
+/// driving real import discovery so each std module is acquired at its physical
+/// path under the discovery std root and receives trusted-standard-library
+/// provenance. Each entry is `(file_index, canonical_physical_path, source)`;
+/// `root` reaches a module by importing that physical path (e.g.
+/// `@import("std/option.rue")`).
+///
+/// Trusted provenance is what a fallible intrinsic's result and `?` require:
+/// they bind the exact std `Option`/`Result`, so a fixture exercising them must
+/// name the real std producer rather than a same-shape local lookalike. The
+/// lightweight fixture-import graph used inside the compiler crate is
+/// `cfg(test)`-only and unavailable here, so the oracle drives the supported
+/// discovery loop end to end.
+fn query_cfg_state_with_trusted_std(
+    root: &str,
+    std_modules: &[(u32, &str, &str)],
+) -> Result<CompileState, CompileErrors> {
+    use rue_compiler::unstable::{
+        DiscoverySourceAssembler, ImportDemandMode, begin_import_input_request,
+        import_demand_frontier_for_roots, import_observation_ledger,
+        publish_import_observation_batch,
+    };
+    use rue_compiler::{
+        AcceptedImportSource, CompilerSession, FileMetadataFingerprint, ImportDiscoveryContext,
+        ImportObservation, PhysicalFileIdentity,
+    };
+    use std::sync::Arc;
+
+    let context =
+        ImportDiscoveryContext::new(1, "/project", Some("/project/std"), "oracle-trusted-std")
+            .expect("valid discovery context");
+    let root = Arc::new(root.to_owned());
+    let mut assembler = DiscoverySourceAssembler::new(
+        context.clone(),
+        "/project/main.rue",
+        "/project/main.rue",
+        PhysicalFileIdentity::new(1, 1),
+        FileMetadataFingerprint::new(root.len() as u64, 0, 0),
+        root,
+    )
+    .expect("root source assembler");
+    let std_sources = std_modules
+        .iter()
+        .map(|(index, path, source)| (*index as u64, *path, Arc::new(source.to_string())))
+        .collect::<Vec<_>>();
+
+    let mut session = CompilerSession::new();
+    let initial = assembler.snapshot().expect("trusted std root snapshot");
+    let mut revision = begin_import_input_request(
+        &mut session,
+        &initial,
+        context.clone(),
+        assembler.accepted_read_manifest(),
+    )
+    .expect("begin trusted std request");
+    loop {
+        let snapshot = assembler.snapshot().expect("trusted std snapshot");
+        let ledger = import_observation_ledger(&session, revision).expect("current std ledger");
+        let plan = session
+            .stage_import_discovery(
+                &snapshot,
+                context.clone(),
+                assembler.accepted_read_manifest().shared_slice(),
+                ledger.clone(),
+            )
+            .expect("valid trusted std discovery plan");
+        let frontier = import_demand_frontier_for_roots(
+            &mut session,
+            revision,
+            &plan,
+            ImportDemandMode::Rooted,
+            &plan.demand_roots(),
+        )
+        .expect("trusted std frontier");
+        if frontier.requests().is_empty() {
+            session
+                .close_import_discovery(ledger)
+                .expect("close valid import discovery revision");
+            break;
+        }
+        let observations = frontier
+            .requests()
+            .iter()
+            .cloned()
+            .map(|request| {
+                let requested = request.requested_path();
+                let (index, canonical, source) = std_sources
+                    .iter()
+                    .find(|(_, path, _)| *path == requested)
+                    .unwrap_or_else(|| panic!("unexpected import request {requested}"));
+                let accepted = AcceptedImportSource::new(
+                    requested,
+                    *canonical,
+                    PhysicalFileIdentity::new(1, *index),
+                    FileMetadataFingerprint::new(source.len() as u64, 0, 0),
+                    source.clone(),
+                )
+                .expect("accepted trusted standard-library source");
+                ImportObservation::accepted(request, accepted)
+                    .expect("observation matches discovery request")
+            })
+            .collect::<Vec<_>>();
+        let mut assembly_ledger = ledger;
+        for observation in observations.iter().cloned() {
+            assembly_ledger
+                .record(observation)
+                .expect("unique representative observation");
+        }
+        assembler
+            .add_plan_reads(&plan, &assembly_ledger)
+            .expect("assemble accepted std reads");
+        let successor = assembler.snapshot().expect("successor std snapshot");
+        revision = publish_import_observation_batch(
+            &mut session,
+            &frontier,
+            &successor,
+            assembler.accepted_read_manifest(),
+            observations,
+        )
+        .expect("publish std observation batch");
+    }
+    query_cfg_state_from_session(session, &CompileOptions::default())
+}
+
+/// The trusted standard-library `Option` producer source, provided verbatim at
+/// the `\0rue-std/option.rue` identity by `query_cfg_state_with_trusted_std`.
+const TRUSTED_OPTION_MODULE_SOURCE: &str =
+    "pub fn Option(comptime T: type) -> type { enum { Some(T), None } }";
+
 #[test]
 fn option_returning_intrinsics_require_the_exact_payload_type() {
-    let state = query_cfg_state(
-        r#"fn Option(comptime T: type) -> type { enum { Some(T), None } }
+    // A fallible intrinsic's result is the exact trusted std `Option(payload)`
+    // (RUE-1112), so the match arms must name the real std `Option`, imported
+    // from the trusted module — a same-shape local `fn Option` lookalike is a
+    // different producer and is rejected as the intrinsic annotation.
+    let state = query_cfg_state_with_trusted_std(
+        r#"const option = @import("std/option.rue");
+        const Option = option.Option;
         fn parse32() -> i32 {
             let O = Option(i32);
             match @parse_i32("1") { O.Some(n) => n, O.None => 0 }
@@ -1107,6 +1241,7 @@ fn option_returning_intrinsics_require_the_exact_payload_type() {
             match @parse_i64("2") { O.Some(n) => @intCast(n), O.None => 0 }
         }
         fn main() -> i32 { parse32() + parse64() }"#,
+        &[(2, "/project/std/option.rue", TRUSTED_OPTION_MODULE_SOURCE)],
     )
     .expect("Option intrinsic signature probe must compile");
     let interp = Interp {
@@ -1163,18 +1298,15 @@ fn option_returning_intrinsics_require_the_exact_payload_type() {
 
 #[test]
 fn read_line_requires_trusted_source_strbuf_payload_metadata() {
-    use rue_compiler::unstable::{
-        DiscoverySourceAssembler, ImportDemandMode, begin_import_input_request,
-        import_demand_frontier_for_roots, import_observation_ledger,
-        publish_import_observation_batch,
-    };
-    use rue_compiler::{
-        AcceptedImportSource, CompilerSession, FileMetadataFingerprint, ImportDiscoveryContext,
-        ImportObservation, PhysicalFileIdentity,
-    };
-    use std::sync::Arc;
-
-    let root = Arc::new(
+    let strbuf = r#"pub struct StrBuf {
+            buf: ptr mut u8,
+            len: u64,
+            cap: u64,
+            fn len(borrow self) -> u64 { self.len }
+            fn as_ptr(borrow self) -> ptr mut u8 { self.buf }
+        }
+        drop fn StrBuf(self) { }"#;
+    let state = query_cfg_state_with_trusted_std(
         r#"const strbuf = @import("std/strbuf.rue");
         const option = @import("std/option.rue");
         const StrBuf = strbuf.StrBuf;
@@ -1187,116 +1319,13 @@ fn read_line_requires_trusted_source_strbuf_payload_metadata() {
             let O = Option(i32);
             match @parse_i32("1") { O.Some(value) => value, O.None => 0 }
         }
-        fn main() -> i32 { line() + parse() }"#
-            .to_owned(),
-    );
-    let strbuf = Arc::new(
-        r#"pub struct StrBuf {
-            buf: ptr mut u8,
-            len: u64,
-            cap: u64,
-            fn len(borrow self) -> u64 { self.len }
-            fn as_ptr(borrow self) -> ptr mut u8 { self.buf }
-        }
-        drop fn StrBuf(self) { }"#
-            .to_owned(),
-    );
-    let option = Arc::new(
-        r#"pub fn Option(comptime T: type) -> type { enum { Some(T), None } }"#.to_owned(),
-    );
-    let context =
-        ImportDiscoveryContext::new(1, "/project", Some("/project/std"), "oracle-call-contract")
-            .expect("valid discovery context");
-    let mut assembler = DiscoverySourceAssembler::new(
-        context.clone(),
-        "/project/main.rue",
-        "/project/main.rue",
-        PhysicalFileIdentity::new(1, 1),
-        FileMetadataFingerprint::new(root.len() as u64, 0, 0),
-        root,
+        fn main() -> i32 { line() + parse() }"#,
+        &[
+            (2, "/project/std/strbuf.rue", strbuf),
+            (3, "/project/std/option.rue", TRUSTED_OPTION_MODULE_SOURCE),
+        ],
     )
-    .expect("root source assembler");
-    let standard_sources = [
-        (2, "/project/std/strbuf.rue", strbuf),
-        (3, "/project/std/option.rue", option),
-    ];
-    let mut session = CompilerSession::new();
-    let initial = assembler.snapshot().expect("trusted std root snapshot");
-    let mut revision = begin_import_input_request(
-        &mut session,
-        &initial,
-        context.clone(),
-        assembler.accepted_read_manifest(),
-    )
-    .expect("begin trusted std request");
-    loop {
-        let snapshot = assembler.snapshot().expect("trusted std snapshot");
-        let ledger = import_observation_ledger(&session, revision).expect("current std ledger");
-        let plan = session
-            .stage_import_discovery(
-                &snapshot,
-                context.clone(),
-                assembler.accepted_read_manifest(),
-                ledger.clone(),
-            )
-            .expect("valid trusted std discovery plan");
-        let frontier = import_demand_frontier_for_roots(
-            &mut session,
-            revision,
-            &plan,
-            ImportDemandMode::Rooted,
-            &plan.demand_roots(),
-        )
-        .expect("trusted std frontier");
-        if frontier.requests().is_empty() {
-            session
-                .close_import_discovery(ledger)
-                .expect("close valid import discovery revision");
-            break;
-        }
-        let observations = frontier
-            .requests()
-            .iter()
-            .cloned()
-            .map(|request| {
-                let requested = request.requested_path();
-                let (index, canonical, source) = standard_sources
-                    .iter()
-                    .find(|(_, path, _)| *path == requested)
-                    .unwrap_or_else(|| panic!("unexpected import request {requested}"));
-                let accepted = AcceptedImportSource::new(
-                    requested,
-                    *canonical,
-                    PhysicalFileIdentity::new(1, *index),
-                    FileMetadataFingerprint::new(source.len() as u64, 0, 0),
-                    source.clone(),
-                )
-                .expect("accepted trusted standard-library source");
-                ImportObservation::accepted(request, accepted)
-                    .expect("observation matches discovery request")
-            })
-            .collect::<Vec<_>>();
-        let mut assembly_ledger = ledger;
-        for observation in observations.iter().cloned() {
-            assembly_ledger
-                .record(observation)
-                .expect("unique representative observation");
-        }
-        assembler
-            .add_plan_reads(&plan, &assembly_ledger)
-            .expect("assemble accepted std reads");
-        let successor = assembler.snapshot().expect("successor std snapshot");
-        revision = publish_import_observation_batch(
-            &mut session,
-            &frontier,
-            &successor,
-            assembler.accepted_read_manifest(),
-            observations,
-        )
-        .expect("publish std observation batch");
-    }
-    let state = query_cfg_state_from_session(session, &CompileOptions::default())
-        .expect("trusted Option(StrBuf) @read_line probe must compile");
+    .expect("trusted Option(StrBuf) @read_line probe must compile");
     let interp = Interp {
         state: &state,
         stdout: String::new(),

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -310,6 +310,12 @@ impl<V> QueryTerminal<V> {
         self.stamp
     }
 
+    /// Opaque session-local incarnation of the node which owns this terminal,
+    /// preventing stamp ABA after eviction.
+    pub const fn node_incarnation(&self) -> u64 {
+        self.node_incarnation
+    }
+
     /// Runtime request which originally computed this immutable terminal.
     pub fn origin_request_id(&self) -> u64 {
         self.origin_request
@@ -812,11 +818,78 @@ struct RevisionStore {
     retired_through: u64,
 }
 
+impl RevisionStore {
+    /// The stamp of `input` in `revision_id`, resolving through the revision's
+    /// overlay chain. `None` means the leaf is absent (a recorded-absent optional
+    /// leaf reads as absent here).
+    fn input_stamp(&self, revision_id: u64, input: &InputIdentity) -> Option<u64> {
+        self.entries.get(&revision_id)?.inputs.stamp(input)
+    }
+
+    /// Whether `input` is present in `revision_id` (through the overlay chain).
+    fn input_present(&self, revision_id: u64, input: &InputIdentity) -> bool {
+        self.input_stamp(revision_id, input).is_some()
+    }
+}
+
 #[derive(Debug)]
 struct RevisionEntry {
     revision: Revision,
-    inputs: Arc<BTreeMap<InputIdentity, u64>>,
+    inputs: Arc<RevisionInputs>,
     active_requests: usize,
+}
+
+/// Overlay chains longer than this are compacted into one complete map at the
+/// next successor publication, so lookup depth stays bounded even if a caller
+/// publishes an unexpectedly long chain.
+const OVERLAY_COMPACTION_DEPTH: usize = 16;
+
+/// The immutable leaf view of one revision: either a complete map, or a sparse
+/// successor overlay whose unresolved leaves are STRUCTURALLY INHERITED from the
+/// parent's input node by `Arc` (RUE-1112). The parent input node is owned by the
+/// overlay itself, so the parent's revision-store ENTRY may retire while every
+/// child's logical view stays complete — retention never has to pin ancestors.
+#[derive(Debug)]
+enum RevisionInputs {
+    Full(Arc<BTreeMap<InputIdentity, u64>>),
+    Overlay {
+        parent: Arc<RevisionInputs>,
+        delta: Arc<BTreeMap<InputIdentity, u64>>,
+        depth: usize,
+    },
+}
+
+impl RevisionInputs {
+    /// Resolve one leaf: the newest overlay delta wins, then ancestors in order.
+    fn stamp(&self, input: &InputIdentity) -> Option<u64> {
+        match self {
+            Self::Full(map) => map.get(input).copied(),
+            Self::Overlay { parent, delta, .. } => {
+                delta.get(input).copied().or_else(|| parent.stamp(input))
+            }
+        }
+    }
+
+    fn depth(&self) -> usize {
+        match self {
+            Self::Full(_) => 0,
+            Self::Overlay { depth, .. } => *depth,
+        }
+    }
+
+    /// Materialize the complete logical leaf map (used only for compaction).
+    fn flatten(&self) -> BTreeMap<InputIdentity, u64> {
+        match self {
+            Self::Full(map) => map.as_ref().clone(),
+            Self::Overlay { parent, delta, .. } => {
+                let mut merged = parent.flatten();
+                for (input, stamp) in delta.iter() {
+                    merged.insert(input.clone(), *stamp);
+                }
+                merged
+            }
+        }
+    }
 }
 
 struct RevisionLease {
@@ -965,6 +1038,40 @@ impl QueryRuntime {
         K: QueryKey,
         V: Clone + Send + Sync + 'static,
     {
+        self.family_inner(stable_name, retention_limit, value_equal, evaluator, false)
+    }
+
+    /// Creates a typed family REGISTERED CONTENT-ADDRESSED: the family asserts
+    /// every record is a pure function of its key alone, so no revision leaf
+    /// can change the value behind an unchanged key. This registration is the
+    /// SOLE minting authority for [`AdoptableTerminal`]
+    /// ([`QueryFamily::adoptable_terminal`]); an ordinary input-dependent
+    /// family can never endorse a stale value through terminal adoption.
+    pub fn content_addressed_family_with_equality<K, V>(
+        &self,
+        stable_name: impl Into<Arc<str>>,
+        retention_limit: usize,
+        value_equal: fn(&V, &V) -> bool,
+    ) -> Result<QueryFamily<K, V>, FamilyError>
+    where
+        K: QueryKey,
+        V: Clone + Send + Sync + 'static,
+    {
+        self.family_inner(stable_name, retention_limit, value_equal, None, true)
+    }
+
+    fn family_inner<K, V>(
+        &self,
+        stable_name: impl Into<Arc<str>>,
+        retention_limit: usize,
+        value_equal: fn(&V, &V) -> bool,
+        evaluator: Option<Arc<FamilyEvaluator<K, V>>>,
+        content_addressed: bool,
+    ) -> Result<QueryFamily<K, V>, FamilyError>
+    where
+        K: QueryKey,
+        V: Clone + Send + Sync + 'static,
+    {
         let name = stable_name.into();
         if name.is_empty() {
             return Err(FamilyError::EmptyName);
@@ -980,6 +1087,7 @@ impl QueryRuntime {
                     runtime: self.core.identity,
                     family: self.core.next_family.fetch_add(1, Ordering::Relaxed),
                 },
+                content_addressed,
                 retention_limit,
                 value_equal,
                 evaluator,
@@ -1016,10 +1124,125 @@ impl QueryRuntime {
         let inputs = Arc::new(exact);
         let mut revisions = lock(&self.core.revisions);
         match revisions.entries.get(&revision.id) {
-            Some(previous)
-                if previous.revision == revision && previous.inputs.as_ref() == inputs.as_ref() =>
-            {
+            Some(previous) if previous.revision == revision => match previous.inputs.as_ref() {
+                RevisionInputs::Full(previous_inputs)
+                    if previous_inputs.as_ref() == inputs.as_ref() =>
+                {
+                    Ok(())
+                }
+                _ => Err(RevisionError::AlreadyPublished(revision)),
+            },
+            Some(_) => Err(RevisionError::AlreadyPublished(revision)),
+            None => {
+                if revision.id <= revisions.retired_through {
+                    return Err(RevisionError::Retired(revision));
+                }
+                revisions.entries.insert(
+                    revision.id,
+                    RevisionEntry {
+                        revision,
+                        inputs: Arc::new(RevisionInputs::Full(inputs)),
+                        active_requests: 0,
+                    },
+                );
+                self.core.enforce_revision_retention(&mut revisions);
                 Ok(())
+            }
+        }
+    }
+
+    /// Publishes a sparse immutable successor overlay revision (RUE-1112).
+    ///
+    /// The successor is a logically complete immutable input view: `delta` leaves
+    /// resolve from the overlay, and every other leaf is STRUCTURALLY INHERITED
+    /// from `parent`'s input node by `Arc` — only the delta is materialized. The
+    /// delta may ADD new leaves and may RE-STAMP an existing leaf identity (the
+    /// ordinary sparse representation of a changed derived input in a new
+    /// immutable revision — the parent view itself is never mutated, and
+    /// observers of a re-stamped identity are dirtied by red/green validation
+    /// exactly as under a full publication). Removal is inexpressible.
+    ///
+    /// `parent` must be a currently retained revision of this runtime with the
+    /// SAME compatibility token (an overlay never crosses a fresh observation
+    /// generation), and `revision.id` must be strictly newer than `parent.id`
+    /// (acyclic, monotonic lineage). The overlay owns the parent's input node, so
+    /// the parent's revision-store entry may retire without breaking any child;
+    /// chains deeper than [`OVERLAY_COMPACTION_DEPTH`] are compacted at
+    /// publication. This layer does NOT verify domain additivity — a caller such
+    /// as the compiler's trusted-toolchain lineage enforces its own
+    /// strictly-additive source contract before publishing. Fresh generations
+    /// keep using the complete [`Self::publish_revision`] path.
+    pub fn publish_revision_overlay(
+        &self,
+        revision: Revision,
+        parent: Revision,
+        delta: impl IntoIterator<Item = (InputIdentity, u64)>,
+    ) -> Result<(), RevisionError> {
+        let mut delta_map = BTreeMap::new();
+        for (input, stamp) in delta {
+            if stamp == 0 {
+                return Err(RevisionError::ReservedInputStamp(input));
+            }
+            if let Some(previous) = delta_map.insert(input.clone(), stamp)
+                && previous != stamp
+            {
+                return Err(RevisionError::ConflictingInput(input));
+            }
+        }
+        let delta_map = Arc::new(delta_map);
+        let mut revisions = lock(&self.core.revisions);
+        let Some(parent_entry) = revisions
+            .entries
+            .get(&parent.id)
+            .filter(|entry| entry.revision == parent)
+        else {
+            return Err(RevisionError::OverlayParentUnavailable(parent));
+        };
+        if revision.compatibility != parent.compatibility {
+            return Err(RevisionError::IncompatibleOverlayParent(parent));
+        }
+        if revision.id <= parent.id {
+            return Err(RevisionError::NonMonotonicOverlay(revision));
+        }
+        let parent_inputs = parent_entry.inputs.clone();
+        let inputs = if parent_inputs.depth() >= OVERLAY_COMPACTION_DEPTH {
+            // Compact a deep chain into one complete map so lookup depth stays
+            // bounded; the merged map is the same logical view.
+            let mut merged = parent_inputs.flatten();
+            for (input, stamp) in delta_map.iter() {
+                merged.insert(input.clone(), *stamp);
+            }
+            Arc::new(RevisionInputs::Full(Arc::new(merged)))
+        } else {
+            Arc::new(RevisionInputs::Overlay {
+                depth: parent_inputs.depth() + 1,
+                parent: parent_inputs,
+                delta: delta_map.clone(),
+            })
+        };
+        match revisions.entries.get(&revision.id) {
+            Some(previous) if previous.revision == revision => {
+                // Idempotent only for the identical logical view: same parent
+                // input node and identical delta (or the identical compaction).
+                let identical = match (previous.inputs.as_ref(), inputs.as_ref()) {
+                    (
+                        RevisionInputs::Overlay {
+                            parent: previous_parent,
+                            delta: previous_delta,
+                            ..
+                        },
+                        RevisionInputs::Overlay { parent, delta, .. },
+                    ) => Arc::ptr_eq(previous_parent, parent) && previous_delta == delta,
+                    (RevisionInputs::Full(previous_map), RevisionInputs::Full(map)) => {
+                        previous_map == map
+                    }
+                    _ => false,
+                };
+                if identical {
+                    Ok(())
+                } else {
+                    Err(RevisionError::AlreadyPublished(revision))
+                }
             }
             Some(_) => Err(RevisionError::AlreadyPublished(revision)),
             None => {
@@ -1298,6 +1521,15 @@ pub enum RevisionError {
     ReservedInputStamp(InputIdentity),
     /// This publication identity is older than the bounded retired watermark.
     Retired(Revision),
+    /// A successor overlay named a parent revision that is not currently a
+    /// retained revision of this runtime lineage.
+    OverlayParentUnavailable(Revision),
+    /// A successor overlay named a parent from a different compatibility
+    /// generation; an overlay never crosses a fresh observation generation.
+    IncompatibleOverlayParent(Revision),
+    /// A successor overlay's revision id is not strictly newer than its
+    /// parent's; the overlay lineage is acyclic and monotonic.
+    NonMonotonicOverlay(Revision),
 }
 
 /// Invalid family declaration.
@@ -1378,6 +1610,12 @@ where
 struct FamilyInner<K: QueryKey, V: Clone + Send + Sync + 'static> {
     name: Arc<str>,
     token: FamilyToken,
+    /// Registration policy: the family asserts every record is a pure function
+    /// of its key alone, so no revision leaf can change the value behind an
+    /// unchanged key. This registration is the SOLE minting authority for
+    /// [`AdoptableTerminal`] — an ordinary input-dependent family can never
+    /// endorse a stale value through adoption.
+    content_addressed: bool,
     retention_limit: usize,
     value_equal: fn(&V, &V) -> bool,
     evaluator: Option<Arc<FamilyEvaluator<K, V>>>,
@@ -1442,6 +1680,12 @@ trait ErasedNode: fmt::Debug + Send + Sync {
         task: &Arc<Task>,
         active: &mut BTreeSet<u64>,
     ) -> Result<Option<u64>, QueryAbort>;
+
+    /// The typed node behind this erased handle, for the family-owned
+    /// exact-terminal adoption path ([`QueryFamily::observe_adopted_terminal`])
+    /// to recover its own `Node<K, V>` from the incarnation index without a
+    /// key lookup.
+    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync>;
 }
 
 impl<K, V> ErasedNode for Node<K, V>
@@ -1488,6 +1732,10 @@ where
         });
         active.remove(&self.incarnation);
         stamp
+    }
+
+    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync> {
+        self
     }
 }
 
@@ -2350,6 +2598,187 @@ where
         })
     }
 
+    /// Mint the exact-terminal adoption capability for a terminal of THIS
+    /// family. Only a family REGISTERED CONTENT-ADDRESSED
+    /// ([`QueryRuntime::content_addressed_family_with_equality`]) can mint
+    /// one: the registration is the mechanical assertion that the key alone
+    /// pins each terminal's value, which is what makes an input-free
+    /// endorsement at another revision sound. Any other family is refused.
+    pub fn adoptable_terminal(
+        &self,
+        terminal: &Arc<QueryTerminal<V>>,
+    ) -> Result<AdoptableTerminal<V>, AdoptTerminalError> {
+        if terminal.family_token != self.inner.token {
+            return Err(AdoptTerminalError::ForeignFamily);
+        }
+        if !self.inner.content_addressed {
+            return Err(AdoptTerminalError::NotContentAddressed);
+        }
+        Ok(AdoptableTerminal {
+            terminal: terminal.clone(),
+        })
+    }
+
+    /// Record an ALREADY-HELD adoptable terminal of this family as a
+    /// dependency of the computing task: an exact-terminal capability that
+    /// never hashes or compares the terminal's content key (the node is
+    /// located by incarnation). The terminal must still be retained on its
+    /// node — a stale or evicted terminal is rejected, never silently
+    /// re-derived. On success the task observes the exact
+    /// `{node, incarnation, stamp}` identity of the held terminal and leases
+    /// it for the request's lifetime, and the node is endorsed at the task's
+    /// pinned revision — an input-free republication with the SAME stamp,
+    /// routed through the family's ordinary retained-publication accounting
+    /// (metrics, retention queue, eviction) — so red/green validation of the
+    /// recorded observation succeeds at this revision and its compatible
+    /// descendants without touching the leaves the original computation
+    /// observed. Soundness comes from the capability: only a
+    /// content-addressed registration mints [`AdoptableTerminal`].
+    pub fn observe_adopted_terminal(
+        &self,
+        context: &QueryContext,
+        adoptable: &AdoptableTerminal<V>,
+    ) -> Result<(), AdoptTerminalError> {
+        let terminal = &adoptable.terminal;
+        if terminal.family_token != self.inner.token {
+            return Err(AdoptTerminalError::ForeignFamily);
+        }
+        if !self.inner.content_addressed {
+            return Err(AdoptTerminalError::NotContentAddressed);
+        }
+        if !Arc::ptr_eq(&self.core, &context.task.core) {
+            return Err(AdoptTerminalError::ForeignRuntime);
+        }
+        // Pin FIRST (mirroring reuse-candidate discovery) so the terminal
+        // cannot be evicted between validation and the lease transfer below.
+        let pin = self
+            .pin_terminal(terminal)
+            .map_err(|_| AdoptTerminalError::ForeignFamily)?;
+        // Locate the node by INCARNATION — never by key hash or equality —
+        // and recover this family's typed node from the erased handle.
+        let node = lock(&self.core.nodes)
+            .get(&terminal.node_incarnation)
+            .and_then(Weak::upgrade)
+            .ok_or(AdoptTerminalError::Evicted)?;
+        let node = node
+            .as_any()
+            .downcast::<Node<K, V>>()
+            .map_err(|_| AdoptTerminalError::Evicted)?;
+        // An incarnation-index anomaly (a recycled slot or foreign node) must
+        // never endorse an unrelated node.
+        if node.incarnation != terminal.node_incarnation || node.identity != terminal.node {
+            return Err(AdoptTerminalError::Evicted);
+        }
+        let endorsed_pin = self.endorse_adopted_stamp(&node, context.task.revision, terminal)?;
+        // Record the exact observation and transfer BOTH pins into the task's
+        // request-scoped lease set: the held predecessor and the endorsement
+        // itself, whose lease identity differs by its adopting revision. The
+        // endorsement pin was acquired under the node lock, so there is no
+        // instant in which it is both exposed and evictable.
+        context.task.observe(terminal);
+        self.lease_observed_pin(&context.task, pin);
+        self.lease_observed_pin(&context.task, endorsed_pin);
+        Ok(())
+    }
+
+    /// Endorse a still-retained stamp of `node` at `revision` by an input-free
+    /// republication of the held value with the SAME stamp, accounted exactly
+    /// like an ordinary retained publication: metered, enqueued for retention,
+    /// and evictable — an adoption chain is bounded by the family's retention
+    /// limit, and an evicted endorsement simply dirties its dependents through
+    /// ordinary red/green validation.
+    fn endorse_adopted_stamp(
+        &self,
+        node: &Arc<Node<K, V>>,
+        revision: Revision,
+        held: &Arc<QueryTerminal<V>>,
+    ) -> Result<TerminalPin<K, V>, AdoptTerminalError> {
+        let (attempt_id, endorsed_pin) = {
+            let mut state = lock(&node.state);
+            // The endorsed stamp must still be retained on this node; a stale
+            // or evicted terminal is rejected, never silently re-derived.
+            let retained = state.attempts.iter().any(|attempt| {
+                matches!(
+                    &attempt.state,
+                    AttemptState::Terminal { terminal, .. } if terminal.stamp == held.stamp
+                )
+            });
+            if !retained {
+                return Err(AdoptTerminalError::Evicted);
+            }
+            // Idempotent per (revision, stamp); the scan is bounded by the
+            // retention limit because endorsements are evictable entries. The
+            // existing endorsement is re-pinned under the lock so THIS
+            // adopting attempt protects it too.
+            let endorsed = state.attempts.iter().find_map(|attempt| {
+                if attempt.revision != revision {
+                    return None;
+                }
+                match &attempt.state {
+                    AttemptState::Terminal { terminal, .. }
+                        if terminal.stamp == held.stamp && terminal.inputs.is_empty() =>
+                    {
+                        Some(terminal.clone())
+                    }
+                    _ => None,
+                }
+            });
+            if let Some(endorsed) = endorsed {
+                return Ok(self
+                    .pin_terminal(&endorsed)
+                    .expect("a family pins its own retained terminal"));
+            }
+            let adopted = Arc::new(QueryTerminal {
+                family_token: held.family_token,
+                node: held.node.clone(),
+                node_incarnation: held.node_incarnation,
+                revision,
+                stamp: held.stamp,
+                origin_request: held.origin_request,
+                outcome: held.outcome.clone(),
+                kind: held.kind,
+                diagnostics: held.diagnostics.clone(),
+                work: held.work.clone(),
+                dependencies: Arc::from([]),
+                inputs: Arc::from([]),
+                pins: AtomicUsize::new(0),
+            });
+            let id = state.next_attempt;
+            state.next_attempt += 1;
+            state.attempts.push_back(Attempt {
+                id,
+                revision,
+                state: AttemptState::Terminal {
+                    terminal: adopted.clone(),
+                    waiters: 0,
+                },
+            });
+            // Pin UNDER the node lock, before the endorsement is enqueued or
+            // reachable to a concurrent enforcer: `pins > 0` is established
+            // atomically with insertion, so retention pressure (including the
+            // enforcement pass below) can never evict it at birth.
+            let pin = self
+                .pin_terminal(&adopted)
+                .expect("a family pins its own retained terminal");
+            (id, pin)
+        };
+        self.core
+            .metrics
+            .green_publications
+            .fetch_add(1, Ordering::Relaxed);
+        self.core
+            .metrics
+            .retained_terminals
+            .fetch_add(1, Ordering::Relaxed);
+        self.inner.retained_count.fetch_add(1, Ordering::Relaxed);
+        lock(&self.inner.retention).push_back(RetentionEntry {
+            node: Arc::downgrade(node),
+            attempt: attempt_id,
+        });
+        self.enforce_retention();
+        Ok(endorsed_pin)
+    }
+
     /// Transfers an already-acquired [`TerminalPin`] into a task's request-scoped
     /// lease set, retaining it for the lifetime of the rooted request.
     ///
@@ -2371,7 +2800,11 @@ where
     /// false`) are speculative and their pins are dropped by the caller.
     fn lease_observed_pin(&self, task: &Arc<Task>, pin: TerminalPin<K, V>) {
         let mut leases = lock(&task.leases);
-        let identity = (pin.terminal.node_incarnation, pin.terminal.stamp);
+        let identity = (
+            pin.terminal.node_incarnation,
+            pin.terminal.stamp,
+            pin.terminal.revision,
+        );
         if leases.observed.insert(identity) {
             leases.held.push(Box::new(pin));
         }
@@ -2428,6 +2861,42 @@ where
 pub enum PinError {
     /// The terminal's unforgeable family token does not match.
     ForeignFamily,
+}
+
+/// Errors from minting or recording an exact-terminal adoption capability
+/// ([`QueryFamily::adoptable_terminal`] /
+/// [`QueryFamily::observe_adopted_terminal`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdoptTerminalError {
+    /// The terminal's unforgeable family token does not match this family.
+    ForeignFamily,
+    /// The computing task belongs to a different runtime than this family.
+    ForeignRuntime,
+    /// The family is not registered content-addressed, so it has no authority
+    /// to mint adoption capabilities: an input-dependent family endorsing a
+    /// held value input-free at another revision could validate a stale
+    /// result green.
+    NotContentAddressed,
+    /// The terminal (or its node) is no longer retained: a stale or evicted
+    /// terminal is rejected, never silently re-derived.
+    Evicted,
+}
+
+/// The exact-terminal adoption capability: a terminal of a family whose
+/// CONTENT-ADDRESSED registration is the sole minting authority
+/// ([`QueryFamily::adoptable_terminal`]). Holding one proves the family
+/// asserted its key alone pins the terminal's value, which is what makes an
+/// input-free endorsement at another revision sound.
+#[derive(Debug, Clone)]
+pub struct AdoptableTerminal<V> {
+    terminal: Arc<QueryTerminal<V>>,
+}
+
+impl<V> AdoptableTerminal<V> {
+    /// The held terminal.
+    pub fn terminal(&self) -> &Arc<QueryTerminal<V>> {
+        &self.terminal
+    }
 }
 
 impl<K, V> Drop for TerminalPin<K, V>
@@ -2675,9 +3144,14 @@ struct Task {
 /// Terminals leased for the lifetime of one rooted request (its task).
 #[derive(Default)]
 struct TaskLeases {
-    /// `(node incarnation, red/green stamp)` of every terminal this task has
-    /// already leased, so re-observing a terminal never double-pins it.
-    observed: BTreeSet<(u64, u64)>,
+    /// `(node incarnation, red/green stamp, terminal revision)` of every
+    /// terminal this task has already leased, so re-observing a terminal never
+    /// double-pins it. The revision is part of the identity because an
+    /// adoption endorsement deliberately shares its predecessor's incarnation
+    /// and stamp while being a DISTINCT terminal at the adopting revision —
+    /// both must stay leased; collapsing them would leave the endorsement
+    /// unprotected. Re-observations of one exact terminal still deduplicate.
+    observed: BTreeSet<(u64, u64, Revision)>,
     /// Live pins, type-erased across families. Dropping the task drops these,
     /// each of which decrements its terminal's pin count and re-enforces the
     /// owning family's retention bound.
@@ -2989,11 +3463,15 @@ struct WaitEdge {
 
 impl RuntimeCore {
     fn revision_input(&self, revision: Revision, input: &InputIdentity) -> Option<u64> {
-        lock(&self.revisions)
+        let revisions = lock(&self.revisions);
+        if revisions
             .entries
             .get(&revision.id)
-            .filter(|entry| entry.revision == revision)
-            .and_then(|entry| entry.inputs.get(input).copied())
+            .is_none_or(|entry| entry.revision != revision)
+        {
+            return None;
+        }
+        revisions.input_stamp(revision.id, input)
     }
 
     fn valid_for_revision<V>(
@@ -3017,18 +3495,18 @@ impl RuntimeCore {
         // checked exactly, while dependency stamps are validated recursively
         // against the current compatible terminal of the exact child node.
         let revisions = lock(&self.revisions);
-        let Some(entry) = revisions
+        if revisions
             .entries
             .get(&task.revision.id)
-            .filter(|entry| entry.revision == task.revision)
-        else {
+            .is_none_or(|entry| entry.revision != task.revision)
+        {
             return Ok(false);
-        };
+        }
         let direct_inputs_valid = terminal.inputs.iter().all(|observed| {
             if observed.stamp == 0 {
-                !entry.inputs.contains_key(&observed.input)
+                !revisions.input_present(task.revision.id, &observed.input)
             } else {
-                entry.inputs.get(&observed.input) == Some(&observed.stamp)
+                revisions.input_stamp(task.revision.id, &observed.input) == Some(observed.stamp)
             }
         });
         drop(revisions);
@@ -3076,6 +3554,9 @@ impl RuntimeCore {
     }
 
     fn enforce_revision_retention(&self, revisions: &mut RevisionStore) {
+        // An overlay entry owns its parent's INPUT NODE by `Arc`, so retiring a
+        // parent's revision-store entry never breaks a child's logical view;
+        // retention stays a simple bounded sweep with no ancestor pinning.
         while revisions.entries.len() > REVISION_RETENTION_LIMIT {
             let Some(id) = revisions
                 .entries
@@ -3297,6 +3778,221 @@ mod tests {
         for revision in revisions {
             runtime.publish_revision(revision, []).unwrap();
         }
+    }
+
+    #[test]
+    fn overlay_replaces_one_stamp_recomputing_its_observer_and_reusing_the_rest() {
+        let runtime = QueryRuntime::new(1);
+        let family = runtime.family::<Key, u64>("overlay", 8).unwrap();
+        let base = InputIdentity::new("source", "base.rue");
+        let topology = InputIdentity::new("derived", "topology");
+        let leaf = InputIdentity::new("source", "leaf.rue");
+        let parent = Revision::new(1, 7);
+        let successor = Revision::new(2, 7);
+        runtime
+            .publish_revision(parent, [(base.clone(), 11), (topology.clone(), 1)])
+            .unwrap();
+
+        // Queries at the parent: one reads the stable base leaf, one reads the
+        // aggregate derived identity that the overlay will re-stamp.
+        let base_terminal = runtime
+            .query(&family, parent, Key("base"), CancellationToken::new(), {
+                let base = base.clone();
+                move |context| {
+                    assert_eq!(context.input(base.clone())?, 11);
+                    Ok(QueryOutput::success(1))
+                }
+            })
+            .unwrap();
+        let topology_terminal = runtime
+            .query(
+                &family,
+                parent,
+                Key("topology"),
+                CancellationToken::new(),
+                {
+                    let topology = topology.clone();
+                    move |context| {
+                        assert_eq!(context.input(topology.clone())?, 1);
+                        Ok(QueryOutput::success(10))
+                    }
+                },
+            )
+            .unwrap();
+        assert_eq!(topology_terminal.outcome(), &QueryOutcome::Success(10));
+
+        // A sparse successor overlay: adds one leaf and RE-STAMPS the aggregate
+        // derived identity (same stable identity, new stamp).
+        runtime
+            .publish_revision_overlay(
+                successor,
+                parent,
+                [(leaf.clone(), 22), (topology.clone(), 2)],
+            )
+            .unwrap();
+
+        // The base-reading terminal is REUSED across the overlay boundary: its
+        // inherited leaf is unchanged, so the compute never re-runs.
+        let reused = runtime
+            .query(
+                &family,
+                successor,
+                Key("base"),
+                CancellationToken::new(),
+                |_| panic!("an inherited unchanged leaf must reuse the parent's green terminal"),
+            )
+            .unwrap();
+        assert!(Arc::ptr_eq(&base_terminal, &reused));
+
+        // The observer of the re-stamped identity is DIRTIED and recomputes
+        // against the overlay's new stamp.
+        let recomputed = runtime
+            .query(
+                &family,
+                successor,
+                Key("topology"),
+                CancellationToken::new(),
+                {
+                    let topology = topology.clone();
+                    move |context| {
+                        assert_eq!(context.input(topology.clone())?, 2);
+                        Ok(QueryOutput::success(20))
+                    }
+                },
+            )
+            .unwrap();
+        assert_eq!(recomputed.outcome(), &QueryOutcome::Success(20));
+
+        // The added leaf resolves through the delta.
+        let added = runtime
+            .query(&family, successor, Key("leaf"), CancellationToken::new(), {
+                let leaf = leaf.clone();
+                move |context| {
+                    assert_eq!(context.input(leaf.clone())?, 22);
+                    Ok(QueryOutput::success(2))
+                }
+            })
+            .unwrap();
+        assert_eq!(added.outcome(), &QueryOutcome::Success(2));
+    }
+
+    #[test]
+    fn overlay_rejects_missing_parent_generation_crossing_and_id_reuse() {
+        let runtime = QueryRuntime::new(1);
+        let base = InputIdentity::new("source", "base.rue");
+        let parent = Revision::new(1, 7);
+        runtime
+            .publish_revision(parent, [(base.clone(), 11)])
+            .unwrap();
+
+        // A parent that is not a retained revision of this lineage is rejected.
+        assert!(matches!(
+            runtime.publish_revision_overlay(
+                Revision::new(3, 7),
+                Revision::new(9, 7),
+                [(InputIdentity::new("source", "x"), 1)],
+            ),
+            Err(RevisionError::OverlayParentUnavailable(_))
+        ));
+        // An overlay never crosses a fresh observation generation: a child whose
+        // compatibility token differs from its parent's is rejected.
+        assert!(matches!(
+            runtime.publish_revision_overlay(
+                Revision::new(2, 8),
+                parent,
+                [(InputIdentity::new("source", "x"), 1)],
+            ),
+            Err(RevisionError::IncompatibleOverlayParent(_))
+        ));
+        // The lineage is acyclic and monotonic: a child id at or below its
+        // parent's is rejected.
+        assert!(matches!(
+            runtime.publish_revision_overlay(
+                Revision::new(1, 7),
+                parent,
+                [(InputIdentity::new("source", "x"), 1)],
+            ),
+            Err(RevisionError::NonMonotonicOverlay(_))
+        ));
+        // Re-publishing the same overlay view is idempotent.
+        let leaf = InputIdentity::new("source", "leaf.rue");
+        runtime
+            .publish_revision_overlay(Revision::new(4, 7), parent, [(leaf.clone(), 5)])
+            .unwrap();
+        runtime
+            .publish_revision_overlay(Revision::new(4, 7), parent, [(leaf.clone(), 5)])
+            .unwrap();
+        // A different delta for the same revision id is rejected.
+        assert!(matches!(
+            runtime.publish_revision_overlay(Revision::new(4, 7), parent, [(leaf.clone(), 6)]),
+            Err(RevisionError::AlreadyPublished(_))
+        ));
+        // One publication supplying two stamps for the same leaf is rejected.
+        assert!(matches!(
+            runtime.publish_revision_overlay(
+                Revision::new(5, 7),
+                parent,
+                [(leaf.clone(), 5), (leaf.clone(), 6)],
+            ),
+            Err(RevisionError::ConflictingInput(_))
+        ));
+    }
+
+    #[test]
+    fn overlay_chain_beyond_retention_keeps_newest_child_queryable() {
+        let runtime = QueryRuntime::new(1);
+        let family = runtime.family::<Slot, u64>("overlay-chain", 4).unwrap();
+        let base = InputIdentity::new("source", "base.rue");
+        let mut parent = Revision::new(1, 7);
+        runtime
+            .publish_revision(parent, [(base.clone(), 11)])
+            .unwrap();
+
+        // A chain of overlays far beyond the revision-retention limit. Each child
+        // owns its parent's input node by Arc, so ancestor revision-store ENTRIES
+        // may retire freely (no pinning) while every child's logical view stays
+        // complete.
+        let depth = REVISION_RETENTION_LIMIT as u64 + 8;
+        for step in 0..depth {
+            let child = Revision::new(parent.id() + 1, 7);
+            runtime
+                .publish_revision_overlay(
+                    child,
+                    parent,
+                    [(
+                        InputIdentity::new("source", format!("leaf-{step}")),
+                        step + 1,
+                    )],
+                )
+                .unwrap();
+            parent = child;
+        }
+        // Retention stayed bounded: ancestor entries retired.
+        assert!(runtime.metrics().retained_revisions <= REVISION_RETENTION_LIMIT as u64);
+
+        // The newest child still resolves the ORIGINAL inherited leaf (whose
+        // publishing entry retired long ago) and its own newest delta leaf.
+        let newest = parent;
+        let inherited = runtime
+            .query(&family, newest, Slot(1), CancellationToken::new(), {
+                let base = base.clone();
+                move |context| {
+                    assert_eq!(context.input(base.clone())?, 11);
+                    Ok(QueryOutput::success(1))
+                }
+            })
+            .unwrap();
+        assert_eq!(inherited.outcome(), &QueryOutcome::Success(1));
+        let newest_leaf = InputIdentity::new("source", format!("leaf-{}", depth - 1));
+        let delta = runtime
+            .query(&family, newest, Slot(2), CancellationToken::new(), {
+                move |context| {
+                    assert_eq!(context.input(newest_leaf.clone())?, depth);
+                    Ok(QueryOutput::success(2))
+                }
+            })
+            .unwrap();
+        assert_eq!(delta.outcome(), &QueryOutcome::Success(2));
     }
 
     #[test]
@@ -6081,5 +6777,410 @@ mod tests {
         // dropped now, at the end of the test.
         assert!(attempt.terminal().is_some());
         drop(attempt);
+    }
+
+    /// An adopted terminal is recorded with its EXACT identity — node,
+    /// incarnation, and stamp — and the endorsement makes the dependent
+    /// validate green at the adopting revision even though the adopted
+    /// terminal's original leaf does not exist there. No key hash or content
+    /// comparison is involved.
+    #[test]
+    fn adopted_terminal_is_an_exact_dependency_across_revisions() {
+        let runtime = QueryRuntime::new(1);
+        let family = runtime
+            .content_addressed_family_with_equality::<Key, u64>("adopt", 8, PartialEq::eq)
+            .unwrap();
+        let dependents = runtime.family::<Key, u64>("adopt-dependent", 8).unwrap();
+        let source = InputIdentity::new("source", "a.rue");
+        let parent = Revision::new(1, 7);
+        let successor = Revision::new(2, 7);
+        runtime
+            .publish_revision(parent, [(source.clone(), 11)])
+            .unwrap();
+        // The successor revision does NOT carry the adopted terminal's leaf.
+        runtime.publish_revision(successor, []).unwrap();
+        let predecessor = runtime
+            .query(&family, parent, Key("pred"), CancellationToken::new(), {
+                let source = source.clone();
+                move |context| {
+                    context.input(source.clone())?;
+                    Ok(QueryOutput::success(7))
+                }
+            })
+            .unwrap();
+
+        let dependent = runtime
+            .query(
+                &dependents,
+                successor,
+                Key("succ"),
+                CancellationToken::new(),
+                {
+                    let family = family.clone();
+                    let adoptable = family.adoptable_terminal(&predecessor).unwrap();
+                    move |context| {
+                        family
+                            .observe_adopted_terminal(context, &adoptable)
+                            .unwrap();
+                        Ok(QueryOutput::success(8))
+                    }
+                },
+            )
+            .unwrap();
+        // The recorded observation is the held terminal's exact identity.
+        assert_eq!(dependent.dependencies().len(), 1);
+        let observation = &dependent.dependencies()[0];
+        assert_eq!(observation.node, *predecessor.node());
+        assert_eq!(observation.incarnation, predecessor.node_incarnation());
+        assert_eq!(observation.stamp, predecessor.stamp());
+        // The dependent revalidates green at the adopting revision through the
+        // endorsement: the compute never re-runs.
+        let reused = runtime
+            .query(
+                &dependents,
+                successor,
+                Key("succ"),
+                CancellationToken::new(),
+                |_| panic!("a green adopted dependency must reuse the terminal"),
+            )
+            .unwrap();
+        assert!(Arc::ptr_eq(&reused, &dependent));
+    }
+
+    /// Recording a stale or evicted terminal is REJECTED — never silently
+    /// re-derived — and a terminal of another family is refused outright.
+    #[test]
+    fn adopting_a_stale_or_foreign_terminal_is_rejected() {
+        let runtime = QueryRuntime::new(1);
+        let family = runtime
+            .content_addressed_family_with_equality::<Key, u64>("adopt-stale", 1, PartialEq::eq)
+            .unwrap();
+        let dependents = runtime
+            .content_addressed_family_with_equality::<Key, u64>(
+                "adopt-stale-dependent",
+                8,
+                PartialEq::eq,
+            )
+            .unwrap();
+        let parent = Revision::new(1, 7);
+        let successor = Revision::new(2, 7);
+        publish_empty(&runtime, [parent, successor]);
+        let stale = runtime
+            .query(
+                &family,
+                parent,
+                Key("old"),
+                CancellationToken::new(),
+                |_| Ok(QueryOutput::success(1)),
+            )
+            .unwrap();
+        // Flood the retention-1 family so the held terminal is evicted.
+        runtime
+            .query(
+                &family,
+                parent,
+                Key("new"),
+                CancellationToken::new(),
+                |_| Ok(QueryOutput::success(2)),
+            )
+            .unwrap();
+        runtime
+            .query(
+                &dependents,
+                successor,
+                Key("succ"),
+                CancellationToken::new(),
+                {
+                    let family = family.clone();
+                    let dependents = dependents.clone();
+                    let stale = family.adoptable_terminal(&stale).unwrap();
+                    move |context| {
+                        assert_eq!(
+                            family.observe_adopted_terminal(context, &stale),
+                            Err(AdoptTerminalError::Evicted),
+                            "an evicted terminal must be rejected, not re-derived"
+                        );
+                        assert_eq!(
+                            dependents.observe_adopted_terminal(context, &stale),
+                            Err(AdoptTerminalError::ForeignFamily),
+                            "another family's terminal must be refused"
+                        );
+                        Ok(QueryOutput::success(0))
+                    }
+                },
+            )
+            .unwrap();
+    }
+
+    /// The content-addressed registration is the SOLE minting authority for
+    /// adoption capabilities: an ordinary input-dependent family cannot mint
+    /// one at all, so it can never endorse a stale value input-free after its
+    /// input changes — the unsound path is unreachable, not merely
+    /// discouraged.
+    #[test]
+    fn ordinary_input_dependent_family_cannot_mint_adoption_capability() {
+        let runtime = QueryRuntime::new(1);
+        let family = runtime.family::<Key, u64>("adopt-ordinary", 8).unwrap();
+        let source = InputIdentity::new("source", "a.rue");
+        let parent = Revision::new(1, 7);
+        runtime
+            .publish_revision(parent, [(source.clone(), 11)])
+            .unwrap();
+        // An input-DEPENDENT terminal: its value would change with the leaf.
+        let terminal = runtime
+            .query(&family, parent, Key("k"), CancellationToken::new(), {
+                let source = source.clone();
+                move |context| {
+                    let stamp = context.input(source.clone())?;
+                    Ok(QueryOutput::success(stamp))
+                }
+            })
+            .unwrap();
+        // The leaf changes in a later revision; endorsing the old terminal
+        // there would validate a stale value green — minting is refused.
+        assert_eq!(
+            family.adoptable_terminal(&terminal).unwrap_err(),
+            AdoptTerminalError::NotContentAddressed,
+        );
+    }
+
+    /// Endorsements are ordinary retained publications: metered, enqueued for
+    /// retention, and evictable. An adoption chain longer than the family's
+    /// retention limit stays bounded — old endorsements are deterministically
+    /// evicted rather than accumulating unevictable attempts.
+    #[test]
+    fn adoption_chain_is_bounded_by_family_retention() {
+        const LIMIT: usize = 4;
+        let runtime = QueryRuntime::new(1);
+        let family = runtime
+            .content_addressed_family_with_equality::<Key, u64>("adopt-bound", LIMIT, PartialEq::eq)
+            .unwrap();
+        let dependents = runtime
+            .family::<Slot, u64>("adopt-bound-dependent", LIMIT)
+            .unwrap();
+        let parent = Revision::new(1, 7);
+        runtime.publish_revision(parent, []).unwrap();
+        let predecessor = runtime
+            .query(
+                &family,
+                parent,
+                Key("pred"),
+                CancellationToken::new(),
+                |_| Ok(QueryOutput::success(7)),
+            )
+            .unwrap();
+        let adoptable = family.adoptable_terminal(&predecessor).unwrap();
+        // Keep the ORIGINAL terminal protected (as a live selection would);
+        // its endorsements are unprotected and must cycle out.
+        let _pin = family.pin_terminal(&predecessor).unwrap();
+        // Adopt across far more distinct revisions than the retention limit.
+        for round in 2..(LIMIT as u64 * 8) {
+            let revision = Revision::new(round, 7);
+            runtime.publish_revision(revision, []).unwrap();
+            runtime
+                .query(
+                    &dependents,
+                    revision,
+                    Slot(round),
+                    CancellationToken::new(),
+                    {
+                        let family = family.clone();
+                        let adoptable = adoptable.clone();
+                        move |context| {
+                            family
+                                .observe_adopted_terminal(context, &adoptable)
+                                .unwrap();
+                            Ok(QueryOutput::success(round))
+                        }
+                    },
+                )
+                .unwrap();
+            // Bounded: retained terminals never exceed the configured limit
+            // by more than the protected roots (the pinned original).
+            let retention = family.retention();
+            assert!(
+                retention.terminals <= LIMIT + 1,
+                "adoption endorsements must stay bounded by family retention: {retention:?}"
+            );
+        }
+    }
+
+    /// Endorsement protection is atomic with insertion, and its lease
+    /// identity is distinct from its predecessor's. At retention limit 1 the
+    /// enforcement rotations themselves are the pressure: one pass runs inside
+    /// the endorsement's own insertion (where a zero-pin endorsement would be
+    /// evicted at birth while the pinned predecessor rotates through), one at
+    /// every pin release (where a lease identity collapsed with the
+    /// predecessor's `(incarnation, stamp)` would drop the endorsement's pin
+    /// and evict it on the spot), and one at request teardown. The adopting
+    /// attempt's lease holds the endorsement through all of them, so the
+    /// dependent still revalidates GREEN without recomputation.
+    #[test]
+    fn adoption_survives_birth_eviction_pressure_at_retention_limit_one() {
+        let runtime = QueryRuntime::new(1);
+        let family = runtime
+            .content_addressed_family_with_equality::<Key, u64>("adopt-birth", 1, PartialEq::eq)
+            .unwrap();
+        let dependents = runtime
+            .family::<Key, u64>("adopt-birth-dependent", 8)
+            .unwrap();
+        let source = InputIdentity::new("source", "a.rue");
+        let parent = Revision::new(1, 7);
+        let successor = Revision::new(2, 7);
+        runtime
+            .publish_revision(parent, [(source.clone(), 11)])
+            .unwrap();
+        // The successor revision lacks the predecessor's source leaf, so ONLY
+        // the endorsement can validate the recorded dependency there.
+        runtime.publish_revision(successor, []).unwrap();
+        let predecessor = runtime
+            .query(&family, parent, Key("pred"), CancellationToken::new(), {
+                let source = source.clone();
+                move |context| {
+                    context.input(source.clone())?;
+                    Ok(QueryOutput::success(7))
+                }
+            })
+            .unwrap();
+        let adoptable = family.adoptable_terminal(&predecessor).unwrap();
+        let computes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let dependent = runtime
+            .query(
+                &dependents,
+                successor,
+                Key("succ"),
+                CancellationToken::new(),
+                {
+                    let family = family.clone();
+                    let adoptable = adoptable.clone();
+                    let computes = computes.clone();
+                    move |context| {
+                        computes.fetch_add(1, Ordering::SeqCst);
+                        family
+                            .observe_adopted_terminal(context, &adoptable)
+                            .unwrap();
+                        Ok(QueryOutput::success(8))
+                    }
+                },
+            )
+            .unwrap();
+        assert_eq!(computes.load(Ordering::SeqCst), 1);
+        // The retention-1 bound held: at most one unprotected terminal
+        // survives the teardown rotation, and it is the ENDORSEMENT (the
+        // predecessor rotated out), so the family stays within its bound.
+        let retention = family.retention();
+        assert!(
+            retention.terminals <= 1,
+            "the retention bound must hold after the adopting request: {retention:?}"
+        );
+        // The dependent revalidates GREEN through the surviving endorsement:
+        // the compute never re-runs.
+        let reused = runtime
+            .query(
+                &dependents,
+                successor,
+                Key("succ"),
+                CancellationToken::new(),
+                |_| panic!("a green adopted dependency must reuse the terminal"),
+            )
+            .unwrap();
+        assert!(Arc::ptr_eq(&reused, &dependent));
+        assert_eq!(computes.load(Ordering::SeqCst), 1);
+    }
+
+    /// Exact-terminal adoption never touches the predecessor key's `Hash` or
+    /// `Eq`: after the predecessor is computed, its key instrumentation is
+    /// FROZEN (any further hash or equality panics), and adoption still
+    /// succeeds — the node is located by incarnation alone.
+    #[test]
+    fn adoption_never_hashes_or_compares_the_predecessor_key() {
+        #[derive(Clone)]
+        struct FrozenKey {
+            name: &'static str,
+            frozen: Arc<std::sync::atomic::AtomicBool>,
+        }
+        impl std::hash::Hash for FrozenKey {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                assert!(
+                    !self.frozen.load(Ordering::SeqCst),
+                    "the predecessor key was hashed after freeze"
+                );
+                self.name.hash(state);
+            }
+        }
+        impl PartialEq for FrozenKey {
+            fn eq(&self, other: &Self) -> bool {
+                assert!(
+                    !self.frozen.load(Ordering::SeqCst),
+                    "the predecessor key was equality-compared after freeze"
+                );
+                self.name == other.name
+            }
+        }
+        impl Eq for FrozenKey {}
+        impl QueryKey for FrozenKey {
+            fn stable_identity(&self) -> String {
+                self.name.to_owned()
+            }
+        }
+
+        let runtime = QueryRuntime::new(1);
+        let family = runtime
+            .content_addressed_family_with_equality::<FrozenKey, u64>(
+                "adopt-frozen",
+                8,
+                PartialEq::eq,
+            )
+            .unwrap();
+        let dependents = runtime
+            .family::<Key, u64>("adopt-frozen-dependent", 8)
+            .unwrap();
+        let parent = Revision::new(1, 7);
+        let successor = Revision::new(2, 7);
+        publish_empty(&runtime, [parent, successor]);
+        let frozen = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let key = FrozenKey {
+            name: "pred",
+            frozen: frozen.clone(),
+        };
+        let predecessor = runtime
+            .query(&family, parent, key, CancellationToken::new(), |_| {
+                Ok(QueryOutput::success(7))
+            })
+            .unwrap();
+        let adoptable = family.adoptable_terminal(&predecessor).unwrap();
+        // From here on, ANY hash or equality of the predecessor key panics.
+        frozen.store(true, Ordering::SeqCst);
+        let dependent = runtime
+            .query(
+                &dependents,
+                successor,
+                Key("succ"),
+                CancellationToken::new(),
+                {
+                    let family = family.clone();
+                    let adoptable = adoptable.clone();
+                    move |context| {
+                        family
+                            .observe_adopted_terminal(context, &adoptable)
+                            .unwrap();
+                        Ok(QueryOutput::success(8))
+                    }
+                },
+            )
+            .unwrap();
+        assert_eq!(dependent.dependencies().len(), 1);
+        assert_eq!(dependent.dependencies()[0].stamp, predecessor.stamp());
+        // Reuse validation of the dependent likewise never touches the key.
+        let reused = runtime
+            .query(
+                &dependents,
+                successor,
+                Key("succ"),
+                CancellationToken::new(),
+                |_| panic!("a green adopted dependency must reuse the terminal"),
+            )
+            .unwrap();
+        assert!(Arc::ptr_eq(&reused, &dependent));
     }
 }

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -866,15 +866,17 @@ runtime_error = "integer cast overflow"
 # =============================================================================
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "read_line_returns_option_string"
 spec = ["4.13:33", "4.13:35"]
 source = """
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    // Type checking: @read_line returns Option(StrBuf).
-    let Opt = Option(StrBuf);
+    // Type checking: @read_line returns std.option.Option(StrBuf).
+    let Opt = std.option.Option(StrBuf);
     let line: Opt = @read_line();
     match line {
         Opt.Some(s) => @dbg(s),
@@ -889,15 +891,17 @@ real_std = true
 compile_only = true
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "read_line_no_args"
 spec = ["4.13:34"]
 source = """
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     // Verify @read_line takes no arguments.
-    let Opt = Option(StrBuf);
+    let Opt = std.option.Option(StrBuf);
     let line: Opt = @read_line();
     match line {
         Opt.Some(s) => @dbg(s),
@@ -920,6 +924,10 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "argument"
+# A reached fallible intrinsic inherently demands the trusted std Option/StrBuf
+# (RUE-1112); std is a toolchain guarantee. Provide it so the arg-count
+# diagnostic — not the toolchain park — is what this case exercises.
+real_std = true
 
 [[case]]
 name = "read_line_wrong_arg_count_two"
@@ -932,20 +940,24 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "argument"
+# See read_line_wrong_arg_count_one: the fallible intrinsic demands trusted std.
+real_std = true
 
 # =============================================================================
 # @read_line Runtime Behavior
 # =============================================================================
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "read_line_basic_input"
 spec = ["4.13:33", "4.13:36", "4.13:37"]
 source = """
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let Opt = Option(StrBuf);
+    let Opt = std.option.Option(StrBuf);
     match @read_line() {
         Opt.Some(line) => @dbg(line),
         Opt.None => {},
@@ -959,14 +971,16 @@ expected_stdout = "Hello World"
 exit_code = 0
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "read_line_strips_newline"
 spec = ["4.13:37"]
 source = """
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let Opt = Option(StrBuf);
+    let Opt = std.option.Option(StrBuf);
     match @read_line() {
         Opt.Some(line) => @dbg(line),
         Opt.None => {},
@@ -980,14 +994,16 @@ expected_stdout = "test"
 exit_code = 0
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "read_line_multiple_lines"
 spec = ["4.13:36"]
 source = """
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let Opt = Option(StrBuf);
+    let Opt = std.option.Option(StrBuf);
     match @read_line() {
         Opt.Some(line) => @dbg(line),
         Opt.None => {},
@@ -1008,14 +1024,16 @@ second
 exit_code = 0
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "read_line_partial_line_at_eof"
 spec = ["4.13:38"]
 source = """
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let Opt = Option(StrBuf);
+    let Opt = std.option.Option(StrBuf);
     match @read_line() {
         Opt.Some(line) => @dbg(line),
         Opt.None => {},
@@ -1030,14 +1048,16 @@ expected_stdout = "partial"
 exit_code = 0
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "read_line_empty_line"
 spec = ["4.13:36", "4.13:37"]
 source = """
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let Opt = Option(StrBuf);
+    let Opt = std.option.Option(StrBuf);
     match @read_line() {
         Opt.Some(line) => @dbg(line),
         Opt.None => {},
@@ -1052,14 +1072,16 @@ expected_stdout = ""
 exit_code = 0
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "read_line_eof_no_data_yields_none"
 spec = ["4.13:39"]
 source = """
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let Opt = Option(StrBuf);
+    let Opt = std.option.Option(StrBuf);
     let line: Opt = @read_line();
     // EOF with no data is None, not a trap: this returns 0, exit success.
     match line {
@@ -1081,72 +1103,91 @@ exit_code = 0
 # =============================================================================
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "parse_i32_basic"
 spec = ["4.13:43", "4.13:44", "4.13:45"]
 source = """
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const std = @import("std");
 fn main() -> i32 {
-    let Opt = Option(i32);
+    let Opt = std.option.Option(i32);
     match @parse_i32("42") {
         Opt.Some(n) => n,
         Opt.None => 0,
     }
 }
 """
+real_std = true
 exit_code = 42
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "parse_i32_negative"
 spec = ["4.13:43", "4.13:44", "4.13:47"]
 source = """
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const std = @import("std");
 fn main() -> i32 {
-    let Opt = Option(i32);
+    let Opt = std.option.Option(i32);
     match @parse_i32("-17") {
         Opt.Some(n) => n,
         Opt.None => 0,
     }
 }
 """
+real_std = true
 exit_code = 239
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "parse_i32_zero"
 spec = ["4.13:43", "4.13:44"]
 source = """
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const std = @import("std");
 fn main() -> i32 {
-    let Opt = Option(i32);
+    let Opt = std.option.Option(i32);
     match @parse_i32("0") {
         Opt.Some(n) => n,
         Opt.None => 1,
     }
 }
 """
+real_std = true
 exit_code = 0
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "parse_i32_leading_zeros"
 spec = ["4.13:43", "4.13:47"]
 source = """
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const std = @import("std");
 fn main() -> i32 {
-    let Opt = Option(i32);
+    let Opt = std.option.Option(i32);
     match @parse_i32("007") {
         Opt.Some(n) => n,
         Opt.None => 0,
     }
 }
 """
+real_std = true
 exit_code = 7
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "parse_i32_string_not_consumed"
 spec = ["4.13:46"]
 source = """
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const std = @import("std");
 fn main() -> i32 {
-    let Opt = Option(i32);
+    let Opt = std.option.Option(i32);
     let s = "42";
     let n: Opt = @parse_i32(s);
     @dbg(s);
@@ -1156,66 +1197,83 @@ fn main() -> i32 {
     }
 }
 """
+real_std = true
 exit_code = 42
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "parse_i64_basic"
 spec = ["4.13:43", "4.13:44", "4.13:45"]
 source = """
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const std = @import("std");
 fn main() -> i32 {
-    let Opt = Option(i64);
+    let Opt = std.option.Option(i64);
     match @parse_i64("123") {
         Opt.Some(n) => @intCast(n),
         Opt.None => 0,
     }
 }
 """
+real_std = true
 exit_code = 123
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "parse_i64_negative"
 spec = ["4.13:43", "4.13:44", "4.13:47"]
 source = """
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const std = @import("std");
 fn main() -> i32 {
-    let Opt = Option(i64);
+    let Opt = std.option.Option(i64);
     match @parse_i64("-5") {
         Opt.Some(n) => @intCast(n),
         Opt.None => 0,
     }
 }
 """
+real_std = true
 exit_code = 251
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "parse_u32_basic"
 spec = ["4.13:43", "4.13:44", "4.13:45"]
 source = """
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const std = @import("std");
 fn main() -> i32 {
-    let Opt = Option(u32);
+    let Opt = std.option.Option(u32);
     match @parse_u32("42") {
         Opt.Some(n) => @intCast(n),
         Opt.None => 0,
     }
 }
 """
+real_std = true
 exit_code = 42
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "parse_u64_basic"
 spec = ["4.13:43", "4.13:44", "4.13:45"]
 source = """
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const std = @import("std");
 fn main() -> i32 {
-    let Opt = Option(u64);
+    let Opt = std.option.Option(u64);
     match @parse_u64("99") {
         Opt.Some(n) => @intCast(n),
         Opt.None => 0,
     }
 }
 """
+real_std = true
 exit_code = 99
 
 [[case]]
@@ -1228,6 +1286,9 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
+# The fallible intrinsic demands trusted std Option (RUE-1112); provide it so
+# the arg-count diagnostic, not the toolchain park, is exercised.
+real_std = true
 
 [[case]]
 name = "parse_wrong_arg_count_two"
@@ -1239,6 +1300,8 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
+# See parse_wrong_arg_count_zero: the fallible intrinsic demands trusted std.
+real_std = true
 
 [[case]]
 name = "parse_non_string_argument"
@@ -1251,128 +1314,223 @@ fn main() -> i32 {
 compile_fail = true
 # Text consumers accept every text rung and diagnose that shared contract.
 error_contains = "expects text"
+# The fallible intrinsic demands trusted std Option (RUE-1112); provide it so
+# the argument-type diagnostic, not the toolchain park, is exercised.
+real_std = true
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "parse_empty_string_yields_none"
 spec = ["4.13:49"]
 source = """
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const std = @import("std");
 fn main() -> i32 {
-    let Opt = Option(i32);
+    let Opt = std.option.Option(i32);
     match @parse_i32("") {
         Opt.Some(n) => n,
         Opt.None => 42,
     }
 }
 """
+real_std = true
 exit_code = 42
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "parse_invalid_char_yields_none"
 spec = ["4.13:49"]
 source = """
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const std = @import("std");
 fn main() -> i32 {
-    let Opt = Option(i32);
+    let Opt = std.option.Option(i32);
     match @parse_i32("12abc") {
         Opt.Some(n) => n,
         Opt.None => 42,
     }
 }
 """
+real_std = true
 exit_code = 42
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "parse_overflow_i32_yields_none"
 spec = ["4.13:49"]
 source = """
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const std = @import("std");
 fn main() -> i32 {
-    let Opt = Option(i32);
+    let Opt = std.option.Option(i32);
     match @parse_i32("2147483648") {
         Opt.Some(n) => n,
         Opt.None => 42,
     }
 }
 """
+real_std = true
 exit_code = 42
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "parse_overflow_u32_yields_none"
 spec = ["4.13:49"]
 source = """
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const std = @import("std");
 fn main() -> i32 {
-    let Opt = Option(u32);
+    let Opt = std.option.Option(u32);
     match @parse_u32("4294967296") {
         Opt.Some(n) => @intCast(n),
         Opt.None => 42,
     }
 }
 """
+real_std = true
 exit_code = 42
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "parse_negative_unsigned_yields_none"
 spec = ["4.13:48", "4.13:49"]
 source = """
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const std = @import("std");
 fn main() -> i32 {
-    let Opt = Option(u32);
+    let Opt = std.option.Option(u32);
     match @parse_u32("-1") {
         Opt.Some(n) => @intCast(n),
         Opt.None => 42,
     }
 }
 """
+real_std = true
 exit_code = 42
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "parse_i32_max"
 spec = ["4.13:43", "4.13:44"]
 source = """
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const std = @import("std");
 fn main() -> i32 {
-    let Opt = Option(i32);
+    let Opt = std.option.Option(i32);
     match @parse_i32("127") {
         Opt.Some(n) => n,
         Opt.None => 0,
     }
 }
 """
+real_std = true
 exit_code = 127
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "parse_i32_boundary"
 spec = ["4.13:43", "4.13:44"]
 source = """
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const std = @import("std");
 fn main() -> i32 {
     // Test parsing of i32.MAX (doesn't overflow)
-    let Opt = Option(i32);
+    let Opt = std.option.Option(i32);
     match @parse_i32("2147483647") {
         Opt.Some(n) => if n == 2147483647 { 255 } else { 1 },
         Opt.None => 1,
     }
 }
 """
+real_std = true
 exit_code = 255
 
 [[case]]
+# Fallible intrinsics yield the exact trusted std Option(payload); context
+# checks that identity (4.13:35/:44). Contextual annotations and matches use
+# std.option.Option.
 name = "parse_i32_min"
 spec = ["4.13:43", "4.13:44", "4.13:47"]
 source = """
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const std = @import("std");
 fn main() -> i32 {
     // Test parsing of i32.MIN (doesn't overflow)
-    let Opt = Option(i32);
+    let Opt = std.option.Option(i32);
     match @parse_i32("-2147483648") {
         Opt.Some(n) => if n == -2147483648 { 254 } else { 1 },
         Opt.None => 1,
     }
 }
 """
+real_std = true
 exit_code = 254
+
+# =============================================================================
+# RUE-1112 NEW context-mismatch negatives: an intrinsic yields the EXACT trusted
+# std Option; context only CHECKS that identity. A contextual annotation of a
+# user-defined lookalike receiving an intrinsic result is a type mismatch
+# (E0702, IntrinsicTypeMismatch), not a nominal the intrinsic adopts. Earlier
+# context SELECTED the annotated nominal and these compiled; the diagnostic is
+# the new-rule outcome, so both require the new machinery.
+# =============================================================================
+
+[[case]]
+# RUE-1112: context-mismatch. @parse_i32 yields the trusted std Option(i32); the
+# `let n: Bad` annotation is a lookalike, so context-checking rejects it (E0702).
+# No `@import`: the trusted std Option(i32) is compiler-rooted, so `real_std`
+# supplies the toolchain std root the acquisition reads from.
+name = "parse_lookalike_annotation_mismatch"
+spec = ["4.13:44"]
+description = "Annotating an @parse_i32 result with a user-defined Option lookalike is a type mismatch (E0702)."
+compile_fail = true
+error_contains = ["[E0702]", "@parse_i32"]
+source = """
+fn Lookalike(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn main() -> i32 {
+    let Bad = Lookalike(i32);
+    let n: Bad = @parse_i32("42");
+    match n {
+        Bad.Some(v) => v,
+        Bad.None => 0,
+    }
+}
+"""
+real_std = true
+
+[[case]]
+# RUE-1112: context-mismatch. @read_line yields the trusted std Option(StrBuf);
+# the `let line: Bad` annotation is a lookalike, so context-checking rejects it
+# (E0702).
+name = "read_line_lookalike_annotation_mismatch"
+spec = ["4.13:35"]
+description = "Annotating an @read_line result with a user-defined Option lookalike is a type mismatch (E0702)."
+compile_fail = true
+error_contains = ["[E0702]", "@read_line"]
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn Lookalike(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn main() -> i32 {
+    let Bad = Lookalike(StrBuf);
+    let line: Bad = @read_line();
+    match line {
+        Bad.Some(_s) => 1,
+        Bad.None => 0,
+    }
+}
+"""
+real_std = true
 
 # =============================================================================
 # @random_u32 Intrinsic

--- a/crates/rue-spec/cases/expressions/try.toml
+++ b/crates/rue-spec/cases/expressions/try.toml
@@ -1,3 +1,7 @@
+# `?` accepts ONLY exact specializations of the trusted std producers
+# (std.option.Option / std.result.Result). User-defined Some/None lookalikes
+# are ordinary enums with no `?` behavior. Fallible intrinsics yield the exact
+# trusted std Option in every context.
 [section]
 id = "expressions.try"
 spec_chapter = "4.15"
@@ -10,30 +14,30 @@ description = "The postfix `?` operator unwraps an Option, short-circuiting the 
 # =============================================================================
 
 [[case]]
+# `?` unwraps a trusted std Option value; the function continues if Some.
 name = "try_some_unwraps"
 spec = ["4.15:1", "4.15:2", "4.15:5", "4.15:6"]
 description = "`?` on a Some value unwraps the payload; the function continues."
 source = """
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
-fn some_val() -> Option(i64) {
-    let O = Option(i64);
+const std = @import("std");
+fn some_val() -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
     O.Some(20)
 }
-fn use_it() -> Option(i64) {
-    let O = Option(i64);
+fn use_it() -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
     let v = some_val()?;
     O.Some(v + 1)
 }
 fn main() -> i32 {
-    let O = Option(i64);
+    let O = std.option.Option(i64);
     match use_it() {
         O.Some(n) => @intCast(n),
         O.None => 0,
     }
 }
 """
+real_std = true
 exit_code = 21
 
 # =============================================================================
@@ -41,30 +45,30 @@ exit_code = 21
 # =============================================================================
 
 [[case]]
+# `?` short-circuits when applied to a None value.
 name = "try_none_short_circuits"
 spec = ["4.15:1", "4.15:7"]
 description = "`?` on a None value returns None from the enclosing function; code after it does not run."
 source = """
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
-fn none_val() -> Option(i64) {
-    let O = Option(i64);
+const std = @import("std");
+fn none_val() -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
     O.None
 }
-fn use_it() -> Option(i64) {
-    let O = Option(i64);
+fn use_it() -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
     let v = none_val()?;
     O.Some(v + 1)
 }
 fn main() -> i32 {
-    let O = Option(i64);
+    let O = std.option.Option(i64);
     match use_it() {
         O.Some(n) => @intCast(n),
         O.None => 7,
     }
 }
 """
+real_std = true
 exit_code = 7
 
 # =============================================================================
@@ -72,29 +76,29 @@ exit_code = 7
 # =============================================================================
 
 [[case]]
+# The `?` operator evaluates to the unwrapped payload type.
 name = "try_result_type_is_payload"
 spec = ["4.15:5", "4.15:6"]
 description = "`operand?` where operand: Option(i64) has type i64 and is usable directly."
 source = """
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
-fn wrap(x: i64) -> Option(i64) {
-    let O = Option(i64);
+const std = @import("std");
+fn wrap(x: i64) -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
     O.Some(x)
 }
-fn add_two(x: i64) -> Option(i64) {
-    let O = Option(i64);
+fn add_two(x: i64) -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
     O.Some(wrap(x)? + 2)
 }
 fn main() -> i32 {
-    let O = Option(i64);
+    let O = std.option.Option(i64);
     match add_two(40) {
         O.Some(n) => @intCast(n),
         O.None => 0,
     }
 }
 """
+real_std = true
 exit_code = 42
 
 # =============================================================================
@@ -102,23 +106,23 @@ exit_code = 42
 # =============================================================================
 
 [[case]]
+# `?` requires the operand to be an Option; applying it to other types is E0504.
 name = "try_on_non_option_error"
 spec = ["4.15:3"]
 description = "Applying `?` to a non-Option value is a compile error (E0504)."
 compile_fail = true
 error_contains = "the `?` operator can only be applied to an `Option`"
 source = """
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
-fn f() -> Option(i64) {
+const std = @import("std");
+fn f() -> std.option.Option(i64) {
     let x = 5;
     let y = x?;
-    let O = Option(i64);
+    let O = std.option.Option(i64);
     O.Some(y)
 }
 fn main() -> i32 { f(); 0 }
 """
+real_std = true
 
 # =============================================================================
 # Legality: `?` requires the enclosing function to return an Option
@@ -126,17 +130,16 @@ fn main() -> i32 { f(); 0 }
 # =============================================================================
 
 [[case]]
+# `?` requires the enclosing function to return an Option; using it elsewhere is E0503.
 name = "try_outside_option_fn_error"
 spec = ["4.15:4"]
 description = "Using `?` in a function whose return type is not Option is a compile error (E0503)."
 compile_fail = true
 error_contains = "the `?` operator can only be used in a function that returns an `Option`"
 source = """
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
-fn some_val() -> Option(i64) {
-    let O = Option(i64);
+const std = @import("std");
+fn some_val() -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
     O.Some(1)
 }
 fn main() -> i32 {
@@ -144,28 +147,81 @@ fn main() -> i32 {
     @intCast(v)
 }
 """
+real_std = true
 
 # =============================================================================
-# `?` on a bare fallible intrinsic resolves the intrinsic's own Option
-# (4.15:9): @read_line()? / @parse_i64(s)? need no annotation. RUE-318.
+# Lookalike rejection: a user-defined Some/None lookalike is an ordinary enum,
+# not the trusted std Option, and receives no `?` behavior (4.15:3, 4.15:4).
 # =============================================================================
 
 [[case]]
+# User-defined Some/None lookalike operands are not accepted by `?` (E0504).
+name = "try_lookalike_operand_rejected"
+spec = ["4.15:3"]
+description = "`?` on a user-defined Some/None lookalike (not trusted std Option) is E0504."
+compile_fail = true
+error_contains = "the `?` operator can only be applied to an `Option`"
+source = """
+const std = @import("std");
+fn Lookalike(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn make() -> Lookalike(i64) {
+    let L = Lookalike(i64);
+    L.Some(1)
+}
+fn use_it() -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
+    let v = make()?;
+    O.Some(v)
+}
+fn main() -> i32 { use_it(); 0 }
+"""
+real_std = true
+
+[[case]]
+# `?` is not permitted in functions returning a user-defined lookalike (E0503).
+name = "try_lookalike_return_rejected"
+spec = ["4.15:4"]
+description = "`?` in a function returning a user-defined lookalike (not trusted std Option) is E0503."
+compile_fail = true
+error_contains = "the `?` operator can only be used in a function that returns an `Option`"
+source = """
+const std = @import("std");
+fn Lookalike(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn make() -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
+    O.Some(1)
+}
+fn use_it() -> Lookalike(i64) {
+    let v = make()?;
+    let L = Lookalike(i64);
+    L.Some(v)
+}
+fn main() -> i32 { use_it(); 0 }
+"""
+real_std = true
+
+# =============================================================================
+# Fallible intrinsics: @read_line()? / @parse_i64(s)? resolve the exact trusted
+# std Option (4.15:9, 4.13:35, 4.13:44) with no local annotation needed.
+# =============================================================================
+
+[[case]]
+# @read_line() yields the exact trusted std Option(StrBuf); `?` unwraps it.
 name = "try_read_line_intrinsic_some"
-spec = ["4.15:9"]
+spec = ["4.15:9", "4.13:35"]
 description = "`@read_line()?` unwraps the line at a non-EOF read; the tail @parse_i64 yields the number."
 source = """
 const std = @import("std");
-const StrBuf = std.strbuf.StrBuf;
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
-fn read_num() -> Option(i64) {
+fn read_num() -> std.option.Option(i64) {
     let line = @read_line()?;
     @parse_i64(line)
 }
 fn main() -> i32 {
-    let O = Option(i64);
+    let O = std.option.Option(i64);
     match read_num() {
         O.Some(n) => @intCast(n),
         O.None => 0,
@@ -177,21 +233,18 @@ stdin = "42\n"
 exit_code = 42
 
 [[case]]
+# @read_line() returns None at EOF, and `?` short-circuits (no trap).
 name = "try_read_line_intrinsic_none_at_eof"
-spec = ["4.15:9"]
+spec = ["4.15:9", "4.13:35"]
 description = "`@read_line()?` short-circuits the function to None at end-of-input (no trap)."
 source = """
 const std = @import("std");
-const StrBuf = std.strbuf.StrBuf;
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
-fn read_num() -> Option(i64) {
+fn read_num() -> std.option.Option(i64) {
     let line = @read_line()?;
     @parse_i64(line)
 }
 fn main() -> i32 {
-    let O = Option(i64);
+    let O = std.option.Option(i64);
     match read_num() {
         O.Some(n) => @intCast(n),
         O.None => 7,
@@ -203,47 +256,78 @@ stdin = ""
 exit_code = 7
 
 [[case]]
+# @parse_i64(s) yields the exact trusted std Option(i64); `?` unwraps it.
 name = "try_parse_intrinsic_some"
-spec = ["4.15:9"]
+spec = ["4.15:9", "4.13:44"]
 description = "`@parse_i64(s)?` unwraps the parsed integer without an annotated binding."
 source = """
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
-fn add_one(s: str) -> Option(i64) {
-    let O = Option(i64);
+const std = @import("std");
+fn add_one(s: str) -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
     let n = @parse_i64(s)?;
     O.Some(n + 1)
 }
 fn main() -> i32 {
-    let O = Option(i64);
+    let O = std.option.Option(i64);
     match add_one("41") {
         O.Some(n) => @intCast(n),
         O.None => 0,
     }
 }
 """
+real_std = true
 exit_code = 42
 
 [[case]]
+# @parse_i64(s) returns None on parse failure; `?` short-circuits.
 name = "try_parse_intrinsic_none_short_circuits"
-spec = ["4.15:9"]
+spec = ["4.15:9", "4.13:44"]
 description = "`@parse_i64(s)?` short-circuits to None when the string is not a number."
 source = """
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
-fn add_one(s: str) -> Option(i64) {
-    let O = Option(i64);
+const std = @import("std");
+fn add_one(s: str) -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
     let n = @parse_i64(s)?;
     O.Some(n + 1)
 }
 fn main() -> i32 {
-    let O = Option(i64);
+    let O = std.option.Option(i64);
     match add_one("nope") {
         O.Some(n) => @intCast(n),
         O.None => 9,
     }
 }
 """
+real_std = true
 exit_code = 9
+
+# =============================================================================
+# Compiler-rooted trusted module: even a program that imports nothing still
+# resolves fallible intrinsics to the exact trusted std Option. The intrinsic's
+# Option type is resolved by the compiler's demand for the trusted module,
+# independent of user-written imports. This exercises the guarantee that `?`
+# works on intrinsics with no contextual annotation.
+# =============================================================================
+
+[[case]]
+# Fallible intrinsics yield the exact trusted std Option even in a program that
+# does not import std. The intrinsic's option type is compiler-rooted; the
+# enclosing function must still name std.option.Option to type its return.
+name = "try_parse_freestanding_no_imports"
+spec = ["4.15:9", "4.13:44"]
+description = "`@parse_i64(s)?` with no local Option yields the trusted std Option(i64) and `?` propagates it."
+source = """
+const std = @import("std");
+fn add_one(s: str) -> std.option.Option(i64) {
+    let n = @parse_i64(s)?;
+    std.option.Option(i64).Some(n + 1)
+}
+fn main() -> i32 {
+    match add_one("41") {
+        std.option.Option(i64).Some(n) => @intCast(n),
+        std.option.Option(i64).None => 0,
+    }
+}
+"""
+real_std = true
+exit_code = 42

--- a/crates/rue-ui-tests/cases/diagnostics/result_try_errors.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/result_try_errors.toml
@@ -2,34 +2,36 @@
 id = "diagnostics.result-try-errors"
 name = "`?` on Result: targeted diagnostics (RUE-591, ADR-0038)"
 description = """
-`?` now propagates Result (Ok/Err), not just Option. These pin the two Result-
+`?` propagates Result (Ok/Err), not just Option. These pin the two Result-
 specific error diagnostics: using `?` on a Result in a function that doesn't
 return a Result (E0505), and a Result whose error type doesn't match the
 function's error type (E0506) — Rue has no error conversion until traits exist.
-`?` recognizes Result by shape, so these use an inline `Result` (the UI harness
-provides no std). Functions are reached from main so the driver analyzes them.
+`?` recognizes Result by exact trusted-producer identity, not shape, so these
+use the trusted `std.result.Result` (a local Ok/Err lookalike would be E0504
+QuestionOnNonOption, not these diagnostics). Functions are reached from main so
+the driver analyzes them.
 """
 
 [[case]]
 name = "question_on_result_in_non_result_fn"
-description = "`?` on a Result inside an Option-returning fn is E0505, not the Option E0503."
+description = "`?` on a trusted std Result inside a std-Option-returning fn is E0505, not the Option E0503."
 source = """
-fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
-fn div(a: i32, b: i32) -> Result(i32, i32) {
-    let R = Result(i32, i32);
+const std = @import("std");
+fn div(a: i32, b: i32) -> std.result.Result(i32, i32) {
+    let R = std.result.Result(i32, i32);
     if b == 0 { R.Err(1) } else { R.Ok(a / b) }
 }
-fn f() -> Option(i32) {
-    let O = Option(i32);
+fn f() -> std.option.Option(i32) {
+    let O = std.option.Option(i32);
     let q = div(4, 2)?;
     O.Some(q)
 }
 fn main() -> i32 {
-    let O = Option(i32);
+    let O = std.option.Option(i32);
     match f() { O.Some(v) => v, O.None => 0 }
 }
 """
+real_std = true
 compile_fail = true
 error_contains = [
     "E0505",
@@ -38,23 +40,24 @@ error_contains = [
 
 [[case]]
 name = "question_result_err_type_mismatch"
-description = "`?` on Err(i32) in a fn returning Err(bool) is E0506 (no error conversion yet)."
+description = "`?` on a std Result Err(i32) in a fn returning std Result(i32, bool) is E0506 (no error conversion yet)."
 source = """
-fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
-fn div(a: i32, b: i32) -> Result(i32, i32) {
-    let R = Result(i32, i32);
+const std = @import("std");
+fn div(a: i32, b: i32) -> std.result.Result(i32, i32) {
+    let R = std.result.Result(i32, i32);
     if b == 0 { R.Err(1) } else { R.Ok(a / b) }
 }
-fn f() -> Result(i32, bool) {
-    let R = Result(i32, bool);
+fn f() -> std.result.Result(i32, bool) {
+    let R = std.result.Result(i32, bool);
     let q = div(4, 2)?;
     R.Ok(q)
 }
 fn main() -> i32 {
-    let R = Result(i32, bool);
+    let R = std.result.Result(i32, bool);
     match f() { R.Ok(v) => v, R.Err(e) => 0 }
 }
 """
+real_std = true
 compile_fail = true
 error_contains = [
     "E0506",

--- a/crates/rue/src/emit.rs
+++ b/crates/rue/src/emit.rs
@@ -63,17 +63,29 @@ pub(crate) struct EmitWork {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum EmitFrontendRoute {
+    /// Tokens — presented directly from parsed modules; no frontend query.
     None,
+    /// AST — presented from the parse terminal; no lowering, no semantics.
     AstOnlySyntax,
+    /// RIR — presented from the RIR terminal (parse + lowering) but WITHOUT any
+    /// semantic body analysis. Because the trusted-toolchain park is raised only
+    /// by reached-body semantic analysis, an RIR emit runs no park and no std
+    /// acquisition: it is a pre-semantic presentation of the untyped IR.
+    RirOnly,
+    /// A backend stage (AIR and later) that requires semantic body analysis.
     SessionQuery,
 }
 
-pub(crate) fn emit_frontend_route(stages: &[EmitStage]) -> EmitFrontendRoute {
-    if stages.iter().any(|stage| {
+/// Whether any requested stage requires semantic body analysis (AIR and later).
+/// RIR, AST, tokens, and deps are all pre-semantic presentations, so an emit made
+/// up only of those never analyzes a body — and therefore never parks on a
+/// trusted-toolchain demand or acquires std. The host acquisition loop is gated on
+/// this so an `--emit rir`/`--emit ast` run performs zero std reads.
+pub(crate) fn emit_requires_semantic(stages: &[EmitStage]) -> bool {
+    stages.iter().any(|stage| {
         matches!(
             stage,
-            EmitStage::Rir
-                | EmitStage::Air
+            EmitStage::Air
                 | EmitStage::Cfg
                 | EmitStage::Lowering
                 | EmitStage::Mir
@@ -82,8 +94,14 @@ pub(crate) fn emit_frontend_route(stages: &[EmitStage]) -> EmitFrontendRoute {
                 | EmitStage::Asm
                 | EmitStage::StackFrame
         )
-    }) {
+    })
+}
+
+pub(crate) fn emit_frontend_route(stages: &[EmitStage]) -> EmitFrontendRoute {
+    if emit_requires_semantic(stages) {
         EmitFrontendRoute::SessionQuery
+    } else if stages.contains(&EmitStage::Rir) {
+        EmitFrontendRoute::RirOnly
     } else if stages.contains(&EmitStage::Ast) {
         EmitFrontendRoute::AstOnlySyntax
     } else {
@@ -264,20 +282,38 @@ pub(crate) fn execute(request: EmitRequest<'_, '_>) -> Result<(), ()> {
         return Err(());
     }
     let frontend_route = emit_frontend_route(stages);
-    let frontend_state = if frontend_route == EmitFrontendRoute::SessionQuery {
-        let frontend = match build_emit_frontend_in_session(session, compile_options.clone()) {
-            Ok(frontend) => frontend,
-            Err(errors) => {
+    let frontend_state = match frontend_route {
+        EmitFrontendRoute::SessionQuery => {
+            let frontend = match build_emit_frontend_in_session(session, compile_options.clone()) {
+                Ok(frontend) => frontend,
+                Err(errors) => {
+                    diagnostics.print_errors(&errors);
+                    return Err(());
+                }
+            };
+            Some(frontend)
+        }
+        EmitFrontendRoute::RirOnly => {
+            // RIR is a pre-semantic presentation: force the RIR terminal so its
+            // parse/lowering diagnostics are attributed canonically, but never run
+            // semantic body analysis. Because the trusted-toolchain park is raised
+            // only by reached-body semantic analysis, this performs no park and no
+            // std acquisition — an `--emit rir` run reads zero std modules even for
+            // a reached fallible intrinsic. Semantic-only diagnostics (e.g. an
+            // undefined variable) belong to a normal build or a later `--emit`
+            // stage, not to the untyped-IR presentation.
+            if let Err(errors) = session.rir() {
                 diagnostics.print_errors(&errors);
                 return Err(());
             }
-        };
-        Some(frontend)
-    } else {
-        None
+            None
+        }
+        EmitFrontendRoute::AstOnlySyntax | EmitFrontendRoute::None => None,
     };
     if let Some(state) = &frontend_state {
-        // Every --emit mode must surface frontend warnings (RUE-130).
+        // Every semantic-frontend --emit mode must surface frontend warnings
+        // (RUE-130). Pre-semantic presentations (tokens/ast/rir) have no semantic
+        // warnings to surface.
         diagnostics.print_warnings(state.warnings());
         let work = state.query_work();
         debug_assert_eq!(state.parsed.modules().len(), source_snapshot.len());

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -18,7 +18,7 @@ mod timing;
 
 use emit::EmitStage;
 #[cfg(test)]
-use emit::{EmitFrontendRoute, build_emit_frontend, emit_frontend_route};
+use emit::{EmitFrontendRoute, build_emit_frontend, emit_frontend_route, emit_requires_semantic};
 #[cfg(test)]
 use rue_compiler::unstable::update_for_presentation;
 use rue_compiler::unstable::{MultiFileFormatter, MultiFileJsonFormatter, SourceInfo};
@@ -945,6 +945,38 @@ fn get_peak_memory_bytes() -> Option<u64> {
     }
 }
 
+/// Present a source-loading failure and exit. The four classes carry disjoint
+/// presentations: an ordinary message; a broken-toolchain (environmental) error;
+/// a hermetic build-configuration denial (distinct from a broken toolchain — the
+/// remedy is the source manifest, not the installation); and program diagnostics
+/// rendered against the failing snapshot's source views.
+fn report_source_load_error(error: SourceLoadError, error_format: ErrorFormat) -> ! {
+    match error {
+        SourceLoadError::Message(message) => {
+            eprintln!("{message}");
+        }
+        SourceLoadError::Toolchain(error) => {
+            eprintln!("{error}");
+        }
+        SourceLoadError::HermeticDenial(error) => {
+            eprintln!("{error}");
+        }
+        SourceLoadError::Compiler { snapshot, errors } => {
+            let infos = snapshot
+                .as_ref()
+                .map(|snapshot| {
+                    snapshot
+                        .files()
+                        .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
+                        .collect()
+                })
+                .unwrap_or_default();
+            DiagnosticOutput::new(error_format, infos).print_errors(&errors);
+        }
+    }
+    std::process::exit(1);
+}
+
 fn main() {
     // Rust's startup ignores SIGPIPE, so a write to a closed pipe
     // (`rue --emit tokens x.rue | head`) returns EPIPE and `println!` panics
@@ -1025,27 +1057,45 @@ fn main() {
             std_root: captured_std_root.as_deref(),
         }) {
             Ok(result) => result,
-            Err(SourceLoadError::Message(message)) => {
-                eprintln!("{message}");
-                std::process::exit(1);
-            }
-            Err(SourceLoadError::Compiler { snapshot, errors }) => {
-                let infos = snapshot
-                    .as_ref()
-                    .map(|snapshot| {
-                        snapshot
-                            .files()
-                            .map(|source| {
-                                (source.file_id, SourceInfo::new(source.source, source.path))
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                DiagnosticOutput::new(options.error_format, infos).print_errors(&errors);
-                std::process::exit(1);
-            }
+            Err(error) => report_source_load_error(error, options.error_format),
         }
     };
+
+    let compile_options = CompileOptions {
+        target: options.target,
+        linker: options.linker.clone(),
+        opt_level: options.opt_level,
+        preview_features: options.preview_features.clone(),
+        link_archives: options.link_archives.clone(),
+    };
+
+    // Acquire any trusted toolchain modules a reached fallible intrinsic requires
+    // but no `@import` pulled — the compiler-rooted std `Option` for a fallible
+    // intrinsic, plus std `StrBuf` for `@read_line`'s `Option(StrBuf)` payload.
+    // This runs the rooted, park-aware semantic attempt and satisfies exactly the
+    // demands it parks on, so an unreachable helper never forces a std read; a
+    // reached-body demand a broken or policy-denied toolchain cannot satisfy
+    // surfaces as its own environmental / build-configuration error. Host
+    // filesystem access lives outside the compiler's snapshot/query evaluation,
+    // which is why the driver owns this loop rather than the session.
+    //
+    // INVARIANT: acquisition runs only when the run will analyze bodies — a normal
+    // compile, or an `--emit` of a semantic stage (AIR and later). The park is
+    // raised only by reached-body semantic analysis, so a pre-semantic `--emit`
+    // (tokens/ast/rir/deps) presents its artifact without ever parking; gating the
+    // loop out keeps such an emit at ZERO std reads even for a reached fallible
+    // intrinsic with a broken std on disk. When it does run, it runs before both
+    // emit and compile, matching the acquire-before-everything ordering.
+    if options.emit_stages.is_empty() || emit::emit_requires_semantic(&options.emit_stages) {
+        let _compile = compile_span.enter();
+        if let Err(error) = source_loader::acquire_reached_toolchain_modules(
+            &mut import_discovery,
+            &compile_options,
+        ) {
+            report_source_load_error(error, options.error_format);
+        }
+    }
+
     #[cfg(rue_benchmark_allocations)]
     if options.benchmark_json {
         allocation::pause();
@@ -1080,13 +1130,7 @@ fn main() {
                 session: &mut import_discovery.session,
                 stages: &options.emit_stages,
                 discovery_revision: &import_discovery.revision,
-                compile_options: CompileOptions {
-                    target: options.target,
-                    linker: options.linker.clone(),
-                    opt_level: options.opt_level,
-                    preview_features: options.preview_features.clone(),
-                    link_archives: options.link_archives.clone(),
-                },
+                compile_options: compile_options.clone(),
                 diagnostics: &diagnostics,
             }) {
                 std::process::exit(1);
@@ -1131,13 +1175,6 @@ fn main() {
     };
 
     // Normal compilation - uses multi-file compilation for all source files
-    let compile_options = CompileOptions {
-        target: options.target,
-        linker: options.linker.clone(),
-        opt_level: options.opt_level,
-        preview_features: options.preview_features.clone(),
-        link_archives: options.link_archives.clone(),
-    };
     #[cfg(rue_benchmark_allocations)]
     if options.benchmark_json {
         allocation::resume();
@@ -1637,9 +1674,10 @@ mod tests {
     // ========== --emit tests ==========
 
     #[test]
-    fn rir_and_later_emits_share_the_canonical_frontend_route() {
+    fn semantic_emits_share_the_canonical_frontend_route_but_rir_is_pre_semantic() {
+        // AIR and later stages require semantic body analysis and share the
+        // session-query frontend.
         for stage in [
-            EmitStage::Rir,
             EmitStage::Air,
             EmitStage::Cfg,
             EmitStage::Lowering,
@@ -1649,23 +1687,38 @@ mod tests {
             EmitStage::Asm,
             EmitStage::StackFrame,
         ] {
+            assert!(emit_requires_semantic(&[stage]));
             assert_eq!(
                 emit_frontend_route(&[stage]),
                 EmitFrontendRoute::SessionQuery
             );
         }
+        // RIR is a pre-semantic presentation: it lowers but never analyzes bodies,
+        // so it routes away from the semantic frontend and requires no semantics.
+        assert!(!emit_requires_semantic(&[EmitStage::Rir]));
+        assert_eq!(
+            emit_frontend_route(&[EmitStage::Rir]),
+            EmitFrontendRoute::RirOnly
+        );
+        // A mixed emit that includes any semantic stage still requires semantics
+        // (and so acquisition), regardless of the pre-semantic stages alongside it.
+        assert!(emit_requires_semantic(&[EmitStage::Ast, EmitStage::Air]));
         assert_eq!(
             emit_frontend_route(&[EmitStage::Ast, EmitStage::Air]),
             EmitFrontendRoute::SessionQuery
         );
+        assert!(emit_requires_semantic(&[EmitStage::Rir, EmitStage::Air]));
         assert_eq!(
             emit_frontend_route(&[EmitStage::Rir, EmitStage::Air]),
             EmitFrontendRoute::SessionQuery
         );
+        // Pure pre-semantic emits require no semantics.
+        assert!(!emit_requires_semantic(&[EmitStage::Ast]));
         assert_eq!(
             emit_frontend_route(&[EmitStage::Ast]),
             EmitFrontendRoute::AstOnlySyntax
         );
+        assert!(!emit_requires_semantic(&[EmitStage::Tokens]));
         assert_eq!(
             emit_frontend_route(&[EmitStage::Tokens]),
             EmitFrontendRoute::None

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -5,17 +5,34 @@ use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
+#[cfg(test)]
+use rue_compiler::unstable::frontend_query_invalidations;
 use rue_compiler::unstable::{
-    DiscoverySourceAssembler, ImportDemandMode, begin_import_input_request, discovery_attempt,
-    import_demand_frontier_for_roots, import_observation_ledger, publish_import_observation_batch,
+    DiscoverySourceAssembler, ImportDemandFrontier, ImportDemandMode, ImportInputRevision,
+    SemanticParkOutcome, TrustedSuccessorDelta, begin_import_input_request,
+    close_import_discovery_successor, closed_discovery_continuation, discovery_attempt,
+    import_demand_frontier_for_roots, import_observation_ledger, plan_delta_roots,
+    publish_import_observation_batch, publish_trusted_toolchain_successor,
+    semantic_or_toolchain_park, stage_import_discovery_successor,
+};
+#[cfg(test)]
+use rue_compiler::unstable::{
+    committed_successor_sharing, exact_import_groups_dispatched, import_close_records_reduced,
+    import_frontier_roots_requested, import_plan_groups_constructed,
+    import_view_full_leaves_published, import_view_ledger_entries_cloned,
+    import_view_overlay_leaves_published, import_view_read_entries_compared,
+    import_view_source_entries_compared, parse_invalidation_entries_compared,
+    parse_key_entries_compared, parse_modules_dispatched, parse_sources_materialized,
 };
 use rue_compiler::{
-    AcceptedImportSource, AcceptedReadManifestEntry, CompileErrors, CompilerSession,
+    AcceptedImportSource, AcceptedReadManifest, CompileErrors, CompileOptions, CompilerSession,
     DependencyEnvelope, FileId, FileMetadataFingerprint, ImportDiscoveryContext,
-    ImportDiscoveryRequest, ImportDiscoveryView, ImportObservation, ImportObservationStatus,
-    PhysicalFileIdentity, SourceMetadata, SourceSnapshot,
+    ImportDiscoveryRequest, ImportDiscoveryStatus, ImportDiscoveryView, ImportObservation,
+    ImportObservationStatus, PhysicalFileIdentity, SourceMetadata, SourceSnapshot,
+    TrustedToolchainModuleDemand,
 };
 
+#[derive(Debug)]
 pub(crate) struct SourceManifest {
     path: PathBuf,
     allowed: std::collections::HashSet<PathBuf>,
@@ -147,6 +164,7 @@ fn normalize_lexical_path(path: &Path) -> PathBuf {
     normalized
 }
 
+#[derive(Debug)]
 enum StableReadError {
     Io(std::io::Error),
     Changed,
@@ -460,6 +478,19 @@ pub(crate) enum SourceLoadError {
         snapshot: Option<SourceSnapshot>,
         errors: CompileErrors,
     },
+    /// A trusted toolchain module a reached fallible intrinsic requires could
+    /// not be acquired because the toolchain itself is broken (missing,
+    /// unreadable, or malformed std). This is a broken-installation /
+    /// environmental error, not a program error — surfaced loudly with its own
+    /// message.
+    Toolchain(ToolchainIntegrityError),
+    /// A trusted toolchain module resolves to a path the hermetic build
+    /// configuration forbids (RUE-1112). This is deterministically DISTINCT
+    /// from a broken toolchain: the installation may be intact, but the sandbox
+    /// policy denies the read, so the remedy is the source manifest, not the
+    /// toolchain. It carries its own outer classification and presentation, never
+    /// the "toolchain integrity" / broken-installation framing.
+    HermeticDenial(HermeticDenialError),
 }
 
 pub(crate) fn load(
@@ -472,7 +503,7 @@ pub(crate) fn load(
         .map_err(SourceLoadError::Message)?;
     validate_manifest_allows_source(manifest.as_ref(), request.root_source, "root")
         .map_err(SourceLoadError::Message)?;
-    discover_and_load_imports(request.root_source, manifest.as_ref(), request.std_root)
+    discover_and_load_imports(request.root_source, manifest, request.std_root)
 }
 
 #[derive(Debug)]
@@ -481,12 +512,27 @@ pub(crate) struct ImportDiscoveryResult {
     /// Immutable, normalized inputs used by every compiler discovery plan.
     pub(crate) resolution: SourceResolutionInputs,
     /// Canonical physical reads accepted while assembling `source_snapshot`.
-    pub(crate) read_manifest: Arc<[AcceptedReadManifestEntry]>,
+    pub(crate) read_manifest: AcceptedReadManifest,
     /// Canonical import topology and diagnostics published by the compiler.
     pub(crate) revision: Arc<ImportDiscoveryView>,
     #[cfg(test)]
-    pub(crate) input_revision: rue_compiler::unstable::ImportInputRevision,
+    pub(crate) input_revision: ImportInputRevision,
     pub(crate) session: CompilerSession,
+    /// Acquisition context threaded out for the host park/retry loop
+    /// (`acquire_reached_toolchain_modules`). Host filesystem access lives
+    /// outside snapshot/query evaluation, so the loop owns the assembler and read
+    /// policy directly; the compiler only issues typed demands and verifies
+    /// strictly-additive successors from records.
+    assembler: DiscoverySourceAssembler,
+    /// The standard-library root a demanded trusted module resolves against, or
+    /// `None` when no toolchain std is configured.
+    std_root: Option<PathBuf>,
+    /// The read policy trusted-module acquisition obeys (same authority as an
+    /// ordinary import read), or `None` when unrestricted.
+    source_manifest: Option<SourceManifest>,
+    /// The empty rooted closure witness of the current committed close — the
+    /// frontier a same-generation trusted-toolchain successor continues from.
+    witness: ImportDemandFrontier,
 }
 
 #[derive(Debug, Clone)]
@@ -495,8 +541,22 @@ pub(crate) struct SourceResolutionInputs {
     pub(crate) context: ImportDiscoveryContext,
 }
 
-/// Reject a source before discovery lexing if Rue's span representation cannot
-/// describe its byte offsets.
+/// The closed import-discovery revision produced by
+/// [`drive_import_discovery_to_close`].
+struct ClosedDiscovery {
+    /// The closed source snapshot.
+    snapshot: SourceSnapshot,
+    /// The committed closed discovery view.
+    closed: Arc<ImportDiscoveryView>,
+    /// The final import input revision of this close. Read only by the test-only
+    /// `ImportDiscoveryResult::input_revision` frontier-round assertions.
+    #[cfg_attr(not(test), allow(dead_code))]
+    input_revision: ImportInputRevision,
+    /// The final empty rooted frontier that witnessed closure — the closure
+    /// witness a same-generation trusted-toolchain successor continues from.
+    witness: ImportDemandFrontier,
+}
+
 /// Reach the parser-owned import fixed point by executing compiler-generated
 /// filesystem requests. This driver owns only the read-policy checks and
 /// physical observation transactions; the compiler owns recognition,
@@ -507,9 +567,201 @@ pub(crate) struct SourceResolutionInputs {
 /// discovery loads below. There is therefore no set of "extra positional
 /// sources" to reconcile against the import graph — the flat-mode surface that
 /// once needed that reconciliation (RUE-434) was removed.
+///
+/// Drive parser-owned import discovery to its fixed point and close it against
+/// the current `assembler` source set, committing a closed import-discovery
+/// revision in `staging`. Returns the closed source snapshot, its committed
+/// discovery view, the final import input revision, and the empty rooted closure
+/// witness.
+///
+/// `continuation` selects the request generation. `None` begins a fresh
+/// external-input observation generation (the initial close) and roots discovery
+/// in the whole plan. `Some(revision)` is a SAME-GENERATION re-close on a
+/// strictly-additive successor already published into `revision`: it never begins
+/// a new generation — doing so would defeat the same-generation guarantee the
+/// trusted-toolchain continuation relies on.
+///
+/// `reclose` is `Some` (alongside a `continuation`) for a trusted-toolchain
+/// re-close. It carries the opaque, compiler-derived successor-delta capability
+/// (the host cannot choose or edit its module set) and the predecessor module
+/// set. A trusted std leaf such as `strbuf.rue` DOES carry import edges (it
+/// imports `option.rue`, `arraybuf.rue`, `rawbuf.rue`), so the re-close must
+/// discover them; but the predecessor graph already closed valid and its ledger
+/// is carried unchanged. The re-close therefore roots its discovery frontier ONLY
+/// in import occurrences owned by modules added since the predecessor close
+/// (`strbuf` and, transitively, `arraybuf`/`rawbuf`). A predecessor module's
+/// import occurrences are never re-rooted or re-resolved: the re-close continues
+/// from the verified closed predecessor graph rather than rebuilding it, so
+/// acquisition cost is O(new leaves), not O(existing import topology).
+struct ReClose<'a> {
+    delta: &'a TrustedSuccessorDelta,
+}
+
+fn drive_import_discovery_to_close(
+    assembler: &mut DiscoverySourceAssembler,
+    staging: &mut CompilerSession,
+    context: &ImportDiscoveryContext,
+    source_manifest: Option<&SourceManifest>,
+    continuation: Option<ImportInputRevision>,
+    reclose: Option<ReClose<'_>>,
+) -> Result<ClosedDiscovery, SourceLoadError> {
+    let mut input_revision = match continuation {
+        Some(revision) => revision,
+        None => {
+            let initial_snapshot = assembler
+                .snapshot()
+                .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+            begin_import_input_request(
+                staging,
+                &initial_snapshot,
+                context.clone(),
+                assembler.accepted_read_manifest(),
+            )
+            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?
+        }
+    };
+    let final_plan;
+    let witness;
+    loop {
+        let snapshot = assembler
+            .snapshot()
+            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        let ledger = import_observation_ledger(staging, input_revision)
+            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        // A trusted-toolchain successor stages from the compiler-published view
+        // itself; the host supplies only the opaque capability. The assembler's
+        // snapshot/manifest reach the compiler solely through the verified
+        // observation-batch publication.
+        let staged = match &reclose {
+            Some(reclose) => stage_import_discovery_successor(staging, reclose.delta),
+            None => staging.stage_import_discovery(
+                &snapshot,
+                context.clone(),
+                assembler.accepted_read_manifest().shared_slice(),
+                ledger.clone(),
+            ),
+        };
+        let plan = match staged {
+            Ok(plan) => plan,
+            Err(_) => {
+                let diagnostics = staging
+                    .import_diagnostics()
+                    .expect("failed staging publishes canonical import diagnostics");
+                let errors = CompileErrors::from(diagnostics.errors().to_vec());
+                return Err(SourceLoadError::Compiler {
+                    snapshot: Some(snapshot),
+                    errors,
+                });
+            }
+        };
+        // A trusted-toolchain re-close roots its frontier only in the plan's delta
+        // occurrences — those owned by modules added since the predecessor close.
+        // These come straight from the plan's delta segment, never by filtering the
+        // merged predecessor plan.
+        let roots = match &reclose {
+            Some(_) => plan_delta_roots(&plan),
+            None => plan.demand_roots(),
+        };
+        let frontier = import_demand_frontier_for_roots(
+            staging,
+            input_revision,
+            &plan,
+            ImportDemandMode::Rooted,
+            &roots,
+        )
+        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        if frontier.requests().is_empty() {
+            final_plan = plan;
+            witness = frontier;
+            break;
+        }
+        let observations = frontier
+            .requests()
+            .iter()
+            .cloned()
+            .map(|request| execute_import_request(request, source_manifest))
+            .collect::<Vec<_>>();
+        // In a trusted-toolchain re-close every frontier request resolves an
+        // `@import` edge owned by an appended leaf or a leaf newly discovered from
+        // it (e.g. strbuf → arraybuf/rawbuf). These edges are toolchain-internal,
+        // so a non-accepted observation there is an environmental failure of THAT
+        // transitive leaf, not a program error — attribute it to the exact failing
+        // module before the outcome is folded into an opaque close diagnostic.
+        if reclose.is_some()
+            && let Some(error) = classify_trusted_transitive_failure(context, &observations)
+        {
+            return Err(error);
+        }
+        let mut next_ledger = ledger;
+        for observation in observations.iter().cloned() {
+            next_ledger
+                .record(observation)
+                .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        }
+        // Assemble only the newly read leaves: a successor adds its delta groups'
+        // accepted sources, never re-feeding the predecessor plan through the
+        // winner map.
+        let assembled = match &reclose {
+            Some(_) => assembler.add_successor_plan_reads(&plan, &next_ledger),
+            None => assembler.add_plan_reads(&plan, &next_ledger),
+        };
+        let _ = assembled.map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        let successor_snapshot = assembler
+            .snapshot()
+            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        input_revision = publish_import_observation_batch(
+            staging,
+            &frontier,
+            &successor_snapshot,
+            assembler.accepted_read_manifest(),
+            observations,
+        )
+        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+    }
+
+    let snapshot = assembler
+        .snapshot()
+        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+    debug_assert_eq!(final_plan.source_revision(), snapshot.source_revision());
+    let ledger = import_observation_ledger(staging, input_revision)
+        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+    // A trusted-toolchain successor closes over only the modules its opaque delta
+    // capability authorizes, merging their topology into the committed
+    // predecessor's closed graph; the initial close reduces the whole plan.
+    let close_result = match &reclose {
+        Some(reclose) => close_import_discovery_successor(staging, reclose.delta),
+        None => staging.close_import_discovery(ledger),
+    };
+    let closed = match close_result {
+        Ok(closed) => closed,
+        Err(errors) => {
+            let attempted = discovery_attempt(staging)
+                .expect("failed closure publishes an attempted import revision");
+            if DependencyEnvelope::from_closed_revision(&attempted).is_some() {
+                // Missing and ambiguous resolution are structurally closed and
+                // therefore have canonical topology for `--emit deps`. The
+                // caller owns their one diagnostic rendering so the envelope
+                // can be written first. All other failures have no topology.
+                attempted
+            } else {
+                return Err(SourceLoadError::Compiler {
+                    snapshot: Some(snapshot),
+                    errors,
+                });
+            }
+        }
+    };
+    Ok(ClosedDiscovery {
+        snapshot,
+        closed,
+        input_revision,
+        witness,
+    })
+}
+
 pub(crate) fn discover_and_load_imports(
     root_source: &str,
-    source_manifest: Option<&SourceManifest>,
+    source_manifest: Option<SourceManifest>,
     std_root: Option<&Path>,
 ) -> Result<ImportDiscoveryResult, SourceLoadError> {
     // Validate the root source's span representability before discovery aliases
@@ -533,6 +785,7 @@ pub(crate) fn discover_and_load_imports(
         .to_path_buf();
     let std_root = std_root.map(normalize_lexical_path);
     let policy_revision = source_manifest
+        .as_ref()
         .map(SourceManifest::policy_revision)
         .unwrap_or_else(|| "unrestricted".into());
     let context = ImportDiscoveryContext::new(
@@ -548,7 +801,10 @@ pub(crate) fn discover_and_load_imports(
     let root_canonical = fs::canonicalize(&root_path).map_err(|error| {
         SourceLoadError::Message(format!("Error reading {}: {error}", root_path.display()))
     })?;
-    if source_manifest.is_some_and(|manifest| !manifest.allows_canonical(&root_canonical)) {
+    if source_manifest
+        .as_ref()
+        .is_some_and(|manifest| !manifest.allows_canonical(&root_canonical))
+    {
         return Err(SourceLoadError::Message(
             "Error: root source escapes the source manifest after canonicalization".into(),
         ));
@@ -573,117 +829,583 @@ pub(crate) fn discover_and_load_imports(
     .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
 
     let mut staging = CompilerSession::new();
-    let initial_snapshot = assembler
-        .snapshot()
-        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-    let mut input_revision = begin_import_input_request(
+    // Reach the parser-owned import fixed point and close. Trusted
+    // toolchain-module acquisition (the compiler-rooted std `Option`/`StrBuf` a
+    // reached fallible intrinsic needs but no `@import` pulls) is NOT done here:
+    // it is driven by the host park/retry loop (`acquire_reached_toolchain_modules`)
+    // against real reached-body semantic demands, so an unreachable helper never
+    // forces a std read. This close threads its assembler, read policy, std root,
+    // and closure witness out so that loop can satisfy demands and re-close in the
+    // same request generation.
+    let close = drive_import_discovery_to_close(
+        &mut assembler,
         &mut staging,
-        &initial_snapshot,
-        context.clone(),
-        assembler.accepted_read_manifest(),
-    )
-    .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-    let final_plan;
-    loop {
-        let snapshot = assembler
-            .snapshot()
-            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-        let ledger = import_observation_ledger(&staging, input_revision)
-            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-        let plan = match staging.stage_import_discovery(
-            &snapshot,
-            context.clone(),
-            assembler.accepted_read_manifest(),
-            ledger.clone(),
-        ) {
-            Ok(plan) => plan,
-            Err(_) => {
-                let diagnostics = staging
-                    .import_diagnostics()
-                    .expect("failed staging publishes canonical import diagnostics");
-                let errors = CompileErrors::from(diagnostics.errors().to_vec());
-                return Err(SourceLoadError::Compiler {
-                    snapshot: Some(snapshot),
+        &context,
+        source_manifest.as_ref(),
+        None,
+        None,
+    )?;
+
+    Ok(ImportDiscoveryResult {
+        source_snapshot: close.snapshot,
+        resolution: SourceResolutionInputs { root_path, context },
+        read_manifest: assembler.accepted_read_manifest(),
+        revision: close.closed,
+        #[cfg(test)]
+        input_revision: close.input_revision,
+        session: staging,
+        assembler,
+        std_root,
+        source_manifest,
+        witness: close.witness,
+    })
+}
+
+/// Bounded rounds for reached-body trusted-toolchain acquisition. Each satisfied
+/// round adds at least one demanded module and shrinks the outstanding demand
+/// set, so the batched `Option`/`StrBuf` acquisition converges in one round; the
+/// bound only guards against a compiler invariant violation that would spin.
+const MAX_TOOLCHAIN_ACQUISITION_ROUNDS: usize = 4;
+
+/// Drive reached-body trusted-toolchain acquisition to a fixed point on
+/// `result`'s session (RUE-1112). Runs rooted, park-aware semantic analysis on
+/// the committed closed revision: a reached body demanding an absent trusted std
+/// module parks, the host satisfies exactly the parked demands under the B4
+/// policy checks, publishes ONE strictly-additive successor in the same request
+/// generation, and re-closes discovery on it before retrying.
+///
+/// Host filesystem access lives outside snapshot/query evaluation, so this loop
+/// owns the physical reads and the assembler while the compiler only issues typed
+/// demands and verifies each successor from records. A program with no reached
+/// fallible intrinsic never parks and never reads std, so an unrelated program is
+/// untouched even when std is malformed on disk. Returns `Ok(())` once semantic
+/// analysis reaches a settled outcome — satisfied, or settled program
+/// diagnostics that the driver's emit/compile surfaces report behind their own
+/// preflight ordering. Only toolchain/hermetic acquisition failures surface
+/// through [`SourceLoadError`].
+pub(crate) fn acquire_reached_toolchain_modules(
+    result: &mut ImportDiscoveryResult,
+    options: &CompileOptions,
+) -> Result<(), SourceLoadError> {
+    // A discovery that did not close valid (missing or ambiguous imports) has no
+    // queryable program, so semantic analysis cannot run and there is nothing to
+    // acquire. Leave it untouched: the driver surfaces the canonical import
+    // diagnostics through its closed-revision check, exactly as before this loop
+    // existed. Running semantic here would preempt that with an opaque
+    // "no successful parsed program" error.
+    if result.revision.status() != ImportDiscoveryStatus::ClosedValid {
+        return Ok(());
+    }
+    for _ in 0..MAX_TOOLCHAIN_ACQUISITION_ROUNDS {
+        match semantic_or_toolchain_park(&mut result.session, options) {
+            // Analysis satisfied every reached-body demand (or there were none).
+            SemanticParkOutcome::Ready(_) => return Ok(()),
+            // Deterministic program diagnostics — the source itself, not the
+            // toolchain, is at fault, and an erroneous body raises no toolchain
+            // park, so there is nothing here to acquire. Reporting stays with
+            // the driver's emit/compile surfaces, which run their own preflight
+            // checks (e.g. the output-alias guard) ahead of semantic
+            // diagnostics; surfacing the errors from this loop would invert
+            // that ordering. The semantic attempt is memoized, so the later
+            // surface re-reads the cached outcome rather than re-analyzing.
+            SemanticParkOutcome::Errors(_) => return Ok(()),
+            // A reached body demands trusted std modules absent from the current
+            // revision. Satisfy exactly the parked demands, publish one successor,
+            // and re-close so semantic can retry on it.
+            SemanticParkOutcome::Parked(park) => {
+                for demand in park.demands() {
+                    satisfy_toolchain_module_demand(
+                        &mut result.assembler,
+                        result.std_root.as_deref(),
+                        result.source_manifest.as_ref(),
+                        demand,
+                    )
+                    .map_err(SourceLoadError::from)?;
+                }
+                let successor = result
+                    .assembler
+                    .snapshot()
+                    .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+                let reads = result.assembler.accepted_read_manifest();
+                // The park just attached its exact demanded set to the closed
+                // continuation, so an authorizing token must be outstanding.
+                let token = closed_discovery_continuation(&result.session).ok_or_else(|| {
+                    SourceLoadError::Message(
+                        "Error: internal compiler invariant — a reached-body toolchain park issued no authorizing continuation".into(),
+                    )
+                })?;
+                let delta = publish_trusted_toolchain_successor(
+                    &mut result.session,
+                    token,
+                    &result.witness,
+                    &successor,
+                    reads,
+                )
+                .map_err(|errors| SourceLoadError::Compiler {
+                    snapshot: Some(successor.clone()),
                     errors,
-                });
+                })?;
+                // Same-generation re-close on the successor. Its module delta is
+                // derived and verified from the opaque `delta` capability by the
+                // compiler — the host cannot choose or omit it. The appended
+                // leaves' `@import` edges (e.g. strbuf → option/arraybuf/rawbuf)
+                // are discovered and read here; the predecessor graph is carried
+                // closed and never re-rooted. A malformed or missing transitive
+                // trusted leaf fails during this re-close, and classification
+                // (below) attributes it to the actual failing module.
+                let reclosed = drive_import_discovery_to_close(
+                    &mut result.assembler,
+                    &mut result.session,
+                    &result.resolution.context,
+                    result.source_manifest.as_ref(),
+                    Some(delta.revision()),
+                    Some(ReClose { delta: &delta }),
+                )
+                .map_err(|error| {
+                    reclassify_reclose_failure(error, result.std_root.as_deref(), park.demands())
+                })?;
+                result.source_snapshot = reclosed.snapshot;
+                result.revision = reclosed.closed;
+                result.read_manifest = result.assembler.accepted_read_manifest();
+                result.witness = reclosed.witness;
+                #[cfg(test)]
+                {
+                    result.input_revision = reclosed.input_revision;
+                }
             }
+        }
+    }
+    // Still parking after the bound: acquisition is not converging even though
+    // every round published a successor. Surface as a toolchain-integrity error
+    // rather than spinning.
+    Err(SourceLoadError::Toolchain(
+        ToolchainIntegrityError::UnsatisfiedAfterPublish {
+            logical_path: "<reached-body trusted-toolchain acquisition did not converge>"
+                .to_owned(),
+        },
+    ))
+}
+
+/// Derive the trusted logical path (`\0rue-std/<relative>`) for a std file the
+/// re-close read against the configured std root, falling back to the requested
+/// filesystem path when it lies outside the root's lexical prefix. Used only to
+/// name the exact failing transitive leaf in an environmental error.
+fn trusted_logical_path_for_requested(context: &ImportDiscoveryContext, requested: &str) -> String {
+    const STD_NAMESPACE: &str = "\0rue-std/";
+    match context.std_root() {
+        Some(root) => match Path::new(requested).strip_prefix(root) {
+            Ok(relative) => format!("{STD_NAMESPACE}{}", relative.to_string_lossy()),
+            Err(_) => requested.to_owned(),
+        },
+        None => requested.to_owned(),
+    }
+}
+
+/// Attribute a non-accepted observation for a toolchain-internal `@import` edge
+/// (a transitive trusted leaf reached during the re-close) to the exact failing
+/// module. A policy/containment denial is a hermetic build-configuration failure;
+/// an absent, unreadable, or invalid-type module is a broken-installation
+/// (toolchain-integrity) failure. An accepted observation returns `None`.
+fn classify_trusted_transitive_failure(
+    context: &ImportDiscoveryContext,
+    observations: &[ImportObservation],
+) -> Option<SourceLoadError> {
+    for observation in observations {
+        let requested = observation.request().requested_path().to_owned();
+        let logical = trusted_logical_path_for_requested(context, &requested);
+        let path = PathBuf::from(&requested);
+        let error = match observation.status() {
+            ImportObservationStatus::PresentReadable { .. } => continue,
+            ImportObservationStatus::Absent => {
+                SourceLoadError::Toolchain(ToolchainIntegrityError::Missing {
+                    logical_path: logical,
+                    path,
+                })
+            }
+            ImportObservationStatus::InvalidPhysicalType { .. } => {
+                SourceLoadError::Toolchain(ToolchainIntegrityError::Missing {
+                    logical_path: logical,
+                    path,
+                })
+            }
+            ImportObservationStatus::PresentUnreadable(reason) => {
+                SourceLoadError::Toolchain(ToolchainIntegrityError::Unreadable {
+                    logical_path: logical,
+                    path,
+                    reason: reason.to_string(),
+                })
+            }
+            ImportObservationStatus::UnstableRead(reason) => {
+                SourceLoadError::Toolchain(ToolchainIntegrityError::Unreadable {
+                    logical_path: logical,
+                    path,
+                    reason: reason.to_string(),
+                })
+            }
+            ImportObservationStatus::DeniedLexical => {
+                SourceLoadError::HermeticDenial(HermeticDenialError {
+                    logical_path: logical,
+                    path,
+                    reason: "the source manifest does not declare this path".to_owned(),
+                })
+            }
+            ImportObservationStatus::DeniedCanonical { canonical_path } => {
+                SourceLoadError::HermeticDenial(HermeticDenialError {
+                    logical_path: logical,
+                    path: PathBuf::from(canonical_path.as_ref()),
+                    reason: "its canonical path is not listed in the source manifest".to_owned(),
+                })
+            }
+            ImportObservationStatus::Cancelled => continue,
         };
-        let roots = plan.demand_roots();
-        let frontier = import_demand_frontier_for_roots(
-            &mut staging,
-            input_revision,
-            &plan,
-            ImportDemandMode::Rooted,
-            &roots,
-        )
-        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-        if frontier.requests().is_empty() {
-            final_plan = plan;
-            break;
+        return Some(error);
+    }
+    None
+}
+
+/// Classify a compiler failure from a trusted-toolchain re-close. The re-close's
+/// only new modules are trusted std leaves (the appended leaves plus the
+/// transitive helpers they import), so a parse/close compiler failure is a
+/// malformed toolchain module — a broken installation, not a program error. The
+/// failure is attributed to the module the diagnostics point at (via the error
+/// span's file), so a malformed transitive leaf such as `arraybuf.rue` is named
+/// as itself rather than the root demand. Denial, absence, and unreadable
+/// transitive leaves are already classified from their observation earlier in the
+/// re-close; only a malformed (read-but-unparseable) leaf reaches here.
+/// Infrastructure failures (`Message`) and already-typed toolchain/hermetic
+/// errors pass through unchanged.
+fn reclassify_reclose_failure(
+    error: SourceLoadError,
+    std_root: Option<&Path>,
+    demands: &[TrustedToolchainModuleDemand],
+) -> SourceLoadError {
+    match error {
+        SourceLoadError::Compiler { snapshot, errors } => {
+            // Attribute to the module the diagnostics locate, if any.
+            let failing = snapshot.as_ref().and_then(|snapshot| {
+                errors
+                    .iter()
+                    .find_map(|error| error.span())
+                    .and_then(|span| {
+                        let module = snapshot.module_id(span.file_id)?;
+                        let path = snapshot
+                            .metadata()
+                            .physical_path(span.file_id)
+                            .map(PathBuf::from)
+                            .unwrap_or_default();
+                        Some((module.as_str().to_owned(), path))
+                    })
+            });
+            let (logical_path, path) = failing.unwrap_or_else(|| {
+                // No locatable span: fall back to the first parked demand.
+                let demand = demands.first();
+                (
+                    demand
+                        .map(|demand| demand.logical_path().to_owned())
+                        .unwrap_or_default(),
+                    demand
+                        .map(|demand| toolchain_module_path(std_root, demand))
+                        .unwrap_or_default(),
+                )
+            });
+            SourceLoadError::Toolchain(ToolchainIntegrityError::Malformed {
+                logical_path,
+                path,
+                errors,
+            })
         }
-        let observations = frontier
-            .requests()
-            .iter()
-            .cloned()
-            .map(|request| execute_import_request(request, source_manifest))
-            .collect::<Vec<_>>();
-        let mut next_ledger = ledger;
-        for observation in observations.iter().cloned() {
-            next_ledger
-                .record(observation)
-                .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        other => other,
+    }
+}
+
+/// A deterministic toolchain-integrity failure raised by the host while
+/// satisfying a [`TrustedToolchainModuleDemand`].
+///
+/// The standard library exists as a toolchain guarantee: a missing, unreadable,
+/// or malformed `option.rue` at the host read is a broken installation, like a
+/// missing linker — a loud, typed, environmental failure, not a language-semantics
+/// state. It is raised only for a program whose reached bodies actually demand the
+/// module; programs that never demand it never observe it. It is folded into
+/// [`SourceLoadError::Toolchain`] and kept distinct from a hermetic policy denial.
+#[derive(Debug)]
+pub(crate) enum ToolchainIntegrityError {
+    /// A trusted toolchain module was demanded but no standard-library root is
+    /// configured, so the host cannot resolve it at all.
+    StdRootUnavailable { logical_path: String },
+    /// The trusted module does not exist under the configured std root.
+    Missing { logical_path: String, path: PathBuf },
+    /// The trusted module exists but could not be read stably.
+    Unreadable {
+        logical_path: String,
+        path: PathBuf,
+        reason: String,
+    },
+    /// The trusted module was read but does not form a well-formed module.
+    Malformed {
+        logical_path: String,
+        path: PathBuf,
+        errors: CompileErrors,
+    },
+    /// The host published the successor but the demanded trusted module did not
+    /// appear in it — an internal contradiction, surfaced loudly rather than
+    /// looping forever.
+    UnsatisfiedAfterPublish { logical_path: String },
+}
+
+impl std::fmt::Display for ToolchainIntegrityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Toolchain integrity error: ")?;
+        match self {
+            Self::StdRootUnavailable { logical_path } => write!(
+                f,
+                "the program requires the trusted standard-library module '{logical_path}', but no standard-library path is configured (set RUE_STD_PATH). This is a broken toolchain installation, not a program error."
+            ),
+            Self::Missing { logical_path, path } => write!(
+                f,
+                "the trusted standard-library module '{logical_path}' is missing from the toolchain at '{}'. The standard library must exist as a toolchain guarantee; this is a broken installation.",
+                path.display()
+            ),
+            Self::Unreadable {
+                logical_path,
+                path,
+                reason,
+            } => write!(
+                f,
+                "the trusted standard-library module '{logical_path}' at '{}' could not be read: {reason}. This is a broken toolchain installation.",
+                path.display()
+            ),
+            Self::Malformed {
+                logical_path,
+                path,
+                errors,
+            } => write!(
+                f,
+                "the trusted standard-library module '{logical_path}' at '{}' is malformed: {errors}. This is a broken toolchain installation.",
+                path.display()
+            ),
+            Self::UnsatisfiedAfterPublish { logical_path } => write!(
+                f,
+                "the trusted standard-library module '{logical_path}' was read and published but did not appear in the successor module set. This is a compiler invariant violation."
+            ),
         }
-        let _ = assembler
-            .add_plan_reads(&plan, &next_ledger)
-            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-        let successor_snapshot = assembler
-            .snapshot()
-            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-        input_revision = publish_import_observation_batch(
-            &mut staging,
-            &frontier,
-            &successor_snapshot,
-            assembler.accepted_read_manifest(),
-            observations,
+    }
+}
+
+/// A hermetic build-configuration denial while satisfying a
+/// [`TrustedToolchainModuleDemand`] (RUE-1112).
+///
+/// A trusted-module path the hermetic build configuration forbids — the
+/// `--source-manifest` policy did not authorize the read, or the module
+/// canonicalizes outside the standard-library root (a symlink escape). This is
+/// deterministically DISTINCT from a missing or broken toolchain: the
+/// installation may be intact, but the sandbox policy denies the read, so the
+/// remedy is the source manifest, not the toolchain. It therefore carries its
+/// own outer classification and presentation and never the "toolchain integrity"
+/// / broken-installation framing. A manifest denial is enforced before any
+/// filesystem probe, so a denied path is never even stat-ed.
+#[derive(Debug)]
+pub(crate) struct HermeticDenialError {
+    pub(crate) logical_path: String,
+    pub(crate) path: PathBuf,
+    pub(crate) reason: String,
+}
+
+impl std::fmt::Display for HermeticDenialError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Hermetic build configuration error: the trusted standard-library module '{}' at '{}' is not permitted by the hermetic build configuration: {}. This is a build-configuration error (adjust the source manifest), not a broken toolchain.",
+            self.logical_path,
+            self.path.display(),
+            self.reason
         )
-        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+    }
+}
+
+/// The outcome of a failed trusted-toolchain-module acquisition: either the
+/// toolchain itself is broken ([`ToolchainIntegrityError`]) or the hermetic build
+/// configuration denies the read ([`HermeticDenialError`]). These two classes are
+/// kept distinct all the way to the CLI so a denied read is never presented as a
+/// corrupt toolchain.
+#[derive(Debug)]
+pub(crate) enum ToolchainAcquisitionError {
+    Toolchain(ToolchainIntegrityError),
+    Hermetic(HermeticDenialError),
+}
+
+impl std::fmt::Display for ToolchainAcquisitionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Toolchain(error) => write!(f, "{error}"),
+            Self::Hermetic(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl From<ToolchainIntegrityError> for ToolchainAcquisitionError {
+    fn from(error: ToolchainIntegrityError) -> Self {
+        Self::Toolchain(error)
+    }
+}
+
+impl From<HermeticDenialError> for ToolchainAcquisitionError {
+    fn from(error: HermeticDenialError) -> Self {
+        Self::Hermetic(error)
+    }
+}
+
+impl From<ToolchainAcquisitionError> for SourceLoadError {
+    fn from(error: ToolchainAcquisitionError) -> Self {
+        match error {
+            ToolchainAcquisitionError::Toolchain(error) => SourceLoadError::Toolchain(error),
+            ToolchainAcquisitionError::Hermetic(error) => SourceLoadError::HermeticDenial(error),
+        }
+    }
+}
+
+/// Resolve one trusted module against the std root, read it under the same
+/// stability contract as ordinary imports, and add it to the assembler through
+/// the trusted classification. This never touches the import ledger.
+///
+/// A trusted-module read obeys the same manifest policy as an ordinary import
+/// read: the manifest is the authority, consulted *before* any filesystem
+/// probe. The lexical declaration check runs first so a denied path is never
+/// even stat-ed; the resolved module must then canonicalize under the std root
+/// (a symlink that escapes it is rejected) and satisfy the manifest's canonical
+/// allow-list. A policy denial is a hermetic build-configuration failure,
+/// deterministically distinct from a missing or malformed toolchain.
+fn satisfy_toolchain_module_demand(
+    assembler: &mut DiscoverySourceAssembler,
+    std_root: Option<&Path>,
+    source_manifest: Option<&SourceManifest>,
+    demand: &TrustedToolchainModuleDemand,
+) -> Result<(), ToolchainAcquisitionError> {
+    let std_root = std_root.ok_or_else(|| ToolchainIntegrityError::StdRootUnavailable {
+        logical_path: demand.logical_path().to_owned(),
+    })?;
+    let requested = normalize_lexical_path(&std_root.join(demand.std_relative_path()));
+
+    // Manifest authority before any probe. A path the policy does not lexically
+    // declare must not touch the filesystem at all, so this check precedes
+    // `canonicalize`.
+    if let Some(manifest) = source_manifest
+        && !manifest.declares_path_without_probe(&requested)
+    {
+        return Err(HermeticDenialError {
+            logical_path: demand.logical_path().to_owned(),
+            path: requested,
+            reason: format!(
+                "the source manifest '{}' does not declare this path",
+                manifest.display_path()
+            ),
+        }
+        .into());
     }
 
-    let snapshot = assembler
-        .snapshot()
-        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-    let read_manifest = assembler.accepted_read_manifest();
-    debug_assert_eq!(final_plan.source_revision(), snapshot.source_revision());
-    let ledger = import_observation_ledger(&staging, input_revision)
-        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-    let closed = match staging.close_import_discovery(ledger) {
-        Ok(closed) => closed,
-        Err(errors) => {
-            let attempted = discovery_attempt(&staging)
-                .expect("failed closure publishes an attempted import revision");
-            if DependencyEnvelope::from_closed_revision(&attempted).is_some() {
-                // Missing and ambiguous resolution are structurally closed and
-                // therefore have canonical topology for `--emit deps`. The
-                // caller owns their one diagnostic rendering so the envelope
-                // can be written first. All other failures have no topology.
-                attempted
-            } else {
-                return Err(SourceLoadError::Compiler {
-                    snapshot: Some(snapshot),
-                    errors,
-                });
+    let canonical = match fs::canonicalize(&requested) {
+        Ok(canonical) => canonical,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(ToolchainIntegrityError::Missing {
+                logical_path: demand.logical_path().to_owned(),
+                path: requested,
             }
+            .into());
+        }
+        Err(error) => {
+            return Err(ToolchainIntegrityError::Unreadable {
+                logical_path: demand.logical_path().to_owned(),
+                path: requested,
+                reason: error.to_string(),
+            }
+            .into());
         }
     };
-    Ok(ImportDiscoveryResult {
-        source_snapshot: snapshot,
-        resolution: SourceResolutionInputs { root_path, context },
-        read_manifest,
-        revision: closed,
-        #[cfg(test)]
-        input_revision,
-        session: staging,
-    })
+    if !canonical.is_file() {
+        return Err(ToolchainIntegrityError::Missing {
+            logical_path: demand.logical_path().to_owned(),
+            path: requested,
+        }
+        .into());
+    }
+
+    // Canonical containment: the resolved module must lie under the canonical
+    // std root. Trusted classification grants standard-library provenance, so a
+    // symlink that escapes the std root (pointing at an arbitrary file) can never
+    // be admitted as trusted — that would let a hostile layout inject a "trusted"
+    // module from outside the toolchain.
+    let canonical_std_root = fs::canonicalize(std_root).map_err(|error| HermeticDenialError {
+        logical_path: demand.logical_path().to_owned(),
+        path: requested.clone(),
+        reason: format!(
+            "the standard-library root '{}' cannot be canonicalized: {error}",
+            std_root.display()
+        ),
+    })?;
+    if !canonical.starts_with(&canonical_std_root) {
+        return Err(HermeticDenialError {
+            logical_path: demand.logical_path().to_owned(),
+            path: canonical,
+            reason: format!(
+                "it canonicalizes outside the standard-library root '{}'",
+                canonical_std_root.display()
+            ),
+        }
+        .into());
+    }
+
+    // Canonical manifest allow-list: after canonicalization the module must still
+    // be an allowed read, matching the ordinary import policy's canonical arm.
+    if let Some(manifest) = source_manifest
+        && !manifest.allows_canonical(&canonical)
+    {
+        return Err(HermeticDenialError {
+            logical_path: demand.logical_path().to_owned(),
+            path: canonical,
+            reason: format!(
+                "its canonical path is not listed in the source manifest '{}'",
+                manifest.display_path()
+            ),
+        }
+        .into());
+    }
+
+    let read = stable_read_to_string(&canonical).map_err(|error| match error {
+        StableReadError::Io(error) => ToolchainIntegrityError::Unreadable {
+            logical_path: demand.logical_path().to_owned(),
+            path: requested.clone(),
+            reason: error.to_string(),
+        },
+        StableReadError::Changed => ToolchainIntegrityError::Unreadable {
+            logical_path: demand.logical_path().to_owned(),
+            path: requested.clone(),
+            reason: "module metadata changed during read".to_owned(),
+        },
+    })?;
+
+    assembler
+        .add_explicit(
+            requested.to_string_lossy().as_ref(),
+            canonical.to_string_lossy().as_ref(),
+            read.identity,
+            read.fingerprint,
+            Arc::new(read.source),
+        )
+        .map_err(|error| ToolchainIntegrityError::Unreadable {
+            logical_path: demand.logical_path().to_owned(),
+            path: requested,
+            reason: format!("trusted classification rejected the module: {error}"),
+        })?;
+    Ok(())
+}
+
+fn toolchain_module_path(
+    std_root: Option<&Path>,
+    demand: &TrustedToolchainModuleDemand,
+) -> PathBuf {
+    match std_root {
+        Some(root) => normalize_lexical_path(&root.join(demand.std_relative_path())),
+        None => PathBuf::from(demand.logical_path()),
+    }
 }
 
 #[cfg(test)]
@@ -891,7 +1613,7 @@ mod tests {
         );
         let manifest_path = project.write("sources.manifest", "main.rue\n");
         let manifest = SourceManifest::load(manifest_path.to_str().unwrap()).unwrap();
-        match discover_and_load_imports(main.to_str().unwrap(), Some(&manifest), None) {
+        match discover_and_load_imports(main.to_str().unwrap(), Some(manifest), None) {
             Err(SourceLoadError::Compiler { errors, .. }) => {
                 let rendered = errors.to_string();
                 assert!(rendered.contains("source manifest"), "{rendered}");
@@ -900,7 +1622,916 @@ mod tests {
             Err(SourceLoadError::Message(message)) => {
                 panic!("policy denial escaped typed diagnostics: {message}")
             }
+            Err(SourceLoadError::Toolchain(error)) => {
+                panic!("policy denial escaped as a toolchain error: {error}")
+            }
+            Err(SourceLoadError::HermeticDenial(error)) => {
+                panic!("import policy denial escaped as a hermetic toolchain denial: {error}")
+            }
             Ok(_) => panic!("policy denial unexpectedly closed successfully"),
         }
+    }
+
+    // ---- RUE-1112 reached-body trusted-toolchain acquisition proofs ------
+    //
+    // These drive the whole host flow the driver runs: the initial import-discovery
+    // close, then the reached-body park/retry acquisition loop
+    // (`acquire_reached_toolchain_modules`). For a freestanding zero-import program
+    // the initial close is the root alone; whether std is read is then decided by
+    // real reached-body semantic demand, not a lexical scan — so an unreachable
+    // helper never forces a std read. The observable guarantees (which trusted
+    // module is acquired, and how a missing/malformed/denied one is classified)
+    // are what these tests pin.
+
+    /// Run the full host flow for `root`: initial close, then the reached-body
+    /// park/retry acquisition loop, exactly as `main` orders them.
+    fn load_and_acquire(
+        root: &Path,
+        source_manifest: Option<SourceManifest>,
+        std_root: Option<&Path>,
+    ) -> Result<ImportDiscoveryResult, SourceLoadError> {
+        let mut result =
+            discover_and_load_imports(root.to_str().unwrap(), source_manifest, std_root)?;
+        acquire_reached_toolchain_modules(&mut result, &CompileOptions::default())?;
+        Ok(result)
+    }
+
+    fn contains_trusted_option(snapshot: &SourceSnapshot) -> bool {
+        snapshot.source_revision().modules().iter().any(|revision| {
+            revision.module.is_trusted_standard_library()
+                && revision.module.as_str() == rue_compiler::OPTION_MODULE_LOGICAL_PATH
+        })
+    }
+
+    const FALLIBLE_ROOT: &str = "fn main() -> i32 { let _ = @parse_i64(\"1\"); 0 }";
+    const VALID_OPTION: &str = "pub fn Option(comptime T: type) -> type { enum { Some(T), None } }";
+    const MALFORMED_OPTION: &str = "this is not a valid rue module @@@ ???";
+
+    /// t4: a freestanding fallible-intrinsic program acquires the trusted std
+    /// `Option` its reached body demands. The acquired successor carries the
+    /// module present and classified trusted alongside the root, and the assembler
+    /// retains an accepted-read PROVENANCE leaf for it (never an import-ledger
+    /// entry). Acquisition succeeding means the reached-body demand is satisfied.
+    #[test]
+    fn t4_freestanding_fallible_program_acquires_trusted_option() {
+        let project = TestDir::new("t4-project");
+        let stdlib = TestDir::new("t4-std");
+        let main = project.write("main.rue", FALLIBLE_ROOT);
+        stdlib.write("option.rue", VALID_OPTION);
+        let std_root = fs::canonicalize(&stdlib.path).unwrap();
+
+        let result =
+            load_and_acquire(&main, None, Some(&std_root)).expect("host satisfies the demand");
+
+        // The acquired snapshot contains the trusted Option, added exactly once
+        // alongside the root.
+        assert_eq!(result.source_snapshot.source_revision().modules().len(), 2);
+        assert!(contains_trusted_option(&result.source_snapshot));
+
+        // Provenance: an accepted-read leaf for the trusted module (a provenance
+        // leaf, NOT an import-ledger entry).
+        assert!(
+            result
+                .read_manifest
+                .iter()
+                .any(|entry| entry.module().is_trusted_standard_library()
+                    && entry.module().as_str() == rue_compiler::OPTION_MODULE_LOGICAL_PATH)
+        );
+    }
+
+    /// t1: a freestanding program with NO reached fallible intrinsic performs
+    /// zero std reads and is untouched — even when the std path's option.rue is
+    /// deliberately malformed. Unrelated programs never observe it.
+    #[test]
+    fn t1_no_fallible_intrinsic_never_reads_malformed_std() {
+        let project = TestDir::new("t1-project");
+        let stdlib = TestDir::new("t1-std");
+        let main = project.write("main.rue", "fn main() -> i32 { let x = 1 + 2; x }");
+        // Deliberately malformed; it must never be read.
+        stdlib.write("option.rue", MALFORMED_OPTION);
+        let std_root = fs::canonicalize(&stdlib.path).unwrap();
+
+        let result = load_and_acquire(&main, None, Some(&std_root))
+            .expect("a program with no reached demand never touches std");
+
+        // No std read happened: only the root module, no trusted module, and no
+        // trusted leaf in the accepted-read manifest.
+        assert_eq!(result.source_snapshot.source_revision().modules().len(), 1);
+        assert!(!contains_trusted_option(&result.source_snapshot));
+        assert!(
+            !result
+                .read_manifest
+                .iter()
+                .any(|entry| entry.module().is_trusted_standard_library())
+        );
+    }
+
+    /// t5: a reached-body demand for an UNREACHABLE fallible intrinsic is never
+    /// raised — a helper that mentions `@parse_i64` but is never called forces no
+    /// std read even when std is malformed on disk. This is the reachability win
+    /// the semantic-driven park has over a lexical scan.
+    #[test]
+    fn t5_unreachable_fallible_helper_never_reads_malformed_std() {
+        let project = TestDir::new("t5-project");
+        let stdlib = TestDir::new("t5-std");
+        let main = project.write(
+            "main.rue",
+            "fn helper() -> i32 { let _ = @parse_i64(\"1\"); 0 }\n\
+             fn main() -> i32 { 0 }",
+        );
+        // Malformed; it must never be read because `helper` is never reached.
+        stdlib.write("option.rue", MALFORMED_OPTION);
+        let std_root = fs::canonicalize(&stdlib.path).unwrap();
+
+        let result = load_and_acquire(&main, None, Some(&std_root))
+            .expect("an unreachable fallible helper raises no demand and reads no std");
+        assert!(!contains_trusted_option(&result.source_snapshot));
+        assert!(
+            !result
+                .read_manifest
+                .iter()
+                .any(|entry| entry.module().is_trusted_standard_library())
+        );
+    }
+
+    /// Toolchain-integrity arm: a reached fallible intrinsic with a MISSING std
+    /// option.rue yields the deterministic environmental error.
+    #[test]
+    fn toolchain_integrity_missing_std_option_is_environmental_error() {
+        let project = TestDir::new("integrity-missing-project");
+        let stdlib = TestDir::new("integrity-missing-std");
+        let main = project.write("main.rue", FALLIBLE_ROOT);
+        // No option.rue written under std_root.
+        let std_root = fs::canonicalize(&stdlib.path).unwrap();
+
+        let error = load_and_acquire(&main, None, Some(&std_root))
+            .expect_err("a missing trusted module is a toolchain-integrity error");
+        assert!(
+            matches!(
+                error,
+                SourceLoadError::Toolchain(ToolchainIntegrityError::Missing { .. })
+            ),
+            "expected Missing, got {error:?}"
+        );
+        let rendered = error_display(&error);
+        assert!(rendered.contains("Toolchain integrity error"), "{rendered}");
+        assert!(rendered.contains("broken"), "{rendered}");
+    }
+
+    /// Toolchain-integrity arm: a reached fallible intrinsic with a MALFORMED std
+    /// option.rue yields the deterministic environmental error. A malformed
+    /// trusted module fails to parse at the same-generation re-close (the only new
+    /// module there is the one just acquired), so it is classified as a broken
+    /// installation, not a program error.
+    #[test]
+    fn toolchain_integrity_malformed_std_option_is_environmental_error() {
+        let project = TestDir::new("integrity-malformed-project");
+        let stdlib = TestDir::new("integrity-malformed-std");
+        let main = project.write("main.rue", FALLIBLE_ROOT);
+        stdlib.write("option.rue", MALFORMED_OPTION);
+        let std_root = fs::canonicalize(&stdlib.path).unwrap();
+
+        let error = load_and_acquire(&main, None, Some(&std_root))
+            .expect_err("a malformed trusted module is a toolchain-integrity error");
+        assert!(
+            matches!(
+                error,
+                SourceLoadError::Toolchain(ToolchainIntegrityError::Malformed { .. })
+            ),
+            "expected Malformed, got {error:?}"
+        );
+        assert!(error_display(&error).contains("malformed"), "{error:?}");
+    }
+
+    /// Toolchain-integrity arm: a reached fallible intrinsic with NO std root
+    /// configured cannot resolve the demand at all.
+    #[test]
+    fn toolchain_integrity_absent_std_root_is_environmental_error() {
+        let project = TestDir::new("integrity-nostd-project");
+        let main = project.write("main.rue", FALLIBLE_ROOT);
+
+        let error =
+            load_and_acquire(&main, None, None).expect_err("no std root cannot satisfy the demand");
+        assert!(
+            matches!(
+                error,
+                SourceLoadError::Toolchain(ToolchainIntegrityError::StdRootUnavailable { .. })
+            ),
+            "expected StdRootUnavailable, got {error:?}"
+        );
+    }
+
+    /// Render a `SourceLoadError`'s environmental/hermetic message for assertions.
+    fn error_display(error: &SourceLoadError) -> String {
+        match error {
+            SourceLoadError::Toolchain(error) => error.to_string(),
+            SourceLoadError::HermeticDenial(error) => error.to_string(),
+            SourceLoadError::Message(message) => message.clone(),
+            SourceLoadError::Compiler { errors, .. } => errors.to_string(),
+        }
+    }
+
+    /// Load a `SourceManifest` from a written manifest file whose entries are the
+    /// given absolute paths (one per line).
+    fn manifest_allowing(project: &TestDir, entries: &[&Path]) -> SourceManifest {
+        let body = entries
+            .iter()
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let manifest_path = project.write("sources.manifest", &format!("{body}\n"));
+        SourceManifest::load(manifest_path.to_str().unwrap()).unwrap()
+    }
+
+    /// Manifest authority: a std path the manifest does not declare is DENIED
+    /// before any filesystem probe. The option.rue on disk is deliberately
+    /// malformed; if acquisition read it the error would be `Malformed`, so a
+    /// hermetic-denial result proves the read never happened.
+    #[test]
+    fn b4_manifest_denied_std_module_is_hermetic_denial_without_probe() {
+        let project = TestDir::new("b4-denied-project");
+        let stdlib = TestDir::new("b4-denied-std");
+        let main = project.write("main.rue", FALLIBLE_ROOT);
+        stdlib.write("option.rue", MALFORMED_OPTION);
+        let std_root = fs::canonicalize(&stdlib.path).unwrap();
+        // The manifest authorizes only the root source, not the std module.
+        let root_canonical = fs::canonicalize(&main).unwrap();
+        let manifest = manifest_allowing(&project, &[&root_canonical]);
+
+        let error = load_and_acquire(&main, Some(manifest), Some(&std_root))
+            .expect_err("a manifest-denied std module cannot be acquired");
+        assert!(
+            matches!(error, SourceLoadError::HermeticDenial(_)),
+            "expected a hermetic denial (never probed), got {error:?}"
+        );
+        assert!(
+            error_display(&error).contains("hermetic build configuration"),
+            "{error:?}"
+        );
+    }
+
+    /// CLI classification: a hermetic denial is presented as a distinct
+    /// build-configuration failure, NOT as toolchain corruption. The two error
+    /// classes carry disjoint labels ("Hermetic build configuration error" vs
+    /// "Toolchain integrity error") and disjoint remedies, so the CLI never tells
+    /// a user their toolchain is broken when the sandbox policy denied the read.
+    #[test]
+    fn b4_hermetic_denial_label_is_distinct_from_toolchain_corruption() {
+        let project = TestDir::new("b4-label-project");
+        let stdlib = TestDir::new("b4-label-std");
+        let main = project.write("main.rue", FALLIBLE_ROOT);
+        // Malformed on disk: if acquisition read it the class would be Toolchain
+        // corruption. The manifest denies it, so the class must be Hermetic.
+        stdlib.write("option.rue", MALFORMED_OPTION);
+        let std_root = fs::canonicalize(&stdlib.path).unwrap();
+        let root_canonical = fs::canonicalize(&main).unwrap();
+        let manifest = manifest_allowing(&project, &[&root_canonical]);
+
+        let denied = load_and_acquire(&main, Some(manifest), Some(&std_root))
+            .expect_err("a manifest-denied std module is a hermetic denial");
+
+        // Distinct outer classification.
+        let SourceLoadError::HermeticDenial(hermetic) = &denied else {
+            panic!(
+                "a manifest denial must classify as SourceLoadError::HermeticDenial: {denied:?}"
+            );
+        };
+        let hermetic_message = hermetic.to_string();
+        assert!(
+            hermetic_message.contains("Hermetic build configuration error"),
+            "the hermetic denial must carry its own label: {hermetic_message}",
+        );
+        assert!(
+            hermetic_message.contains("adjust the source manifest"),
+            "the hermetic denial must point at the manifest remedy: {hermetic_message}",
+        );
+        assert!(
+            !hermetic_message.contains("Toolchain integrity error"),
+            "the hermetic denial must NOT be presented as toolchain corruption: {hermetic_message}",
+        );
+        assert!(
+            !hermetic_message.contains("broken toolchain installation"),
+            "the hermetic denial must NOT claim a broken installation: {hermetic_message}",
+        );
+
+        // The genuine toolchain-corruption class keeps the opposite label, so the
+        // two are provably disjoint at the CLI boundary.
+        let corruption = ToolchainIntegrityError::Missing {
+            logical_path: rue_compiler::OPTION_MODULE_LOGICAL_PATH.to_owned(),
+            path: std_root.join("option.rue"),
+        }
+        .to_string();
+        assert!(
+            corruption.contains("Toolchain integrity error")
+                && !corruption.contains("Hermetic build configuration error"),
+            "toolchain corruption must keep its distinct label: {corruption}",
+        );
+    }
+
+    /// Manifest authority: when the manifest declares AND allows the canonical
+    /// std module, acquisition proceeds exactly as an unrestricted read would.
+    #[test]
+    fn b4_manifest_allowed_std_module_acquires() {
+        let project = TestDir::new("b4-allowed-project");
+        let stdlib = TestDir::new("b4-allowed-std");
+        let main = project.write("main.rue", FALLIBLE_ROOT);
+        let option = stdlib.write("option.rue", VALID_OPTION);
+        let std_root = fs::canonicalize(&stdlib.path).unwrap();
+        let root_canonical = fs::canonicalize(&main).unwrap();
+        let option_canonical = fs::canonicalize(&option).unwrap();
+        let manifest = manifest_allowing(&project, &[&root_canonical, &option_canonical]);
+
+        let result = load_and_acquire(&main, Some(manifest), Some(&std_root))
+            .expect("a manifest-allowed std module is acquired");
+        assert!(contains_trusted_option(&result.source_snapshot));
+    }
+
+    /// Canonical containment: a std module that is a symlink escaping the std
+    /// root is rejected as a hermetic denial. Trusted classification must never
+    /// be granted to a file outside the toolchain, even one reachable through a
+    /// symlink named `option.rue` under the std root.
+    #[test]
+    #[cfg(unix)]
+    fn b4_symlink_escape_from_std_root_is_hermetic_denial() {
+        let project = TestDir::new("b4-escape-project");
+        let stdlib = TestDir::new("b4-escape-std");
+        let main = project.write("main.rue", FALLIBLE_ROOT);
+        // A perfectly valid Option module, but OUTSIDE the std root.
+        let outside = project.write("escape_option.rue", VALID_OPTION);
+        let outside_canonical = fs::canonicalize(&outside).unwrap();
+        // `std_root/option.rue` is a symlink pointing at the outside file.
+        let link = stdlib.path.join("option.rue");
+        std::os::unix::fs::symlink(&outside_canonical, &link).unwrap();
+        let std_root = fs::canonicalize(&stdlib.path).unwrap();
+
+        let error = load_and_acquire(&main, None, Some(&std_root))
+            .expect_err("a symlink escaping the std root cannot be trusted");
+        assert!(
+            matches!(error, SourceLoadError::HermeticDenial(_)),
+            "expected a hermetic denial for the escape, got {error:?}"
+        );
+        assert!(
+            error_display(&error).contains("outside the standard-library root"),
+            "{error:?}"
+        );
+    }
+
+    // ---- RUE-1112 leaf-only re-close acquisition proofs ------------------
+    //
+    // `@read_line` demands the trusted std `Option` and `StrBuf`. The real
+    // `StrBuf` module imports `option.rue`, `arraybuf.rue`, and `rawbuf.rue`, and
+    // `arraybuf.rue` imports `option.rue` and `rawbuf.rue`, so satisfying the
+    // demand reads four trusted leaves in total. These tests build that exact
+    // import shape with `TestDir` and pin that the re-close discovers it by
+    // rooting ONLY in the newly appended leaves — never re-rooting the project's
+    // pre-existing imports — and that a broken transitive leaf is attributed to
+    // itself.
+
+    /// A root whose reached body hits `@read_line`, demanding Option + StrBuf.
+    const READ_LINE_ROOT: &str = "fn main() -> i32 { let _ = @read_line(); 0 }";
+    const VALID_RAWBUF: &str = "pub struct RawBuf { cap: u64, }";
+    const VALID_ARRAYBUF: &str = "const option = @import(\"option.rue\");\n\
+         const rawbuf = @import(\"rawbuf.rue\");\n\
+         pub struct ArrayBuf { len: u64, }";
+    const VALID_STRBUF: &str = "const option = @import(\"option.rue\");\n\
+         const arraybuf = @import(\"arraybuf.rue\");\n\
+         const rawbuf = @import(\"rawbuf.rue\");\n\
+         pub struct StrBuf { len: u64, }";
+
+    /// Write the trusted std tree with the real `@read_line` topology: `strbuf`
+    /// imports `option`/`arraybuf`/`rawbuf`, `arraybuf` imports `option`/`rawbuf`.
+    /// Returns the canonicalized std root.
+    fn write_read_line_std(stdlib: &TestDir) -> PathBuf {
+        stdlib.write("option.rue", VALID_OPTION);
+        stdlib.write("rawbuf.rue", VALID_RAWBUF);
+        stdlib.write("arraybuf.rue", VALID_ARRAYBUF);
+        stdlib.write("strbuf.rue", VALID_STRBUF);
+        fs::canonicalize(&stdlib.path).unwrap()
+    }
+
+    /// Number of trusted std leaves in an accepted-read manifest.
+    fn trusted_read_count(manifest: &AcceptedReadManifest) -> usize {
+        manifest
+            .iter()
+            .filter(|entry| entry.module().is_trusted_standard_library())
+            .count()
+    }
+
+    /// Number of ordinary (non-trusted) reads in an accepted-read manifest.
+    fn project_read_count(manifest: &AcceptedReadManifest) -> usize {
+        manifest
+            .iter()
+            .filter(|entry| !entry.module().is_trusted_standard_library())
+            .count()
+    }
+
+    /// The re-close that acquires `@read_line`'s trusted leaves roots its demand
+    /// frontier ONLY in the newly appended leaves and the transitive helpers they
+    /// import — never in the project's pre-existing imports. Proven by driving two
+    /// projects whose predecessor import topologies differ sharply (one with no
+    /// project imports, one with several project modules importing each other) and
+    /// asserting the re-close's frontier-root count is IDENTICAL, while the
+    /// initial close's frontier-root count differs (it is topology-sensitive). The
+    /// four trusted leaves are each read exactly once and no predecessor import is
+    /// re-read.
+    /// The four predecessor-sensitive work counters instrumented at each import
+    /// discovery layer: host frontier roots, plan-group construction, close-time
+    /// `ResolveImport` projection dispatch, and canonical graph reduction.
+    #[derive(Clone, Copy)]
+    struct ImportWorkProfile {
+        frontier_roots: u64,
+        plan_groups: u64,
+        resolve_dispatched: u64,
+        records_reduced: u64,
+        full_leaves_published: u64,
+        overlay_leaves_published: u64,
+        ledger_entries_cloned: u64,
+        source_entries_compared: u64,
+        read_entries_compared: u64,
+        snapshot_sources_rebuilt: u64,
+        snapshot_sources_appended: u64,
+        manifest_entries_rebuilt: u64,
+        manifest_entries_appended: u64,
+        parse_sources_materialized: u64,
+        parse_key_entries_compared: u64,
+        parse_modules_dispatched: u64,
+        parse_invalidation_entries_compared: u64,
+        frontend_invalidations: u64,
+    }
+
+    fn import_work_profile(result: &ImportDiscoveryResult) -> ImportWorkProfile {
+        ImportWorkProfile {
+            frontier_roots: import_frontier_roots_requested(&result.session),
+            plan_groups: import_plan_groups_constructed(&result.session),
+            resolve_dispatched: exact_import_groups_dispatched(&result.session),
+            records_reduced: import_close_records_reduced(&result.session),
+            full_leaves_published: import_view_full_leaves_published(&result.session),
+            overlay_leaves_published: import_view_overlay_leaves_published(&result.session),
+            ledger_entries_cloned: import_view_ledger_entries_cloned(&result.session),
+            source_entries_compared: import_view_source_entries_compared(&result.session),
+            read_entries_compared: import_view_read_entries_compared(&result.session),
+            snapshot_sources_rebuilt: result.assembler.snapshot_sources_rebuilt(),
+            snapshot_sources_appended: result.assembler.snapshot_sources_appended(),
+            manifest_entries_rebuilt: result.assembler.manifest_entries_rebuilt(),
+            manifest_entries_appended: result.assembler.manifest_entries_appended(),
+            parse_sources_materialized: parse_sources_materialized(&result.session),
+            parse_key_entries_compared: parse_key_entries_compared(&result.session),
+            parse_modules_dispatched: parse_modules_dispatched(&result.session),
+            parse_invalidation_entries_compared: parse_invalidation_entries_compared(
+                &result.session,
+            ),
+            frontend_invalidations: frontend_query_invalidations(&result.session),
+        }
+    }
+
+    /// The result of driving one project through acquisition, with the per-layer
+    /// re-close work delta and the graph record-sharing witnesses before and after
+    /// acquisition.
+    struct Acquired {
+        result: ImportDiscoveryResult,
+        initial: ImportWorkProfile,
+        reclose: ImportWorkProfile,
+        /// Structural-sharing witnesses `[graph_records, plan_groups,
+        /// resolution_modules]`, each `(predecessor_segment_address, delta_len)`,
+        /// for the committed discovery before acquisition (the flat initial close)
+        /// and after (the shared successor).
+        sharing_before: Option<[(usize, usize); 3]>,
+        sharing_after: Option<[(usize, usize); 3]>,
+    }
+
+    /// The work each layer performed during acquisition (the re-close delta),
+    /// isolated from the initial close by differencing, plus the structural-sharing
+    /// witnesses.
+    fn acquisition_work(root: &Path, std_root: &Path) -> Acquired {
+        let mut result =
+            discover_and_load_imports(root.to_str().unwrap(), None, Some(std_root)).unwrap();
+        let initial = import_work_profile(&result);
+        let sharing_before = committed_successor_sharing(&result.session);
+        acquire_reached_toolchain_modules(&mut result, &CompileOptions::default())
+            .expect("the project acquires its trusted leaves");
+        let after = import_work_profile(&result);
+        let sharing_after = committed_successor_sharing(&result.session);
+        let reclose = ImportWorkProfile {
+            frontier_roots: after.frontier_roots - initial.frontier_roots,
+            plan_groups: after.plan_groups - initial.plan_groups,
+            resolve_dispatched: after.resolve_dispatched - initial.resolve_dispatched,
+            records_reduced: after.records_reduced - initial.records_reduced,
+            full_leaves_published: after.full_leaves_published - initial.full_leaves_published,
+            overlay_leaves_published: after.overlay_leaves_published
+                - initial.overlay_leaves_published,
+            ledger_entries_cloned: after.ledger_entries_cloned - initial.ledger_entries_cloned,
+            source_entries_compared: after.source_entries_compared
+                - initial.source_entries_compared,
+            read_entries_compared: after.read_entries_compared - initial.read_entries_compared,
+            snapshot_sources_rebuilt: after.snapshot_sources_rebuilt
+                - initial.snapshot_sources_rebuilt,
+            snapshot_sources_appended: after.snapshot_sources_appended
+                - initial.snapshot_sources_appended,
+            manifest_entries_rebuilt: after.manifest_entries_rebuilt
+                - initial.manifest_entries_rebuilt,
+            manifest_entries_appended: after.manifest_entries_appended
+                - initial.manifest_entries_appended,
+            parse_sources_materialized: after.parse_sources_materialized
+                - initial.parse_sources_materialized,
+            parse_key_entries_compared: after.parse_key_entries_compared
+                - initial.parse_key_entries_compared,
+            parse_modules_dispatched: after.parse_modules_dispatched
+                - initial.parse_modules_dispatched,
+            parse_invalidation_entries_compared: after.parse_invalidation_entries_compared
+                - initial.parse_invalidation_entries_compared,
+            frontend_invalidations: after.frontend_invalidations - initial.frontend_invalidations,
+        };
+        Acquired {
+            result,
+            initial,
+            reclose,
+            sharing_before,
+            sharing_after,
+        }
+    }
+
+    #[test]
+    fn read_line_reclose_roots_only_new_leaves_independent_of_project_topology() {
+        // Small project: the root has no project imports at all.
+        let small_project = TestDir::new("leaf-small-project");
+        let small_stdlib = TestDir::new("leaf-small-std");
+        let small_main = small_project.write("main.rue", READ_LINE_ROOT);
+        let small_std_root = write_read_line_std(&small_stdlib);
+        let small_acq = acquisition_work(&small_main, &small_std_root);
+        let (small, small_initial, small_reclose) =
+            (&small_acq.result, small_acq.initial, small_acq.reclose);
+
+        // Big project: several project modules importing each other, so the
+        // initial close does much more work at every layer.
+        let big_project = TestDir::new("leaf-big-project");
+        let big_stdlib = TestDir::new("leaf-big-std");
+        big_project.write("c.rue", "pub fn cv() -> i32 { 3 }");
+        big_project.write(
+            "b.rue",
+            "const c = @import(\"c.rue\"); pub fn bv() -> i32 { 2 }",
+        );
+        big_project.write(
+            "a.rue",
+            "const b = @import(\"b.rue\");\nconst c = @import(\"c.rue\");\npub fn av() -> i32 { 1 }",
+        );
+        let big_main = big_project.write(
+            "main.rue",
+            "const a = @import(\"a.rue\");\nconst b = @import(\"b.rue\");\n\
+             fn main() -> i32 { let _ = @read_line(); 0 }",
+        );
+        let big_std_root = write_read_line_std(&big_stdlib);
+        let big_acq = acquisition_work(&big_main, &big_std_root);
+        let (big, big_initial, big_reclose) = (&big_acq.result, big_acq.initial, big_acq.reclose);
+
+        // Both acquire the demanded Option and StrBuf.
+        assert!(contains_trusted_option(&small.source_snapshot));
+        assert!(contains_trusted_option(&big.source_snapshot));
+
+        // The INITIAL close is topology-sensitive at every layer: the big project
+        // roots, constructs, projects, and reduces strictly more than the
+        // import-free small project. (The small project has no project imports, so
+        // its initial frontier roots and dispatch are zero.)
+        assert_eq!(small_initial.frontier_roots, 0);
+        assert!(
+            big_initial.frontier_roots > small_initial.frontier_roots,
+            "initial frontier roots must scale with the predecessor topology: big={} small={}",
+            big_initial.frontier_roots,
+            small_initial.frontier_roots
+        );
+        assert!(
+            big_initial.plan_groups > small_initial.plan_groups,
+            "initial plan-group construction must scale with the predecessor topology: big={} small={}",
+            big_initial.plan_groups,
+            small_initial.plan_groups
+        );
+        assert!(
+            big_initial.resolve_dispatched > small_initial.resolve_dispatched,
+            "initial ResolveImport dispatch must scale with the predecessor topology: big={} small={}",
+            big_initial.resolve_dispatched,
+            small_initial.resolve_dispatched
+        );
+        assert!(
+            big_initial.records_reduced > small_initial.records_reduced,
+            "initial graph reduction must scale with the predecessor topology: big={} small={}",
+            big_initial.records_reduced,
+            small_initial.records_reduced
+        );
+
+        // The RE-CLOSE is topology-INDEPENDENT at EVERY layer: it roots,
+        // constructs, projects, and reduces only the newly appended leaves and the
+        // transitive helpers discovered from them, so every counter's acquisition
+        // delta is identical across the two sharply different predecessor graphs.
+        assert_eq!(
+            small_reclose.frontier_roots, big_reclose.frontier_roots,
+            "re-close frontier roots must not depend on the predecessor topology: small={} big={}",
+            small_reclose.frontier_roots, big_reclose.frontier_roots
+        );
+        assert_eq!(
+            small_reclose.plan_groups, big_reclose.plan_groups,
+            "re-close plan-group construction must not depend on the predecessor topology: small={} big={}",
+            small_reclose.plan_groups, big_reclose.plan_groups
+        );
+        assert_eq!(
+            small_reclose.resolve_dispatched, big_reclose.resolve_dispatched,
+            "re-close ResolveImport dispatch must not depend on the predecessor topology: small={} big={}",
+            small_reclose.resolve_dispatched, big_reclose.resolve_dispatched
+        );
+        assert_eq!(
+            small_reclose.records_reduced, big_reclose.records_reduced,
+            "re-close graph reduction must not depend on the predecessor topology: small={} big={}",
+            small_reclose.records_reduced, big_reclose.records_reduced
+        );
+        // PUBLICATION is O(delta) too: acquisition publishes ONLY through the
+        // sparse successor overlay (zero complete-path leaves), and the overlay
+        // leaf count — the new leaves' sources/provenance/observations plus the
+        // re-stamped aggregate topology — is identical across the two predecessor
+        // topologies. Predecessor leaves are structurally inherited, never
+        // rehashed, revalidated, or republished.
+        assert_eq!(
+            small_reclose.full_leaves_published, 0,
+            "acquisition must never publish through the complete path"
+        );
+        assert_eq!(
+            big_reclose.full_leaves_published, 0,
+            "acquisition must never publish through the complete path"
+        );
+        assert_eq!(
+            small_reclose.overlay_leaves_published, big_reclose.overlay_leaves_published,
+            "re-close overlay publication must not depend on the predecessor topology: small={} big={}",
+            small_reclose.overlay_leaves_published, big_reclose.overlay_leaves_published
+        );
+        // The persistent ledger deep-copies only per-step recorded deltas on
+        // clone (frozen predecessor segments are shared by Arc), so the
+        // acquisition's total deep-copied observation count is identical across
+        // the two predecessor topologies.
+        assert_eq!(
+            small_reclose.ledger_entries_cloned, big_reclose.ledger_entries_cloned,
+            "re-close ledger cloning must not depend on the predecessor topology: small={} big={}",
+            small_reclose.ledger_entries_cloned, big_reclose.ledger_entries_cloned
+        );
+        // The assembler seam is O(delta): once a lineage's first snapshot exists,
+        // every successor snapshot is an extension appending only the newly read
+        // sources — never a rebuild of all prior modules — so acquisition
+        // materializes ZERO full-path sources and a topology-independent appended
+        // count. The publication's source additions likewise flow from structural
+        // authority (successor segments sharing the parent view by Arc identity),
+        // so its fallback comparison path never touches a predecessor entry.
+        assert_eq!(
+            small_reclose.snapshot_sources_rebuilt, 0,
+            "acquisition must never rebuild a full snapshot"
+        );
+        assert_eq!(
+            big_reclose.snapshot_sources_rebuilt, 0,
+            "acquisition must never rebuild a full snapshot"
+        );
+        assert_eq!(
+            small_reclose.snapshot_sources_appended, big_reclose.snapshot_sources_appended,
+            "snapshot extension must not depend on the predecessor topology: small={} big={}",
+            small_reclose.snapshot_sources_appended, big_reclose.snapshot_sources_appended
+        );
+        assert!(small_reclose.snapshot_sources_appended > 0);
+        assert_eq!(
+            small_reclose.source_entries_compared, 0,
+            "structural authority must publish source additions without comparing predecessor entries"
+        );
+        assert_eq!(
+            big_reclose.source_entries_compared, 0,
+            "structural authority must publish source additions without comparing predecessor entries"
+        );
+        // The accepted-read provenance manifest is O(delta) through the same
+        // mechanism: acquisition extends the assembler's cached manifest with
+        // only the newly accepted entries (never a full rebuild), and the
+        // publication takes the shared segment identity as its authority for the
+        // parent's provenance, so the fallback comparison path never touches a
+        // predecessor read entry.
+        assert_eq!(
+            small_reclose.manifest_entries_rebuilt, 0,
+            "acquisition must never rebuild a full accepted-read manifest"
+        );
+        assert_eq!(
+            big_reclose.manifest_entries_rebuilt, 0,
+            "acquisition must never rebuild a full accepted-read manifest"
+        );
+        assert_eq!(
+            small_reclose.manifest_entries_appended, big_reclose.manifest_entries_appended,
+            "manifest extension must not depend on the predecessor topology: small={} big={}",
+            small_reclose.manifest_entries_appended, big_reclose.manifest_entries_appended
+        );
+        assert!(small_reclose.manifest_entries_appended > 0);
+        assert_eq!(
+            small_reclose.read_entries_compared, 0,
+            "structural authority must publish provenance additions without comparing predecessor entries"
+        );
+        assert_eq!(
+            big_reclose.read_entries_compared, 0,
+            "structural authority must publish provenance additions without comparing predecessor entries"
+        );
+        // The PARSE projection is O(delta) on the successor path too: each
+        // re-close stage extends the retained predecessor parsed program and
+        // presentation order (never materializing a whole-program view), keys
+        // on the published lineage identity plus the appended segment (never
+        // re-hashing predecessor content), dispatches only the appended
+        // modules' parse queries, and classifies invalidation over the delta
+        // alone.
+        assert_eq!(
+            small_reclose.parse_sources_materialized, 0,
+            "a successor stage must never materialize a whole-program parse projection"
+        );
+        assert_eq!(
+            big_reclose.parse_sources_materialized, 0,
+            "a successor stage must never materialize a whole-program parse projection"
+        );
+        assert_eq!(
+            small_reclose.parse_key_entries_compared, big_reclose.parse_key_entries_compared,
+            "successor parse keys must not depend on the predecessor topology: small={} big={}",
+            small_reclose.parse_key_entries_compared, big_reclose.parse_key_entries_compared
+        );
+        assert!(small_reclose.parse_key_entries_compared > 0);
+        assert_eq!(
+            small_reclose.parse_modules_dispatched, big_reclose.parse_modules_dispatched,
+            "successor parse dispatch must not depend on the predecessor topology: small={} big={}",
+            small_reclose.parse_modules_dispatched, big_reclose.parse_modules_dispatched
+        );
+        assert!(small_reclose.parse_modules_dispatched > 0);
+        assert_eq!(
+            small_reclose.parse_invalidation_entries_compared,
+            big_reclose.parse_invalidation_entries_compared,
+            "successor parse invalidation must not depend on the predecessor topology: small={} big={}",
+            small_reclose.parse_invalidation_entries_compared,
+            big_reclose.parse_invalidation_entries_compared
+        );
+        assert!(small_reclose.parse_invalidation_entries_compared > 0);
+        // The successor observes its predecessor parse through the
+        // exact-terminal adoption capability — by node incarnation, never by
+        // key — proven mechanically by the rue-query frozen-key regression
+        // (`adoption_never_hashes_or_compares_the_predecessor_key`).
+        // Additive successor adoption keeps the predecessor's immutable source
+        // leaf live, so acquisition invalidates NO retained frontend terminal —
+        // the predecessor's retained downstream is never walked.
+        assert_eq!(
+            small_reclose.frontend_invalidations, 0,
+            "additive successor adoption must not invalidate retained frontend terminals"
+        );
+        assert_eq!(
+            big_reclose.frontend_invalidations, 0,
+            "additive successor adoption must not invalidate retained frontend terminals"
+        );
+        // The re-close genuinely did work (it discovered and reduced the new
+        // leaves' edges); the flat deltas are not a vacuous zero.
+        assert!(small_reclose.frontier_roots > 0);
+        assert!(small_reclose.records_reduced > 0);
+        assert!(small_reclose.overlay_leaves_published > 0);
+
+        // Each of the four trusted leaves is read exactly once, and the project
+        // reads are exactly the project's own modules — nothing re-read: the small
+        // project has only its root, the big project its root plus a/b/c.
+        assert_eq!(trusted_read_count(&small.read_manifest), 4);
+        assert_eq!(trusted_read_count(&big.read_manifest), 4);
+        assert_eq!(project_read_count(&small.read_manifest), 1);
+        assert_eq!(project_read_count(&big.read_manifest), 4);
+
+        // STRUCTURAL SHARING: the committed successor carries the predecessor
+        // close's segment `Arc` by reference for ALL THREE additive artifacts —
+        // canonical graph records, plan request groups, and the module-resolution
+        // table. Each artifact's shared predecessor-segment address is
+        // byte-identical to the predecessor close's flat address (so no predecessor
+        // entry was copied, re-sorted, or reallocated), and each delta size is
+        // non-vacuous and identical across the two sharply different predecessor
+        // topologies (allocation independent of predecessor size).
+        let artifacts = ["graph records", "plan groups", "resolution modules"];
+        for acq in [&small_acq, &big_acq] {
+            let before = acq
+                .sharing_before
+                .expect("initial close has committed artifacts");
+            let after = acq
+                .sharing_after
+                .expect("successor close has committed artifacts");
+            for (index, name) in artifacts.iter().enumerate() {
+                let (before_ptr, before_delta) = before[index];
+                let (after_ptr, after_delta) = after[index];
+                assert_eq!(before_delta, 0, "the initial close is flat for {name}");
+                assert_eq!(
+                    before_ptr, after_ptr,
+                    "the successor must share the predecessor {name} Arc by reference (no copy)"
+                );
+                assert!(after_delta > 0, "the successor delta must carry new {name}");
+            }
+        }
+        let small_after = small_acq.sharing_after.unwrap();
+        let big_after = big_acq.sharing_after.unwrap();
+        for (index, name) in artifacts.iter().enumerate() {
+            assert_eq!(
+                small_after[index].1, big_after[index].1,
+                "the successor {name} delta size must be independent of the predecessor topology"
+            );
+        }
+    }
+
+    /// A manifest that denies a newly introduced transitive helper (`arraybuf.rue`,
+    /// pulled in by `strbuf.rue`) surfaces as a typed hermetic denial attributed to
+    /// that helper — not as toolchain corruption, and not attributed to the first
+    /// parked demand (`option`).
+    #[test]
+    fn read_line_transitive_manifest_denial_is_hermetic_and_attributed_to_helper() {
+        let project = TestDir::new("transitive-denied-project");
+        let stdlib = TestDir::new("transitive-denied-std");
+        let main = project.write("main.rue", READ_LINE_ROOT);
+        let std_root = write_read_line_std(&stdlib);
+        // Allow the root and every trusted leaf EXCEPT arraybuf.rue.
+        let root_canonical = fs::canonicalize(&main).unwrap();
+        let option_canonical = fs::canonicalize(std_root.join("option.rue")).unwrap();
+        let strbuf_canonical = fs::canonicalize(std_root.join("strbuf.rue")).unwrap();
+        let rawbuf_canonical = fs::canonicalize(std_root.join("rawbuf.rue")).unwrap();
+        let manifest = manifest_allowing(
+            &project,
+            &[
+                &root_canonical,
+                &option_canonical,
+                &strbuf_canonical,
+                &rawbuf_canonical,
+            ],
+        );
+
+        let error = load_and_acquire(&main, Some(manifest), Some(&std_root))
+            .expect_err("a manifest-denied transitive helper cannot be acquired");
+        let SourceLoadError::HermeticDenial(denial) = &error else {
+            panic!("a transitive manifest denial must be a hermetic denial: {error:?}");
+        };
+        let message = denial.to_string();
+        assert!(
+            message.contains("arraybuf.rue"),
+            "the denial must name the denied helper: {message}"
+        );
+        assert!(
+            !message.contains("option.rue"),
+            "the denial must not be attributed to the first demand: {message}"
+        );
+    }
+
+    /// A malformed transitive helper (`arraybuf.rue` with garbage, imported by
+    /// `strbuf.rue`) is classified as a malformed toolchain module attributed to
+    /// `arraybuf.rue` — not to `option.rue` or `strbuf.rue`.
+    #[test]
+    fn read_line_malformed_transitive_helper_is_attributed_to_that_helper() {
+        let project = TestDir::new("transitive-malformed-project");
+        let stdlib = TestDir::new("transitive-malformed-std");
+        let main = project.write("main.rue", READ_LINE_ROOT);
+        let std_root = write_read_line_std(&stdlib);
+        // Corrupt only the transitive helper; option and strbuf remain valid.
+        stdlib.write("arraybuf.rue", MALFORMED_OPTION);
+
+        let error = load_and_acquire(&main, None, Some(&std_root))
+            .expect_err("a malformed transitive helper is a toolchain-integrity error");
+        let SourceLoadError::Toolchain(ToolchainIntegrityError::Malformed {
+            logical_path,
+            path,
+            ..
+        }) = &error
+        else {
+            panic!("a malformed transitive helper must classify as Malformed: {error:?}");
+        };
+        assert!(
+            logical_path.contains("arraybuf.rue"),
+            "the malformed leaf must be named by its logical path: {logical_path}"
+        );
+        assert!(
+            path.to_string_lossy().contains("arraybuf.rue"),
+            "the malformed leaf must be named by its filesystem path: {}",
+            path.display()
+        );
+        assert!(
+            !logical_path.contains("option.rue") && !logical_path.contains("strbuf.rue"),
+            "the malformed leaf must not be attributed to option or strbuf: {logical_path}"
+        );
+    }
+
+    /// A missing transitive helper (`arraybuf.rue` absent though `strbuf.rue`
+    /// imports it) is a toolchain-integrity error identifying that leaf.
+    #[test]
+    fn read_line_missing_transitive_helper_identifies_that_helper() {
+        let project = TestDir::new("transitive-missing-project");
+        let stdlib = TestDir::new("transitive-missing-std");
+        let main = project.write("main.rue", READ_LINE_ROOT);
+        // Write the tree, then remove the transitive helper strbuf imports.
+        let std_root = write_read_line_std(&stdlib);
+        fs::remove_file(std_root.join("arraybuf.rue")).unwrap();
+
+        let error = load_and_acquire(&main, None, Some(&std_root))
+            .expect_err("a missing transitive helper is a toolchain-integrity error");
+        let SourceLoadError::Toolchain(ToolchainIntegrityError::Missing { logical_path, path }) =
+            &error
+        else {
+            panic!("a missing transitive helper must classify as Missing: {error:?}");
+        };
+        assert!(
+            logical_path.contains("arraybuf.rue")
+                || path.to_string_lossy().contains("arraybuf.rue"),
+            "the missing leaf must be named: logical={logical_path} path={}",
+            path.display()
+        );
+        assert!(
+            !logical_path.contains("option.rue"),
+            "the missing leaf must not be attributed to the first demand: {logical_path}"
+        );
     }
 }

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -389,7 +389,7 @@ The `@read_line` intrinsic reads a line of text from standard input.
 
 {{ rule(id="4.13:35", cat="normative") }}
 
-The return type of `@read_line` is `Option(StrBuf)`, where `Option` is the ordinary comptime-generic library enum (`enum { Some(T), None }`, ADR-0038). The concrete `Option(StrBuf)` type is taken from the surrounding context — a `let` binding annotation, or the arms of a `match` on the result — so `Option` must be in scope (e.g. imported) at the call site. As a special case, when `@read_line()` is the operand of the `?` operator (§4.15), the context supplies no annotation, so the intrinsic instantiates its own `Option(StrBuf)` directly (see rule 4.15:9).
+The return type of `@read_line` is the trusted standard `Option` specialized at `StrBuf` — the producer-nominal enum declared by `std.option.Option` (`std/option.rue`, ADR-0038), instantiated as `Option(StrBuf)`. The intrinsic yields this exact standard specialization in every context: bare as the operand of the `?` operator (§4.15), as the initializer of an annotated `let`, as the scrutinee of a `match`, or as a freestanding expression. Surrounding context never *selects* which nominal the intrinsic produces; when an annotation or `match` is present it only *checks* that the intrinsic's standard `Option(StrBuf)` matches, and any other type — including a user-defined enum that repeats the `Some`/`None` shape under a different producer — is an ordinary type error (E0702). Because the standard `Option` is a toolchain guarantee, `@read_line` has this type even in a program that does not import `std` lexically; the compiler roots the trusted-module demand itself, and an absent standard library is a toolchain-integrity error rather than a language state.
 
 {{ rule(id="4.13:36", cat="dynamic-semantics") }}
 
@@ -459,13 +459,13 @@ The integer parsing intrinsics convert a string to an integer value.
 
 {{ rule(id="4.13:44", cat="normative") }}
 
-Each parsing intrinsic returns `Option(T)` for its target integer type `T`, where `Option` is the ordinary comptime-generic library enum (ADR-0038):
+Each parsing intrinsic returns the trusted standard `Option` specialized at its target integer type `T` — the producer-nominal enum declared by `std.option.Option` (`std/option.rue`, ADR-0038):
 - `@parse_i32` returns `Option(i32)`
 - `@parse_i64` returns `Option(i64)`
 - `@parse_u32` returns `Option(u32)`
 - `@parse_u64` returns `Option(u64)`
 
-The concrete `Option(T)` type is taken from the surrounding context (a `let` annotation, or the arms of a `match` on the result), so `Option` must be in scope at the call site. As a special case, when a parsing intrinsic is the operand of the `?` operator (§4.15), the intrinsic instantiates its own `Option(T)` directly (see rule 4.15:9).
+The intrinsic yields this exact standard specialization in every context — bare as the operand of the `?` operator (§4.15), as the initializer of an annotated `let`, as the scrutinee of a `match`, or as a freestanding expression. Surrounding context never *selects* the nominal; when present it only *checks* that the intrinsic's standard `Option(T)` matches, and any other type — including a user-defined `Some`/`None` lookalike under a different producer — is an ordinary type error (E0702). As with `@read_line` (rule 4.13:35), the compiler roots the trusted standard `Option` itself, so a parsing intrinsic has this type even without a lexical `std` import.
 
 {{ rule(id="4.13:45", cat="normative") }}
 

--- a/docs/spec/src/04-expressions/15-try-expressions.md
+++ b/docs/spec/src/04-expressions/15-try-expressions.md
@@ -24,15 +24,29 @@ The `?` operator is postfix and binds as tightly as the other postfix operators
 
 {{ rule(id="4.15:3", cat="legality-rule") }}
 
-The operand of `?` **MUST** have an `Option` type: an enum with exactly two
-variants, a single-payload `Some(T)` and a payload-less `None`. Applying `?` to
-any other type is a compile error (E0504).
+The operand of `?` **MUST** have a type that is an exact specialization of a
+*trusted producer*: the standard `Option` declared by `std.option.Option`
+(`std/option.rue`) or the standard `Result` declared by `std.result.Result`
+(`std/result.rue`) (ADR-0038). The trusted producers are exactly these two
+standard declarations. A user-defined enum that repeats the `Some`/`None` or
+`Ok`/`Err` shape under a different producer is an ordinary enum (§4.14), not a
+trusted producer, and receives no `?` behavior. Applying `?` to such a
+lookalike, or to any other type, is a compile error (E0504).
 
 {{ rule(id="4.15:4", cat="legality-rule") }}
 
 A try expression **MUST** appear in the body of a function whose declared return
-type is an `Option`. Using `?` in a function that does not return an `Option` is
-a compile error (E0503).
+type is an exact specialization of the **same** trusted producer as the operand
+(rule 4.15:3). When the operand is a standard `Option(T)`, the enclosing function
+**MUST** return a standard `Option(U)`; the success payload may differ (`U` need
+not equal `T`), but using `?` in a function that does not return a standard
+`Option` is a compile error (E0503). When the operand is a standard
+`Result(T, E)`, the enclosing function **MUST** return a standard `Result(U, E)`
+whose error type `E` is **identical** to the operand's — Rue has no error
+conversion until traits exist. Using `?` on a `Result` in a function that does
+not return a standard `Result` is a compile error (E0505), and a mismatched
+error type is a compile error (E0506). In every case the failure arm constructs
+the `None` or `Err(e)` of the enclosing function's own return type (rule 4.15:7).
 
 {{ rule(id="4.15:5", cat="normative") }}
 
@@ -63,24 +77,22 @@ where the returned `None` is the `None` variant of the enclosing function's
 {{ rule(id="4.15:8") }}
 
 ```rue
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
+const std = @import("std");
 
-fn checked_div(a: i64, b: i64) -> Option(i64) {
-    let O = Option(i64);
+fn checked_div(a: i64, b: i64) -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
     if b == 0 { O.None } else { O.Some(a / b) }
 }
 
-fn halve_then_div(a: i64, b: i64) -> Option(i64) {
-    let O = Option(i64);
+fn halve_then_div(a: i64, b: i64) -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
     // `?` unwraps the quotient, or short-circuits to None when b == 0.
     let q = checked_div(a, b)?;
     O.Some(q / 2)
 }
 
 fn main() -> i32 {
-    let O = Option(i64);
+    let O = std.option.Option(i64);
     match halve_then_div(40, 4) {
         O.Some(n) => n,      // 40 / 4 / 2 == 5
         O.None => 0 - 1,
@@ -91,30 +103,31 @@ fn main() -> i32 {
 {{ rule(id="4.15:9", cat="normative") }}
 
 When the operand of `?` is a bare call to a fallible intrinsic — `@read_line`
-or one of the `@parse_*` intrinsics (§4.13) — the intrinsic's `Option` type is
-resolved from the intrinsic itself rather than from a surrounding annotation or
-`match`. Each such intrinsic has a fixed payload (`@read_line` → `StrBuf`,
-`@parse_i64` → `i64`, and so on), so `operand?` unwraps to that payload and
-short-circuits the enclosing function with its `None` on failure. This is what
-lets `@read_line()?` and `@parse_i64(s)?` be written directly, without first
-binding the result to an annotated `let` (RUE-318).
+or one of the `@parse_*` intrinsics (§4.13) — no special resolution applies: the
+operand already has the trusted standard `Option` type that the intrinsic always
+produces (rules 4.13:35, 4.13:44). Its fixed payload (`@read_line` → `StrBuf`,
+`@parse_i64` → `i64`, and so on) is unwrapped by `?`, which short-circuits the
+enclosing standard-`Option`-returning function with the standard `None` on
+failure. This is what lets `@read_line()?` and `@parse_i64(s)?` be written
+directly, without first binding the result to an annotated `let` (RUE-318). The
+enclosing function still needs no lexical `std` import for the intrinsic's type
+to be the standard `Option` (rule 4.13:35).
 
 {{ rule(id="4.15:10") }}
 
 ```rue
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
+const std = @import("std");
 
 // `@read_line()?` short-circuits to None at end-of-input; the tail
-// `@parse_i64(line)` is None on a line that is not a number.
-fn read_num() -> Option(i64) {
+// `@parse_i64(line)` is None on a line that is not a number. Both intrinsics
+// already have the trusted standard `Option`, so no local `Option` is declared.
+fn read_num() -> std.option.Option(i64) {
     let line = @read_line()?;
     @parse_i64(line)
 }
 
 fn main() -> i32 {
-    let O = Option(i64);
+    let O = std.option.Option(i64);
     match read_num() {
         O.Some(n) => @intCast(n),
         O.None => 0,


### PR DESCRIPTION
Std `Option` (`std/option.rue`) and `Result` (`std/result.rue`) become the blessed fallible types, completing the RUE-1089 producer-nominal arc and unblocking the RUE-1090 measurement gate. Scope frozen on RUE-1113.

## Language decision

`?` accepts only exact specializations of the trusted std producers — operand and enclosing return each, same producer family both sides; the Option success payload may change; Result keeps the exact error-type rule. User-defined lookalike enums stay fully legal ordinary enums with no `?` behavior; the identifiers are not reserved. Every fallible intrinsic (`@read_line`, `@parse_i32/i64/u32/u64`) returns the exact std `Option(payload)` in every context; context checks that identity (E0702 on mismatch) and never selects a nominal. Std is a toolchain guarantee: freestanding programs need no lexical import for an intrinsic's own type, and a missing/unreadable/malformed trusted module is a deterministic toolchain-integrity error — distinct from a hermetic manifest denial (build-configuration error) — never a language state.

## Semantics machinery

A registered per-body `body_toolchain_demands` query derives typed trusted-module demands from each reached body's RIR (`?`-operand fallible intrinsics; `@read_line` also demands `StrBuf`). Semantic analysis parks before the body transaction when a reached body's demands are unsatisfied; parks batch deterministically across reached bodies and propagate out-of-band to the rooted attempt only. The resolved nominal is projected through a narrow per-body `WellKnownTypes` input, exported as body-produced state so identity is durable across composition. The last structural selector (`find_compatible_anon_enum`) is deleted; `?` legality is producer identity against the trusted endpoints, and lookalikes are rejected without materializing std.

## Host acquisition and the trusted successor

The driver owns a park/retry loop after import discovery closes: parked demands are satisfied by policy-checked reads under manifest authority and canonical containment (symlink escapes rejected), published as a strictly-additive successor, and discovery re-closes in the same request generation. Pre-semantic `--emit` never parks and reads zero std. Transitive std helpers (`strbuf → option/arraybuf/rawbuf`) are discovered from the new leaves only, each read exactly once, with failures attributed to the actual failing leaf.

Publication is capability-gated end to end: an opaque, compiler-derived successor delta — bound to session, nonce, revision, and the verified appended set, lineage-complete across snapshot, context, provenance, and ledger — makes omission, injection, and same-ID predecessor mutation inexpressible; frontier batches extend the lineage only by their own accepted additions; any external source/presentation update invalidates outstanding authority.

The re-close is O(delta) at every layer, proven by work counters asserted flat or zero across small-vs-large predecessor topologies: sparse immutable revision overlays inherit predecessor leaves structurally (`publish_revision_overlay` in rue-query, with compatibility-epoch and retention/lease-correct parent handling); `SharedSegments` carries plan, graph, resolution table, ledger, manifest, snapshot, and parsed-program artifacts as Arc-shared predecessor segments plus sorted deltas (persistent across all acquisition rounds); successor query keys are `{published predecessor identity, exact delta}` with ordinary content-keyed warm reuse preserved; the successor parse observes its exact predecessor terminal through a content-addressed adoption capability (registration-gated, pin-under-lock endorsement, retention-accounted and bounded, provably no key hashing via a frozen-key regression); and adoption publishes the successor source leaf without disappearing the predecessor's, so retained downstream terminals survive acquisition (zero frontend invalidations asserted).

One bounded refinement is deferred to the RUE-1090 gate work: successor parse keys carry the cumulative lineage delta rather than the exact per-stage segment (predecessor-flat, bounded by the four-round driver).

## Spec + corpus

Rules 4.13:35/:44 amended (exact std Option in every context; context checks identity); 4.15:3/:4 amended (exact-specialization legality, E0503/E0504/E0505/E0506); 4.15:9 simplified (no selection rule). Corpus migrated to the trusted std types across spec try/intrinsics, CLI try_intrinsic/try_operator/stdin/programs, UI result_try, and the ABI-conformance fixture; new acceptance and adversarial coverage spans identity durability, per-body isolation, park/retry classification (missing/malformed/denied/transitive), capability forgery (omission/injection/mutation/substitution/stale/foreign), reclosure flatness, adoption soundness and boundedness, and preflight-vs-semantic diagnostic ordering.

## Validation

Spec 2178 · UI 204 · air 568 · compiler 735 · rue 186 · rue-query 53 · parser 43 · rir 59 · differential oracle, public-api, payload-schema, rue-oracle, scaling-matrix · CLI corpus green in CI (sharded) · clippy/fmt clean · direct executions: freestanding acquire-and-run, std-import `?`, plain `@parse`, zero-read pre-semantic emits, real-std `@read_line` end-to-end.

Fixes RUE-1112
Part of RUE-1089