### PR TITLE
RUE-1091: body-local semantic overlay + publication conversion (slice 2b)

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -9,6 +9,7 @@
 const PRODUCTION_MODULES: &[(&str, &str)] = &[
     ("artifact_views", include_str!("artifact_views.rs")),
     ("backend", include_str!("backend.rs")),
+    ("body_overlay", include_str!("body_overlay.rs")),
     ("body_query", include_str!("body_query.rs")),
     ("bound_definitions", include_str!("bound_definitions.rs")),
     ("canonical_lower", include_str!("canonical_lower.rs")),

--- a/crates/rue-compiler/src/body_overlay.rs
+++ b/crates/rue-compiler/src/body_overlay.rs
@@ -186,6 +186,24 @@ impl BodySemanticOverlay {
     pub(crate) fn module_slot_count(&self) -> usize {
         self.module_ids.len()
     }
+
+    /// The number of stable definition keys recorded in the forward mint map.
+    #[cfg(test)]
+    pub(crate) fn definition_slots_len(&self) -> usize {
+        self.definition_slots.len()
+    }
+
+    /// The number of module ids recorded in the forward mint map.
+    #[cfg(test)]
+    pub(crate) fn module_slots_len(&self) -> usize {
+        self.module_slots.len()
+    }
+
+    /// The number of recipes cached in the body-local stable-fact → local-ID map.
+    #[cfg(test)]
+    pub(crate) fn recipe_tokens_len(&self) -> usize {
+        self.recipe_tokens.len()
+    }
 }
 
 impl BodyOutcomeResolver for BodySemanticOverlay {
@@ -547,11 +565,12 @@ mod tests {
         );
     }
 
-    // A canceled overlay evaluation publishes nothing and retains no state: the
-    // request control state dominates before any recipe is materialized, so the
-    // overlay's token space stays empty and no `BodyTransaction` is produced.
+    // A cancellation observed BEFORE the body is reached publishes nothing and
+    // leaves the overlay empty: the request control state dominates before any
+    // recipe is materialized, so every map stays empty and no `BodyTransaction`
+    // is produced.
     #[test]
-    fn canceled_overlay_publishes_nothing_and_leaks_no_state() {
+    fn cancel_before_body_publishes_nothing_and_mints_no_state() {
         let inputs = BodyQueryInputs::build("fn main() -> i32 { 0 }");
         let key = inputs.body_key(StableDefinitionKind::Function, "main");
         let cancellation = rue_query::CancellationToken::new();
@@ -559,11 +578,61 @@ mod tests {
         let mut overlay = BodySemanticOverlay::new();
         let result = inputs.overlay(&key, &cancellation, &mut overlay);
         assert!(matches!(result, Err(rue_query::QueryAbort::Canceled)));
-        assert_eq!(
-            overlay.definition_slot_count(),
-            0,
-            "a canceled overlay materializes no recipe and retains no local ID"
-        );
+        // No recipe was materialized: every owned map is empty.
+        assert_eq!(overlay.definition_slot_count(), 0);
         assert_eq!(overlay.module_slot_count(), 0);
+        assert_eq!(overlay.definition_slots_len(), 0);
+        assert_eq!(overlay.module_slots_len(), 0);
+        assert_eq!(overlay.recipe_tokens_len(), 0);
+    }
+
+    // A cancellation observed MID-ANALYSIS — after the overlay has already
+    // materialized recipes and minted local slots — still publishes no partial
+    // overlay or dependency set. The injection flips cancellation between seeding
+    // and body analysis, so the overlay is populated at cancel time; the driver
+    // returns `Canceled` and produces no `BodyTransaction`. The overlay owns all
+    // of its state by value (owned `StableDefinitionKey`/`ModuleId` maps, no
+    // handle to live analysis state and no published artifact escapes), so
+    // dropping it is the end of that state — there is nothing left to retain.
+    #[test]
+    fn cancel_mid_analysis_with_populated_overlay_publishes_nothing() {
+        let inputs =
+            BodyQueryInputs::build("fn helper() -> i32 { 7 } fn main() -> i32 { helper() }");
+        let key = inputs.body_key(StableDefinitionKind::Function, "main");
+        // Not canceled at entry: the driver runs its prefix and seeds the overlay.
+        let cancellation = rue_query::CancellationToken::new();
+        let mut overlay = BodySemanticOverlay::new();
+        // Materialize a recipe first so the stable-fact -> local-ID cache is also
+        // populated at cancel time, not just the seed maps.
+        let recipe = definition_recipe("helper");
+        overlay.import_recipe(&recipe);
+
+        let result =
+            crate::canonical_semantic::with_test_overlay_cancel_after_seed_injection(|| {
+                inputs.overlay(&key, &cancellation, &mut overlay)
+            });
+        assert!(
+            matches!(result, Err(rue_query::QueryAbort::Canceled)),
+            "a mid-analysis cancellation must publish no transaction, got {result:?}"
+        );
+
+        // The overlay is populated: seeding minted a local token space and the
+        // recipe cache holds the imported fact.
+        assert!(
+            overlay.definition_slots_len() > 0,
+            "seed minted definitions"
+        );
+        assert!(overlay.module_slots_len() > 0, "seed minted modules");
+        assert_eq!(
+            overlay.recipe_tokens_len(),
+            1,
+            "the recipe was materialized"
+        );
+        assert!(overlay.definition_slot_count() >= overlay.recipe_tokens_len());
+
+        // No partial artifact escaped: `result` carries no `BodyTransaction`, and
+        // the overlay owns its whole token space by value. Dropping it reclaims
+        // every mint with no observable residue.
+        drop(overlay);
     }
 }

--- a/crates/rue-compiler/src/body_overlay.rs
+++ b/crates/rue-compiler/src/body_overlay.rs
@@ -82,7 +82,10 @@ impl BodySemanticOverlay {
     /// key. Interning in the caller's order assigns dense slots; seeding in the
     /// bound definition universe's sorted order therefore yields slots that
     /// mirror the whole-epoch token space, so publication resolves identically.
-    pub(crate) fn intern_definition(&mut self, key: &StableDefinitionKey) -> SemanticDefinitionToken {
+    pub(crate) fn intern_definition(
+        &mut self,
+        key: &StableDefinitionKey,
+    ) -> SemanticDefinitionToken {
         if let Some(&slot) = self.definition_slots.get(key) {
             return SemanticDefinitionToken::new(self.issuer, slot);
         }
@@ -236,8 +239,8 @@ mod tests {
         DurableDeclarationPayload, DurableDeclarationSemantic, DurableType,
     };
     use crate::{
-        CompileOptions, StableDefinitionKind, StableDefinitionNamespace, StablePreviewFeatures,
-        SourceMetadata, SourceSnapshot,
+        CompileOptions, SourceMetadata, SourceSnapshot, StableDefinitionKind,
+        StableDefinitionNamespace, StablePreviewFeatures,
     };
     use rue_span::FileId;
 
@@ -296,9 +299,15 @@ mod tests {
         );
         // The body-local cache makes a repeated import a constant-time read that
         // returns the same token and mints no second slot.
-        assert_eq!(first.import_recipe(&recipe), LocalToken::Definition(first_token));
+        assert_eq!(
+            first.import_recipe(&recipe),
+            LocalToken::Definition(first_token)
+        );
         assert_eq!(first.definition_slot_count(), 1);
-        assert_eq!(first.imported_local_token(&logical), Some(LocalToken::Definition(first_token)));
+        assert_eq!(
+            first.imported_local_token(&logical),
+            Some(LocalToken::Definition(first_token))
+        );
     }
 
     // Two overlays for different bodies share no local ID, slot pool, or recorded
@@ -321,7 +330,11 @@ mod tests {
         first.import_recipe(&private);
 
         assert_eq!(first.definition_slot_count(), 2);
-        assert_eq!(second.definition_slot_count(), 1, "second overlay is untouched");
+        assert_eq!(
+            second.definition_slot_count(),
+            1,
+            "second overlay is untouched"
+        );
         assert!(second.imported_local_token(&private_logical).is_none());
 
         // Distinct token spaces: the first overlay's shared token is a foreign
@@ -378,18 +391,17 @@ mod tests {
                     options.target,
                 )
                 .unwrap();
-            let query_shells =
-                crate::canonical_semantic::query_owned_declaration_shells_for_test(
-                    &merged,
-                    &rir,
-                    options.preview_features.clone(),
-                    options.target,
-                    &imports,
-                )
-                .unwrap()
-                .declaration_shells()
-                .cloned()
-                .collect::<Vec<_>>();
+            let query_shells = crate::canonical_semantic::query_owned_declaration_shells_for_test(
+                &merged,
+                &rir,
+                options.preview_features.clone(),
+                options.target,
+                &imports,
+            )
+            .unwrap()
+            .declaration_shells()
+            .cloned()
+            .collect::<Vec<_>>();
             Self {
                 merged,
                 rir,
@@ -401,7 +413,11 @@ mod tests {
             }
         }
 
-        fn body_key(&self, kind: StableDefinitionKind, name: &str) -> crate::body_query::BodyQueryKey {
+        fn body_key(
+            &self,
+            kind: StableDefinitionKind,
+            name: &str,
+        ) -> crate::body_query::BodyQueryKey {
             let definition = self
                 .definitions
                 .definitions()

--- a/crates/rue-compiler/src/body_overlay.rs
+++ b/crates/rue-compiler/src/body_overlay.rs
@@ -1,0 +1,553 @@
+//! Task-owned body-local semantic overlay (RUE-1091, ADR-0066 §4).
+//!
+//! Each body evaluation creates one `BodySemanticOverlay`. The overlay owns the
+//! body-local compact token space: it mints its own issuer-scoped
+//! `SemanticDefinitionToken`/`SemanticModuleToken` slots and records the
+//! stable-fact → local-ID mapping so repeated reads within the body are
+//! constant-time. Materializing a recipe mints the *consuming* overlay's local
+//! token; issuer-scoped tokens are never shared between two overlays, and no
+//! local ID, slot pool, or minted token is retained in a recipe. Publication
+//! converts the overlay result back to the durable body artifact through the
+//! shared `BodyOutcomeResolver`, so compact overlay IDs never cross the query
+//! boundary and the published diagnostics keep their upstream stable order.
+//!
+//! Slice 2b keeps this machinery inert to the production path: the production
+//! `analyze_body_query` still publishes through the whole-epoch
+//! `BoundDefinitionSet`. The overlay is exercised only by tests (and the
+//! test-only overlay driver in `canonical_semantic`).
+
+#![allow(dead_code)] // RUE-1091 slice 2b is inert: driven by later slices.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use rue_air::{
+    BodyOwnerToken, SemanticDefinitionToken, SemanticModuleToken, SemanticStableResolutionFailure,
+};
+
+use crate::canonical_semantic::BodyOutcomeResolver;
+use crate::declaration_recipe::{DeclarationRecipe, EndpointRecipe, RecipeLogicalKey};
+use crate::{ModuleId, StableDefinitionKey};
+
+/// The overlay-local token minted for one imported recipe. It is scoped to the
+/// overlay's issuer and is meaningless in any other overlay.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LocalToken {
+    Definition(SemanticDefinitionToken),
+    Module(SemanticModuleToken),
+}
+
+/// A fresh overlay issuer per body. The counter only needs to make distinct
+/// overlays mint distinct issuer-scoped token spaces; the value is never
+/// compared across overlays except by inequality.
+static NEXT_OVERLAY_ISSUER: AtomicU64 = AtomicU64::new(1);
+
+/// One task-owned body-local semantic overlay.
+///
+/// The overlay owns every compact ID it hands out. Definition slots are dense
+/// indices into `definition_keys` (the reverse map used by publication) and are
+/// interned through `definition_slots` (the forward map used to drive analysis);
+/// module slots are dense indices into `module_ids`. `recipe_tokens` is the
+/// body-local stable-fact → local-ID cache guaranteeing constant-time repeated
+/// imports of the same recipe.
+pub(crate) struct BodySemanticOverlay {
+    issuer: u64,
+    definition_keys: Vec<Option<StableDefinitionKey>>,
+    definition_slots: HashMap<StableDefinitionKey, u32>,
+    module_ids: Vec<ModuleId>,
+    module_slots: HashMap<ModuleId, u32>,
+    recipe_tokens: HashMap<RecipeLogicalKey, LocalToken>,
+}
+
+impl BodySemanticOverlay {
+    /// Create an empty overlay with a fresh, unshared local token space.
+    pub(crate) fn new() -> Self {
+        Self {
+            issuer: NEXT_OVERLAY_ISSUER.fetch_add(1, Ordering::Relaxed),
+            definition_keys: Vec::new(),
+            definition_slots: HashMap::new(),
+            module_ids: Vec::new(),
+            module_slots: HashMap::new(),
+            recipe_tokens: HashMap::new(),
+        }
+    }
+
+    /// This overlay's issuer. Two overlays never share an issuer, so a token
+    /// minted here is rejected by any other overlay's resolver.
+    pub(crate) fn issuer(&self) -> u64 {
+        self.issuer
+    }
+
+    /// Mint (or return the existing) overlay-local definition token for a stable
+    /// key. Interning in the caller's order assigns dense slots; seeding in the
+    /// bound definition universe's sorted order therefore yields slots that
+    /// mirror the whole-epoch token space, so publication resolves identically.
+    pub(crate) fn intern_definition(&mut self, key: &StableDefinitionKey) -> SemanticDefinitionToken {
+        if let Some(&slot) = self.definition_slots.get(key) {
+            return SemanticDefinitionToken::new(self.issuer, slot);
+        }
+        let slot = self.definition_keys.len() as u32;
+        self.definition_keys.push(Some(key.clone()));
+        self.definition_slots.insert(key.clone(), slot);
+        SemanticDefinitionToken::new(self.issuer, slot)
+    }
+
+    /// Mint an overlay-local module token for a module id.
+    pub(crate) fn intern_module(&mut self, module: &ModuleId) -> SemanticModuleToken {
+        if let Some(&slot) = self.module_slots.get(module) {
+            return SemanticModuleToken::new(self.issuer, slot);
+        }
+        let slot = self.module_ids.len() as u32;
+        self.module_ids.push(module.clone());
+        self.module_slots.insert(module.clone(), slot);
+        SemanticModuleToken::new(self.issuer, slot)
+    }
+
+    /// A definition endpoint recipe carries a resolvable identity but not the
+    /// full stable definition key. It still mints an owned local slot so the
+    /// token space stays dense; the reverse map records no key, which publication
+    /// treats as unresolved (analysis never issues such a token for a real body).
+    fn mint_endpoint_definition(&mut self) -> SemanticDefinitionToken {
+        let slot = self.definition_keys.len() as u32;
+        self.definition_keys.push(None);
+        SemanticDefinitionToken::new(self.issuer, slot)
+    }
+
+    /// Lazily import a recipe, minting this overlay's local token on first
+    /// consumption and recording the stable-fact → local-ID mapping. A repeated
+    /// import of the same recipe is a constant-time cache read that returns the
+    /// same local token and never mints a second slot.
+    pub(crate) fn import_recipe(&mut self, recipe: &DeclarationRecipe) -> LocalToken {
+        let logical = recipe.logical_key();
+        if let Some(token) = self.recipe_tokens.get(&logical) {
+            return *token;
+        }
+        let token = match recipe {
+            DeclarationRecipe::Definition(recipe) => {
+                LocalToken::Definition(self.intern_definition(&recipe.key))
+            }
+            DeclarationRecipe::BodyOwner(recipe) => {
+                LocalToken::Definition(self.intern_definition(&recipe.key))
+            }
+            DeclarationRecipe::Module(recipe) => {
+                LocalToken::Module(self.intern_module(&recipe.module))
+            }
+            DeclarationRecipe::Endpoint(EndpointRecipe::Module(recipe)) => {
+                LocalToken::Module(self.intern_module(&recipe.module))
+            }
+            DeclarationRecipe::Endpoint(EndpointRecipe::Definition(_)) => {
+                LocalToken::Definition(self.mint_endpoint_definition())
+            }
+        };
+        self.recipe_tokens.insert(logical, token);
+        token
+    }
+
+    /// The overlay-local definition token previously minted for a stable key, or
+    /// `Missing` if the body never imported that fact. Used to drive analysis.
+    pub(crate) fn semantic_token_for_key(
+        &self,
+        key: &StableDefinitionKey,
+    ) -> Result<SemanticDefinitionToken, SemanticStableResolutionFailure> {
+        self.definition_slots
+            .get(key)
+            .map(|&slot| SemanticDefinitionToken::new(self.issuer, slot))
+            .ok_or(SemanticStableResolutionFailure::Missing)
+    }
+
+    /// The overlay-local module token previously minted for a module id.
+    pub(crate) fn module_token_for(
+        &self,
+        module: &ModuleId,
+    ) -> Result<SemanticModuleToken, SemanticStableResolutionFailure> {
+        self.module_slots
+            .get(module)
+            .map(|&slot| SemanticModuleToken::new(self.issuer, slot))
+            .ok_or(SemanticStableResolutionFailure::Missing)
+    }
+
+    /// The stable identity mapping recorded for a previously imported recipe, if
+    /// any. Two overlays that imported the same recipe map it to distinct local
+    /// tokens but to the same stable identity through their reverse maps.
+    #[cfg(test)]
+    pub(crate) fn imported_local_token(&self, logical: &RecipeLogicalKey) -> Option<LocalToken> {
+        self.recipe_tokens.get(logical).copied()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn definition_slot_count(&self) -> usize {
+        self.definition_keys.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn module_slot_count(&self) -> usize {
+        self.module_ids.len()
+    }
+}
+
+impl BodyOutcomeResolver for BodySemanticOverlay {
+    fn key_for_semantic_token(
+        &self,
+        token: SemanticDefinitionToken,
+    ) -> Result<StableDefinitionKey, SemanticStableResolutionFailure> {
+        if token.issuer() != self.issuer {
+            return Err(SemanticStableResolutionFailure::ForeignIssuer);
+        }
+        self.definition_keys
+            .get(token.slot() as usize)
+            .and_then(|key| key.clone())
+            .ok_or(SemanticStableResolutionFailure::Missing)
+    }
+
+    fn module_for_semantic_token(
+        &self,
+        token: SemanticModuleToken,
+    ) -> Result<ModuleId, SemanticStableResolutionFailure> {
+        if token.issuer() != self.issuer {
+            return Err(SemanticStableResolutionFailure::ForeignIssuer);
+        }
+        self.module_ids
+            .get(token.slot() as usize)
+            .cloned()
+            .ok_or(SemanticStableResolutionFailure::Missing)
+    }
+
+    fn definition_key_for_body_token(
+        &self,
+        token: BodyOwnerToken,
+    ) -> Result<StableDefinitionKey, String> {
+        if token.issuer() != self.issuer {
+            return Err("body owner token belongs to a foreign overlay issuer".to_owned());
+        }
+        self.definition_keys
+            .get(token.slot() as usize)
+            .and_then(|key| key.clone())
+            .ok_or_else(|| "body owner token has an invalid overlay slot".to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::declaration_recipe::{DeclarationRecipe, DefinitionRecipe};
+    use crate::durable_semantics::{
+        DurableDeclarationPayload, DurableDeclarationSemantic, DurableType,
+    };
+    use crate::{
+        CompileOptions, StableDefinitionKind, StableDefinitionNamespace, StablePreviewFeatures,
+        SourceMetadata, SourceSnapshot,
+    };
+    use rue_span::FileId;
+
+    fn definition_recipe(name: &str) -> DeclarationRecipe {
+        let key = StableDefinitionKey::for_test(
+            ModuleId::from_logical_path("pkg/main.rue").unwrap(),
+            StableDefinitionNamespace::Value,
+            StableDefinitionKind::Function,
+            name,
+            None,
+        );
+        DeclarationRecipe::Definition(Box::new(DefinitionRecipe::from_durable(
+            &DurableDeclarationSemantic {
+                key,
+                is_public: true,
+                payload: DurableDeclarationPayload::Callable {
+                    parameters: Arc::from([]),
+                    result: DurableType::Unit,
+                    has_self: false,
+                    is_unchecked: false,
+                },
+            },
+            &[],
+        )))
+    }
+
+    // Two overlays that materialize the SAME recipe mint distinct local tokens
+    // (distinct issuer-scoped token spaces) while recording the same stable
+    // identity. This is the local-token-minting invariant: a recipe carries no
+    // token, and each consuming overlay mints its own.
+    #[test]
+    fn same_recipe_mints_distinct_local_tokens_with_equal_stable_identity() {
+        let recipe = definition_recipe("apply");
+        let logical = recipe.logical_key();
+
+        let mut first = BodySemanticOverlay::new();
+        let mut second = BodySemanticOverlay::new();
+        assert_ne!(first.issuer(), second.issuer(), "overlays share no issuer");
+
+        let first_token = first.import_recipe(&recipe);
+        let second_token = second.import_recipe(&recipe);
+        assert_ne!(
+            first_token, second_token,
+            "the same recipe must mint distinct local tokens in two overlays"
+        );
+
+        let (LocalToken::Definition(first_token), LocalToken::Definition(second_token)) =
+            (first_token, second_token)
+        else {
+            panic!("a definition recipe mints a definition token");
+        };
+        // Same stable identity through each overlay's own reverse map.
+        assert_eq!(
+            first.key_for_semantic_token(first_token).unwrap(),
+            second.key_for_semantic_token(second_token).unwrap()
+        );
+        // The body-local cache makes a repeated import a constant-time read that
+        // returns the same token and mints no second slot.
+        assert_eq!(first.import_recipe(&recipe), LocalToken::Definition(first_token));
+        assert_eq!(first.definition_slot_count(), 1);
+        assert_eq!(first.imported_local_token(&logical), Some(LocalToken::Definition(first_token)));
+    }
+
+    // Two overlays for different bodies share no local ID, slot pool, or recorded
+    // mapping. Mutating one overlay is invisible to the other, proven by both
+    // construction (distinct issuers) and assertion (independent maps).
+    #[test]
+    fn two_overlays_share_no_local_state() {
+        let shared = definition_recipe("shared");
+        let shared_logical = shared.logical_key();
+        let private = definition_recipe("private_to_first");
+        let private_logical = private.logical_key();
+
+        let mut first = BodySemanticOverlay::new();
+        let mut second = BodySemanticOverlay::new();
+
+        first.import_recipe(&shared);
+        second.import_recipe(&shared);
+
+        // Mutate only the first overlay.
+        first.import_recipe(&private);
+
+        assert_eq!(first.definition_slot_count(), 2);
+        assert_eq!(second.definition_slot_count(), 1, "second overlay is untouched");
+        assert!(second.imported_local_token(&private_logical).is_none());
+
+        // Distinct token spaces: the first overlay's shared token is a foreign
+        // issuer to the second overlay's resolver, so it never resolves there.
+        let LocalToken::Definition(first_shared) =
+            first.imported_local_token(&shared_logical).unwrap()
+        else {
+            unreachable!()
+        };
+        assert!(
+            second.key_for_semantic_token(first_shared).is_err(),
+            "one overlay's token must be foreign to another overlay"
+        );
+    }
+
+    fn snapshot(source: &str) -> SourceSnapshot {
+        let file = FileId::new(1);
+        let metadata = SourceMetadata::new(
+            file,
+            [(file, "/main.rue".to_owned())].into_iter().collect(),
+            [(file, "main.rue".to_owned())].into_iter().collect(),
+        )
+        .unwrap();
+        SourceSnapshot::new(
+            metadata,
+            [(file, Arc::new(source.to_owned()))].into_iter().collect(),
+        )
+        .unwrap()
+    }
+
+    struct BodyQueryInputs {
+        merged: crate::CanonicalMergedProgram,
+        rir: crate::CanonicalRirOutput,
+        options: CompileOptions,
+        imports: crate::CanonicalImportGraph,
+        query_shells: Vec<rue_air::SemanticDeclarationShell>,
+        query_declarations: Arc<[DurableDeclarationSemantic]>,
+        definitions: crate::bound_definitions::BoundDefinitionSet,
+    }
+
+    impl BodyQueryInputs {
+        fn build(source: &str) -> Self {
+            let snapshot = snapshot(source);
+            let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
+            let merged = crate::merge_parsed_modules(&parsed).unwrap();
+            let rir = crate::lower_canonical_rir(&merged).unwrap();
+            let options = CompileOptions::default();
+            let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+            let (definitions, query_declarations, _) =
+                crate::bound_definitions::bind_canonical_declaration_semantics(
+                    &merged,
+                    &rir,
+                    options.preview_features.clone(),
+                    options.target,
+                )
+                .unwrap();
+            let query_shells =
+                crate::canonical_semantic::query_owned_declaration_shells_for_test(
+                    &merged,
+                    &rir,
+                    options.preview_features.clone(),
+                    options.target,
+                    &imports,
+                )
+                .unwrap()
+                .declaration_shells()
+                .cloned()
+                .collect::<Vec<_>>();
+            Self {
+                merged,
+                rir,
+                options,
+                imports,
+                query_shells,
+                query_declarations,
+                definitions,
+            }
+        }
+
+        fn body_key(&self, kind: StableDefinitionKind, name: &str) -> crate::body_query::BodyQueryKey {
+            let definition = self
+                .definitions
+                .definitions()
+                .iter()
+                .find(|record| {
+                    record.stable_key().kind() == kind && record.stable_key().name() == name
+                })
+                .unwrap_or_else(|| panic!("no {kind:?} named {name}"))
+                .stable_key()
+                .clone();
+            crate::body_query::BodyQueryKey {
+                instance: crate::FunctionInstanceKey::Definition(definition),
+                configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration {
+                    target: self.options.target,
+                    preview_features: StablePreviewFeatures::new(&self.options.preview_features),
+                },
+            }
+        }
+
+        fn production(
+            &self,
+            key: &crate::body_query::BodyQueryKey,
+            cancellation: &rue_query::CancellationToken,
+        ) -> Result<crate::body_query::BodyTransaction, rue_query::QueryAbort> {
+            let mut work = rue_air::PerBodyDeclarationContextWork::default();
+            crate::canonical_semantic::analyze_body_query(
+                &self.merged,
+                &self.rir,
+                &self.options,
+                &self.imports,
+                &self.query_shells,
+                &self.query_declarations,
+                &[],
+                &crate::body_query::WellKnownOptionResolution::default(),
+                key,
+                cancellation,
+                &mut work,
+            )
+        }
+
+        fn overlay(
+            &self,
+            key: &crate::body_query::BodyQueryKey,
+            cancellation: &rue_query::CancellationToken,
+            overlay: &mut BodySemanticOverlay,
+        ) -> Result<crate::body_query::BodyTransaction, rue_query::QueryAbort> {
+            crate::canonical_semantic::analyze_body_via_overlay(
+                &self.merged,
+                &self.rir,
+                &self.options,
+                &self.imports,
+                &self.query_shells,
+                &self.query_declarations,
+                &[],
+                &crate::body_query::WellKnownOptionResolution::default(),
+                key,
+                cancellation,
+                overlay,
+            )
+        }
+    }
+
+    // An overlay-built body result publishes a durable `BodyTransaction` equal to
+    // what the production `BoundDefinitionSet` path publishes for the same body,
+    // across representative bodies: a plain free function, a method with a
+    // receiver, and a producer body that materializes a producer-nominal
+    // anonymous type. Equality includes references, produced nominals, and the
+    // canonical body itself.
+    #[test]
+    fn overlay_publication_equals_production_for_representative_bodies() {
+        let cases: &[(&str, StableDefinitionKind, &str)] = &[
+            (
+                "fn add(x: i32, y: i32) -> i32 { x + y } fn main() -> i32 { add(1, 2) }",
+                StableDefinitionKind::Function,
+                "main",
+            ),
+            (
+                "struct Counter { value: i32, fn get(self) -> i32 { self.value } } \
+                 fn main() -> i32 { Counter { value: 3 }.get() }",
+                StableDefinitionKind::Method,
+                "get",
+            ),
+            (
+                "fn Pair() -> type { struct { a: i32, b: i32 } } \
+                 fn main() -> i32 { let P = Pair(); let p: P = P { a: 1, b: 2 }; p.a + p.b }",
+                StableDefinitionKind::Function,
+                "Pair",
+            ),
+        ];
+        for (source, kind, name) in cases {
+            let inputs = BodyQueryInputs::build(source);
+            let key = inputs.body_key(*kind, name);
+            let cancellation = rue_query::CancellationToken::new();
+            let production = inputs.production(&key, &cancellation).unwrap();
+            let mut overlay = BodySemanticOverlay::new();
+            let overlaid = inputs.overlay(&key, &cancellation, &mut overlay).unwrap();
+            assert!(
+                crate::body_query::transaction_equal(&production, &overlaid),
+                "overlay publication diverged from production for body `{name}`:\n  \
+                 production={production:?}\n  overlay={overlaid:?}"
+            );
+            // The overlay owns a token space disjoint from any epoch's.
+            assert!(overlay.definition_slot_count() > 0);
+        }
+    }
+
+    // A body that fails semantic analysis through the overlay yields the same
+    // deterministic failure artifact and the same ordered diagnostics as the
+    // production path. `transaction_equal` compares the rendered diagnostic
+    // stream, so an ordering difference would fail this assertion.
+    #[test]
+    fn overlay_publication_equals_production_for_a_failing_body() {
+        let inputs = BodyQueryInputs::build("fn main() -> i32 { true }");
+        let key = inputs.body_key(StableDefinitionKind::Function, "main");
+        let cancellation = rue_query::CancellationToken::new();
+        let production = inputs.production(&key, &cancellation).unwrap();
+        assert!(matches!(
+            production,
+            crate::body_query::BodyTransaction::DeterministicFailure { .. }
+        ));
+        let mut overlay = BodySemanticOverlay::new();
+        let overlaid = inputs.overlay(&key, &cancellation, &mut overlay).unwrap();
+        assert!(
+            crate::body_query::transaction_equal(&production, &overlaid),
+            "overlay failure diverged from production:\n  production={production:?}\n  \
+             overlay={overlaid:?}"
+        );
+    }
+
+    // A canceled overlay evaluation publishes nothing and retains no state: the
+    // request control state dominates before any recipe is materialized, so the
+    // overlay's token space stays empty and no `BodyTransaction` is produced.
+    #[test]
+    fn canceled_overlay_publishes_nothing_and_leaks_no_state() {
+        let inputs = BodyQueryInputs::build("fn main() -> i32 { 0 }");
+        let key = inputs.body_key(StableDefinitionKind::Function, "main");
+        let cancellation = rue_query::CancellationToken::new();
+        cancellation.cancel();
+        let mut overlay = BodySemanticOverlay::new();
+        let result = inputs.overlay(&key, &cancellation, &mut overlay);
+        assert!(matches!(result, Err(rue_query::QueryAbort::Canceled)));
+        assert_eq!(
+            overlay.definition_slot_count(),
+            0,
+            "a canceled overlay materializes no recipe and retains no local ID"
+        );
+        assert_eq!(overlay.module_slot_count(), 0);
+    }
+}

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -1511,8 +1511,7 @@ pub(crate) fn project_function_instance_key(
 
 fn project_produced_anonymous_nominals(
     values: &[rue_air::SemanticProducedAnonymousNominal],
-    merged: &CanonicalMergedProgram,
-    definitions: &BoundDefinitionSet,
+    resolver: &dyn BodyOutcomeResolver,
 ) -> Result<
     crate::body_query::BodyProducedAnonymousNominals,
     rue_air::SemanticStableResolutionFailure,
@@ -1528,12 +1527,8 @@ fn project_produced_anonymous_nominals(
         rue_air::SemanticModuleToken,
     >| {
         let ty = ty.try_map_identities(
-            &|token| definitions.key_for_semantic_token(*token).cloned(),
-            &|token| {
-                definitions
-                    .module_for_semantic_token(merged, *token)
-                    .cloned()
-            },
+            &|token| resolver.key_for_semantic_token(*token),
+            &|token| resolver.module_for_semantic_token(*token),
         )?;
         crate::revisioned_query_database::durable_type_from_instance_key(&ty)
             .ok_or(rue_air::SemanticStableResolutionFailure::WrongKind)
@@ -1543,12 +1538,8 @@ fn project_produced_anonymous_nominals(
         rue_air::SemanticModuleToken,
     >| {
         let value = value.try_map_identities(
-            &|token| definitions.key_for_semantic_token(*token).cloned(),
-            &|token| {
-                definitions
-                    .module_for_semantic_token(merged, *token)
-                    .cloned()
-            },
+            &|token| resolver.key_for_semantic_token(*token),
+            &|token| resolver.module_for_semantic_token(*token),
         )?;
         crate::revisioned_query_database::durable_value_from_argument(&value)
             .ok_or(rue_air::SemanticStableResolutionFailure::WrongKind)
@@ -1563,12 +1554,8 @@ fn project_produced_anonymous_nominals(
         .iter()
         .map(|value| {
             let identity = value.identity.try_map_identities(
-                &|token| definitions.key_for_semantic_token(*token).cloned(),
-                &|token| {
-                    definitions
-                        .module_for_semantic_token(merged, *token)
-                        .cloned()
-                },
+                &|token| resolver.key_for_semantic_token(*token),
+                &|token| resolver.module_for_semantic_token(*token),
             )?;
             let method_type = |ty: &rue_air::SemanticProducedAnonymousMethodType| {
                 Ok(match ty {
@@ -1676,8 +1663,7 @@ pub(crate) fn analyze_body_query(
     // any stage and never charges installation for a body that never installed.
     work: &mut PerBodyDeclarationContextWork,
 ) -> Result<crate::body_query::BodyTransaction, rue_query::QueryAbort> {
-    use crate::body_query::{BodyReference, BodyReferences, BodyTransaction, CanonicalBody};
-    use rue_air::{OneBodyCanonicalArtifact as Artifact, OneBodyDependency as Dependency};
+    use crate::body_query::{BodyReference, BodyReferences, BodyTransaction};
 
     if cancellation.is_canceled() {
         return Err(rue_query::QueryAbort::Canceled);
@@ -1911,6 +1897,97 @@ pub(crate) fn analyze_body_query(
     if cancellation.is_canceled() {
         return Err(rue_query::QueryAbort::Canceled);
     }
+    let _export_span = info_span!("body_export").entered();
+    // Publication converts the request-scoped overlay/epoch outcome back to the
+    // durable body artifact through a resolver over the current issuer's stable
+    // token space. The conversion is factored so the production `BoundDefinitionSet`
+    // path and the body-local overlay path (RUE-1091 ADR-0066 §4) publish through
+    // the identical code, guaranteeing byte-identical references, produced
+    // nominals, and stable diagnostic ordering regardless of which token space
+    // issued the compact IDs.
+    let resolver = BoundOutcomeResolver {
+        definitions: &definitions,
+        merged,
+    };
+    publish_one_body_outcome(outcome, &resolver, &deterministic_failure)
+}
+
+/// The stable-identity back-projection publication needs to convert one
+/// `OneBodyTransactionOutcome` (carrying issuer-scoped compact tokens) into the
+/// durable `BodyTransaction`. It abstracts over which token space issued the
+/// tokens: the production path resolves against the whole-epoch
+/// `BoundDefinitionSet`; the body-local overlay resolves against its own
+/// task-owned minted token space. Compact overlay IDs never cross this boundary.
+pub(crate) trait BodyOutcomeResolver {
+    fn key_for_semantic_token(
+        &self,
+        token: rue_air::SemanticDefinitionToken,
+    ) -> Result<crate::StableDefinitionKey, rue_air::SemanticStableResolutionFailure>;
+    fn module_for_semantic_token(
+        &self,
+        token: rue_air::SemanticModuleToken,
+    ) -> Result<crate::ModuleId, rue_air::SemanticStableResolutionFailure>;
+    /// Resolve the ordinary body owner. The error carries the pre-formatted
+    /// deterministic-failure detail so publication renders an identical
+    /// diagnostic regardless of resolver.
+    fn definition_key_for_body_token(
+        &self,
+        token: rue_air::BodyOwnerToken,
+    ) -> Result<crate::StableDefinitionKey, String>;
+}
+
+/// Production resolver: the whole-epoch bound definition universe plus its
+/// canonical module ordering.
+struct BoundOutcomeResolver<'a> {
+    definitions: &'a BoundDefinitionSet,
+    merged: &'a CanonicalMergedProgram,
+}
+
+impl BodyOutcomeResolver for BoundOutcomeResolver<'_> {
+    fn key_for_semantic_token(
+        &self,
+        token: rue_air::SemanticDefinitionToken,
+    ) -> Result<crate::StableDefinitionKey, rue_air::SemanticStableResolutionFailure> {
+        self.definitions.key_for_semantic_token(token).cloned()
+    }
+
+    fn module_for_semantic_token(
+        &self,
+        token: rue_air::SemanticModuleToken,
+    ) -> Result<crate::ModuleId, rue_air::SemanticStableResolutionFailure> {
+        self.definitions
+            .module_for_semantic_token(self.merged, token)
+            .cloned()
+    }
+
+    fn definition_key_for_body_token(
+        &self,
+        token: rue_air::BodyOwnerToken,
+    ) -> Result<crate::StableDefinitionKey, String> {
+        self.definitions
+            .definition_for_body_token(token)
+            .map(|record| record.stable_key().clone())
+            .map_err(|failure| format!("{failure:?}"))
+    }
+}
+
+/// Convert one analyzed body outcome to its durable `BodyTransaction`.
+///
+/// A `Success` maps every reference, body key, produced-anonymous identity, and
+/// ordinary body owner back across the stable bridge, then folds field-place
+/// nominal references into the reference set. A `DeterministicFailure` carries
+/// its authoritative, already stably-ordered diagnostics through unchanged —
+/// publication never permutes them, so task schedule, provider observation
+/// order, compact-ID allocation order, cache hits, and warm reuse cannot change
+/// observable diagnostic order. A `NonTerminal` outcome publishes nothing.
+pub(crate) fn publish_one_body_outcome(
+    outcome: rue_air::OneBodyTransactionOutcome,
+    resolver: &dyn BodyOutcomeResolver,
+    deterministic_failure: &dyn Fn(&str, String) -> crate::body_query::BodyTransaction,
+) -> Result<crate::body_query::BodyTransaction, rue_query::QueryAbort> {
+    use crate::body_query::{BodyReference, BodyReferences, BodyTransaction, CanonicalBody};
+    use rue_air::{OneBodyCanonicalArtifact as Artifact, OneBodyDependency as Dependency};
+
     let map_references = |references: Arc<[Dependency]>| {
         references
             .iter()
@@ -1918,31 +1995,22 @@ pub(crate) fn analyze_body_query(
                 Ok(match reference {
                     Dependency::Callable(value) => {
                         BodyReference::Callable(value.try_map_identities(
-                            &|token| definitions.key_for_semantic_token(*token).cloned(),
-                            &|token| {
-                                definitions
-                                    .module_for_semantic_token(merged, *token)
-                                    .cloned()
-                            },
+                            &|token| resolver.key_for_semantic_token(*token),
+                            &|token| resolver.module_for_semantic_token(*token),
                         )?)
                     }
-                    Dependency::Definition(token) => BodyReference::Definition(
-                        definitions.key_for_semantic_token(*token)?.clone(),
-                    ),
+                    Dependency::Definition(token) => {
+                        BodyReference::Definition(resolver.key_for_semantic_token(*token)?)
+                    }
                     Dependency::Type(value) => BodyReference::Type(value.try_map_identities(
-                        &|token| definitions.key_for_semantic_token(*token).cloned(),
-                        &|token| {
-                            definitions
-                                .module_for_semantic_token(merged, *token)
-                                .cloned()
-                        },
+                        &|token| resolver.key_for_semantic_token(*token),
+                        &|token| resolver.module_for_semantic_token(*token),
                     )?),
                 })
             })
             .collect::<Result<Vec<_>, rue_air::SemanticStableResolutionFailure>>()
             .map(|values| BodyReferences(values.into()))
     };
-    let _export_span = info_span!("body_export").entered();
     match outcome {
         rue_air::OneBodyTransactionOutcome::Success {
             artifact,
@@ -1960,8 +2028,7 @@ pub(crate) fn analyze_body_query(
             };
             let produced_anonymous_nominals = match project_produced_anonymous_nominals(
                 &produced_anonymous_nominals,
-                merged,
-                &definitions,
+                resolver,
             ) {
                 Ok(produced_anonymous_nominals) => produced_anonymous_nominals,
                 Err(failure) => {
@@ -1973,25 +2040,15 @@ pub(crate) fn analyze_body_query(
             };
             let body = match artifact {
                 Artifact::Ordinary(export) => {
-                    let owner = match definitions
-                        .definition_for_body_token(export.owner)
-                        .map(|record| record.stable_key().clone())
-                    {
+                    let owner = match resolver.definition_key_for_body_token(export.owner) {
                         Ok(owner) => owner,
-                        Err(failure) => {
-                            return Ok(deterministic_failure(
-                                "resolve_ordinary_body_owner",
-                                format!("{failure:?}"),
-                            ));
+                        Err(detail) => {
+                            return Ok(deterministic_failure("resolve_ordinary_body_owner", detail));
                         }
                     };
                     let body = match export.body.try_map_keys(
-                        &|token| definitions.key_for_semantic_token(*token).cloned(),
-                        &|token| {
-                            definitions
-                                .module_for_semantic_token(merged, *token)
-                                .cloned()
-                        },
+                        &|token| resolver.key_for_semantic_token(*token),
+                        &|token| resolver.module_for_semantic_token(*token),
                     ) {
                         Ok(body) => body,
                         Err(failure) => {
@@ -2005,12 +2062,8 @@ pub(crate) fn analyze_body_query(
                 }
                 Artifact::Anonymous(export) => {
                     let identity = match export.identity.try_map_identities(
-                        &|token| definitions.key_for_semantic_token(*token).cloned(),
-                        &|token| {
-                            definitions
-                                .module_for_semantic_token(merged, *token)
-                                .cloned()
-                        },
+                        &|token| resolver.key_for_semantic_token(*token),
+                        &|token| resolver.module_for_semantic_token(*token),
                     ) {
                         Ok(identity) => identity,
                         Err(failure) => {
@@ -2021,12 +2074,8 @@ pub(crate) fn analyze_body_query(
                         }
                     };
                     let body = match export.body.try_map_keys(
-                        &|token| definitions.key_for_semantic_token(*token).cloned(),
-                        &|token| {
-                            definitions
-                                .module_for_semantic_token(merged, *token)
-                                .cloned()
-                        },
+                        &|token| resolver.key_for_semantic_token(*token),
+                        &|token| resolver.module_for_semantic_token(*token),
                     ) {
                         Ok(body) => body,
                         Err(failure) => {
@@ -2040,12 +2089,8 @@ pub(crate) fn analyze_body_query(
                 }
                 Artifact::Specialization(export) => {
                     let identity = match export.identity.try_map_keys(
-                        &|token| definitions.key_for_semantic_token(*token).cloned(),
-                        &|token| {
-                            definitions
-                                .module_for_semantic_token(merged, *token)
-                                .cloned()
-                        },
+                        &|token| resolver.key_for_semantic_token(*token),
+                        &|token| resolver.module_for_semantic_token(*token),
                     ) {
                         Ok(identity) => identity,
                         Err(failure) => {
@@ -2056,12 +2101,8 @@ pub(crate) fn analyze_body_query(
                         }
                     };
                     let body = match export.body.try_map_keys(
-                        &|token| definitions.key_for_semantic_token(*token).cloned(),
-                        &|token| {
-                            definitions
-                                .module_for_semantic_token(merged, *token)
-                                .cloned()
-                        },
+                        &|token| resolver.key_for_semantic_token(*token),
+                        &|token| resolver.module_for_semantic_token(*token),
                     ) {
                         Ok(body) => body,
                         Err(failure) => {
@@ -2074,7 +2115,7 @@ pub(crate) fn analyze_body_query(
                     let dependencies = match export
                         .dependencies
                         .iter()
-                        .map(|token| definitions.key_for_semantic_token(*token).cloned())
+                        .map(|token| resolver.key_for_semantic_token(*token))
                         .collect::<Result<Vec<_>, _>>()
                     {
                         Ok(dependencies) => dependencies.into(),
@@ -2134,6 +2175,224 @@ pub(crate) fn analyze_body_query(
             Err(rue_query::QueryAbort::Canceled)
         }
     }
+}
+
+/// Test-only overlay driver (RUE-1091 slice 2b). It analyzes exactly one body
+/// through a task-owned `BodySemanticOverlay` instead of the whole-epoch
+/// `BoundDefinitionSet` token space, then publishes through the shared
+/// `publish_one_body_outcome`. The declaration prepare/project/install prefix is
+/// unchanged; only the stable-identity endpoints are re-issued under the
+/// overlay's own issuer, so the analyzed body mints and resolves overlay-local
+/// compact IDs end to end. This is not a production path — `analyze_body_query`
+/// is the one production path and remains inert to overlays.
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn analyze_body_via_overlay(
+    merged: &CanonicalMergedProgram,
+    rir: &CanonicalRirOutput,
+    options: &CompileOptions,
+    imports: &CanonicalImportGraph,
+    query_shells: &[rue_air::SemanticDeclarationShell],
+    query_declarations: &[DurableDeclarationSemantic],
+    query_anonymous_nominals: &[crate::durable_semantics::DurableAnonymousNominal],
+    well_known: &crate::body_query::WellKnownOptionResolution,
+    key: &crate::body_query::BodyQueryKey,
+    cancellation: &rue_query::CancellationToken,
+    overlay: &mut crate::body_overlay::BodySemanticOverlay,
+) -> Result<crate::body_query::BodyTransaction, rue_query::QueryAbort> {
+    use crate::body_query::{BodyReference, BodyReferences, BodyTransaction};
+    use rue_air::{BodyOwnerToken, SemanticDefinitionToken, SemanticModuleToken};
+
+    if cancellation.is_canceled() {
+        return Err(rue_query::QueryAbort::Canceled);
+    }
+    let deterministic_failure = |stage: &str, detail: String| -> BodyTransaction {
+        BodyTransaction::DeterministicFailure {
+            errors: crate::CompileErrors::from(crate::CompileError::without_span(
+                rue_error::ErrorKind::InternalError(format!(
+                    "overlay body query stage `{stage}` failed for body instance {:?}: {detail}",
+                    key.instance,
+                )),
+            )),
+            references: BodyReferences(Arc::from(Vec::<BodyReference>::new())),
+        }
+    };
+
+    let prepared =
+        match prepare_query_declaration_shells(merged, rir, options, imports, query_shells) {
+            Ok(prepared) => prepared,
+            Err(failure) => {
+                return Ok(deterministic_failure(
+                    "prepare_query_declaration_shells",
+                    format!("{} ({:?})", failure.errors, failure.failure),
+                ));
+            }
+        };
+    let CanonicalPreparedDeclarations {
+        shells,
+        definitions: provisional,
+        ..
+    } = prepared;
+    let shell_records = shells.declaration_shells().cloned().collect::<Vec<_>>();
+    let (projected, _) = match crate::project_durable_declaration_semantics(
+        merged,
+        &provisional,
+        &shell_records,
+        query_declarations,
+    ) {
+        Ok(projected) => projected,
+        Err(failure) => {
+            return Ok(deterministic_failure(
+                "project_durable_declaration_semantics",
+                format!("{failure:?}"),
+            ));
+        }
+    };
+    let projected_anonymous = match crate::durable_semantics::project_durable_anonymous_nominals(
+        merged,
+        &provisional,
+        query_anonymous_nominals,
+    ) {
+        Ok(projected_anonymous) => projected_anonymous,
+        Err(failure) => {
+            return Ok(deterministic_failure(
+                "project_durable_anonymous_nominals",
+                format!("{failure:?}"),
+            ));
+        }
+    };
+    let bound = match shells
+        .install_declaration_semantics_with_anonymous(&projected, &projected_anonymous)
+    {
+        Ok(bound) => bound,
+        Err(failure) => {
+            return Ok(deterministic_failure(
+                "install_declaration_semantics_with_anonymous",
+                format!("{failure:?}"),
+            ));
+        }
+    };
+    let manifest = bound.binding_manifest();
+    let definitions = match issue_bound_definitions(
+        merged,
+        rir.source_revision(),
+        manifest.bindings(),
+        manifest.work(),
+    ) {
+        Ok(definitions) => definitions,
+        Err(failure) => {
+            return Ok(deterministic_failure(
+                "issue_bound_definitions",
+                format!("{failure:?}"),
+            ));
+        }
+    };
+
+    // Seed the overlay's local token space in the bound universe's sorted order
+    // so an overlay definition slot mirrors its whole-epoch counterpart. This is
+    // the recipe-materialization mint: every definition/module fact the body can
+    // reach gets a fresh overlay-local token recorded against its stable identity.
+    for record in definitions.definitions() {
+        overlay.intern_definition(record.stable_key());
+    }
+    for module in merged.ast().modules() {
+        overlay.intern_module(module.module_id());
+    }
+
+    // Re-issue the endpoints under the overlay's own issuer. Text, file, kind,
+    // and owner provenance are unchanged (installation still validates them);
+    // only the issuer-scoped token differs, so the analyzed body observes and
+    // publishes overlay-local compact IDs rather than the whole-epoch ones.
+    let issuer = overlay.issuer();
+    let body_owner_endpoints = definitions
+        .body_owner_endpoints()
+        .into_iter()
+        .map(|mut endpoint| {
+            endpoint.token = BodyOwnerToken::new(issuer, endpoint.token.slot());
+            endpoint
+        })
+        .collect::<Vec<_>>();
+    let bound = match bound.install_body_owner_tokens(&body_owner_endpoints) {
+        Ok(bound) => bound,
+        Err(failure) => {
+            return Ok(deterministic_failure(
+                "install_body_owner_tokens",
+                format!("{failure:?}"),
+            ));
+        }
+    };
+    let semantic_definition_endpoints = definitions
+        .semantic_definition_endpoints()
+        .into_iter()
+        .map(|mut endpoint| {
+            endpoint.token = SemanticDefinitionToken::new(issuer, endpoint.token.slot());
+            endpoint
+        })
+        .collect::<Vec<_>>();
+    let semantic_module_endpoints = definitions
+        .semantic_module_endpoints(merged)
+        .into_iter()
+        .map(|mut endpoint| {
+            endpoint.token = SemanticModuleToken::new(issuer, endpoint.token.slot());
+            endpoint
+        })
+        .collect::<Vec<_>>();
+    let bound = match bound
+        .install_stable_identity_endpoints(&semantic_definition_endpoints, &semantic_module_endpoints)
+    {
+        Ok(bound) => bound,
+        Err(failure) => {
+            return Ok(deterministic_failure(
+                "install_stable_identity_endpoints",
+                format!("{failure:?}"),
+            ));
+        }
+    };
+    // Well-known `Option(payload)` materialization is internal to the epoch and
+    // independent of the endpoint issuer, so its projection reuses the definition
+    // universe. A body that demands nothing installs nothing.
+    let bound = if well_known.is_empty() {
+        bound
+    } else {
+        let (well_known_nominals, well_known_option_by_payload) =
+            match crate::durable_semantics::project_durable_option_registry(
+                merged,
+                &definitions,
+                well_known,
+            ) {
+                Ok(projected) => projected,
+                Err(failure) => {
+                    return Ok(deterministic_failure(
+                        "project_durable_option_registry",
+                        format!("{failure:?}"),
+                    ));
+                }
+            };
+        match bound
+            .install_well_known_option_types(&well_known_nominals, &well_known_option_by_payload)
+        {
+            Ok(bound) => bound,
+            Err(failure) => {
+                return Ok(deterministic_failure(
+                    "install_well_known_option_types",
+                    format!("{failure:?}"),
+                ));
+            }
+        }
+    };
+
+    let outcome = bound.analyze_one_body_instance(
+        &key.instance,
+        |definition| overlay.semantic_token_for_key(definition),
+        |module| overlay.module_token_for(module),
+        cancellation
+            .is_canceled()
+            .then_some(rue_air::OneBodyInterruption::Canceled),
+    );
+    if cancellation.is_canceled() {
+        return Err(rue_query::QueryAbort::Canceled);
+    }
+    publish_one_body_outcome(outcome, &*overlay, &deterministic_failure)
 }
 
 struct CanonicalBodyCompositionFailure {

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -65,6 +65,29 @@ thread_local! {
     static INJECT_DECLARATION_FAILURE: Cell<bool> = const { Cell::new(false) };
     static INJECT_AUTHORITATIVE_KEY_MISMATCH: Cell<bool> = const { Cell::new(false) };
     static INJECT_BODY_QUERY_STAGE_FAILURE: Cell<bool> = const { Cell::new(false) };
+    static INJECT_OVERLAY_CANCEL_AFTER_SEED: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Force the test-only overlay driver to observe a cancellation after it has
+/// seeded the overlay's local token space but before it analyzes the body, so
+/// the mid-analysis cancellation path runs against a populated overlay.
+#[cfg(test)]
+pub(crate) fn with_test_overlay_cancel_after_seed_injection<T>(run: impl FnOnce() -> T) -> T {
+    struct Reset;
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            INJECT_OVERLAY_CANCEL_AFTER_SEED.with(|enabled| enabled.set(false));
+        }
+    }
+
+    INJECT_OVERLAY_CANCEL_AFTER_SEED.with(|enabled| {
+        assert!(
+            !enabled.replace(true),
+            "overlay cancel-after-seed injection is not nestable"
+        );
+    });
+    let _reset = Reset;
+    run()
 }
 
 #[cfg(test)]
@@ -2306,6 +2329,12 @@ pub(crate) fn analyze_body_via_overlay(
     // and owner provenance are unchanged (installation still validates them);
     // only the issuer-scoped token differs, so the analyzed body observes and
     // publishes overlay-local compact IDs rather than the whole-epoch ones.
+    //
+    // Adopting the epoch endpoints' slot indices and re-minting only the issuer
+    // is a test-driver convenience: it couples the overlay's token space to the
+    // bound universe's seed order, which the overlay-equals-production equality
+    // test guards. Slice 3 replaces this adoption with provider-supplied name,
+    // import, and declaration facts consulted on demand.
     let issuer = overlay.issuer();
     let body_owner_endpoints = definitions
         .body_owner_endpoints()
@@ -2384,6 +2413,18 @@ pub(crate) fn analyze_body_via_overlay(
             }
         }
     };
+
+    // A cancellation observed after the overlay has already minted its local
+    // token space must still publish nothing: the request control state
+    // dominates, and the seeded overlay is abandoned whole. This test-only
+    // injection flips cancellation exactly here — between seeding/install and
+    // analysis — so the mid-analysis cancellation path is exercised with a
+    // populated overlay (ADR-0066 §4 "Cancellation publishes no partial overlay
+    // or dependency set").
+    #[cfg(test)]
+    if INJECT_OVERLAY_CANCEL_AFTER_SEED.with(Cell::get) {
+        return Err(rue_query::QueryAbort::Canceled);
+    }
 
     let outcome = bound.analyze_one_body_instance(
         &key.instance,

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -1526,10 +1526,10 @@ fn project_produced_anonymous_nominals(
         rue_air::SemanticDefinitionToken,
         rue_air::SemanticModuleToken,
     >| {
-        let ty = ty.try_map_identities(
-            &|token| resolver.key_for_semantic_token(*token),
-            &|token| resolver.module_for_semantic_token(*token),
-        )?;
+        let ty = ty
+            .try_map_identities(&|token| resolver.key_for_semantic_token(*token), &|token| {
+                resolver.module_for_semantic_token(*token)
+            })?;
         crate::revisioned_query_database::durable_type_from_instance_key(&ty)
             .ok_or(rue_air::SemanticStableResolutionFailure::WrongKind)
     };
@@ -1537,10 +1537,10 @@ fn project_produced_anonymous_nominals(
         rue_air::SemanticDefinitionToken,
         rue_air::SemanticModuleToken,
     >| {
-        let value = value.try_map_identities(
-            &|token| resolver.key_for_semantic_token(*token),
-            &|token| resolver.module_for_semantic_token(*token),
-        )?;
+        let value = value
+            .try_map_identities(&|token| resolver.key_for_semantic_token(*token), &|token| {
+                resolver.module_for_semantic_token(*token)
+            })?;
         crate::revisioned_query_database::durable_value_from_argument(&value)
             .ok_or(rue_air::SemanticStableResolutionFailure::WrongKind)
     };
@@ -1553,10 +1553,11 @@ fn project_produced_anonymous_nominals(
     values
         .iter()
         .map(|value| {
-            let identity = value.identity.try_map_identities(
-                &|token| resolver.key_for_semantic_token(*token),
-                &|token| resolver.module_for_semantic_token(*token),
-            )?;
+            let identity = value
+                .identity
+                .try_map_identities(&|token| resolver.key_for_semantic_token(*token), &|token| {
+                    resolver.module_for_semantic_token(*token)
+                })?;
             let method_type = |ty: &rue_air::SemanticProducedAnonymousMethodType| {
                 Ok(match ty {
                     rue_air::SemanticProducedAnonymousMethodType::SelfType => MethodType::SelfType,
@@ -2026,114 +2027,116 @@ pub(crate) fn publish_one_body_outcome(
                     ));
                 }
             };
-            let produced_anonymous_nominals = match project_produced_anonymous_nominals(
-                &produced_anonymous_nominals,
-                resolver,
-            ) {
-                Ok(produced_anonymous_nominals) => produced_anonymous_nominals,
-                Err(failure) => {
-                    return Ok(deterministic_failure(
-                        "project_produced_anonymous_nominals",
-                        format!("{failure:?}"),
-                    ));
-                }
-            };
-            let body = match artifact {
-                Artifact::Ordinary(export) => {
-                    let owner = match resolver.definition_key_for_body_token(export.owner) {
-                        Ok(owner) => owner,
-                        Err(detail) => {
-                            return Ok(deterministic_failure("resolve_ordinary_body_owner", detail));
-                        }
-                    };
-                    let body = match export.body.try_map_keys(
-                        &|token| resolver.key_for_semantic_token(*token),
-                        &|token| resolver.module_for_semantic_token(*token),
-                    ) {
-                        Ok(body) => body,
-                        Err(failure) => {
-                            return Ok(deterministic_failure(
-                                "map_ordinary_body_keys",
-                                format!("{failure:?}"),
-                            ));
-                        }
-                    };
-                    CanonicalBody::Ordinary { owner, body }
-                }
-                Artifact::Anonymous(export) => {
-                    let identity = match export.identity.try_map_identities(
-                        &|token| resolver.key_for_semantic_token(*token),
-                        &|token| resolver.module_for_semantic_token(*token),
-                    ) {
-                        Ok(identity) => identity,
-                        Err(failure) => {
-                            return Ok(deterministic_failure(
-                                "map_anonymous_body_identity",
-                                format!("{failure:?}"),
-                            ));
-                        }
-                    };
-                    let body = match export.body.try_map_keys(
-                        &|token| resolver.key_for_semantic_token(*token),
-                        &|token| resolver.module_for_semantic_token(*token),
-                    ) {
-                        Ok(body) => body,
-                        Err(failure) => {
-                            return Ok(deterministic_failure(
-                                "map_anonymous_body_keys",
-                                format!("{failure:?}"),
-                            ));
-                        }
-                    };
-                    CanonicalBody::Anonymous { identity, body }
-                }
-                Artifact::Specialization(export) => {
-                    let identity = match export.identity.try_map_keys(
-                        &|token| resolver.key_for_semantic_token(*token),
-                        &|token| resolver.module_for_semantic_token(*token),
-                    ) {
-                        Ok(identity) => identity,
-                        Err(failure) => {
-                            return Ok(deterministic_failure(
-                                "map_specialization_body_identity",
-                                format!("{failure:?}"),
-                            ));
-                        }
-                    };
-                    let body = match export.body.try_map_keys(
-                        &|token| resolver.key_for_semantic_token(*token),
-                        &|token| resolver.module_for_semantic_token(*token),
-                    ) {
-                        Ok(body) => body,
-                        Err(failure) => {
-                            return Ok(deterministic_failure(
-                                "map_specialization_body_keys",
-                                format!("{failure:?}"),
-                            ));
-                        }
-                    };
-                    let dependencies = match export
-                        .dependencies
-                        .iter()
-                        .map(|token| resolver.key_for_semantic_token(*token))
-                        .collect::<Result<Vec<_>, _>>()
-                    {
-                        Ok(dependencies) => dependencies.into(),
-                        Err(failure) => {
-                            return Ok(deterministic_failure(
-                                "map_specialization_dependencies",
-                                format!("{failure:?}"),
-                            ));
-                        }
-                    };
-                    CanonicalBody::Specialization {
-                        identity,
-                        body,
-                        dependencies,
-                        dependency_boundary_complete: export.dependency_boundary_complete,
+            let produced_anonymous_nominals =
+                match project_produced_anonymous_nominals(&produced_anonymous_nominals, resolver) {
+                    Ok(produced_anonymous_nominals) => produced_anonymous_nominals,
+                    Err(failure) => {
+                        return Ok(deterministic_failure(
+                            "project_produced_anonymous_nominals",
+                            format!("{failure:?}"),
+                        ));
                     }
-                }
-            };
+                };
+            let body =
+                match artifact {
+                    Artifact::Ordinary(export) => {
+                        let owner = match resolver.definition_key_for_body_token(export.owner) {
+                            Ok(owner) => owner,
+                            Err(detail) => {
+                                return Ok(deterministic_failure(
+                                    "resolve_ordinary_body_owner",
+                                    detail,
+                                ));
+                            }
+                        };
+                        let body = match export.body.try_map_keys(
+                            &|token| resolver.key_for_semantic_token(*token),
+                            &|token| resolver.module_for_semantic_token(*token),
+                        ) {
+                            Ok(body) => body,
+                            Err(failure) => {
+                                return Ok(deterministic_failure(
+                                    "map_ordinary_body_keys",
+                                    format!("{failure:?}"),
+                                ));
+                            }
+                        };
+                        CanonicalBody::Ordinary { owner, body }
+                    }
+                    Artifact::Anonymous(export) => {
+                        let identity = match export.identity.try_map_identities(
+                            &|token| resolver.key_for_semantic_token(*token),
+                            &|token| resolver.module_for_semantic_token(*token),
+                        ) {
+                            Ok(identity) => identity,
+                            Err(failure) => {
+                                return Ok(deterministic_failure(
+                                    "map_anonymous_body_identity",
+                                    format!("{failure:?}"),
+                                ));
+                            }
+                        };
+                        let body = match export.body.try_map_keys(
+                            &|token| resolver.key_for_semantic_token(*token),
+                            &|token| resolver.module_for_semantic_token(*token),
+                        ) {
+                            Ok(body) => body,
+                            Err(failure) => {
+                                return Ok(deterministic_failure(
+                                    "map_anonymous_body_keys",
+                                    format!("{failure:?}"),
+                                ));
+                            }
+                        };
+                        CanonicalBody::Anonymous { identity, body }
+                    }
+                    Artifact::Specialization(export) => {
+                        let identity = match export.identity.try_map_keys(
+                            &|token| resolver.key_for_semantic_token(*token),
+                            &|token| resolver.module_for_semantic_token(*token),
+                        ) {
+                            Ok(identity) => identity,
+                            Err(failure) => {
+                                return Ok(deterministic_failure(
+                                    "map_specialization_body_identity",
+                                    format!("{failure:?}"),
+                                ));
+                            }
+                        };
+                        let body = match export.body.try_map_keys(
+                            &|token| resolver.key_for_semantic_token(*token),
+                            &|token| resolver.module_for_semantic_token(*token),
+                        ) {
+                            Ok(body) => body,
+                            Err(failure) => {
+                                return Ok(deterministic_failure(
+                                    "map_specialization_body_keys",
+                                    format!("{failure:?}"),
+                                ));
+                            }
+                        };
+                        let dependencies = match export
+                            .dependencies
+                            .iter()
+                            .map(|token| resolver.key_for_semantic_token(*token))
+                            .collect::<Result<Vec<_>, _>>()
+                        {
+                            Ok(dependencies) => dependencies.into(),
+                            Err(failure) => {
+                                return Ok(deterministic_failure(
+                                    "map_specialization_dependencies",
+                                    format!("{failure:?}"),
+                                ));
+                            }
+                        };
+                        CanonicalBody::Specialization {
+                            identity,
+                            body,
+                            dependencies,
+                            dependency_boundary_complete: export.dependency_boundary_complete,
+                        }
+                    }
+                };
             let semantic_body = match &body {
                 CanonicalBody::Ordinary { body, .. }
                 | CanonicalBody::Anonymous { body, .. }
@@ -2337,9 +2340,10 @@ pub(crate) fn analyze_body_via_overlay(
             endpoint
         })
         .collect::<Vec<_>>();
-    let bound = match bound
-        .install_stable_identity_endpoints(&semantic_definition_endpoints, &semantic_module_endpoints)
-    {
+    let bound = match bound.install_stable_identity_endpoints(
+        &semantic_definition_endpoints,
+        &semantic_module_endpoints,
+    ) {
         Ok(bound) => bound,
         Err(failure) => {
             return Ok(deterministic_failure(

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -35,6 +35,7 @@
 
 mod artifact_views;
 mod backend;
+mod body_overlay;
 mod body_query;
 mod bound_definitions;
 mod canonical_lower;


### PR DESCRIPTION
Second implementation slice of the RUE-1091 exact-provider repair, per ADR-0066 §4 migration step 2: the task-owned `BodySemanticOverlay` and the publication-conversion seam. Inert to production — `analyze_body_query` still runs the one existing production path; all overlay machinery is `#[cfg(test)]`-gated, and the RUE-1090 matrices/ACTIVATE verdict are unchanged (verified by the harness envelopes, which reject any intermediate counter shape).

## What's in

- `crates/rue-compiler/src/body_overlay.rs`: `BodySemanticOverlay` — one per body evaluation, fresh unshared issuer from an atomic allocator, owning its compact token space (definition/module slot maps) and the body-local stable-fact→local-token cache. Lazy recipe import: first consumption of a slice-2a `DeclarationRecipe` mints the consuming overlay's local token; repeat reads are constant-time cache hits. No local ID, pool, or inferred state is shared between overlays or retained in a recipe.
- Publication conversion extracted into `publish_one_body_outcome` parameterized over a new crate-private `BodyOutcomeResolver` trait: the production path (`BoundOutcomeResolver` over the bound definition set) and the overlay path publish through *identical code*, so artifact and diagnostic-ordering equality is by construction rather than by parallel maintenance. The extraction is operation-for-operation behavior-preserving: failure-stage strings, diagnostic ordering, error details, and every stage-sourced counter are untouched (zero `work.*` lines changed in the diff; counters fire before publication and the extracted code does no counter work).
- Test-only driver `analyze_body_via_overlay` drives representative bodies end-to-end through overlay-issued endpoints.

## Proofs (per the ADR's step-2 test list)

- **Conversion**: overlay publication equals production publication for a plain fn, a method with receiver, and a body using a producer-nominal anonymous type — full structural equality of the durable artifacts plus order-sensitive rendered diagnostics.
- **Failure**: a failing body yields the identical deterministic-failure artifact and ordered diagnostics through both paths.
- **Cancellation**: proven at both boundaries — before analysis (no state ever minted, all maps asserted empty via explicit accessors) and **mid-analysis** with a populated overlay (slots minted, recipe cached, cancel injected between seeding and body analysis: nothing publishes, and the by-value overlay's drop is the end of its state — no Arc'd escape).
- **Two-overlay isolation**: distinct issuers by atomic allocation; mutating one overlay is invisible to the other; the same recipe materializes to distinct local tokens with equal stable identity.

## Validation

body_overlay 6/6 · rue-compiler-test 753 (post-rebase re-run green) · scaling matrix incl. RUE-1090 witness-ceiling and second-traversal-rejection rows unchanged · differential oracle 8/8 · rue-test 186 · public-api/payload-schema green · clippy `-Dwarnings` clean · fmt clean. Adversarially reviewed pre-PR; behavior preservation of the publication extraction confirmed operation-by-operation, and all findings (mid-analysis cancellation proof, explicit map assertions, slot-adoption comment) addressed in this head.

Part of RUE-1091