### PR TITLE
RUE-723: complete inout oracle coverage

### DIFF
--- a/crates/rue-cli-tests/cases/differential_opt.toml
+++ b/crates/rue-cli-tests/cases/differential_opt.toml
@@ -191,34 +191,64 @@ fn main() -> i32 {
 stdout = ""
 exit_code = 42
 
-# Exact fixed-string references retain one-pointer identity through forwarding
-# and projected field/array-element lvalues. The typed `make` calls construct
-# the array elements as Str(8); contextual typing of bare literals inside an
-# annotated fixed-string array is a separate inference concern.
+# Exact fixed-string references retain one-pointer identity through direct and
+# multi-hop forwarding into projected field/array-element lvalues. Equality,
+# indexing, and length checks prove the copied-back value's content, while every
+# helper's exact Str(8) signature pins the nominal capacity. The separate
+# `inout str` chain is read-only: a view may be forwarded, but unlike an exact
+# `inout Str(8)` it cannot replace the caller's whole value.
 [[case]]
 name = "fixed_string_inout_forwarding_and_projected_lvalues_across_opt_levels"
 differential_opt = true
 files = [{ path = "main.rue", source = """
-struct Holder { value: Str(8) }
+struct Holder {
+    direct: Str(8),
+    forwarded: Str(8),
+}
 
 fn replace(inout value: Str(8), replacement: Str(8)) {
     value = replacement;
 }
 
-fn forward(inout value: Str(8)) {
-    replace(inout value, "forward");
+fn forward(inout value: Str(8), replacement: Str(8)) {
+    replace(inout value, replacement);
 }
 
 fn make(value: Str(8)) -> Str(8) { value }
 
+fn exact(value: Str(8), expected: Str(8), expected_len: u64) -> bool {
+    value == expected && value.len() == expected_len && value[0] == expected[0]
+}
+
+fn view_len(inout value: str) -> u64 {
+    value.len()
+}
+
+fn forward_view_len(inout value: str) -> u64 {
+    view_len(inout value)
+}
+
 fn main() -> i32 {
     let mut local: Str(8) = "local";
-    let mut holder = Holder { value: "field" };
+    let mut holder = Holder { direct: "field", forwarded: "other" };
     let mut values: [Str(8); 2] = [make("zero"), make("one")];
-    forward(inout local);
-    replace(inout holder.value, "project");
-    replace(inout values[1], "array");
-    if local.len() == 7 && holder.value.len() == 7 && values[1].len() == 5 {
+
+    forward(inout local, "forward");
+    replace(inout holder.direct, "project");
+    forward(inout holder.forwarded, "nested");
+    replace(inout values[0], "array");
+    forward(inout values[1], "element");
+
+    let field_view_len = forward_view_len(inout holder.forwarded);
+    let array_view_len = forward_view_len(inout values[1]);
+    if exact(local, "forward", 7)
+        && exact(holder.direct, "project", 7)
+        && exact(holder.forwarded, "nested", field_view_len)
+        && exact(values[0], "array", 5)
+        && exact(values[1], "element", array_view_len)
+        && field_view_len == 6
+        && array_view_len == 7
+    {
         42
     } else {
         1

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -163,10 +163,11 @@ const ENTRIES: &[Entry] = &[
     ),
     // std.fs v1 follow-ups (ADR-0057 "Future Work"): seek/tell, fstat/newfstatat
     // metadata, rename, unlink, and directory create/remove. Same raw-pointer
-    // substrate as v0 (StrBuf/ArrayBuf `@int_to_ptr` prologue), so the oracle
-    // model, with the heap now modeled, stops at the inout-forwarding gap. These cases are `only_on` the two
-    // Linux targets (macOS stat layout + Darwin *at syscall numbers are a
-    // documented, unverified follow-up), so their scope is Linux-only to match.
+    // substrate as v0; with heap allocation and inout forwarding modeled, the
+    // oracle reaches the still-unmodeled byte-copy intrinsic. These cases are
+    // `only_on` the two Linux targets (macOS stat layout + Darwin *at syscall
+    // numbers are a documented, unverified follow-up), so their scope is
+    // Linux-only to match.
     Entry::new(
         "cli.fs_file_io",
         "fs_seek_set_read_back",
@@ -601,9 +602,6 @@ fn render_kind(kind: ModelGapKind) -> String {
         }
         ModelGapKind::Semantic(SemanticGapKind::TextProjectionRead) => {
             "semantic(SemanticGapKind::TextProjectionRead)".to_string()
-        }
-        ModelGapKind::Semantic(SemanticGapKind::InoutParameterForwarding) => {
-            "semantic(SemanticGapKind::InoutParameterForwarding)".to_string()
         }
         ModelGapKind::ExternalDependency(kind) => {
             format!("external(ExternalDependencyKind::{kind:?})")

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -467,9 +467,6 @@ fn render_kind(kind: ModelGapKind) -> String {
         ModelGapKind::Semantic(SemanticGapKind::TextProjectionRead) => {
             "semantic(SemanticGapKind::TextProjectionRead)".to_string()
         }
-        ModelGapKind::Semantic(SemanticGapKind::InoutParameterForwarding) => {
-            "semantic(SemanticGapKind::InoutParameterForwarding)".to_string()
-        }
         ModelGapKind::ExternalDependency(kind) => {
             format!("external(ExternalDependencyKind::{kind:?})")
         }

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -266,7 +266,6 @@ pub enum SemanticGapKind {
     RuntimeCall(UnsupportedRuntimeCallKind),
     FlattenedParameterSlot,
     TextProjectionRead,
-    InoutParameterForwarding,
 }
 
 /// A dependency whose value comes from outside deterministic Rue semantics.

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -800,8 +800,8 @@ fn inout_param_forwarded_to_nested_inout_call() {
     // Forwarding a writable `inout` parameter as a *nested* call's `inout`
     // argument. This is the container `self`-chain — `ArrayBuf::push` calls
     // `self.reserve()`, forwarding its own `inout self` — and before RUE-1010 it
-    // was the `InoutParameterForwarding` model gap. The mutation must thread
-    // through both call boundaries back to the original caller.
+    // was an oracle model gap. The mutation must thread through both call
+    // boundaries back to the original caller.
     let src = "fn add(inout x: i32, k: i32) { x = x + k; }
     fn bump(inout x: i32) { add(inout x, 1); }
     fn main() -> i32 {

--- a/crates/rue-oracle/src/tests/place_contracts.rs
+++ b/crates/rue-oracle/src/tests/place_contracts.rs
@@ -72,7 +72,7 @@ fn core_str_length_is_modeled_and_inout_forwarding_threads_through_nested_calls(
     // argument is now modeled (RUE-1010): `f` forwards its own `inout v` to
     // `g`, whose mutation threads back through both call boundaries. This is the
     // container `self`-chain (`push` -> `self.reserve()`) that previously
-    // reached the `InoutParameterForwarding` gap.
+    // reached an oracle model gap.
     let forwarding = run_source_with_preview_features(
         "struct D { x: i32 }
         fn g(inout v: D) -> i32 { v.x = v.x + 1; v.x }


### PR DESCRIPTION
## Summary

- expand the fixed-string differential case to cover direct and multi-hop `inout Str(8)` writeback through struct fields and array elements
- verify exact content, length, and nominal capacity while keeping forwarded `inout str` views read-only
- remove the dead `InoutParameterForwarding` model-gap variant and its CLI/spec registry renderers

## Why

RUE-1010 implemented parameter forwarding and projected writeback in the oracle, but the exact fixed-string regression shape was only weakly covered and the retired gap still survived in the public enum and registry presentation code.

## Validation

- `scripts/rue cli differential_opt`
- focused oracle differential: 24/24 modeled cases agree
- `scripts/rue unit oracle`
- `scripts/rue quick`
- `./buck2 test //:oracle-diff-generated-smoke`
- `/opt/homebrew/bin/bash ./clippy.sh`
- `scripts/rue fmt`

Fixes RUE-723
