### PR TITLE
spec: correct stale global type-name uniqueness rule 6.0:2

### DIFF
--- a/docs/spec/src/06-items/_index.md
+++ b/docs/spec/src/06-items/_index.md
@@ -42,7 +42,7 @@ implementations under a type the way an `impl` block does in other languages.
 
 {{ rule(id="6.0:2", cat="legality-rule") }}
 
-User-defined type names (structs and enums) **MUST** be unique within a program. Defining multiple types with the same name produces a compile-time error.
+User-defined type names (structs and enums) **MUST** be unique within their defining module (source file). Defining multiple types with the same name in one file produces a compile-time error (E0436; this is the per-file check of 10.5:1). Distinct modules **MAY** each define a type with the same name (10.5:2); declarations in other modules do not participate in this check and do not constrain the names a module may define.
 
 {{ rule(id="6.0:3", cat="legality-rule") }}
 


### PR DESCRIPTION
Rule 6.0:2 claimed struct/enum names must be unique "within a program" — stale pre-module text that contradicts the authoritative module rules and actual compiler behavior:

- **10.5:1** makes the duplicate check per-file across all item kinds (E0436, RUE-239/RUE-572), explicitly "it never considers items in other loaded files".
- **10.5:2** states two loaded files MAY define top-level items with the same name, with positive spec cases proving it (`same_named_functions_across_imported_files_ok`, `same_named_consts_across_imported_files_ok`).
- Every spec case keyed to 6.0:2 is a single-file duplicate — the global claim was never test-backed.

The rule now states module-scoped uniqueness with explicit cross-references to 10.5:1/10.5:2 and a locality sentence ("declarations in other modules do not participate in this check"), so the global phrasing cannot be faithfully reimplemented by a future reader. Doc-only; rule ID and all existing cases unchanged.

Surfaced while retiring the analogous pre-module global-uniqueness fallback for bare const names (RUE-1091 slice r0), where the same historical pattern lives in compiler behavior rather than spec text.

---
_Generated by [Claude Code](https://claude.ai/code/session_019h99YFzR3fuDy2phd2vU9r)_