### PR TITLE
RUE-1091 r0: bare const names follow scoped resolution

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -668,12 +668,12 @@ impl<'a> ConstraintGenerator<'a> {
     /// against file-level integer constants (`[i32; K]`). Names that don't
     /// resolve here (e.g. a `comptime` value parameter, only known at
     /// specialization) yield `None`; sema resolves and diagnoses them (RUE-16).
-    fn resolve_infer_array_length(&self, len: &ArrayLen) -> Option<u64> {
+    fn resolve_infer_array_length(&self, len: &ArrayLen, file_id: FileId) -> Option<u64> {
         match len {
             ArrayLen::Literal(n) => Some(*n),
             ArrayLen::Named(name) => {
                 let sym = self.interner.get(name)?;
-                let value = self.unique_const_value(&sym)?;
+                let value = self.scoped_const_value(sym, file_id)?;
                 u64::try_from(value).ok()
             }
         }
@@ -691,51 +691,42 @@ impl<'a> ConstraintGenerator<'a> {
         &self,
         len: &ArrayLen,
         values: &HashMap<Spur, i128>,
+        file_id: FileId,
     ) -> Option<u64> {
         match len {
             ArrayLen::Literal(n) => Some(*n),
             ArrayLen::Named(name) => {
                 let sym = self.interner.get(name)?;
+                // A comptime value parameter captured at the call site takes
+                // precedence over a file-level `const` of the same name (RUE-252).
                 let value = values
                     .get(&sym)
                     .copied()
-                    .or_else(|| self.unique_const_value(&sym))?;
+                    .or_else(|| self.scoped_const_value(sym, file_id))?;
                 u64::try_from(value).ok()
             }
         }
     }
 
-    /// Bare-name integer-const lookup for the name-string type-resolution
-    /// helpers, which carry no reference file. Returns the value only when
-    /// the name denotes exactly one constant program-wide, so same-named
-    /// constants in sibling files can never bleed into each other (RUE-638);
-    /// an ambiguous name defers to sema's by-file resolution.
-    fn unique_const_value(&self, sym: &Spur) -> Option<i128> {
-        let mut found = None;
-        for ((_, name), value) in self.const_values?.iter() {
-            if name == sym {
-                if found.is_some() {
-                    return None;
-                }
-                found = Some(*value);
-            }
-        }
-        found
+    /// Resolve a bare integer-const name in array-length position against the
+    /// referencing file's scope. A bare name denotes the same-module `const`
+    /// (`const_values` is keyed by declaring file); a constant in another
+    /// module is reached qualified and does not participate here merely because
+    /// it is globally unique. Matches sema's authoritative by-file resolution
+    /// (`resolve_const_info_in_file`) so inference and checking agree, and a
+    /// same-named constant in an unrelated module cannot perturb a local length.
+    fn scoped_const_value(&self, sym: Spur, file_id: FileId) -> Option<i128> {
+        self.const_values
+            .and_then(|values| values.get(&(file_id, sym)).copied())
     }
 
-    /// Bare-name type-alias lookup with the same unique-name guard as
-    /// [`Self::unique_const_value`] (RUE-638).
-    fn unique_const_type_alias(&self, sym: &Spur) -> Option<Type> {
-        let mut found = None;
-        for ((_, name), ty) in self.const_type_aliases?.iter() {
-            if name == sym {
-                if found.is_some() {
-                    return None;
-                }
-                found = Some(*ty);
-            }
-        }
-        found
+    /// Resolve a bare type-alias name in alias-head position against the
+    /// referencing file's scope, with the same by-file discipline as
+    /// [`Self::scoped_const_value`]: a `const T = SomeType(...)` in the current
+    /// module resolves; a same-named alias elsewhere is qualified, not bare.
+    fn scoped_const_type_alias(&self, sym: Spur, file_id: FileId) -> Option<Type> {
+        self.const_type_aliases
+            .and_then(|aliases| aliases.get(&(file_id, sym)).copied())
     }
 
     /// Get the type variables allocated for integer literals.
@@ -3814,6 +3805,15 @@ impl<'a> ConstraintGenerator<'a> {
     /// parameters (e.g. `T` with `T=i32` resolves `[T; 3]` to `[i32; 3]`).
     /// Returns `None` when a mentioned type parameter isn't in `subst` (the
     /// check then happens in sema / after specialization).
+    /// `file_id` is deliberately the REFERENCE site's file (`span.file_id`),
+    /// not the declaring file of whatever signature the symbol came from. For
+    /// callee signatures re-resolved at a cross-file call site, a callee-file
+    /// const array length therefore resolves to `None` here — inference is
+    /// best-effort in that position and sema, which resolves the length in the
+    /// callee's own file scope, stays authoritative (it still rejects size
+    /// mismatches; see `cross_file_generic_signature_*` in
+    /// bare_const_scope.toml). Do not widen this lookup beyond the reference
+    /// file: a program-wide search is the retired RUE-638 fallback.
     fn resolve_type_sym_with_subst(
         &self,
         sym: Spur,
@@ -3844,7 +3844,7 @@ impl<'a> ConstraintGenerator<'a> {
         if let Some((element_type_str, len)) = parse_array_type_syntax(name) {
             let element_ty =
                 self.resolve_type_name_with_subst(&element_type_str, subst, values, file_id)?;
-            let length = self.resolve_infer_array_length_with_values(&len, values)?;
+            let length = self.resolve_infer_array_length_with_values(&len, values, file_id)?;
             return Some(InferType::Array {
                 element: Box::new(element_ty),
                 length,
@@ -3880,7 +3880,7 @@ impl<'a> ConstraintGenerator<'a> {
         if let Some((element_type_str, len)) = parse_array_type_syntax(name) {
             // Recursively resolve the element type
             let element_ty = self.resolve_type_name(&element_type_str, file_id)?;
-            let length = self.resolve_infer_array_length(&len)?;
+            let length = self.resolve_infer_array_length(&len, file_id)?;
             return Some(InferType::Array {
                 element: Box::new(element_ty),
                 length,
@@ -3938,7 +3938,7 @@ impl<'a> ConstraintGenerator<'a> {
             if let Some(&enum_ty) = self.builtin_enums.get(&name_spur) {
                 return Some(InferType::Concrete(enum_ty));
             }
-            if let Some(alias_ty) = self.unique_const_type_alias(&name_spur) {
+            if let Some(alias_ty) = self.scoped_const_type_alias(name_spur, file_id) {
                 return Some(InferType::Concrete(alias_ty));
             }
         }
@@ -4778,5 +4778,211 @@ mod tests {
                 _ => panic!("Expected Equal constraint in match"),
             }
         }
+    }
+
+    // --- Scoped resolution of bare const names in array-length and
+    // --- type-alias-head positions (RUE-1091 slice r0).
+    //
+    // A bare name resolves by ordinary scoped resolution — the same by-file
+    // keying sema uses (`resolve_const_info_in_file`). A constant in another
+    // module does not participate merely because it is globally unique; it is
+    // reached qualified. These tests pin that rule and the invariants the
+    // maintainer ruling requires: locality (no spooky action), the
+    // comptime-value precedence, and the value-vs-type distinction.
+
+    fn cgen_fixture() -> (rue_rir::RirEditor, ThreadedRodeo, TypeInternPool) {
+        make_test_rir_interner_and_type_pool()
+    }
+
+    #[test]
+    fn array_length_bare_const_resolves_in_declaring_file_scope() {
+        let (rir, interner, type_pool) = cgen_fixture();
+        let functions = HashMap::new();
+        let structs = HashMap::new();
+        let enums = HashMap::new();
+        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let file_a = FileId::new(0);
+        let k = interner.get_or_intern("K");
+        let mut const_values: HashMap<(FileId, Spur), i128> = HashMap::new();
+        const_values.insert((file_a, k), 4);
+
+        let cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        )
+        .with_const_values(&const_values);
+
+        // In-scope, same module: resolves to the declared value.
+        assert_eq!(
+            cgen.resolve_infer_array_length(&ArrayLen::Named("K".to_string()), file_a),
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn array_length_bare_const_out_of_scope_does_not_resolve() {
+        let (rir, interner, type_pool) = cgen_fixture();
+        let functions = HashMap::new();
+        let structs = HashMap::new();
+        let enums = HashMap::new();
+        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let file_a = FileId::new(0);
+        let file_b = FileId::new(1);
+        let k = interner.get_or_intern("K");
+        // The only `K` lives in file_b; referencing it bare from file_a is out
+        // of scope even though `K` is globally unique.
+        let mut const_values: HashMap<(FileId, Spur), i128> = HashMap::new();
+        const_values.insert((file_b, k), 4);
+
+        let cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        )
+        .with_const_values(&const_values);
+
+        assert_eq!(
+            cgen.resolve_infer_array_length(&ArrayLen::Named("K".to_string()), file_a),
+            None
+        );
+    }
+
+    /// Named regression for the retired whole-program uniqueness fallback: a
+    /// same-named constant added in an unrelated module must NOT change a
+    /// body's local resolution. Under the old scan two `N`s were "ambiguous"
+    /// and a valid local `N` stopped resolving (spooky action at a distance);
+    /// scoped resolution keeps file_a's `N` resolving to its own value.
+    #[test]
+    fn array_length_distant_same_named_const_cannot_perturb_local_resolution() {
+        let (rir, interner, type_pool) = cgen_fixture();
+        let functions = HashMap::new();
+        let structs = HashMap::new();
+        let enums = HashMap::new();
+        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let file_a = FileId::new(0);
+        let file_b = FileId::new(1);
+        let n = interner.get_or_intern("N");
+        let mut const_values: HashMap<(FileId, Spur), i128> = HashMap::new();
+        const_values.insert((file_a, n), 3);
+        // An unrelated distant const of the same name.
+        const_values.insert((file_b, n), 99);
+
+        let cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        )
+        .with_const_values(&const_values);
+
+        // file_a resolves its own N (no ambiguity, no bleed from file_b)...
+        assert_eq!(
+            cgen.resolve_infer_array_length(&ArrayLen::Named("N".to_string()), file_a),
+            Some(3)
+        );
+        // ...and file_b resolves its own, independently.
+        assert_eq!(
+            cgen.resolve_infer_array_length(&ArrayLen::Named("N".to_string()), file_b),
+            Some(99)
+        );
+    }
+
+    /// A comptime value parameter captured at the call site takes precedence
+    /// over a file-level `const` of the same name (RUE-252). Preserving this
+    /// ordering is required by the maintainer ruling.
+    #[test]
+    fn array_length_comptime_value_param_precedes_file_const() {
+        let (rir, interner, type_pool) = cgen_fixture();
+        let functions = HashMap::new();
+        let structs = HashMap::new();
+        let enums = HashMap::new();
+        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let file_a = FileId::new(0);
+        let n = interner.get_or_intern("N");
+        let mut const_values: HashMap<(FileId, Spur), i128> = HashMap::new();
+        const_values.insert((file_a, n), 9);
+
+        let cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        )
+        .with_const_values(&const_values);
+
+        // With a comptime value binding N=5, the value parameter wins over the
+        // file-level const N=9.
+        let mut values: HashMap<Spur, i128> = HashMap::new();
+        values.insert(n, 5);
+        assert_eq!(
+            cgen.resolve_infer_array_length_with_values(
+                &ArrayLen::Named("N".to_string()),
+                &values,
+                file_a
+            ),
+            Some(5)
+        );
+        // With no value binding, the same-file const supplies the length.
+        let empty: HashMap<Spur, i128> = HashMap::new();
+        assert_eq!(
+            cgen.resolve_infer_array_length_with_values(
+                &ArrayLen::Named("N".to_string()),
+                &empty,
+                file_a
+            ),
+            Some(9)
+        );
+    }
+
+    #[test]
+    fn alias_head_bare_name_resolves_in_declaring_file_scope_only() {
+        let (rir, interner, type_pool) = cgen_fixture();
+        let functions = HashMap::new();
+        let structs = HashMap::new();
+        let enums = HashMap::new();
+        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let file_a = FileId::new(0);
+        let file_b = FileId::new(1);
+        let alias = interner.get_or_intern("MyAlias");
+        let mut const_type_aliases: HashMap<(FileId, Spur), Type> = HashMap::new();
+        const_type_aliases.insert((file_a, alias), Type::I32);
+
+        let cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        )
+        .with_const_type_aliases(&const_type_aliases);
+
+        // Same module: the alias head resolves to its aliased type.
+        assert_eq!(
+            cgen.resolve_type_name("MyAlias", file_a),
+            Some(InferType::Concrete(Type::I32))
+        );
+        // Another module: out of scope, does not resolve bare.
+        assert_eq!(cgen.resolve_type_name("MyAlias", file_b), None);
+    }
+
+    /// Array lengths need an integer value; alias heads need a type. The two
+    /// scoped lookups consult separate typed maps and must not collapse into a
+    /// fuzzy "a const named X exists" match: a type-alias name never satisfies
+    /// an array length, and an integer const never satisfies an alias head.
+    #[test]
+    fn scoped_lookups_keep_value_and_type_kinds_distinct() {
+        let (rir, interner, type_pool) = cgen_fixture();
+        let functions = HashMap::new();
+        let structs = HashMap::new();
+        let enums = HashMap::new();
+        let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+        let file_a = FileId::new(0);
+        let value_name = interner.get_or_intern("K");
+        let type_name = interner.get_or_intern("T");
+        let mut const_values: HashMap<(FileId, Spur), i128> = HashMap::new();
+        const_values.insert((file_a, value_name), 4);
+        let mut const_type_aliases: HashMap<(FileId, Spur), Type> = HashMap::new();
+        const_type_aliases.insert((file_a, type_name), Type::I32);
+
+        let cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        )
+        .with_const_values(&const_values)
+        .with_const_type_aliases(&const_type_aliases);
+
+        // A type-alias name in array-length position is not an integer value.
+        assert_eq!(
+            cgen.resolve_infer_array_length(&ArrayLen::Named("T".to_string()), file_a),
+            None
+        );
+        // An integer const name in alias-head position is not a type alias.
+        assert_eq!(cgen.resolve_type_name("K", file_a), None);
     }
 }

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -621,8 +621,9 @@ impl<D: DeclarationPhase> SemaTypeSyntaxProvider<'_, '_, '_, D> {
                 );
                 value
             } else {
+                let hint = self.out_of_scope_const_hint(symbol, root_file);
                 return Err(self.invalid_array_length(format!(
-                    "'{name}' is not a compile-time constant; array lengths must be an integer literal, a `const`, or a `comptime` value parameter"
+                    "'{name}' is not a compile-time constant; array lengths must be an integer literal, a `const`, or a `comptime` value parameter{hint}"
                 )));
             }
         } else {
@@ -723,6 +724,40 @@ impl<D: DeclarationPhase> SemaTypeSyntaxProvider<'_, '_, '_, D> {
 
     fn invalid_array_length(&self, reason: String) -> CompileError {
         CompileError::new(ErrorKind::InvalidArrayLength { reason }, self.span)
+    }
+
+    /// Error-path-only candidate hint for a bare array-length name that is not
+    /// in the referencing file's scope. Bare names resolve by ordinary scoped
+    /// resolution (same module + visibility); a same-named constant in another
+    /// module does not resolve merely because it is globally unique. When such
+    /// constants exist elsewhere, name the modules that declare a visible
+    /// (`pub`) integer constant of that name so the diagnostic can steer the
+    /// author to an import + file-level `const` alias. The bounded scan runs
+    /// only after the keyed lookup has already missed, so the happy path stays
+    /// a single by-file lookup.
+    fn out_of_scope_const_hint(&self, symbol: Spur, exclude: FileId) -> String {
+        let mut modules: Vec<&str> = self
+            .sema
+            .value_consts()
+            .filter(|((file, name), info)| {
+                *file != exclude
+                    && *name == symbol
+                    && info.is_pub
+                    && info.value.as_int_value().is_some()
+            })
+            .filter_map(|((file, _), _)| self.sema.file_paths.get(file).map(String::as_str))
+            .collect();
+        modules.sort_unstable();
+        modules.dedup();
+        match modules.as_slice() {
+            [] => String::new(),
+            _ => format!(
+                "; an integer constant of that name is declared in {} — import that module and bind a file-level `const` (for example `const {}: i32 = <module>.{};`) to use it as an array length here",
+                modules.join(", "),
+                self.sema.interner.resolve(&symbol),
+                self.sema.interner.resolve(&symbol),
+            ),
+        }
     }
 
     fn observe_materialized_type_fact(&mut self, ty: Type) {

--- a/crates/rue-cli-tests/cases/bare_const_scope.toml
+++ b/crates/rue-cli-tests/cases/bare_const_scope.toml
@@ -1,0 +1,236 @@
+# Bare const names in array-length and type-alias-head positions resolve by
+# ordinary scoped resolution — the same by-file keying every other name uses
+# (RUE-1091 slice r0). The pre-module whole-program uniqueness fallback is
+# retired: a constant in another module does not participate in a bare-name
+# lookup merely because it is globally unique; it is reached qualified, or bound
+# into the current file with a file-level `const`. These cases pin locality (a
+# distant same-named const cannot change local resolution), visibility, the
+# grammar boundary for qualified paths, and the migration path the diagnostic
+# points at.
+
+[section]
+id = "cli.bare_const_scope"
+name = "Bare const scope"
+description = "Bare const names in array-length and alias-head positions follow scoped (by-file) resolution; the global-uniqueness fallback is retired (RUE-1091)."
+
+[[case]]
+name = "local_array_length_const_ignores_unrelated_imported_sibling"
+description = "A local `const K` sizes `[i32; K]` even though an imported (but unused) sibling module also declares `pub const K`: bare resolution is by-file, so the distant const cannot bleed in (RUE-1091 locality)."
+files = [
+    { path = "main.rue", source = """
+const other = @import("other.rue");
+const K: i32 = 4;
+fn main() -> i32 {
+    let a: [i32; K] = [10, 20, 30, 40];
+    a[0] + a[3]
+}
+""" },
+    { path = "other.rue", source = """
+pub const K: i32 = 99;
+""" },
+]
+exit_code = 50
+
+[[case]]
+name = "pure_unrelated_sibling_const_does_not_participate"
+description = "A same-named `pub const K` in a sibling file that is never imported cannot change the local `K` resolution — adding a distant constant does not perturb a body that never references it (RUE-1091 locality; the spooky-action-at-a-distance case)."
+files = [
+    { path = "main.rue", source = """
+const K: i32 = 4;
+fn main() -> i32 {
+    let a: [i32; K] = [10, 20, 30, 40];
+    a[0] + a[3]
+}
+""" },
+    { path = "other.rue", source = """
+pub const K: i32 = 99;
+""" },
+]
+exit_code = 50
+
+[[case]]
+name = "bare_cross_module_const_in_array_length_is_out_of_scope"
+description = "A bare array-length name resolving to a `pub const` in another module is out of scope: the diagnostic is an ordinary resolution error that names the module and suggests binding a file-level `const` (RUE-1091 scoped resolution + candidate hint)."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib.rue");
+fn main() -> i32 {
+    let a: [i32; K] = [1, 2, 3];
+    a[0]
+}
+""" },
+    { path = "lib.rue", source = """
+pub const K: i32 = 3;
+""" },
+]
+compile_fail = true
+error_contains = [
+    "E0481",
+    "not a compile-time constant",
+    "declared in lib.rue",
+    "file-level `const`",
+]
+
+[[case]]
+name = "importing_a_module_does_not_put_its_members_in_bare_scope"
+description = "`const m = @import(...)` binds the module, not its members: a `pub const N` inside `m` is reached as `m.N`, never as a bare `N`, so a bare `N` in array-length position is still out of scope (RUE-1091: import binding does not widen bare scope)."
+files = [
+    { path = "main.rue", source = """
+const m = @import("m.rue");
+fn main() -> i32 {
+    let a: [i32; N] = [1, 2];
+    a[0]
+}
+""" },
+    { path = "m.rue", source = """
+pub const N: i32 = 2;
+""" },
+]
+compile_fail = true
+error_contains = ["E0481", "not a compile-time constant", "declared in m.rue"]
+
+[[case]]
+name = "qualified_path_is_not_valid_in_array_length_position"
+description = "Array-length grammar admits an identifier or a comptime call, not a member-access path: `[i32; lib.K]` is a syntax error. The migration for a cross-module length constant is a file-level `const` alias, not qualification in place (RUE-1091: pins the grammar boundary)."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib.rue");
+fn main() -> i32 {
+    let a: [i32; lib.K] = [1, 2, 3];
+    a[0]
+}
+""" },
+    { path = "lib.rue", source = """
+pub const K: i32 = 3;
+""" },
+]
+compile_fail = true
+error_contains = ["E0100"]
+
+[[case]]
+name = "private_imported_const_is_not_visible_bare"
+description = "A non-`pub` constant in an imported module is not in bare scope and is not offered as a candidate (only visible constants are actionable import targets): the length name is an ordinary out-of-scope error (RUE-1091 visibility)."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib.rue");
+fn main() -> i32 {
+    let a: [i32; K] = [1];
+    a[0]
+}
+""" },
+    { path = "lib.rue", source = """
+const K: i32 = 3;
+pub fn touch() -> i32 { K }
+""" },
+]
+compile_fail = true
+error_contains = ["E0481", "not a compile-time constant"]
+# The only candidate is private, so the actionable-import hint must be absent
+# entirely — a private name must never be offered (or leaked) as a candidate.
+compile_stderr_not_contains = ["declared in"]
+
+[[case]]
+# Inference resolves a callee signature's `[T; K]` at the CALL SITE's file
+# (best-effort; K is out of the caller's scope so inference drops the length
+# constraint) — sema resolves K in the callee's own file and stays
+# authoritative. This is the one scenario that would regress if sema ever
+# stopped re-checking: the mismatch below must still be rejected.
+name = "cross_file_generic_signature_size_mismatch_still_rejected"
+description = "A generic callee signature `[T; K]` with K a callee-file const: a caller passing the wrong array size is still rejected (E0206) because sema resolves K in the callee's file scope, even though caller-file inference no longer resolves K (RUE-1091: sema authority over best-effort inference)."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib.rue");
+fn main() -> i32 {
+    let xs = [10, 20];
+    lib.firstof(i32, xs)
+}
+""" },
+    { path = "lib.rue", source = """
+pub const K: i32 = 3;
+pub fn firstof(comptime T: type, a: [T; K]) -> T { a[0] }
+""" },
+]
+compile_fail = true
+error_contains = ["E0206"]
+
+[[case]]
+name = "cross_file_generic_signature_size_match_accepted"
+description = "The matching-size companion: a caller passing the right array size to a generic `[T; K]` callee signature compiles and runs even though K is a callee-file const the caller never names (RUE-1091: cross-file signatures keep working without the global fallback)."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib.rue");
+fn main() -> i32 {
+    let xs = [10, 20, 30];
+    lib.firstof(i32, xs)
+}
+""" },
+    { path = "lib.rue", source = """
+pub const K: i32 = 3;
+pub fn firstof(comptime T: type, a: [T; K]) -> T { a[0] }
+""" },
+]
+exit_code = 10
+
+[[case]]
+name = "cross_module_array_length_migrates_via_file_level_const_alias"
+description = "The migration the out-of-scope diagnostic suggests: bind the other module's constant into this file with a file-level `const`, after which the bare name sizes the array (RUE-1091; a[0]+a[2] = 1+3)."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib.rue");
+const K: i32 = lib.K;
+fn main() -> i32 {
+    let a: [i32; K] = [1, 2, 3];
+    a[0] + a[2]
+}
+""" },
+    { path = "lib.rue", source = """
+pub const K: i32 = 3;
+""" },
+]
+exit_code = 4
+
+[[case]]
+name = "bare_alias_head_resolves_in_same_file_scope"
+description = "A bare type-alias head (`const Ints = ...; -> Ints`) resolves against its own file's scope in the alias-head position that the retired fallback used to serve (RUE-1091 alias-head scoped resolution)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const std = @import("std");
+const Ints = std.arraybuf.ArrayBuf(i64);
+fn make() -> Ints {
+    let mut b = Ints.new();
+    b.push(0 - 1);
+    b
+}
+fn main() -> i32 {
+    let b = make();
+    let neg: i64 = 0 - 1;
+    if b.get_or(0, 0) == neg { 42 } else { 1 }
+}
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "bare_alias_head_from_another_module_is_out_of_scope"
+description = "A `pub const` type alias declared in another module is not a bare type in the importing file — it is reached qualified (`lib.MyBuf`). A bare reference is an ordinary unknown-type error (RUE-1091 alias-head locality)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib.rue");
+fn make() -> MyBuf {
+    MyBuf.new()
+}
+fn main() -> i32 {
+    let b = make();
+    let _ = b;
+    0
+}
+""" },
+    { path = "lib.rue", source = """
+const std = @import("std");
+pub const MyBuf = std.arraybuf.ArrayBuf(i64);
+""" },
+]
+compile_fail = true
+error_contains = ["E0204", "unknown type 'MyBuf'"]

--- a/docs/notes/rue-1091-analyzer-rewire-plan.md
+++ b/docs/notes/rue-1091-analyzer-rewire-plan.md
@@ -296,6 +296,13 @@ target (RISK R2), not a new edge.
 - **Files**: differential adapter, oracle harness.
 - **Tests**: whole-body `transaction_equal` across schedule permutations; edge-completeness (no
   epoch namespace/table read remains — capability guard); forced-eviction + cancellation.
+- **Carried from r0** (recorded per the r0 acceptance criteria): the full structural locality
+  assertion — adding a same-named constant in an unrelated module does not change a body's
+  recorded dependency-edge set. r0 could pin it only at the resolution-function level (the
+  spooky-action unit test) and the counter level
+  (`identity_per_body_lookup_invariant_to_unrelated_declarations`); the recorded-edge-set
+  differential needs this slice's provider harness. The E0481 candidate-hint scan must also be
+  shown to record no dependency edges (it is error-path diagnostic material, not resolution).
 - **Size**: **M**. After this, ProviderFacts is proven equal for every corpus shape and the flip is
   a pure delete.
 
@@ -430,7 +437,16 @@ lands first, alone, with the full semantics-change discipline:
   migrate each (qualification or import). Cases asserting the old ambiguity
   failure mode flip to the scoped diagnostic.
 - Diagnostic quality: the not-in-scope error names the candidates that exist in
-  other modules to guide the import.
+  other modules to guide the import. Discipline (review caution, adopted): the
+  candidate set is computed when the diagnostic is materialized during
+  analysis — never during rendering — with deterministic ordering, and it is
+  error-path-only. An exhaustive cross-module candidate search is a global
+  reverse-name dependency for failed lookups; that is tolerable pre-flip
+  (bounded to erroring bodies under the eager epoch), but at the provider flip
+  the hint must be served by a keyed (name, kind) suggestion index whose edge
+  is recorded at diagnostic construction, or degrade to a generic suggestion.
+  An erroring body may not retain a whole-universe dependency past the flip;
+  rFinal's edge-completeness check covers this case explicitly.
 
 Design review (2026-07-23) confirmed the direction with no blockers and
 strengthened the acceptance criteria below; r0 is not done until all of them

--- a/docs/spec/src/07-arrays/01-fixed-arrays.md
+++ b/docs/spec/src/07-arrays/01-fixed-arrays.md
@@ -169,13 +169,23 @@ comptime-evaluable function (rule 7.1:41).
 
 An array length **MAY** be an identifier naming a compile-time constant in
 addition to an integer literal. A file-level `const` of an integer type and a
-`comptime` value parameter both qualify.
+`comptime` value parameter both qualify. The identifier is resolved by ordinary
+scoped resolution (rule 10.3:8): a bare name in these positions is resolved in
+the declaration or body scope in which the length appears — a `const` of that
+same file, or a `comptime` value parameter in scope there — and a `comptime`
+value parameter takes precedence over a same-named file-level `const`.
+Declarations outside that scope do not participate merely because they are
+globally unique: a constant declared only in another module is reached by
+binding it into this file with a file-level `const`, and adding a same-named
+constant in an unrelated module never changes which length a bare name
+resolves to.
 
 {{ rule(id="7.1:33", cat="legality-rule") }}
 
 A named array length **MUST** resolve to a non-negative integer compile-time
-constant. A runtime variable, a negative value, or an undefined name in
-length position is a compile-time error.
+constant. A runtime variable, a negative value, or a name that does not resolve
+in scope — including a name that names a constant only in another module (rule
+10.3:8) — in length position is a compile-time error.
 
 {{ rule(id="7.1:34", cat="normative") }}
 


### PR DESCRIPTION
Slice r0 of the RUE-1091 analyzer rewire: retire the RUE-638 global bare-name uniqueness fallback (`unique_const_value` / `unique_const_type_alias`) so bare const names in array-length and alias-head positions resolve through ordinary module/import/visibility scope rules, per the maintainer language ruling recorded in the merged plan.

## Why this is safe as a semantic change

Corpus-impact enumeration found **zero cross-module reliance**: sema's authoritative resolver was already same-file scoped (E0481/E0204 reject cross-module bare names today), so the retired scans were inference-only over-resolution that sema always overrode — no compiling program depended on them, and migration count is 0. Their one observable effect was spooky action at a distance (a same-named constant in an unrelated module flipped the uniqueness predicate and broke local inference), now pinned impossible by a named regression test.

## What's in the slice

- **generate.rs**: keyed by-file `scoped_const_value`/`scoped_const_type_alias` replace the whole-program scans; the reference site's file governs; comptime-value parameter precedence preserved; value vs type stay in separate typed maps. Callee signatures re-resolved at cross-file call sites are documented best-effort in inference — sema stays authoritative, pinned by the `cross_file_generic_signature_*` CLI cases (mismatches still rejected).
- **typeck.rs**: `out_of_scope_const_hint` on E0481 names visible (`pub`) candidate modules — error-path only, deterministic order, built at error materialization per the plan's pinned diagnostic discipline; private names never offered (asserted by test).
- **Spec** 7.1:32/7.1:33: scoped rule with the explicit locality sentence citing 10.3:8; no new rule identifiers.
- **Plan**: const-hint discipline pinned; the full recorded-edge-set locality assertion is recorded as carried to rFinal (r0 pins it at the resolution-function and counter levels).
- **Tests**: 6 rue-air unit tests + 11 CLI cases (`bare_const_scope.toml`) — locality including the spooky-action regression, visibility with an absent-hint assertion, import-binding boundary, qualified-path grammar boundary (E0100), the migration path, both alias-head positions, and cross-file generic signatures in both directions.

## Validation

rue-air 574, rue-compiler 790, spec corpus 2178, full CLI corpus, differential oracle, scaling filter 13/13 with the **RUE-1090 verdict unchanged at ACTIVATE**, clippy (66 targets), fmt — plus a controlled A/B on the heavy `harbor` example (identical 445s compile time on trunk vs this change). Adversarially reviewed with no blockers: the sema-authority claim was attacked directly with cross-file repros and survived (including a cross-file array-size mismatch still correctly rejected); review findings (carried-assertion record, best-effort comment, negative hint assertion, new signature cases) are folded in.

Part of RUE-1091