### PR TITLE
Fix invalid comptime type argument ICE

### DIFF
--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -192,7 +192,12 @@ impl<'a> BodySema<'a> {
                     }
                 }
                 crate::inference::InferenceBodyDependency::IncompleteCallable => {
-                    incomplete = true;
+                    // This path is reached only while publishing an inference
+                    // error. An unresolved callable is therefore part of the
+                    // rejected source construct, not evidence that a query
+                    // dependency is absent. Treating it as retryable discards
+                    // the user diagnostic and makes the uncanceled body query
+                    // surface E9000 instead.
                 }
             }
         }

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -4227,7 +4227,7 @@ fn main() -> i32 {
     }
 
     #[test]
-    fn failed_one_body_inference_with_unresolved_generic_identity_is_non_terminal() {
+    fn failed_one_body_inference_with_unresolved_generic_identity_is_deterministic() {
         use crate::sema::{OneBodyRequest as R, OneBodyTransactionOutcome as O};
         let source = r#"
             fn generic(comptime T: type, value: T) -> T { value }
@@ -4245,8 +4245,11 @@ fn main() -> i32 {
             None,
         );
         let outcome = bound.analyze_one_body_for_test(R::Definition(bad), None);
-        assert!(matches!(outcome, O::NonTerminal { .. }), "{outcome:?}");
-        assert_eq!(outcome.references(), None);
+        let O::DeterministicFailure { errors, references } = outcome else {
+            panic!("inference failure did not publish a deterministic terminal: {outcome:?}")
+        };
+        assert!(!errors.is_empty());
+        assert!(references.is_empty(), "{references:?}");
     }
 
     #[test]

--- a/crates/rue-cli-tests/cases/ice_regressions.toml
+++ b/crates/rue-cli-tests/cases/ice_regressions.toml
@@ -457,3 +457,24 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["E0425", "inout argument must be"]
+[[case]]
+name = "invalid_comptime_type_argument_reports_diagnostic"
+description = "A rejected comptime type argument is a deterministic user error, not an incomplete body query."
+files = [{ path = "main.rue", source = """
+fn id(comptime T: type, value: T) -> T { value }
+fn main() -> i32 { id(32, 42) }
+""" }]
+compile_fail = true
+error_contains = ["E0206", "type mismatch"]
+compile_stderr_not_contains = ["internal compiler error", "did not publish a terminal"]
+
+[[case]]
+name = "unknown_comptime_type_argument_reports_diagnostic"
+description = "An unknown type passed to a comptime type parameter does not abort body-query publication."
+files = [{ path = "main.rue", source = """
+fn id(comptime T: type, value: T) -> T { value }
+fn main() -> i32 { id(i34, 42) }
+""" }]
+compile_fail = true
+error_contains = ["E0206", "type mismatch"]
+compile_stderr_not_contains = ["internal compiler error", "did not publish a terminal"]


### PR DESCRIPTION
## Summary

- publish inference failures with unresolved comptime callables as deterministic diagnostics
- update the one-body transaction contract test
- add CLI regressions for the nightly fuzz reproducers

## Root cause

`InferenceBodyDependency::IncompleteCallable` was treated as a retryable missing dependency even while an authoritative inference error was being published. The body query therefore discarded E0206 and returned a non-terminal result, which the uncanceled compiler surfaced as E9000.

## Validation

- reproduced and rechecked all three crash artifacts from runs 29887117306 and 29976636537
- `scripts/rue cli ice_regressions` (37 passed)
- `scripts/rue unit air failed_one_body_inference_with_unresolved_generic_identity_is_deterministic`
- `scripts/rue quick` (36 targets passed)
- `scripts/rue fmt`

Fixes #1893