### PR TITLE
RUE-1044: prefer Option for lookup absence

### DIFF
--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -5,6 +5,12 @@
 
 use super::*;
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum IntegerSentinel {
+    UnsignedMax,
+    NegativeOne,
+}
+
 impl<'a> BodySema<'a> {
     /// Convert RIR argument mode to AIR argument mode.
     pub(super) fn convert_arg_mode(mode: RirArgMode) -> AirArgMode {
@@ -367,6 +373,15 @@ impl<'a> BodySema<'a> {
             ));
         }
 
+        if allow_bool && self.is_sentinel_lookup_test(lhs, rhs) {
+            ctx.warnings.push(
+                CompileWarning::new(WarningKind::SentinelLookup, span).with_help(
+                    "preserve absence in the type system: use an Option-returning lookup \
+                     such as `get`, `index_of`, or `find`, then match on `Some`/`None`",
+                ),
+            );
+        }
+
         let comparison = make_data(lhs_result.air_ref, rhs_result.air_ref);
         if matches!(comparison, AirInstData::Eq(..) | AirInstData::Ne(..))
             && let Some(result) = self.try_prepare_aggregate_equality(
@@ -387,6 +402,42 @@ impl<'a> BodySema<'a> {
             span,
         });
         Ok(AnalysisResult::new(air_ref, Type::BOOL))
+    }
+
+    fn is_sentinel_lookup_test(&self, lhs: InstRef, rhs: InstRef) -> bool {
+        self.integer_sentinel(rhs)
+            .is_some_and(|sentinel| self.is_get_or_with_sentinel(lhs, sentinel))
+            || self
+                .integer_sentinel(lhs)
+                .is_some_and(|sentinel| self.is_get_or_with_sentinel(rhs, sentinel))
+    }
+
+    fn is_get_or_with_sentinel(&self, inst: InstRef, sentinel: IntegerSentinel) -> bool {
+        let InstData::MethodCall { method, args, .. } = &self.rir.get(inst).data else {
+            return false;
+        };
+        if self.interner.resolve(method) != "get_or" {
+            return false;
+        }
+        let args = self.rir.call_args(args);
+        let mut args = args.iter();
+        let (Some(_index), Some(default), None) = (args.next(), args.next(), args.next()) else {
+            return false;
+        };
+        self.integer_sentinel(default.value) == Some(sentinel)
+    }
+
+    fn integer_sentinel(&self, inst: InstRef) -> Option<IntegerSentinel> {
+        match self.rir.get(inst).data {
+            InstData::IntConst(u64::MAX) => Some(IntegerSentinel::UnsignedMax),
+            InstData::Sub { lhs, rhs }
+                if matches!(self.rir.get(lhs).data, InstData::IntConst(0))
+                    && matches!(self.rir.get(rhs).data, InstData::IntConst(1)) =>
+            {
+                Some(IntegerSentinel::NegativeOne)
+            }
+            _ => None,
+        }
     }
 
     /// Check if an RIR instruction is a VarRef to a comptime type variable.

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -2188,6 +2188,9 @@ pub enum WarningKind {
     /// A pattern that will never be matched because a previous pattern already covers it.
     #[error("unreachable pattern '{0}'")]
     UnreachablePattern(String),
+    /// A lookup's fallback sentinel is compared with the same sentinel to test absence.
+    #[error("integer sentinel used to test lookup absence")]
+    SentinelLookup,
 }
 
 /// A compilation warning with optional source location information.

--- a/crates/rue-ui-tests/cases/warnings/sentinel_lookup.toml
+++ b/crates/rue-ui-tests/cases/warnings/sentinel_lookup.toml
@@ -1,0 +1,77 @@
+[section]
+id = "warnings.sentinel_lookup"
+name = "Sentinel lookup warnings"
+description = "Prefer Option-returning lookup APIs when absence is meaningful."
+
+[[case]]
+name = "get_or_negative_one_membership_test_warns"
+source = """
+struct Map {
+    value: i64,
+
+    fn get_or(borrow self, key: i64, default: i64) -> i64 {
+        if key == 0 { self.value } else { default }
+    }
+}
+
+fn main() -> i32 {
+    let map = Map { value: 7 };
+    if map.get_or(1, 0 - 1) == 0 - 1 { 42 } else { 0 }
+}
+"""
+exit_code = 42
+warning_contains = [
+    "integer sentinel used to test lookup absence",
+    "Option-returning lookup",
+]
+expected_warning_count = 1
+
+[[case]]
+name = "get_or_unsigned_max_membership_test_warns"
+source = """
+struct Map {
+    value: u64,
+
+    fn get_or(borrow self, key: u64, default: u64) -> u64 {
+        if key == 0 { self.value } else { default }
+    }
+}
+
+fn main() -> i32 {
+    let map = Map { value: 7 };
+    if 18446744073709551615 != map.get_or(1, 18446744073709551615) { 0 } else { 42 }
+}
+"""
+exit_code = 42
+warning_contains = ["integer sentinel used to test lookup absence"]
+expected_warning_count = 1
+
+[[case]]
+name = "get_or_sentinel_as_domain_default_does_not_warn"
+source = """
+struct Map {
+    value: i64,
+
+    fn get_or(borrow self, key: i64, default: i64) -> i64 {
+        if key == 0 { self.value } else { default }
+    }
+}
+
+fn main() -> i32 {
+    let map = Map { value: 7 };
+    @intCast(map.get_or(1, 0 - 1) + 43)
+}
+"""
+exit_code = 42
+no_warnings = true
+
+[[case]]
+name = "ordinary_max_arithmetic_does_not_warn"
+source = """
+fn main() -> i32 {
+    let max: u64 = 18446744073709551615;
+    if max - 1 < max { 42 } else { 0 }
+}
+"""
+exit_code = 42
+no_warnings = true

--- a/examples/hashmap/main.rue
+++ b/examples/hashmap/main.rue
@@ -1,4 +1,6 @@
 const map = @import("map.rue");
+const std = @import("std");
+const OptI64 = std.option.Option(i64);
 
 fn main() -> i32 {
     let mut m = map.Map.with_capacity(4);
@@ -23,7 +25,10 @@ fn main() -> i32 {
         k = k + 1;
     }
     // Spot checks
-    @assert(m.get_or(0 - 300, 0 - 1) == 0 - 1 || true, "probe");
+    match m.get(0 - 300) {
+        OptI64.Some(unexpected) => @assert(unexpected != unexpected, "removed key is absent"),
+        OptI64.None => {},
+    }
     let a = m.get_or(98 * 7 - 300, 0 - 1);        // overwritten -> 98 (98*7-300=386, not on the 21k-300 removal stride)
     let b = m.get_or(151 * 7 - 300, 0 - 1);       // untouched -> 151*151 (757 not on the removal stride)
     let c = m.get_or(7000, 0 - 1);                // absent -> -1

--- a/examples/hashmap/map.rue
+++ b/examples/hashmap/map.rue
@@ -3,6 +3,7 @@
 // buffer (0=empty, 1=full, 2=tombstone).
 const std = @import("std");
 const Ints = std.arraybuf.ArrayBuf(i64);
+const OptI64 = std.option.Option(i64);
 
 pub struct Map {
     keys: Ints,
@@ -60,25 +61,28 @@ pub struct Map {
         }
     }
 
-    fn get_or(borrow self, key: i64, default: i64) -> i64 {
+    fn get(borrow self, key: i64) -> OptI64 {
         let mut i = self.hash(key);
         let mut probes: u64 = 0;
-        let mut result = default;
-        let mut found = false;
         while probes < self.cap {
             let s = self.state.get_or(i, 0);
             if s == 0 { break; }
             if s == 1 {
                 if self.keys.get_or(i, 0) == key {
-                    result = self.vals.get_or(i, 0);
-                    found = true;
-                    break;
+                    return OptI64.Some(self.vals.get_or(i, 0));
                 }
             }
             i = (i + 1) % self.cap;
             probes = probes + 1;
         }
-        if found { result } else { result }
+        OptI64.None
+    }
+
+    fn get_or(borrow self, key: i64, default: i64) -> i64 {
+        match self.get(key) {
+            OptI64.Some(value) => value,
+            OptI64.None => default,
+        }
     }
 
     fn remove(inout self, key: i64) -> bool {

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -14,8 +14,10 @@
 // - std.intmap.IntMap / std.strmap.StrMap: open-addressing hash maps
 // - std.strbuf.StrBuf: Growable strings, with copying bridges to str and
 //   ArrayBuf(u8) (`from_str`, `from_bytes`, `to_bytes`, and append variants)
-// - std.arraybuf.ArrayBuf: Growable heap-backed collections; ArrayBuf(u8) can
-//   copy from str with `from_str` / `extend_str`
+// - std.arraybuf.ArrayBuf: Growable heap-backed collections; `get` and
+//   `index_of` preserve absence as `Option`, while `get_or` is for a genuine
+//   fallback value. ArrayBuf(u8) can copy from str with `from_str` /
+//   `extend_str`.
 // - std.fs.File: File IO (open/create/append/read/write/seek/tell/metadata/close
 //   over @syscall) plus fs.rename/remove/create_dir/remove_dir/metadata
 // - std.binary: endianness-explicit integer<->byte conversions

--- a/std/arraybuf.rue
+++ b/std/arraybuf.rue
@@ -42,6 +42,10 @@
 // scope-exit destructor is then a safe no-op. `get`/`pop` return `Option(T)`
 // (RUE-313).
 //
+// Absence is represented with `Option`, never an integer sentinel. Use `get`
+// when an index may be out of bounds and `index_of` when searching for a value;
+// reserve `get_or` for callers that truly have a domain value to substitute.
+//
 // SCOPE / KNOWN LIMITATIONS (tracked separately — this file deliberately does
 // not work around them):
 //


### PR DESCRIPTION
## Summary

- add a narrow warning for `get_or(_, sentinel)` comparisons that use the same integer sentinel to test absence
- document `Option` as the canonical no-index/no-value representation and reserve `get_or` for genuine fallback values
- give the hashmap example an `Option`-returning `get` API and use it for membership testing

## Why

Rue can already represent optional copy values, and `ArrayBuf.index_of` already returns `Option(u64)`. This closes the remaining guidance and adoption gap without touching the incremental compiler work or converting legitimate fallback uses.

Fixes RUE-1044.

## Validation

- `scripts/rue fmt`
- `scripts/rue unit parser`
- `scripts/rue ui sentinel_lookup`
- `scripts/rue cli hashmap`
- `scripts/rue quick`
- `scripts/rue test`
