### PR TITLE
Ruelex: accept wildcard payload bindings

### DIFF
--- a/crates/rue-frontend-diff/src/main.rs
+++ b/crates/rue-frontend-diff/src/main.rs
@@ -36,6 +36,10 @@ const SYNTAX_PROBES: &[(&str, &str)] = &[
         "slice-types.rue",
         "fn f(borrow bytes: [u8]) -> u64 { @size_of([u8]) }",
     ),
+    (
+        "wildcard-payload-pattern.rue",
+        "enum Maybe { None, Some(u64) } fn f(value: Maybe) -> u64 { match value { Maybe.Some(_) => 1, Maybe.None => 0 } }",
+    ),
 ];
 
 fn node(kind: &str, meta: &str, a: String, b: String, c: String, d: String) -> String {

--- a/examples/ruelex/parse.rue
+++ b/examples/ruelex/parse.rue
@@ -397,7 +397,11 @@ pub struct Parser {
         let mut binds: u64 = 0;
         if self.eat(token.LPAREN) {
             while !self.at(token.RPAREN) && !self.eof() {
-                let b = self.expect(token.IDENT);
+                let b = if self.at(token.UNDERSCORE) {
+                    self.bump()
+                } else {
+                    self.expect(token.IDENT)
+                };
                 binds = self.append(binds, self.add(ast.IDENT, b.value, b.start, b.end, 0, 0, 0));
                 if !self.eat(token.COMMA) { break; }
             }


### PR DESCRIPTION
## Summary

- accept `_` alongside named bindings in Ruelex variant payload patterns
- add an end-to-end frontend-differential syntax probe for `Maybe.Some(_)`

## Root cause

The production parser represents wildcard payload bindings through the same identifier-shaped binding list as named payloads. Ruelex instead required every payload token to be `IDENT`, so it rejected the production-valid `UNDERSCORE` token before constructing that node.

## Impact

Ruelex now accepts valid wildcard payload patterns and the differential harness protects this production/Ruelex conformance boundary directly.

## Validation

- `./buck2 test //crates/rue-frontend-diff:frontend-diff-test`
- `scripts/rue quick`
- `scripts/rue cli rueparse`
