### PR TITLE
Check cumulative function frame budgets

### DIFF
--- a/crates/rue-air/src/layout.rs
+++ b/crates/rue-air/src/layout.rs
@@ -25,6 +25,30 @@
 /// derive their byte quantities from this constant so they cannot drift apart.
 pub const SLOT_BYTES: u64 = 8;
 
+/// Call-boundary stack alignment shared by both supported targets.
+pub const STACK_FRAME_ALIGNMENT: u64 = 16;
+
+/// Largest aligned frame or transient call area representable by the signed
+/// 32-bit displacements used throughout both machine backends.
+///
+/// Rounding the architectural `i32::MAX` bound down keeps the subsequent
+/// alignment operation inside the same representable range.
+pub const MAX_FUNCTION_FRAME_BYTES: u64 =
+    (i32::MAX as u64 / STACK_FRAME_ALIGNMENT) * STACK_FRAME_ALIGNMENT;
+
+/// [`MAX_FUNCTION_FRAME_BYTES`] expressed as slot-shaped frame cells.
+pub const MAX_FUNCTION_FRAME_SLOTS: u64 = MAX_FUNCTION_FRAME_BYTES / SLOT_BYTES;
+
+/// Add one slot-shaped region to a cumulative function-frame total.
+///
+/// This is the semantic-analysis boundary: it rejects cumulative locals or
+/// parameters before their per-slot metadata is allocated.
+#[inline]
+pub fn checked_function_frame_slots(current: u32, additional: u32) -> Option<u32> {
+    let total = u64::from(current).checked_add(u64::from(additional))?;
+    (total <= MAX_FUNCTION_FRAME_SLOTS).then_some(total as u32)
+}
+
 /// The physical layout of a materializable type.
 ///
 /// `size` counts every byte the value occupies including tail padding, `stride`

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -426,27 +426,17 @@ impl<'a> BodySema<'a> {
             debug_assert!(matches!(mode, RirParamMode::Inout | RirParamMode::Borrow));
         }
 
-        let mut param_vec: Vec<ParamInfo> = Vec::new();
-        let mut param_by_ref: Vec<bool> = Vec::new();
-        let mut param_writable: Vec<bool> = Vec::new();
-
-        // Add parameters to the param vec, tracking ABI slot offsets.
-        // Each parameter starts at the next available ABI slot.
-        // For struct parameters, the slot count is the number of fields.
-        let mut next_abi_slot: u32 = 0;
-        for (pname, ptype, mode, is_comptime) in params.iter() {
+        // Classify and total every parameter before allocating per-slot mode
+        // metadata. This makes a cumulatively oversized signature fail with
+        // E0907 instead of first attempting a displacement-sized allocation
+        // (RUE-780).
+        let mut num_param_slots = 0_u32;
+        let mut param_layouts = Vec::with_capacity(params.len());
+        for (pname, ptype, mode, _) in params.iter() {
             // Only the synthetic `self` entry of a `mut self` method can be a
             // mutable by-value binding; ordinary parameters have no `mut`
             // form.
             let is_mut_binding = self_is_mut && *pname == self_sym && *mode == RirParamMode::Normal;
-            param_vec.push(ParamInfo {
-                name: *pname,
-                abi_slot: next_abi_slot,
-                ty: *ptype,
-                mode: *mode,
-                is_comptime: *is_comptime,
-                is_mut: is_mut_binding,
-            });
             // Inout and Borrow parameters are passed by reference.
             // Comptime parameters are VALUE params (like `comptime n: i32`), passed by value.
             // Normal parameters are passed by value.
@@ -483,18 +473,38 @@ impl<'a> BodySema<'a> {
                 // frame: reject an oversized type (E0906, RUE-561).
                 self.require_layout_slots(*ptype, self.rir.get(body).span)?
             };
-            for _ in 0..slot_count {
-                param_by_ref.push(is_by_ref);
-                // "Writable" means the body may store to the slot: `inout`
-                // (by-ref, written back to the caller) or a `mut self`
-                // receiver (by-value, callee-local). Optimizers and the
-                // oracle contract read this to know the slot can change
-                // between reads.
-                param_writable.push(*mode == RirParamMode::Inout || is_mut_binding);
-            }
+            self.reserve_frame_slots(&mut num_param_slots, slot_count, self.rir.get(body).span)?;
+            param_layouts.push((is_by_ref, is_mut_binding, slot_count));
+        }
+
+        let mut param_vec: Vec<ParamInfo> = Vec::with_capacity(params.len());
+        let mut param_by_ref: Vec<bool> = Vec::with_capacity(num_param_slots as usize);
+        let mut param_writable: Vec<bool> = Vec::with_capacity(num_param_slots as usize);
+
+        // Publish the already-validated offsets and per-slot modes.
+        let mut next_abi_slot = 0_u32;
+        for ((pname, ptype, mode, is_comptime), (is_by_ref, is_mut_binding, slot_count)) in
+            params.iter().zip(param_layouts)
+        {
+            param_vec.push(ParamInfo {
+                name: *pname,
+                abi_slot: next_abi_slot,
+                ty: *ptype,
+                mode: *mode,
+                is_comptime: *is_comptime,
+                is_mut: is_mut_binding,
+            });
+            param_by_ref.resize(param_by_ref.len() + slot_count as usize, is_by_ref);
+            // "Writable" means the body may store to the slot: `inout`
+            // (by-ref, written back to the caller) or a `mut self` receiver
+            // (by-value, callee-local).
+            param_writable.resize(
+                param_writable.len() + slot_count as usize,
+                *mode == RirParamMode::Inout || is_mut_binding,
+            );
             next_abi_slot += slot_count;
         }
-        let num_param_slots = next_abi_slot;
+        debug_assert_eq!(next_abi_slot, num_param_slots);
         let param_modes = ParamSlotModes::new(param_by_ref, param_writable);
 
         // The callee owns its pass-by-value (Normal) parameters and must drop

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -269,8 +269,8 @@ impl<'a> BodySema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<(u32, AirRef, AirRef)> {
-        let slot = ctx.next_slot;
-        ctx.next_slot += self.require_layout_slots(ty, span)?;
+        let slots = self.require_layout_slots(ty, span)?;
+        let slot = self.reserve_frame_slots(&mut ctx.next_slot, slots, span)?;
         let live = air.add_inst(AirInst {
             data: AirInstData::StorageLive { slot },
             ty,
@@ -318,8 +318,8 @@ impl<'a> BodySema<'a> {
         if self.is_addressable_read(air, value) {
             return Ok((value, prefix));
         }
-        let slot = ctx.next_slot;
-        ctx.next_slot += self.require_layout_slots(ty, span)?;
+        let slots = self.require_layout_slots(ty, span)?;
+        let slot = self.reserve_frame_slots(&mut ctx.next_slot, slots, span)?;
         let live = air.add_inst(AirInst {
             data: AirInstData::StorageLive { slot },
             ty,
@@ -547,8 +547,8 @@ impl<'a> BodySema<'a> {
             });
             return Ok(air.add_block(&stmts, value, result_type, span)?);
         }
-        let temp_slot = ctx.next_slot;
-        ctx.next_slot += self.require_layout_slots(base_type, span)?;
+        let slots = self.require_layout_slots(base_type, span)?;
+        let temp_slot = self.reserve_frame_slots(&mut ctx.next_slot, slots, span)?;
 
         let storage_live = air.add_inst(AirInst {
             data: AirInstData::StorageLive { slot: temp_slot },
@@ -1038,9 +1038,8 @@ impl<'a> BodySema<'a> {
         let allow_unused = self.has_allow_directive(directives.iter(), "unused_variable");
 
         // Allocate slots
-        let slot = ctx.next_slot;
         let num_slots = self.require_layout_slots(var_type, span)?;
-        ctx.next_slot += num_slots;
+        let slot = self.reserve_frame_slots(&mut ctx.next_slot, num_slots, span)?;
 
         // A `for`-loop element binder over a NON-Copy collection aliases an
         // element the collection still owns and drops (spec 4.8:26): mark its
@@ -2173,9 +2172,8 @@ impl<'a> BodySema<'a> {
         let field_type = struct_field.ty;
 
         // Allocate a temporary slot for the computed struct value
-        let temp_slot = ctx.next_slot;
         let num_slots = self.require_layout_slots(base_type, span)?;
-        ctx.next_slot += num_slots;
+        let temp_slot = self.reserve_frame_slots(&mut ctx.next_slot, num_slots, span)?;
 
         // Emit StorageLive for the temporary
         let storage_live_ref = air.add_inst(AirInst {
@@ -2517,9 +2515,8 @@ impl<'a> BodySema<'a> {
         }
 
         // Allocate a temporary slot for the computed array value
-        let temp_slot = ctx.next_slot;
         let num_slots = self.require_layout_slots(base_type, span)?;
-        ctx.next_slot += num_slots;
+        let temp_slot = self.reserve_frame_slots(&mut ctx.next_slot, num_slots, span)?;
 
         // Emit StorageLive for the temporary
         let storage_live_ref = air.add_inst(AirInst {

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -3241,6 +3241,28 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         }
     }
 
+    /// Reserve a cumulative local or parameter frame region without allowing
+    /// individually valid layouts to overflow the function-wide displacement
+    /// budget (RUE-780).
+    pub(crate) fn reserve_frame_slots(
+        &self,
+        current: &mut u32,
+        additional: u32,
+        span: Span,
+    ) -> CompileResult<u32> {
+        let start = *current;
+        *current =
+            crate::layout::checked_function_frame_slots(start, additional).ok_or_else(|| {
+                CompileError::new(
+                    ErrorKind::FunctionFrameTooLarge {
+                        max_bytes: crate::layout::MAX_FUNCTION_FRAME_BYTES,
+                    },
+                    span,
+                )
+            })?;
+        Ok(start)
+    }
+
     /// Checked companion to [`Self::abi_slot_count`]: `None` when the type's
     /// layout overflows or exceeds [`MAX_TYPE_SLOTS`] (RUE-561). Computed in
     /// u64 with checked arithmetic so large array lengths cannot truncate to

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -371,6 +371,8 @@ pub struct Emitter<'a> {
     callee_saved: Vec<Reg>,
     /// Whether a stack frame was emitted (prologue was executed).
     has_frame: bool,
+    /// Canonical checked layout supplied by the production pipeline.
+    frame_layout: Option<crate::frame_layout::FrameLayout>,
     /// String constants (for StringConstPtr/StringConstLen)
     strings: &'a [String],
     /// Byte offset where the current instruction started (for recording).
@@ -416,6 +418,7 @@ impl<'a> Emitter<'a> {
             has_sret: false,
             callee_saved: callee_saved.to_vec(),
             has_frame: false,
+            frame_layout: None,
             strings,
             inst_start: 0,
             emit_asm: false,
@@ -438,6 +441,14 @@ impl<'a> Emitter<'a> {
     /// register assignment, and reserves the sret pointer frame slot.
     pub fn with_sret(mut self, has_sret: bool) -> Self {
         self.has_sret = has_sret;
+        self
+    }
+
+    pub(crate) fn with_frame_layout(
+        mut self,
+        frame_layout: crate::frame_layout::FrameLayout,
+    ) -> Self {
+        self.frame_layout = Some(frame_layout);
         self
     }
 
@@ -615,9 +626,15 @@ impl<'a> Emitter<'a> {
         // sret pointer slot, if any.
         let total_slots = self.num_locals + self.num_params + self.has_sret as u32;
         if total_slots > 0 {
-            let stack_size = crate::frame_layout::align_frame_size(
-                crate::frame_layout::slot_region_bytes(total_slots),
-            );
+            let frame = self.frame_layout.unwrap_or_else(|| {
+                crate::frame_layout::FrameLayout::try_new(
+                    crate::frame_layout::SavedRegScheme::Aarch64,
+                    self.callee_saved.len(),
+                    total_slots,
+                )
+                .expect("emitter frame must fit the checked function-frame budget")
+            });
+            let stack_size = frame.frame_size() as i32 - frame.saved_area_bytes();
             if stack_size > 0 {
                 self.begin_inst();
                 self.emit_sub_imm(Reg::Sp, Reg::Sp, stack_size as u32);
@@ -1440,9 +1457,15 @@ impl<'a> Emitter<'a> {
             // Must mirror the prologue's allocation exactly: locals + ALL
             // params + the sret pointer slot.
             let total_slots = self.num_locals + self.num_params + self.has_sret as u32;
-            let stack_size = crate::frame_layout::align_frame_size(
-                crate::frame_layout::slot_region_bytes(total_slots),
-            );
+            let frame = self.frame_layout.unwrap_or_else(|| {
+                crate::frame_layout::FrameLayout::try_new(
+                    crate::frame_layout::SavedRegScheme::Aarch64,
+                    self.callee_saved.len(),
+                    total_slots,
+                )
+                .expect("emitter frame must fit the checked function-frame budget")
+            });
+            let stack_size = frame.frame_size() as i32 - frame.saved_area_bytes();
             if stack_size > 0 {
                 self.begin_inst();
                 self.emit_add_imm(Reg::Sp, Reg::Sp, stack_size as u32);

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -38,7 +38,7 @@ use crate::regalloc::RegAllocDebugInfo;
 // Re-export from parent
 pub use super::{EmittedCode, EmittedRelocation};
 
-fn prepare_backend(
+pub(crate) fn prepare_backend(
     cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
@@ -48,7 +48,9 @@ fn prepare_backend(
     crate::codegen_pipeline::prepare_mir(
         cfg,
         type_pool,
+        cfg_lower::ARG_REGS.len() as u32,
         cfg_lower::RET_REGS.len() as u32,
+        crate::frame_layout::SavedRegScheme::Aarch64,
         || CfgLower::new_with_symbols(cfg, type_pool, interner, target, symbols).lower(),
         |mir, existing_slots| RegAlloc::new(mir, existing_slots).allocate_with_spills(),
         |mir| {
@@ -104,6 +106,7 @@ where
         &local_strings,
     )
     .with_sret(prepared.has_sret)
+    .with_frame_layout(prepared.frame_layout)
     .with_param_homing(prepared.param_homing.clone());
     let emitted = emit(emitter)?;
     Ok((emitted, local_strings))
@@ -234,18 +237,35 @@ pub fn generate_regalloc_info(
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<RegAllocDebugInfo<Reg>> {
-    let num_locals = cfg.num_locals();
-    let num_params = cfg.num_params();
-    let has_sret =
-        crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
+    let has_sret = crate::codegen_pipeline::validate_pre_lowering_budget(
+        cfg,
+        type_pool,
+        cfg_lower::ARG_REGS.len() as u32,
+        cfg_lower::RET_REGS.len() as u32,
+        crate::frame_layout::SavedRegScheme::Aarch64,
+    )?;
 
     // Lower CFG to Aarch64Mir with virtual registers
     let mir = CfgLower::new(cfg, type_pool, interner, target).lower()?;
 
     // Allocate physical registers with debug info
-    let existing_slots = num_locals + num_params + has_sret as u32;
-    let (_mir, _num_spills, _used_callee_saved, debug_info) =
+    let existing_slots = crate::codegen_pipeline::checked_slot_sum([
+        cfg.num_locals(),
+        cfg.num_params(),
+        u32::from(has_sret),
+    ])
+    .ok_or_else(|| crate::codegen_pipeline::frame_budget_error(cfg, None))?;
+    let (_mir, num_spills, used_callee_saved, debug_info) =
         RegAlloc::new(mir, existing_slots).allocate_with_debug()?;
+    let total_slots = existing_slots
+        .checked_add(num_spills)
+        .ok_or_else(|| crate::codegen_pipeline::frame_budget_error(cfg, None))?;
+    crate::frame_layout::FrameLayout::try_new(
+        crate::frame_layout::SavedRegScheme::Aarch64,
+        used_callee_saved.len(),
+        total_slots,
+    )
+    .map_err(|_| crate::codegen_pipeline::frame_budget_error(cfg, None))?;
 
     Ok(debug_info)
 }

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -286,6 +286,7 @@ pub fn type_uses_sret_return(
 
 /// Does this function return its value via the sret convention?
 /// See [`type_uses_sret_return`] for the convention.
+#[cfg(test)]
 pub(crate) fn fn_uses_sret_return(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -5,9 +5,11 @@
 //! those passes run — and the distinction between spill-placement slots and
 //! emitted-frame locals — is common to every machine-code emission entry point.
 
-use rue_air::FrozenTypeInternPool;
-use rue_cfg::Cfg;
-use rue_error::CompileResult;
+use rue_air::{ArgClass, ArgConvention, FrozenTypeInternPool, NativeCallAbi, ReturnClass};
+use rue_cfg::{Cfg, CfgArgMode, CfgInstData, CfgValue};
+use rue_error::{CompileError, CompileResult, ErrorKind};
+
+use crate::frame_layout::{FrameLayout, SavedRegScheme};
 
 /// How the callee prologue homes one source parameter's incoming argument
 /// registers into its frame parameter slots (ADR-0052 phase 5.8, RUE-1005).
@@ -62,6 +64,83 @@ pub(crate) struct PreparedMir<M, R> {
     pub(crate) used_callee_saved: Vec<R>,
     /// Per-source-parameter prologue homing plan (RUE-1005).
     pub(crate) param_homing: Vec<ParamHoming>,
+    /// Validated final layout consumed by emission and presentation paths.
+    pub(crate) frame_layout: FrameLayout,
+}
+
+pub(crate) fn frame_budget_error(cfg: &Cfg, value: Option<CfgValue>) -> CompileError {
+    let kind = ErrorKind::FunctionFrameTooLarge {
+        max_bytes: rue_air::layout::MAX_FUNCTION_FRAME_BYTES,
+    };
+    value
+        .map(|value| CompileError::new(kind.clone(), cfg.get_inst(value).span))
+        .unwrap_or_else(|| CompileError::without_span(kind))
+}
+
+pub(crate) fn checked_slot_sum(parts: impl IntoIterator<Item = u32>) -> Option<u32> {
+    parts.into_iter().try_fold(0_u32, u32::checked_add)
+}
+
+/// Reject every base-frame and outgoing-call calculation before lowering can
+/// narrow it to a backend immediate or allocate proportional metadata.
+pub(crate) fn validate_pre_lowering_budget(
+    cfg: &Cfg,
+    type_pool: &FrozenTypeInternPool,
+    arg_reg_count: u32,
+    return_reg_count: u32,
+    scheme: SavedRegScheme,
+) -> CompileResult<bool> {
+    let return_class =
+        NativeCallAbi::new(type_pool, return_reg_count).classify_return(cfg.return_type());
+    let has_sret = return_class.uses_sret();
+    let base_slots = checked_slot_sum([cfg.num_locals(), cfg.num_params(), u32::from(has_sret)])
+        .ok_or_else(|| frame_budget_error(cfg, None))?;
+    FrameLayout::try_new(scheme, 0, base_slots).map_err(|_| frame_budget_error(cfg, None))?;
+
+    let argument_abi = NativeCallAbi::for_arguments(type_pool);
+    for raw in 0..cfg.value_count() {
+        let value = CfgValue::from_raw(raw as u32);
+        let inst = cfg.get_inst(value);
+        let CfgInstData::Call { .. } = &inst.data else {
+            continue;
+        };
+        let return_class = NativeCallAbi::new(type_pool, return_reg_count).classify_return(inst.ty);
+        let (mut abi_slots, sret_bytes) = match return_class {
+            ReturnClass::Indirect { slot_count } => {
+                let bytes = u64::from(slot_count)
+                    .checked_mul(rue_air::layout::SLOT_BYTES)
+                    .ok_or_else(|| frame_budget_error(cfg, Some(value)))?;
+                let bytes = crate::frame_layout::checked_aligned_region_bytes(bytes)
+                    .map_err(|_| frame_budget_error(cfg, Some(value)))?;
+                (1_u32, u64::from(bytes))
+            }
+            _ => (0_u32, 0),
+        };
+        let mut indirect_bytes = 0_u64;
+        for arg in cfg.get_call_args(&inst.data) {
+            let ty = cfg.get_inst(arg.value).ty;
+            let convention = match arg.mode {
+                CfgArgMode::Normal => ArgConvention::ByValue,
+                CfgArgMode::Inout | CfgArgMode::Borrow => ArgConvention::ByReference,
+            };
+            let class = argument_abi.classify_arg(ty, convention);
+            abi_slots = abi_slots
+                .checked_add(class.crossing_slots())
+                .ok_or_else(|| frame_budget_error(cfg, Some(value)))?;
+            if arg.mode == CfgArgMode::Normal && class == ArgClass::Indirect {
+                let bytes =
+                    crate::frame_layout::checked_aligned_region_bytes(type_pool.layout(ty).size)
+                        .map_err(|_| frame_budget_error(cfg, Some(value)))?;
+                indirect_bytes = indirect_bytes
+                    .checked_add(u64::from(bytes))
+                    .ok_or_else(|| frame_budget_error(cfg, Some(value)))?;
+            }
+        }
+        let stack_slots = u64::from(abi_slots.saturating_sub(arg_reg_count));
+        crate::frame_layout::checked_call_area_bytes(stack_slots, sret_bytes, indirect_bytes)
+            .map_err(|_| frame_budget_error(cfg, Some(value)))?;
+    }
+    Ok(has_sret)
 }
 
 /// Run the target-independent backend pipeline around concrete pass hooks.
@@ -76,7 +155,9 @@ pub(crate) struct PreparedMir<M, R> {
 pub(crate) fn prepare_mir<M, R, Lower, Allocate, Peephole, Schedule, Verify>(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,
+    arg_reg_count: u32,
     return_reg_count: u32,
+    scheme: SavedRegScheme,
     lower: Lower,
     allocate: Allocate,
     peephole: Peephole,
@@ -92,25 +173,36 @@ where
 {
     let num_locals_original = cfg.num_locals();
     let num_params = cfg.num_params();
-    let has_sret = crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, return_reg_count);
+    let has_sret =
+        validate_pre_lowering_budget(cfg, type_pool, arg_reg_count, return_reg_count, scheme)?;
     let param_homing = param_homing_plan(cfg);
 
     let mir = lower()?;
-    let existing_slots = num_locals_original + num_params + u32::from(has_sret);
+    let existing_slots = checked_slot_sum([num_locals_original, num_params, u32::from(has_sret)])
+        .ok_or_else(|| frame_budget_error(cfg, None))?;
     let (mut mir, num_spills, used_callee_saved) = allocate(mir, existing_slots)?;
 
     peephole(&mut mir);
     schedule(&mut mir);
     verify(&mir)?;
 
+    let total_locals = num_locals_original
+        .checked_add(num_spills)
+        .ok_or_else(|| frame_budget_error(cfg, None))?;
+    let total_slots = checked_slot_sum([total_locals, num_params, u32::from(has_sret)])
+        .ok_or_else(|| frame_budget_error(cfg, None))?;
+    let frame_layout = FrameLayout::try_new(scheme, used_callee_saved.len(), total_slots)
+        .map_err(|_| frame_budget_error(cfg, None))?;
+
     Ok(PreparedMir {
         mir,
-        total_locals: num_locals_original + num_spills,
+        total_locals,
         num_locals_original,
         num_params,
         has_sret,
         used_callee_saved,
         param_homing,
+        frame_layout,
     })
 }
 
@@ -118,10 +210,12 @@ where
 mod tests {
     use std::cell::RefCell;
 
+    use lasso::Spur;
     use rue_air::{Type, TypeInternPool};
-    use rue_cfg::Cfg;
+    use rue_cfg::{Cfg, CfgArgMode, CfgCallArg, CfgInst, CfgInstData};
+    use rue_span::Span;
 
-    use super::prepare_mir;
+    use super::{SavedRegScheme, prepare_mir, validate_pre_lowering_budget};
 
     #[test]
     fn pass_order_and_frame_slot_formulas_are_single_source() {
@@ -144,6 +238,8 @@ mod tests {
             &cfg,
             &type_pool,
             6,
+            6,
+            SavedRegScheme::X86_64,
             || {
                 events.borrow_mut().push("lower");
                 Ok(10_u32)
@@ -179,5 +275,73 @@ mod tests {
         assert_eq!(prepared.num_params, 2);
         assert!(prepared.has_sret);
         assert_eq!(prepared.used_callee_saved, [5]);
+    }
+
+    #[test]
+    fn target_frame_boundaries_are_checked_before_lowering() {
+        let type_pool = TypeInternPool::new().freeze();
+        let max_slots = rue_air::layout::MAX_FUNCTION_FRAME_SLOTS as u32;
+        let cfg = Cfg::new(Type::UNIT, max_slots, 0, "boundary".into(), vec![]);
+
+        assert!(
+            validate_pre_lowering_budget(&cfg, &type_pool, 6, 6, SavedRegScheme::X86_64,).is_ok()
+        );
+        assert!(
+            validate_pre_lowering_budget(&cfg, &type_pool, 8, 8, SavedRegScheme::Aarch64,).is_err(),
+            "AArch64's mandatory FP/LR save must count against the same budget"
+        );
+
+        let param_boundary = Cfg::new(Type::UNIT, 0, max_slots, "param_boundary".into(), vec![]);
+        assert!(
+            validate_pre_lowering_budget(
+                &param_boundary,
+                &type_pool,
+                6,
+                6,
+                SavedRegScheme::X86_64,
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn aggregate_argument_buffers_and_sret_share_one_call_area_budget() {
+        let type_pool = TypeInternPool::new();
+        let array_id = type_pool.intern_array_from_type(Type::I32, 134_217_728);
+        let huge = Type::new_array(array_id);
+        let type_pool = type_pool.freeze();
+        let mut cfg = Cfg::new(Type::UNIT, 0, 0, "call_budget".into(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let args = (0..4)
+            .map(|_| {
+                let value = cfg.append_inst(
+                    entry,
+                    CfgInst {
+                        data: CfgInstData::Const(0),
+                        ty: huge,
+                        span: Span::default(),
+                    },
+                );
+                CfgCallArg {
+                    value,
+                    mode: CfgArgMode::Normal,
+                }
+            })
+            .collect::<Vec<_>>();
+        cfg.append_call(entry, None, Spur::default(), args, huge, Span::default())
+            .unwrap();
+
+        for (arg_regs, ret_regs, scheme) in [
+            (6, 6, SavedRegScheme::X86_64),
+            (8, 8, SavedRegScheme::Aarch64),
+        ] {
+            let error = validate_pre_lowering_budget(&cfg, &type_pool, arg_regs, ret_regs, scheme)
+                .unwrap_err();
+            assert!(matches!(
+                error.kind,
+                rue_error::ErrorKind::FunctionFrameTooLarge { .. }
+            ));
+        }
     }
 }

--- a/crates/rue-codegen/src/frame_layout.rs
+++ b/crates/rue-codegen/src/frame_layout.rs
@@ -18,11 +18,44 @@
 //! authority; conversion between a slot-shaped value and narrow memory happens
 //! at explicit pack/unpack boundaries, not in frame arithmetic.
 
-use rue_air::layout::SLOT_BYTES;
+use rue_air::layout::{MAX_FUNCTION_FRAME_BYTES, SLOT_BYTES, STACK_FRAME_ALIGNMENT};
 
-/// Call-boundary stack alignment. Both supported targets keep the frame
-/// 16-byte aligned at calls.
-pub const STACK_FRAME_ALIGNMENT: u64 = 16;
+/// A frame or transient call area exceeded the one displacement-sized budget
+/// shared by semantic analysis, lowering, emission, and presentation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FrameBudgetExceeded;
+
+/// Convert a byte count into an aligned, backend-immediate-sized stack region.
+#[inline]
+pub fn checked_aligned_region_bytes(bytes: u64) -> Result<u32, FrameBudgetExceeded> {
+    let aligned = bytes
+        .checked_add(STACK_FRAME_ALIGNMENT - 1)
+        .ok_or(FrameBudgetExceeded)?
+        / STACK_FRAME_ALIGNMENT
+        * STACK_FRAME_ALIGNMENT;
+    if aligned > MAX_FUNCTION_FRAME_BYTES {
+        return Err(FrameBudgetExceeded);
+    }
+    Ok(aligned as u32)
+}
+
+/// Validate one outgoing call's simultaneous stack reservation: hidden return
+/// storage, compact by-value argument copies, and stack-passed ABI slots.
+pub fn checked_call_area_bytes(
+    stack_slots: u64,
+    sret_storage_bytes: u64,
+    indirect_argument_bytes: u64,
+) -> Result<u32, FrameBudgetExceeded> {
+    let stack_bytes = stack_slots
+        .checked_mul(frame_cell_bytes())
+        .ok_or(FrameBudgetExceeded)?;
+    let stack_bytes = u64::from(checked_aligned_region_bytes(stack_bytes)?);
+    let total = sret_storage_bytes
+        .checked_add(indirect_argument_bytes)
+        .and_then(|bytes| bytes.checked_add(stack_bytes))
+        .ok_or(FrameBudgetExceeded)?;
+    checked_aligned_region_bytes(total)
+}
 
 /// Byte size of one frame storage cell holding a slot-shaped value fragment.
 ///
@@ -50,7 +83,8 @@ pub fn slot_offset_pre_saved(slot: u32) -> i32 {
 /// Total byte span of `num_slots` contiguous frame cells.
 #[inline]
 pub fn slot_region_bytes(num_slots: u32) -> i32 {
-    frame_cell_bytes() as i32 * num_slots as i32
+    i32::try_from(frame_cell_bytes() * u64::from(num_slots))
+        .expect("frame slot region must be validated before offset calculation")
 }
 
 /// FP-relative byte offset of frame slot `slot` on AArch64, matching the
@@ -84,8 +118,11 @@ pub fn aarch64_callee_saved_pair_offset(pair_index: usize) -> i32 {
 /// Round a frame byte size up to [`STACK_FRAME_ALIGNMENT`].
 #[inline]
 pub fn align_frame_size(bytes: i32) -> i32 {
-    let align = STACK_FRAME_ALIGNMENT as i32;
-    ((bytes + align - 1) / align) * align
+    i32::try_from(
+        checked_aligned_region_bytes(bytes as u64)
+            .expect("frame size must be validated before alignment"),
+    )
+    .expect("validated frame size fits i32")
 }
 
 /// How a target saves the registers that sit between the frame pointer and the
@@ -138,12 +175,34 @@ pub struct FrameLayout {
 impl FrameLayout {
     /// Build a frame layout for `num_slots` slot cells sitting below the saved
     /// registers described by `scheme`.
-    pub fn new(scheme: SavedRegScheme, num_callee_saved: usize, num_slots: u32) -> Self {
-        Self {
-            scheme,
-            saved_area_bytes: scheme.saved_area_bytes(num_callee_saved),
-            num_slots,
+    pub fn try_new(
+        scheme: SavedRegScheme,
+        num_callee_saved: usize,
+        num_slots: u32,
+    ) -> Result<Self, FrameBudgetExceeded> {
+        let saved_area_bytes = scheme.saved_area_bytes(num_callee_saved);
+        let slot_bytes = frame_cell_bytes()
+            .checked_mul(u64::from(num_slots))
+            .ok_or(FrameBudgetExceeded)?;
+        let unaligned = match scheme {
+            SavedRegScheme::X86_64 => saved_area_bytes
+                .checked_add(slot_bytes)
+                .ok_or(FrameBudgetExceeded)?,
+            SavedRegScheme::Aarch64 => slot_bytes,
+        };
+        checked_aligned_region_bytes(unaligned)?;
+        if scheme == SavedRegScheme::Aarch64
+            && saved_area_bytes
+                .checked_add(u64::from(checked_aligned_region_bytes(slot_bytes)?))
+                .is_none_or(|bytes| bytes > MAX_FUNCTION_FRAME_BYTES)
+        {
+            return Err(FrameBudgetExceeded);
         }
+        Ok(Self {
+            scheme,
+            saved_area_bytes,
+            num_slots,
+        })
     }
 
     /// Bytes reserved for saved registers between the frame pointer and the
@@ -221,7 +280,7 @@ mod tests {
     #[test]
     fn frame_size_matches_prior_x86_64_rounding() {
         // round16(callee_saved_size + total_slots * 8).
-        let layout = FrameLayout::new(SavedRegScheme::X86_64, 1, 2);
+        let layout = FrameLayout::try_new(SavedRegScheme::X86_64, 1, 2).unwrap();
         // saved = 8, slots = 16 -> round16(24) = 32.
         assert_eq!(layout.frame_size(), 32);
         assert_eq!(layout.slot_offset(0), -8 - 8);
@@ -257,9 +316,27 @@ mod tests {
     #[test]
     fn frame_size_matches_prior_aarch64_rounding() {
         // fp_lr(16) + callee_saved_pairs*16 + round16(total_slots * 8).
-        let layout = FrameLayout::new(SavedRegScheme::Aarch64, 1, 3);
+        let layout = FrameLayout::try_new(SavedRegScheme::Aarch64, 1, 3).unwrap();
         // saved = 16 + 16 = 32, slots = 24 -> round16(24) = 32; total = 64.
         assert_eq!(layout.frame_size(), 64);
         assert_eq!(layout.slot_offset(0), -32 - 8);
+    }
+
+    #[test]
+    fn cumulative_frame_budget_covers_alignment_and_saved_areas() {
+        let max_slots = (MAX_FUNCTION_FRAME_BYTES / frame_cell_bytes()) as u32;
+        assert!(FrameLayout::try_new(SavedRegScheme::X86_64, 0, max_slots).is_ok());
+        assert!(FrameLayout::try_new(SavedRegScheme::X86_64, 1, max_slots).is_err());
+        assert!(FrameLayout::try_new(SavedRegScheme::Aarch64, 0, max_slots).is_err());
+    }
+
+    #[test]
+    fn outgoing_call_budget_checks_every_simultaneous_region() {
+        assert_eq!(checked_call_area_bytes(1, 16, 16), Ok(48));
+        assert!(
+            checked_call_area_bytes(1, MAX_FUNCTION_FRAME_BYTES, 0).is_err(),
+            "alignment plus one stack slot must exceed the displacement budget"
+        );
+        assert!(checked_call_area_bytes(u64::MAX, 0, 0).is_err());
     }
 }

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -832,8 +832,8 @@ struct SpillSlotAllocator {
     /// ever reusable) rescans the whole growing slot list per spill — O(spills²)
     /// (RUE-302).
     min_slot_end: Option<usize>,
-    /// Base offset for spill slots (after existing locals).
-    base_offset: i32,
+    /// Number of occupied frame slots before the spill region.
+    base_slots: u32,
 }
 
 impl SpillSlotAllocator {
@@ -845,10 +845,7 @@ impl SpillSlotAllocator {
         Self {
             slots: Vec::new(),
             min_slot_end: None,
-            // Spill slots continue the frame's slot region after the existing
-            // locals/params, so the first spill homes at the same offset the
-            // frame-layout authority gives slot `existing_locals`.
-            base_offset: crate::frame_layout::slot_offset_pre_saved(existing_locals),
+            base_slots: existing_locals,
         }
     }
 
@@ -896,7 +893,11 @@ impl SpillSlotAllocator {
     /// Get the stack offset for a given spill slot index (each spill cell is
     /// one frame cell below the previous, continuing the slot region).
     fn offset_for_slot(&self, slot_index: usize) -> i32 {
-        self.base_offset - crate::frame_layout::slot_region_bytes(slot_index as u32)
+        let one_based_slot = u64::from(self.base_slots)
+            .saturating_add(slot_index as u64)
+            .saturating_add(1);
+        let bytes = one_based_slot.saturating_mul(rue_air::layout::SLOT_BYTES);
+        i32::try_from(bytes).map_or(i32::MIN, |bytes| -bytes)
     }
 
     /// Get the number of unique spill slots used.
@@ -1074,6 +1075,7 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
     /// Run normal allocation and target rewriting.
     pub fn allocate(mut self) -> CompileResult<B::Mir> {
         self.assign_registers();
+        self.validate_spill_budget()?;
         self.rewrite_instructions()?;
         Ok(self.mir)
     }
@@ -1081,6 +1083,7 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
     /// Run normal allocation and return spill/frame bookkeeping.
     pub fn allocate_with_spills(mut self) -> CompileResult<(B::Mir, u32, Vec<B::Reg>)> {
         self.assign_registers();
+        self.validate_spill_budget()?;
         self.rewrite_instructions()?;
         Ok((self.mir, self.num_spills, self.used_callee_saved))
     }
@@ -1090,6 +1093,7 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
         mut self,
     ) -> CompileResult<(B::Mir, u32, Vec<B::Reg>, RegAllocDebugInfo<B::Reg>)> {
         let debug_info = self.assign_registers_with_debug();
+        self.validate_spill_budget()?;
         self.rewrite_instructions()?;
         Ok((
             self.mir,
@@ -1127,6 +1131,16 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
         self.num_spills = num_spills;
         self.used_callee_saved = used_callee_saved;
         debug_info
+    }
+
+    fn validate_spill_budget(&self) -> CompileResult<()> {
+        rue_air::layout::checked_function_frame_slots(self.existing_locals, self.num_spills)
+            .map(|_| ())
+            .ok_or_else(|| {
+                rue_error::CompileError::without_span(rue_error::ErrorKind::FunctionFrameTooLarge {
+                    max_bytes: rue_air::layout::MAX_FUNCTION_FRAME_BYTES,
+                })
+            })
     }
 
     fn rewrite_instructions(&mut self) -> CompileResult<()> {

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -276,29 +276,26 @@ fn generate_x86_64_stack_frame(
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<StackFrameInfo> {
-    use crate::x86_64::{CfgLower, RegAlloc};
-
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
     // sret returns reserve one extra frame slot for the incoming buffer
     // pointer and shift user args by one ABI slot (RUE-106).
-    let has_sret = crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, 6);
-    let sret_slots = has_sret as u32;
-
-    // Lower CFG to X86Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, interner).lower()?;
-
-    // Allocate physical registers (may add spill slots)
-    let existing_slots = num_locals + num_params + sret_slots;
-    let (_mir, num_spills, used_callee_saved) =
-        RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
+    let prepared = crate::x86_64::prepare_backend(
+        cfg,
+        type_pool,
+        interner,
+        crate::MachineSymbolResolver::default(),
+    )?;
+    let has_sret = prepared.has_sret;
+    let sret_slots = u32::from(has_sret);
+    let num_spills = prepared.total_locals - prepared.num_locals_original;
+    let used_callee_saved = &prepared.used_callee_saved;
 
     // Calculate stack layout through the byte-based frame-layout authority
     // (ALL params get frame slots: the prologue copies stack-passed args into
     // the frame param area). Every slot cell is one frame cell today.
-    use crate::frame_layout::{FrameLayout, SavedRegScheme, frame_cell_bytes};
-    let total_slots = num_locals + num_spills + num_params + sret_slots;
-    let frame = FrameLayout::new(SavedRegScheme::X86_64, used_callee_saved.len(), total_slots);
+    use crate::frame_layout::frame_cell_bytes;
+    let frame = prepared.frame_layout;
     let stack_size = frame.frame_size() as i32;
 
     let mut slots = Vec::new();
@@ -418,34 +415,27 @@ fn generate_aarch64_stack_frame(
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<StackFrameInfo> {
-    use crate::aarch64::{CfgLower, RegAlloc};
-
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
     // sret returns reserve one extra frame slot for the incoming buffer
     // pointer and shift user args by one ABI slot (RUE-106).
-    let has_sret = crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, 8);
-    let sret_slots = has_sret as u32;
-
-    // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, interner, target).lower()?;
-
-    // Allocate physical registers (may add spill slots)
-    let existing_slots = num_locals + num_params + sret_slots;
-    let (_mir, num_spills, used_callee_saved) =
-        RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
+    let prepared = crate::aarch64::prepare_backend(
+        cfg,
+        type_pool,
+        interner,
+        target,
+        crate::MachineSymbolResolver::default(),
+    )?;
+    let has_sret = prepared.has_sret;
+    let sret_slots = u32::from(has_sret);
+    let num_spills = prepared.total_locals - prepared.num_locals_original;
+    let used_callee_saved = &prepared.used_callee_saved;
 
     // Calculate stack layout for AArch64 through the byte-based frame-layout
     // authority. Callee-saved registers are saved in pairs (16 bytes per pair)
     // and the FP/LR pair (16 bytes) sits above them; ALL params get frame slots
     // (the prologue copies stack-passed args into the frame param area).
-    use crate::frame_layout::{FrameLayout, SavedRegScheme};
-    let total_slots = num_locals + num_spills + num_params + sret_slots;
-    let frame = FrameLayout::new(
-        SavedRegScheme::Aarch64,
-        used_callee_saved.len(),
-        total_slots,
-    );
+    let frame = prepared.frame_layout;
     let frame_size = frame.frame_size() as usize;
 
     // Every FP-relative location below is derived from the same frame-layout

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -240,6 +240,8 @@ pub struct Emitter<'a> {
     strings: &'a [String],
     /// Whether a stack frame was emitted (prologue was executed).
     has_frame: bool,
+    /// Canonical checked layout supplied by the production pipeline.
+    frame_layout: Option<crate::frame_layout::FrameLayout>,
     /// Byte offset where the current instruction started (for recording).
     inst_start: usize,
     /// Whether to generate assembly text (only needed for --emit asm).
@@ -289,6 +291,7 @@ impl<'a> Emitter<'a> {
             callee_saved: callee_saved.to_vec(),
             strings,
             has_frame: false,
+            frame_layout: None,
             inst_start: 0,
             emit_asm: false,
             param_homing: Vec::new(),
@@ -310,6 +313,14 @@ impl<'a> Emitter<'a> {
     /// register assignment, and reserves the sret pointer frame slot.
     pub fn with_sret(mut self, has_sret: bool) -> Self {
         self.has_sret = has_sret;
+        self
+    }
+
+    pub(crate) fn with_frame_layout(
+        mut self,
+        frame_layout: crate::frame_layout::FrameLayout,
+    ) -> Self {
+        self.frame_layout = Some(frame_layout);
         self
     }
 
@@ -508,13 +519,15 @@ impl<'a> Emitter<'a> {
         // Each slot is one frame cell; the total (including callee-saved
         // pushes) is 16-byte aligned by the frame-layout authority.
         let total_slots = self.num_locals + self.num_params + self.has_sret as u32;
-        let needed_bytes = crate::frame_layout::slot_region_bytes(total_slots);
-        // Account for callee-saved pushes for alignment calculation.
-        // At this point: rbp is set, callee_saved are pushed.
-        // After sub rsp, N: rsp should be 16-byte aligned.
-        let current_offset = self.callee_saved_size();
-        let stack_size =
-            crate::frame_layout::align_frame_size(current_offset + needed_bytes) - current_offset;
+        let frame = self.frame_layout.unwrap_or_else(|| {
+            crate::frame_layout::FrameLayout::try_new(
+                crate::frame_layout::SavedRegScheme::X86_64,
+                self.callee_saved.len(),
+                total_slots,
+            )
+            .expect("emitter frame must fit the checked function-frame budget")
+        });
+        let stack_size = frame.frame_size() as i32 - frame.saved_area_bytes();
 
         if stack_size > 0 {
             // sub rsp, imm32: 48 81 EC imm32

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -36,7 +36,7 @@ use rue_error::CompileResult;
 // Re-export from parent
 pub use super::{EmittedCode, EmittedRelocation, MachineCode};
 
-fn prepare_backend(
+pub(crate) fn prepare_backend(
     cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
@@ -45,7 +45,9 @@ fn prepare_backend(
     crate::codegen_pipeline::prepare_mir(
         cfg,
         type_pool,
+        cfg_lower::ARG_REGS.len() as u32,
         cfg_lower::RET_REGS.len() as u32,
+        crate::frame_layout::SavedRegScheme::X86_64,
         || CfgLower::new_with_symbols(cfg, type_pool, interner, symbols).lower(),
         |mir, existing_slots| RegAlloc::new(mir, existing_slots).allocate_with_spills(),
         |mir| {
@@ -100,6 +102,7 @@ where
         &local_strings,
     )
     .with_sret(prepared.has_sret)
+    .with_frame_layout(prepared.frame_layout)
     .with_param_homing(prepared.param_homing.clone());
     let emitted = emit(emitter)?;
     Ok((emitted, local_strings))
@@ -222,18 +225,35 @@ pub fn generate_regalloc_info(
     type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
 ) -> CompileResult<RegAllocDebugInfo<Reg>> {
-    let num_locals = cfg.num_locals();
-    let num_params = cfg.num_params();
-    let has_sret =
-        crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
+    let has_sret = crate::codegen_pipeline::validate_pre_lowering_budget(
+        cfg,
+        type_pool,
+        cfg_lower::ARG_REGS.len() as u32,
+        cfg_lower::RET_REGS.len() as u32,
+        crate::frame_layout::SavedRegScheme::X86_64,
+    )?;
 
     // Lower CFG to X86Mir with virtual registers
     let mir = CfgLower::new(cfg, type_pool, interner).lower()?;
 
     // Allocate physical registers with debug info
-    let existing_slots = num_locals + num_params + has_sret as u32;
-    let (_mir, _num_spills, _used_callee_saved, debug_info) =
+    let existing_slots = crate::codegen_pipeline::checked_slot_sum([
+        cfg.num_locals(),
+        cfg.num_params(),
+        u32::from(has_sret),
+    ])
+    .ok_or_else(|| crate::codegen_pipeline::frame_budget_error(cfg, None))?;
+    let (_mir, num_spills, used_callee_saved, debug_info) =
         RegAlloc::new(mir, existing_slots).allocate_with_debug()?;
+    let total_slots = existing_slots
+        .checked_add(num_spills)
+        .ok_or_else(|| crate::codegen_pipeline::frame_budget_error(cfg, None))?;
+    crate::frame_layout::FrameLayout::try_new(
+        crate::frame_layout::SavedRegScheme::X86_64,
+        used_callee_saved.len(),
+        total_slots,
+    )
+    .map_err(|_| crate::codegen_pipeline::frame_budget_error(cfg, None))?;
 
     Ok(debug_info)
 }

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -368,6 +368,7 @@ impl ErrorCode {
     pub const MOVE_OUT_OF_INDEX: Self = Self(904);
     pub const ARRAY_REPEAT_NON_COPY: Self = Self(905);
     pub const TYPE_TOO_LARGE: Self = Self(906);
+    pub const FUNCTION_FRAME_TOO_LARGE: Self = Self(907);
 
     // ========================================================================
     // Linker/target errors (E1000-E1099)
@@ -1572,6 +1573,13 @@ pub enum ErrorKind {
     /// zero-sized).
     #[error("type '{type_name}' exceeds the maximum supported object size ({max_bytes} bytes)")]
     TypeTooLarge { type_name: String, max_bytes: u64 },
+    /// A function's cumulative locals, parameter homes, sret cell, spills, or
+    /// transient outgoing call area exceeds the backend displacement budget.
+    #[error(
+        "function stack frame or outgoing call area exceeds the maximum supported size \
+         ({max_bytes} bytes)"
+    )]
+    FunctionFrameTooLarge { max_bytes: u64 },
     /// Assignment into an array (element write, or a write through an element)
     /// while one or more of its elements are moved out (RUE-186). Reinstating
     /// per-element ownership through writes is not supported; the whole array
@@ -1912,6 +1920,7 @@ impl ErrorKind {
             ErrorKind::MoveOutOfIndex { .. } => ErrorCode::MOVE_OUT_OF_INDEX,
             ErrorKind::ArrayRepeatNonCopy { .. } => ErrorCode::ARRAY_REPEAT_NON_COPY,
             ErrorKind::TypeTooLarge { .. } => ErrorCode::TYPE_TOO_LARGE,
+            ErrorKind::FunctionFrameTooLarge { .. } => ErrorCode::FUNCTION_FRAME_TOO_LARGE,
             ErrorKind::AssignToPartiallyMovedArray { .. } => {
                 ErrorCode::ASSIGN_TO_PARTIALLY_MOVED_ARRAY
             }

--- a/crates/rue-ui-tests/cases/diagnostics/function_frame_too_large.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/function_frame_too_large.toml
@@ -1,0 +1,16 @@
+[section]
+id = "diagnostics.function_frame_too_large"
+name = "Oversized function frames and call areas (E0907)"
+description = "Cumulative function storage exceeding the backend displacement budget is rejected before per-slot metadata or machine code is produced (RUE-780)."
+
+[[case]]
+name = "cumulative_locals_exceed_frame_budget"
+source = """
+fn main() -> i32 {
+    let a = [0; 134217728];
+    let b = [0; 134217728];
+    a[0] + b[0]
+}
+"""
+compile_fail = true
+error_contains = ["[E0907]", "function stack frame or outgoing call area", "2147483632"]

--- a/docs/spec/src/appendices/C-implementation-limits.md
+++ b/docs/spec/src/appendices/C-implementation-limits.md
@@ -59,6 +59,12 @@ Practical limits on array size are determined by available memory and platform c
 
 The current implementation limits any single object (including an array type) to 2,147,483,647 bytes (`i32::MAX`), matching the code generator's frame-offset addressing range. A type whose layout exceeds this limit is rejected with a diagnostic (E0906) wherever a value of the type would be materialized — a variable, a parameter, or a `@size_of`/`@align_of` query.
 
+The cumulative storage for one function is limited to 2,147,483,632 bytes: the
+largest 16-byte-aligned value within that same signed displacement range.
+Locals, parameter homes, hidden return storage, register-allocation spills, and
+the simultaneous outgoing call area all count toward this checked budget.
+Exceeding it is rejected with diagnostic E0907.
+
 ## Identifier Limits
 
 {{ rule(id="C.5:1", cat="informative") }}


### PR DESCRIPTION
## Summary

- define one signed-displacement-sized, 16-byte-aligned budget for function frames and transient call areas
- reject cumulative parameter/local storage and spill growth with a source-facing E0907 diagnostic
- validate hidden return storage, indirect aggregate argument buffers, stack arguments, saved registers, and alignment before lowering narrows sizes
- pass the checked `FrameLayout` through x86-64 and AArch64 emission and stack-frame inspection
- document the implementation limit while preserving E0906 for individually oversized types

## Root cause

Frame consumers independently performed unchecked slot additions, alignment, and narrowing casts. Individually valid types could therefore overflow the cumulative frame, spill, or outgoing-call region before code generation diagnosed the program.

## Validation

- `scripts/rue fmt`
- `scripts/rue unit codegen frame_layout`
- `scripts/rue unit codegen codegen_pipeline`
- focused `function_frame_too_large` UI test
- `scripts/rue quick` (36 targets)

Fixes RUE-780.
