### PR TITLE
RUE-1091 r1c: hoist aggregate resolution behind epoch facts

### DIFF
--- a/crates/rue-air/src/sema/aggregate_resolution.rs
+++ b/crates/rue-air/src/sema/aggregate_resolution.rs
@@ -1,0 +1,280 @@
+//! Provider-generic aggregate, field, and variant resolution.
+//!
+//! Selection order lives here. [`EpochFacts`] is the production adapter that
+//! reproduces the declaration-epoch reads used by body analysis.
+
+use lasso::Spur;
+use rue_rir::{InstData, InstRef, Rir};
+use rue_span::FileId;
+
+use super::context::{ConstValue, LocalVar};
+use super::{ConstInfo, DeclarationPhase, Sema};
+use crate::types::{EnumId, ModuleId, StructId, Type};
+
+pub(crate) trait AggregateFacts {
+    fn value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo>;
+    fn module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo>;
+    fn struct_in_file(&self, file: FileId, name: Spur) -> Option<StructId>;
+    fn enum_in_file(&self, file: FileId, name: Spur) -> Option<EnumId>;
+    fn builtin_struct(&self, name: Spur) -> Option<StructId>;
+    fn builtin_enum(&self, name: Spur) -> Option<EnumId>;
+    fn module(&self, module: ModuleId) -> AggregateModuleFact;
+    fn file_path(&self, file: FileId) -> Option<&str>;
+    fn source_path(&self, span: rue_span::Span) -> Option<&str>;
+}
+
+pub(crate) struct AggregateModuleFact {
+    pub(crate) file: FileId,
+    file_path: String,
+    import_path: String,
+}
+
+impl AggregateModuleFact {
+    pub(crate) fn file_path(&self) -> &str {
+        &self.file_path
+    }
+
+    pub(crate) fn import_path(&self) -> &str {
+        &self.import_path
+    }
+}
+
+pub(crate) struct EpochFacts<'s, 'a, D: DeclarationPhase> {
+    sema: &'s Sema<'a, D>,
+}
+
+impl<'s, 'a, D: DeclarationPhase> EpochFacts<'s, 'a, D> {
+    pub(crate) fn new(sema: &'s Sema<'a, D>) -> Self {
+        Self { sema }
+    }
+}
+
+impl<D: DeclarationPhase> AggregateFacts for EpochFacts<'_, '_, D> {
+    fn value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
+        self.sema.value_const(&(file, name)).cloned()
+    }
+
+    fn module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
+        self.sema.module_binding(&(file, name)).cloned()
+    }
+
+    fn struct_in_file(&self, file: FileId, name: Spur) -> Option<StructId> {
+        self.sema.structs_by_file_name.get(&(file, name)).copied()
+    }
+
+    fn enum_in_file(&self, file: FileId, name: Spur) -> Option<EnumId> {
+        self.sema.enums_by_file_name.get(&(file, name)).copied()
+    }
+
+    fn builtin_struct(&self, name: Spur) -> Option<StructId> {
+        self.sema.resolve_builtin_struct_name(name)
+    }
+
+    fn builtin_enum(&self, name: Spur) -> Option<EnumId> {
+        self.sema.resolve_builtin_enum_name(name)
+    }
+
+    fn module(&self, module: ModuleId) -> AggregateModuleFact {
+        let def = self.sema.module_registry.get_def(module);
+        AggregateModuleFact {
+            file: def.file_id,
+            file_path: def.file_path,
+            import_path: def.import_path,
+        }
+    }
+
+    fn file_path(&self, file: FileId) -> Option<&str> {
+        self.sema.get_file_path(file)
+    }
+
+    fn source_path(&self, span: rue_span::Span) -> Option<&str> {
+        self.sema.get_source_path(span)
+    }
+}
+
+pub(crate) enum StructLiteralHead {
+    Bound(Type),
+    Named(StructId),
+    Absent,
+}
+
+pub(crate) enum ModuleTypeMember {
+    Struct(StructId),
+    Enum(EnumId),
+    Const(ConstInfo),
+    Absent,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum QualifiedType {
+    Enum(EnumId),
+    Struct(StructId),
+    Absent,
+}
+
+pub(crate) fn resolve_enum_type_name<P: AggregateFacts>(
+    facts: &P,
+    local_type: Option<Type>,
+    file: FileId,
+    name: Spur,
+) -> Option<(EnumId, bool)> {
+    if let Some(ty) = local_type {
+        return ty.as_enum().map(|id| (id, true));
+    }
+    if let Some(info) = facts.value_const(file, name)
+        && let ConstValue::Type(ty) = info.value
+    {
+        return ty.as_enum().map(|id| (id, true));
+    }
+    facts
+        .enum_in_file(file, name)
+        .or_else(|| facts.builtin_enum(name))
+        .map(|id| (id, false))
+}
+
+pub(crate) fn resolve_struct_type_name<P: AggregateFacts>(
+    facts: &P,
+    local_type: Option<Type>,
+    file: FileId,
+    name: Spur,
+) -> Option<(StructId, bool)> {
+    if let Some(ty) = local_type {
+        return ty.as_struct().map(|id| (id, true));
+    }
+    if let Some(info) = facts.value_const(file, name)
+        && let ConstValue::Type(ty) = info.value
+    {
+        return ty.as_struct().map(|id| (id, true));
+    }
+    facts
+        .struct_in_file(file, name)
+        .or_else(|| facts.builtin_struct(name))
+        .map(|id| (id, false))
+}
+
+pub(crate) fn select_struct_literal_head<P: AggregateFacts>(
+    facts: &P,
+    local_type: Option<Type>,
+    file: FileId,
+    name: Spur,
+) -> StructLiteralHead {
+    if let Some(ty) = local_type {
+        return StructLiteralHead::Bound(ty);
+    }
+    if let Some(info) = facts.value_const(file, name)
+        && let ConstValue::Type(ty) = info.value
+    {
+        return StructLiteralHead::Bound(ty);
+    }
+    facts
+        .struct_in_file(file, name)
+        .or_else(|| facts.builtin_struct(name))
+        .map_or(StructLiteralHead::Absent, StructLiteralHead::Named)
+}
+
+pub(crate) fn select_module_type_member<P: AggregateFacts>(
+    facts: &P,
+    file: FileId,
+    name: Spur,
+) -> ModuleTypeMember {
+    if let Some(id) = facts.struct_in_file(file, name) {
+        return ModuleTypeMember::Struct(id);
+    }
+    if let Some(id) = facts.enum_in_file(file, name) {
+        return ModuleTypeMember::Enum(id);
+    }
+    if let Some(info) = facts
+        .module_binding(file, name)
+        .or_else(|| facts.value_const(file, name))
+    {
+        return ModuleTypeMember::Const(info);
+    }
+    ModuleTypeMember::Absent
+}
+
+pub(crate) fn select_qualified_type<P: AggregateFacts>(
+    facts: &P,
+    file: FileId,
+    name: Spur,
+) -> QualifiedType {
+    if let Some(id) = facts.enum_in_file(file, name) {
+        return QualifiedType::Enum(id);
+    }
+    facts
+        .struct_in_file(file, name)
+        .map_or(QualifiedType::Absent, QualifiedType::Struct)
+}
+
+pub(crate) fn select_qualified_enum<P: AggregateFacts>(
+    facts: &P,
+    file: FileId,
+    name: Spur,
+) -> Option<EnumId> {
+    facts.enum_in_file(file, name)
+}
+
+pub(crate) fn resolve_aggregate_module_ref<P: AggregateFacts>(
+    facts: &P,
+    rir: &Rir,
+    inst_ref: InstRef,
+    root_file: FileId,
+    locals: &std::collections::HashMap<Spur, LocalVar>,
+) -> Option<ModuleId> {
+    match rir.get(inst_ref).data {
+        InstData::VarRef { name, .. } => {
+            if let Some(local) = locals.get(&name) {
+                if let Some(module_id) = local.ty.as_module() {
+                    return Some(module_id);
+                }
+            }
+            facts
+                .module_binding(root_file, name)
+                .and_then(|binding| binding.ty.as_module())
+        }
+        InstData::FieldGet { base, field } => {
+            let parent = resolve_aggregate_module_ref(facts, rir, base, root_file, locals)?;
+            let parent_file = facts.module(parent).file;
+            facts
+                .module_binding(parent_file, field)
+                .and_then(|binding| binding.ty.as_module())
+        }
+        _ => None,
+    }
+}
+
+pub(crate) fn resolve_visibility_module_ref<P: AggregateFacts>(
+    facts: &P,
+    rir: &Rir,
+    inst_ref: InstRef,
+    locals: &std::collections::HashMap<Spur, LocalVar>,
+) -> Option<ModuleId> {
+    let inst = rir.get(inst_ref);
+    let module_ty = match inst.data {
+        InstData::VarRef { name, .. } => locals.get(&name).map(|local| local.ty).or_else(|| {
+            facts
+                .module_binding(inst.span.file_id, name)
+                .map(|binding| binding.ty)
+        }),
+        InstData::FieldGet { base, field } => {
+            let parent = resolve_visibility_module_ref(facts, rir, base, locals)?;
+            let parent_file = facts.module(parent).file;
+            facts
+                .module_binding(parent_file, field)
+                .map(|binding| binding.ty)
+        }
+        _ => None,
+    }?;
+    module_ty.as_module()
+}
+
+pub(crate) fn is_accessible<P: AggregateFacts>(
+    facts: &P,
+    accessing_file: FileId,
+    defining_file: FileId,
+    is_public: bool,
+) -> bool {
+    let accessing =
+        crate::SemanticVisibilityDomain::from_file_path(facts.file_path(accessing_file));
+    let defining = crate::SemanticVisibilityDomain::from_file_path(facts.file_path(defining_file));
+    defining.is_visible_from(&accessing, is_public)
+}

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -11,6 +11,12 @@ use rue_rir::{InstData, InstRef, RirParamMode};
 use rue_span::Span;
 
 use super::BodySema;
+use super::aggregate_resolution::{
+    AggregateFacts, EpochFacts, ModuleTypeMember, QualifiedType, StructLiteralHead,
+    resolve_aggregate_module_ref, resolve_enum_type_name, resolve_struct_type_name,
+    select_module_type_member, select_qualified_enum, select_qualified_type,
+    select_struct_literal_head,
+};
 use super::analysis::FirstClassStrSite;
 use super::context::{AnalysisContext, AnalysisResult, ConstValue};
 use crate::inst::{Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirRef};
@@ -30,19 +36,13 @@ impl<'a> BodySema<'a> {
         type_name: Spur,
         ctx: &AnalysisContext,
     ) -> Option<(crate::types::EnumId, bool)> {
-        if let Some(&ty) = ctx.comptime_type_vars.get(&type_name) {
-            return ty.as_enum().map(|id| (id, true));
-        }
-        if let Some(info) = self.value_const(&(ctx.current_file_id, type_name))
-            && let ConstValue::Type(ty) = info.value
-        {
-            return ty.as_enum().map(|id| (id, true));
-        }
-        self.enums_by_file_name
-            .get(&(ctx.current_file_id, type_name))
-            .copied()
-            .or_else(|| self.resolve_builtin_enum_name(type_name))
-            .map(|id| (id, false))
+        let facts = EpochFacts::new(self);
+        resolve_enum_type_name(
+            &facts,
+            ctx.comptime_type_vars.get(&type_name).copied(),
+            ctx.current_file_id,
+            type_name,
+        )
     }
 
     /// Resolve a `Type.assoc()` / `Type { .. }` struct type name that may be a
@@ -62,19 +62,13 @@ impl<'a> BodySema<'a> {
         type_name: Spur,
         ctx: &AnalysisContext,
     ) -> Option<(crate::types::StructId, bool)> {
-        if let Some(&ty) = ctx.comptime_type_vars.get(&type_name) {
-            return ty.as_struct().map(|id| (id, true));
-        }
-        if let Some(info) = self.value_const(&(ctx.current_file_id, type_name))
-            && let ConstValue::Type(ty) = info.value
-        {
-            return ty.as_struct().map(|id| (id, true));
-        }
-        self.structs_by_file_name
-            .get(&(ctx.current_file_id, type_name))
-            .copied()
-            .or_else(|| self.resolve_builtin_struct_name(type_name))
-            .map(|id| (id, false))
+        let facts = EpochFacts::new(self);
+        resolve_struct_type_name(
+            &facts,
+            ctx.comptime_type_vars.get(&type_name).copied(),
+            ctx.current_file_id,
+            type_name,
+        )
     }
 
     /// Analyze construction of an enum tuple variant with a payload
@@ -362,15 +356,11 @@ impl<'a> BodySema<'a> {
                     span,
                 ));
             };
-            let module_def = self.module_registry.get_def(module_id);
-            let module_file_id = Some(module_def.file_id);
-            let struct_id = module_file_id
-                .and_then(|file_id| {
-                    self.structs_by_file_name
-                        .get(&(file_id, type_name))
-                        .copied()
-                })
-                .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.to_string()), span)?;
+            let struct_id = {
+                let facts = EpochFacts::new(self);
+                facts.struct_in_file(facts.module(module_id).file, type_name)
+            }
+            .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.to_string()), span)?;
             // Module-qualified visibility is E0706 (RUE-525), uniform with
             // enum members and associated-function calls through a module;
             // E0460 is the diagnostic for unqualified naming forms.
@@ -385,63 +375,47 @@ impl<'a> BodySema<'a> {
                 ));
             }
             struct_id
-        } else if let Some(&ty) = ctx.comptime_type_vars.get(&type_name) {
-            // Extract struct ID from the comptime type
-            match ty.kind() {
-                TypeKind::Struct(id) => id,
-                _ => {
-                    return Err(CompileError::new(
-                        ErrorKind::TypeMismatch {
-                            expected: "struct type".to_string(),
-                            found: ty.safe_name_with_pool(Some(&self.type_pool)),
-                        },
-                        span,
-                    ));
-                }
-            }
-        } else if let Some(info) = self.value_const(&(span.file_id, type_name))
-            && let ConstValue::Type(ty) = info.value
-        {
-            // Module-level `const P = Point(i32); P { .. }` (RUE-595): the
-            // specialization arrived through a `const` binding, mirroring the
-            // comptime-type-variable branch above — privacy-exempt for the same
-            // reason (the type value came from a binding, not by naming the
-            // struct). Without this arm the literal head was `UnknownType`
-            // (E0204) even though the annotation form (`fn f() -> P`) resolved.
-            match ty.kind() {
-                TypeKind::Struct(id) => id,
-                _ => {
-                    return Err(CompileError::new(
-                        ErrorKind::TypeMismatch {
-                            expected: "struct type".to_string(),
-                            found: ty.safe_name_with_pool(Some(&self.type_pool)),
-                        },
-                        span,
-                    ));
-                }
-            }
         } else {
-            let struct_id = self
-                .structs_by_file_name
-                .get(&(span.file_id, type_name))
-                .copied()
-                .or_else(|| self.resolve_builtin_struct_name(type_name))
-                .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.to_string()), span)?;
-            // Privacy (E0460, RUE-183): a struct literal names the type
-            // unqualified, so a private struct from another directory is not
-            // constructible here — privacy is uniform across item kinds
-            // (spec 10.3:1, 10.3:7). The comptime-type-variable branch above
-            // is exempt: the type value arrived through a binding (e.g. a
-            // `pub` comptime function's return), not by naming the struct.
-            let def = self.type_pool.struct_def(struct_id);
-            self.check_unqualified_visibility(
-                "struct",
-                type_name_str,
-                def.file_id,
-                def.is_pub,
-                span,
-            )?;
-            struct_id
+            let head = {
+                let facts = EpochFacts::new(self);
+                select_struct_literal_head(
+                    &facts,
+                    ctx.comptime_type_vars.get(&type_name).copied(),
+                    span.file_id,
+                    type_name,
+                )
+            };
+            match head {
+                StructLiteralHead::Bound(ty) => match ty.kind() {
+                    TypeKind::Struct(id) => id,
+                    _ => {
+                        return Err(CompileError::new(
+                            ErrorKind::TypeMismatch {
+                                expected: "struct type".to_string(),
+                                found: ty.safe_name_with_pool(Some(&self.type_pool)),
+                            },
+                            span,
+                        ));
+                    }
+                },
+                StructLiteralHead::Named(struct_id) => {
+                    let def = self.type_pool.struct_def(struct_id);
+                    self.check_unqualified_visibility(
+                        "struct",
+                        type_name_str,
+                        def.file_id,
+                        def.is_pub,
+                        span,
+                    )?;
+                    struct_id
+                }
+                StructLiteralHead::Absent => {
+                    return Err(CompileError::new(
+                        ErrorKind::UnknownType(type_name_str.to_string()),
+                        span,
+                    ));
+                }
+            }
         };
 
         // Get struct def (returns owned copy from pool)
@@ -632,24 +606,28 @@ impl<'a> BodySema<'a> {
         // `./helper.rue`) refer to the same module (spec 10.2:4, RUE-240).
         // `module_file_path` is then that file's stored path, used for the
         // directory-based visibility checks below.
-        let module_def = self.module_registry.get_def(module_id);
-        let module_file_id = Some(module_def.file_id);
-        let module_file_path = module_file_id
-            .and_then(|id| self.get_file_path(id))
-            .map(str::to_string)
-            .unwrap_or_else(|| module_def.file_path.clone());
+        let (module_fact, module_file_path) = {
+            let facts = EpochFacts::new(self);
+            let module = facts.module(module_id);
+            let module_file_path = facts
+                .file_path(module.file)
+                .map(str::to_string)
+                .unwrap_or_else(|| module.file_path().to_string());
+            (module, module_file_path)
+        };
 
         // Get the accessing file's directory for visibility check
-        let accessing_file_path = self.get_source_path(span).map(|s| s.to_string());
+        let accessing_file_path = EpochFacts::new(self).source_path(span).map(str::to_string);
+        let member = {
+            let facts = EpochFacts::new(self);
+            select_module_type_member(&facts, module_fact.file, member_name)
+        };
 
         // First, try to find a struct with this name defined by the module's
         // file. Same-named structs in sibling modules are distinct nominal
         // types (RUE-454).
-        if let Some(struct_id) = module_file_id.and_then(|file_id| {
-            self.structs_by_file_name
-                .get(&(file_id, member_name))
-                .copied()
-        }) {
+        if let ModuleTypeMember::Struct(struct_id) = &member {
+            let struct_id = *struct_id;
             let struct_def = self.type_pool.struct_def(struct_id);
 
             // Check visibility: pub structs are visible to all, private only to same directory
@@ -686,11 +664,8 @@ impl<'a> BodySema<'a> {
         }
 
         // Next, try to find an enum with this name defined by the module's file.
-        if let Some(enum_id) = module_file_id.and_then(|file_id| {
-            self.enums_by_file_name
-                .get(&(file_id, member_name))
-                .copied()
-        }) {
+        if let ModuleTypeMember::Enum(enum_id) = &member {
+            let enum_id = *enum_id;
             let enum_def = self.type_pool.enum_def(enum_id);
 
             // Check visibility: pub enums are visible to all, private only to same directory
@@ -733,12 +708,7 @@ impl<'a> BodySema<'a> {
         // member-by-member (RUE-136). Module bindings live in the per-file
         // tagged module-binding variant keyed by the facade's FileId (RUE-113);
         // value consts are found by defining file and member name.
-        let member_const = module_file_id
-            .and_then(|file_id| self.module_binding(&(file_id, member_name)))
-            .or_else(|| {
-                module_file_id.and_then(|file_id| self.value_const(&(file_id, member_name)))
-            });
-        if let Some(const_info) = member_const.cloned() {
+        if let ModuleTypeMember::Const(const_info) = member {
             if !const_info.is_pub {
                 let same_dir = match &accessing_file_path {
                     Some(accessing) => {
@@ -808,7 +778,7 @@ impl<'a> BodySema<'a> {
         // Member not found in the module
         Err(CompileError::new(
             ErrorKind::UnknownModuleMember {
-                module_name: module_def.import_path.clone(),
+                module_name: module_fact.import_path().to_string(),
                 member_name: member_name_str,
             },
             span,
@@ -911,28 +881,8 @@ impl<'a> BodySema<'a> {
         span: Span,
         ctx: &AnalysisContext,
     ) -> Option<crate::types::ModuleId> {
-        match self.rir.get(inst_ref).data {
-            InstData::VarRef { name, .. } => {
-                if let Some(local) = ctx.locals.get(&name) {
-                    if let Some(module_id) = local.ty.as_module() {
-                        return Some(module_id);
-                    }
-                }
-                self.module_binding(&(span.file_id, name))
-                    .and_then(|binding| binding.ty.as_module())
-            }
-            // Nested submodule: `parent.sub` where `parent` is a module and `sub`
-            // is a module re-exported from `parent`'s file (`pub const sub =
-            // @import(...)`).
-            InstData::FieldGet { base, field } => {
-                let parent_id = self.try_module_id_of(base, span, ctx)?;
-                let parent_def = self.module_registry.get_def(parent_id);
-                let parent_file = parent_def.file_id;
-                self.module_binding(&(parent_file, field))
-                    .and_then(|binding| binding.ty.as_module())
-            }
-            _ => None,
-        }
+        let facts = EpochFacts::new(self);
+        resolve_aggregate_module_ref(&facts, self.rir, inst_ref, span.file_id, &ctx.locals)
     }
 
     /// Try to analyze a module-qualified type-member call:
@@ -958,13 +908,16 @@ impl<'a> BodySema<'a> {
         let Some(module_id) = self.try_module_id_of(module_ref, span, ctx) else {
             return Ok(None);
         };
-        let module_def = self.module_registry.get_def(module_id);
-        let file_id = module_def.file_id;
+        let selected = {
+            let facts = EpochFacts::new(self);
+            let file = facts.module(module_id).file;
+            select_qualified_type(&facts, file, type_name)
+        };
 
         // Enum member: `module.Enum.Variant(payload)` is tuple-variant
         // construction. Resolve the enum in the receiver module's defining
         // file and apply module-qualified visibility (E0706).
-        if let Some(enum_id) = self.enums_by_file_name.get(&(file_id, type_name)).copied() {
+        if let QualifiedType::Enum(enum_id) = selected {
             let enum_def = self.type_pool.enum_def(enum_id);
             if !self.is_accessible(span.file_id, enum_def.file_id, enum_def.is_pub) {
                 return Err(CompileError::new(
@@ -1004,11 +957,7 @@ impl<'a> BodySema<'a> {
         // pass it through (RUE-525): dispatching on the bare name would
         // re-resolve in the caller's file (module-local rules) and miss.
         // Module-qualified visibility is E0706, mirroring the enum branch.
-        if let Some(struct_id) = self
-            .structs_by_file_name
-            .get(&(file_id, type_name))
-            .copied()
-        {
+        if let QualifiedType::Struct(struct_id) = selected {
             let struct_def = self.type_pool.struct_def(struct_id);
             if !self.is_accessible(span.file_id, struct_def.file_id, struct_def.is_pub) {
                 return Err(CompileError::new(
@@ -1055,11 +1004,11 @@ impl<'a> BodySema<'a> {
         let Some(module_id) = self.try_module_id_of(module_ref, span, ctx) else {
             return Ok(None);
         };
-        let module_def = self.module_registry.get_def(module_id);
-        let module_file_id = Some(module_def.file_id);
-        let Some(enum_id) = module_file_id
-            .and_then(|file_id| self.enums_by_file_name.get(&(file_id, type_name)).copied())
-        else {
+        let Some(enum_id) = ({
+            let facts = EpochFacts::new(self);
+            let file = facts.module(module_id).file;
+            select_qualified_enum(&facts, file, type_name)
+        }) else {
             // `type_name` is not an enum in this module: this is const/field
             // access through the module, not a variant path. Fall through.
             return Ok(None);

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -27,6 +27,7 @@
 //! - [`BoundSema::analyze_one_body_instance`] - Analyze one exact query-owned body
 //! - [`BoundSema::compose_queried_bodies`] - Import queried bodies into final output
 
+mod aggregate_resolution;
 mod aggregates;
 pub(crate) mod analysis;
 mod analyze_ops;

--- a/crates/rue-air/src/sema/visibility.rs
+++ b/crates/rue-air/src/sema/visibility.rs
@@ -7,10 +7,11 @@
 use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_span::FileId;
 
-use crate::types::EnumId;
-use rue_rir::InstData;
-
+use super::aggregate_resolution::{
+    AggregateFacts, EpochFacts, is_accessible, resolve_visibility_module_ref, select_qualified_enum,
+};
 use super::{DeclarationPhase, Sema, context::AnalysisContext};
+use crate::types::EnumId;
 
 impl<D: DeclarationPhase> Sema<'_, D> {
     /// Check if the accessing file can see a private item from the target file.
@@ -30,11 +31,8 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         target_file_id: FileId,
         is_pub: bool,
     ) -> bool {
-        let accessing =
-            crate::SemanticVisibilityDomain::from_file_path(self.get_file_path(accessing_file_id));
-        let defining =
-            crate::SemanticVisibilityDomain::from_file_path(self.get_file_path(target_file_id));
-        defining.is_visible_from(&accessing, is_pub)
+        let facts = EpochFacts::new(self);
+        is_accessible(&facts, accessing_file_id, target_file_id, is_pub)
     }
 
     /// Check that an *unqualified* reference may reach the item (RUE-37,
@@ -68,8 +66,8 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         // `is_accessible` is permissive when either file path is unknown
         // (single-file mode, synthetic items), so the item's path is
         // always known here.
-        let defining_file = self
-            .get_file_path(defining_file_id)
+        let defining_file = EpochFacts::new(self)
+            .file_path(defining_file_id)
             .unwrap_or("<unknown>")
             .to_string();
 
@@ -112,7 +110,11 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         // defining file. If the receiver has no module identity, it is not a
         // valid qualified type path.
         let enum_id = module_file_id
-            .and_then(|file_id| self.enums_by_file_name.get(&(file_id, type_name)).copied())
+            .and_then(|module_id| {
+                let facts = EpochFacts::new(self);
+                let file = facts.module(module_id).file;
+                select_qualified_enum(&facts, file, type_name)
+            })
             .ok_or_else(|| {
                 CompileError::new(ErrorKind::UnknownEnumType(type_name_str.to_string()), span)
             })?;
@@ -139,24 +141,8 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         &self,
         module_ref: rue_rir::InstRef,
         ctx: &AnalysisContext,
-    ) -> Option<FileId> {
-        let inst = self.rir.get(module_ref);
-        let module_ty = match inst.data {
-            InstData::VarRef { name, .. } => {
-                ctx.locals.get(&name).map(|local| local.ty).or_else(|| {
-                    self.module_binding(&(inst.span.file_id, name))
-                        .map(|binding| binding.ty)
-                })
-            }
-            InstData::FieldGet { base, field } => {
-                let parent_file = self.module_file_for_ref(base, ctx)?;
-                self.module_binding(&(parent_file, field))
-                    .map(|binding| binding.ty)
-            }
-            _ => None,
-        }?;
-        let module_id = module_ty.as_module()?;
-        let module_def = self.module_registry.get_def(module_id);
-        Some(module_def.file_id)
+    ) -> Option<crate::types::ModuleId> {
+        let facts = EpochFacts::new(self);
+        resolve_visibility_module_ref(&facts, self.rir, module_ref, &ctx.locals)
     }
 }


### PR DESCRIPTION
Hoist family 1D aggregate, field, variant, pattern, and visibility resolution behind an internal `AggregateFacts` seam.

## What changed

- Add provider-generic selection logic for unqualified aggregate heads, module-member precedence, qualified enum/struct dispatch, module spines, and visibility.
- Add a short-lived concrete `EpochFacts` adapter that reproduces the existing epoch reads and lookup order.
- Repoint only `aggregates.rs` and `visibility.rs`; the family-1C equality-method lookup remains untouched.
- Preserve the original path borrowing and clone points so the refactor adds no hidden allocation work.

This is a refactor-only r1c slice. It does not add `ProviderFacts`, change diagnostics, or alter the production path.

## Validation

- rue-air: 574/574
- rue-compiler: 790/790
- full spec corpus: 2,193
- full CLI corpus: 1,735
- differential oracle: 4/4
- scaling filter: 13/13; `RUE-1090 VERDICT: ACTIVATE RUE-1091` unchanged
- clippy: 66 targets
- fmt
- byte-equality spot proof on `dijkstra`, `jsonfmt`, and `bignum`: stderr and linked artifacts identical before/after

Part of RUE-1091
