### PR TITLE
RUE-1091 r1a: BodyEndpointProvider seam + EpochFacts

### DIFF
--- a/crates/rue-air/src/sema/body_endpoint.rs
+++ b/crates/rue-air/src/sema/body_endpoint.rs
@@ -1,0 +1,342 @@
+//! Endpoint / definition-selection resolution for exact-one-body analysis.
+//!
+//! Family 1A of the RUE-1091 analyzer rewire (slice r1a). The endpoint,
+//! nominal, and module reads that `one_body.rs` performs while turning a
+//! canonical body request or reference into a concrete declaration, method,
+//! destructor, or materialized [`Type`] no longer touch the semantic epoch
+//! tables directly. They flow through [`BodyEndpointProvider`] — the
+//! value/definition-world analog of [`crate::SemanticTypeSyntaxProvider`] — so
+//! the selection *logic* is provider-generic and a later slice can supply the
+//! same facts from a body-fact provider + overlay instead of the epoch `Sema`.
+//!
+//! [`EpochFacts`] is the one production implementation: each operation is the
+//! verbatim epoch-table read the inline `one_body.rs` code performed, so the
+//! hoist is byte-identical. Every operation is `&self` and returns owned or
+//! `Copy` data, so a caller inside an `&mut Sema` stack constructs a
+//! short-lived [`EpochFacts`] per resolution (mirroring `SemaTypeSyntaxProvider`)
+//! without retaining a borrow across the surrounding mutations.
+
+use lasso::Spur;
+use rue_rir::InstRef;
+use rue_span::FileId;
+
+use super::BodySema;
+use super::anon_structs::IssuedAnonymousNominalKey;
+use super::declaration_index::RirDestructorDeclaration;
+use super::info::{FunctionInfo, MethodInfo};
+use crate::types::{EnumId, ModuleId, StructId, Type};
+use crate::{
+    SemanticDefinitionEndpoint, SemanticDefinitionToken, SemanticModuleEndpoint,
+    SemanticModuleToken, StableDefinitionKind,
+};
+
+/// The exact endpoint/definition-selection fact boundary consumed by
+/// `one_body.rs`. Every operation answers one point query against the
+/// declaration universe and returns owned/`Copy` data — no borrowed epoch table
+/// or live `Sema` handle escapes.
+pub(in crate::sema) trait BodyEndpointProvider {
+    /// Intern a source name to its symbol, or `None` if never interned. Mirrors
+    /// `interner.get`.
+    fn name_symbol(&self, name: &str) -> Option<Spur>;
+
+    /// The current stable endpoint for a definition token.
+    fn definition_endpoint(
+        &self,
+        token: SemanticDefinitionToken,
+    ) -> Option<SemanticDefinitionEndpoint>;
+
+    /// The current stable endpoint for a module token.
+    fn module_endpoint(&self, token: SemanticModuleToken) -> Option<SemanticModuleEndpoint>;
+
+    /// The internal free-function symbol declared as `(file, name)`.
+    fn function_by_file_name(&self, file: FileId, name: Spur) -> Option<Spur>;
+
+    /// The struct id declared as `(file, name)`.
+    fn struct_by_file_name(&self, file: FileId, name: Spur) -> Option<StructId>;
+
+    /// The enum id declared as `(file, name)`.
+    fn enum_by_file_name(&self, file: FileId, name: Spur) -> Option<EnumId>;
+
+    /// The built-in or compiler-generated struct id for a bare name, preferring
+    /// the built-in table. Mirrors `builtin_structs.or_else(generated_structs)`.
+    fn builtin_or_generated_struct(&self, name: Spur) -> Option<StructId>;
+
+    /// The compiler-generated struct id for a bare name.
+    fn generated_struct(&self, name: Spur) -> Option<StructId>;
+
+    /// The built-in enum id for a bare name.
+    fn builtin_enum(&self, name: Spur) -> Option<EnumId>;
+
+    /// The struct id for an issued anonymous nominal identity.
+    fn anon_struct(&self, identity: &IssuedAnonymousNominalKey) -> Option<StructId>;
+
+    /// The enum id for an issued anonymous nominal identity.
+    fn anon_enum(&self, identity: &IssuedAnonymousNominalKey) -> Option<EnumId>;
+
+    /// Whether a bare name is a built-in or compiler-generated struct.
+    fn is_builtin_or_generated_struct(&self, name: Spur) -> bool;
+
+    /// Whether a bare name is a built-in enum.
+    fn is_builtin_enum(&self, name: Spur) -> bool;
+
+    /// The signature/binding info for an internal free-function symbol.
+    fn function_info(&self, name: Spur) -> Option<FunctionInfo>;
+
+    /// The signature/binding info for a `(struct, name)` member.
+    fn method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo>;
+
+    /// The source name a specialized/internal function name derives from.
+    /// Mirrors `Sema::source_function_name` (identity when unmapped).
+    fn source_function_name(&self, name: Spur) -> Spur;
+
+    /// The first free-function RIR declaration for `(source, file)`.
+    fn first_free_function(&self, source: Spur, file_id: FileId) -> Option<InstRef>;
+
+    /// The named-method RIR declaration for `(struct, name)`.
+    fn named_method_declaration(&self, struct_id: StructId, name: Spur) -> Option<InstRef>;
+
+    /// The destructor declaration record for `(file, type_name)`.
+    fn destructor(&self, file: u32, type_name: Spur) -> Option<RirDestructorDeclaration>;
+
+    /// The module id whose definition lives in `file`.
+    fn module_id_for_file(&self, file: u32) -> Option<ModuleId>;
+
+    /// Intern an array type, or `None` on a type-validation failure.
+    fn intern_array(&self, element: Type, len: u64) -> Option<Type>;
+
+    /// Intern a `ptr const` type, or `None` on a type-validation failure.
+    fn intern_ptr_const(&self, pointee: Type) -> Option<Type>;
+
+    /// Intern a `ptr mut` type, or `None` on a type-validation failure.
+    fn intern_ptr_mut(&self, pointee: Type) -> Option<Type>;
+}
+
+/// The production [`BodyEndpointProvider`]: every operation is the verbatim
+/// epoch-table read the inline `one_body.rs` code performed.
+pub(in crate::sema) struct EpochFacts<'s, 'a> {
+    sema: &'s BodySema<'a>,
+}
+
+/// Construct a short-lived [`EpochFacts`] borrowing `sema` for the duration of
+/// one endpoint resolution.
+pub(in crate::sema) fn endpoint_facts<'s, 'a>(sema: &'s BodySema<'a>) -> EpochFacts<'s, 'a> {
+    EpochFacts { sema }
+}
+
+impl BodyEndpointProvider for EpochFacts<'_, '_> {
+    fn name_symbol(&self, name: &str) -> Option<Spur> {
+        self.sema.interner.get(name)
+    }
+
+    fn definition_endpoint(
+        &self,
+        token: SemanticDefinitionToken,
+    ) -> Option<SemanticDefinitionEndpoint> {
+        self.sema.stable_definition_endpoints.get(&token).cloned()
+    }
+
+    fn module_endpoint(&self, token: SemanticModuleToken) -> Option<SemanticModuleEndpoint> {
+        self.sema.stable_module_endpoints.get(&token).copied()
+    }
+
+    fn function_by_file_name(&self, file: FileId, name: Spur) -> Option<Spur> {
+        self.sema.functions_by_file_name.get(&(file, name)).copied()
+    }
+
+    fn struct_by_file_name(&self, file: FileId, name: Spur) -> Option<StructId> {
+        self.sema.structs_by_file_name.get(&(file, name)).copied()
+    }
+
+    fn enum_by_file_name(&self, file: FileId, name: Spur) -> Option<EnumId> {
+        self.sema.enums_by_file_name.get(&(file, name)).copied()
+    }
+
+    fn builtin_or_generated_struct(&self, name: Spur) -> Option<StructId> {
+        self.sema
+            .builtin_structs
+            .get(&name)
+            .or_else(|| self.sema.generated_structs.get(&name))
+            .copied()
+    }
+
+    fn generated_struct(&self, name: Spur) -> Option<StructId> {
+        self.sema.generated_structs.get(&name).copied()
+    }
+
+    fn builtin_enum(&self, name: Spur) -> Option<EnumId> {
+        self.sema.builtin_enums.get(&name).copied()
+    }
+
+    fn anon_struct(&self, identity: &IssuedAnonymousNominalKey) -> Option<StructId> {
+        self.sema.anon_struct_identities.get(identity).copied()
+    }
+
+    fn anon_enum(&self, identity: &IssuedAnonymousNominalKey) -> Option<EnumId> {
+        self.sema.anon_enum_identities.get(identity).copied()
+    }
+
+    fn is_builtin_or_generated_struct(&self, name: Spur) -> bool {
+        self.sema.builtin_structs.contains_key(&name)
+            || self.sema.generated_structs.contains_key(&name)
+    }
+
+    fn is_builtin_enum(&self, name: Spur) -> bool {
+        self.sema.builtin_enums.contains_key(&name)
+    }
+
+    fn function_info(&self, name: Spur) -> Option<FunctionInfo> {
+        self.sema.function_info(name).copied()
+    }
+
+    fn method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
+        self.sema.method_info((struct_id, name)).copied()
+    }
+
+    fn source_function_name(&self, name: Spur) -> Spur {
+        self.sema.source_function_name(name)
+    }
+
+    fn first_free_function(&self, source: Spur, file_id: FileId) -> Option<InstRef> {
+        self.sema
+            .declaration_index
+            .first_free_function(source, Some(file_id))
+    }
+
+    fn named_method_declaration(&self, struct_id: StructId, name: Spur) -> Option<InstRef> {
+        self.sema
+            .named_method_declarations
+            .get(&(struct_id, name))
+            .copied()
+    }
+
+    fn destructor(&self, file: u32, type_name: Spur) -> Option<RirDestructorDeclaration> {
+        self.sema
+            .declaration_index
+            .destructors()
+            .iter()
+            .find(|record| record.span.file_id.index() == file && record.type_name == type_name)
+            .copied()
+    }
+
+    fn module_id_for_file(&self, file: u32) -> Option<ModuleId> {
+        (0..self.sema.module_registry.len())
+            .map(|index| ModuleId::new(index as u32))
+            .find(|id| self.sema.module_registry.get_def(*id).file_id.index() == file)
+    }
+
+    fn intern_array(&self, element: Type, len: u64) -> Option<Type> {
+        self.sema.type_pool.try_intern_array(element, len).ok()
+    }
+
+    fn intern_ptr_const(&self, pointee: Type) -> Option<Type> {
+        self.sema.type_pool.try_intern_ptr_const(pointee).ok()
+    }
+
+    fn intern_ptr_mut(&self, pointee: Type) -> Option<Type> {
+        self.sema.type_pool.try_intern_ptr_mut(pointee).ok()
+    }
+}
+
+/// Resolve a definition-token function reference to its internal free-function
+/// symbol. The endpoint, name interning, and by-file lookup all fail to the
+/// same `MissingStableIdentity` in the caller, so a single `None` is faithful.
+pub(in crate::sema) fn resolve_free_function_symbol<P: BodyEndpointProvider>(
+    facts: &P,
+    token: SemanticDefinitionToken,
+) -> Option<Spur> {
+    let endpoint = facts.definition_endpoint(token)?;
+    let symbol = facts.name_symbol(endpoint.name.as_ref())?;
+    facts.function_by_file_name(FileId::new(endpoint.file), symbol)
+}
+
+/// Materialize a canonical type-instance key into a concrete [`Type`]. The
+/// provider-generic form of `one_body::materialize_instance_type`: an exact
+/// transcription of the epoch code, with every table read routed through
+/// `facts` and every failure mapped to `MissingStableIdentity`.
+pub(in crate::sema) fn resolve_instance_type<P: BodyEndpointProvider>(
+    facts: &P,
+    value: &crate::TypeInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
+) -> Result<Type, crate::SemanticBodyExportFailure> {
+    use crate::{AnonymousNominalKind as AK, NominalInstanceKey as N, TypeInstanceKey as T};
+    let missing = || crate::SemanticBodyExportFailure::MissingStableIdentity;
+    Ok(match value {
+        T::I8 => Type::I8,
+        T::I16 => Type::I16,
+        T::I32 => Type::I32,
+        T::I64 => Type::I64,
+        T::U8 => Type::U8,
+        T::U16 => Type::U16,
+        T::U32 => Type::U32,
+        T::U64 => Type::U64,
+        T::Bool => Type::BOOL,
+        T::Unit => Type::UNIT,
+        T::Never => Type::NEVER,
+        T::ComptimeType => Type::COMPTIME_TYPE,
+        T::BuiltinNominal { kind, name } => {
+            let symbol = facts.name_symbol(name.as_ref()).ok_or_else(missing)?;
+            match kind {
+                AK::Struct => Type::new_struct(
+                    facts
+                        .builtin_or_generated_struct(symbol)
+                        .ok_or_else(missing)?,
+                ),
+                AK::Enum => Type::new_enum(facts.builtin_enum(symbol).ok_or_else(missing)?),
+            }
+        }
+        T::Nominal(N::Builtin { kind, name }) => {
+            let symbol = facts.name_symbol(name.as_ref()).ok_or_else(missing)?;
+            match kind {
+                AK::Struct => Type::new_struct(
+                    facts
+                        .builtin_or_generated_struct(symbol)
+                        .ok_or_else(missing)?,
+                ),
+                AK::Enum => Type::new_enum(facts.builtin_enum(symbol).ok_or_else(missing)?),
+            }
+        }
+        T::Nominal(N::Named(token)) => {
+            let endpoint = facts.definition_endpoint(*token).ok_or_else(missing)?;
+            let symbol = facts
+                .name_symbol(endpoint.name.as_ref())
+                .ok_or_else(missing)?;
+            match endpoint.kind {
+                StableDefinitionKind::Struct => Type::new_struct(
+                    facts
+                        .struct_by_file_name(FileId::new(endpoint.file), symbol)
+                        .ok_or_else(missing)?,
+                ),
+                StableDefinitionKind::Enum => Type::new_enum(
+                    facts
+                        .enum_by_file_name(FileId::new(endpoint.file), symbol)
+                        .ok_or_else(missing)?,
+                ),
+                _ => return Err(missing()),
+            }
+        }
+        T::Nominal(N::Anonymous(identity)) => match identity.kind {
+            AK::Struct => Type::new_struct(facts.anon_struct(identity).ok_or_else(missing)?),
+            AK::Enum => Type::new_enum(facts.anon_enum(identity).ok_or_else(missing)?),
+        },
+        T::Array { element, len } => facts
+            .intern_array(resolve_instance_type(facts, element)?, *len)
+            .ok_or_else(missing)?,
+        T::Slice { name, .. } => {
+            let symbol = facts.name_symbol(name.as_ref()).ok_or_else(missing)?;
+            Type::new_struct(facts.generated_struct(symbol).ok_or_else(missing)?)
+        }
+        T::PtrConst(value) => facts
+            .intern_ptr_const(resolve_instance_type(facts, value)?)
+            .ok_or_else(missing)?,
+        T::PtrMut(value) => facts
+            .intern_ptr_mut(resolve_instance_type(facts, value)?)
+            .ok_or_else(missing)?,
+        T::Module(token) => {
+            let endpoint = facts.module_endpoint(*token).ok_or_else(missing)?;
+            let id = facts
+                .module_id_for_file(endpoint.file)
+                .ok_or_else(missing)?;
+            Type::new_module(id)
+        }
+        T::GenericParameter(_) => return Err(missing()),
+    })
+}

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -32,6 +32,7 @@ pub(crate) mod analysis;
 mod analyze_ops;
 mod anon_structs;
 mod binding_manifest;
+mod body_endpoint;
 mod builtins;
 mod comptime_eval;
 mod context;

--- a/crates/rue-air/src/sema/one_body.rs
+++ b/crates/rue-air/src/sema/one_body.rs
@@ -16,6 +16,7 @@ use rue_error::{CompileError, CompileErrors, ErrorKind};
 use rue_rir::InstData;
 use rue_span::{FileId, Span};
 
+use super::body_endpoint::{BodyEndpointProvider, endpoint_facts};
 use super::{AnalyzedBodyOwnerEvent, AnalyzedFunction, BodyOwnerKind, BodySema};
 use crate::{
     FunctionInstanceKey, NominalInstanceKey, SemanticBodyExport, SemanticDefinitionToken,
@@ -243,11 +244,10 @@ fn target_dependency(
         }
         T::NamedType { file, name, kind } => {
             if let Some(symbol) = sema.interner.get(name.as_str()) {
-                let builtin_kind = if sema.builtin_enums.contains_key(&symbol) {
+                let facts = endpoint_facts(sema);
+                let builtin_kind = if facts.is_builtin_enum(symbol) {
                     Some(crate::AnonymousNominalKind::Enum)
-                } else if sema.builtin_structs.contains_key(&symbol)
-                    || sema.generated_structs.contains_key(&symbol)
-                {
+                } else if facts.is_builtin_or_generated_struct(symbol) {
                     Some(crate::AnonymousNominalKind::Struct)
                 } else {
                     None
@@ -597,7 +597,7 @@ fn body_references(
         references.insert(OneBodyDependency::Callable(identity));
     }
     for (structure, method) in referenced_methods {
-        let Some(info) = sema.method_info((*structure, *method)) else {
+        let Some(info) = endpoint_facts(sema).method_info(*structure, *method) else {
             return Err(ReferenceProjectionFailure::EngineAbort);
         };
         let symbol = sema.method_symbol(*structure, sema.interner.resolve(method), info.has_self);
@@ -643,9 +643,8 @@ fn body_references(
             continue;
         }
         if sema.interner.get(&event.target_name).is_some_and(|symbol| {
-            sema.builtin_structs.contains_key(&symbol)
-                || sema.generated_structs.contains_key(&symbol)
-                || sema.builtin_enums.contains_key(&symbol)
+            let facts = endpoint_facts(sema);
+            facts.is_builtin_or_generated_struct(symbol) || facts.is_builtin_enum(symbol)
         }) {
             continue;
         }
@@ -867,7 +866,7 @@ pub(super) fn analyze_one_body(
             type_arguments,
             value_arguments,
         } => {
-            let Some(endpoint) = sema.stable_definition_endpoints.get(&base) else {
+            let Some(endpoint) = endpoint_facts(&sema).definition_endpoint(base) else {
                 return fail(
                     &sema,
                     None,
@@ -885,9 +884,8 @@ pub(super) fn analyze_one_body(
                     )),
                 );
             };
-            let Some(&base_name) = sema
-                .functions_by_file_name
-                .get(&(FileId::new(endpoint.file), source_name))
+            let Some(base_name) = endpoint_facts(&sema)
+                .function_by_file_name(FileId::new(endpoint.file), source_name)
             else {
                 return fail(
                     &sema,
@@ -903,7 +901,7 @@ pub(super) fn analyze_one_body(
                 value_args: value_arguments,
             };
             let base_name = key.base_name;
-            let base_info = sema.function_info(base_name).cloned();
+            let base_info = endpoint_facts(&sema).function_info(base_name);
             let owner = base_info.as_ref().map(|info| {
                 sema.body_owner_token(
                     info.file_id,
@@ -1180,7 +1178,7 @@ fn analyze_anonymous_member(
             CompileError::without_span(ErrorKind::UndefinedFunction(member.name.to_string())),
         );
     };
-    let Some(method_info) = sema.method_info((struct_id, method_name)).cloned() else {
+    let Some(method_info) = endpoint_facts(&sema).method_info(struct_id, method_name) else {
         return fail(
             &sema,
             None,
@@ -1354,26 +1352,18 @@ pub(in crate::sema) fn materialize_argument_value(
     value: &crate::CanonicalArgumentValue<SemanticDefinitionToken, SemanticModuleToken>,
 ) -> Result<super::ConstValue, crate::SemanticBodyExportFailure> {
     use crate::CanonicalArgumentValue as V;
+    let facts = super::body_endpoint::endpoint_facts(sema);
     Ok(match value {
         V::Integer(value) => super::ConstValue::Integer(*value),
         V::Bool(value) => super::ConstValue::Bool(*value),
-        V::Type(value) => super::ConstValue::Type(materialize_instance_type(sema, value)?),
+        V::Type(value) => {
+            super::ConstValue::Type(super::body_endpoint::resolve_instance_type(&facts, value)?)
+        }
         V::Function(value) => {
             let FunctionInstanceKey::Definition(token) = value.as_ref() else {
                 return Err(crate::SemanticBodyExportFailure::MissingStableIdentity);
             };
-            let endpoint = sema
-                .stable_definition_endpoints
-                .get(token)
-                .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?;
-            let symbol = sema
-                .interner
-                .get(endpoint.name.as_ref())
-                .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?;
-            let symbol = sema
-                .functions_by_file_name
-                .get(&(FileId::new(endpoint.file), symbol))
-                .copied()
+            let symbol = super::body_endpoint::resolve_free_function_symbol(&facts, *token)
                 .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?;
             super::ConstValue::Function(symbol)
         }
@@ -1386,130 +1376,7 @@ pub(in crate::sema) fn materialize_instance_type(
     sema: &BodySema<'_>,
     value: &TypeInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
 ) -> Result<Type, crate::SemanticBodyExportFailure> {
-    use crate::{AnonymousNominalKind as AK, NominalInstanceKey as N, TypeInstanceKey as T};
-    let missing = || crate::SemanticBodyExportFailure::MissingStableIdentity;
-    Ok(match value {
-        T::I8 => Type::I8,
-        T::I16 => Type::I16,
-        T::I32 => Type::I32,
-        T::I64 => Type::I64,
-        T::U8 => Type::U8,
-        T::U16 => Type::U16,
-        T::U32 => Type::U32,
-        T::U64 => Type::U64,
-        T::Bool => Type::BOOL,
-        T::Unit => Type::UNIT,
-        T::Never => Type::NEVER,
-        T::ComptimeType => Type::COMPTIME_TYPE,
-        T::BuiltinNominal { kind, name } => {
-            let symbol = sema.interner.get(name.as_ref()).ok_or_else(missing)?;
-            match kind {
-                AK::Struct => Type::new_struct(
-                    sema.builtin_structs
-                        .get(&symbol)
-                        .or_else(|| sema.generated_structs.get(&symbol))
-                        .copied()
-                        .ok_or_else(missing)?,
-                ),
-                AK::Enum => Type::new_enum(
-                    sema.builtin_enums
-                        .get(&symbol)
-                        .copied()
-                        .ok_or_else(missing)?,
-                ),
-            }
-        }
-        T::Nominal(N::Builtin { kind, name }) => {
-            let symbol = sema.interner.get(name.as_ref()).ok_or_else(missing)?;
-            match kind {
-                AK::Struct => Type::new_struct(
-                    sema.builtin_structs
-                        .get(&symbol)
-                        .or_else(|| sema.generated_structs.get(&symbol))
-                        .copied()
-                        .ok_or_else(missing)?,
-                ),
-                AK::Enum => Type::new_enum(
-                    sema.builtin_enums
-                        .get(&symbol)
-                        .copied()
-                        .ok_or_else(missing)?,
-                ),
-            }
-        }
-        T::Nominal(N::Named(token)) => {
-            let endpoint = sema
-                .stable_definition_endpoints
-                .get(token)
-                .ok_or_else(missing)?;
-            let symbol = sema
-                .interner
-                .get(endpoint.name.as_ref())
-                .ok_or_else(missing)?;
-            match endpoint.kind {
-                StableDefinitionKind::Struct => Type::new_struct(
-                    sema.structs_by_file_name
-                        .get(&(FileId::new(endpoint.file), symbol))
-                        .copied()
-                        .ok_or_else(missing)?,
-                ),
-                StableDefinitionKind::Enum => Type::new_enum(
-                    sema.enums_by_file_name
-                        .get(&(FileId::new(endpoint.file), symbol))
-                        .copied()
-                        .ok_or_else(missing)?,
-                ),
-                _ => return Err(missing()),
-            }
-        }
-        T::Nominal(N::Anonymous(identity)) => match identity.kind {
-            AK::Struct => Type::new_struct(
-                sema.anon_struct_identities
-                    .get(identity)
-                    .copied()
-                    .ok_or_else(missing)?,
-            ),
-            AK::Enum => Type::new_enum(
-                sema.anon_enum_identities
-                    .get(identity)
-                    .copied()
-                    .ok_or_else(missing)?,
-            ),
-        },
-        T::Array { element, len } => sema
-            .type_pool
-            .try_intern_array(materialize_instance_type(sema, element)?, *len)
-            .map_err(|_| missing())?,
-        T::Slice { name, .. } => {
-            let symbol = sema.interner.get(name.as_ref()).ok_or_else(missing)?;
-            Type::new_struct(
-                sema.generated_structs
-                    .get(&symbol)
-                    .copied()
-                    .ok_or_else(missing)?,
-            )
-        }
-        T::PtrConst(value) => sema
-            .type_pool
-            .try_intern_ptr_const(materialize_instance_type(sema, value)?)
-            .map_err(|_| missing())?,
-        T::PtrMut(value) => sema
-            .type_pool
-            .try_intern_ptr_mut(materialize_instance_type(sema, value)?)
-            .map_err(|_| missing())?,
-        T::Module(token) => {
-            let endpoint = sema
-                .stable_module_endpoints
-                .get(token)
-                .ok_or_else(missing)?;
-            let id = (0..sema.module_registry.len())
-                .map(|index| crate::types::ModuleId::new(index as u32))
-                .find(|id| sema.module_registry.get_def(*id).file_id.index() == endpoint.file)
-                .ok_or_else(missing)?;
-            Type::new_module(id)
-        }
-        T::GenericParameter(_) => return Err(missing()),
-    })
+    super::body_endpoint::resolve_instance_type(&super::body_endpoint::endpoint_facts(sema), value)
 }
 
 fn analyze_definition(
@@ -1518,7 +1385,7 @@ fn analyze_definition(
     token: SemanticDefinitionToken,
     interruption: Option<OneBodyInterruption>,
 ) -> OneBodyTransactionOutcome {
-    let Some(endpoint) = sema.stable_definition_endpoints.get(&token).cloned() else {
+    let Some(endpoint) = endpoint_facts(sema).definition_endpoint(token) else {
         return fail(
             sema,
             None,
@@ -1538,9 +1405,8 @@ fn analyze_definition(
                     )),
                 );
             };
-            let Some(&name) = sema
-                .functions_by_file_name
-                .get(&(FileId::new(endpoint.file), source_name))
+            let Some(name) =
+                endpoint_facts(sema).function_by_file_name(FileId::new(endpoint.file), source_name)
             else {
                 return fail(
                     sema,
@@ -1550,7 +1416,9 @@ fn analyze_definition(
                     )),
                 );
             };
-            let info = sema.functions[&name];
+            let info = endpoint_facts(sema)
+                .function_info(name)
+                .expect("functions_by_file_name resolved to a registered function");
             if info.is_generic || info.is_extern {
                 return OneBodyTransactionOutcome::NonTerminal {
                     reason: OneBodyNonTerminalReason::TypedIncomplete(
@@ -1558,10 +1426,8 @@ fn analyze_definition(
                     ),
                 };
             }
-            let source = sema.source_function_name(name);
-            let Some(declaration) = sema
-                .declaration_index
-                .first_free_function(source, Some(info.file_id))
+            let source = endpoint_facts(sema).source_function_name(name);
+            let Some(declaration) = endpoint_facts(sema).first_free_function(source, info.file_id)
             else {
                 return fail(
                     sema,
@@ -1670,9 +1536,8 @@ fn analyze_named_method(
             )),
         );
     };
-    let Some(&struct_id) = sema
-        .structs_by_file_name
-        .get(&(FileId::new(endpoint.file), owner_symbol))
+    let Some(struct_id) =
+        endpoint_facts(sema).struct_by_file_name(FileId::new(endpoint.file), owner_symbol)
     else {
         return fail(
             sema,
@@ -1689,16 +1554,14 @@ fn analyze_named_method(
             CompileError::without_span(ErrorKind::UndefinedFunction(endpoint.name.to_string())),
         );
     };
-    let Some(info) = sema.method_info((struct_id, method_name)).cloned() else {
+    let Some(info) = endpoint_facts(sema).method_info(struct_id, method_name) else {
         return fail(
             sema,
             None,
             CompileError::without_span(ErrorKind::UndefinedFunction(endpoint.name.to_string())),
         );
     };
-    let Some(&declaration) = sema
-        .named_method_declarations
-        .get(&(struct_id, method_name))
+    let Some(declaration) = endpoint_facts(sema).named_method_declaration(struct_id, method_name)
     else {
         return fail(
             sema,
@@ -1811,9 +1674,8 @@ fn analyze_named_destructor(
             )),
         );
     };
-    let Some(&struct_id) = sema
-        .structs_by_file_name
-        .get(&(FileId::new(endpoint.file), owner_symbol))
+    let Some(struct_id) =
+        endpoint_facts(sema).struct_by_file_name(FileId::new(endpoint.file), owner_symbol)
     else {
         return fail(
             sema,
@@ -1823,15 +1685,7 @@ fn analyze_named_destructor(
             )),
         );
     };
-    let Some(record) = sema
-        .declaration_index
-        .destructors()
-        .iter()
-        .find(|record| {
-            record.span.file_id.index() == endpoint.file && record.type_name == owner_symbol
-        })
-        .cloned()
-    else {
+    let Some(record) = endpoint_facts(sema).destructor(endpoint.file, owner_symbol) else {
         return fail(
             sema,
             None,

--- a/docs/notes/rue-1091-analyzer-rewire-plan.md
+++ b/docs/notes/rue-1091-analyzer-rewire-plan.md
@@ -236,13 +236,31 @@ target (RISK R2), not a new edge.
   eager for now (EpochFacts fills it) — demand-population is r-inference. **No `#[cfg(test)]`, no new
   path: the epoch reads simply move behind a trait method.**
 - **Files**: `sema/provider.rs` (traits alongside `BodyFactProvider`), new
-  `sema/call_resolution.rs` (generic logic, mirror of `semantic_type_resolution.rs`), `calls.rs`,
-  `analysis.rs`, `aggregates.rs`, `builtin_ops.rs`, `ownership.rs`, `visibility.rs`, `one_body.rs`,
-  `typeck.rs`.
+  `sema/call_resolution.rs` (generic logic, mirror of the template module
+  `crates/rue-air/src/semantic_type_resolution.rs` — note it lives at the crate `src/` root, NOT
+  under `src/sema/`), `calls.rs`, `analysis.rs`, `aggregates.rs`, `builtin_ops.rs`, `ownership.rs`,
+  `visibility.rs`, `one_body.rs`, `typeck.rs`.
 - **Tests**: full corpus + generated-oracle (byte-identical AIR + diagnostics); `scripts/rue spec`,
   `ui`, `cli`; the existing overlay-equals-production tests (`body_overlay.rs:530,572`) stay green.
 - **Size**: **L** (broad but purely mechanical; the risk is missed reads — mitigate with a guard
   that no target file reads the epoch tables outside an EpochFacts impl).
+
+#### r1 packaging: landed as three independently gauntlet-proven sub-slices (r1a/r1b/r1c)
+r1 preserves every design decision above (same traits, same §1 inventory, same seam, same
+byte-identical bar); only its packaging is split, mirroring how the type-syntax family landed one
+resolution family at a time. Each sub-slice is a self-contained, byte-identical refactor proven on
+the full corpus + oracle before the next begins:
+- **r1a** — `BodyEndpointProvider` + concrete `EpochFacts`, covering family **1A**
+  (endpoint/definition selection) in `sema/one_body.rs`: the endpoint/nominal/module resolution
+  behind `resolve_semantic_type_syntax`'s value-world analog. `build_inference_context` stays eager
+  (r5 owns demand-population).
+- **r1b** — `SemanticCallResolutionProvider` + `EpochFacts`, covering family **1C**
+  (free-function/method/operator/module-member calls) in `calls.rs`/`analysis.rs`/`builtin_ops.rs`/
+  `ownership.rs`. This is where the candidate-set-vs-winner selection (R1) moves into generic logic.
+- **r1c** — aggregate/field/variant + `visibility.rs` enum-through-module, covering family **1D**,
+  reusing r1b's `SemanticCallResolutionProvider`.
+The `SignatureFacts` seam and the `call_resolution.rs` generic-logic module named above are
+introduced with r1b/r1c; r1a introduces only the endpoint seam (`sema/body_endpoint.rs`).
 
 ### r2 — ProviderFacts: type-syntax / nominal
 - **Scope**: second impl of `SemanticTypeSyntaxProvider`/`SemanticModulePathProvider` backed by


### PR DESCRIPTION
Slice r1a of the RUE-1091 analyzer rewire: hoist family 1A (the `one_body.rs` endpoint/definition reads) behind a new internal `BodyEndpointProvider` trait with a concrete monomorphized `EpochFacts` production impl. Strictly refactor-only — every op is the verbatim epoch-table read the inline code performed, byte-identical by construction and by proof.

## What changed

- New `crates/rue-air/src/sema/body_endpoint.rs`: `BodyEndpointProvider` (endpoints, by-file-name nominals, builtin/generated classification, anon identities, function/method/destructor info, module-id scan, type-pool interning, name interning) + provider-generic `resolve_instance_type` / `resolve_free_function_symbol` mirroring the proven `semantic_type_resolution.rs` pattern.
- `one_body.rs` call sites re-threaded through the seam (`materialize_instance_type`, `materialize_argument_value`, the analyze_* family, specialization base selection, `target_dependency`, `body_references`); short-lived per-call borrows, no `&dyn`, no borrow retained across mutations.
- Family 1A endpoints are exact keyed lookups (no candidate-set selection), so no selection-order surface exists in this slice; `build_inference_context` stays eager (r5 owns demand-population).
- Plan doc: records the r1a/r1b/r1c split of r1 (packaging only; design unchanged) and fixes the template path reference.

## Byte-identity proof

Stash-and-baseline method: built HEAD without the change, captured `--emit air/deps/asm` + stderr, restored, diffed:
- **jsonfmt** (heavy): air 148KB, deps 102KB, asm 447KB — md5-identical
- **harbor** (37-import multi-file): air 1.78MB, deps 448KB — md5-identical
- **multidiag** (E0202/E0411/E0207): diagnostic stderr byte-identical (text + order), recorded deps identical

## Validation

Local: rue-air 574/574, differential oracle pass, full spec corpus 2178/2178, clippy (66 targets), fmt. Full CLI corpus, rue-compiler suite, and the scaling filter ride CI per the push-first process. Adversarial review round running in parallel; auto-merge will be enabled once it's clean.

Part of RUE-1091

---
_Generated by [Claude Code](https://claude.ai/code/session_019h99YFzR3fuDy2phd2vU9r)_