### PR TITLE
RUE-1091 r1b: CallResolutionFacts seam + EpochFacts

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -21,6 +21,10 @@ use rue_rir::{InstData, InstRef, Rir, RirArgMode, RirCallArg, RirParamMode};
 use rue_span::{FileId, Span};
 use rue_target::{Arch, DataModel, Os};
 
+use super::call_resolution::{
+    CallResolutionFacts, StaticCallReference, call_facts, classify_static_call,
+    resolve_static_call_reference,
+};
 use super::context::{AnalysisContext, AnalysisResult, CallLoanKind, ConstValue, ParamInfo};
 use super::{AnalyzedFunction, BodySema, InferenceContext, MethodInfo, ParamSlotModes, SemaOutput};
 use crate::inference::{
@@ -334,7 +338,9 @@ fn composed_callable_metadata(
                 .interner
                 .get(member.name.as_ref())
                 .ok_or_else(missing)?;
-            let info = sema.method_info((struct_id, method)).ok_or_else(missing)?;
+            let info = call_facts(sema)
+                .method_info(struct_id, method)
+                .ok_or_else(missing)?;
             Ok((
                 sema.method_symbol(struct_id, member.name.as_ref(), info.has_self),
                 if member.kind == crate::AnonymousMemberKind::Destructor {
@@ -785,8 +791,8 @@ pub(crate) fn import_staged_body(
             .get(&(FileId::new(identity.file), owner))
             .copied()
             .ok_or(BF::Semantic(F::MissingFunction))?;
-        let info = sema
-            .method_info((struct_id, name))
+        let info = call_facts(sema)
+            .method_info(struct_id, name)
             .ok_or(BF::Semantic(F::MissingFunction))?;
         let expected = match identity.kind {
             DK::Method => info.has_self && identity.name.as_ref() != "__drop",
@@ -829,8 +835,8 @@ pub(crate) fn import_staged_body(
                     .interner
                     .get(member.name.as_ref())
                     .ok_or(BF::Semantic(F::MissingFunction))?;
-                let info = sema
-                    .method_info((struct_id, name))
+                let info = call_facts(sema)
+                    .method_info(struct_id, name)
                     .ok_or(BF::Semantic(F::MissingFunction))?;
                 let expected = match member.kind {
                     crate::AnonymousMemberKind::Method => {
@@ -940,12 +946,14 @@ pub(crate) fn imported_body_references(
         let AirInstData::Call { name, .. } = instruction.data else {
             continue;
         };
-        if sema.functions.contains_key(&name) {
-            functions.insert(name);
-            continue;
-        }
-        if let Some((struct_id, method, _)) = sema.named_method_by_callable_symbol(name) {
-            methods.insert((struct_id, method));
+        match classify_static_call(&call_facts(sema), name) {
+            Some(StaticCallReference::Free(name)) => {
+                functions.insert(name);
+            }
+            Some(StaticCallReference::Method(struct_id, method)) => {
+                methods.insert((struct_id, method));
+            }
+            None => {}
         }
     }
     (functions, methods)
@@ -1334,23 +1342,11 @@ fn collect_static_function_references(sema: &BodySema<'_>) -> HashSet<Spur> {
     let mut referenced = HashSet::new();
 
     for (_, inst) in sema.rir.iter() {
-        if let InstData::Call { name, .. } = &inst.data {
-            let mut target = *name;
-            let mut resolved_alias = false;
-            if let Some(const_info) = sema.resolve_const_info_in_file(target, inst.span.file_id)
-                && let Some(callee) = const_info.value.as_function()
-            {
-                target = callee;
-                resolved_alias = true;
-            }
-
-            if resolved_alias && sema.functions.contains_key(&target) {
-                referenced.insert(target);
-            } else if let Some(function_key) =
-                sema.resolve_function_name_local(target, inst.span.file_id)
-            {
-                referenced.insert(function_key);
-            }
+        if let InstData::Call { name, .. } = &inst.data
+            && let Some(function_key) =
+                resolve_static_call_reference(&call_facts(sema), *name, inst.span.file_id)
+        {
+            referenced.insert(function_key);
         }
     }
 
@@ -1363,7 +1359,7 @@ fn collect_static_function_references(sema: &BodySema<'_>) -> HashSet<Spur> {
             continue;
         };
         if let Some(function) =
-            sema.resolve_function_name_local(name, FileId::new(event.callable_file))
+            call_facts(sema).resolve_function_name_local(name, FileId::new(event.callable_file))
         {
             referenced.insert(function);
         }
@@ -1414,9 +1410,8 @@ fn named_method_dependency_events(
     referenced_functions: &HashSet<Spur>,
     referenced_methods: &HashSet<(StructId, Spur)>,
 ) -> CompileResult<Vec<super::NamedMethodDependencyEvent>> {
-    let caller_info = sema
-        .methods
-        .get(&(caller_struct, caller_method))
+    let caller_info = call_facts(sema)
+        .named_method_info(caller_struct, caller_method)
         .ok_or_else(|| {
             CompileError::new(
                 ErrorKind::InvalidCompilerInput(
@@ -1429,7 +1424,7 @@ fn named_method_dependency_events(
     let caller_method_name = sema.interner.resolve(&caller_method).to_string();
     let mut events = Vec::new();
     for callee in referenced_functions {
-        let info = sema.functions.get(callee).ok_or_else(|| {
+        let info = call_facts(sema).function_info(*callee).ok_or_else(|| {
             CompileError::new(
                 ErrorKind::InvalidCompilerInput(
                     "named method references a free function absent from semantic declarations"
@@ -1456,7 +1451,7 @@ fn named_method_dependency_events(
                 file: info.file_id.index(),
                 name: sema
                     .interner
-                    .resolve(&sema.source_function_name(*callee))
+                    .resolve(&call_facts(sema).source_function_name(*callee))
                     .to_string(),
             },
         });
@@ -1466,9 +1461,8 @@ fn named_method_dependency_events(
         if owner_name.starts_with("__anon_struct_") {
             continue;
         }
-        let info = sema
-            .methods
-            .get(&(*callee_struct, *callee_method))
+        let info = call_facts(sema)
+            .named_method_info(*callee_struct, *callee_method)
             .ok_or_else(|| {
                 CompileError::new(
                     ErrorKind::InvalidCompilerInput(
@@ -1512,7 +1506,7 @@ fn named_destructor_dependency_events(
     let caller_owner_name = sema.type_pool.struct_def(caller_struct).name.clone();
     let mut events = Vec::new();
     for callee in referenced_functions {
-        let info = sema.functions.get(callee).ok_or_else(|| {
+        let info = call_facts(sema).function_info(*callee).ok_or_else(|| {
             CompileError::new(
                 ErrorKind::InvalidCompilerInput(
                     "named destructor references an absent free function".into(),
@@ -1533,7 +1527,7 @@ fn named_destructor_dependency_events(
                 file: info.file_id.index(),
                 name: sema
                     .interner
-                    .resolve(&sema.source_function_name(*callee))
+                    .resolve(&call_facts(sema).source_function_name(*callee))
                     .to_string(),
             },
         });
@@ -1543,9 +1537,8 @@ fn named_destructor_dependency_events(
         if owner_name.starts_with("__anon_struct_") {
             continue;
         }
-        let info = sema
-            .methods
-            .get(&(*callee_struct, *callee_method))
+        let info = call_facts(sema)
+            .named_method_info(*callee_struct, *callee_method)
             .ok_or_else(|| {
                 CompileError::new(
                     ErrorKind::InvalidCompilerInput(
@@ -1691,7 +1684,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
 
     // Find main() - the reference root for executable body analysis.
     let main_sym = match sema.interner.get("main") {
-        Some(sym) if sema.functions.contains_key(&sym) => sym,
+        Some(sym) if call_facts(sema).function_contains(sym) => sym,
         _ => {
             // No main function found - this is an error
             return Err(CompileErrors::from(CompileError::without_span(
@@ -1838,8 +1831,8 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                 analyzed_functions.insert(fn_name);
 
                 // Look up the function info
-                let fn_info = match sema.functions.get(&fn_name) {
-                    Some(info) => *info,
+                let fn_info = match call_facts(sema).function_info(fn_name) {
+                    Some(info) => info,
                     None => continue, // Should not happen, but be defensive
                 };
                 let function_identity = match sema.function_identity(fn_name) {
@@ -1966,7 +1959,9 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                             },
                         );
                         for callee in &ordered_referenced_fns {
-                            let callee_info = sema.functions[callee];
+                            let callee_info = call_facts(sema)
+                                .function_info(*callee)
+                                .expect("referenced free function is present in declarations");
                             sema.ordinary_free_function_dependencies.push(
                                 super::OrdinaryFreeFunctionDependencyEvent {
                                     caller_token: ordinary_owner,
@@ -1975,7 +1970,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                                     callee_file: callee_info.file_id.index(),
                                     callee_name: sema
                                         .interner
-                                        .resolve(&sema.source_function_name(*callee))
+                                        .resolve(&call_facts(sema).source_function_name(*callee))
                                         .to_string(),
                                 },
                             );
@@ -2121,7 +2116,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                                 name: sema.interner.resolve(&source_name).to_string(),
                             });
                         for callee in &referenced_fns {
-                            if let Some(callee_info) = sema.functions.get(callee) {
+                            if let Some(callee_info) = call_facts(sema).function_info(*callee) {
                                 sema.ordinary_free_function_dependencies.push(
                                     super::OrdinaryFreeFunctionDependencyEvent {
                                         caller_token: sema.body_owner_token(
@@ -2138,7 +2133,9 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                                         callee_file: callee_info.file_id.index(),
                                         callee_name: sema
                                             .interner
-                                            .resolve(&sema.source_function_name(*callee))
+                                            .resolve(
+                                                &call_facts(sema).source_function_name(*callee),
+                                            )
                                             .to_string(),
                                     },
                                 );
@@ -2175,8 +2172,8 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                 analyzed_methods.insert((struct_id, method_name));
 
                 // Look up the method info
-                let method_info = match sema.method_info((struct_id, method_name)) {
-                    Some(info) => info.clone(),
+                let method_info = match call_facts(sema).method_info(struct_id, method_name) {
+                    Some(info) => info,
                     None => continue,
                 };
 
@@ -2367,9 +2364,8 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                 }
 
                 sema.body_analysis_work.named_method_record_lookups += 1;
-                let Some(&method_ref) = sema
-                    .named_method_declarations
-                    .get(&(struct_id, method_name))
+                let Some(method_ref) =
+                    call_facts(sema).named_method_declaration(struct_id, method_name)
                 else {
                     debug_assert!(
                         false,

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -3,6 +3,7 @@
 //! This category owns builtin operations within the canonical semantic-analysis
 //! implementation.
 
+use super::super::call_resolution::{CallResolutionFacts, call_facts};
 use super::*;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -98,7 +99,7 @@ impl<'a> BodySema<'a> {
             span,
         )?;
         let method = self.interner.get_or_intern("concat_borrowed");
-        if self.method_info((struct_id, method)).is_none() {
+        if call_facts(self).method_info(struct_id, method).is_none() {
             return Err(CompileError::new(
                 ErrorKind::InternalError("canonical StrBuf is missing concat_borrowed".to_string()),
                 span,

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -7,6 +7,7 @@
 //! `analysis::ownership`.
 
 use super::*;
+use crate::sema::call_resolution::{CallResolutionFacts, call_facts};
 use crate::sema::{FunctionInfo, NamedConstDependencyTargetEvent};
 
 /// Validate membership and visibility for a module-member function call.
@@ -223,7 +224,7 @@ impl<'a> BodySema<'a> {
         let source_name = name;
         let mut name = name;
         let mut resolved_alias = false;
-        if let Some(const_info) = self.resolve_const_info_in_file(name, span.file_id).cloned()
+        if let Some(const_info) = call_facts(self).resolve_const_info_in_file(name, span.file_id)
             && let Some(callee) = const_info.value.as_function()
         {
             let alias_name = self.interner.resolve(&name).to_string();
@@ -243,7 +244,7 @@ impl<'a> BodySema<'a> {
         }
 
         let local_name = (!resolved_alias)
-            .then(|| self.resolve_function_name_local(name, span.file_id))
+            .then(|| call_facts(self).resolve_function_name_local(name, span.file_id))
             .flatten();
         if let Some(local_name) = local_name {
             name = local_name;
@@ -270,13 +271,11 @@ impl<'a> BodySema<'a> {
         }
 
         // Look up the function
-        let source_name = self.source_function_name(name);
+        let source_name = call_facts(self).source_function_name(name);
         let fn_name_str = self.interner.resolve(&source_name).to_string();
-        let fn_info = self
-            .functions
-            .get(&name)
+        let fn_info = call_facts(self)
+            .function_info(name)
             .ok_or_compile_error(ErrorKind::UndefinedFunction(fn_name_str.clone()), span)?;
-        let fn_info = fn_info.clone();
 
         self.analyze_resolved_function_call(air, name, fn_info, args_range, span, ctx, true)
     }
@@ -302,7 +301,7 @@ impl<'a> BodySema<'a> {
         ctx: &mut AnalysisContext,
         check_unqualified_visibility: bool,
     ) -> CompileResult<AnalysisResult> {
-        let source_name = self.source_function_name(name);
+        let source_name = call_facts(self).source_function_name(name);
         let fn_name_str = self.interner.resolve(&source_name).to_string();
 
         // Visibility (E0460, RUE-37/RUE-180): an unqualified call must not
@@ -813,7 +812,7 @@ impl<'a> BodySema<'a> {
                 let ty = self.peek_place_type(receiver, ctx)?;
                 let struct_id = ty.as_struct()?;
 
-                let info = self.method_info((struct_id, method))?;
+                let info = call_facts(self).method_info(struct_id, method)?;
                 matches!(info.self_mode, RirParamMode::Inout | RirParamMode::Borrow).then_some(root)
             })
         };
@@ -906,13 +905,15 @@ impl<'a> BodySema<'a> {
 
         // Look up the method using StructId directly
         let method_key = (struct_id, method);
-        let method_info = self.method_info(method_key).copied().ok_or_compile_error(
-            ErrorKind::UndefinedMethod {
-                type_name: struct_name_str.clone(),
-                method_name: method_name_str.clone(),
-            },
-            span,
-        )?;
+        let method_info = call_facts(self)
+            .method_info(struct_id, method)
+            .ok_or_compile_error(
+                ErrorKind::UndefinedMethod {
+                    type_name: struct_name_str.clone(),
+                    method_name: method_name_str.clone(),
+                },
+                span,
+            )?;
 
         // Track this method as referenced (for lazy analysis). Anonymous
         // struct methods are often registered while reducing a comptime type
@@ -1126,10 +1127,11 @@ impl<'a> BodySema<'a> {
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         let fn_name_str = self.interner.resolve(&function_name).to_string();
-        let module_def = self.module_registry.get_def(module_id);
+        let module_def = call_facts(self).module_def(module_id);
         let module_file_id = Some(module_def.file_id);
-        let mut function_key = module_file_id
-            .and_then(|file_id| self.resolve_function_name_local(function_name, file_id));
+        let mut function_key = module_file_id.and_then(|file_id| {
+            call_facts(self).resolve_function_name_local(function_name, file_id)
+        });
 
         // Fallback: a re-exported function member — `pub const f = @import("x").f;`
         // in the facade binds `f` to a function value (ADR-0026, RUE-592). It is
@@ -1142,12 +1144,12 @@ impl<'a> BodySema<'a> {
         if function_key.is_none()
             && let Some(mfile) = module_file_id
         {
-            let reexport =
-                self.value_const(&(mfile, function_name))
-                    .and_then(|info| match info.value {
-                        ConstValue::Function(fkey) => Some((fkey, info.is_pub)),
-                        _ => None,
-                    });
+            let reexport = call_facts(self)
+                .value_const(mfile, function_name)
+                .and_then(|info| match info.value {
+                    ConstValue::Function(fkey) => Some((fkey, info.is_pub)),
+                    _ => None,
+                });
             if let Some((fkey, is_pub)) = reexport {
                 if !self.is_accessible(span.file_id, mfile, is_pub) {
                     return Err(CompileError::new(
@@ -1177,17 +1179,15 @@ impl<'a> BodySema<'a> {
                 span,
             )
         })?;
-        let fn_info = self
-            .functions
-            .get(&function_key)
+        let fn_info = call_facts(self)
+            .function_info(function_key)
             .ok_or_compile_error(
                 ErrorKind::UnknownModuleMember {
                     module_name: module_def.import_path.clone(),
                     member_name: fn_name_str.clone(),
                 },
                 span,
-            )?
-            .clone();
+            )?;
 
         // Track this function as referenced (for lazy analysis)
         ctx.referenced_functions.insert(function_key);
@@ -1289,7 +1289,7 @@ impl<'a> BodySema<'a> {
                     ));
                 }
             }
-        } else if let Some(info) = self.value_const(&(ctx.current_file_id, type_name))
+        } else if let Some(info) = call_facts(self).value_const(ctx.current_file_id, type_name)
             && let ConstValue::Type(ty) = info.value
         {
             // Module-level `const C = Counter(i32); C.zero()` (RUE-595): the
@@ -1339,13 +1339,15 @@ impl<'a> BodySema<'a> {
 
         // Look up the function using StructId
         let method_key = (struct_id, function);
-        let method_info = self.method_info(method_key).copied().ok_or_compile_error(
-            ErrorKind::UndefinedAssocFn {
-                type_name: type_name_str.clone(),
-                function_name: function_name_str.clone(),
-            },
-            span,
-        )?;
+        let method_info = call_facts(self)
+            .method_info(struct_id, function)
+            .ok_or_compile_error(
+                ErrorKind::UndefinedAssocFn {
+                    type_name: type_name_str.clone(),
+                    function_name: function_name_str.clone(),
+                },
+                span,
+            )?;
 
         // Track this associated function/method as referenced (for lazy analysis)
         ctx.referenced_methods.insert(method_key);

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -5,6 +5,7 @@
 //! them. It extends the canonical [`BodySema`] rather than introducing peer
 //! analysis state.
 
+use super::super::call_resolution::{CallResolutionFacts, call_facts};
 use super::super::context::{LocalVar, VariableMoveState};
 use super::*;
 use crate::inst::AirPlaceRef;
@@ -370,8 +371,8 @@ impl<'a> BodySema<'a> {
         // owner backs both calls.
         let ptr_method = self.interner.get_or_intern("as_ptr");
         let len_method = self.interner.get_or_intern("len");
-        let Some(ptr_ty) = self
-            .method_info((struct_id, ptr_method))
+        let Some(ptr_ty) = call_facts(self)
+            .method_info(struct_id, ptr_method)
             .map(|m| m.return_type)
         else {
             return Err(CompileError::new(
@@ -381,8 +382,8 @@ impl<'a> BodySema<'a> {
                 span,
             ));
         };
-        let Some(len_ty) = self
-            .method_info((struct_id, len_method))
+        let Some(len_ty) = call_facts(self)
+            .method_info(struct_id, len_method)
             .map(|m| m.return_type)
         else {
             return Err(CompileError::new(
@@ -1392,7 +1393,7 @@ impl<'a> BodySema<'a> {
         // @import("math")`). Module bindings are per-file scoped (RUE-113),
         // so the lookup is keyed by the reference's own file and takes
         // precedence over file-local value constants.
-        if let Some(binding) = self.module_binding(&(span.file_id, name)).cloned() {
+        if let Some(binding) = call_facts(self).module_binding(span.file_id, name) {
             self.record_body_named_dependency(
                 super::super::NamedConstDependencyTargetEvent::ModuleBinding {
                     file: span.file_id.index(),
@@ -1414,7 +1415,7 @@ impl<'a> BodySema<'a> {
         // checked above. The value was evaluated once during declaration
         // gathering (RUE-171); materialize it directly — the initializer is
         // never re-analyzed at use sites.
-        if let Some(const_info) = self.resolve_const_info_in_file(name, span.file_id).cloned() {
+        if let Some(const_info) = call_facts(self).resolve_const_info_in_file(name, span.file_id) {
             // Apply the uniform privacy rule even though ordinary unqualified
             // lookup resolves in the reference file (spec 10.3:1, 10.3:7).
             self.check_unqualified_visibility(
@@ -2619,7 +2620,7 @@ impl<'a> BodySema<'a> {
             ));
         };
         let method = self.interner.get_or_intern("byte_at_borrowed");
-        if self.method_info((struct_id, method)).is_none() {
+        if call_facts(self).method_info(struct_id, method).is_none() {
             return Err(CompileError::new(
                 ErrorKind::InternalError(
                     "trusted std StrBuf is missing its source `byte_at_borrowed` method"

--- a/crates/rue-air/src/sema/call_resolution.rs
+++ b/crates/rue-air/src/sema/call_resolution.rs
@@ -1,0 +1,220 @@
+//! Call / method / operator / module-member resolution for exact-one-body
+//! analysis.
+//!
+//! Family 1C of the RUE-1091 analyzer rewire (slice r1b). The free-function,
+//! method, operator-overload, and module-member reads that `analysis.rs`,
+//! `calls.rs`, `ownership.rs`, and `builtin_ops.rs` perform while resolving a
+//! call, method, or operator to its callee no longer touch the semantic epoch
+//! tables directly. They flow through [`CallResolutionFacts`] — the
+//! value/call-world analog of [`crate::SemanticTypeSyntaxProvider`] and a
+//! sibling of `body_endpoint`'s [`super::body_endpoint::BodyEndpointProvider`]
+//! (family 1A) — so the selection *logic* is provider-generic and a later slice
+//! can supply the same facts from a body-fact provider + overlay instead of the
+//! epoch `Sema`.
+//!
+//! [`EpochFacts`] is the one production implementation: each operation is the
+//! verbatim epoch-table read the inline analyzer code performed, so the hoist is
+//! byte-identical. Every operation is `&self` and returns owned or `Copy` data,
+//! so a caller inside an `&mut Sema` stack constructs a short-lived
+//! [`EpochFacts`] per resolution (mirroring `SemaTypeSyntaxProvider`) without
+//! retaining a borrow across the surrounding mutations.
+//!
+//! Where the analyzer selects a winner across *several* candidate reads — the
+//! reachability classifier's free-function-then-named-method order, and the
+//! static call-reference resolver's const-alias-then-local order — that
+//! selection lives in the provider-generic free functions below
+//! ([`classify_static_call`], [`resolve_static_call_reference`]) rather than in
+//! the impl, so both `EpochFacts` and a future body-fact impl replay the exact
+//! same candidate order, short-circuits, and first-match-wins tie-breaks
+//! (RUE-1091 risk R1). Winner-picking that a single epoch accessor already
+//! performs internally (`method_info`'s anonymous-then-named fallback, the
+//! callable-symbol single-candidate check) stays inside that point query,
+//! matching the `body_endpoint` convention.
+
+use lasso::Spur;
+use rue_rir::InstRef;
+use rue_span::FileId;
+
+use super::BodySema;
+use super::info::{ConstInfo, FunctionInfo, MethodInfo};
+use crate::types::{ModuleDef, ModuleId, StructId};
+
+/// The exact call/method/operator-resolution fact boundary consumed by the
+/// family-1C analyzer sites. Every operation answers one point query against
+/// the declaration universe and returns owned/`Copy` data — no borrowed epoch
+/// table or live `Sema` handle escapes.
+pub(in crate::sema) trait CallResolutionFacts {
+    /// The signature/binding info for an internal free-function symbol.
+    /// Mirrors `Sema::function_info` (`functions.get`).
+    fn function_info(&self, name: Spur) -> Option<FunctionInfo>;
+
+    /// Whether an internal free-function symbol is declared. Mirrors
+    /// `functions.contains_key`.
+    fn function_contains(&self, name: Spur) -> bool;
+
+    /// The source name a specialized/internal function name derives from.
+    /// Mirrors `Sema::source_function_name` (identity when unmapped).
+    fn source_function_name(&self, name: Spur) -> Spur;
+
+    /// The internal free-function symbol a source name resolves to inside its
+    /// own file. Mirrors `Sema::resolve_function_name_local`.
+    fn resolve_function_name_local(&self, name: Spur, file: FileId) -> Option<Spur>;
+
+    /// The value-constant info declared as `(file, name)`. Mirrors
+    /// `Sema::resolve_const_info_in_file` (a file-scoped `value_const`).
+    fn resolve_const_info_in_file(&self, name: Spur, file: FileId) -> Option<ConstInfo>;
+
+    /// The value-constant info declared as `(file, name)`. Mirrors
+    /// `value_const`; distinct from [`Self::resolve_const_info_in_file`] only in
+    /// how the key is spelled at the call site.
+    fn value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo>;
+
+    /// The module-binding const declared as `(file, name)`. Mirrors
+    /// `module_binding`.
+    fn module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo>;
+
+    /// The method/associated-function info for `(struct, name)`, preferring the
+    /// anonymous table then the named table. Mirrors `Sema::method_info`.
+    fn method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo>;
+
+    /// The *named* method/associated-function info for `(struct, name)`,
+    /// consulting only the named table. Mirrors a direct `methods.get`, so it
+    /// deliberately does not fall back to the anonymous table the way
+    /// [`Self::method_info`] does.
+    fn named_method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo>;
+
+    /// The unique named `(struct, method, info)` a callable symbol resolves to,
+    /// or `None` when the symbol is absent or ambiguous. Mirrors
+    /// `Sema::named_method_by_callable_symbol`.
+    fn named_method_by_callable_symbol(&self, name: Spur) -> Option<(StructId, Spur, MethodInfo)>;
+
+    /// The named-method RIR declaration for `(struct, name)`. Mirrors
+    /// `named_method_declarations.get`.
+    fn named_method_declaration(&self, struct_id: StructId, name: Spur) -> Option<InstRef>;
+
+    /// The module definition for a module id. Mirrors
+    /// `module_registry.get_def`.
+    fn module_def(&self, module_id: ModuleId) -> ModuleDef;
+}
+
+/// The production [`CallResolutionFacts`]: every operation is the verbatim
+/// epoch-table read the inline analyzer code performed.
+pub(in crate::sema) struct EpochFacts<'s, 'a> {
+    sema: &'s BodySema<'a>,
+}
+
+/// Construct a short-lived [`EpochFacts`] borrowing `sema` for the duration of
+/// one call/method/operator resolution.
+pub(in crate::sema) fn call_facts<'s, 'a>(sema: &'s BodySema<'a>) -> EpochFacts<'s, 'a> {
+    EpochFacts { sema }
+}
+
+impl CallResolutionFacts for EpochFacts<'_, '_> {
+    fn function_info(&self, name: Spur) -> Option<FunctionInfo> {
+        self.sema.function_info(name).copied()
+    }
+
+    fn function_contains(&self, name: Spur) -> bool {
+        self.sema.functions.contains_key(&name)
+    }
+
+    fn source_function_name(&self, name: Spur) -> Spur {
+        self.sema.source_function_name(name)
+    }
+
+    fn resolve_function_name_local(&self, name: Spur, file: FileId) -> Option<Spur> {
+        self.sema.resolve_function_name_local(name, file)
+    }
+
+    fn resolve_const_info_in_file(&self, name: Spur, file: FileId) -> Option<ConstInfo> {
+        self.sema.resolve_const_info_in_file(name, file).cloned()
+    }
+
+    fn value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
+        self.sema.value_const(&(file, name)).cloned()
+    }
+
+    fn module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
+        self.sema.module_binding(&(file, name)).cloned()
+    }
+
+    fn method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
+        self.sema.method_info((struct_id, name)).copied()
+    }
+
+    fn named_method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
+        self.sema.methods.get(&(struct_id, name)).copied()
+    }
+
+    fn named_method_by_callable_symbol(&self, name: Spur) -> Option<(StructId, Spur, MethodInfo)> {
+        self.sema
+            .named_method_by_callable_symbol(name)
+            .map(|(struct_id, method, info)| (struct_id, method, *info))
+    }
+
+    fn named_method_declaration(&self, struct_id: StructId, name: Spur) -> Option<InstRef> {
+        self.sema
+            .named_method_declarations
+            .get(&(struct_id, name))
+            .copied()
+    }
+
+    fn module_def(&self, module_id: ModuleId) -> ModuleDef {
+        self.sema.module_registry.get_def(module_id)
+    }
+}
+
+/// The reachability classification of a statically discovered call name.
+pub(in crate::sema) enum StaticCallReference {
+    /// The name is a free function.
+    Free(Spur),
+    /// The name is the callable symbol of the unique `(struct, method)`.
+    Method(StructId, Spur),
+}
+
+/// Classify a discovered call name as a free function or a unique named method,
+/// preferring the free function. The provider-generic form of the inline
+/// classifier in `imported_body_references`: a free-function candidate
+/// wins over a named-method candidate (first-match-wins), and the named-method
+/// read is skipped entirely when the free-function membership check succeeds.
+pub(in crate::sema) fn classify_static_call<P: CallResolutionFacts>(
+    facts: &P,
+    name: Spur,
+) -> Option<StaticCallReference> {
+    if facts.function_contains(name) {
+        return Some(StaticCallReference::Free(name));
+    }
+    if let Some((struct_id, method, _)) = facts.named_method_by_callable_symbol(name) {
+        return Some(StaticCallReference::Method(struct_id, method));
+    }
+    None
+}
+
+/// Resolve a statically discovered call name to the free-function symbol it
+/// references for reachability. The provider-generic form of the inline
+/// resolution in `collect_static_function_references`, replaying `analyze_call`'s
+/// alias-then-local selection: a function-valued constant alias is consulted
+/// first (and, when it names a declared function, wins directly); otherwise the
+/// file-local function name is resolved. The alias read is skipped when the name
+/// binds no function-valued const, and the local read is skipped when the alias
+/// already resolved to a declared function.
+pub(in crate::sema) fn resolve_static_call_reference<P: CallResolutionFacts>(
+    facts: &P,
+    name: Spur,
+    file: FileId,
+) -> Option<Spur> {
+    let mut target = name;
+    let mut resolved_alias = false;
+    if let Some(const_info) = facts.resolve_const_info_in_file(name, file)
+        && let Some(callee) = const_info.value.as_function()
+    {
+        target = callee;
+        resolved_alias = true;
+    }
+
+    if resolved_alias && facts.function_contains(target) {
+        Some(target)
+    } else {
+        facts.resolve_function_name_local(target, file)
+    }
+}

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -34,6 +34,7 @@ mod anon_structs;
 mod binding_manifest;
 mod body_endpoint;
 mod builtins;
+mod call_resolution;
 mod comptime_eval;
 mod context;
 mod control_flow;

--- a/crates/rue-cli-tests/cases/module_shadowing.toml
+++ b/crates/rue-cli-tests/cases/module_shadowing.toml
@@ -1,0 +1,92 @@
+[section]
+id = "cli.module_shadowing"
+name = "Local binding shadowing a same-named module binding in a module-qualified position"
+description = """
+A file-level module binding `const helper = @import("helper.rue");` and a
+function-local `let helper = 5;` share the name `helper`. When the local is in
+scope, a module-qualified use of that name — a member call `helper.value()` or a
+struct-literal head `helper.Foo { .. }` — resolves against the LOCAL, not the
+module binding: the local wins and the module-qualified read fails against the
+local's (non-module) type. Removing the local restores ordinary module-member
+resolution.
+
+This pins today's production behavior exactly (RUE-1091 slice r1b; promised in
+the r1c review). It exists so the aggregate-path receiver fall-through
+(`resolve_aggregate_module_ref`, introduced by the parallel r1c aggregate slice
+and NOT present in this tree) can never be silently re-unified with the call /
+visibility flavor: any future change that makes the shadowed module binding win
+in either position must update these assertions consciously rather than drift.
+
+NOTE (flagged for reconciliation with the r1c reviewer): the r1b coordinator's
+brief described current production as "the non-module local falls through and the
+MODULE binding resolves". In this tree that is NOT what happens for either the
+call form or the struct-literal form — the local shadows and the module-qualified
+read is a type error (recorded below). The control case shows the module binding
+resolving only when no local shadows it.
+"""
+
+# The module-qualified CALL form (family 1C, call/method resolution). With a
+# local `helper: i32` in scope, `helper.value()` is a method call on i32, not a
+# module-member call; the module function `value` is not reached.
+[[case]]
+name = "module_qualified_call_resolves_to_shadowing_local"
+description = "`helper.value()` under `let helper = 5;` is a call on the local i32, not a module member."
+compile_fail = true
+error_contains = ["E0413", "no method named 'value'", "i32"]
+files = [
+    { path = "main.rue", source = """
+const helper = @import("helper.rue");
+
+fn main() -> i32 {
+    let helper = 5;
+    return helper.value();
+}
+""" },
+    { path = "helper.rue", source = """
+pub fn value() -> i32 { 7 }
+""" },
+]
+
+# The module-qualified STRUCT-LITERAL head form (aggregate path). With a local
+# `helper: i32` in scope, `helper.Foo { .. }` treats `helper` as the local value,
+# so the aggregate head sees `i32` where it expected a module.
+[[case]]
+name = "module_qualified_struct_literal_head_resolves_to_shadowing_local"
+description = "`helper.Foo { .. }` under `let helper = 5;` reads the local i32, not the module type."
+compile_fail = true
+error_contains = ["E0206", "expected module", "i32"]
+files = [
+    { path = "main.rue", source = """
+const helper = @import("helper.rue");
+
+fn main() -> i32 {
+    let helper = 5;
+    let f = helper.Foo { v: 9 };
+    return f.v;
+}
+""" },
+    { path = "helper.rue", source = """
+pub struct Foo {
+    v: i32,
+}
+""" },
+]
+
+# Control: with no local shadow, the module-member call resolves normally and the
+# program returns the module function's result.
+[[case]]
+name = "module_qualified_call_resolves_to_module_without_shadow"
+description = "Without the local, `helper.value()` resolves to the imported module function."
+files = [
+    { path = "main.rue", source = """
+const helper = @import("helper.rue");
+
+fn main() -> i32 {
+    return helper.value();
+}
+""" },
+    { path = "helper.rue", source = """
+pub fn value() -> i32 { 7 }
+""" },
+]
+exit_code = 7


### PR DESCRIPTION
Slice r1b of the RUE-1091 analyzer rewire: hoist family 1C (call/method/operator resolution) behind a new internal `CallResolutionFacts` trait with a concrete monomorphized `EpochFacts` production impl, following r1a&#39;s per-family convention. Strictly refactor-only, byte-identical.

## What changed

- New `crates/rue-air/src/sema/call_resolution.rs`: `CallResolutionFacts` (function/const/method/module point queries, each a verbatim epoch read) + two provider-generic selection functions extracted so any future impl replays identical order: `classify_static_call` (free-function-then-named-method first-match with the named-method read skipped on hit) and `resolve_static_call_reference` (const-alias-then-local with exact short-circuit gating).
- The mutation-interleaved selection chains (`analyze_call`&#39;s alias→local→builtin→direct; module-member local→reexport with mid-selection privacy diagnostic) keep their inline control flow with every epoch read routed through the trait — same execution points, r1a&#39;s precedent.
- `method_info` keeps its anonymous-then-named fallback inside the accessor; one infallible index preserved as `.expect` (panic-text-only difference on an unreachable path).
- Universe-enumeration scans (`intern_named_callable_symbols`, unused-function warnings, anonymous-destructor enqueue) deliberately stay inline — they&#39;re r5 demand-population material, not call resolution.
- New `crates/rue-cli-tests/cases/module_shadowing.toml`: 3 cases pinning today&#39;s behavior when a non-module local shadows a same-named module binding in module-qualified positions (E0413 call form / E0206 literal head / no-shadow control) — the regression tripwire promised in the #1926 review; these will catch any silent re-unification of the aggregate/visibility module-ref flavors.

## Byte-identity proof

Stash/baseline/diff against r1a: AIR byte-identical for jsonfmt (std module-member dense), hashmap (user multi-file), and a method/operator/UFCS-dense program; diagnostic probes byte-identical for E0202/E0411/E0415.

## Validation

Local: rue-air 574/574, clippy (66 targets), fmt, the new CLI section green. Full corpora/oracle/scaling ride CI per the push-first process. Adversarially reviewed: PASS, 40/40 read reconciliation, no blockers.

Part of RUE-1091