### PR TITLE
Clarify Todo issue state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,8 +272,9 @@ use them instead of a plain reference.
 All issue tracking lives in Linear under team Rue (`RUE-NN`). Do not create a
 parallel Markdown backlog.
 
-- `Todo`: actionable without a maintainer design decision. Autonomous work may
-  claim unblocked Todo issues.
+- `Todo`: approved and actionable without a maintainer design decision. A Todo
+  issue may still wait on an explicit blocker; autonomous work may claim only
+  unblocked Todo issues.
 - `Backlog`: requires design or discussion. Analyze when asked, but do not make
   the decision or begin implementation autonomously.
 - Read issue comments before acting; maintainers often refine scope there.


### PR DESCRIPTION
## Summary

- clarify that Todo issues are approved and actionable
- document that Todo issues may still wait on explicit blockers
- preserve the rule that autonomous work claims only unblocked Todo issues

## Why

The previous wording could be read as requiring every Todo issue to be
immediately unblocked. Rue uses Todo for approved work, while dependency
relations determine when that work can begin.

## Impact

Future backlog triage can distinguish design approval from execution order
without moving approved, blocked work back to Backlog.

## Validation

- `git diff --check`
