### PR TITLE
RUE-1091 r5b: demand-populated inference context

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -13,13 +13,14 @@ use crate::intern_pool::TypeInternPool;
 use crate::scope::ScopedContext;
 use crate::sema::ConstValue;
 use crate::types::{
-    ArrayLen, PtrMutability, StructId, TypeKind, parse_array_type_syntax,
+    ArrayLen, ModuleId, PtrMutability, StructId, TypeKind, parse_array_type_syntax,
     parse_pointer_type_syntax, parse_type_call_syntax,
 };
 use lasso::{Spur, ThreadedRodeo};
 use rue_rir::{InstData, InstRef, RepeatCount, Rir};
 use rue_span::{FileId, Span};
 use std::collections::HashMap;
+use std::rc::Rc;
 
 /// Exact callable selections made while the test-only one-body transaction is
 /// generating constraints.  These observations are consumed only when HM
@@ -226,6 +227,37 @@ pub struct MethodSig {
     pub return_type: InferType,
 }
 
+/// Demand-population seam for the inference context (RUE-1091 slice r5b).
+///
+/// Constraint generation consults the thirteen declaration-universe families
+/// purely by key. Rather than eagerly project the whole universe into owned
+/// `HashMap`s before any body is analyzed (the O(universe)-per-body term
+/// RUE-1083 removes), the production path implements this trait over the frozen
+/// declaration state and materializes each consulted signature/type on first
+/// lookup. Every method answers exactly the same value the eager projection
+/// would have held for that key; the non-`Copy` signature families return owned
+/// `Rc` handles because a demand cache cannot lend a `'a` borrow across the
+/// generator's `&mut self` recursion.
+///
+/// Unit tests keep constructing the generator from literal maps (the eager
+/// path, `lazy == None`); only the production body pipeline installs a lazy
+/// provider.
+pub(crate) trait LazyInferenceFacts {
+    fn func_sig(&self, name: Spur) -> Option<Rc<FunctionSig>>;
+    fn method_sig(&self, key: (StructId, Spur)) -> Option<Rc<MethodSig>>;
+    fn builtin_struct_type(&self, name: Spur) -> Option<Type>;
+    fn struct_type_by_file(&self, key: (FileId, Spur)) -> Option<Type>;
+    fn builtin_enum_type(&self, name: Spur) -> Option<Type>;
+    fn enum_type_by_file(&self, key: (FileId, Spur)) -> Option<Type>;
+    fn const_type(&self, key: (FileId, Spur)) -> Option<Type>;
+    fn const_type_alias(&self, key: (FileId, Spur)) -> Option<Type>;
+    fn const_value(&self, key: (FileId, Spur)) -> Option<i128>;
+    fn const_function_alias(&self, key: (FileId, Spur)) -> Option<Spur>;
+    fn module_binding_type(&self, key: (FileId, Spur)) -> Option<Type>;
+    fn module_file_id(&self, module: ModuleId) -> Option<FileId>;
+    fn function_by_file(&self, key: (FileId, Spur)) -> Option<Spur>;
+}
+
 /// Context for constraint generation within a single function.
 pub struct ConstraintContext<'a> {
     /// Local variables in scope.
@@ -303,18 +335,28 @@ pub struct ConstraintGenerator<'a> {
     constraints: Vec<Constraint>,
     /// Mapping from RIR instruction to its inferred type.
     expr_types: HashMap<InstRef, InferType>,
-    /// Function signatures (for call type checking).
-    functions: &'a HashMap<Spur, FunctionSig>,
-    /// Built-in struct types, which have no defining source file.
-    builtin_structs: &'a HashMap<Spur, Type>,
+    /// Function signatures (for call type checking). `None` when the generator
+    /// is driven by a lazy provider (`lazy`), which materializes signatures on
+    /// demand; unit tests still supply an eager map.
+    functions: Option<&'a HashMap<Spur, FunctionSig>>,
+    /// Built-in struct types, which have no defining source file. `None` under
+    /// a lazy provider (see `functions`).
+    builtin_structs: Option<&'a HashMap<Spur, Type>>,
     /// Module-local struct types ((defining file, source name) -> Type::new_struct(id)).
     structs_by_file_name: Option<&'a HashMap<(FileId, Spur), Type>>,
-    /// Built-in enum types, which have no defining source file.
-    builtin_enums: &'a HashMap<Spur, Type>,
+    /// Built-in enum types, which have no defining source file. `None` under a
+    /// lazy provider (see `functions`).
+    builtin_enums: Option<&'a HashMap<Spur, Type>>,
     /// Module-local enum types ((defining file, source name) -> Type::new_enum(id)).
     enums_by_file_name: Option<&'a HashMap<(FileId, Spur), Type>>,
-    /// Method signatures: (struct_id, method_name) -> MethodSig
-    methods: &'a HashMap<(StructId, Spur), MethodSig>,
+    /// Method signatures: (struct_id, method_name) -> MethodSig. `None` under a
+    /// lazy provider (see `functions`).
+    methods: Option<&'a HashMap<(StructId, Spur), MethodSig>>,
+    /// Demand-population provider (RUE-1091 slice r5b). When present, the
+    /// thirteen declaration-universe families are materialized on first consult
+    /// through this seam instead of read from eager maps. `None` in unit tests,
+    /// which construct the generator from literal maps.
+    lazy: Option<&'a dyn LazyInferenceFacts>,
     /// Type variables allocated for integer literals.
     /// These start as unbound and need to be defaulted to i32 if unconstrained.
     int_literal_vars: Vec<TypeVarId>,
@@ -468,12 +510,66 @@ impl<'a> ConstraintGenerator<'a> {
             type_vars: TypeVarAllocator::new(),
             constraints: Vec::new(),
             expr_types: HashMap::new(),
-            functions,
-            builtin_structs,
+            functions: Some(functions),
+            builtin_structs: Some(builtin_structs),
             structs_by_file_name: None,
-            builtin_enums,
+            builtin_enums: Some(builtin_enums),
             enums_by_file_name: None,
-            methods,
+            methods: Some(methods),
+            lazy: None,
+            int_literal_vars: Vec::new(),
+            string_literal_vars: Vec::new(),
+            string_literal_default,
+            strbuf_type,
+            type_subst,
+            const_types: None,
+            const_type_aliases: None,
+            module_binding_types: None,
+            functions_by_file_name: None,
+            module_file_ids: None,
+            comptime_local_bindings: None,
+            comptime_alias_types: HashMap::new(),
+            alias_scope_stack: Vec::new(),
+            inline_ctor_head_types: None,
+            extra_method_sigs: None,
+            const_values: None,
+            const_function_aliases: None,
+            comptime_values: None,
+            type_pool,
+            body_dependencies: Vec::new(),
+        }
+    }
+
+    /// Create a generator driven by a demand-population provider (RUE-1091
+    /// slice r5b).
+    ///
+    /// The eager family maps stay `None`; every keyed consult of the thirteen
+    /// declaration-universe families routes through `lazy`, which materializes
+    /// only the signatures and types the body actually names. This is the
+    /// production body-analysis path — the eager `new`/`with_type_subst`
+    /// constructors remain for unit tests that build literal maps.
+    pub(crate) fn with_lazy_facts(
+        rir: &'a Rir,
+        interner: &'a ThreadedRodeo,
+        type_pool: &'a TypeInternPool,
+        type_subst: Option<&'a HashMap<Spur, Type>>,
+        lazy: &'a dyn LazyInferenceFacts,
+    ) -> Self {
+        let strbuf_type = type_pool.lang_item_type(crate::LangItem::StrBuf);
+        let string_literal_default = Type::ERROR;
+        Self {
+            rir,
+            interner,
+            type_vars: TypeVarAllocator::new(),
+            constraints: Vec::new(),
+            expr_types: HashMap::new(),
+            functions: None,
+            builtin_structs: None,
+            structs_by_file_name: None,
+            builtin_enums: None,
+            enums_by_file_name: None,
+            methods: None,
+            lazy: Some(lazy),
             int_literal_vars: Vec::new(),
             string_literal_vars: Vec::new(),
             string_literal_default,
@@ -716,6 +812,9 @@ impl<'a> ConstraintGenerator<'a> {
     /// (`resolve_const_info_in_file`) so inference and checking agree, and a
     /// same-named constant in an unrelated module cannot perturb a local length.
     fn scoped_const_value(&self, sym: Spur, file_id: FileId) -> Option<i128> {
+        if let Some(lazy) = self.lazy {
+            return lazy.const_value((file_id, sym));
+        }
         self.const_values
             .and_then(|values| values.get(&(file_id, sym)).copied())
     }
@@ -725,6 +824,9 @@ impl<'a> ConstraintGenerator<'a> {
     /// [`Self::scoped_const_value`]: a `const T = SomeType(...)` in the current
     /// module resolves; a same-named alias elsewhere is qualified, not bare.
     fn scoped_const_type_alias(&self, sym: Spur, file_id: FileId) -> Option<Type> {
+        if let Some(lazy) = self.lazy {
+            return lazy.const_type_alias((file_id, sym));
+        }
         self.const_type_aliases
             .and_then(|aliases| aliases.get(&(file_id, sym)).copied())
     }
@@ -761,12 +863,129 @@ impl<'a> ConstraintGenerator<'a> {
         }
     }
 
-    /// Look up a method signature, falling back to the late-registered
-    /// (anonymous-struct) signatures when the shared map misses (RUE-164).
-    fn method_sig(&self, key: &(StructId, Spur)) -> Option<&'a MethodSig> {
+    /// Look up a method signature.
+    ///
+    /// Under the lazy provider (production) this materializes the method
+    /// signature on demand — including late-registered anonymous-struct methods,
+    /// which the provider reads from the live method tables, subsuming the eager
+    /// `extra_method_sigs` reconciliation (RUE-164). The eager (unit-test) path
+    /// still consults the literal map plus `extra_method_sigs`.
+    fn method_sig(&self, key: &(StructId, Spur)) -> Option<Rc<MethodSig>> {
+        if let Some(lazy) = self.lazy {
+            return lazy.method_sig(*key);
+        }
         self.methods
-            .get(key)
+            .and_then(|methods| methods.get(key))
             .or_else(|| self.extra_method_sigs.and_then(|sigs| sigs.get(key)))
+            .map(|sig| Rc::new(sig.clone()))
+    }
+
+    /// Look up a function signature by internal key. Materialized on demand
+    /// under the lazy provider; the eager path clones from the literal map.
+    fn func_sig(&self, name: Spur) -> Option<Rc<FunctionSig>> {
+        if let Some(lazy) = self.lazy {
+            return lazy.func_sig(name);
+        }
+        self.functions
+            .and_then(|functions| functions.get(&name))
+            .map(|sig| Rc::new(sig.clone()))
+    }
+
+    /// Look up a built-in struct type by source name.
+    fn builtin_struct_type(&self, name: Spur) -> Option<Type> {
+        if let Some(lazy) = self.lazy {
+            return lazy.builtin_struct_type(name);
+        }
+        self.builtin_structs
+            .and_then(|builtins| builtins.get(&name).copied())
+    }
+
+    /// Look up a module-local struct type by (defining file, source name).
+    fn struct_type_by_file(&self, key: (FileId, Spur)) -> Option<Type> {
+        if let Some(lazy) = self.lazy {
+            return lazy.struct_type_by_file(key);
+        }
+        self.structs_by_file_name
+            .and_then(|map| map.get(&key).copied())
+    }
+
+    /// Look up a built-in enum type by source name.
+    fn builtin_enum_type(&self, name: Spur) -> Option<Type> {
+        if let Some(lazy) = self.lazy {
+            return lazy.builtin_enum_type(name);
+        }
+        self.builtin_enums
+            .and_then(|builtins| builtins.get(&name).copied())
+    }
+
+    /// Look up a module-local enum type by (defining file, source name).
+    fn enum_type_by_file(&self, key: (FileId, Spur)) -> Option<Type> {
+        if let Some(lazy) = self.lazy {
+            return lazy.enum_type_by_file(key);
+        }
+        self.enums_by_file_name
+            .and_then(|map| map.get(&key).copied())
+    }
+
+    /// Look up a file-level constant's declared type by (declaring file, name).
+    fn const_type(&self, key: (FileId, Spur)) -> Option<Type> {
+        if let Some(lazy) = self.lazy {
+            return lazy.const_type(key);
+        }
+        self.const_types.and_then(|map| map.get(&key).copied())
+    }
+
+    /// Look up a file-level type alias by (declaring file, name).
+    fn const_type_alias(&self, key: (FileId, Spur)) -> Option<Type> {
+        if let Some(lazy) = self.lazy {
+            return lazy.const_type_alias(key);
+        }
+        self.const_type_aliases
+            .and_then(|map| map.get(&key).copied())
+    }
+
+    /// Look up a file-level integer constant value by (declaring file, name).
+    fn const_value(&self, key: (FileId, Spur)) -> Option<i128> {
+        if let Some(lazy) = self.lazy {
+            return lazy.const_value(key);
+        }
+        self.const_values.and_then(|map| map.get(&key).copied())
+    }
+
+    /// Look up a module-binding type by (declaring file, name).
+    fn module_binding_type(&self, key: (FileId, Spur)) -> Option<Type> {
+        if let Some(lazy) = self.lazy {
+            return lazy.module_binding_type(key);
+        }
+        self.module_binding_types
+            .and_then(|map| map.get(&key).copied())
+    }
+
+    /// Look up a function-valued-constant callee alias by (declaring file, name).
+    fn const_function_alias(&self, key: (FileId, Spur)) -> Option<Spur> {
+        if let Some(lazy) = self.lazy {
+            return lazy.const_function_alias(key);
+        }
+        self.const_function_aliases
+            .and_then(|map| map.get(&key).copied())
+    }
+
+    /// Resolve a module registry file identity.
+    fn module_file_id(&self, module: ModuleId) -> Option<FileId> {
+        if let Some(lazy) = self.lazy {
+            return lazy.module_file_id(module);
+        }
+        self.module_file_ids
+            .and_then(|map| map.get(&module).copied())
+    }
+
+    /// Look up a source-level function key by (defining file, source name).
+    fn function_by_file(&self, key: (FileId, Spur)) -> Option<Spur> {
+        if let Some(lazy) = self.lazy {
+            return lazy.function_by_file(key);
+        }
+        self.functions_by_file_name
+            .and_then(|map| map.get(&key).copied())
     }
 
     /// Resolve a field's declared type on a concrete struct type.
@@ -1056,20 +1275,14 @@ impl<'a> ConstraintGenerator<'a> {
                     local.ty.clone()
                 } else if let Some(param) = ctx.params.get(name) {
                     param.ty.clone()
-                } else if let Some(binding_ty) = self
-                    .module_binding_types
-                    .and_then(|bindings| bindings.get(&(span.file_id, *name)))
-                {
+                } else if let Some(binding_ty) = self.module_binding_type((span.file_id, *name)) {
                     self.body_dependencies
                         .push(InferenceBodyDependency::ModuleBinding(span.file_id, *name));
                     // Module binding declared in this file (`const m =
                     // @import(...)`): per-file scoped and distinct from the
                     // file's value-constant namespace (RUE-113).
-                    self.type_to_infer(*binding_ty)
-                } else if let Some(const_ty) = self
-                    .const_types
-                    .and_then(|consts| consts.get(&(span.file_id, *name)))
-                {
+                    self.type_to_infer(binding_ty)
+                } else if let Some(const_ty) = self.const_type((span.file_id, *name)) {
                     self.body_dependencies
                         .push(InferenceBodyDependency::ValueConst {
                             file: span.file_id,
@@ -1082,7 +1295,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // types for `const m = @import(...)`). Yielding it here
                     // anchors expressions like `N + 1` and `m.go() + 1` to the
                     // declaration's concrete type (RUE-142).
-                    self.type_to_infer(*const_ty)
+                    self.type_to_infer(const_ty)
                 } else {
                     // Unknown variable - will be caught during semantic analysis
                     InferType::Concrete(Type::ERROR)
@@ -1111,10 +1324,7 @@ impl<'a> ConstraintGenerator<'a> {
                         .comptime_alias_types
                         .get(ty_sym)
                         .copied()
-                        .or_else(|| {
-                            self.const_type_aliases
-                                .and_then(|aliases| aliases.get(&(span.file_id, *ty_sym)).copied())
-                        })
+                        .or_else(|| self.const_type_alias((span.file_id, *ty_sym)))
                         .map(|ty| self.type_to_infer(ty))
                         .or_else(|| {
                             self.resolve_type_name(self.interner.resolve(ty_sym), span.file_id)
@@ -1246,15 +1456,9 @@ impl<'a> ConstraintGenerator<'a> {
 
             // Function call
             InstData::Call { name, args } => {
-                let alias_target = self
-                    .const_function_aliases
-                    .and_then(|aliases| aliases.get(&(span.file_id, *name)))
-                    .copied();
-                let function_key = alias_target.or_else(|| {
-                    self.functions_by_file_name
-                        .and_then(|functions| functions.get(&(span.file_id, *name)))
-                        .copied()
-                });
+                let alias_target = self.const_function_alias((span.file_id, *name));
+                let function_key =
+                    alias_target.or_else(|| self.function_by_file((span.file_id, *name)));
                 let args = self.rir.call_args(args);
                 if alias_target.is_some() {
                     self.body_dependencies
@@ -1279,7 +1483,7 @@ impl<'a> ConstraintGenerator<'a> {
                         self.generate(arg.value, ctx);
                     }
                     InferType::Concrete(Type::UNIT)
-                } else if let Some(func) = function_key.and_then(|key| self.functions.get(&key)) {
+                } else if let Some(func) = function_key.and_then(|key| self.func_sig(key)) {
                     if !func.is_generic && call_contract_matches(&args, &func.param_modes) {
                         self.body_dependencies
                             .push(InferenceBodyDependency::Function {
@@ -1335,7 +1539,7 @@ impl<'a> ConstraintGenerator<'a> {
                         if call_contract_matches(&args, &func.param_modes) {
                             self.body_dependencies.extend(generic_body_dependency(
                                 function_key.expect("resolved signature has a function key"),
-                                func,
+                                &func,
                                 &type_subst,
                                 &value_subst,
                                 &arg_infos,
@@ -1849,7 +2053,7 @@ impl<'a> ConstraintGenerator<'a> {
                 } else if intrinsic_name == "target_arch" {
                     // @target_arch: returns Arch enum
                     if let Some(arch_spur) = self.interner.get("Arch") {
-                        if let Some(&arch_ty) = self.builtin_enums.get(&arch_spur) {
+                        if let Some(arch_ty) = self.builtin_enum_type(arch_spur) {
                             InferType::Concrete(arch_ty)
                         } else {
                             InferType::Concrete(Type::ERROR)
@@ -1860,7 +2064,7 @@ impl<'a> ConstraintGenerator<'a> {
                 } else if intrinsic_name == "target_os" {
                     // @target_os: returns Os enum
                     if let Some(os_spur) = self.interner.get("Os") {
-                        if let Some(&os_ty) = self.builtin_enums.get(&os_spur) {
+                        if let Some(os_ty) = self.builtin_enum_type(os_spur) {
                             InferType::Concrete(os_ty)
                         } else {
                             InferType::Concrete(Type::ERROR)
@@ -1871,7 +2075,7 @@ impl<'a> ConstraintGenerator<'a> {
                 } else if intrinsic_name == "target_data_model" {
                     // @target_data_model: returns DataModel enum
                     if let Some(dm_spur) = self.interner.get("DataModel") {
-                        if let Some(&dm_ty) = self.builtin_enums.get(&dm_spur) {
+                        if let Some(dm_ty) = self.builtin_enum_type(dm_spur) {
                             InferType::Concrete(dm_ty)
                         } else {
                             InferType::Concrete(Type::ERROR)
@@ -2254,25 +2458,15 @@ impl<'a> ConstraintGenerator<'a> {
                         _ => None,
                     };
                     module_id
-                        .and_then(|module_id| {
-                            self.module_file_ids
-                                .and_then(|module_file_ids| module_file_ids.get(&module_id))
-                                .copied()
-                        })
-                        .and_then(|file_id| {
-                            self.structs_by_file_name
-                                .and_then(|structs| structs.get(&(file_id, *type_name)))
-                                .copied()
-                        })
+                        .and_then(|module_id| self.module_file_id(module_id))
+                        .and_then(|file_id| self.struct_type_by_file((file_id, *type_name)))
                 } else {
                     self.type_subst
                         .and_then(|subst| subst.get(type_name).copied())
                         .or_else(|| self.comptime_alias_types.get(type_name).copied())
                         .or_else(|| {
-                            self.structs_by_file_name
-                                .and_then(|structs| structs.get(&(span.file_id, *type_name)))
-                                .copied()
-                                .or_else(|| self.builtin_structs.get(type_name).copied())
+                            self.struct_type_by_file((span.file_id, *type_name))
+                                .or_else(|| self.builtin_struct_type(*type_name))
                         })
                 };
 
@@ -2386,16 +2580,9 @@ impl<'a> ConstraintGenerator<'a> {
                         let member_const = match &base_info.ty {
                             InferType::Concrete(ty) if ty.is_module() => ty
                                 .as_module()
-                                .and_then(|module_id| {
-                                    self.module_file_ids
-                                        .and_then(|ids| ids.get(&module_id))
-                                        .copied()
-                                })
+                                .and_then(|module_id| self.module_file_id(module_id))
                                 .and_then(|file_id| {
-                                    self.const_types
-                                        .and_then(|consts| consts.get(&(file_id, *field)))
-                                        .copied()
-                                        .map(|ty| (file_id, ty))
+                                    self.const_type((file_id, *field)).map(|ty| (file_id, ty))
                                 }),
                             _ => None,
                         };
@@ -2421,16 +2608,8 @@ impl<'a> ConstraintGenerator<'a> {
                         let member_module_ty = match &base_info.ty {
                             InferType::Concrete(ty) if ty.is_module() => ty
                                 .as_module()
-                                .and_then(|module_id| {
-                                    self.module_file_ids
-                                        .and_then(|ids| ids.get(&module_id))
-                                        .copied()
-                                })
-                                .and_then(|file_id| {
-                                    self.module_binding_types
-                                        .and_then(|m| m.get(&(file_id, *field)))
-                                        .copied()
-                                }),
+                                .and_then(|module_id| self.module_file_id(module_id))
+                                .and_then(|file_id| self.module_binding_type((file_id, *field))),
                             _ => None,
                         };
                         match member_const_ty.or(member_module_ty) {
@@ -2511,9 +2690,8 @@ impl<'a> ConstraintGenerator<'a> {
                 let resolved = match count {
                     RepeatCount::Literal(n) => Some(*n),
                     RepeatCount::Named(sym) => self
-                        .const_values
-                        .and_then(|cv| cv.get(&(span.file_id, *sym)))
-                        .and_then(|v| u64::try_from(*v).ok()),
+                        .const_value((span.file_id, *sym))
+                        .and_then(|v| u64::try_from(v).ok()),
                 };
                 match resolved {
                     Some(length) => InferType::Array {
@@ -2706,21 +2884,12 @@ impl<'a> ConstraintGenerator<'a> {
                     // `m.go() + 1` to the member declaration (RUE-142).
                     InferType::Concrete(ty) if ty.is_module() => {
                         let module_id = ty.as_module().expect("module type has a module id");
-                        let module_file = self
-                            .module_file_ids
-                            .and_then(|ids| ids.get(&module_id))
-                            .copied();
-                        let alias_target = module_file.and_then(|file_id| {
-                            self.const_function_aliases
-                                .and_then(|aliases| aliases.get(&(file_id, *method)))
-                                .copied()
-                        });
+                        let module_file = self.module_file_id(module_id);
+                        let alias_target = module_file
+                            .and_then(|file_id| self.const_function_alias((file_id, *method)));
                         let function_key = alias_target.or_else(|| {
-                            module_file.and_then(|file_id| {
-                                self.functions_by_file_name
-                                    .and_then(|m| m.get(&(file_id, *method)))
-                                    .copied()
-                            })
+                            module_file
+                                .and_then(|file_id| self.function_by_file((file_id, *method)))
                         });
                         if let (Some(file), Some(_)) = (module_file, alias_target) {
                             self.body_dependencies
@@ -2731,7 +2900,7 @@ impl<'a> ConstraintGenerator<'a> {
                                     qualified: true,
                                 });
                         }
-                        if let Some(func) = function_key.and_then(|key| self.functions.get(&key)) {
+                        if let Some(func) = function_key.and_then(|key| self.func_sig(key)) {
                             #[cfg(test)]
                             if !func.is_generic
                                 && call_contract_matches(&call_args, &func.param_modes)
@@ -2809,7 +2978,7 @@ impl<'a> ConstraintGenerator<'a> {
                                     self.body_dependencies.extend(generic_body_dependency(
                                         function_key
                                             .expect("resolved module signature has a function key"),
-                                        func,
+                                        &func,
                                         &type_subst,
                                         &value_subst,
                                         &arg_infos,
@@ -3357,16 +3526,11 @@ impl<'a> ConstraintGenerator<'a> {
                 // unconstrained — an integer-literal expression argument then
                 // defaulted to i32 and was zero-extended into the declared
                 // 64-bit slot (miscompile, RUE-633).
-                self.const_type_aliases
-                    .and_then(|aliases| aliases.get(&(file_id, *type_name)).copied())
+                self.const_type_alias((file_id, *type_name))
                     .filter(|ty| ty.as_struct().is_some())
             })
-            .or_else(|| {
-                self.structs_by_file_name
-                    .and_then(|structs| structs.get(&(file_id, *type_name)))
-                    .copied()
-            })
-            .or_else(|| self.builtin_structs.get(type_name).copied())
+            .or_else(|| self.struct_type_by_file((file_id, *type_name)))
+            .or_else(|| self.builtin_struct_type(*type_name))
     }
 
     fn enum_type_for(&self, type_name: &Spur, file_id: FileId) -> Option<Type> {
@@ -3383,33 +3547,23 @@ impl<'a> ConstraintGenerator<'a> {
                 // File-level const enum aliases, for the same reason as
                 // `struct_type_for` (RUE-633): a construction rooted at the
                 // alias must constrain its payload arguments.
-                self.const_type_aliases
-                    .and_then(|aliases| aliases.get(&(file_id, *type_name)).copied())
+                self.const_type_alias((file_id, *type_name))
                     .filter(|ty| ty.is_enum())
             })
-            .or_else(|| {
-                self.enums_by_file_name
-                    .and_then(|enums| enums.get(&(file_id, *type_name)))
-                    .copied()
-            })
-            .or_else(|| self.builtin_enums.get(type_name).copied())
+            .or_else(|| self.enum_type_by_file((file_id, *type_name)))
+            .or_else(|| self.builtin_enum_type(*type_name))
     }
 
     fn enum_type_for_module(&self, module: InstRef, type_name: &Spur) -> Option<Type> {
         let file_id = self.module_member_file(module)?;
-        self.enums_by_file_name
-            .and_then(|enums| enums.get(&(file_id, *type_name)))
-            .copied()
-            .or_else(|| {
-                // A type-valued const member (`pub const Opt = Option(i64)`)
-                // is as good as a declaration here (RUE-630/RUE-633): without
-                // it the qualified alias head left the whole chain
-                // unconstrained.
-                self.const_type_aliases
-                    .and_then(|aliases| aliases.get(&(file_id, *type_name)))
-                    .copied()
-                    .filter(|ty| ty.is_enum())
-            })
+        self.enum_type_by_file((file_id, *type_name)).or_else(|| {
+            // A type-valued const member (`pub const Opt = Option(i64)`)
+            // is as good as a declaration here (RUE-630/RUE-633): without
+            // it the qualified alias head left the whole chain
+            // unconstrained.
+            self.const_type_alias((file_id, *type_name))
+                .filter(|ty| ty.is_enum())
+        })
     }
 
     /// Struct analogue of [`Self::enum_type_for_module`], for
@@ -3420,17 +3574,12 @@ impl<'a> ConstraintGenerator<'a> {
     /// value at run time (the RUE-633 miscompile family).
     fn struct_type_for_module(&self, module: InstRef, type_name: &Spur) -> Option<Type> {
         let file_id = self.module_member_file(module)?;
-        self.structs_by_file_name
-            .and_then(|structs| structs.get(&(file_id, *type_name)))
-            .copied()
-            .or_else(|| {
-                // Type-valued const members participate like declarations —
-                // see `enum_type_for_module` (RUE-630/RUE-633).
-                self.const_type_aliases
-                    .and_then(|aliases| aliases.get(&(file_id, *type_name)))
-                    .copied()
-                    .filter(|ty| ty.as_struct().is_some())
-            })
+        self.struct_type_by_file((file_id, *type_name)).or_else(|| {
+            // Type-valued const members participate like declarations —
+            // see `enum_type_for_module` (RUE-630/RUE-633).
+            self.const_type_alias((file_id, *type_name))
+                .filter(|ty| ty.as_struct().is_some())
+        })
     }
 
     /// The defining file of `module`'s target: a `VarRef` naming an imported
@@ -3444,18 +3593,12 @@ impl<'a> ConstraintGenerator<'a> {
         let inst = self.rir.get(module);
         match &inst.data {
             InstData::VarRef { name, .. } => {
-                let module_ty = self
-                    .module_binding_types
-                    .and_then(|bindings| bindings.get(&(inst.span.file_id, *name)))
-                    .copied()?;
+                let module_ty = self.module_binding_type((inst.span.file_id, *name))?;
                 self.module_file(module_ty)
             }
             InstData::FieldGet { base, field } => {
                 let base_file = self.module_member_file(*base)?;
-                let module_ty = self
-                    .module_binding_types
-                    .and_then(|bindings| bindings.get(&(base_file, *field)))
-                    .copied()?;
+                let module_ty = self.module_binding_type((base_file, *field))?;
                 self.module_file(module_ty)
             }
             _ => None,
@@ -3464,9 +3607,7 @@ impl<'a> ConstraintGenerator<'a> {
 
     fn module_file(&self, module_ty: Type) -> Option<FileId> {
         let module_id = module_ty.as_module()?;
-        self.module_file_ids
-            .and_then(|module_file_ids| module_file_ids.get(&module_id))
-            .copied()
+        self.module_file_id(module_id)
     }
 
     /// Get the inferred type for a pattern.
@@ -3514,10 +3655,10 @@ impl<'a> ConstraintGenerator<'a> {
                     return Some(ty);
                 }
             }
-            if let Some(&ty) = self.builtin_structs.get(sym) {
+            if let Some(ty) = self.builtin_struct_type(*sym) {
                 return Some(ty);
             }
-            if let Some(&ty) = self.builtin_enums.get(sym) {
+            if let Some(ty) = self.builtin_enum_type(*sym) {
                 return Some(ty);
             }
             None
@@ -3607,9 +3748,7 @@ impl<'a> ConstraintGenerator<'a> {
                 .and_then(|m| m.get(name).copied())
                 .or_else(|| {
                     let file_id = self.rir.get(inst).span.file_id;
-                    self.const_values
-                        .and_then(|m| m.get(&(file_id, *name)).copied())
-                        .map(Integer)
+                    self.const_value((file_id, *name)).map(Integer)
                 }),
             InstData::Neg { operand } => match self.eval_comptime_value(*operand)? {
                 Integer(n) => Some(Integer(n.checked_neg()?)),
@@ -3920,22 +4059,16 @@ impl<'a> ConstraintGenerator<'a> {
 
         // Check for struct types (including builtin String)
         if let Some(name_spur) = self.interner.get(name) {
-            if let Some(ty) = self
-                .structs_by_file_name
-                .and_then(|types| types.get(&(file_id, name_spur)).copied())
-            {
+            if let Some(ty) = self.struct_type_by_file((file_id, name_spur)) {
                 return Some(InferType::Concrete(ty));
             }
-            if let Some(ty) = self
-                .enums_by_file_name
-                .and_then(|types| types.get(&(file_id, name_spur)).copied())
-            {
+            if let Some(ty) = self.enum_type_by_file((file_id, name_spur)) {
                 return Some(InferType::Concrete(ty));
             }
-            if let Some(&struct_ty) = self.builtin_structs.get(&name_spur) {
+            if let Some(struct_ty) = self.builtin_struct_type(name_spur) {
                 return Some(InferType::Concrete(struct_ty));
             }
-            if let Some(&enum_ty) = self.builtin_enums.get(&name_spur) {
+            if let Some(enum_ty) = self.builtin_enum_type(name_spur) {
                 return Some(InferType::Concrete(enum_ty));
             }
             if let Some(alias_ty) = self.scoped_const_type_alias(name_spur, file_id) {

--- a/crates/rue-air/src/inference/mod.rs
+++ b/crates/rue-air/src/inference/mod.rs
@@ -54,6 +54,6 @@ pub use generate::{
     ConstraintContext, ConstraintGenerator, ExprInfo, FunctionSig, LocalVarInfo, MethodSig,
     ParamVarInfo,
 };
-pub(crate) use generate::{InferenceBodyDependency, InferenceCallRoute};
+pub(crate) use generate::{InferenceBodyDependency, InferenceCallRoute, LazyInferenceFacts};
 pub use types::{InferType, TypeVarAllocator, TypeVarId};
 pub use unify::{UnificationError, Unifier, UnifyResult};

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -4,6 +4,7 @@
 //! analysis and records resolved expression types.
 
 use super::*;
+use crate::inference::LazyInferenceFacts;
 
 impl<'a> BodySema<'a> {
     fn inference_function_is_selected(
@@ -299,152 +300,25 @@ impl<'a> BodySema<'a> {
         let inline_ctor_head_types =
             self.precompute_inline_ctor_head_types(type_subst, value_subst, &comptime_local_types);
 
-        // Anonymous-struct methods are registered lazily (during comptime
-        // evaluation, including the pre-pass above), after the shared
-        // `InferenceContext` was built — so collect the signatures it doesn't
-        // know about. Without these, a method call on an anonymous-struct
-        // receiver inferred to `<error>` and poisoned sibling constraints
-        // (RUE-164).
-        let extra_method_sigs: HashMap<(StructId, Spur), crate::inference::MethodSig> = self
-            .anonymous_methods
-            .iter()
-            .filter(|(key, _)| !infer_ctx.method_sigs.contains_key(*key))
-            .map(|(key, info)| {
-                (
-                    *key,
-                    crate::inference::MethodSig {
-                        struct_type: info.struct_type,
-                        has_self: info.has_self,
-                        param_types: self
-                            .param_arena
-                            .types(info.params)
-                            .iter()
-                            .map(|t| self.type_to_infer_type(*t))
-                            .collect(),
-                        param_modes: self.param_arena.modes(info.params).to_vec(),
-                        return_type: self.type_to_infer_type(info.return_type),
-                    },
-                )
-            })
-            .collect();
-
-        // Create constraint generator using pre-computed inference context
-        let mut cgen = ConstraintGenerator::with_type_subst(
-            self.rir,
-            self.interner,
-            &infer_ctx.func_sigs,
-            &infer_ctx.builtin_struct_types,
-            &infer_ctx.builtin_enum_types,
-            &infer_ctx.method_sigs,
-            &self.type_pool,
-            type_subst,
-        );
-        cgen = cgen.with_strbuf_type(self.strbuf_type());
-        let str_name = self
-            .interner
-            .get("str")
-            .expect("stable string default was registered before inference");
-        let str_ty = infer_ctx
-            .builtin_struct_types
-            .get(&str_name)
-            .copied()
-            .expect("canonical str type is present in the inference context");
-        cgen = cgen.with_string_literal_default(str_ty);
-        let mut cgen = cgen
-            .with_const_types(&infer_ctx.const_types)
-            .with_const_type_aliases(&infer_ctx.const_type_aliases)
-            .with_const_values(&infer_ctx.const_values)
-            .with_const_function_aliases(&infer_ctx.const_function_aliases)
-            .with_structs_by_file_name(&infer_ctx.struct_types_by_file_name)
-            .with_enums_by_file_name(&infer_ctx.enum_types_by_file_name)
-            .with_module_binding_types(&infer_ctx.module_binding_types)
-            .with_module_file_ids(&infer_ctx.module_file_ids)
-            .with_functions_by_file_name(&infer_ctx.functions_by_file_name)
-            .with_comptime_local_bindings(&comptime_local_bindings)
-            .with_inline_ctor_head_types(&inline_ctor_head_types)
-            .with_comptime_values(value_subst)
-            .with_extra_method_sigs(&extra_method_sigs);
-
-        // Build parameter map for constraint context.
-        // Convert Type to InferType so arrays are represented structurally.
-        let mut param_vars: HashMap<Spur, ParamVarInfo> = params
-            .iter()
-            .map(|(name, ty, mode, _is_comptime)| {
-                (
-                    *name,
-                    ParamVarInfo {
-                        ty: self.type_to_infer_type(*ty),
-                        is_inout: *mode == RirParamMode::Inout,
-                    },
-                )
-            })
-            .collect();
-
-        // Add comptime value variables as if they were parameters
-        // This allows constraint generation to see captured comptime values
-        // (anonymous-struct methods capturing `comptime N` from the enclosing
-        // function). Real parameters keep their declared type: in a
-        // value-specialized body (RUE-166) the comptime value parameter is
-        // also a runtime parameter with a precise type (e.g. `comptime n:
-        // i64`), inserted into `param_vars` above, which the gap-filling
-        // `or_insert` here must not clobber.
+        // Demand-population provider for the inference-context families
+        // (RUE-1091 slice r5b). It materializes each consulted function/method
+        // signature and struct/enum/const on first lookup from the frozen
+        // declaration state, reading the live method tables — so a method call
+        // on an anonymous-struct receiver whose signature was registered lazily
+        // (during comptime evaluation, including the pre-pass above) resolves to
+        // its declared type on first consult, subsuming the old per-body
+        // `extra_method_sigs` reconciliation (RUE-164) with no behavior change.
         //
-        // A *captured* integer value carries only its magnitude — its declared
-        // width is not threaded through the capture — so it is typed as a
-        // fresh integer-literal variable and takes its width from use (a
-        // `comptime N: u8` read where u8 is expected unifies to u8), exactly
-        // like the literal it stands in for. Emission then reads that resolved
-        // width back out of `resolved_types` instead of hard-coding i32
-        // (RUE-216).
-        if let Some(values) = value_subst {
-            for (name, const_val) in values {
-                let ty = match const_val {
-                    ConstValue::Integer(_) => {
-                        param_vars.entry(*name).or_insert(ParamVarInfo {
-                            ty: InferType::Var(cgen.fresh_int_literal_var()),
-                            is_inout: false,
-                        });
-                        continue;
-                    }
-                    ConstValue::Bool(_) => Type::BOOL,
-                    ConstValue::Type(t) => *t,
-                    ConstValue::Function(_) => Type::COMPTIME_TYPE,
-                    // No comptime parameter has a string type, so a captured
-                    // string value never occurs (RUE-957); skip rather than
-                    // fabricate a type for it.
-                    ConstValue::String(_) => continue,
-                    ConstValue::Unit => Type::UNIT,
-                };
-                param_vars.entry(*name).or_insert(ParamVarInfo {
-                    ty: self.type_to_infer_type(ty),
-                    is_inout: false,
-                });
-            }
-        }
-
-        // Create constraint context
-        let mut cgen_ctx = ConstraintContext::new(&param_vars, return_type);
-
-        // Phase 1: Generate constraints
-        let body_info = cgen.generate(body, &mut cgen_ctx);
-
-        let inference_body_dependencies = cgen.body_dependencies().to_vec();
-
-        // The function body's type must match the return type.
-        // This handles implicit returns like `fn foo() -> i8 { 42 }`.
-        // For arrays, we need to convert Type to InferType structurally.
-        //
-        // String literals use marked inference variables whose allowed nominal
-        // targets include `str` and `Str(N)`, so this constraint retains the
-        // implicit literal coercion while rejecting every other mismatched
-        // tail before AIR/CFG construction (RUE-1652).
-        cgen.add_constraint(Constraint::equal(
-            body_info.ty,
-            self.type_to_infer_type(return_type),
-            body_info.span,
-        ));
-
-        // Consume the constraint generator to release borrows
+        // The provider holds an immutable borrow of `self`; it is dropped right
+        // after Phase-1 constraint generation completes, before any `&mut self`
+        // access resumes. This is the detached-context wiring: the shared
+        // `InferenceContext` cache carries no `Sema` borrow (it outlives every
+        // body's `&mut self`), while the fill source is threaded here per body,
+        // sound because constraint generation reads `Sema` only immutably.
+        // Phase 1 runs in its own scope so the provider's immutable borrow of
+        // `self` ends before Phase 2 resumes `&mut self` access (RUE-1091 slice
+        // r5b): the shared `InferenceContext` cache holds no `Sema` borrow, and
+        // the fill source is threaded here per body.
         let (
             constraints,
             int_literal_vars,
@@ -452,7 +326,130 @@ impl<'a> BodySema<'a> {
             string_literal_default,
             expr_types,
             type_var_count,
-        ) = cgen.into_parts();
+            inference_body_dependencies,
+        ) = {
+            let facts = crate::sema::SemaInferenceFacts::new(infer_ctx, self);
+
+            // Create constraint generator driven by the demand-population provider.
+            let mut cgen = ConstraintGenerator::with_lazy_facts(
+                self.rir,
+                self.interner,
+                &self.type_pool,
+                type_subst,
+                &facts,
+            );
+            cgen = cgen.with_strbuf_type(self.strbuf_type());
+            let str_name = self
+                .interner
+                .get("str")
+                .expect("stable string default was registered before inference");
+            let str_ty = facts
+                .builtin_struct_type(str_name)
+                .expect("canonical str type is present in the inference context");
+            cgen = cgen.with_string_literal_default(str_ty);
+            let mut cgen = cgen
+                .with_comptime_local_bindings(&comptime_local_bindings)
+                .with_inline_ctor_head_types(&inline_ctor_head_types)
+                .with_comptime_values(value_subst);
+
+            // Build parameter map for constraint context.
+            // Convert Type to InferType so arrays are represented structurally.
+            let mut param_vars: HashMap<Spur, ParamVarInfo> = params
+                .iter()
+                .map(|(name, ty, mode, _is_comptime)| {
+                    (
+                        *name,
+                        ParamVarInfo {
+                            ty: self.type_to_infer_type(*ty),
+                            is_inout: *mode == RirParamMode::Inout,
+                        },
+                    )
+                })
+                .collect();
+
+            // Add comptime value variables as if they were parameters
+            // This allows constraint generation to see captured comptime values
+            // (anonymous-struct methods capturing `comptime N` from the enclosing
+            // function). Real parameters keep their declared type: in a
+            // value-specialized body (RUE-166) the comptime value parameter is
+            // also a runtime parameter with a precise type (e.g. `comptime n:
+            // i64`), inserted into `param_vars` above, which the gap-filling
+            // `or_insert` here must not clobber.
+            //
+            // A *captured* integer value carries only its magnitude — its declared
+            // width is not threaded through the capture — so it is typed as a
+            // fresh integer-literal variable and takes its width from use (a
+            // `comptime N: u8` read where u8 is expected unifies to u8), exactly
+            // like the literal it stands in for. Emission then reads that resolved
+            // width back out of `resolved_types` instead of hard-coding i32
+            // (RUE-216).
+            if let Some(values) = value_subst {
+                for (name, const_val) in values {
+                    let ty = match const_val {
+                        ConstValue::Integer(_) => {
+                            param_vars.entry(*name).or_insert(ParamVarInfo {
+                                ty: InferType::Var(cgen.fresh_int_literal_var()),
+                                is_inout: false,
+                            });
+                            continue;
+                        }
+                        ConstValue::Bool(_) => Type::BOOL,
+                        ConstValue::Type(t) => *t,
+                        ConstValue::Function(_) => Type::COMPTIME_TYPE,
+                        // No comptime parameter has a string type, so a captured
+                        // string value never occurs (RUE-957); skip rather than
+                        // fabricate a type for it.
+                        ConstValue::String(_) => continue,
+                        ConstValue::Unit => Type::UNIT,
+                    };
+                    param_vars.entry(*name).or_insert(ParamVarInfo {
+                        ty: self.type_to_infer_type(ty),
+                        is_inout: false,
+                    });
+                }
+            }
+
+            // Create constraint context
+            let mut cgen_ctx = ConstraintContext::new(&param_vars, return_type);
+
+            // Phase 1: Generate constraints
+            let body_info = cgen.generate(body, &mut cgen_ctx);
+
+            let inference_body_dependencies = cgen.body_dependencies().to_vec();
+
+            // The function body's type must match the return type.
+            // This handles implicit returns like `fn foo() -> i8 { 42 }`.
+            // For arrays, we need to convert Type to InferType structurally.
+            //
+            // String literals use marked inference variables whose allowed nominal
+            // targets include `str` and `Str(N)`, so this constraint retains the
+            // implicit literal coercion while rejecting every other mismatched
+            // tail before AIR/CFG construction (RUE-1652).
+            cgen.add_constraint(Constraint::equal(
+                body_info.ty,
+                self.type_to_infer_type(return_type),
+                body_info.span,
+            ));
+
+            // Consume the constraint generator to release borrows
+            let (
+                constraints,
+                int_literal_vars,
+                string_literal_vars,
+                string_literal_default,
+                expr_types,
+                type_var_count,
+            ) = cgen.into_parts();
+            (
+                constraints,
+                int_literal_vars,
+                string_literal_vars,
+                string_literal_default,
+                expr_types,
+                type_var_count,
+                inference_body_dependencies,
+            )
+        };
 
         // Phase 2: Solve constraints via unification
         // Pre-size the substitution for better performance on large functions

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -20,7 +20,6 @@ use rue_span::{FileId, Span};
 
 use super::{ConstInfo, ConstValue, DeclarationPhase, InferenceContext, Sema};
 use super::{FunctionInfo, MethodInfo};
-use crate::inference::{FunctionSig, MethodSig};
 use crate::path_norm::{mangle_symbol_component, normalize_module_path};
 use crate::types::StructField;
 use crate::types::{EnumDef, EnumId, StructDef, StructId, Type, TypeKind};
@@ -110,193 +109,21 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         })
     }
 
-    /// Build an `InferenceContext` from the collected type information.
+    /// Build the demand-population [`InferenceContext`] for constraint
+    /// generation (RUE-1091 slice r5b).
     ///
-    /// This should be called after the collection phase and builds the
-    /// pre-computed maps needed for Hindley-Milner type inference.
-    /// Building this once and reusing for all function analyses avoids
-    /// the O(n²) cost of rebuilding these maps per function.
-    ///
-    /// # Performance
-    ///
-    /// This converts all function/method signatures to use `InferType`
-    /// (which handles arrays structurally rather than by ID). This conversion
-    /// is done once instead of per-function.
+    /// Formerly this eagerly converted every function/method signature and
+    /// projected every struct/enum/const family into owned `HashMap`s — an
+    /// O(universe) pass paid before any body was analyzed (and, on the
+    /// per-body-query hot path, paid afresh for every reached body). It now
+    /// returns a context whose signature caches start empty and materialize on
+    /// first consult through [`SemaInferenceFacts`], so only the signatures and
+    /// types a body actually names are converted. The only eager work retained
+    /// is a small snapshot of the generated-nominal overlays, which must be
+    /// frozen at this point so a nominal generated while analyzing a later body
+    /// cannot retroactively perturb an earlier body's type resolution.
     pub fn build_inference_context(&self) -> InferenceContext {
-        // Build function signatures with InferType for constraint generation
-        let func_sigs: HashMap<Spur, FunctionSig> = self
-            .functions
-            .iter()
-            .map(|(name, info)| {
-                (
-                    *name,
-                    FunctionSig {
-                        param_types: self
-                            .param_arena
-                            .types(info.params)
-                            .iter()
-                            .map(|t| self.type_to_infer_type(*t))
-                            .collect(),
-                        return_type: self.type_to_infer_type(info.return_type),
-                        is_generic: info.is_generic,
-                        param_modes: self.param_arena.modes(info.params).to_vec(),
-                        param_comptime: self.param_arena.comptime(info.params).to_vec(),
-                        param_comptime_type: self.comptime_type_param_flags(info),
-                        param_names: self.param_arena.names(info.params).to_vec(),
-                        param_type_syms: self
-                            .rir
-                            .params(info.rir_params(self.rir))
-                            .iter()
-                            .map(|p| p.ty)
-                            .collect(),
-                        return_type_sym: info.return_type_sym,
-                    },
-                )
-            })
-            .collect();
-
-        // Builtins have no defining source module. Every source declaration
-        // appears only in the by-file map below.
-        let mut builtin_struct_types: HashMap<Spur, Type> = self
-            .builtin_structs
-            .iter()
-            .map(|(name, id)| (*name, Type::new_struct(*id)))
-            .collect();
-        for (name, id) in &self.generated_structs {
-            if self.type_pool.struct_def(*id).is_builtin {
-                builtin_struct_types.insert(*name, Type::new_struct(*id));
-            }
-        }
-        let mut struct_types_by_file_name: HashMap<(FileId, Spur), Type> = self
-            .structs_by_file_name
-            .iter()
-            .map(|(key, id)| (*key, Type::new_struct(*id)))
-            .collect();
-        for (name, id) in &self.generated_structs {
-            let file_id = self.type_pool.struct_def(*id).file_id;
-            struct_types_by_file_name
-                .entry((file_id, *name))
-                .or_insert(Type::new_struct(*id));
-        }
-
-        let builtin_enum_types: HashMap<Spur, Type> = self
-            .builtin_enums
-            .iter()
-            .map(|(name, id)| (*name, Type::new_enum(*id)))
-            .collect();
-
-        let mut enum_types_by_file_name: HashMap<(FileId, Spur), Type> = self
-            .enums_by_file_name
-            .iter()
-            .map(|(key, id)| (*key, Type::new_enum(*id)))
-            .collect();
-        for (name, id) in &self.generated_enums {
-            let file_id = self.type_pool.enum_def(*id).file_id;
-            enum_types_by_file_name
-                .entry((file_id, *name))
-                .or_insert(Type::new_enum(*id));
-        }
-
-        // Build method signatures with InferType for constraint generation
-        let method_sigs: HashMap<(StructId, Spur), MethodSig> = self
-            .methods
-            .iter()
-            .chain(self.anonymous_methods.iter())
-            .map(|((struct_id, method_name), info)| {
-                (
-                    (*struct_id, *method_name),
-                    MethodSig {
-                        struct_type: info.struct_type,
-                        has_self: info.has_self,
-                        param_types: self
-                            .param_arena
-                            .types(info.params)
-                            .iter()
-                            .map(|t| self.type_to_infer_type(*t))
-                            .collect(),
-                        param_modes: self.param_arena.modes(info.params).to_vec(),
-                        return_type: self.type_to_infer_type(info.return_type),
-                    },
-                )
-            })
-            .collect();
-
-        // Constant types (resolved during declaration gathering) so a const
-        // reference in a function body infers to its declared type instead of
-        // `<error>` (RUE-142).
-        // All four const maps are keyed by (declaring file, name), built from
-        // the by-file table: same-named constants in sibling modules are
-        // distinct declarations, so every inference lookup carries the
-        // reference file or receiver-module identity (RUE-638).
-        let const_types: HashMap<(FileId, Spur), Type> = self
-            .value_consts()
-            .map(|(key, info)| {
-                let ty = match info.value {
-                    ConstValue::Type(_) => Type::COMPTIME_TYPE,
-                    _ => info.ty,
-                };
-                (*key, ty)
-            })
-            .collect();
-
-        // File-level type aliases (`const T = SomeType(...)`) map the alias
-        // name to the concrete type value it denotes. Constraint generation
-        // consults this in type positions; expression positions still use
-        // `const_types` above and see the binding itself as `type`.
-        let const_type_aliases: HashMap<(FileId, Spur), Type> = self
-            .value_consts()
-            .filter_map(|(key, info)| match info.value {
-                ConstValue::Type(ty) => Some((*key, ty)),
-                _ => None,
-            })
-            .collect();
-
-        // Integer constant values, so an array length naming a `const`
-        // (`[i32; K]`) resolves to a concrete length during inference (RUE-16).
-        let const_values: HashMap<(FileId, Spur), i128> = self
-            .value_consts()
-            .filter_map(|(key, info)| info.value.as_int_value().map(|v| (*key, v)))
-            .collect();
-
-        // Function-valued constants are callable aliases only. Constraint
-        // generation uses this map to type `alias(...)` like the real callee.
-        let const_function_aliases: HashMap<(FileId, Spur), Spur> = self
-            .value_consts()
-            .filter_map(|(key, info)| info.value.as_function().map(|callee| (*key, callee)))
-            .collect();
-
-        // Module-binding types (`const utils = @import(...)`), keyed by the
-        // declaring file: bindings are per-file scoped (RUE-113), so a
-        // reference resolves against the file it appears in.
-        let module_binding_types: HashMap<(FileId, Spur), Type> = self
-            .module_binding_consts()
-            .map(|(key, info)| (*key, info.ty))
-            .collect();
-
-        let module_file_ids: HashMap<crate::types::ModuleId, FileId> =
-            (0..self.module_registry.len())
-                .map(|index| {
-                    let module_id = crate::types::ModuleId::new(index as u32);
-                    let module_def = self.module_registry.get_def(module_id);
-                    (module_id, module_def.file_id)
-                })
-                .collect();
-
-        InferenceContext {
-            func_sigs,
-            builtin_struct_types,
-            struct_types_by_file_name,
-            builtin_enum_types,
-            enum_types_by_file_name,
-            method_sigs,
-            const_types,
-            const_type_aliases,
-            const_values,
-            const_function_aliases,
-            module_binding_types,
-            module_file_ids,
-            functions_by_file_name: self.functions_by_file_name.clone(),
-        }
+        InferenceContext::new(self)
     }
     /// Check if a directive list contains the @copy directive
     pub(crate) fn has_copy_directive<'r>(

--- a/crates/rue-air/src/sema/inference_ctx.rs
+++ b/crates/rue-air/src/sema/inference_ctx.rs
@@ -1,76 +1,284 @@
-//! Pre-computed type information for constraint generation.
+//! Demand-populated type information for constraint generation.
 //!
-//! This module contains [`InferenceContext`] which holds function, struct, enum,
-//! and method signature maps in `InferType` format for use in Hindley-Milner
-//! type inference.
+//! This module contains [`InferenceContext`], the per-analysis cache that backs
+//! Hindley-Milner constraint generation, and [`SemaInferenceFacts`], the
+//! [`LazyInferenceFacts`] provider that materializes each consulted
+//! function/struct/enum/method/const family on first lookup instead of eagerly
+//! projecting the whole declaration universe (RUE-1091 slice r5b).
 
+use std::cell::RefCell;
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use lasso::Spur;
 use rue_span::FileId;
 
-use crate::inference::{FunctionSig, MethodSig};
-use crate::types::{StructId, Type};
+use super::{ConstValue, DeclarationPhase, Sema};
+use crate::inference::{FunctionSig, LazyInferenceFacts, MethodSig};
+use crate::types::{ModuleId, StructId, Type};
 
-/// Pre-computed type information for constraint generation.
+/// Demand-population cache for constraint generation (RUE-1091 slice r5b).
 ///
-/// This struct holds the function, struct, enum, and method signature maps
-/// converted to `InferType` format for use in Hindley-Milner type inference.
-/// Building this once and reusing it for all function analyses avoids the
-/// O(n²) cost of rebuilding these maps for each function.
+/// Constraint generation consults the thirteen declaration-universe families
+/// purely by key. Rather than convert every function/method signature and
+/// project every struct/enum/const into owned `HashMap`s before a single body
+/// is analyzed — the O(universe)-per-body term RUE-1083 removes — this context
+/// holds only:
 ///
-/// # Performance
+/// - **positive-only caches** for the two non-`Copy` signature families
+///   (`func_sigs`, `method_sigs`), materialized on first consult through
+///   [`SemaInferenceFacts`]; and
+/// - **small frozen snapshots** of the generated (synthetic) nominal overlays
+///   that the eager projection merged at build time, so a slice/`Str(N)` struct
+///   generated while analyzing a *later* body cannot retroactively change an
+///   earlier body's builtin/by-file type resolution.
 ///
-/// For a program with 100 functions and 50 structs:
-/// - **Before**: 100 × (HashMap rebuild + InferType conversions) per analysis
-/// - **After**: 1 × (HashMap build + InferType conversions) total
-#[derive(Debug)]
+/// Every other family is answered by a direct keyed lookup against the frozen
+/// declaration state, which is already O(consumed).
+///
+/// The cache carries no borrow of `Sema`: it is built once and shared across
+/// every reached body's `&mut self` analysis, so it cannot hold `&Sema`. The
+/// fill source (immutable `Sema` sub-borrows) is threaded separately per body
+/// via [`SemaInferenceFacts`], which is sound because Phase-1 constraint
+/// generation only reads `Sema` immutably.
+///
+/// # Cross-body caching soundness
+///
+/// The two signature caches are shared across bodies (in the whole-program
+/// path) so each consulted signature is converted at most once. Named functions
+/// and methods are frozen after declaration gathering, so a cached value never
+/// diverges. Anonymous-struct methods are registered lazily during body
+/// analysis, but their `(StructId, name)` entries are immutable once present and
+/// negatives are never cached, so a late-registered method is materialized on
+/// its first consult — subsuming the old per-body `extra_method_sigs`
+/// reconciliation (RUE-164) with no behavior change.
+#[derive(Debug, Default)]
 pub struct InferenceContext {
-    /// Function signatures with InferType (for constraint generation).
-    pub func_sigs: HashMap<Spur, FunctionSig>,
-    /// Built-in struct types, which are not owned by a source module.
-    pub builtin_struct_types: HashMap<Spur, Type>,
-    /// Module-local struct types: (defining file, source name) -> Type::new_struct(id).
-    pub struct_types_by_file_name: HashMap<(FileId, Spur), Type>,
-    /// Built-in enum types, which are not owned by a source module.
-    pub builtin_enum_types: HashMap<Spur, Type>,
-    /// Module-local enum types: (defining file, source name) -> Type::new_enum(id).
-    pub enum_types_by_file_name: HashMap<(FileId, Spur), Type>,
-    /// Method signatures with InferType: (struct_id, method_name) -> MethodSig.
-    pub method_sigs: HashMap<(StructId, Spur), MethodSig>,
-    /// File-level constant types: name -> declared type (e.g. `Type::I32` for
-    /// `const N: i32 = 41`, a module type for `const m = @import(...)`). Constant
-    /// types are fully resolved during declaration gathering, before any
-    /// function body is inferred, so they can be consulted like params here.
-    /// Keyed by (declaring file, name) so references receive their declared
-    /// type (RUE-142) and same-named constants in sibling modules remain
-    /// distinct declarations (RUE-638).
-    pub const_types: HashMap<(FileId, Spur), Type>,
-    /// File-level type aliases: name -> concrete type denoted by a
-    /// type-valued constant (`const OptI = std.option.Option(i64)`). These are
-    /// consulted in type positions; expression positions see the binding's
-    /// own type as `type` through `const_types`. Keyed by (declaring file,
-    /// name) — see `const_types` (RUE-638).
-    pub const_type_aliases: HashMap<(FileId, Spur), Type>,
-    /// File-level integer constant values (name -> value). Constants are fully
-    /// evaluated during declaration gathering, so an array length naming one
-    /// (`[i32; K]`) can be resolved to a concrete length during constraint
-    /// generation (RUE-16). Only integer-valued constants appear here.
-    /// Keyed by (declaring file, name) — see `const_types` (RUE-638).
-    pub const_values: HashMap<(FileId, Spur), i128>,
-    /// Function-valued constants: (declaring file, alias name) -> callee
-    /// function name. These are callable aliases only, not first-class
-    /// runtime values. By-file keyed — see `const_types` (RUE-638).
-    pub const_function_aliases: HashMap<(FileId, Spur), Spur>,
-    /// Module-binding types (`const utils = @import(...)`): (declaring file,
-    /// name) -> module type. Module bindings are per-file scoped (RUE-113),
-    /// so they're keyed by file rather than living in `const_types`.
-    pub module_binding_types: HashMap<(FileId, Spur), Type>,
-    /// Module registry file identity for inference-time member type lookup.
-    pub module_file_ids: HashMap<crate::types::ModuleId, FileId>,
-    /// Source-level function lookup: (defining file, source name) -> internal
-    /// function key. Same-named functions across files get module-qualified
-    /// internal keys, so a module-member call must resolve through this map
-    /// before consulting `func_sigs` — the bare source name misses (RUE-576).
-    pub functions_by_file_name: HashMap<(FileId, Spur), Spur>,
+    func_sigs: RefCell<HashMap<Spur, Rc<FunctionSig>>>,
+    method_sigs: RefCell<HashMap<(StructId, Spur), Rc<MethodSig>>>,
+    /// Generated builtin struct nominals present when the context was built,
+    /// keyed by source name. In the eager projection these *overwrote* the base
+    /// builtin table, so they win over `builtin_structs` at lookup.
+    gen_builtin_struct_types: HashMap<Spur, Type>,
+    /// Generated struct nominals keyed by (defining file, source name). In the
+    /// eager projection the base `structs_by_file_name` was inserted first and
+    /// these only filled gaps (`or_insert`), so the base wins at lookup.
+    gen_struct_types_by_file: HashMap<(FileId, Spur), Type>,
+    /// Generated enum nominals keyed by (defining file, source name). Base wins,
+    /// as for `gen_struct_types_by_file`.
+    gen_enum_types_by_file: HashMap<(FileId, Spur), Type>,
+}
+
+impl InferenceContext {
+    /// Construct the context, snapshotting the generated-nominal overlays that
+    /// the eager projection merged. The signature caches start empty and fill on
+    /// demand.
+    pub(crate) fn new<D: DeclarationPhase>(sema: &Sema<'_, D>) -> Self {
+        let mut gen_builtin_struct_types = HashMap::new();
+        let mut gen_struct_types_by_file = HashMap::new();
+        for (name, id) in &sema.generated_structs {
+            let def = sema.type_pool.struct_def(*id);
+            if def.is_builtin {
+                gen_builtin_struct_types.insert(*name, Type::new_struct(*id));
+            }
+            gen_struct_types_by_file
+                .entry((def.file_id, *name))
+                .or_insert_with(|| Type::new_struct(*id));
+        }
+        let mut gen_enum_types_by_file = HashMap::new();
+        for (name, id) in &sema.generated_enums {
+            let def = sema.type_pool.enum_def(*id);
+            gen_enum_types_by_file
+                .entry((def.file_id, *name))
+                .or_insert_with(|| Type::new_enum(*id));
+        }
+        Self {
+            func_sigs: RefCell::new(HashMap::new()),
+            method_sigs: RefCell::new(HashMap::new()),
+            gen_builtin_struct_types,
+            gen_struct_types_by_file,
+            gen_enum_types_by_file,
+        }
+    }
+}
+
+/// The demand-population provider that materializes inference-context families
+/// from a body's frozen `Sema` state (RUE-1091 slice r5b).
+///
+/// Constructed fresh per `run_type_inference` call, holding the shared
+/// [`InferenceContext`] cache plus an immutable borrow of the analyzing `Sema`.
+/// The generator consults it through [`LazyInferenceFacts`]; every answer equals
+/// the value the eager projection would have held for that key.
+pub(crate) struct SemaInferenceFacts<'a, 'src, D: DeclarationPhase> {
+    ctx: &'a InferenceContext,
+    sema: &'a Sema<'src, D>,
+}
+
+impl<'a, 'src, D: DeclarationPhase> SemaInferenceFacts<'a, 'src, D> {
+    pub(crate) fn new(ctx: &'a InferenceContext, sema: &'a Sema<'src, D>) -> Self {
+        Self { ctx, sema }
+    }
+
+    fn build_func_sig(&self, name: Spur) -> Option<FunctionSig> {
+        let info = self.sema.functions.get(&name)?;
+        Some(FunctionSig {
+            param_types: self
+                .sema
+                .param_arena
+                .types(info.params)
+                .iter()
+                .map(|t| self.sema.type_to_infer_type(*t))
+                .collect(),
+            return_type: self.sema.type_to_infer_type(info.return_type),
+            is_generic: info.is_generic,
+            param_modes: self.sema.param_arena.modes(info.params).to_vec(),
+            param_comptime: self.sema.param_arena.comptime(info.params).to_vec(),
+            param_comptime_type: self.sema.comptime_type_param_flags(info),
+            param_names: self.sema.param_arena.names(info.params).to_vec(),
+            param_type_syms: self
+                .sema
+                .rir
+                .params(info.rir_params(self.sema.rir))
+                .iter()
+                .map(|p| p.ty)
+                .collect(),
+            return_type_sym: info.return_type_sym,
+        })
+    }
+
+    fn build_method_sig(&self, key: (StructId, Spur)) -> Option<MethodSig> {
+        // Anonymous-wins, matching `Sema::method_info` and the retired eager
+        // projection's chain order. The keyspaces are disjoint today, so the
+        // order is unobservable — but every consult site must agree on it.
+        let info = self
+            .sema
+            .anonymous_methods
+            .get(&key)
+            .or_else(|| self.sema.methods.get(&key))?;
+        Some(MethodSig {
+            struct_type: info.struct_type,
+            has_self: info.has_self,
+            param_types: self
+                .sema
+                .param_arena
+                .types(info.params)
+                .iter()
+                .map(|t| self.sema.type_to_infer_type(*t))
+                .collect(),
+            param_modes: self.sema.param_arena.modes(info.params).to_vec(),
+            return_type: self.sema.type_to_infer_type(info.return_type),
+        })
+    }
+}
+
+impl<D: DeclarationPhase> LazyInferenceFacts for SemaInferenceFacts<'_, '_, D> {
+    fn func_sig(&self, name: Spur) -> Option<Rc<FunctionSig>> {
+        if let Some(cached) = self.ctx.func_sigs.borrow().get(&name) {
+            return Some(Rc::clone(cached));
+        }
+        let sig = Rc::new(self.build_func_sig(name)?);
+        self.ctx
+            .func_sigs
+            .borrow_mut()
+            .insert(name, Rc::clone(&sig));
+        Some(sig)
+    }
+
+    fn method_sig(&self, key: (StructId, Spur)) -> Option<Rc<MethodSig>> {
+        if let Some(cached) = self.ctx.method_sigs.borrow().get(&key) {
+            return Some(Rc::clone(cached));
+        }
+        let sig = Rc::new(self.build_method_sig(key)?);
+        self.ctx
+            .method_sigs
+            .borrow_mut()
+            .insert(key, Rc::clone(&sig));
+        Some(sig)
+    }
+
+    fn builtin_struct_type(&self, name: Spur) -> Option<Type> {
+        // Generated builtin overlays overwrote the base table in the eager
+        // projection, so they win here.
+        self.ctx
+            .gen_builtin_struct_types
+            .get(&name)
+            .copied()
+            .or_else(|| {
+                self.sema
+                    .builtin_structs
+                    .get(&name)
+                    .map(|id| Type::new_struct(*id))
+            })
+    }
+
+    fn struct_type_by_file(&self, key: (FileId, Spur)) -> Option<Type> {
+        // Base declarations win; generated overlays only filled gaps.
+        self.sema
+            .structs_by_file_name
+            .get(&key)
+            .map(|id| Type::new_struct(*id))
+            .or_else(|| self.ctx.gen_struct_types_by_file.get(&key).copied())
+    }
+
+    fn builtin_enum_type(&self, name: Spur) -> Option<Type> {
+        // The eager projection built builtin enum types from the base table
+        // only (no generated overlay).
+        self.sema
+            .builtin_enums
+            .get(&name)
+            .map(|id| Type::new_enum(*id))
+    }
+
+    fn enum_type_by_file(&self, key: (FileId, Spur)) -> Option<Type> {
+        self.sema
+            .enums_by_file_name
+            .get(&key)
+            .map(|id| Type::new_enum(*id))
+            .or_else(|| self.ctx.gen_enum_types_by_file.get(&key).copied())
+    }
+
+    fn const_type(&self, key: (FileId, Spur)) -> Option<Type> {
+        self.sema.value_const(&key).map(|info| match info.value {
+            ConstValue::Type(_) => Type::COMPTIME_TYPE,
+            _ => info.ty,
+        })
+    }
+
+    fn const_type_alias(&self, key: (FileId, Spur)) -> Option<Type> {
+        self.sema
+            .value_const(&key)
+            .and_then(|info| match info.value {
+                ConstValue::Type(ty) => Some(ty),
+                _ => None,
+            })
+    }
+
+    fn const_value(&self, key: (FileId, Spur)) -> Option<i128> {
+        self.sema
+            .value_const(&key)
+            .and_then(|info| info.value.as_int_value())
+    }
+
+    fn const_function_alias(&self, key: (FileId, Spur)) -> Option<Spur> {
+        self.sema
+            .value_const(&key)
+            .and_then(|info| info.value.as_function())
+    }
+
+    fn module_binding_type(&self, key: (FileId, Spur)) -> Option<Type> {
+        self.sema.module_binding(&key).map(|info| info.ty)
+    }
+
+    fn module_file_id(&self, module: ModuleId) -> Option<FileId> {
+        // The eager projection keyed every module id in `0..registry.len()`.
+        if (module.index() as usize) < self.sema.module_registry.len() {
+            Some(self.sema.module_registry.get_def(module).file_id)
+        } else {
+            None
+        }
+    }
+
+    fn function_by_file(&self, key: (FileId, Spur)) -> Option<Spur> {
+        self.sema.functions_by_file_name.get(&key).copied()
+    }
 }

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -67,6 +67,7 @@ pub use binding_manifest::{
 pub use context::ConstValue;
 pub use declaration_index::RirDeclarationIndexWork;
 pub use inference_ctx::InferenceContext;
+pub(crate) use inference_ctx::SemaInferenceFacts;
 use info::ConstResolution;
 pub use info::{AnonMethodSig, AnonMethodType, ConstInfo, FunctionInfo, MethodInfo};
 pub use known_symbols::KnownSymbols;
@@ -179,6 +180,10 @@ impl DeclarationNamespace {
             .filter_map(|(key, value)| value.value().map(|info| (key, info)))
     }
 
+    // Only the `#[cfg(test)]` namespace-boundary snapshot enumerates module
+    // bindings wholesale now; per-body inference resolves them by key through
+    // the demand-population provider (RUE-1091 slice r5b).
+    #[cfg_attr(not(test), allow(dead_code))]
     fn module_binding_consts(&self) -> impl Iterator<Item = (&(FileId, Spur), &ConstInfo)> {
         self.const_resolutions
             .iter()

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -2771,10 +2771,10 @@ mod tests {
         // The inference-side signature must carry the identical source-mode
         // vector rather than a type-only shadow of MethodInfo (RUE-634).
         let inference = sema.build_inference_context();
-        let signature = inference
-            .method_sigs
-            .get(&(struct_id, method_name))
-            .unwrap();
+        let facts = crate::sema::SemaInferenceFacts::new(&inference, &sema);
+        let signature =
+            crate::inference::LazyInferenceFacts::method_sig(&facts, (struct_id, method_name))
+                .unwrap();
         assert_eq!(
             signature.param_modes,
             vec![
@@ -2809,11 +2809,13 @@ mod tests {
         sema.generated_structs.insert(name, generated_id);
 
         let inference = sema.build_inference_context();
+        let facts = crate::sema::SemaInferenceFacts::new(&inference, &sema);
         assert_eq!(
-            inference
-                .struct_types_by_file_name
-                .get(&(FileId::new(0), name)),
-            Some(&Type::new_struct(source_id))
+            crate::inference::LazyInferenceFacts::struct_type_by_file(
+                &facts,
+                (FileId::new(0), name)
+            ),
+            Some(Type::new_struct(source_id))
         );
     }
 


### PR DESCRIPTION
Slice r5b of the RUE-1091 analyzer rewire: convert `build_inference_context` from the eager O(universe) projection to demand-populated keyed lookups. This is the O(U)-per-body term the RUE-1083 repair exists to remove, done to the byte-identical bar.

## What changed

- `InferenceContext` is now a pure cache: private `RefCell` signature caches (positive-only, `Rc`-valued) + three frozen generated-nominal snapshots; no Sema borrow, so it survives the whole body loop. `SemaInferenceFacts` (fresh per `run_type_inference`, immutable `&Sema` fill source) answers consults; Phase-1 constraint generation is verified mutation-free, so the borrow shape is sound.
- 11 Copy-valued families answer as direct keyed lookups (recompute-per-consult, O(consumed)); the const families are ordinary keyed lookups post-r0. The 2 signature families materialize on first consult and cache across bodies (negatives never cached — late-registered anonymous methods retry live).
- Generated-nominal snapshots freeze the eager view at the same instant the old projection ran — necessary because `generated_structs`/`generated_enums` grow during body analysis; all four merge-precedence semantics replicated exactly (review-verified line-by-line against the deleted code).
- `extra_method_sigs` eliminated: anonymous methods register in the pre-passes before the provider is built, and Phase 1 can't register (no interior mutability on the tables), so live `anonymous_methods ∪ methods` equals the old union with no divergence window (review-verified). Method-vs-anonymous precedence made consistent with `Sema::method_info` (anonymous-wins) per review.
- `build_inference_context` shrank from ~175 lines of O(universe) iteration to snapshot construction. Production is 100% lazy; the eager path survives only for unit-test constructions and is deleted at the flip.

## R4 audit

Zero whole-map consumers across all 13 families — every access point is a keyed lookup. The one direct-field read missed on the first sweep (`ArrayRepeat{count: Named}`) was caught by the byte-proof itself and routed through the accessor.

## Byte-identity proof

17/17 byte-identical comparisons (AIR + deps + diagnostics stderr) across 6 programs covering generic-dense inference, comptime parameters, const array lengths, module bindings, methods/enums, and a diagnostic case. Families the 6 programs don't reach (`@target_*` builtin enums, function-valued const aliases) are covered by the full suites, which run the production lazy path throughout.

## Validation

Local: rue-air 574/574, rue-compiler 794/794 (including the RUE-1090 scaling gate — verdict unchanged at ACTIVATE, as expected: the gate measures the still-eager durable-declaration term, which is r5a/flip territory), spec suite, differential oracles, CLI suite, clippy, fmt. Adversarially reviewed: no L1/L2; the `&dyn` fact-dispatch was explicitly ruled acceptable (one dispatch per consult, dominated by the HashMap work; monomorphizing is invasive for zero measurable gain); L3 precedence-consistency fix folded in.

Part of RUE-1091