### PR TITLE
RUE-1091 r4a-1: callable-symbol method boundary op

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -66,7 +66,7 @@ pub use intern_pool::{
 pub use layout::{Layout, LayoutKind, PaddingRange, SLOT_BYTES};
 pub use module_registry::ModuleRegistry;
 pub use param_arena::{ParamArena, ParamRange};
-pub use path_norm::normalize_module_path;
+pub use path_norm::{mangle_symbol_component, normalize_module_path, unmangle_symbol_component};
 pub use runtime_call::{
     OptionVariant, RuntimeAirArgument, RuntimeAirType, RuntimeCallActivation, RuntimeCallKind,
     RuntimeOperandOrigin,

--- a/crates/rue-air/src/path_norm.rs
+++ b/crates/rue-air/src/path_norm.rs
@@ -55,7 +55,8 @@ pub fn normalize_module_path(path: &str) -> String {
 ///
 /// Rue identifiers contain only ASCII alphanumerics and `_`; encoding every
 /// other byte (including `_` itself) as `_xx` keeps the result unambiguous.
-pub(crate) fn mangle_symbol_component(component: &str) -> String {
+/// Paired with [`unmangle_symbol_component`], its exact inverse.
+pub fn mangle_symbol_component(component: &str) -> String {
     let mut mangled = String::new();
     for byte in component.bytes() {
         match byte {
@@ -67,6 +68,43 @@ pub(crate) fn mangle_symbol_component(component: &str) -> String {
         }
     }
     mangled
+}
+
+/// Decode a machine-symbol component produced by [`mangle_symbol_component`]
+/// back to its original bytes, or `None` when `component` is not a well-formed
+/// mangling.
+///
+/// The encoding is injective: an alphanumeric byte stands for itself and every
+/// other byte is `_` followed by exactly two lowercase hex digits (including
+/// `_` itself, `_5f`). Decoding is therefore exact — a bare `_` not followed by
+/// two hex digits, or bytes that do not form valid UTF-8, could never have been
+/// emitted by the encoder, so they fail closed with `None`. Used by the
+/// callable-symbol reversal to recover a nominal's defining module path from the
+/// file-qualified component of its symbol without re-consulting the type pool.
+pub fn unmangle_symbol_component(component: &str) -> Option<String> {
+    let bytes = component.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            byte @ (b'0'..=b'9' | b'A'..=b'Z' | b'a'..=b'z') => {
+                out.push(byte);
+                index += 1;
+            }
+            b'_' => {
+                let hex = component.get(index + 1..index + 3)?;
+                out.push(u8::from_str_radix(hex, 16).ok().filter(|_| {
+                    // Reject upper-case or `+`/`-`-prefixed hex the encoder never
+                    // emits, so the round trip is byte-exact in both directions.
+                    hex.bytes()
+                        .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
+                })?);
+                index += 3;
+            }
+            _ => return None,
+        }
+    }
+    String::from_utf8(out).ok()
 }
 
 #[cfg(test)]
@@ -107,5 +145,31 @@ mod tests {
         assert_eq!(m("left/shared.rue"), "left_2fshared_2erue");
         assert_eq!(m("a_b"), "a_5fb");
         assert_ne!(m("a/b"), m("a_2fb"));
+    }
+
+    #[test]
+    fn unmangle_is_the_exact_inverse_of_mangle() {
+        use super::unmangle_symbol_component as um;
+        for path in [
+            "left/shared.rue",
+            "a_b",
+            "a/b",
+            "m.rue",
+            "pkg/nested/main.rue",
+            "../std/opt.rue",
+        ] {
+            assert_eq!(um(&m(path)).as_deref(), Some(path), "round trip of {path}");
+        }
+    }
+
+    #[test]
+    fn unmangle_rejects_malformed_components() {
+        use super::unmangle_symbol_component as um;
+        // A bare `_` with no hex pair, a truncated pair, and an upper-case pair
+        // the encoder never emits all fail closed rather than decode wrongly.
+        assert_eq!(um("a_"), None);
+        assert_eq!(um("a_2"), None);
+        assert_eq!(um("a_2E"), None);
+        assert_eq!(um("a_zz"), None);
     }
 }

--- a/crates/rue-air/src/sema/provider.rs
+++ b/crates/rue-air/src/sema/provider.rs
@@ -429,6 +429,30 @@ pub trait BodyFactProvider {
     /// including absent, rejected, and ambiguous results.
     fn resolve_import(&self, module: &Self::ModuleRef, specifier: &str) -> ImportResolution;
 
+    /// Reverse a rendered callable symbol to the unique named method it names,
+    /// or `None`.
+    ///
+    /// This is the receiver-keyed inverse of the AIR/codegen symbol a named
+    /// method is rendered under (`Type.method` for a `self`-taking method,
+    /// `Type::method` for an associated function, file-qualified per the epoch's
+    /// `method_symbol` rules). It is the exact-provider analog of the epoch's
+    /// `named_method_by_callable_symbol` accessor: the sole consumer is import
+    /// reversal (`classify_static_call`), which turns a call symbol discovered in
+    /// reused/imported AIR back into the `(receiver, method)` dependency the body
+    /// took.
+    ///
+    /// **Fail-closed single-candidate contract**, observationally equivalent to
+    /// the epoch accessor on valid corpora (the epoch buckets by full symbol,
+    /// this query guards at receiver-name granularity; the inputs that would
+    /// separate them are rejected as duplicate definitions before analysis):
+    /// the answer is `Some` only when the symbol reverses to one named
+    /// method whose forward rendering reproduces the symbol byte for byte. An
+    /// absent name, an ambiguous receiver nominal (a symbol whose type name
+    /// resolves to more than one nominal), an ambiguous or absent method, and a
+    /// symbol whose forward re-render does not match are all `None` — the query
+    /// never guesses a winner. Winner-picking stays inside this point query.
+    fn callable_symbol_method(&self, symbol: &str) -> Option<(Self::ReceiverType, Arc<str>)>;
+
     /// Exact producer-body facts already required by the body.
     fn producer_body_facts(&self, decl: &Self::DeclarationRef) -> Option<Self::ProducerBodyFacts>;
 

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -12131,6 +12131,84 @@ impl rue_air::BodyFactProvider for CompilerBodyFactProvider<'_> {
         }
     }
 
+    fn callable_symbol_method(&self, symbol: &str) -> Option<(ReceiverTypeIdentity, Arc<str>)> {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Cat;
+        // Split the rendered symbol into its `Type`-symbol prefix, the member
+        // name, and the receiver form. An associated function renders `Type::m`,
+        // a `self`-taking method `Type.m`; neither the file-qualified prefix nor
+        // an identifier contains a raw `:` or `.` (they mangle to `_3a` / `_2e`),
+        // so the separator is unambiguous and unique.
+        let (prefix, method, has_self) = if let Some((prefix, method)) = symbol.rsplit_once("::") {
+            (prefix, method, false)
+        } else if let Some((prefix, method)) = symbol.rsplit_once('.') {
+            (prefix, method, true)
+        } else {
+            return None;
+        };
+        if method.is_empty() {
+            return None;
+        }
+        // The prefix is `Type$file`; a bare prefix (no `$`) is a builtin /
+        // language-item / anonymous owner whose defining module is not recoverable
+        // from the symbol alone — deferred to r6 with the well-known facts.
+        let (type_name, file_component) = prefix.split_once('$')?;
+        if type_name.is_empty() || file_component.is_empty() {
+            return None;
+        }
+        let module_path = rue_air::unmangle_symbol_component(file_component)?;
+        let module = ModuleId::from_logical_path(&module_path).ok()?;
+
+        // Resolve the receiver nominal by its unqualified name in the recovered
+        // module (records the lookup-name edge, metered as a name lookup). The
+        // receiver is unique or the query fails closed: an absent name, an
+        // unavailable index, or an ambiguous nominal (a struct and enum sharing
+        // the name) all yield `None`, mirroring the epoch bucket that retains
+        // collisions so ambiguity never depends on iteration order.
+        let resolution =
+            self.lookup_unqualified(&module, rue_air::ProviderNamespace::ModuleItem, type_name);
+        let mut nominals = resolution.candidates().iter().filter(|candidate| {
+            matches!(
+                candidate.kind,
+                rue_air::ProviderDefinitionKind::Struct | rue_air::ProviderDefinitionKind::Enum
+            )
+        });
+        let nominal = nominals.next()?;
+        if nominals.next().is_some() {
+            return None;
+        }
+        let category = match nominal.kind {
+            rue_air::ProviderDefinitionKind::Struct => Cat::Struct,
+            rue_air::ProviderDefinitionKind::Enum => Cat::Enum,
+            _ => return None,
+        };
+        let receiver = ReceiverTypeIdentity::new(module.clone(), type_name, category);
+
+        // Select the unique member of that receiver name whose `self`-receiver
+        // classification (sourced from its signature) matches the symbol's form
+        // (records the member edges, metered as a method-candidate lookup).
+        let candidates = self.method_candidates(&receiver, method);
+        let mut matching = candidates
+            .iter()
+            .filter(|candidate| candidate.has_self_receiver == has_self);
+        let member = matching.next()?;
+        if matching.next().is_some() {
+            return None;
+        }
+
+        // Reproduce the epoch's `method_symbol` rendering (file-qualified via the
+        // same `mangle(normalize(path))` composition the type pool's
+        // `struct_symbol_name` uses) and require a byte-exact match, so a symbol
+        // the epoch could never have produced fails closed.
+        let file_component =
+            rue_air::mangle_symbol_component(&rue_air::normalize_module_path(module.as_str()));
+        let separator = if has_self { "." } else { "::" };
+        let rendered = format!("{type_name}${file_component}{separator}{method}");
+        if rendered != symbol {
+            return None;
+        }
+        Some((receiver, member.name.clone()))
+    }
+
     fn producer_body_facts(
         &self,
         decl: &crate::declaration_candidate::DeclarationCandidateKey,
@@ -20271,6 +20349,186 @@ mod tests {
                     || *family == "compiler.body-toolchain-demands"),
             "declaration facts observe only their exact backing terminals: {families:?}"
         );
+    }
+
+    #[test]
+    fn provider_callable_symbol_reverses_named_methods_match_epoch() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Cat;
+        use rue_air::BodyFactProvider;
+        // A self-taking method (`get`) and an associated function (`make`) on the
+        // same struct. Their AIR/codegen symbols are `Box$<file>.get` and
+        // `Box$<file>::make`; the op reverses each back to its `(receiver, method)`.
+        let source = "struct Box { value: i32, \
+             fn get(borrow self) -> i32 { self.value } \
+             fn make(start: i32) -> Box { Box { value: start } } }\n\
+             fn main() -> i32 { 0 }\n";
+        let snapshot = source_snapshot(&[(1, "/m.rue", "m.rue", source)], 1);
+        let m = ModuleId::from_logical_path("m.rue").unwrap();
+
+        // Independent epoch truth: the production frontend renders `Box`'s symbol
+        // through the type pool's own `struct_symbol_name` (a wholly separate path
+        // from the provider), so the symbols the op must reverse are authoritative,
+        // not self-produced.
+        let (_, semantic, _) = crate::test_support::test_frontend_snapshot(
+            &snapshot,
+            &crate::CompileOptions::default(),
+        )
+        .expect("frontend compiles");
+        let pool = semantic.type_pool();
+        let box_id = pool
+            .all_struct_ids()
+            .find(|id| pool.struct_def(*id).name == "Box")
+            .expect("Box struct exists");
+        let box_symbol = pool.struct_symbol_name(box_id);
+        // File-qualified, not bare: this is the rendering the op must reproduce.
+        assert!(
+            box_symbol.contains('$'),
+            "user nominal is file-qualified: {box_symbol}"
+        );
+        let get_symbol = format!("{box_symbol}.get");
+        let make_symbol = format!("{box_symbol}::make");
+
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &snapshot);
+
+        let probes = {
+            let get = get_symbol.clone();
+            let make = make_symbol.clone();
+            let box_sym = box_symbol.clone();
+            move |provider: &CompilerBodyFactProvider<'_>| {
+                (
+                    // Unique self-method and unique associated function.
+                    provider.callable_symbol_method(&get),
+                    provider.callable_symbol_method(&make),
+                    // Absent: an unknown method name and an unknown receiver type.
+                    provider.callable_symbol_method(&format!("{box_sym}.absent")),
+                    provider.callable_symbol_method("Ghost$m_2erue.get"),
+                    // Wrong receiver form: `get` is a method, not an associated fn,
+                    // and `make` is an associated fn, not a method — each fails the
+                    // signature-sourced `has_self` check, never a guessed winner.
+                    provider.callable_symbol_method(&format!("{box_sym}::get")),
+                    provider.callable_symbol_method(&format!("{box_sym}.make")),
+                    // A bare (unqualified) symbol has no recoverable module.
+                    provider.callable_symbol_method("i32.get"),
+                )
+            }
+        };
+        let outcome =
+            database.probe_body_facts(revision, semantic_configuration(), "callable", probes);
+        let (get, make, absent_method, absent_type, get_as_assoc, make_as_method, bare) =
+            outcome.result;
+
+        let box_receiver = ReceiverTypeIdentity::new(m.clone(), "Box", Cat::Struct);
+        assert_eq!(get, Some((box_receiver.clone(), Arc::from("get"))));
+        assert_eq!(make, Some((box_receiver, Arc::from("make"))));
+        assert_eq!(absent_method, None);
+        assert_eq!(absent_type, None);
+        assert_eq!(get_as_assoc, None);
+        assert_eq!(make_as_method, None);
+        assert_eq!(bare, None);
+
+        // Edge-recording proof: the reversal observes only its exact backing
+        // terminals — the receiver name lookup and the member semantic-nucleus
+        // facts — recorded at materialization, exactly as the sibling ops do.
+        let families: std::collections::BTreeSet<&str> = outcome
+            .dependencies
+            .iter()
+            .map(|node| node.family())
+            .collect();
+        assert!(
+            families.contains("compiler.lookup-name"),
+            "the receiver lookup is observed: {families:?}"
+        );
+        assert!(
+            families
+                .iter()
+                .all(|family| *family == "compiler.lookup-name"
+                    || *family == "compiler.semantic-nucleus"),
+            "callable-symbol reversal observes only its backing terminals: {families:?}"
+        );
+    }
+
+    #[test]
+    fn provider_callable_symbol_file_qualification_distinguishes_siblings_and_fails_ambiguity() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Cat;
+        use rue_air::BodyFactProvider;
+        // Two same-named `Payload` types in different files each carry a `score`
+        // method. Their symbols differ ONLY in the file-qualified component, so a
+        // correct reversal recovers a different defining module for each — the
+        // property file-qualification exists to guarantee. A third module makes a
+        // name genuinely ambiguous (a struct and an enum share it), so that symbol
+        // reverses to nothing: the fail-closed multi-candidate path.
+        let payload = "pub struct Payload { value: i32, \
+             fn score(borrow self) -> i32 { self.value } }\n";
+        let snapshot = source_snapshot(
+            &[
+                (1, "/left.rue", "left.rue", payload),
+                (2, "/right.rue", "right.rue", payload),
+                (
+                    3,
+                    "/dup.rue",
+                    "dup.rue",
+                    "struct Dup { a: i32 }\nenum Dup { X }\n",
+                ),
+            ],
+            1,
+        );
+        let left = ModuleId::from_logical_path("left.rue").unwrap();
+        let right = ModuleId::from_logical_path("right.rue").unwrap();
+
+        // Build each sibling's symbol from the shared rendering primitive; the
+        // primitive itself is pinned against the epoch's own renderer by
+        // `provider_callable_symbol_reverses_named_methods_match_epoch`, so reusing
+        // it here isolates the property under test — that distinct file components
+        // recover distinct receivers.
+        let file_component = |module: &ModuleId| {
+            rue_air::mangle_symbol_component(&rue_air::normalize_module_path(module.as_str()))
+        };
+        let left_symbol = format!("Payload${}.score", file_component(&left));
+        let right_symbol = format!("Payload${}.score", file_component(&right));
+        let dup_symbol = format!(
+            "Dup${}.whatever",
+            file_component(&ModuleId::from_logical_path("dup.rue").unwrap())
+        );
+
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &snapshot);
+
+        let probes = {
+            let left_symbol = left_symbol.clone();
+            let right_symbol = right_symbol.clone();
+            let dup_symbol = dup_symbol.clone();
+            move |provider: &CompilerBodyFactProvider<'_>| {
+                (
+                    provider.callable_symbol_method(&left_symbol),
+                    provider.callable_symbol_method(&right_symbol),
+                    provider.callable_symbol_method(&dup_symbol),
+                )
+            }
+        };
+        let outcome =
+            database.probe_body_facts(revision, semantic_configuration(), "siblings", probes);
+        let (left_result, right_result, dup_result) = outcome.result;
+
+        assert_eq!(
+            left_result,
+            Some((
+                ReceiverTypeIdentity::new(left.clone(), "Payload", Cat::Struct),
+                Arc::from("score"),
+            )),
+        );
+        assert_eq!(
+            right_result,
+            Some((
+                ReceiverTypeIdentity::new(right.clone(), "Payload", Cat::Struct),
+                Arc::from("score"),
+            )),
+        );
+        // The two symbols reverse to genuinely distinct receivers (distinct
+        // modules), never one collapsed answer.
+        assert_ne!(left_result, right_result);
+        // A name owned by two nominals is a multi-candidate: fail closed.
+        assert_eq!(dup_result, None);
     }
 
     #[test]

--- a/docs/notes/rue-1091-analyzer-rewire-plan.md
+++ b/docs/notes/rue-1091-analyzer-rewire-plan.md
@@ -360,6 +360,86 @@ id-minting `type_pool`. r4 still owns the full cost of the pool that mints epoch
 
 ---
 
+## Rider: r3→r4 fold, r4 sub-slice map, and the pool keystone (recorded landing r4a-1)
+
+**(a) The r3→r4 fold.** r3 (endpoint-seam call/method/operator/module-member ProviderFacts) and r4
+(aggregates/patterns/endpoints ProviderFacts) are folded into one **r4** effort. Rationale: r1b's
+`SemanticCallResolutionProvider` seam is **epoch-concrete**, not provider-generic like the
+type-syntax seam — it drives the non-generic value/endpoint analyzer whose answers are expressed in
+materialized-identity terms (`StructId`/`Type`/`FunctionInfo`). A call ProviderFacts has no
+pool-free generic domain to resolve into the way `resolve_semantic_type_syntax` resolves into
+`DurableType`: the call facts are inseparable from the id-minting pool that r2's pool-free metadata
+deliberately withholds. Splitting "call resolution" from "endpoint/pool assembly" would draw a seam
+through the middle of one indivisible act, so r3 and r4 land together as r4.
+
+**(b) r4 sub-slice map.** r4 lands as byte-identical re-points (each proven on corpus + oracle
+before the next), NOT one envelope:
+- **r4a-1** (this slice): the `callable_symbol_method` boundary op — the keyed reverse of the epoch's
+  `named_method_by_callable_symbol`, the sole missing symbol→method surface. Ships independent of the
+  pool.
+- **r4a-2a**: nominal / type-identity pool — the overlay-owned id-minting `type_pool` r2 withheld,
+  minting `StructId`/`Type` from r2's durable metadata.
+- **r4a-2b**: callable identities / `ParamRange` assembly (`FunctionInfo`/`MethodInfo`-equivalent)
+  on top of r5's signatures.
+- **r4a-2c**: the RIR-index answers (`first_free_function`/`destructors`/`named_method_declarations`
+  → body key) the endpoint seam consumes.
+- **r4b-1/2/3**: the ProviderFacts impls per family (calls, aggregates/patterns, endpoints) driven by
+  r4a's pool, each a differential re-point of one family.
+
+**(c) The pool keystone.** Published artifacts are durable-keyed **at export**
+(`semantic_body_export.rs` is the single funnel), so the r4a pool may mint **internally-consistent**
+ids with correct durable metadata — it need NOT reproduce epoch `StructId`/`Type` NUMBERING. Byte
+identity is a property of the exported durable keys, not of the transient pool indices, so the
+differential compares durable structure and materialized metadata (as r2 already does), never a
+pool-relative index. r4a-1 is the first concrete instance: its answer is a durable-keyed
+`(ReceiverType, method)` — a `ReceiverTypeIdentity` (module + type name + category) plus the owned
+method name — never a `StructId`, exactly because the pool that would mint one is r4a-2a's job.
+
+**(d) Builtin / slice name facts deferred to r6.** r4a-1's reverse covers **user named methods**: a
+file-qualified symbol `Type$file.method` / `Type$file::method` whose defining module is recoverable
+from the mangled component. A **bare** symbol (builtin / language-item / anonymous owner — no `$`)
+carries no recoverable module and is returned `None`, deferred to r6 with the well-known `Option`
+facts (the same slice that ports `install_well_known_option_types`). This matches the epoch: for an
+import-free, string-free corpus the epoch's `named_callable_methods_by_symbol` contains exactly the
+user methods, so the keyed reversal is complete over its differential scope.
+
+**(e) Open Steve-level question (does not block r4a-1).** Whether import reversal is ultimately
+**retired** in favor of recording the `(receiver, method)` dependency **at resolution** (so no
+symbol ever needs reversing), or **kept** as a keyed op, is an open design question. r4a-1 ships the
+keyed op **either way**: it is the honest provider analog of the epoch accessor the current consumer
+(`classify_static_call`) needs, and it costs nothing if the record-at-resolution direction later
+subsumes it — the op simply loses its caller, exactly like an EpochFacts impl at the flip.
+
+**Rendering-parity note (source-verified while landing r4a-1).** The op reproduces
+`TypeInternPool::struct_symbol_name` exactly, which under ADR-0066 / RUE-1089 is now **unconditional**
+file-qualification for user nominals (`{name}${mangle(normalize(module_path))}`), not the older
+RUE-571 "qualify only on ambiguity" the §1 tables paraphrase — the exemptions (builtin / language
+item / `__anon_*`) keep their bare names. The reversal recovers the module by inverting the mangling
+(`unmangle_symbol_component`, the exact inverse now paired with `mangle_symbol_component`, both public
+in rue-air) and **re-renders forward** to require a byte-exact match before answering, so a symbol the
+epoch could never have produced fails closed. Because the boundary is keyed and exposes no
+program-wide method enumeration, the op is realized as a per-symbol keyed reversal (recover receiver
+from the symbol → confirm the nominal and member via the existing `lookup_unqualified` /
+`method_candidates` point queries, recording their edges) rather than a materialized whole-program
+index; that is the boundary-honest form of "a reverse index built from the durable declaration set,"
+and it fails closed on absent, ambiguous-receiver, wrong-`self`-form, and non-matching-render inputs.
+
+**r4a-1 review carry-forwards (recorded obligations, not defects).**
+- **Bare-owner reversal divergence → r4b differential xfail.** The epoch's callable index contains
+  BARE symbols for builtin / lang-item / anonymous owners (`struct_symbol_name` exempts them from
+  file-qualification), and imported bodies calling e.g. `StrBuf` methods reverse through them; the
+  r4a-1 op refuses bare symbols by design pending r6's well-known/builtin-name facts. r4b's
+  differential MUST record this class as an explicit known-divergence (xfail) tied to the r6 port,
+  and pin at least one case where the epoch genuinely answers a bare symbol the op refuses — the
+  current tests only exercise bare symbols the epoch also refuses, which masks the gap.
+- **Provider edges are the post-flip truth.** The epoch's index lookup records no body edges; the
+  op records the lookup-name and semantic-nucleus edges it genuinely consults. rFinal's
+  edge-differential must treat the RICHER provider-era edge set as the new truth after the flip
+  (the finer dependencies are the more-correct incremental behavior), not force the op to suppress
+  edges to match the epoch's index-masked footprint.
+
+---
+
 ## 4. RISKS (top 5 for this rewire)
 
 | # | Risk | Mitigation |


### PR DESCRIPTION
Slice r4a-1 of the RUE-1091 analyzer rewire: the callable-symbol→method boundary op that r4b's call-resolution ProviderFacts needs for imported-body reachability reversal — plus the plan rider recording the r3→r4 fold, the r4 sub-slice map, and the pool design keystone from the r4a checkpoint.

## What changed

- `BodyFactProvider::callable_symbol_method` (trait addition; sole implementor is the cfg(test) provider, so zero production code paths change — verified by review, clippy-clean production build).
- The cfg(test) impl does **keyed per-symbol reversal** rather than materializing a whole-program reverse index (which would be the very O(U) shape this project deletes): parse the symbol, invert the module mangling (`unmangle_symbol_component`, the new exact inverse of `mangle_symbol_component`), confirm receiver and member via the existing point queries (recording their edges at materialization), then **re-render forward and require a byte-exact match**. Review verdict on the correctness core: the parse is provably unambiguous (identifier charset + mangle escaping leave each separator a unique raw occurrence) and the re-render backstop makes aliasing to a wrong-but-valid module impossible.
- Parity differentials with independent epoch truth: production-rendered symbols (from `struct_symbol_name` directly), self/assoc forms, absent/wrong-form/bare rejections, file-qualification distinguishing same-named siblings, multi-candidate fail-closed, edge-recording assertions, and mangle/unmangle round-trip + malformed-rejection unit tests.
- Plan rider: r3→r4 fold rationale; r4a/r4b sub-slice map; the export-time durable-keying keystone (pool mints internally-consistent ids, not epoch numbering); builtin/bare-owner deferral to r6; the open (non-blocking) record-at-resolution question; and two review carry-forwards recorded as obligations — the bare-owner reversal divergence must be an explicit xfail in r4b's differential, and rFinal must treat the richer provider-era edge set as post-flip truth.

## Validation

Local: rue-air 576/576 (+2 round-trip tests), rue-compiler 804/804 (+2 differentials), clippy (66 targets), fmt. Corpora ride CI. Adversarially reviewed: no blockers; the two L2s are the forward obligations now recorded in the plan, and the doc-precision nit is folded in.

Part of RUE-1091

---
_Generated by [Claude Code](https://claude.ai/code/session_019h99YFzR3fuDy2phd2vU9r)_