### PR TITLE
Clarify symbol qualification documentation

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -2302,13 +2302,12 @@ impl TypeInternPool {
     /// (`P.__drop`), and drop glue (`__rue_drop_P`) — RUE-571.
     ///
     /// Same-named nominal types across files are legal (RUE-558), but these
-    /// symbols are program-wide identities: when this struct's source name is
-    /// registered by more than one struct or enum, the name is qualified with
-    /// the defining file (`P$left_2fmodel_2erue`). `$` cannot appear in a source
-    /// identifier, so a qualified name can never collide with a real type;
-    /// unambiguous names (the common case) are returned bare, keeping symbols
-    /// and `--emit` output unchanged. Builtins are never qualified (their
-    /// symbols pair with runtime-provided definitions).
+    /// symbols are program-wide identities. Every named user nominal is
+    /// unconditionally qualified with the defining file
+    /// (`P$left_2fmodel_2erue`) (ADR-0066, RUE-1089). `$` cannot appear in a
+    /// source identifier, so a qualified name can never collide with a real
+    /// type. Builtins remain bare so their symbols pair with runtime-provided
+    /// definitions.
     ///
     /// Every layer that names a function after a type — sema (definition and
     /// call sites), the drop-glue generator in `rue-compiler`, and both
@@ -2320,8 +2319,9 @@ impl TypeInternPool {
     }
 
     /// The symbol-name component for an enum's drop glue (`__rue_drop_E`),
-    /// file-qualified when another struct or enum has the same source name.
-    /// See [`Self::struct_symbol_name`] (RUE-571) — same rule, same reason.
+    /// unconditionally file-qualified for named user enums (ADR-0066,
+    /// RUE-1089), while builtins remain bare. See
+    /// [`Self::struct_symbol_name`] — same rule, same reason.
     pub fn enum_symbol_name(&self, enum_id: EnumId) -> String {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
         inner.enum_symbol_name(enum_id)

--- a/crates/rue-air/src/param_arena.rs
+++ b/crates/rue-air/src/param_arena.rs
@@ -137,7 +137,7 @@ pub struct ParamArena {
     /// All parameter types, indexed by position in the arena.
     types: Vec<Type>,
 
-    /// All parameter modes (Normal, Inout, Borrow, Comptime).
+    /// All parameter modes (Normal, Inout, Borrow).
     modes: Vec<RirParamMode>,
 
     /// Whether each parameter is a comptime parameter.

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -1835,10 +1835,11 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     }
 
     /// Symbol for a method (`Type.method`) or associated function
-    /// (`Type::method`) of `struct_id`, file-qualified when the type name is
-    /// ambiguous (RUE-571). Definition sites (function-body analysis) and
-    /// call sites (method / assoc-fn call analysis) must both build the name
-    /// through this helper so they meet in AIR/codegen.
+    /// (`Type::method`) of `struct_id`. Named user types are unconditionally
+    /// file-qualified (ADR-0066, RUE-1089), while builtins remain bare.
+    /// Definition sites (function-body analysis) and call sites (method /
+    /// assoc-fn call analysis) must both build the name through this helper so
+    /// they meet in AIR/codegen.
     pub(crate) fn method_symbol(
         &self,
         struct_id: StructId,
@@ -1853,8 +1854,9 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         }
     }
 
-    /// Symbol for the destructor of `struct_id` (`Type.__drop`),
-    /// file-qualified when the type name is ambiguous (RUE-571).
+    /// Symbol for the destructor of `struct_id` (`Type.__drop`). Named user
+    /// types are unconditionally file-qualified (ADR-0066, RUE-1089), while
+    /// builtins remain bare.
     pub(crate) fn destructor_symbol(&self, struct_id: StructId) -> String {
         format!("{}.__drop", self.symbol_type_name(struct_id))
     }


### PR DESCRIPTION
## Summary

- document unconditional file qualification for named user nominal symbols
- retain the documented bare-symbol exception for builtins
- remove the nonexistent `Comptime` entry from the parameter-mode comment

This is a comments-only cleanup; compiler behavior and tests are unchanged.

## Validation

- `scripts/rue fmt`
- `git diff --check`
- changed-line audit confirming the commit modifies only Rust comments
