### PR TITLE
RUE-1091: add step-6 measurement gauntlet runner

### DIFF
--- a/docs/notes/rue-1091-measurement-results.md
+++ b/docs/notes/rue-1091-measurement-results.md
@@ -1,0 +1,65 @@
+# RUE-1091 post-flip measurement results
+
+Use this template for the authoritative run after the analyzer flip. The runner
+retains a `summary.tsv` plus one full log per stage:
+
+```sh
+scripts/rue-1091-measurement.sh --results-dir /absolute/path/to/results
+```
+
+For plumbing validation on current trunk, use `--pre-flip`. That mode changes
+only the Caldera stage to `--allow-fail`; it does not relax any structural or
+correctness stage. Resume an interrupted run with `--stage N` and the same
+results directory.
+
+## Provenance
+
+- Commit:
+- Date/time:
+- Host and OS:
+- CPU / logical processors:
+- Memory:
+- Build configuration: Buck2 release platform for measurement stages
+- Results directory:
+- Mode: post-flip authoritative / pre-flip plumbing
+- Caldera budget: 300 seconds (authoritative runs must leave
+  `RUE_1091_CALDERA_BUDGET_SECONDS` unset)
+
+Timing and memory in stage 8 come from the ordinary allocator binary. Allocation
+counts in stage 7 come from the distinct counting-allocator binary. Do not merge
+or compare their orchestration times from `summary.tsv`; those values include
+build and harness overhead and are operational only. The R5 evidence is the
+compiler timing reported by stage 8 only.
+
+## Stage ledger
+
+| Stage | Metric | Baseline reference | Post-flip value | Verdict |
+| ---: | --- | --- | --- | --- |
+| 1 | RUE-1090 normal matrices: fixed bodies / 100→1,000 declarations; fixed declarations / 100→1,000 bodies; identity invariance | Frozen ratios derived from the checked-in harness formulas and reproduced by the pre-cut control run: projection `20301/101 → 111201/101`; install `20301/101 → 111201/101`; endpoints `40703/101 → 222503/101`. The growing-bodies rows must remain linear in body count; identity rows must be invariant. Cancellation requires exact ratio equality (zero slope). | TBD | TBD |
+| 2 | RUE-1090 large declaration matrix: stage-1 fixed-body rows plus 10,000 unrelated declarations | Same frozen 100-declaration denominators as stage 1. Historical whole-universe 10k-declaration witnesses derived from the checked-in harness formulas: projection/install `1020201/101`; endpoints `2040503/101`. These witnesses are informational; the verdict still requires exact flatness. | TBD | TBD |
+| 3 | RUE-1121 exact-flat cold rows and edit invalidation: unrelated declaration, body-only edit, exact declaration consumers, negative→positive lookup | Baseline is the checked-in RUE-1121 target/witness envelope. Post-flip target: exact-flat context rows; recompute sets `∅`, `{b0}`, `{left,right}`, and `{extra,main}` respectively, with warm/fresh parity. | TBD | TBD |
+| 4 | Differential warm/fresh oracle corpus: artifacts, diagnostics, references, identities, failures, recovery, and bounded eviction | Current-trunk `//crates/rue-compiler:rue-compiler-differential-oracle-test` passes. | TBD | TBD |
+| 5 | Forced-eviction and cancellation suites | Current-trunk compiler cancellation and eviction unit suites pass; no canceled/stale value may commit or survive eviction incorrectly. | TBD | TBD |
+| 6 | Whole-body transaction equality across schedule permutations, including the forced-eviction/cancellation corpus shape | Current-trunk rFinal side-A self-equality schedule oracle passes. | TBD | TBD |
+| 7 | Cold and warm-edit allocation calls/bytes at 1,000 bodies / 100 unrelated declarations | Capture a paired pre-flip counting-allocator run if comparison is required; no frozen numeric allocation baseline exists today. | TBD | TBD |
+| 8 | Ordinary-allocator cold/warm semantic and pre-link timing plus cold peak RSS at 1,000 bodies / 100 unrelated declarations | R5 comparison baseline: paired pre-flip stage-8 log. The historical ~45 ms Caldera pre-link figure is an eventual reference-host target, not this synthetic-corpus gate. | TBD | TBD |
+| 9 | Caldera cold release compile wall time and `--time-passes`; hard post-flip budget ≤300 s | RUE-1090 activation evidence, with RUE-1083 history: the session-local `rue-caldera-post1112-baseline/` artifact recorded a DNF after approximately 41 minutes. Operator must confirm that baseline provenance at run time. Post-flip acceptance budget: 300 seconds. | TBD | TBD |
+
+## RUE-1090 raw audit rows
+
+Copy the stage 1 and stage 2 audit lines verbatim, including totals, cold-body
+denominators, exact signed slope numerators, historical-tripwire results, and
+combined verdicts.
+
+```text
+TBD
+```
+
+## Notes and anomalies
+
+- Record retries, host contention, unavailable peak-RSS support, and any
+  `ALLOW_FAIL` result here.
+- A non-flat RUE-1090 ratio is a failure even if wall time improves.
+- A historical-witness ceiling failure is a measurement blocker, not an
+  ordinary activation result.
+- The authoritative post-flip run must not contain `ALLOW_FAIL`.

--- a/scripts/rue-1091-measurement.sh
+++ b/scripts/rue-1091-measurement.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+#
+# Run the RUE-1091 post-flip measurement gauntlet.
+#
+# This script is intentionally orchestration only. The structural assertions
+# remain in the RUE-1090/RUE-1121 harnesses, and timing is never collected from
+# the counting-allocator binary.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+start_stage=1
+pre_flip=0
+results_dir=""
+caldera_budget_seconds="${RUE_1091_CALDERA_BUDGET_SECONDS:-300}"
+
+usage() {
+    cat <<'EOF'
+usage: scripts/rue-1091-measurement.sh [--pre-flip] [--stage N] [--results-dir DIR]
+
+Run stages N through 9 (default: all stages):
+
+  1  RUE-1090 normal matrices (both axes plus identity)
+  2  RUE-1090 large declaration matrix (adds the 10,000 row)
+  3  RUE-1121 exact-flat and edit-invalidation rows
+  4  warm/fresh differential oracles
+  5  forced-eviction and cancellation suites
+  6  whole-body schedule permutations
+  7  allocation accounting (counting allocator; no timing)
+  8  cold/warm timing and peak memory (ordinary allocator)
+  9  Caldera cold compile with the 300-second budget
+
+--stage N resumes at stage N; it does not rerun earlier stages.
+--pre-flip marks only stage 9 --allow-fail. This is the plumbing-validation
+mode for current trunk; every other stage remains required to pass.
+
+Logs and summary.tsv are written to a fresh temporary directory unless
+--results-dir is supplied. The directory is retained after the run.
+
+RUE_1091_CALDERA_BUDGET_SECONDS overrides the Caldera timeout for operator
+testing. Leave it unset for the authoritative 300-second post-flip run.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pre-flip)
+            pre_flip=1
+            shift
+            ;;
+        --stage)
+            if [[ $# -lt 2 || ! "$2" =~ ^[1-9]$ ]]; then
+                echo "error: --stage requires an integer from 1 through 9" >&2
+                exit 2
+            fi
+            start_stage="$2"
+            shift 2
+            ;;
+        --results-dir)
+            if [[ $# -lt 2 || -z "$2" ]]; then
+                echo "error: --results-dir requires a path" >&2
+                exit 2
+            fi
+            results_dir="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument '$1'" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ ! "$caldera_budget_seconds" =~ ^[1-9][0-9]*$ ]]; then
+    echo "error: RUE_1091_CALDERA_BUDGET_SECONDS must be a positive integer" >&2
+    exit 2
+fi
+
+if [[ -z "$results_dir" ]]; then
+    results_dir="$(mktemp -d "${TMPDIR:-/tmp}/rue-1091-measurement.XXXXXX")"
+else
+    mkdir -p "$results_dir"
+    results_dir="$(cd "$results_dir" && pwd)"
+fi
+
+summary="$results_dir/summary.tsv"
+if [[ "$start_stage" -gt 1 && ! -f "$summary" ]]; then
+    echo "error: --stage $start_stage requires an existing $summary" >&2
+    exit 2
+fi
+if [[ "$start_stage" -eq 1 ]]; then
+    printf 'stage\tname\tresult\texit_code\torchestration_seconds\tlog\n' >"$summary"
+else
+    summary_prefix="$results_dir/summary-prefix.tsv"
+    awk -F '\t' -v resume="$start_stage" \
+        'NR == 1 || ($1 ~ /^[0-9]+$/ && $1 < resume)' \
+        "$summary" >"$summary_prefix"
+    mv "$summary_prefix" "$summary"
+fi
+
+run_with_timeout() {
+    local seconds="$1"
+    shift
+    python3 - "$seconds" "$@" <<'PY'
+import os
+import signal
+import subprocess
+import sys
+
+budget = float(sys.argv[1])
+command = sys.argv[2:]
+process = subprocess.Popen(command, start_new_session=True)
+try:
+    raise SystemExit(process.wait(timeout=budget))
+except subprocess.TimeoutExpired:
+    os.killpg(process.pid, signal.SIGTERM)
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGKILL)
+        process.wait()
+    print(f"TIMEOUT: command exceeded {budget:g} seconds", file=sys.stderr)
+    raise SystemExit(124)
+PY
+}
+
+stage_1() {
+    scripts/rue unit compiler:scaling-matrix-test \
+        scaling_matrix_ --nocapture
+}
+
+stage_2() {
+    RUE_SCALING_LARGE=1 \
+        scripts/rue unit compiler:scaling-matrix-test \
+        scaling_matrix_fixed_bodies_growing_declarations --nocapture
+}
+
+stage_3() {
+    set -e
+    # The exact-flat cold rows are emitted by stages 1 and 2 from the shared
+    # RUE-1090/RUE-1121 matrix. Exercise the small exact-flat row again so this
+    # stage remains independently auditable, then run every edit row.
+    scripts/rue unit compiler \
+        scaling_smoke_fixed_bodies_growing_declarations --nocapture
+    scripts/rue unit compiler invalidation_ --nocapture
+}
+
+stage_4() {
+    scripts/rue unit \
+        compiler:rue-compiler-differential-oracle-test --nocapture
+}
+
+stage_5() {
+    set -e
+    scripts/rue unit compiler cancellation --nocapture
+    scripts/rue unit compiler eviction --nocapture
+}
+
+stage_6() {
+    scripts/rue unit compiler \
+        side_a_is_self_equal_across_full_shape_corpus_and_schedule_permutations \
+        --nocapture
+}
+
+stage_7() {
+    set -e
+    # Do not add timing around the measured compiler intervals in this stage:
+    # this binary installs the counting allocator.
+    ./buck2 run --target-platforms //platforms:release \
+        //crates/rue-scaling-bench:rue-scaling-bench-allocations -- \
+        --mode alloc --bodies 1000 --decls 100
+    ./buck2 run --target-platforms //platforms:release \
+        //crates/rue-scaling-bench:rue-scaling-bench-allocations -- \
+        --mode alloc --warm --bodies 1000 --decls 100
+}
+
+stage_8() {
+    set -e
+    # R5: these are separate processes built without the counting allocator.
+    ./buck2 run --target-platforms //platforms:release \
+        //crates/rue-scaling-bench:rue-scaling-bench -- \
+        --mode timing --bodies 1000 --decls 100 --iterations 5 --json
+    ./buck2 run --target-platforms //platforms:release \
+        //crates/rue-scaling-bench:rue-scaling-bench -- \
+        --mode timing --warm --bodies 1000 --decls 100 --iterations 20 --json
+    ./buck2 run --target-platforms //platforms:release \
+        //crates/rue-scaling-bench:rue-scaling-bench -- \
+        --mode memory --bodies 1000 --decls 100
+}
+
+stage_9() {
+    set -e
+    local rue_binary
+    rue_binary="$(scripts/rue-bin --target-platforms //platforms:release)"
+    run_with_timeout "$caldera_budget_seconds" env \
+        RUE_STD_PATH="$repo_root/std" \
+        "$rue_binary" --time-passes examples/caldera/main.rue \
+        -o "$results_dir/caldera"
+}
+
+stage_names=(
+    ""
+    "rue-1090-normal-matrices"
+    "rue-1090-large-10k-declaration-matrix"
+    "rue-1121-rows"
+    "differential-oracles"
+    "forced-eviction-and-cancellation"
+    "schedule-permutations"
+    "counting-allocator"
+    "timing-and-memory"
+    "caldera-300-second-budget"
+)
+
+required_failure=0
+for stage in $(seq "$start_stage" 9); do
+    name="${stage_names[$stage]}"
+    log="$results_dir/stage-${stage}-${name}.log"
+    allow_fail=0
+    if [[ "$stage" -eq 9 && "$pre_flip" -eq 1 ]]; then
+        allow_fail=1
+    fi
+
+    echo
+    echo "== stage $stage/9: $name =="
+    if [[ "$allow_fail" -eq 1 ]]; then
+        echo "policy: --allow-fail (pre-flip Caldera only)"
+    else
+        echo "policy: required"
+    fi
+    echo "log: $log"
+
+    started="$SECONDS"
+    set +e
+    "stage_$stage" 2>&1 | tee "$log"
+    status=${PIPESTATUS[0]}
+    set -e
+    elapsed=$((SECONDS - started))
+
+    if [[ "$status" -eq 0 ]]; then
+        result="PASS"
+    elif [[ "$allow_fail" -eq 1 ]]; then
+        result="ALLOW_FAIL"
+    else
+        result="FAIL"
+        required_failure=1
+    fi
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$stage" "$name" "$result" "$status" "$elapsed" "$log" >>"$summary"
+    echo "stage $stage: $result (exit=$status, orchestration=${elapsed}s)"
+
+    if [[ "$required_failure" -ne 0 ]]; then
+        echo "stopping after required stage failure; resume with --stage $stage" >&2
+        break
+    fi
+done
+
+echo
+echo "summary: $summary"
+if [[ "$required_failure" -ne 0 ]]; then
+    exit 1
+fi
+
+ledger_error="$(
+    awk -F '\t' -v pre_flip="$pre_flip" '
+        NR == 1 {
+            if ($1 != "stage" || $3 != "result") {
+                print "invalid summary header"
+            }
+            next
+        }
+        {
+            rows++
+            if ($1 != rows) {
+                print "missing or out-of-order stage: expected " rows ", found " $1
+            }
+            allowed_pre_flip = pre_flip && $1 == 9 && $3 == "ALLOW_FAIL"
+            if ($3 != "PASS" && !allowed_pre_flip) {
+                print "non-passing stage " $1 ": " $3
+            }
+        }
+        END {
+            if (rows != 9) {
+                print "incomplete ledger: expected 9 stages, found " rows
+            }
+        }
+    ' "$summary"
+)"
+if [[ -n "$ledger_error" ]]; then
+    echo "gauntlet failed ledger validation:" >&2
+    echo "$ledger_error" >&2
+    exit 1
+fi
+echo "gauntlet complete"


### PR DESCRIPTION
Refs RUE-1091.

## Summary

- add a nine-stage, resumable post-flip measurement runner with per-stage logs, pass/fail capture, and an explicit pre-flip Caldera allow-fail policy
- keep counting-allocator evidence isolated from ordinary-allocator timing and memory runs
- add a results ledger prefilled with the frozen RUE-1090 ratios and the 41-minute Caldera DNF baseline reference

## Validation

- `scripts/rue-1091-measurement.sh --pre-flip --results-dir /tmp/rue-1091-preflip-validation`
  - stages 1-8 passed, including the 10k declaration row
  - stage 9 enforced the 300-second Caldera timeout and recorded `ALLOW_FAIL` with exit 124
- `scripts/rue fmt`
- `bash -n scripts/rue-1091-measurement.sh`
- schedule-permutation stage rerun after rebasing onto current trunk