### PR TITLE
RUE-1091: rethread named method declaration seams

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -2364,9 +2364,15 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                 }
 
                 sema.body_analysis_work.named_method_record_lookups += 1;
-                let Some(method_ref) =
-                    call_facts(sema).named_method_declaration(struct_id, method_name)
-                else {
+                let owner_name = sema
+                    .interner
+                    .get(&type_name_str)
+                    .expect("named struct definition must retain its interned source name");
+                let Some(method_ref) = call_facts(sema).named_method_declaration(
+                    struct_def.file_id,
+                    owner_name,
+                    method_name,
+                ) else {
                     debug_assert!(
                         false,
                         "gathered named MethodInfo must have a private declaration record"

--- a/crates/rue-air/src/sema/body_endpoint.rs
+++ b/crates/rue-air/src/sema/body_endpoint.rs
@@ -101,8 +101,14 @@ pub(in crate::sema) trait BodyEndpointProvider {
     /// The first free-function RIR declaration for `(source, file)`.
     fn first_free_function(&self, source: Spur, file_id: FileId) -> Option<InstRef>;
 
-    /// The named-method RIR declaration for `(struct, name)`.
-    fn named_method_declaration(&self, struct_id: StructId, name: Spur) -> Option<InstRef>;
+    /// The named-method RIR declaration for the durable-available
+    /// `(owner_file, owner_type_name, method_name)` preimage.
+    fn named_method_declaration(
+        &self,
+        owner_file: FileId,
+        owner_type_name: Spur,
+        method_name: Spur,
+    ) -> Option<InstRef>;
 
     /// The destructor declaration record for `(file, type_name)`.
     fn destructor(&self, file: u32, type_name: Spur) -> Option<RirDestructorDeclaration>;
@@ -211,10 +217,19 @@ impl BodyEndpointProvider for EpochFacts<'_, '_> {
             .first_free_function(source, Some(file_id))
     }
 
-    fn named_method_declaration(&self, struct_id: StructId, name: Spur) -> Option<InstRef> {
+    fn named_method_declaration(
+        &self,
+        owner_file: FileId,
+        owner_type_name: Spur,
+        method_name: Spur,
+    ) -> Option<InstRef> {
+        let struct_id = self
+            .sema
+            .structs_by_file_name
+            .get(&(owner_file, owner_type_name))?;
         self.sema
             .named_method_declarations
-            .get(&(struct_id, name))
+            .get(&(*struct_id, method_name))
             .copied()
     }
 
@@ -386,14 +401,10 @@ pub(in crate::sema) fn resolve_instance_type<P: BodyEndpointProvider>(
 //   - `nominal_contains_in_module`                                          → C
 // Deferred here, each with its unblocking slice named (reported, never silently
 // answered wrong):
-//   - the `(StructId, name)`-keyed `BodyEndpointProvider::named_method_
-//     declaration` trait op → RE-DEFERRED by r4b-3 to the side-B fill / flip. The
-//     pool mints its own `StructId`s and exposes no `StructId → (owner_file,
-//     owner_type_name)` reverse surface, so a clean trait translation is not
-//     available now; this driver answers the op by its provider-natural preimage
-//     `(owner_file, owner_type_name, method)` on an inherent method (the r4a-2c
-//     "prefer rethreading" resolution), and the `StructId`-keyed trait signature
-//     returns `None` here.
+//   - `named_method_declaration` → LANDED (flip-prep): the production seam now
+//     takes the provider-natural `(owner_file, owner_type_name, method_name)`
+//     preimage already computed by its analyzer caller, so this driver answers
+//     it directly from the RIR index without minting a pool `StructId`.
 //   - `function_info` / `function_by_file_name` → r4b-1's `ProviderCallFacts`
 //     (the call family); `method_info` → r4b-3's `ProviderCallFacts::method_info`
 //     (receiver→pool identity now threaded through the durable method key). Both
@@ -549,10 +560,8 @@ where
 
     /// (R) The named-method RIR declaration for `(owner_file, owner_type_name,
     /// method)` — the durable-available preimage of the epoch's `(StructId,
-    /// method)` key, answered by [`BodyRirIndex`]. Keyed by the preimage DIRECTLY
-    /// (provider-natural), the r4a-2c "prefer rethreading" resolution: the
-    /// `StructId`-keyed `BodyEndpointProvider::named_method_declaration` trait
-    /// signature stays a r4b-3 seam translation (it returns `None` here).
+    /// method)` key, answered by [`BodyRirIndex`]. Keyed by the preimage directly
+    /// (provider-natural), matching the production seam.
     pub fn named_method_declaration(
         &self,
         owner_file: FileId,
@@ -752,10 +761,14 @@ where
         None
     }
 
-    fn named_method_declaration(&self, _struct_id: StructId, _name: Spur) -> Option<InstRef> {
-        // The `StructId`-keyed seam translation is r4b-3; the preimage-keyed
-        // answer is the inherent `named_method_declaration(FileId, &str, &str)`.
-        None
+    fn named_method_declaration(
+        &self,
+        owner_file: FileId,
+        owner_type_name: Spur,
+        method_name: Spur,
+    ) -> Option<InstRef> {
+        self.rir_index
+            .named_method_declaration(owner_file, owner_type_name, method_name)
     }
 
     fn destructor(&self, _file: u32, _type_name: Spur) -> Option<RirDestructorDeclaration> {

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -2604,10 +2604,9 @@ mod tests {
         ] {
             let owner = interner.get(type_name).unwrap();
             let method_sym = interner.get(method);
-            // The epoch keys by the pool-minted StructId; the index keys by the
-            // durable-available (file, type_name) preimage of that StructId.
-            let struct_id = facts.struct_by_file_name(file, owner).unwrap();
-            let epoch_ans = method_sym.and_then(|m| facts.named_method_declaration(struct_id, m));
+            // Both seams now take the durable-available
+            // (file, type_name, method_name) preimage.
+            let epoch_ans = method_sym.and_then(|m| facts.named_method_declaration(file, owner, m));
             let pool_ans = method_sym.and_then(|m| index.named_method_declaration(file, owner, m));
             assert_eq!(
                 pool_ans, epoch_ans,
@@ -2751,7 +2750,7 @@ mod tests {
         let declaration = index.named_method_declaration(file, widget, bump).unwrap();
         assert_eq!(
             Some(declaration),
-            facts.named_method_declaration(struct_id, bump),
+            facts.named_method_declaration(file, widget, bump),
             "index locates the epoch's method declaration"
         );
         let handle = method_handle_from_rir(bs, declaration);

--- a/crates/rue-air/src/sema/call_resolution.rs
+++ b/crates/rue-air/src/sema/call_resolution.rs
@@ -95,9 +95,15 @@ pub(in crate::sema) trait CallResolutionFacts {
     /// `Sema::named_method_by_callable_symbol`.
     fn named_method_by_callable_symbol(&self, name: Spur) -> Option<(StructId, Spur, MethodInfo)>;
 
-    /// The named-method RIR declaration for `(struct, name)`. Mirrors
-    /// `named_method_declarations.get`.
-    fn named_method_declaration(&self, struct_id: StructId, name: Spur) -> Option<InstRef>;
+    /// The named-method RIR declaration for the durable-available
+    /// `(owner_file, owner_type_name, method_name)` preimage. Mirrors
+    /// `structs_by_file_name.get` followed by `named_method_declarations.get`.
+    fn named_method_declaration(
+        &self,
+        owner_file: FileId,
+        owner_type_name: Spur,
+        method_name: Spur,
+    ) -> Option<InstRef>;
 
     /// The module definition for a module id. Mirrors
     /// `module_registry.get_def`.
@@ -159,10 +165,19 @@ impl CallResolutionFacts for EpochFacts<'_, '_> {
             .map(|(struct_id, method, info)| (struct_id, method, *info))
     }
 
-    fn named_method_declaration(&self, struct_id: StructId, name: Spur) -> Option<InstRef> {
+    fn named_method_declaration(
+        &self,
+        owner_file: FileId,
+        owner_type_name: Spur,
+        method_name: Spur,
+    ) -> Option<InstRef> {
+        let struct_id = self
+            .sema
+            .structs_by_file_name
+            .get(&(owner_file, owner_type_name))?;
         self.sema
             .named_method_declarations
-            .get(&(struct_id, name))
+            .get(&(*struct_id, method_name))
             .copied()
     }
 
@@ -271,14 +286,10 @@ pub(in crate::sema) fn resolve_static_call_reference<P: CallResolutionFacts>(
 //     rue-air-internal `ModuleId` registry index the provider has no durable
 //     preimage for; the module-facts + logical-path composition an equivalent
 //     could be built from belongs with the flip's module registry.
-//   - named_method_declaration (the `StructId`-keyed CallResolutionFacts /
-//     BodyEndpointProvider trait op) → RE-DEFERRED to the side-B fill / flip. The
-//     pool mints its own `StructId`s and exposes no `StructId → (owner_file,
-//     owner_type_name)` reverse surface, so a clean StructId-keyed trait
-//     translation is not available now; this driver answers the op by its
-//     provider-natural preimage (the inherent `named_method_declaration`), the
-//     r4a-2c "prefer rethreading" resolution — the analyzer computes the preimage
-//     at the call site, so the trait rethreading is a flip concern.
+//   - named_method_declaration → LANDED (flip-prep). Both seams now take the
+//     provider-natural `(owner_file, owner_type_name, method_name)` preimage;
+//     the epoch adapter alone translates it through `structs_by_file_name` to
+//     the epoch map's `(StructId, method_name)` key.
 //   - source_function_name under specialization → r5 (the specialization name
 //     map); identity otherwise.
 // ---------------------------------------------------------------------------
@@ -401,14 +412,9 @@ where
     /// `named_method_declarations.get` under the `struct_by_file_name`
     /// bijection.
     ///
-    /// This driver keys the op by the preimage DIRECTLY (provider-natural), which
-    /// IS the r4a-2c "prefer rethreading" resolution: it never mints or consults a
-    /// pool `StructId`, so the endpoint seam's production trait signature stays
-    /// untouched. The `StructId`-keyed `CallResolutionFacts::named_method_
-    /// declaration(StructId, name)` trait impl — which must map its incoming
-    /// `StructId` back to this preimage — is the endpoint-seam slice r4b-3's
-    /// concern (it owns receiver→pool identity); r4b-1 exposes the preimage-keyed
-    /// answer the flip will drive.
+    /// This driver keys the op by the preimage directly (provider-natural), the
+    /// r4a-2c "prefer rethreading" resolution. It never mints or consults a pool
+    /// `StructId`; the production seam now carries this same preimage.
     pub fn named_method_declaration(
         &self,
         owner_file: FileId,

--- a/crates/rue-air/src/sema/one_body.rs
+++ b/crates/rue-air/src/sema/one_body.rs
@@ -1561,8 +1561,11 @@ fn analyze_named_method(
             CompileError::without_span(ErrorKind::UndefinedFunction(endpoint.name.to_string())),
         );
     };
-    let Some(declaration) = endpoint_facts(sema).named_method_declaration(struct_id, method_name)
-    else {
+    let Some(declaration) = endpoint_facts(sema).named_method_declaration(
+        FileId::new(endpoint.file),
+        owner_symbol,
+        method_name,
+    ) else {
         return fail(
             sema,
             None,

--- a/docs/notes/rue-1091-analyzer-rewire-plan.md
+++ b/docs/notes/rue-1091-analyzer-rewire-plan.md
@@ -439,11 +439,10 @@ and it fails closed on absent, ambiguous-receiver, wrong-`self`-form, and non-ma
   `shell.declaration_span`. They coincide for inline declarations, and r4b's real handle-fill must
   preserve `inst.span == shell.declaration_span` (or source from the shell) — assert it, don't
   assume it.
-- **The endpoint trait's `named_method_declaration(StructId, name)` signature needs a seam
-  translation in r4b.** The pool answers by the durable preimage `(owner_file, owner_type_name,
-  method_name)` and mints its own StructIds, so the pool-backed impl must either rethread the seam
-  to pass the preimage (the one_body.rs consumer already computes it at the call site) or keep a
-  `StructId → (file, name)` reverse map. Prefer rethreading.
+- **The endpoint trait's `named_method_declaration` seam is rethreaded.** Both production traits
+  now take the durable preimage `(owner_file, owner_type_name, method_name)`. `one_body.rs` passes
+  the preimage it already used to derive the epoch `StructId`; `analysis.rs` passes the named
+  owner's `StructDef.file_id` and interned source name. No pool-side reverse map is needed.
 
 **r4a-1 review carry-forwards (recorded obligations, not defects).**
 - **Bare-owner reversal divergence → r4b differential xfail.** The epoch's callable index contains


### PR DESCRIPTION
## Summary

- rekey `CallResolutionFacts::named_method_declaration` and `BodyEndpointProvider::named_method_declaration` to `(owner_file, owner_type_name, method_name)`
- preserve epoch behavior by deriving the existing `StructId` through `structs_by_file_name` before consulting the unchanged declaration map
- pass the already-held preimage at both production callers and retire the corresponding pool-side deferral notes

`analysis.rs` already retains the named owner preimage through `StructDef.file_id` and `StructDef.name`, so no registration-time reverse map was added.

Refs RUE-1091.

## Validation

- stash/baseline/restore/diff proof on `examples/wordfreq/main.rue`, `examples/dijkstra/main.rue`, and method-dense `examples/rill/main.rue`: AIR, dependency envelope, stderr, and exit status all byte-identical
- rue-air unit suite: 605 passed
- rue-compiler unit suite: 814 passed
- `scripts/rue quick`: 36 targets passed, including frontend and oracle differentials
- Clippy: 66 first-party targets passed
- `scripts/rue fmt`
- body-analysis capability inventory tests and root validator
- type-architecture inventory tests and root validator