### PR TITLE
[BLOCKED until RUE-1091 measurement] Restore the large-program compile guard

### DIFF
--- a/.github/workflows/large-examples.yml
+++ b/.github/workflows/large-examples.yml
@@ -61,9 +61,29 @@ jobs:
 
       - name: Compile every large example
         run: |
-          # RUE-1083 temporary contingency: the query-cutover regression makes
-          # this guard occupy a runner and hold the merge queue for tens of
-          # minutes. Keep the configured job and step present, but return true
-          # until the post-identity-cut repair restores the real bounded corpus.
-          # RUE-1083 owns removal of this stub and restoration of the loop.
-          true
+          RUE="$(scripts/rue-bin --target-platforms //platforms:release)"
+          export RUE_STD_PATH="$PWD/std"
+          status=0
+          for example in rill mosaic harbor lattice meridian caldera; do
+            root="examples/$example/main.rue"
+            echo "::group::$example"
+            start=$(date +%s)
+            if timeout 3600 "$RUE" "$root" -o "/tmp/$example.bin"; then
+              echo "$example compiled in $(( $(date +%s) - start ))s"
+            else
+              code=$?
+              if [ "$example" = caldera ] && [ "$code" -eq 124 ]; then
+                # RUE-1083: Caldera compiles correctly but the query-cutover
+                # performance regression can still push it past this guard's
+                # timeout. Pure slowness is the tracked performance follow-up,
+                # not a compile-correctness regression; a real compile error
+                # still fails this job.
+                echo "::warning::caldera exceeded the guard timeout after $(( $(date +%s) - start ))s (RUE-1083 performance follow-up pending)"
+              else
+                echo "::error::$example failed to compile (exit $code) after $(( $(date +%s) - start ))s"
+                status=1
+              fi
+            fi
+            echo "::endgroup::"
+          done
+          exit $status


### PR DESCRIPTION
## Summary

- restore the real six-example compile loop that PR #1896 temporarily replaced with `true`
- preserve the historical 120-minute job limit and 3,600-second per-example limit, including the warning-only timeout behavior for Caldera
- retain the current release compiler target and all six current example roots; no target-name drift was present on trunk

## Pre-flip validation

- `git diff --check`
- YAML parse of `.github/workflows/large-examples.yml`
- `bash -n` over the embedded guard script
- `./buck2 build --target-platforms //platforms:release //crates/rue:rue`
- real local compile and execution of `examples/rill/main.rue` through `scripts/rue-bin --target-platforms //platforms:release`
- CI `actionlint` passed
- the restored full six-example guard passed in run 30110349716, with measured compile times: Rill 6s, Mosaic 13s, Harbor 54s, Lattice 54s, Meridian 336s, and Caldera 2,825s

The full pre-flip run proves the workflow plumbing and compile correctness, but it also confirms the performance gate is not met: Caldera remains far above the intended 300-second cold budget, and Meridian remains above its intended budget. These timings are pre-flip evidence only, not the required RUE-1091 post-flip measurement.

## Merge gate

This draft merges only after the RUE-1091 step-6 gauntlet passes and the post-flip full-corpus measurement confirms the guard is suitable to re-enable. Plumbing-only validation is not sufficient to merge it.

Before leaving draft, resolve the review carry-forwards against the post-flip measurements: make the Caldera timeout a hard failure and reconcile the 120-minute job cap with the per-example limits so the intended classifier remains authoritative.

Refs RUE-1083.

skip RUE-1091