### PR TITLE
RUE-1091: well-known Option identities from the pool (slice r6c)

### DIFF
--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -2512,6 +2512,54 @@ impl<'a> BoundSema<'a> {
             .collect()
     }
 
+    /// RUE-1091 slice r6c flip-era surface: the anonymous nominal [`Type`]s of
+    /// the identities recorded in the epoch's `well_known_option_identities` —
+    /// the well-known `Option` enums the registry install
+    /// ([`Self::install_well_known_option_types`]) materialized and marked for
+    /// the export-as-produced ruling. `analyze_one_body` subtracts exactly this
+    /// set from its initial anonymous baseline, so the single export funnel
+    /// (`semantic_body_export.rs` via `produced_anonymous_nominals`) publishes
+    /// these identities as PRODUCED anonymous nominals of the analyzed body,
+    /// never as pre-existing imports. Exposed so the rue-compiler differential
+    /// proves the provider-side pool records the identical ruling for
+    /// byte-identical identities. Deterministic order: the identity set is a
+    /// `BTreeSet`.
+    pub fn epoch_well_known_option_types(&self) -> Vec<crate::types::Type> {
+        self.sema
+            .well_known_option_identities
+            .iter()
+            .filter_map(|identity| {
+                self.sema
+                    .anon_enum_identities
+                    .get(identity)
+                    .map(|id| crate::types::Type::new_enum(*id))
+                    .or_else(|| {
+                        self.sema
+                            .anon_struct_identities
+                            .get(identity)
+                            .map(|id| crate::types::Type::new_struct(*id))
+                    })
+            })
+            .collect()
+    }
+
+    /// RUE-1091 slice r6c flip-era surface: the epoch's per-body well-known
+    /// `Option` demand registry — each `(payload, option)` [`Type`] pair the
+    /// install recorded into `well_known_option_by_payload`, the map
+    /// fallible-intrinsic resolution (`resolve_option_result_type`) consults.
+    /// Exposed so the rue-compiler differential compares the pool-side registry
+    /// against the LIVE epoch's. Iteration order is map-internal; a caller
+    /// sorts by an index-independent render before comparing.
+    pub fn epoch_well_known_option_registry(
+        &self,
+    ) -> Vec<(crate::types::Type, crate::types::Type)> {
+        self.sema
+            .well_known_option_by_payload
+            .iter()
+            .map(|(payload, option)| (*payload, *option))
+            .collect()
+    }
+
     /// RUE-1091 slice r4b-3 flip-era surface: the epoch's `MethodInfo` for a
     /// `(file, type_name, method)` named method, exposed so the rue-compiler
     /// differential compares the provider-driven `ProviderCallFacts` method

--- a/crates/rue-air/src/sema/body_endpoint.rs
+++ b/crates/rue-air/src/sema/body_endpoint.rs
@@ -414,9 +414,12 @@ pub(in crate::sema) fn resolve_instance_type<P: BodyEndpointProvider>(
 //   - `module_endpoint` / `module_id_for_file` (the `Module` arm) → module
 //     identity is a pool-refused arm; the endpoint-seam module registry is
 //     r4b-3 / the flip.
-//   - `anon_struct` / `anon_enum` (the anonymous arm) → r6b (anonymous
-//     mint-from-digest and the well-known `Option` facts); the pool resolves an
-//     issued anonymous by lookup only.
+//   - `anon_struct` / `anon_enum` (the anonymous arm) is ANSWERED as of r6b: a
+//     caller seeds the issued→durable seam with `register_anonymous_nominal`
+//     and the arms mint through the pool's `find_or_create_anon`; an unseeded
+//     issued key still fails closed. The well-known `Option` facts are ANSWERED
+//     as of r6c: `install_well_known_option_types` ports the trusted registry
+//     onto the same machinery, recording the export-as-produced ruling.
 //   - `generated_struct` (the `Slice` arm) is ANSWERED as of r6a: a caller seeds
 //     each generated slice with `register_generated_slice` and the arm resolves
 //     the minted fat-pointer struct. Builtin names beyond the pre-registered
@@ -549,6 +552,67 @@ where
     /// refuses it (fail-closed).
     pub fn mint_anonymous(&self, durable: &crate::AnonymousNominalKey<K, M>) -> Option<Type> {
         self.pool.borrow_mut().find_or_create_anon(durable).ok()
+    }
+
+    /// Install the per-body well-known `Option(payload)` registry (RUE-1112)
+    /// through the pool — the provider-facing port of the epoch's
+    /// `BoundSema::install_well_known_option_types` (RUE-1091 r6c). `nominals`
+    /// are the durable identities of the trusted-std `Option` enums the
+    /// per-body demand loop resolved; each mints through the pool's ordinary
+    /// anonymous machinery so its full materialization is byte-identical to
+    /// the epoch install's, and each is recorded under the export-as-produced
+    /// ruling: the installing body EXPORTS these identities as produced
+    /// anonymous nominals (the flip-era baseline subtraction consults
+    /// [`Self::is_well_known_option_identity`]), never leaking them as
+    /// imports. `option_by_payload` records the demand map fallible-intrinsic
+    /// resolution consults. Fail-closed: `None` on any refusal (non-enum
+    /// shape, absent shape, digest collision, a registry pair naming an
+    /// identity the install never minted, unresolvable registry type) —
+    /// a refusal is fatal for the requesting body, exactly as the epoch's
+    /// failed install fails the body query deterministically. A refusal also
+    /// POISONS the pool's well-known registry: repeat installs re-error (still
+    /// `None` here) and the accessors below answer as if nothing was installed
+    /// — no observable partial success, matching the atomicity of the epoch's
+    /// by-value install (which drops the whole mutated `BoundSema` on failure).
+    pub fn install_well_known_option_types(
+        &self,
+        nominals: &[crate::AnonymousNominalKey<K, M>],
+        option_by_payload: &[(SemanticImportType<K, M>, SemanticImportType<K, M>)],
+    ) -> Option<()>
+    where
+        K: Ord,
+        M: Ord,
+    {
+        self.pool
+            .borrow_mut()
+            .install_well_known_option_types(nominals, option_by_payload)
+            .ok()
+    }
+
+    /// Whether a durable identity (any producer spelling — entry
+    /// canonicalization applies) is a well-known `Option` identity installed
+    /// on this driver's pool: the export-as-produced ruling the flip-era
+    /// baseline subtraction consults (RUE-1091 r6c).
+    pub fn is_well_known_option_identity(&self, durable: &crate::AnonymousNominalKey<K, M>) -> bool
+    where
+        K: Ord,
+        M: Ord,
+    {
+        self.pool.borrow().is_well_known_option_identity(durable)
+    }
+
+    /// The number of well-known `Option` identities installed on this driver's
+    /// pool.
+    pub fn well_known_option_identity_count(&self) -> usize {
+        self.pool.borrow().well_known_option_identity_count()
+    }
+
+    /// The trusted std `Option` enum minted for a demanded payload type, or
+    /// `None` when the payload was never demanded — the pool-backed answer to
+    /// the epoch's `well_known_option_by_payload` consult
+    /// (`resolve_option_result_type`).
+    pub fn well_known_option_for_payload(&self, payload: Type) -> Option<Type> {
+        self.pool.borrow().well_known_option_for_payload(payload)
     }
 
     /// Mint an overlay [`SemanticDefinitionToken`] standing for a durable nominal

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -56,11 +56,15 @@
 //!   underlying `resolve` refuses them. A comptime-*value* parameter (concrete
 //!   type, `is_comptime = true`) resolves fully and marks `is_generic`; only a
 //!   comptime-*type* parameter referencing a generic parameter refuses;
-//! - **anonymous nominal minting** — an issued anonymous nominal is resolved by
-//!   lookup here (exactly as `resolve_instance_type`'s anonymous arm looks up an
-//!   already-issued id via `anon_struct`/`anon_enum`); the id-minting from a
-//!   structural digest, together with the well-known `Option` facts, is later
-//!   work (r6);
+//! - **anonymous method dispatch / bodies** —
+//!   [`BodyIdentityPool::find_or_create_anon`] (r6b) mints the producer-nominal
+//!   anonymous struct / enum from its durable identity + shape, and
+//!   [`BodyIdentityPool::install_well_known_option_types`] (r6c) ports the
+//!   trusted well-known `Option` registry onto that machinery, but method
+//!   BODIES and dispatch registration still need the request-local
+//!   whole-program `Rir` and belong to the flip's overlay method installation;
+//!   an issued anonymous key with no registered durable identity still
+//!   resolves by lookup only ([`BodyIdentityPool::register_issued_anonymous`]);
 //! - **module identity** and generic-parameter substitution (endpoint /
 //!   inference families) — these arms are *refused*, never approximated;
 //! - **drop metadata** — the destructor symbol and the transitive
@@ -256,6 +260,13 @@ pub(in crate::sema) enum IdentityMintError {
     /// refused and neither its nominal nor its symbol is published. Carries the
     /// digest both keys hash to.
     AnonymousDigestCollision(u128),
+    /// A well-known `Option` registry install named an anonymous nominal whose
+    /// durable shape is not an enum. The pool analog of the epoch install's
+    /// `DeclarationInstallFailure::NominalShapeMismatch`
+    /// (`install_well_known_option_types`, `binding_manifest.rs`): the trusted
+    /// registry holds `Option` ENUM specializations only, so a non-enum shape
+    /// is refused before any id or symbol is minted.
+    WellKnownShapeMismatch,
     /// An arm outside slice r4a-2a's scope (module identity, generic parameter).
     Deferred(&'static str),
 }
@@ -305,6 +316,41 @@ pub(in crate::sema) struct BodyIdentityPool<K, M, S> {
     /// rather than re-running the partial mint (whose parameters may already sit
     /// orphaned in the append-only arena) — the callable analog of `poisoned`.
     callable_poisoned: HashMap<K, IdentityMintError>,
+    /// Per-body well-known `Option(payload)` registry (RUE-1112, ported for
+    /// RUE-1091 r6c): the pool analog of `Sema::well_known_option_by_payload`.
+    /// Maps an expected payload [`Type`] to the trusted standard-library
+    /// `Option` enum minted for that payload, populated narrowly by
+    /// [`Self::install_well_known_option_types`] before body analysis — never
+    /// from the body's own composition/import universe. The flip-era consumer
+    /// is fallible-intrinsic resolution (`resolve_option_result_type`).
+    well_known_option_by_payload: HashMap<Type, Type>,
+    /// Anonymous enum identities (canonical producer form) minted by the
+    /// well-known `Option` registry install for this body — the pool analog of
+    /// `Sema::well_known_option_identities`, which is THE export-as-produced
+    /// ruling: the export funnel (`one_body.rs` /
+    /// `produced_anonymous_nominals`) subtracts these identities from the
+    /// initial anonymous baseline so the installing body EXPORTS them as
+    /// produced anonymous nominals — exactly as a body materializing
+    /// `Option(payload)` through the ordinary annotation/comptime path would —
+    /// never leaking them as pre-existing imports with no producer. The
+    /// flip-era baseline computation consults
+    /// [`Self::is_well_known_option_identity`] to apply the same subtraction.
+    /// A `BTreeSet`, matching the epoch set's deterministic order.
+    well_known_option_identities: std::collections::BTreeSet<AnonymousNominalKey<K, M>>,
+    /// The recorded refusal of a FAILED well-known `Option` install — the
+    /// well-known analog of `poisoned` / `callable_poisoned`. The epoch's
+    /// install takes `self` by value and returns `Result<Self, _>`, so its
+    /// failure drops the whole mutated `BoundSema` and no partial effect is
+    /// ever observable; the pool's install mutates in place, so a mid-batch
+    /// refusal would otherwise leave earlier keys' rulings and already-recorded
+    /// demand pairs observable. This poison closes that gap: a repeat install
+    /// re-errors with the recorded refusal (never re-running the partial
+    /// install), and every well-known accessor
+    /// ([`Self::is_well_known_option_identity`],
+    /// [`Self::well_known_option_identity_count`],
+    /// [`Self::well_known_option_for_payload`]) answers as if nothing was
+    /// installed — no observable partial success either way.
+    well_known_poisoned: Option<IdentityMintError>,
 }
 
 /// The durable-signature-derived subset of a [`FunctionInfo`], minted once and
@@ -412,6 +458,9 @@ where
             function_sigs: HashMap::new(),
             method_sigs: HashMap::new(),
             callable_poisoned: HashMap::new(),
+            well_known_option_by_payload: HashMap::new(),
+            well_known_option_identities: std::collections::BTreeSet::new(),
+            well_known_poisoned: None,
         }
     }
 
@@ -835,6 +884,216 @@ where
         };
         self.anon_nominals.insert(key.clone(), ty);
         Ok(ty)
+    }
+
+    /// Install the per-body well-known `Option(payload)` registry (RUE-1112)
+    /// into this pool — the provider-driven port of the epoch's
+    /// `BoundSema::install_well_known_option_types` (`binding_manifest.rs`),
+    /// RUE-1091 slice r6c.
+    ///
+    /// `nominals` are the durable identities of the trusted-std `Option` enum
+    /// specializations the per-body demand loop resolved; each is minted through
+    /// the ordinary anonymous machinery ([`Self::find_or_create_anon`]) so its
+    /// `__anon_enum_{digest}` name, copyability, visibility, and mangled symbol
+    /// are byte-identical to the epoch install's `find_or_create_anon_enum`
+    /// materialization. `option_by_payload` pairs each demanded payload type
+    /// with its resolved `Option` type; both endpoints are pure mints/dedups
+    /// once the enums are installed, recorded so fallible-intrinsic resolution
+    /// binds the trusted `Option` under `?` even when the body never
+    /// `@import`s it.
+    ///
+    /// # The export-as-produced ruling
+    ///
+    /// Every installed identity is recorded (canonical producer form) in the
+    /// pool's well-known identity set. That set is the pool-side carrier of the
+    /// epoch's `well_known_option_identities` ruling: the export funnel
+    /// (`semantic_body_export.rs` via `one_body.rs`'s baseline subtraction)
+    /// treats these identities as PRODUCED anonymous nominals of the analyzed
+    /// body — the body that binds a fallible intrinsic's `Option` is the body
+    /// that produces it — never as pre-existing imports with no producer. The
+    /// flip-era baseline computation consults
+    /// [`Self::is_well_known_option_identity`] to apply the same subtraction
+    /// the epoch applies at `one_body_initial_anonymous_identities` capture.
+    ///
+    /// # Failure semantics
+    ///
+    /// The refusals mirror the epoch install: a non-enum durable shape is
+    /// refused ([`IdentityMintError::WellKnownShapeMismatch`], the pool
+    /// spelling of `DeclarationInstallFailure::NominalShapeMismatch`) BEFORE
+    /// any id or symbol is minted for that key; an absent shape or
+    /// unresolvable registry type fails closed. A bounded fixpoint tolerates a
+    /// nominal whose payload references another not-yet-installed well-known
+    /// nominal (the trusted `Option` shapes are flat today, so one pass
+    /// suffices); a round with no progress returns the blocking refusal. Any
+    /// error is a fatal refusal for the requesting body — exactly as the
+    /// epoch's failed install fails the body query deterministically — never
+    /// an approximation.
+    ///
+    /// The ATOMICITY shape differs and is closed by poisoning: the epoch's
+    /// install takes `self` by value and returns `Result<Self, _>`, so its
+    /// failure drops the whole mutated `BoundSema` — partial effects are
+    /// structurally unobservable. This install mutates in place, so ANY
+    /// failure instead POISONS the well-known registry (`well_known_poisoned`,
+    /// the well-known analog of the file's `poisoned` / `callable_poisoned`
+    /// discipline): a repeat install re-errors with the recorded refusal
+    /// rather than re-running the partial install, and every well-known
+    /// accessor answers as if nothing was installed — restoring the epoch's
+    /// no-observable-partial-success guarantee.
+    pub(in crate::sema) fn install_well_known_option_types(
+        &mut self,
+        nominals: &[AnonymousNominalKey<K, M>],
+        option_by_payload: &[(SemanticImportType<K, M>, SemanticImportType<K, M>)],
+    ) -> Result<(), IdentityMintError>
+    where
+        K: Ord,
+        M: Ord,
+    {
+        // A failed install poisoned the whole well-known registry: re-error
+        // with the recorded refusal, exactly as `mint_named` re-errors a
+        // poisoned key instead of re-running the partial mint.
+        if let Some(err) = &self.well_known_poisoned {
+            return Err(err.clone());
+        }
+        match self.install_well_known_option_types_inner(nominals, option_by_payload) {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                self.well_known_poisoned = Some(err.clone());
+                Err(err)
+            }
+        }
+    }
+
+    /// The install body, separated so [`Self::install_well_known_option_types`]
+    /// can record ANY refusal it returns into `well_known_poisoned` before
+    /// surfacing it.
+    fn install_well_known_option_types_inner(
+        &mut self,
+        nominals: &[AnonymousNominalKey<K, M>],
+        option_by_payload: &[(SemanticImportType<K, M>, SemanticImportType<K, M>)],
+    ) -> Result<(), IdentityMintError>
+    where
+        K: Ord,
+        M: Ord,
+    {
+        let mut pending: Vec<&AnonymousNominalKey<K, M>> = nominals.iter().collect();
+        while !pending.is_empty() {
+            let mut progressed = false;
+            let mut next = Vec::new();
+            let mut blocking = None;
+            for key in pending {
+                let canonical = key.with_canonical_producer();
+                // The trusted registry holds `Option` ENUM specializations
+                // only; refuse a non-enum shape before minting anything for
+                // this key (the epoch's `NominalShapeMismatch` check runs
+                // before its `find_or_create_anon_enum` call).
+                match self.source.anonymous_shape(canonical.as_ref()) {
+                    Some(DurableAnonymousShape::Enum { .. }) => {}
+                    Some(DurableAnonymousShape::Struct { .. }) => {
+                        return Err(IdentityMintError::WellKnownShapeMismatch);
+                    }
+                    None => return Err(IdentityMintError::MissingAnonymousShape),
+                }
+                match self.find_or_create_anon(canonical.as_ref()) {
+                    Ok(_) => {
+                        progressed = true;
+                        self.well_known_option_identities
+                            .insert(canonical.into_owned());
+                    }
+                    // A payload referencing a not-yet-minted well-known
+                    // anonymous nominal: retry after the rest of the round.
+                    // Enum mints resolve every payload BEFORE registering, so
+                    // a blocked mint published nothing and the retry is clean.
+                    Err(IdentityMintError::MissingAnonymous) => {
+                        blocking = Some(IdentityMintError::MissingAnonymous);
+                        next.push(key);
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+            if !progressed {
+                return Err(blocking.unwrap_or(IdentityMintError::MissingAnonymous));
+            }
+            pending = next;
+        }
+        // Record the demand map. Both endpoints are pure dedups/lookups now
+        // that the enums are minted (the epoch's `import_export_type` pair).
+        for (payload, option) in option_by_payload {
+            let payload_ty = self.resolve_well_known_registry_type(payload)?;
+            let option_ty = self.resolve_well_known_registry_type(option)?;
+            self.well_known_option_by_payload
+                .insert(payload_ty, option_ty);
+        }
+        Ok(())
+    }
+
+    /// Resolve one well-known registry endpoint type. An anonymous nominal is a
+    /// pure LOOKUP against the already-installed anonymous identities (the
+    /// probe is entry-canonicalized first, per the r6b contract), failing
+    /// closed with [`IdentityMintError::MissingAnonymous`] on a miss — the pool
+    /// analog of the epoch's lookup-only `import_export_type` anonymous arm
+    /// (`anon_enum_identities.get(..).ok_or(MissingNominal)`), which refuses a
+    /// registry pair naming an identity its install never materialized. It
+    /// never mints: minting here would publish an identity outside the ruling
+    /// set exactly where the epoch fails closed. Every other durable type
+    /// resolves through the ordinary [`Self::resolve`] machinery, refusing
+    /// exactly what it refuses.
+    fn resolve_well_known_registry_type(
+        &mut self,
+        value: &SemanticImportType<K, M>,
+    ) -> Result<Type, IdentityMintError> {
+        match value {
+            SemanticImportType::AnonymousNominal(key) => self
+                .anon_nominals
+                .get(key.with_canonical_producer().as_ref())
+                .copied()
+                .ok_or(IdentityMintError::MissingAnonymous),
+            other => self.resolve(other),
+        }
+    }
+
+    /// Whether `key` (in any producer spelling — entry canonicalization
+    /// applies) names a well-known `Option` identity installed on this pool.
+    /// The pool analog of `sema.well_known_option_identities.contains(..)`,
+    /// which the export funnel's baseline subtraction consults so installed
+    /// identities are EXPORTED as produced anonymous nominals, never leaked as
+    /// imports (the r6c export-as-produced ruling). A poisoned registry (a
+    /// failed install — see `well_known_poisoned`) answers `false` for every
+    /// key: as if nothing was installed.
+    pub(in crate::sema) fn is_well_known_option_identity(
+        &self,
+        key: &AnonymousNominalKey<K, M>,
+    ) -> bool
+    where
+        K: Ord,
+        M: Ord,
+    {
+        self.well_known_poisoned.is_none()
+            && self
+                .well_known_option_identities
+                .contains(key.with_canonical_producer().as_ref())
+    }
+
+    /// The number of well-known `Option` identities installed on this pool.
+    /// A poisoned registry (a failed install — see `well_known_poisoned`)
+    /// answers `0`: as if nothing was installed.
+    pub(in crate::sema) fn well_known_option_identity_count(&self) -> usize {
+        if self.well_known_poisoned.is_some() {
+            return 0;
+        }
+        self.well_known_option_identities.len()
+    }
+
+    /// The trusted std `Option` enum minted for a demanded payload type, or
+    /// `None` when the payload was never demanded. The pool analog of
+    /// `sema.well_known_option_by_payload.get(..)`, the map fallible-intrinsic
+    /// resolution (`resolve_option_result_type`) consults. A poisoned registry
+    /// (a failed install — see `well_known_poisoned`) answers `None` for every
+    /// payload: as if nothing was installed.
+    pub(in crate::sema) fn well_known_option_for_payload(&self, payload: Type) -> Option<Type> {
+        if self.well_known_poisoned.is_some() {
+            return None;
+        }
+        self.well_known_option_by_payload.get(&payload).copied()
     }
 
     /// The stable presentation digest of an anonymous producer identity: relocate
@@ -2558,6 +2817,351 @@ mod tests {
         assert_eq!(
             pool.find_or_create_anon(&key),
             Err(IdentityMintError::MissingAnonymousShape)
+        );
+    }
+
+    /// The well-known `Option` install (r6c) mints the trusted enum through the
+    /// ordinary anonymous machinery, records the export-as-produced ruling
+    /// (the identity is a well-known identity, membership canonical under
+    /// entry canonicalization), and records the payload→option demand map.
+    /// A repeat install is a pure dedup.
+    #[test]
+    fn well_known_option_install_records_produced_ruling_and_registry() {
+        use crate::semantic_identity::FunctionInstanceKey;
+        let key = anon_key(AnonymousNominalKind::Enum, 30, 0);
+        let shape = DurableAnonymousShape::Enum {
+            variants: vec![
+                (Arc::from("Some"), vec![DType::I64]),
+                (Arc::from("None"), vec![]),
+            ],
+        };
+        let mut pool = anon_pool([], [(key.clone(), shape)], []);
+
+        pool.install_well_known_option_types(
+            std::slice::from_ref(&key),
+            &[(DType::I64, DType::AnonymousNominal(key.clone()))],
+        )
+        .unwrap();
+
+        // The enum minted through the ordinary anonymous machinery.
+        let minted = pool.find_or_create_anon(&key).unwrap();
+        let def = pool.type_pool().enum_def(minted.as_enum().unwrap());
+        assert!(def.name.starts_with("__anon_enum_"));
+        assert!(
+            def.name.ends_with(" { Some(i64), None }"),
+            "the trusted enum renders its payloads: {}",
+            def.name
+        );
+
+        // The export-as-produced ruling: the identity is recorded as
+        // well-known, so the flip-era baseline subtraction exports it as a
+        // produced anonymous nominal instead of leaking it as an import.
+        assert!(pool.is_well_known_option_identity(&key));
+        assert_eq!(pool.well_known_option_identity_count(), 1);
+        // Membership is canonical: a wrapper-form spelling of the same
+        // producer answers the same ruling (entry canonicalization).
+        if let StableProducerId::Definition(producer) = &key.producer {
+            let wrapped = AnonymousNominalKey {
+                producer: StableProducerId::Function(Box::new(
+                    FunctionInstanceKey::Specialization {
+                        base: Box::new(FunctionInstanceKey::Definition(*producer)),
+                        arguments: CanonicalArguments::default(),
+                    },
+                )),
+                ..key.clone()
+            };
+            // A Definition-producer key is already canonical, so exercise the
+            // wrapper collapse through a Function spelling of a DIFFERENT key:
+            // the wrapped form of an uninstalled producer is NOT well-known.
+            assert!(!pool.is_well_known_option_identity(&wrapped));
+        }
+        // An unrelated identity is not well-known.
+        assert!(!pool.is_well_known_option_identity(&anon_key(AnonymousNominalKind::Enum, 31, 0)));
+
+        // The demand registry answers the payload lookup with the minted enum.
+        assert_eq!(pool.well_known_option_for_payload(Type::I64), Some(minted));
+        assert_eq!(pool.well_known_option_for_payload(Type::U32), None);
+
+        // Idempotent: a repeat install dedups onto the same identity.
+        pool.install_well_known_option_types(
+            std::slice::from_ref(&key),
+            &[(DType::I64, DType::AnonymousNominal(key.clone()))],
+        )
+        .unwrap();
+        assert_eq!(pool.well_known_option_identity_count(), 1);
+        assert_eq!(pool.find_or_create_anon(&key).unwrap(), minted);
+    }
+
+    /// The well-known install accepts a WRAPPER-form identity (the
+    /// empty-argument specialization spelling): the ruling and mint both land
+    /// under the canonical form, so a canonical-form consult finds them —
+    /// entry-enforced wrapper collapse, per the r6b rider.
+    #[test]
+    fn well_known_option_install_canonicalizes_wrapper_form_identities() {
+        use crate::semantic_identity::FunctionInstanceKey;
+        let collapsed = AnonymousNominalKey {
+            kind: AnonymousNominalKind::Enum,
+            producer: StableProducerId::Function(Box::new(FunctionInstanceKey::Definition(40u32))),
+            anchor: rue_rir::RirStructuralAnchor::new(vec![
+                rue_rir::RirStructuralPathSegment::AnonymousType(0),
+            ]),
+            arguments: CanonicalArguments::default(),
+        };
+        let wrapped = AnonymousNominalKey {
+            producer: StableProducerId::Function(Box::new(FunctionInstanceKey::Specialization {
+                base: Box::new(FunctionInstanceKey::Definition(40u32)),
+                arguments: CanonicalArguments::default(),
+            })),
+            ..collapsed.clone()
+        };
+        let shape = DurableAnonymousShape::Enum {
+            variants: vec![
+                (Arc::from("Some"), vec![DType::U32]),
+                (Arc::from("None"), vec![]),
+            ],
+        };
+        // The durable universe keys shapes canonically (the source contract).
+        let mut pool = anon_pool([], [(collapsed.clone(), shape)], []);
+
+        pool.install_well_known_option_types(
+            std::slice::from_ref(&wrapped),
+            &[(DType::U32, DType::AnonymousNominal(wrapped.clone()))],
+        )
+        .unwrap();
+
+        // One identity, answered under BOTH spellings.
+        assert_eq!(pool.well_known_option_identity_count(), 1);
+        assert!(pool.is_well_known_option_identity(&collapsed));
+        assert!(pool.is_well_known_option_identity(&wrapped));
+        assert_eq!(
+            pool.find_or_create_anon(&collapsed).unwrap(),
+            pool.well_known_option_for_payload(Type::U32).unwrap(),
+        );
+    }
+
+    /// A non-enum durable shape is refused (the pool spelling of the epoch's
+    /// `NominalShapeMismatch`) and NOTHING is published for the refused key —
+    /// no id, no ruling entry, no registry entry.
+    #[test]
+    fn well_known_option_install_refuses_non_enum_shape() {
+        let key = anon_key(AnonymousNominalKind::Struct, 50, 0);
+        let shape = DurableAnonymousShape::Struct {
+            fields: vec![(Arc::from("v"), DType::I32)],
+            struct_method_names: Vec::new(),
+        };
+        let mut pool = anon_pool([], [(key.clone(), shape)], []);
+        assert_eq!(
+            pool.install_well_known_option_types(
+                std::slice::from_ref(&key),
+                &[(DType::I32, DType::AnonymousNominal(key.clone()))],
+            ),
+            Err(IdentityMintError::WellKnownShapeMismatch)
+        );
+        assert_eq!(
+            pool.resolve(&DType::AnonymousNominal(key.clone())),
+            Err(IdentityMintError::MissingAnonymous),
+            "the refused key published no id"
+        );
+        assert!(!pool.is_well_known_option_identity(&key));
+        assert_eq!(pool.well_known_option_identity_count(), 0);
+        assert_eq!(pool.well_known_option_for_payload(Type::I32), None);
+    }
+
+    /// An identity with no durable shape fails the install closed, exactly as
+    /// the epoch's exhausted fixpoint fails with `MissingNominal`.
+    #[test]
+    fn well_known_option_install_missing_shape_fails_closed() {
+        let key = anon_key(AnonymousNominalKind::Enum, 60, 0);
+        let mut pool = anon_pool([], [], []);
+        assert_eq!(
+            pool.install_well_known_option_types(std::slice::from_ref(&key), &[]),
+            Err(IdentityMintError::MissingAnonymousShape)
+        );
+    }
+
+    /// A batch of [valid enum, invalid struct]: the struct refusal fails the
+    /// install AND poisons the whole well-known registry, so the valid enum's
+    /// mid-batch publication is unobservable — membership false, count zero,
+    /// registry answers absent — and a repeat install re-errors with the
+    /// recorded refusal instead of re-running the partial install. This is the
+    /// pool's spelling of the epoch install's by-value atomicity (its failure
+    /// drops the whole mutated `BoundSema`), via the file's poisoning
+    /// discipline (`poisoned` / `callable_poisoned`).
+    #[test]
+    fn well_known_option_install_partial_failure_poisons_registry() {
+        let good = anon_key(AnonymousNominalKind::Enum, 80, 0);
+        let bad = anon_key(AnonymousNominalKind::Struct, 81, 0);
+        let good_shape = DurableAnonymousShape::Enum {
+            variants: vec![
+                (Arc::from("Some"), vec![DType::I64]),
+                (Arc::from("None"), vec![]),
+            ],
+        };
+        let bad_shape = DurableAnonymousShape::Struct {
+            fields: vec![(Arc::from("v"), DType::I32)],
+            struct_method_names: Vec::new(),
+        };
+        let mut pool = anon_pool(
+            [],
+            [(good.clone(), good_shape), (bad.clone(), bad_shape)],
+            [],
+        );
+        assert_eq!(
+            pool.install_well_known_option_types(
+                &[good.clone(), bad.clone()],
+                &[(DType::I64, DType::AnonymousNominal(good.clone()))],
+            ),
+            Err(IdentityMintError::WellKnownShapeMismatch)
+        );
+        // No observable partial success: the valid enum DID mint mid-batch
+        // through the ordinary anonymous machinery, but the well-known
+        // registry answers as if nothing was installed.
+        assert!(!pool.is_well_known_option_identity(&good));
+        assert_eq!(pool.well_known_option_identity_count(), 0);
+        assert_eq!(pool.well_known_option_for_payload(Type::I64), None);
+        // A repeat install re-errors with the recorded refusal — even a batch
+        // that would succeed on its own cannot resurrect a poisoned registry.
+        assert_eq!(
+            pool.install_well_known_option_types(std::slice::from_ref(&good), &[]),
+            Err(IdentityMintError::WellKnownShapeMismatch),
+            "poisoned well-known registry re-errors"
+        );
+        assert!(!pool.is_well_known_option_identity(&good));
+    }
+
+    /// A demand pair naming an `Option` identity the install never minted is
+    /// refused: registry-endpoint resolution is LOOKUP-ONLY (the pool analog of
+    /// the epoch's `import_export_type` anonymous arm, which refuses an
+    /// identity absent from `anon_enum_identities`), so the uninstalled
+    /// identity fails closed with `MissingAnonymous` even though its durable
+    /// shape exists and a minting arm would silently succeed. The failure
+    /// poisons the registry, so the pair recorded before it is unobservable.
+    #[test]
+    fn well_known_option_install_refuses_uninstalled_registry_identity() {
+        let installed = anon_key(AnonymousNominalKind::Enum, 90, 0);
+        let uninstalled = anon_key(AnonymousNominalKind::Enum, 91, 0);
+        let installed_shape = DurableAnonymousShape::Enum {
+            variants: vec![
+                (Arc::from("Some"), vec![DType::I64]),
+                (Arc::from("None"), vec![]),
+            ],
+        };
+        // The uninstalled identity HAS a durable enum shape: only a
+        // lookup-only registry arm refuses it, a minting arm would leak it.
+        let uninstalled_shape = DurableAnonymousShape::Enum {
+            variants: vec![
+                (Arc::from("Some"), vec![DType::U32]),
+                (Arc::from("None"), vec![]),
+            ],
+        };
+        let mut pool = anon_pool(
+            [],
+            [
+                (installed.clone(), installed_shape),
+                (uninstalled.clone(), uninstalled_shape),
+            ],
+            [],
+        );
+        assert_eq!(
+            pool.install_well_known_option_types(
+                std::slice::from_ref(&installed),
+                &[
+                    (DType::I64, DType::AnonymousNominal(installed.clone())),
+                    (DType::U32, DType::AnonymousNominal(uninstalled.clone())),
+                ],
+            ),
+            Err(IdentityMintError::MissingAnonymous)
+        );
+        // The refused pair's identity was never minted by the failed resolve —
+        // no silent success, no unproduced-import leak.
+        assert_eq!(
+            pool.resolve(&DType::AnonymousNominal(uninstalled.clone())),
+            Err(IdentityMintError::MissingAnonymous),
+            "the lookup-only registry arm minted nothing"
+        );
+        // And nothing partial is observable: the pair recorded before the
+        // refusal (and the installed enum's ruling) sit behind the poison.
+        assert!(!pool.is_well_known_option_identity(&installed));
+        assert_eq!(pool.well_known_option_identity_count(), 0);
+        assert_eq!(pool.well_known_option_for_payload(Type::I64), None);
+        assert_eq!(
+            pool.install_well_known_option_types(std::slice::from_ref(&installed), &[]),
+            Err(IdentityMintError::MissingAnonymous),
+            "poisoned well-known registry re-errors"
+        );
+    }
+
+    /// The bounded fixpoint tolerates install order: an enum whose payload
+    /// references another well-known nominal installed later in the same batch
+    /// is retried after that dependency mints — mirroring the epoch install's
+    /// pending loop. BOTH batch orders are run ([outer, inner] exercises the
+    /// round-two retry, [inner, outer] the single-pass order) and must agree
+    /// on the minted digests/names and the registry answers.
+    #[test]
+    fn well_known_option_install_fixpoint_orders_nested_payloads() {
+        let inner = anon_key(AnonymousNominalKind::Enum, 70, 0);
+        let outer = anon_key(AnonymousNominalKind::Enum, 71, 0);
+        let inner_shape = DurableAnonymousShape::Enum {
+            variants: vec![
+                (Arc::from("Some"), vec![DType::I32]),
+                (Arc::from("None"), vec![]),
+            ],
+        };
+        let outer_shape = DurableAnonymousShape::Enum {
+            variants: vec![
+                (
+                    Arc::from("Some"),
+                    vec![DType::AnonymousNominal(inner.clone())],
+                ),
+                (Arc::from("None"), vec![]),
+            ],
+        };
+        // One fresh pool per batch order; returns the digest-bearing names so
+        // the orders can be asserted identical across pools.
+        let run = |batch: &[AnonKey]| -> (String, String) {
+            let mut pool = anon_pool(
+                [],
+                [
+                    (inner.clone(), inner_shape.clone()),
+                    (outer.clone(), outer_shape.clone()),
+                ],
+                [],
+            );
+            pool.install_well_known_option_types(
+                batch,
+                &[
+                    (DType::I32, DType::AnonymousNominal(inner.clone())),
+                    (
+                        DType::AnonymousNominal(inner.clone()),
+                        DType::AnonymousNominal(outer.clone()),
+                    ),
+                ],
+            )
+            .unwrap();
+            assert_eq!(pool.well_known_option_identity_count(), 2);
+            assert!(pool.is_well_known_option_identity(&outer));
+            assert!(pool.is_well_known_option_identity(&inner));
+            let inner_ty = pool.find_or_create_anon(&inner).unwrap();
+            let outer_ty = pool.find_or_create_anon(&outer).unwrap();
+            let outer_def = pool.type_pool().enum_def(outer_ty.as_enum().unwrap());
+            assert_eq!(outer_def.variant_payload(0), &[inner_ty]);
+            // The registry answers both demand pairs with the minted enums.
+            assert_eq!(
+                pool.well_known_option_for_payload(Type::I32),
+                Some(inner_ty)
+            );
+            assert_eq!(pool.well_known_option_for_payload(inner_ty), Some(outer_ty));
+            let inner_def = pool.type_pool().enum_def(inner_ty.as_enum().unwrap());
+            (inner_def.name.clone(), outer_def.name.clone())
+        };
+        // OUTER first: its payload consult blocks on the not-yet-minted inner
+        // enum in round one and succeeds in round two.
+        let outer_first = run(&[outer.clone(), inner.clone()]);
+        // INNER first: every mint lands in round one.
+        let inner_first = run(&[inner.clone(), outer.clone()]);
+        assert_eq!(
+            outer_first, inner_first,
+            "batch order must not change the minted digests/names or registry answers"
         );
     }
 

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -323,6 +323,29 @@ impl CanonicalPreparedDeclarations<'_> {
     }
 }
 
+/// The shared test recipe under [`query_owned_declaration_shells_for_test`] and
+/// [`bind_query_owned_declarations_with_definitions_for_test`]: project the
+/// query-owned declaration shells and prepare them through the production
+/// `prepare_query_declaration_shells` path.
+#[cfg(test)]
+fn prepared_query_declarations_for_test<'a>(
+    merged: &CanonicalMergedProgram,
+    rir: &'a CanonicalRirOutput,
+    preview_features: rue_error::PreviewFeatures,
+    target: crate::Target,
+    imports: &CanonicalImportGraph,
+) -> MultiErrorResult<CanonicalPreparedDeclarations<'a>> {
+    let options = CompileOptions {
+        preview_features,
+        target,
+        ..CompileOptions::default()
+    };
+    let query_shells =
+        crate::revisioned_query_database::projected_declaration_shells_for_test(merged)?;
+    prepare_query_declaration_shells(merged, rir, &options, imports, &query_shells)
+        .map_err(|failure| failure.errors)
+}
+
 #[cfg(test)]
 pub(crate) fn query_owned_declaration_shells_for_test<'a>(
     merged: &CanonicalMergedProgram,
@@ -331,15 +354,8 @@ pub(crate) fn query_owned_declaration_shells_for_test<'a>(
     target: crate::Target,
     imports: &CanonicalImportGraph,
 ) -> MultiErrorResult<rue_air::DeclarationShells<'a>> {
-    let options = CompileOptions {
-        preview_features,
-        target,
-        ..CompileOptions::default()
-    };
-    let query_shells =
-        crate::revisioned_query_database::projected_declaration_shells_for_test(merged)?;
-    let prepared = prepare_query_declaration_shells(merged, rir, &options, imports, &query_shells)
-        .map_err(|failure| failure.errors)?;
+    let prepared =
+        prepared_query_declarations_for_test(merged, rir, preview_features, target, imports)?;
     Ok(prepared.shells)
 }
 
@@ -353,6 +369,28 @@ pub(crate) fn bind_query_owned_declarations_for_test<'a>(
 ) -> MultiErrorResult<rue_air::BoundSema<'a>> {
     query_owned_declaration_shells_for_test(merged, rir, preview_features, target, imports)?
         .resolve_declarations_for_test()
+}
+
+/// The [`bind_query_owned_declarations_for_test`] recipe, additionally handing
+/// back the [`BoundDefinitionSet`] whose stable identity endpoints were
+/// installed into the returned epoch. The RUE-1091 r6c differential needs both:
+/// the production well-known `Option` projection
+/// (`project_durable_option_registry`) resolves durable keys through the SAME
+/// definition set that issued the epoch's endpoints, exactly as the production
+/// `body_transaction` install does.
+#[cfg(test)]
+pub(crate) fn bind_query_owned_declarations_with_definitions_for_test<'a>(
+    merged: &CanonicalMergedProgram,
+    rir: &'a CanonicalRirOutput,
+    preview_features: rue_error::PreviewFeatures,
+    target: crate::Target,
+    imports: &CanonicalImportGraph,
+) -> MultiErrorResult<(rue_air::BoundSema<'a>, BoundDefinitionSet)> {
+    let prepared =
+        prepared_query_declarations_for_test(merged, rir, preview_features, target, imports)?;
+    let definitions = prepared.definitions;
+    let bound = prepared.shells.resolve_declarations_for_test()?;
+    Ok((bound, definitions))
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -22158,6 +22158,306 @@ mod tests {
         );
     }
 
+    // RUE-1091 r6c: the well-known `Option` cross-path differential. The trusted
+    // std `Option(payload)` specializations a body's fallible intrinsics demand
+    // (RUE-1112) are produced through BOTH installs — the LIVE epoch's
+    // `install_well_known_option_types` (importing the projected registry and
+    // minting through `find_or_create_anon_enum`) and the provider-side pool's
+    // `install_well_known_option_types` (minting the same durable identities
+    // through `find_or_create_anon` via the real `DurableDeclSource` adapter) —
+    // and their full materializations are asserted equal: the shared-digest
+    // `__anon_enum_{digest} { … }` names, mangled symbols, copyability,
+    // visibility, and variant vocabulary. Both sides start from the SAME
+    // declaration-level durable truth (the nucleus `ComptimeCall` terminals the
+    // production demand loop roots), so agreement is a real cross-path proof.
+    //
+    // The export-as-produced ruling is asserted on both sides: the epoch records
+    // each installed identity in `well_known_option_identities` (the set
+    // `analyze_one_body` subtracts from its initial anonymous baseline, making
+    // the single export funnel publish them as PRODUCED anonymous nominals of
+    // the analyzed body — never pre-existing imports); the pool records the
+    // identical canonical identities under `is_well_known_option_identity`, the
+    // predicate the flip-era baseline subtraction consults.
+    #[test]
+    fn provider_well_known_option_install_matches_epoch() {
+        use crate::semantic_query_nucleus::{
+            ComptimeCallResultProjection as ResultProjection, SemanticNucleusKey as Key,
+            SemanticNucleusValue as V,
+        };
+        use std::collections::HashSet;
+
+        // The freestanding fallible-intrinsic program plus the trusted `Option`
+        // module published at its trusted logical path — exactly the presence
+        // condition `plan_well_known_option_demands` requires. `main` names
+        // `@parse_i64` and `@parse_u32`, so the program demands two payloads.
+        let root = FileId::new(1);
+        let option = FileId::new(2);
+        let physical = HashMap::from([
+            (root, "/project/main.rue".to_owned()),
+            (option, "/sdk/option.rue".to_owned()),
+        ]);
+        let logical = HashMap::from([
+            (root, "main.rue".to_owned()),
+            (option, crate::OPTION_MODULE_LOGICAL_PATH.to_owned()),
+        ]);
+        let metadata = SourceMetadata::new_with_trusted_standard_library(
+            root,
+            physical,
+            logical,
+            HashSet::from([option]),
+        )
+        .unwrap();
+        let snapshot = SourceSnapshot::new(
+            metadata,
+            vec![
+                (
+                    root,
+                    Arc::new(
+                        "fn main() -> i32 { let a = @parse_i64(\"1\"); \
+                         let b = @parse_u32(\"2\"); 0 }"
+                            .to_owned(),
+                    ),
+                ),
+                (
+                    option,
+                    Arc::new(
+                        "pub fn Option(comptime T: type) -> type { enum { Some(T), None } }"
+                            .to_owned(),
+                    ),
+                ),
+            ],
+        )
+        .unwrap();
+
+        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
+        let merged = crate::merge_parsed_modules(&parsed).unwrap();
+        let rir = crate::lower_canonical_rir(&merged).unwrap();
+
+        // The production demand catalogue: one entry per demanded payload, each
+        // carrying the exact `ComptimeCall` the per-body demand loop roots.
+        let demands = crate::well_known_option::plan_well_known_option_demands(
+            &merged,
+            &rir,
+            &semantic_configuration(),
+        );
+        assert_eq!(demands.len(), 2, "i64 and u32 payloads are demanded");
+
+        // Resolve each demand through the nucleus — the declaration-level
+        // durable truth BOTH installs consume — assembling the same
+        // `WellKnownOptionResolution` the production `body_transaction` builds.
+        let mut nucleus_db = RevisionedQueryDatabase::default();
+        let nucleus_revision = nucleus_db.source_revision(
+            &super::super::session::ExactSourceInput::new(&snapshot),
+            &snapshot,
+        );
+        let mut option_by_payload = Vec::new();
+        let mut nominals: BTreeMap<
+            crate::AnonymousNominalKey,
+            crate::durable_semantics::DurableAnonymousNominal,
+        > = BTreeMap::new();
+        for demand in demands.iter() {
+            let value = request_semantic_nucleus(
+                &nucleus_db,
+                nucleus_revision,
+                Key::ComptimeCall(demand.call.clone()),
+            );
+            let V::ComptimeCall(projection) = value else {
+                panic!("trusted Option comptime call did not resolve: {value:?}");
+            };
+            let ResultProjection::Type(option_type) = &projection.result else {
+                panic!(
+                    "Option(payload) must resolve to a type: {:?}",
+                    projection.result
+                );
+            };
+            option_by_payload.push((demand.payload.clone(), option_type.clone()));
+            for nominal in projection.anonymous_nominals.iter() {
+                nominals.insert(nominal.identity.clone(), nominal.clone());
+            }
+        }
+        let resolution = crate::body_query::WellKnownOptionResolution {
+            option_by_payload: Arc::from(option_by_payload),
+            anonymous_nominals: Arc::from(nominals.into_values().collect::<Vec<_>>()),
+        };
+        assert_eq!(
+            resolution.anonymous_nominals.len(),
+            2,
+            "one trusted Option enum per demanded payload"
+        );
+        assert!(
+            resolution.anonymous_nominals.iter().all(|nominal| matches!(
+                nominal.shape,
+                crate::durable_semantics::DurableAnonymousNominalShape::Enum { .. }
+            )),
+            "the trusted registry holds enum shapes only"
+        );
+
+        // ------------------------------------------------------------------
+        // The LIVE epoch install path: bind through the production declaration
+        // recipe, project the registry against the SAME definition set that
+        // issued the epoch's endpoints, and install — exactly the production
+        // `body_transaction` sequence.
+        // ------------------------------------------------------------------
+        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let (bound, definitions) =
+            crate::canonical_semantic::bind_query_owned_declarations_with_definitions_for_test(
+                &merged,
+                &rir,
+                crate::PreviewFeatures::default(),
+                rue_target::Target::X86_64Linux,
+                &imports,
+            )
+            .expect("declarations bind");
+        let (nominal_exports, pair_exports) =
+            crate::durable_semantics::project_durable_option_registry(
+                &merged,
+                &definitions,
+                &resolution,
+            )
+            .expect("the registry projects against the bound definition set");
+        let bound = bound
+            .install_well_known_option_types(&nominal_exports, &pair_exports)
+            .expect("the epoch installs the well-known registry");
+
+        // The export-as-produced ruling, epoch side: every installed identity is
+        // recorded for the baseline subtraction, so the single export funnel
+        // publishes it as a produced anonymous nominal.
+        let epoch_types = bound.epoch_well_known_option_types();
+        assert_eq!(
+            epoch_types.len(),
+            2,
+            "the epoch marked both Option enums for produced export"
+        );
+        let mut epoch_renders: Vec<EndpointNominalRender> = bound.with_type_pool(|pool| {
+            epoch_types
+                .iter()
+                .map(|ty| endpoint_nominal_render(pool, *ty))
+                .collect()
+        });
+        epoch_renders.sort_by(|a, b| a.display.cmp(&b.display));
+        for render in &epoch_renders {
+            assert!(
+                render.display.starts_with("__anon_enum_"),
+                "the epoch spells the digest name: {}",
+                render.display
+            );
+        }
+        // The epoch's demand registry answers each payload with its enum.
+        let epoch_registry = bound.epoch_well_known_option_registry();
+        assert_eq!(epoch_registry.len(), 2);
+        let epoch_option_for = |payload: rue_air::Type| {
+            epoch_registry
+                .iter()
+                .find(|(candidate, _)| *candidate == payload)
+                .map(|(_, option)| *option)
+                .unwrap_or_else(|| panic!("the epoch registry answers {payload:?}"))
+        };
+        let epoch_i64_render = bound.with_type_pool(|pool| {
+            endpoint_nominal_render(pool, epoch_option_for(rue_air::Type::I64))
+        });
+        let epoch_u32_render = bound.with_type_pool(|pool| {
+            endpoint_nominal_render(pool, epoch_option_for(rue_air::Type::U32))
+        });
+        assert!(
+            epoch_i64_render.display.ends_with(" { Some(i64), None }"),
+            "the i64 registry entry is the Option(i64) enum: {}",
+            epoch_i64_render.display
+        );
+        assert!(
+            epoch_u32_render.display.ends_with(" { Some(u32), None }"),
+            "the u32 registry entry is the Option(u32) enum: {}",
+            epoch_u32_render.display
+        );
+
+        // ------------------------------------------------------------------
+        // The provider-side pool install: the same durable identities and
+        // registry pairs, minted through `BodyIdentityPool::
+        // install_well_known_option_types` over the real `DurableDeclSource`
+        // adapter built from the independently produced durable declarations.
+        // ------------------------------------------------------------------
+        let decls = production_declarations(&snapshot);
+        let adapter = DurableDeclSource::from_declarations(&decls)
+            .with_anonymous_nominals(&resolution.anonymous_nominals);
+        let identities: Vec<crate::AnonymousNominalKey> = resolution
+            .anonymous_nominals
+            .iter()
+            .map(|nominal| nominal.identity.clone())
+            .collect();
+        let pairs: Vec<(crate::DurableType, crate::DurableType)> =
+            resolution.option_by_payload.iter().cloned().collect();
+
+        let rir_ref = rir.rir();
+        let interner = rir.semantic_symbols().interner();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &snapshot);
+        let outcome = database.probe_body_facts(
+            revision,
+            semantic_configuration(),
+            "well-known-option-install",
+            move |provider| {
+                let facts =
+                    rue_air::ProviderEndpointFacts::new(provider, adapter, rir_ref, interner);
+                facts
+                    .install_well_known_option_types(&identities, &pairs)
+                    .expect("the pool installs the well-known registry");
+                // Idempotent: a repeat install dedups onto the same identities.
+                facts
+                    .install_well_known_option_types(&identities, &pairs)
+                    .expect("a repeat install is a pure dedup");
+
+                // The export-as-produced ruling, pool side: each installed
+                // identity answers the baseline-subtraction predicate.
+                assert_eq!(facts.well_known_option_identity_count(), 2);
+                for identity in &identities {
+                    assert!(
+                        facts.is_well_known_option_identity(identity),
+                        "an installed identity carries the produced ruling"
+                    );
+                }
+
+                // Materializations, fetched by dedup lookup (nothing re-mints).
+                let renders: Vec<EndpointNominalRender> = identities
+                    .iter()
+                    .map(|identity| {
+                        let ty = facts
+                            .mint_anonymous(identity)
+                            .expect("an installed identity resolves by dedup");
+                        facts.with_type_pool(|pool| endpoint_nominal_render(pool, ty))
+                    })
+                    .collect();
+                let i64_option = facts
+                    .well_known_option_for_payload(rue_air::Type::I64)
+                    .expect("the pool registry answers i64");
+                let u32_option = facts
+                    .well_known_option_for_payload(rue_air::Type::U32)
+                    .expect("the pool registry answers u32");
+                let i64_render =
+                    facts.with_type_pool(|pool| endpoint_nominal_render(pool, i64_option));
+                let u32_render =
+                    facts.with_type_pool(|pool| endpoint_nominal_render(pool, u32_option));
+                (renders, i64_render, u32_render)
+            },
+        );
+        let (mut pool_renders, pool_i64_render, pool_u32_render) = outcome.result;
+        pool_renders.sort_by(|a, b| a.display.cmp(&b.display));
+
+        // The crux: both installs materialized byte-identical identities — the
+        // shared-digest names, mangled symbols, shape, copyability, and
+        // visibility all agree across the two independent paths.
+        assert_eq!(
+            pool_renders, epoch_renders,
+            "the pool's well-known Option install diverged from the LIVE epoch"
+        );
+        assert_eq!(
+            pool_i64_render, epoch_i64_render,
+            "the i64 demand registry entries diverged"
+        );
+        assert_eq!(
+            pool_u32_render, epoch_u32_render,
+            "the u32 demand registry entries diverged"
+        );
+    }
+
     // RUE-1091 r6a: the `Slice` arm resolves once a caller seeds the generated
     // slice struct with `register_generated_slice`, minting the fat-pointer
     // struct byte-identically to the LIVE epoch's generated slice — the positive

--- a/docs/notes/rue-1091-analyzer-rewire-plan.md
+++ b/docs/notes/rue-1091-analyzer-rewire-plan.md
@@ -524,6 +524,85 @@ keystone.
 
 ---
 
+## Rider: well-known Option identities from the pool and the export-as-produced ruling (recorded landing r6c)
+
+**(a) What landed.** The trusted-std well-known `Option` install (RUE-1112) is ported onto the
+provider/pool side: `BodyIdentityPool::install_well_known_option_types`
+(`crates/rue-air/src/sema/body_identity.rs`) is the pool analog of the epoch's
+`BoundSema::install_well_known_option_types` (`binding_manifest.rs`). It takes the durable
+identities of the resolved `Option(payload)` enum specializations plus the durable
+`(payload, option)` demand pairs, mints each enum through the r6b anonymous machinery
+(`find_or_create_anon` — shared digest, entry-enforced wrapper collapse, fail-closed collision
+guard), and records the demand map (`well_known_option_for_payload`, the pool answer to
+`resolve_option_result_type`'s `well_known_option_by_payload` consult). The provider-facing entry
+mirrors the r6b anon-arm approach: `ProviderEndpointFacts::install_well_known_option_types` /
+`is_well_known_option_identity` / `well_known_option_for_payload`
+(`sema/body_endpoint.rs`). Everything is inert pre-flip (`#![cfg_attr(not(test),
+allow(dead_code))]` / `cfg(test)`-only reachability; no production call sites).
+
+**(b) The export-as-produced ruling, as implemented.** In the epoch, the install records each
+materialized identity in `Sema::well_known_option_identities`; `analyze_one_body`
+(`one_body.rs:853`) subtracts exactly that set from `one_body_initial_anonymous_identities`, so
+the single export funnel (`produced_anonymous_nominals` → `semantic_body_export.rs`, durable
+keying at export) publishes the registry-rooted enums as PRODUCED anonymous nominals of the
+analyzed body — never as pre-existing imports with no producer. The pool port carries the same
+ruling as data: every installed identity is recorded (canonical producer form) in a pool-owned
+well-known identity set whose membership predicate
+(`BodyIdentityPool::is_well_known_option_identity`, surfaced as
+`ProviderEndpointFacts::is_well_known_option_identity`) is the flip-era baseline subtraction —
+the flip's export wiring consults it exactly where the epoch consults
+`well_known_option_identities.contains`. No production export code was touched; the ruling is
+proven pre-flip by materialization + registry equality against the LIVE epoch install (below)
+plus both sides' recorded identity sets agreeing in cardinality and digest identity.
+
+**(c) Cross-path differential.** `provider_well_known_option_install_matches_epoch`
+(`revisioned_query_database.rs` test tail) drives BOTH installs from the SAME declaration-level
+durable truth — the nucleus `ComptimeCall` terminals the production demand loop roots
+(`plan_well_known_option_demands` → per-demand `SemanticNucleusKey::ComptimeCall`), for a
+two-payload program (`@parse_i64` + `@parse_u32`) with the trusted `\0rue-std/option.rue` module
+present. The epoch side binds through the production declaration recipe, projects the registry
+against the SAME `BoundDefinitionSet` that issued the epoch's endpoints
+(`project_durable_option_registry`, via the new test helper
+`bind_query_owned_declarations_with_definitions_for_test`), and installs; the pool side installs
+the raw durable identities through the real `DurableDeclSource` adapter. Asserted equal per
+identity: the shared-digest `__anon_enum_{digest} { Some(T), None }` names (digest byte-equality
+via the relocation), mangled symbols, copyability, visibility, and variant vocabulary; plus the
+`(payload → option)` registry answers for both payloads, and the produced-ruling sets on both
+sides. Epoch read surface added for the differential: `BoundSema::epoch_well_known_option_types`
+/ `epoch_well_known_option_registry`. Pool-side failure semantics are unit-pinned in
+`body_identity.rs`: non-enum shape refused (`WellKnownShapeMismatch`, the pool spelling of the
+epoch's `NominalShapeMismatch`) with zero publication for the refused key, absent shape fails
+closed, a demand pair naming an identity the install never minted fails closed
+(`MissingAnonymous` — registry-endpoint resolution is lookup-only against the installed
+anonymous identities, exactly as the epoch's `import_export_type` anonymous arm refuses an
+identity absent from `anon_enum_identities`; it never mints), the bounded fixpoint tolerates
+nested payloads in EITHER batch order (the epoch's pending loop), wrapper-form identities
+collapse on entry, and repeat successful installs are pure dedups. The ATOMICITY shape differs
+from the epoch and is closed by poisoning: the epoch's install takes `self` by value and returns
+`Result<Self, _>`, so a failed install drops the whole mutated `BoundSema` and partial effects
+are structurally unobservable; the pool's install mutates in place, so ANY failure instead
+POISONS the well-known registry (`well_known_poisoned`, the well-known analog of the pool's
+`poisoned`/`callable_poisoned` discipline) — repeat installs re-error with the recorded refusal
+and `is_well_known_option_identity` / `well_known_option_identity_count` /
+`well_known_option_for_payload` answer as if nothing was installed, restoring the epoch's
+no-observable-partial-success guarantee (pinned by the mixed-batch partial-failure and
+uninstalled-registry-identity unit tests).
+
+**(d) STOPs / deferrals.** No new STOP: every consulted fact has declaration-level durable truth
+(the demand catalogue is durable-planned; each specialization is a memoized nucleus terminal;
+producers root at the installed trusted `Option` function endpoint, inside the r6b rider's (c)
+minting scope — const-candidate-rooted producers remain out of scope as recorded there). The
+r6b deferrals stand unchanged: `Pair()` / `Str(8)` TYPE-SYNTAX classification stays pinned in
+`provider_type_facts_deferred_shapes_are_documented_gaps`, and the `Option(StrBuf)` demand is
+exercised only at the planner level here (its payload nominal resolves through the ordinary r4a-2a
+`mint_named` path; the trusted `StrBuf` module fixture is flip-corpus work, with the rFinal
+`trusted_well_known_option_registry` carry-forward still naming the production-path gap). Method
+BODIES / dispatch for anonymous nominals remain with the flip's overlay method installation, and
+capture export (`type_captures`/`value_captures`) stays on the durable nominal itself — the pool
+mints identity + materialization only, exactly the funnel's need.
+
+---
+
 ## 4. RISKS (top 5 for this rewire)
 
 | # | Risk | Mitigation |


### PR DESCRIPTION
Refs RUE-1091.

## Summary

- port the epoch's `install_well_known_option_types` onto the `BodyIdentityPool`: a bounded fixpoint mirroring the epoch's pending loop, with a per-key enum-shape gate (`WellKnownShapeMismatch`, the pool spelling of the epoch's `NominalShapeMismatch`) refusing before any id/symbol mints
- carry the export-as-produced ruling as pool data: every installed identity is recorded canonically in a pool-owned `BTreeSet` whose membership predicate is the flip-era baseline subtraction, consulted exactly where the epoch consults `Sema::well_known_option_identities` (`one_body.rs` subtraction site), so the identities export as PRODUCED anonymous nominals, never imports
- make the install atomic-by-observation: any failure poisons the well-known registry (repeat installs re-error with the recorded refusal; the membership/count/payload accessors behave as if nothing was installed), restoring the epoch's by-value `Result<Self, _>` atomicity under the pool's `&mut self` shape
- keep registry-endpoint resolution lookup-only: the `AnonymousNominal` arm entry-canonicalizes the probe and fails closed with `MissingAnonymous` on a miss, matching the epoch's `import_export_type` refusal instead of minting
- add the provider-facing entry on `ProviderEndpointFacts` (fail-closed install wrapper plus membership/count/payload accessors) and the epoch differential surface on `BoundSema`
- add a live cross-path differential: both installs fed the same production demand catalogue (`plan_well_known_option_demands` resolved through real nucleus `ComptimeCall` terminals) for a two-payload program; epoch side runs production bind → `project_durable_option_registry` → the LIVE install; pool side feeds raw durable identities through the real `DurableDeclSource` adapter; asserts digest-name, symbol, copyability, visibility, variant vocabulary, registry answers, ruling-set membership, and idempotency equality
- unit tests additionally pin partial-failure poisoning, uninstalled-registry-identity refusal, wrapper-form entry canonicalization, non-enum refusal with zero publication, missing-shape fail-closed, order-independent nested-payload fixpoint (both batch orders), and produced-ruling recording
- record the r6c rider in the rewire plan: the ruling as implemented, the poisoning shape, and unchanged deferrals (const-candidate-rooted producers, `Pair()`/`Str(8)` pins, `Option(StrBuf)` full fixture with the rFinal carry-forward naming the production-path gap)

Everything is inert pre-flip: no production call sites; reachability is `#[cfg(test)]` only.

## Validation

- `//crates/rue-air:rue-air-test` — 623 passed
- `//crates/rue-compiler:rue-compiler-test` — 819 passed
- `//:type-architecture-inventory-validation`, `//:body-analysis-capability-inventory-validation` — pass
- `./clippy.sh` — 66 targets, no violations
- `scripts/rue fmt` — clean