### PR TITLE
RUE-1091: add provider module registry flip prep

### DIFF
--- a/crates/rue-air/src/sema/aggregate_resolution.rs
+++ b/crates/rue-air/src/sema/aggregate_resolution.rs
@@ -13,6 +13,7 @@ use rue_span::FileId;
 
 use super::body_identity::{BodyIdentityPool, DurableNominalSource};
 use super::context::{ConstValue, LocalVar};
+use super::provider_module_registry::ProviderModuleRegistry;
 use super::{ConstInfo, DeclarationPhase, Sema};
 use crate::intern_pool::TypeInternPool;
 use crate::types::{EnumId, ModuleId, StructId, Type};
@@ -332,12 +333,12 @@ pub(crate) fn is_accessible<P: AggregateFacts>(
 //     remains unwired pre-flip. The const fall-through of every `select_*` above
 //     therefore answers `Absent` where the epoch answers `Const`; the
 //     differential pins this const-arm divergence.
-//   - module (module_def) and the module spines
-//     ([`resolve_aggregate_module_ref`] / [`resolve_visibility_module_ref`]) →
-//     the flip: `module` answers a rue-air-internal `ModuleId` registry index the
-//     provider has no durable preimage for. The spines are gated behind
-//     `module_binding` (deferred), so they never reach `module`, and this driver
-//     exposes no spine wrapper.
+//   - module (module_def) → LANDED (flip-prep): `ProviderModuleRegistry` mints
+//     the body-local compact id from the durable module handle and stores the
+//     current request file/path/import-path facts. The module spines
+//     ([`resolve_aggregate_module_ref`] / [`resolve_visibility_module_ref`])
+//     remain gated behind `module_binding` (deferred), but their registry answer
+//     is ready.
 //   - source_path → the flip: consumed only by inline `aggregates.rs` diagnostic
 //     paths, never by the provider-generic selection logic this driver drives.
 // ---------------------------------------------------------------------------
@@ -384,6 +385,7 @@ pub enum ProviderStructHead {
 /// by a caller through `&mut self` registration before any consult.
 pub struct ProviderAggregateFacts<K, M, S> {
     pool: RefCell<BodyIdentityPool<K, M, S>>,
+    modules: RefCell<ProviderModuleRegistry<M>>,
     /// The provider-side analog of the epoch's `structs_by_file_name` /
     /// `enums_by_file_name` key maps: `(file, pool-interned name) → durable key`,
     /// populated on demand as a caller registers a nominal. The `Spur` is the
@@ -410,6 +412,7 @@ where
     pub fn new(source: S) -> Self {
         Self {
             pool: RefCell::new(BodyIdentityPool::new(source)),
+            modules: RefCell::new(ProviderModuleRegistry::default()),
             by_file_name: HashMap::new(),
             file_paths: HashMap::new(),
         }
@@ -437,6 +440,34 @@ where
     /// [`Self::is_accessible`] reproduces the epoch's visibility domain exactly.
     pub fn register_file_path(&mut self, file: FileId, path: &str) {
         self.file_paths.insert(file, path.to_owned());
+    }
+
+    /// Register one durable module and its request-local presentation facts in
+    /// the body-local module registry. The returned compact id is the provider
+    /// counterpart of the epoch's canonical `ModuleId`; downstream aggregate
+    /// spines recover the exact file/import paths through [`AggregateFacts::module`].
+    pub fn register_module(
+        &self,
+        module: M,
+        file: FileId,
+        file_path: &str,
+        import_path: &str,
+        durable_id: &str,
+    ) -> Option<ModuleId> {
+        self.modules
+            .borrow_mut()
+            .register(module, file, file_path, import_path, durable_id)
+    }
+
+    /// Owned, index-independent module facts for a registered compact id.
+    pub fn module_fact(&self, module: ModuleId) -> Option<(FileId, String, String)> {
+        self.modules.borrow().get(module).map(|definition| {
+            (
+                definition.file_id,
+                definition.file_path,
+                definition.import_path,
+            )
+        })
     }
 
     /// (P) The struct declared as `(file, name)`, minted through the pool's 2a
@@ -587,15 +618,16 @@ where
             .as_enum()
     }
 
-    fn module(&self, _module: ModuleId) -> AggregateModuleFact {
-        // Deferred to the flip: `module_def` answers a rue-air-internal `ModuleId`
-        // registry index with no durable provider preimage. Unreachable while
-        // `module_binding` is deferred (the module spines short-circuit before
-        // reaching this op); a benign empty fact keeps the refusal total.
+    fn module(&self, module: ModuleId) -> AggregateModuleFact {
+        let definition = self
+            .modules
+            .borrow()
+            .get(module)
+            .expect("provider module id must be registered before aggregate resolution");
         AggregateModuleFact {
-            file: FileId::DEFAULT,
-            file_path: String::new(),
-            import_path: String::new(),
+            file: definition.file_id,
+            file_path: definition.file_path,
+            import_path: definition.import_path,
         }
     }
 

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -2469,6 +2469,45 @@ impl<'a> BoundSema<'a> {
             })
     }
 
+    /// RUE-1091 flip-prep surface: resolve the module whose stable endpoint
+    /// names `file` through the LIVE epoch endpoint + module-registry path. This
+    /// is the independent side of the provider module-overlay differential; the
+    /// returned compact id is epoch-relative, so the differential compares the
+    /// module endpoint/file relationship rather than raw indices.
+    pub fn epoch_module_type(&self, file: FileId) -> Option<crate::types::Type> {
+        use super::body_endpoint::{endpoint_facts, resolve_instance_type};
+        let endpoint = self
+            .sema
+            .stable_module_endpoints
+            .values()
+            .find(|endpoint| endpoint.file == file.index())?;
+        let facts = endpoint_facts(&self.sema);
+        resolve_instance_type(&facts, &crate::TypeInstanceKey::Module(endpoint.token)).ok()
+    }
+
+    /// Recover the current request file for an epoch module type. This is the
+    /// index-independent projection compared with
+    /// `ProviderEndpointFacts::module_file`.
+    pub fn epoch_module_file(&self, ty: crate::types::Type) -> Option<FileId> {
+        let id = ty.as_module()?;
+        Some(self.sema.module_registry.get_def(id).file_id)
+    }
+
+    /// Owned, index-independent presentation facts for an epoch module type.
+    pub fn epoch_module_fact(
+        &self,
+        ty: crate::types::Type,
+    ) -> Option<(FileId, String, String, String)> {
+        let id = ty.as_module()?;
+        let definition = self.sema.module_registry.get_def(id);
+        Some((
+            definition.file_id,
+            definition.file_path,
+            definition.import_path,
+            definition.durable_id,
+        ))
+    }
+
     /// RUE-1091 slice r6a flip-era surface: the epoch's resolved generated
     /// slice-struct [`Type`] for a generated-struct name, exposed so the
     /// rue-compiler differential compares the provider-driven

--- a/crates/rue-air/src/sema/body_endpoint.rs
+++ b/crates/rue-air/src/sema/body_endpoint.rs
@@ -34,6 +34,7 @@ use super::body_identity::{
 use super::declaration_index::RirDestructorDeclaration;
 use super::info::{ConstInfo, FunctionInfo, MethodInfo};
 use super::provider::BodyFactProvider;
+use super::provider_module_registry::ProviderModuleRegistry;
 use crate::intern_pool::TypeInternPool;
 use crate::types::{EnumId, ModuleId, StructId, Type};
 use crate::{
@@ -412,9 +413,9 @@ pub(in crate::sema) fn resolve_instance_type<P: BodyEndpointProvider>(
 //     (the call family); `method_info` → r4b-3's `ProviderCallFacts::method_info`
 //     (receiver→pool identity now threaded through the durable method key). Both
 //     stay `None` on THIS endpoint driver — they belong to the call family.
-//   - `module_endpoint` / `module_id_for_file` (the `Module` arm) → module
-//     identity is a pool-refused arm; the endpoint-seam module registry is
-//     r4b-3 / the flip.
+//   - `module_endpoint` / `module_id_for_file` (the `Module` arm) → O: answered
+//     by the body-local module overlay registered from the durable module
+//     identity + its current request file.
 //   - `anon_struct` / `anon_enum` (the anonymous arm) is ANSWERED as of r6b: a
 //     caller seeds the issued→durable seam with `register_anonymous_nominal`
 //     and the arms mint through the pool's `find_or_create_anon`; an unseeded
@@ -458,6 +459,7 @@ struct EndpointOverlay<K> {
     next_slot: u32,
     tokens: HashMap<SemanticDefinitionToken, EndpointEntry>,
     by_file_name: HashMap<(u32, Spur), K>,
+    module_tokens: HashMap<SemanticModuleToken, SemanticModuleEndpoint>,
     /// Generated slice-struct identities minted on demand (RUE-1091 r6a): the
     /// provider-side analog of the epoch's `generated_structs` name→id map. A
     /// caller seeds one per `[T]` slice with [`ProviderEndpointFacts::
@@ -474,6 +476,7 @@ impl<K> Default for EndpointOverlay<K> {
             next_slot: 0,
             tokens: HashMap::new(),
             by_file_name: HashMap::new(),
+            module_tokens: HashMap::new(),
             generated_slices: HashMap::new(),
         }
     }
@@ -500,6 +503,7 @@ pub struct ProviderEndpointFacts<'a, P, S, K, M> {
     /// from the pool's own interner the nominal ops key on.
     rir_interner: &'a ThreadedRodeo,
     overlay: RefCell<EndpointOverlay<K>>,
+    module_registry: RefCell<ProviderModuleRegistry<M>>,
     /// The issued→durable anonymous seam (RUE-1091 r6b): the anonymous producer
     /// key `resolve_instance_type` carries is in the issued-token domain, so a
     /// caller seeds the durable key it stands for with
@@ -529,6 +533,7 @@ where
             rir_index: BodyRirIndex::new(rir),
             rir_interner,
             overlay: RefCell::new(EndpointOverlay::default()),
+            module_registry: RefCell::new(ProviderModuleRegistry::default()),
             anon_by_issued: RefCell::new(HashMap::new()),
         }
     }
@@ -648,6 +653,55 @@ where
         token
     }
 
+    /// Mint (or return) the body-local module token and compact module id for a
+    /// durable module identity at its current request file. This is the
+    /// provider-side analog of the epoch's `stable_module_endpoints` +
+    /// `module_registry`: the durable identity prevents two registrations of
+    /// one module from minting distinct units, while the file is the exact
+    /// declaration-level request fact consumed by the endpoint lookup.
+    ///
+    /// A conflicting durable→file or file→durable registration is rejected
+    /// rather than guessed. The flip fills this from the admitted durable module
+    /// set keyed by `BodyFactProvider::ModuleRef`, paired with the canonical
+    /// module projection's current file handle.
+    pub fn register_module(
+        &self,
+        module: M,
+        file: FileId,
+        file_path: &str,
+        import_path: &str,
+        durable_id: &str,
+    ) -> Option<SemanticModuleToken> {
+        let id = self.module_registry.borrow_mut().register(
+            module,
+            file,
+            file_path,
+            import_path,
+            durable_id,
+        )?;
+        let token = SemanticModuleToken::new(OVERLAY_ISSUER, id.index());
+        let mut overlay = self.overlay.borrow_mut();
+        overlay.module_tokens.insert(
+            token,
+            SemanticModuleEndpoint {
+                token,
+                file: file.index(),
+            },
+        );
+        Some(token)
+    }
+
+    /// Recover the current request file for a module type minted by this
+    /// driver's body-local registry. Used by the cross-path differential to
+    /// compare index-independent module identity.
+    pub fn module_file(&self, ty: Type) -> Option<FileId> {
+        let id = ty.as_module()?;
+        self.module_registry
+            .borrow()
+            .get(id)
+            .map(|definition| definition.file_id)
+    }
+
     /// Mint (on first sight) the generated slice struct for a `[T]` slice and
     /// record its name→id under the pool's own interner, so the `Slice` arm of
     /// [`resolve_instance_type`] resolves the generated-struct name through
@@ -686,7 +740,7 @@ where
     /// (P) Materialize a canonical type-instance key into a concrete pool
     /// [`Type`], reusing the provider-generic [`resolve_instance_type`] driven
     /// over this pool-backed [`BodyEndpointProvider`]. Every arm the pool
-    /// supports resolves; a deferred arm (module identity, generic parameter,
+    /// supports resolves; a deferred arm (generic parameter, an unregistered
     /// anonymous mint, `Str(N)` builtin name) fails closed to
     /// `MissingStableIdentity`, exactly as the pool refuses it. Generated slice
     /// names resolve once seeded with [`Self::register_generated_slice`] (r6a).
@@ -837,10 +891,8 @@ where
         })
     }
 
-    fn module_endpoint(&self, _token: SemanticModuleToken) -> Option<SemanticModuleEndpoint> {
-        // Module identity is a pool-refused arm; the endpoint-seam module
-        // registry is r4b-3 / the flip. The `Module` arm fails closed here.
-        None
+    fn module_endpoint(&self, token: SemanticModuleToken) -> Option<SemanticModuleEndpoint> {
+        self.overlay.borrow().module_tokens.get(&token).copied()
     }
 
     fn function_by_file_name(&self, _file: FileId, _name: Spur) -> Option<Spur> {
@@ -980,9 +1032,8 @@ where
         None
     }
 
-    fn module_id_for_file(&self, _file: u32) -> Option<ModuleId> {
-        // Module identity is a pool-refused arm (see `module_endpoint`).
-        None
+    fn module_id_for_file(&self, file: u32) -> Option<ModuleId> {
+        self.module_registry.borrow().id_for_file(FileId::new(file))
     }
 
     fn intern_array(&self, element: Type, len: u64) -> Option<Type> {

--- a/crates/rue-air/src/sema/call_resolution.rs
+++ b/crates/rue-air/src/sema/call_resolution.rs
@@ -31,6 +31,7 @@
 //! callable-symbol single-candidate check) stays inside that point query,
 //! matching the `body_endpoint` convention.
 
+use std::cell::RefCell;
 use std::hash::Hash;
 
 use lasso::{Spur, ThreadedRodeo};
@@ -44,6 +45,7 @@ use super::body_identity::{
 };
 use super::info::{ConstInfo, FunctionInfo, MethodInfo};
 use super::provider::BodyFactProvider;
+use super::provider_module_registry::ProviderModuleRegistry;
 use crate::types::{ModuleDef, ModuleId, StructId};
 
 /// The exact call/method/operator-resolution fact boundary consumed by the
@@ -276,16 +278,15 @@ pub(in crate::sema) fn resolve_static_call_reference<P: CallResolutionFacts>(
 //     through 2a) with the RIR handle the RIR index locates for the preimage. The
 //     rue-compiler differential recovers the receiver by joining the method key's
 //     `owner()` back to the owner nominal's durable key.
-//   - value_const / module_binding / resolve_const_info_in_file → RE-DEFERRED to
-//     the flip. Sharpened reason: a `ConstInfo` carries both a declaration `span`
-//     the position-free provider boundary omits (needs a const-declaration RIR
-//     handle — the const twin of the function/method handles) AND a
-//     comptime-evaluated `value` the durable const payload carries but the body
-//     identity pool has no const-minting arm for yet. Both are flip-slice work.
-//   - module_def → RE-DEFERRED to the flip. Sharpened reason: it answers a
-//     rue-air-internal `ModuleId` registry index the provider has no durable
-//     preimage for; the module-facts + logical-path composition an equivalent
-//     could be built from belongs with the flip's module registry.
+//   - value_const / module_binding / resolve_const_info_in_file → the flip. The
+//     pool's const-minting arm and exact RIR declaration handle now exist
+//     (`body_identity.rs`, flip-prep), but this call driver deliberately remains
+//     unwired pre-flip. Module bindings additionally require composing that const
+//     identity with this driver's now-real module registry.
+//   - module_def → LANDED (flip-prep): `ProviderModuleRegistry` mints the
+//     body-local compact id from the durable module handle and stores its
+//     current request file/path/import-path facts; this driver exposes the
+//     owned definition through `module_def`.
 //   - named_method_declaration → LANDED (flip-prep). Both seams now take the
 //     provider-natural `(owner_file, owner_type_name, method_name)` preimage;
 //     the epoch adapter alone translates it through `structs_by_file_name` to
@@ -309,6 +310,7 @@ pub(in crate::sema) fn resolve_static_call_reference<P: CallResolutionFacts>(
 pub struct ProviderCallFacts<'a, P, S, K, M> {
     provider: &'a P,
     pool: BodyIdentityPool<K, M, S>,
+    modules: RefCell<ProviderModuleRegistry<M>>,
     rir_index: BodyRirIndex,
     rir: &'a Rir,
     /// The whole-program RIR interner. Input names arrive already interned here
@@ -331,6 +333,7 @@ where
         Self {
             provider,
             pool: BodyIdentityPool::new(source),
+            modules: RefCell::new(ProviderModuleRegistry::default()),
             rir_index: BodyRirIndex::new(rir),
             rir,
             rir_interner,
@@ -356,6 +359,28 @@ where
     /// parity is asserted through resolved strings.
     pub fn resolve_symbol(&self, symbol: Spur) -> &str {
         self.pool.resolve_symbol(symbol)
+    }
+
+    /// Register one durable module and its current request/presentation facts.
+    /// Module-member call resolution uses the returned body-local compact id;
+    /// [`Self::module_def`] recovers the same owned definition the epoch
+    /// `CallResolutionFacts::module_def` consult returns.
+    pub fn register_module(
+        &self,
+        module: M,
+        file: FileId,
+        file_path: &str,
+        import_path: &str,
+        durable_id: &str,
+    ) -> Option<ModuleId> {
+        self.modules
+            .borrow_mut()
+            .register(module, file, file_path, import_path, durable_id)
+    }
+
+    /// The registered provider-era module definition for a compact id.
+    pub fn module_def(&self, module: ModuleId) -> Option<ModuleDef> {
+        self.modules.borrow().get(module)
     }
 
     /// (P) Assemble a [`FunctionInfo`] for a durable free-function key, composing

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -50,6 +50,7 @@ mod metadata;
 mod one_body;
 mod output;
 pub mod provider;
+mod provider_module_registry;
 mod semantic_body_export;
 mod typeck;
 mod visibility;

--- a/crates/rue-air/src/sema/provider_module_registry.rs
+++ b/crates/rue-air/src/sema/provider_module_registry.rs
@@ -1,0 +1,74 @@
+//! Body-local module registry assembled from durable module facts.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use rue_span::FileId;
+
+use crate::{ModuleDef, ModuleId};
+
+/// Provider-era counterpart of the semantic epoch's `ModuleRegistry`.
+///
+/// The durable module handle is the deduplication key. Presentation paths and
+/// the current request's file handle are registered alongside it because they
+/// are request-local facts, not properties reconstructible from a compact id.
+pub(in crate::sema) struct ProviderModuleRegistry<M> {
+    by_durable: HashMap<M, ModuleId>,
+    by_file: HashMap<FileId, ModuleId>,
+    defs: Vec<ModuleDef>,
+}
+
+impl<M> Default for ProviderModuleRegistry<M> {
+    fn default() -> Self {
+        Self {
+            by_durable: HashMap::new(),
+            by_file: HashMap::new(),
+            defs: Vec::new(),
+        }
+    }
+}
+
+impl<M: Eq + Hash> ProviderModuleRegistry<M> {
+    pub(in crate::sema) fn register(
+        &mut self,
+        durable: M,
+        file: FileId,
+        file_path: &str,
+        import_path: &str,
+        durable_id: &str,
+    ) -> Option<ModuleId> {
+        if let Some(&id) = self.by_durable.get(&durable) {
+            let def = self
+                .defs
+                .get(id.index() as usize)
+                .expect("provider module durable key must index an existing definition");
+            return (def.file_id == file
+                && def.file_path == file_path
+                && def.import_path == import_path
+                && def.durable_id == durable_id)
+                .then_some(id);
+        }
+        if self.by_file.contains_key(&file) {
+            return None;
+        }
+
+        let id = ModuleId::new(self.defs.len() as u32);
+        self.defs.push(ModuleDef::new(
+            import_path.to_owned(),
+            file_path.to_owned(),
+            durable_id.to_owned(),
+            file,
+        ));
+        self.by_durable.insert(durable, id);
+        self.by_file.insert(file, id);
+        Some(id)
+    }
+
+    pub(in crate::sema) fn get(&self, id: ModuleId) -> Option<ModuleDef> {
+        self.defs.get(id.index() as usize).cloned()
+    }
+
+    pub(in crate::sema) fn id_for_file(&self, file: FileId) -> Option<ModuleId> {
+        self.by_file.get(&file).copied()
+    }
+}

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -21650,6 +21650,9 @@ mod tests {
         let point_sym = interner.get("Point").expect("Point interned");
         let holder_sym = interner.get("Holder").expect("Holder interned");
         let color_sym = interner.get("Color").expect("Color interned");
+        let durable_module = merged.ast().modules()[0].module_id().clone();
+        let conflicting_durable_module =
+            crate::ModuleId::from_logical_path("other.rue").expect("second durable module id");
 
         let epoch_point = bound
             .epoch_nominal_type(file, point_sym)
@@ -21660,6 +21663,20 @@ mod tests {
         let epoch_color = bound
             .epoch_nominal_type(file, color_sym)
             .expect("epoch resolves Color");
+        let epoch_module = bound
+            .epoch_module_type(file)
+            .expect("epoch resolves the module endpoint through its registry");
+        let epoch_module_file = bound
+            .epoch_module_file(epoch_module)
+            .expect("epoch module type reverses to its current file");
+        let epoch_module_fact = bound
+            .epoch_module_fact(epoch_module)
+            .expect("epoch module type carries presentation facts");
+        let epoch_aggregate_module_fact = (
+            epoch_module_fact.0,
+            epoch_module_fact.1.clone(),
+            epoch_module_fact.2.clone(),
+        );
         let epoch_point_render =
             bound.with_type_pool(|pool| endpoint_nominal_render(pool, epoch_point));
         let epoch_holder_render =
@@ -21678,6 +21695,8 @@ mod tests {
         let mut database = RevisionedQueryDatabase::default();
         let revision = revision_for(&mut database, &snapshot);
         let adapter = DurableDeclSource::from_declarations(&decls);
+        let call_adapter = DurableDeclSource::from_declarations(&decls);
+        let aggregate_adapter = DurableDeclSource::from_declarations(&decls);
 
         let outcome = database.probe_body_facts(
             revision,
@@ -21736,11 +21755,59 @@ mod tests {
                     })
                     .expect("builtin str resolves through the pool's pre-registered set");
 
-                // A `Module` token constructed here is irrelevant — the arm
-                // fails closed before any lookup.
-                let _ = MTok::new(0, 0);
+                let module_import_path = durable_module.logical_path().to_owned();
+                let module_token = facts
+                    .register_module(
+                        durable_module.clone(),
+                        file,
+                        "/m.rue",
+                        &module_import_path,
+                        &module_import_path,
+                    )
+                    .expect("durable module registration is consistent");
+                assert_eq!(
+                    facts.register_module(
+                        durable_module.clone(),
+                        file,
+                        "/m.rue",
+                        &module_import_path,
+                        &module_import_path,
+                    ),
+                    Some(module_token),
+                    "repeat durable module registration dedups"
+                );
+                assert!(
+                    facts
+                        .register_module(
+                            durable_module.clone(),
+                            FileId::new(2),
+                            "/other.rue",
+                            &module_import_path,
+                            &module_import_path,
+                        )
+                        .is_none(),
+                    "one durable module cannot acquire a conflicting file"
+                );
+                assert!(
+                    facts
+                        .register_module(
+                            conflicting_durable_module,
+                            file,
+                            "/other.rue",
+                            "other.rue",
+                            "other.rue",
+                        )
+                        .is_none(),
+                    "a second durable module cannot claim an already-registered file"
+                );
+                let module_ty = facts
+                    .resolve_instance_type(&T::Module(module_token))
+                    .expect("module arm resolves through provider module facts");
+                let module_file = facts
+                    .module_file(module_ty)
+                    .expect("provider module type reverses to its current file");
 
-                facts.with_type_pool(|pool| {
+                let endpoint_render = facts.with_type_pool(|pool| {
                     (
                         endpoint_nominal_render(pool, point_ty),
                         endpoint_nominal_render(pool, holder_ty),
@@ -21750,12 +21817,62 @@ mod tests {
                         endpoint_display(pool, ptr_mut_ty),
                         endpoint_display(pool, i64_ty),
                         endpoint_display(pool, str_ty),
+                        module_file,
                     )
-                })
+                });
+
+                let call_facts =
+                    rue_air::ProviderCallFacts::new(provider, call_adapter, rir_ref, interner);
+                let call_module = call_facts
+                    .register_module(
+                        durable_module.clone(),
+                        file,
+                        "/m.rue",
+                        &module_import_path,
+                        &module_import_path,
+                    )
+                    .expect("call driver registers durable module facts");
+                let call_module_fact = call_facts
+                    .module_def(call_module)
+                    .map(|definition| {
+                        (
+                            definition.file_id,
+                            definition.file_path,
+                            definition.import_path,
+                            definition.durable_id,
+                        )
+                    })
+                    .expect("call driver answers module_def");
+
+                let aggregate_facts = rue_air::ProviderAggregateFacts::new(aggregate_adapter);
+                let aggregate_module = aggregate_facts
+                    .register_module(
+                        durable_module,
+                        file,
+                        "/m.rue",
+                        &module_import_path,
+                        &module_import_path,
+                    )
+                    .expect("aggregate driver registers durable module facts");
+                let aggregate_module_fact = aggregate_facts
+                    .module_fact(aggregate_module)
+                    .expect("aggregate driver answers module facts");
+
+                (endpoint_render, call_module_fact, aggregate_module_fact)
             },
         );
-        let (point_r, holder_r, color_r, array_d, ptr_const_d, ptr_mut_d, i64_d, str_d) =
-            outcome.result;
+        let (endpoint_render, call_module_fact, aggregate_module_fact) = outcome.result;
+        let (
+            point_r,
+            holder_r,
+            color_r,
+            array_d,
+            ptr_const_d,
+            ptr_mut_d,
+            i64_d,
+            str_d,
+            provider_module_file,
+        ) = endpoint_render;
 
         // Named-nominal arm (struct): full metadata parity against the LIVE epoch.
         assert_eq!(
@@ -21796,6 +21913,18 @@ mod tests {
         assert_eq!(
             str_d, "str",
             "builtin str renders as the pre-registered nominal"
+        );
+        assert_eq!(
+            provider_module_file, epoch_module_file,
+            "module endpoint + registry resolution matches the LIVE epoch"
+        );
+        assert_eq!(
+            call_module_fact, epoch_module_fact,
+            "call module_def matches the LIVE epoch"
+        );
+        assert_eq!(
+            aggregate_module_fact, epoch_aggregate_module_fact,
+            "aggregate module facts match the LIVE epoch"
         );
 
         // The P-op path consults the pool (durable source) + overlay, not the

--- a/docs/notes/rue-1091-analyzer-rewire-plan.md
+++ b/docs/notes/rue-1091-analyzer-rewire-plan.md
@@ -425,10 +425,9 @@ index; that is the boundary-honest form of "a reverse index built from the durab
 and it fails closed on absent, ambiguous-receiver, wrong-`self`-form, and non-matching-render inputs.
 
 **r4b-3 review carry-forwards (flip obligations, not defects).**
-- **The aggregate driver's `by_file_name` overlay needs a stated flip-era fill source.** Its
-  zero-provider-edge property is complete only if the flip fills it from the durable declaration
-  set (keys already carry module/kind/name), or records edges at an upstream lookup. The flip
-  slice states which and asserts the edge story (also doc'd at `register_named_nominal`).
+- **The aggregate driver's `by_file_name` overlay fill source is now stated and pinned.** See the
+  flip-prep rider below: the flip fills it from the admitted durable declaration set, so the fill
+  itself records no provider edge; the provider lookup that selected a name remains the edge.
 - **The production receiver-join adapter must be keyed.** The test fixture's
   `DurableCallableSource::method` recovers the owner nominal by linear scan; the flip-era
   production adapter keys the `owner() → owner-nominal` recovery.
@@ -457,6 +456,74 @@ and it fails closed on absent, ambiguous-receiver, wrong-`self`-form, and non-ma
   edge-differential must treat the RICHER provider-era edge set as the new truth after the flip
   (the finer dependencies are the more-correct incremental behavior), not force the op to suppress
   edges to match the epoch's index-masked footprint.
+
+---
+
+## Rider: flip-prep module registry and overlay fill provenance (recorded landing residue)
+
+The flip has one body-local module registry computation:
+`provider_module_registry::ProviderModuleRegistry`. It deduplicates on the durable
+`BodyFactProvider::ModuleRef`, mints the compact rue-air `ModuleId`, and stores the canonical module
+projection's current `FileId`, physical path, and import/logical path. The endpoint, call, and
+aggregate drivers all delegate their module registration/lookup to that computation:
+`ProviderEndpointFacts::register_module` supplies `module_endpoint` +
+`module_id_for_file`, `ProviderCallFacts::register_module` supplies `module_def`, and
+`ProviderAggregateFacts::register_module` supplies `AggregateFacts::module`. A conflicting
+durable→file/path or file→durable registration fails closed. The
+`provider_endpoint_facts_resolve_instance_type_matches_epoch` differential compares all three
+provider projections with the LIVE epoch registry and pins dedup plus conflict refusal.
+
+### Fill-source provenance at flip time
+
+Every public `register_*` entry point on a provider-era overlay has one source:
+
+- `ProviderEndpointFacts::register_named_nominal`: the nominal's stable key comes from the durable
+  type/signature fact that caused materialization; file/name/kind come from that declaration's
+  candidate handle plus `BodyFactProvider::declaration_identity`. The driver performs only the
+  body-local key→token/id materialization. The named struct+enum rows in
+  `provider_endpoint_facts_resolve_instance_type_matches_epoch` pin this source.
+- `ProviderEndpointFacts::register_anonymous_nominal`: the issued identity is body-local producer
+  output; its durable anonymous identity comes from `BodyFactProvider::anonymous_facts` for
+  declaration-produced shapes or `producer_body_facts` for a reached producer body. The positive
+  struct/enum differentials
+  `provider_endpoint_facts_anonymous_arm_mints_after_registration` and
+  `provider_endpoint_facts_anonymous_enum_mints_match_epoch` pin both materializations.
+- `ProviderEndpointFacts::register_generated_slice`: the durable
+  `SemanticImportType::Slice { element, name }` is the already-resolved signature/type fact; the
+  driver mints the body-local fat-pointer nominal. The r6a slice differential pins the fill.
+- `ProviderEndpointFacts::register_module`, `ProviderCallFacts::register_module`, and
+  `ProviderAggregateFacts::register_module`: the durable module handle is the admitted module-set
+  key (the same key under which `module_declaration_sets` is observed); file/path/import-path are
+  current canonical module-projection inputs. These are registry/materialization facts, not name
+  winners, so registration itself records no provider edge. The module-registry differential named
+  above pins all three consumers against the LIVE epoch.
+- `ProviderAggregateFacts::register_named_nominal`: fill from the admitted durable declaration set
+  (`bind_canonical_declaration_semantics` / the flip's keyed equivalent), whose stable key already
+  carries module/kind/name; the canonical module projection supplies the current `FileId`. No
+  provider edge is invented by this index fill. The struct/enum rows in
+  `provider_aggregate_facts_nominal_and_builtin_match_epoch` construct the driver from exactly that
+  durable set and pin epoch parity.
+- `ProviderAggregateFacts::register_file_path`: fill from request-local source metadata, the same
+  body-local presentation input as RIR spans. It is deliberately not claimed as declaration-level
+  durable truth. `provider_aggregate_facts_is_accessible_matches_epoch` registers the identical
+  physical paths on both sides and pins every visibility row.
+
+### Honest STOPs
+
+The registry residue is closed, but neighboring aggregate/call paths still have deliberately
+unwired compositions that must not be inferred from registry data:
+
+- The durable const identity and exact declaration RIR handle now exist, but
+  `value_const` / `module_binding` are not yet registered into the aggregate/call drivers. The
+  aggregate const-arm differential continues to pin provider `Absent` versus epoch `Const`.
+  Module bindings require the flip to compose that const materialization with the now-real module
+  registry; neither fact substitutes for the missing composition.
+- aggregate `source_path(span)` is request/RIR presentation state, not declaration truth. It remains
+  a flip-time body-local input; no durable provider fact is claimed for it.
+
+This residue is inert before the flip: production still uses the epoch implementations. No new
+public `Type`-named surface was introduced; the shared registry seam is
+`pub(in crate::sema)`.
 
 ---
 
@@ -545,9 +612,10 @@ independently bound records. The pool/RIR machinery remains pre-flip only: no pr
 call site consumes it, and the existing crate-level dead-code discipline remains in force.
 
 **(d) Honest STOPs and the r6b hard boundary.** Module bindings remain refused: their durable target
-module is real, but the pool still lacks the body-local module-registry identity needed to mint the
-epoch's `Type::Module`; the differential pins LIVE-epoch success versus pool `None`. A missing
-declaration-level durable const record likewise returns `MissingConst`, never an inferred value.
+module and the provider drivers' body-local module registry are real, but const-payload
+materialization is not yet composed with that registry to mint the epoch's `Type::Module`; the
+differential pins LIVE-epoch success versus pool `None`. A missing declaration-level durable const
+record likewise returns `MissingConst`, never an inferred value.
 Const payload materialization uses `BodyIdentityPool::resolve`, whose anonymous arm is lookup-only;
 it never calls `find_or_create_anon`. Therefore a producer rooted at an uninstalled const candidate
 whose epoch digest relocation contains session-local `d\u{1}{issuer}\u{1}{slot}` /


### PR DESCRIPTION
## Summary

- add a body-local module registry backed by durable module identities
- answer endpoint, call-resolution, and aggregate module-definition consults from registered facts
- compare each provider projection with the LIVE epoch and pin deduplication plus conflict refusal
- document flip-time provenance for every provider overlay registration entry point and retain honest STOPs where durable declaration truth is still absent

## Scope

This is inert flip preparation and does not switch production body analysis to the provider path. It is independent of #1954.

Refs RUE-1091.

## Validation

- `./buck2 test //:type-architecture-inventory-validation //:body-analysis-capability-inventory-validation`
- `./buck2 test //crates/rue-air:rue-air-test //crates/rue-compiler:rue-compiler-test`
- `scripts/rue quick`
- `./clippy.sh`
- `scripts/rue fmt`