### PR TITLE
RUE-1091: wire provider drivers into the rFinal side-B analyzer

### DIFF
--- a/crates/rue-air/src/sema/body_endpoint.rs
+++ b/crates/rue-air/src/sema/body_endpoint.rs
@@ -770,6 +770,32 @@ where
     pub fn with_type_pool<R>(&self, read: impl FnOnce(&TypeInternPool) -> R) -> R {
         read(self.pool.borrow().type_pool())
     }
+
+    /// Freeze the pool's containment metadata — the pool-side `freeze()` seam
+    /// hook the r4a-2a rider defers to the slice that wires the pool under body
+    /// analysis (RUE-1091 rFinal). A caller invokes this at the same point
+    /// production calls `finalize_containment_metadata` (after every nominal
+    /// the body consumes has been minted, before any drop/ownership read);
+    /// `None` on a containment cycle (fail-closed). Before the freeze,
+    /// [`Self::type_needs_drop`] / [`Self::type_carries_linear`] answer `None`.
+    pub fn finalize_containment_metadata(&self) -> Option<()> {
+        self.pool.borrow().finalize_containment_metadata()
+    }
+
+    /// Whether a minted type transitively needs drop, or `None` before the
+    /// [`Self::finalize_containment_metadata`] freeze. The pool mints every
+    /// nominal with `destructor: None` (drop metadata is out of the pool's
+    /// minting scope), so destructor-symbol parity remains flip work — the
+    /// harness records that as a named gap, never a silent divergence.
+    pub fn type_needs_drop(&self, ty: Type) -> Option<bool> {
+        self.pool.borrow().type_needs_drop(ty)
+    }
+
+    /// Whether a minted type transitively carries a linear component, or `None`
+    /// before the freeze.
+    pub fn type_carries_linear(&self, ty: Type) -> Option<bool> {
+        self.pool.borrow().type_carries_linear(ty)
+    }
 }
 
 impl<P, S, K, M> ProviderEndpointFacts<'_, P, S, K, M>

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -492,6 +492,39 @@ where
         &self.param_arena
     }
 
+    /// Freeze the pool's containment metadata — the pool-side `freeze()`
+    /// hook the module docs defer to the slice that wires the pool under body
+    /// analysis (RUE-1091 rFinal). Called at the same point production freezes
+    /// (`Sema::finalize_containment_metadata` at the end of declaration
+    /// registration, before drop/ownership reads), after every nominal the body
+    /// consumes has been minted. `None` on a containment cycle (fail-closed,
+    /// exactly as production surfaces the cycle as an error). Until this is
+    /// called, [`Self::type_needs_drop`] / [`Self::type_carries_linear`] answer
+    /// `None` — the un-finalized state production's shell/completion pair also
+    /// leaves before its freeze.
+    pub(in crate::sema) fn finalize_containment_metadata(&self) -> Option<()> {
+        self.type_pool
+            .finalize_containment_metadata()
+            .ok()
+            .map(|_| ())
+    }
+
+    /// Whether a minted type transitively needs drop, or `None` before
+    /// [`Self::finalize_containment_metadata`] froze the containment graph.
+    /// NOTE: the pool registers every nominal with `destructor: None` (drop
+    /// metadata is deliberately out of the pool's minting scope — module docs),
+    /// so this answers the containment join over the pool's own registrations;
+    /// destructor-symbol parity is flip work.
+    pub(in crate::sema) fn type_needs_drop(&self, ty: Type) -> Option<bool> {
+        self.type_pool.try_type_needs_drop(ty)
+    }
+
+    /// Whether a minted type transitively carries a linear component, or `None`
+    /// before [`Self::finalize_containment_metadata`].
+    pub(in crate::sema) fn type_carries_linear(&self, ty: Type) -> Option<bool> {
+        self.type_pool.try_type_carries_linear(ty)
+    }
+
     /// Resolve an interned parameter/name symbol to its source string. The
     /// pool's [`Spur`]s are pool-interner-relative (like its pool indices), so
     /// name parity is asserted through resolved strings, never raw symbols.
@@ -2357,6 +2390,37 @@ mod tests {
         );
         assert!(after_first > before, "first consult minted an identity");
         assert_eq!(render(pool.type_pool(), first), "Point");
+    }
+
+    #[test]
+    fn containment_freeze_hook_gates_drop_and_linearity_reads() {
+        // The rFinal seam hook (r4a-2a rider): drop/linearity reads answer
+        // `None` until the pool-side freeze runs, then answer the containment
+        // join over the pool's own registrations. Destructor metadata stays out
+        // of the pool's minting scope, so the join sees `destructor: None`.
+        let mut pool = pool([(
+            0,
+            named(
+                "Point",
+                "pkg/geom.rue",
+                true,
+                struct_body(vec![("x", DType::I64), ("y", DType::I64)], false, false),
+            ),
+        )]);
+        let ty = pool.resolve(&DType::Nominal(0)).unwrap();
+        assert_eq!(
+            pool.type_needs_drop(ty),
+            None,
+            "un-finalized before the freeze, as production leaves it"
+        );
+        assert_eq!(pool.type_carries_linear(ty), None);
+        pool.finalize_containment_metadata()
+            .expect("no containment cycle");
+        assert_eq!(pool.type_needs_drop(ty), Some(false));
+        assert_eq!(pool.type_carries_linear(ty), Some(false));
+        // Repeat freeze is a pure re-finalization, not an error.
+        pool.finalize_containment_metadata()
+            .expect("repeat freeze is fine");
     }
 
     #[test]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -6351,7 +6351,7 @@ impl RevisionedQueryDatabase {
     /// Construct the database with an explicit declaration-keyed memo
     /// retention. Production uses [`DECLARATION_QUERY_MEMO_RETENTION`];
     /// eviction-lifecycle tests pass a small cap so exceeding it stays cheap.
-    fn with_declaration_memo_retention(declaration_memo_retention: usize) -> Self {
+    pub(crate) fn with_declaration_memo_retention(declaration_memo_retention: usize) -> Self {
         let runtime = QueryRuntime::new(1);
         let module_store = Arc::new(Mutex::new(ModuleInputStore::default()));
         #[cfg(test)]
@@ -13247,11 +13247,11 @@ impl<'p, 'db> SignatureFacts<'p, 'db> {
 
 /// The recorded edges and captured result of one provider-observation probe.
 #[cfg(test)]
-struct ProviderProbeOutcome<R> {
+pub(crate) struct ProviderProbeOutcome<R> {
     /// The value the probe closure produced.
-    result: R,
+    pub(crate) result: R,
     /// Every dependency node the provider ops recorded, in observation order.
-    dependencies: Vec<rue_query::NodeIdentity>,
+    pub(crate) dependencies: Vec<rue_query::NodeIdentity>,
 }
 
 #[cfg(test)]
@@ -13270,7 +13270,7 @@ impl RevisionedQueryDatabase {
     /// the exact set of query edges the provider recorded, so a test proves both
     /// the returned facts (differential vs the production epoch) and that each op
     /// recorded exactly its backing terminal.
-    fn probe_body_facts<R>(
+    pub(crate) fn probe_body_facts<R>(
         &self,
         revision: Revision,
         configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
@@ -13324,7 +13324,7 @@ impl RevisionedQueryDatabase {
     /// while the promotion still targets the same evolving root. Returns whether a
     /// root was published (and therefore promoted); a canceled request publishes
     /// no root and its observed pins release with the request, never promoted.
-    fn publish_lookup_root(
+    pub(crate) fn publish_lookup_root(
         &self,
         revision: Revision,
         configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
@@ -13369,8 +13369,417 @@ impl RevisionedQueryDatabase {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Shared test support for the provider differentials and the rFinal harness
+// (`session/tests/rfinal_harness.rs`): the durable declaration adapter the
+// body identity pool consults and the index-independent pool renders. Test
+// only; the flip's production adapter replaces `DurableDeclSource` with a
+// keyed production source (r4b-3 receiver-join obligation).
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+
+    /// The production durable declaration set for a snapshot — the epoch truth
+    /// the provider resolution is diffed against.
+    pub(crate) fn production_declarations(
+        snapshot: &SourceSnapshot,
+    ) -> Arc<[crate::durable_semantics::DurableDeclarationSemantic]> {
+        let parsed = crate::parsed_modules::parse_source_snapshot_modules(snapshot).unwrap();
+        let merged = crate::merge_parsed_modules(&parsed).unwrap();
+        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let (_definitions, query_declarations, _work) =
+            crate::bound_definitions::bind_canonical_declaration_semantics(
+                &merged,
+                &rir,
+                crate::PreviewFeatures::default(),
+                rue_target::Target::X86_64Linux,
+            )
+            .unwrap();
+        query_declarations
+    }
+
+    pub(crate) fn durable_decl<'a>(
+        decls: &'a [crate::durable_semantics::DurableDeclarationSemantic],
+        kind: crate::StableDefinitionKind,
+        name: &str,
+    ) -> &'a crate::durable_semantics::DurableDeclarationSemantic {
+        decls
+            .iter()
+            .find(|record| record.key.kind() == kind && record.key.name() == name)
+            .unwrap_or_else(|| panic!("no production {kind:?} named {name}"))
+    }
+    /// The durable declaration set projected into the body identity pool's
+    /// durable source vocabulary. Reads r2's stable-keyed metadata by key — the
+    /// pool consults it on demand (dedup / poison), the O(consumed) shape.
+    pub(crate) struct DurableDeclSource {
+        by_key: std::collections::HashMap<
+            StableDefinitionKey,
+            crate::durable_semantics::DurableDeclarationSemantic,
+        >,
+        anon_by_identity: std::collections::HashMap<
+            crate::AnonymousNominalKey,
+            crate::durable_semantics::DurableAnonymousNominal,
+        >,
+    }
+
+    impl DurableDeclSource {
+        pub(crate) fn from_declarations(
+            decls: &[crate::durable_semantics::DurableDeclarationSemantic],
+        ) -> Self {
+            Self {
+                by_key: decls.iter().map(|d| (d.key.clone(), d.clone())).collect(),
+                anon_by_identity: std::collections::HashMap::new(),
+            }
+        }
+
+        /// Seed the durable anonymous nominals the pool mints from (RUE-1091 r6b).
+        /// The durable anonymous universe is keyed by the CANONICAL producer form
+        /// (the `DurableAnonymousSource` contract — the pool collapses its
+        /// incoming key on entry and consults shapes under that form), so the
+        /// adapter indexes each nominal by the shared collapse rather than its
+        /// as-projected identity: the declaration-SIGNATURE projection retains an
+        /// empty-argument specialization wrapper production body-export does not.
+        pub(crate) fn with_anonymous_nominals(
+            mut self,
+            anonymous: &[crate::durable_semantics::DurableAnonymousNominal],
+        ) -> Self {
+            self.anon_by_identity = anonymous
+                .iter()
+                .map(|nominal| {
+                    (
+                        nominal.identity.with_canonical_producer().into_owned(),
+                        nominal.clone(),
+                    )
+                })
+                .collect();
+            self
+        }
+    }
+    /// Relocate a durable `StableDefinitionKey` to the exact stable-symbol content
+    /// the epoch's `stable_definition_symbol_component` (rue-air `anon_structs.rs`)
+    /// emits for its installed endpoint, so the pool and the epoch spell the same
+    /// `__anon_*_{digest}` name (RUE-1091 r6b). The durable key carries the module
+    /// logical path, name, owner NAME, and kind — the same four parts the epoch's
+    /// endpoint carries — fed to the ONE shared format assembly
+    /// (`rue_air::stable_digest::stable_definition_component`) the epoch also
+    /// renders through.
+    fn durable_definition_symbol_component(key: &StableDefinitionKey) -> String {
+        rue_air::stable_digest::stable_definition_component(
+            key.module().logical_path(),
+            key.name(),
+            key.owner().map(|owner| owner.name()),
+            key.kind() as u8,
+        )
+    }
+
+    fn durable_module_symbol_component(module: &ModuleId) -> String {
+        rue_air::stable_digest::stable_module_component(module.logical_path())
+    }
+
+    fn durable_anonymous_shape(
+        shape: &crate::durable_semantics::DurableAnonymousNominalShape,
+    ) -> rue_air::DurableAnonymousShape<StableDefinitionKey, ModuleId> {
+        use crate::durable_semantics::DurableAnonymousNominalShape as S;
+        match shape {
+            S::Struct { fields, methods } => rue_air::DurableAnonymousShape::Struct {
+                fields: fields.iter().map(|(n, t)| (n.clone(), t.clone())).collect(),
+                struct_method_names: methods.iter().map(|m| m.name.clone()).collect(),
+            },
+            S::Enum { variants } => rue_air::DurableAnonymousShape::Enum {
+                variants: variants
+                    .iter()
+                    .map(|(n, payload)| (n.clone(), payload.to_vec()))
+                    .collect(),
+            },
+        }
+    }
+
+    impl rue_air::DurableAnonymousSource<StableDefinitionKey, ModuleId> for DurableDeclSource {
+        fn anonymous_shape(
+            &self,
+            key: &crate::AnonymousNominalKey,
+        ) -> Option<rue_air::DurableAnonymousShape<StableDefinitionKey, ModuleId>> {
+            self.anon_by_identity
+                .get(key)
+                .map(|nominal| durable_anonymous_shape(&nominal.shape))
+        }
+
+        fn definition_symbol_component(&self, key: &StableDefinitionKey) -> String {
+            durable_definition_symbol_component(key)
+        }
+
+        fn module_symbol_component(&self, module: &ModuleId) -> String {
+            durable_module_symbol_component(module)
+        }
+    }
+
+    fn provider_durable_param(
+        parameter: &crate::durable_semantics::DurableSemanticParameter,
+    ) -> rue_air::DurableSignatureParameter<StableDefinitionKey, ModuleId> {
+        use crate::durable_semantics::DurableParameterMode as Mode;
+        rue_air::DurableSignatureParameter {
+            name: parameter.name.clone(),
+            ty: parameter.ty.clone(),
+            mode: match parameter.mode {
+                Mode::Value => rue_air::SemanticParameterMode::Value,
+                Mode::Borrow => rue_air::SemanticParameterMode::Borrow,
+                Mode::Inout => rue_air::SemanticParameterMode::Inout,
+            },
+            is_comptime: parameter.is_comptime,
+        }
+    }
+
+    impl rue_air::DurableNominalSource<StableDefinitionKey, ModuleId> for DurableDeclSource {
+        fn nominal(
+            &self,
+            key: &StableDefinitionKey,
+        ) -> Option<rue_air::DurableNominal<StableDefinitionKey, ModuleId>> {
+            use crate::durable_semantics::DurableDeclarationPayload as Payload;
+            let decl = self.by_key.get(key)?;
+            let body = match &decl.payload {
+                Payload::Struct {
+                    fields,
+                    is_copy,
+                    is_linear,
+                } => rue_air::DurableNominalBody::Struct {
+                    fields: fields.iter().map(|(n, t)| (n.clone(), t.clone())).collect(),
+                    is_copy: *is_copy,
+                    is_linear: *is_linear,
+                },
+                Payload::Enum { variants } => rue_air::DurableNominalBody::Enum {
+                    variants: variants
+                        .iter()
+                        .map(|(n, payload)| (n.clone(), payload.to_vec()))
+                        .collect(),
+                },
+                _ => return None,
+            };
+            Some(rue_air::DurableNominal {
+                name: Arc::from(decl.key.name()),
+                module_path: Arc::from(decl.key.module().logical_path()),
+                is_public: decl.is_public,
+                // A user nominal in the durable set: builtin/lang-item/`@repr(c)`
+                // are trusted-provenance / declaration side facts the durable
+                // payload does not carry, so this differential's user corpora
+                // leave them at their non-set defaults.
+                is_builtin: false,
+                lang_item: None,
+                is_repr_c: false,
+                body,
+            })
+        }
+    }
+
+    impl rue_air::DurableCallableSource<StableDefinitionKey, ModuleId> for DurableDeclSource {
+        fn function(
+            &self,
+            key: &StableDefinitionKey,
+        ) -> Option<rue_air::DurableFunction<StableDefinitionKey, ModuleId>> {
+            use crate::durable_semantics::DurableDeclarationPayload as Payload;
+            let decl = self.by_key.get(key)?;
+            let Payload::Callable {
+                parameters,
+                result,
+                has_self,
+                is_unchecked,
+            } = &decl.payload
+            else {
+                return None;
+            };
+            // A `self`-taking callable is a method, not a free function.
+            if *has_self {
+                return None;
+            }
+            Some(rue_air::DurableFunction {
+                parameters: parameters.iter().map(provider_durable_param).collect(),
+                result: result.clone(),
+                is_public: decl.is_public,
+                is_unchecked: *is_unchecked,
+            })
+        }
+
+        fn method(
+            &self,
+            key: &StableDefinitionKey,
+        ) -> Option<rue_air::DurableMethod<StableDefinitionKey, ModuleId>> {
+            // r4b-3: the durable method key's receiver preimage is its owner
+            // nominal. The `Callable` payload carries the explicit parameters and
+            // result (self is separate, tracked by `has_self`); the receiver type
+            // is the owner nominal, recovered by joining the method key's
+            // `owner()` (module + kind + name) back to the owner nominal's own
+            // durable key in this set, so the pool resolves it through the same 2a
+            // nominal machinery as any parameter type.
+            use crate::durable_semantics::DurableDeclarationPayload as Payload;
+            let decl = self.by_key.get(key)?;
+            let Payload::Callable {
+                parameters,
+                result,
+                has_self,
+                ..
+            } = &decl.payload
+            else {
+                return None;
+            };
+            // A free function (no self) is not a method.
+            if !*has_self {
+                return None;
+            }
+            let owner = key.owner()?;
+            let owner_key = self
+                .by_key
+                .keys()
+                .find(|candidate| {
+                    candidate.owner().is_none()
+                        && candidate.module() == owner.module()
+                        && candidate.kind() == owner.kind()
+                        && candidate.name() == owner.name()
+                })?
+                .clone();
+            Some(rue_air::DurableMethod {
+                receiver: rue_air::SemanticImportType::Nominal(owner_key),
+                parameters: parameters.iter().map(provider_durable_param).collect(),
+                result: result.clone(),
+                has_self: *has_self,
+            })
+        }
+    }
+
+    impl rue_air::DurableConstSource<StableDefinitionKey, ModuleId> for DurableDeclSource {
+        fn constant(
+            &self,
+            key: &StableDefinitionKey,
+        ) -> Option<rue_air::DurableConst<StableDefinitionKey, ModuleId>> {
+            use crate::durable_semantics::DurableDeclarationPayload as Payload;
+            let decl = self.by_key.get(key)?;
+            let Payload::Const { ty, value } = &decl.payload else {
+                // Module bindings deliberately STOP here: their durable target
+                // is real, but the body pool has no module-registry identity arm
+                // from which to mint the epoch-local `Type::Module`.
+                return None;
+            };
+            Some(rue_air::DurableConst {
+                is_public: decl.is_public,
+                ty: ty.clone(),
+                value: value.clone(),
+            })
+        }
+
+        fn function_name(&self, key: &StableDefinitionKey) -> Option<Arc<str>> {
+            use crate::durable_semantics::DurableDeclarationPayload as Payload;
+            matches!(self.by_key.get(key)?.payload, Payload::Callable { .. })
+                .then(|| Arc::from(key.name()))
+        }
+    }
+    /// The index-independent render of a nominal pool [`rue_air::Type`]: the
+    /// display, copyability, visibility, mangled symbol, and member vocabulary a
+    /// differential compares across two independently-minted pools (the pool
+    /// mints its own ids; parity is a display/metadata property).
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(crate) struct EndpointNominalRender {
+        pub(crate) display: String,
+        pub(crate) is_copy: bool,
+        pub(crate) is_pub: bool,
+        pub(crate) symbol: String,
+        pub(crate) members: Vec<(String, String)>,
+    }
+
+    /// Render any pool [`rue_air::Type`] to its display, recursing through pool
+    /// indices so it is index-independent and safe to compare across two pools.
+    pub(crate) fn endpoint_display(pool: &rue_air::TypeInternPool, ty: rue_air::Type) -> String {
+        use rue_air::TypeKind;
+        match ty.kind() {
+            TypeKind::I8 => "i8".into(),
+            TypeKind::I16 => "i16".into(),
+            TypeKind::I32 => "i32".into(),
+            TypeKind::I64 => "i64".into(),
+            TypeKind::U8 => "u8".into(),
+            TypeKind::U16 => "u16".into(),
+            TypeKind::U32 => "u32".into(),
+            TypeKind::U64 => "u64".into(),
+            TypeKind::Bool => "bool".into(),
+            TypeKind::Unit => "()".into(),
+            TypeKind::Never => "!".into(),
+            TypeKind::ComptimeType => "type".into(),
+            TypeKind::Struct(id) => pool.struct_def(id).name,
+            TypeKind::Enum(id) => pool.enum_def(id).name,
+            TypeKind::Array(id) => {
+                let (element, len) = pool.array_def(id);
+                format!("[{}; {}]", endpoint_display(pool, element), len)
+            }
+            TypeKind::PtrConst(id) => {
+                format!(
+                    "ptr const {}",
+                    endpoint_display(pool, pool.ptr_const_def(id))
+                )
+            }
+            TypeKind::PtrMut(id) => {
+                format!("ptr mut {}", endpoint_display(pool, pool.ptr_mut_def(id)))
+            }
+            other => format!("{other:?}"),
+        }
+    }
+
+    /// Index-independent copyability, mirroring `Sema::is_type_copy`.
+    pub(crate) fn endpoint_is_copy(pool: &rue_air::TypeInternPool, ty: rue_air::Type) -> bool {
+        use rue_air::TypeKind;
+        match ty.kind() {
+            TypeKind::Struct(id) => pool.struct_def(id).is_copy,
+            TypeKind::Enum(id) => pool
+                .enum_def(id)
+                .variant_payloads
+                .iter()
+                .flatten()
+                .all(|&ty| endpoint_is_copy(pool, ty)),
+            TypeKind::Array(id) => endpoint_is_copy(pool, pool.array_def(id).0),
+            _ => true,
+        }
+    }
+
+    /// Render a nominal (struct or enum) pool [`rue_air::Type`] to its
+    /// index-independent metadata.
+    pub(crate) fn endpoint_nominal_render(
+        pool: &rue_air::TypeInternPool,
+        ty: rue_air::Type,
+    ) -> EndpointNominalRender {
+        use rue_air::TypeKind;
+        match ty.kind() {
+            TypeKind::Struct(id) => {
+                let def = pool.struct_def(id);
+                EndpointNominalRender {
+                    display: def.name.clone(),
+                    is_copy: def.is_copy,
+                    is_pub: def.is_pub,
+                    symbol: pool.struct_symbol_name(id),
+                    members: def
+                        .fields
+                        .iter()
+                        .map(|field| (field.name.clone(), endpoint_display(pool, field.ty)))
+                        .collect(),
+                }
+            }
+            TypeKind::Enum(id) => {
+                let def = pool.enum_def(id);
+                EndpointNominalRender {
+                    display: def.name.clone(),
+                    is_copy: endpoint_is_copy(pool, ty),
+                    is_pub: def.is_pub,
+                    symbol: pool.enum_symbol_name(id),
+                    members: def
+                        .variants
+                        .iter()
+                        .map(|variant| (variant.clone(), String::new()))
+                        .collect(),
+                }
+            }
+            other => panic!("endpoint_nominal_render expects a nominal, got {other:?}"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::test_support::*;
     use super::*;
     use crate::{
         CompilerSession, DiscoverySourceAssembler, FileMetadataFingerprint, ImportDiscoveryContext,
@@ -19760,36 +20169,6 @@ mod tests {
     // produced durable declaration set (`bind_canonical_declaration_semantics`),
     // never the same provider terminal, so agreement is a real cross-path proof.
 
-    /// The production durable declaration set for a snapshot — the epoch truth
-    /// the provider resolution is diffed against.
-    fn production_declarations(
-        snapshot: &SourceSnapshot,
-    ) -> Arc<[crate::durable_semantics::DurableDeclarationSemantic]> {
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(snapshot).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
-        let (_definitions, query_declarations, _work) =
-            crate::bound_definitions::bind_canonical_declaration_semantics(
-                &merged,
-                &rir,
-                crate::PreviewFeatures::default(),
-                rue_target::Target::X86_64Linux,
-            )
-            .unwrap();
-        query_declarations
-    }
-
-    fn durable_decl<'a>(
-        decls: &'a [crate::durable_semantics::DurableDeclarationSemantic],
-        kind: crate::StableDefinitionKind,
-        name: &str,
-    ) -> &'a crate::durable_semantics::DurableDeclarationSemantic {
-        decls
-            .iter()
-            .find(|record| record.key.kind() == kind && record.key.name() == name)
-            .unwrap_or_else(|| panic!("no production {kind:?} named {name}"))
-    }
-
     /// Resolve `syntax` through `ProviderTypeFacts` inside one probe, returning
     /// the resolved durable type (or `None` when resolution failed / deferred),
     /// the overlay metadata materialized for `materialized_key`, and the exact
@@ -20714,265 +21093,6 @@ mod tests {
     // inert flip-prep but are not wired under this call driver; `module_def`
     // answers an epoch-internal registry index with no provider preimage.
 
-    /// The durable declaration set projected into the body identity pool's
-    /// durable source vocabulary. Reads r2's stable-keyed metadata by key — the
-    /// pool consults it on demand (dedup / poison), the O(consumed) shape.
-    struct DurableDeclSource {
-        by_key: HashMap<StableDefinitionKey, crate::durable_semantics::DurableDeclarationSemantic>,
-        anon_by_identity:
-            HashMap<crate::AnonymousNominalKey, crate::durable_semantics::DurableAnonymousNominal>,
-    }
-
-    impl DurableDeclSource {
-        fn from_declarations(
-            decls: &[crate::durable_semantics::DurableDeclarationSemantic],
-        ) -> Self {
-            Self {
-                by_key: decls.iter().map(|d| (d.key.clone(), d.clone())).collect(),
-                anon_by_identity: HashMap::new(),
-            }
-        }
-
-        /// Seed the durable anonymous nominals the pool mints from (RUE-1091 r6b).
-        /// The durable anonymous universe is keyed by the CANONICAL producer form
-        /// (the `DurableAnonymousSource` contract — the pool collapses its
-        /// incoming key on entry and consults shapes under that form), so the
-        /// adapter indexes each nominal by the shared collapse rather than its
-        /// as-projected identity: the declaration-SIGNATURE projection retains an
-        /// empty-argument specialization wrapper production body-export does not.
-        fn with_anonymous_nominals(
-            mut self,
-            anonymous: &[crate::durable_semantics::DurableAnonymousNominal],
-        ) -> Self {
-            self.anon_by_identity = anonymous
-                .iter()
-                .map(|nominal| {
-                    (
-                        nominal.identity.with_canonical_producer().into_owned(),
-                        nominal.clone(),
-                    )
-                })
-                .collect();
-            self
-        }
-    }
-
-    /// Relocate a durable `StableDefinitionKey` to the exact stable-symbol content
-    /// the epoch's `stable_definition_symbol_component` (rue-air `anon_structs.rs`)
-    /// emits for its installed endpoint, so the pool and the epoch spell the same
-    /// `__anon_*_{digest}` name (RUE-1091 r6b). The durable key carries the module
-    /// logical path, name, owner NAME, and kind — the same four parts the epoch's
-    /// endpoint carries — fed to the ONE shared format assembly
-    /// (`rue_air::stable_digest::stable_definition_component`) the epoch also
-    /// renders through.
-    fn durable_definition_symbol_component(key: &StableDefinitionKey) -> String {
-        rue_air::stable_digest::stable_definition_component(
-            key.module().logical_path(),
-            key.name(),
-            key.owner().map(|owner| owner.name()),
-            key.kind() as u8,
-        )
-    }
-
-    fn durable_module_symbol_component(module: &ModuleId) -> String {
-        rue_air::stable_digest::stable_module_component(module.logical_path())
-    }
-
-    fn durable_anonymous_shape(
-        shape: &crate::durable_semantics::DurableAnonymousNominalShape,
-    ) -> rue_air::DurableAnonymousShape<StableDefinitionKey, ModuleId> {
-        use crate::durable_semantics::DurableAnonymousNominalShape as S;
-        match shape {
-            S::Struct { fields, methods } => rue_air::DurableAnonymousShape::Struct {
-                fields: fields.iter().map(|(n, t)| (n.clone(), t.clone())).collect(),
-                struct_method_names: methods.iter().map(|m| m.name.clone()).collect(),
-            },
-            S::Enum { variants } => rue_air::DurableAnonymousShape::Enum {
-                variants: variants
-                    .iter()
-                    .map(|(n, payload)| (n.clone(), payload.to_vec()))
-                    .collect(),
-            },
-        }
-    }
-
-    impl rue_air::DurableAnonymousSource<StableDefinitionKey, ModuleId> for DurableDeclSource {
-        fn anonymous_shape(
-            &self,
-            key: &crate::AnonymousNominalKey,
-        ) -> Option<rue_air::DurableAnonymousShape<StableDefinitionKey, ModuleId>> {
-            self.anon_by_identity
-                .get(key)
-                .map(|nominal| durable_anonymous_shape(&nominal.shape))
-        }
-
-        fn definition_symbol_component(&self, key: &StableDefinitionKey) -> String {
-            durable_definition_symbol_component(key)
-        }
-
-        fn module_symbol_component(&self, module: &ModuleId) -> String {
-            durable_module_symbol_component(module)
-        }
-    }
-
-    fn provider_durable_param(
-        parameter: &crate::durable_semantics::DurableSemanticParameter,
-    ) -> rue_air::DurableSignatureParameter<StableDefinitionKey, ModuleId> {
-        use crate::durable_semantics::DurableParameterMode as Mode;
-        rue_air::DurableSignatureParameter {
-            name: parameter.name.clone(),
-            ty: parameter.ty.clone(),
-            mode: match parameter.mode {
-                Mode::Value => rue_air::SemanticParameterMode::Value,
-                Mode::Borrow => rue_air::SemanticParameterMode::Borrow,
-                Mode::Inout => rue_air::SemanticParameterMode::Inout,
-            },
-            is_comptime: parameter.is_comptime,
-        }
-    }
-
-    impl rue_air::DurableNominalSource<StableDefinitionKey, ModuleId> for DurableDeclSource {
-        fn nominal(
-            &self,
-            key: &StableDefinitionKey,
-        ) -> Option<rue_air::DurableNominal<StableDefinitionKey, ModuleId>> {
-            use crate::durable_semantics::DurableDeclarationPayload as Payload;
-            let decl = self.by_key.get(key)?;
-            let body = match &decl.payload {
-                Payload::Struct {
-                    fields,
-                    is_copy,
-                    is_linear,
-                } => rue_air::DurableNominalBody::Struct {
-                    fields: fields.iter().map(|(n, t)| (n.clone(), t.clone())).collect(),
-                    is_copy: *is_copy,
-                    is_linear: *is_linear,
-                },
-                Payload::Enum { variants } => rue_air::DurableNominalBody::Enum {
-                    variants: variants
-                        .iter()
-                        .map(|(n, payload)| (n.clone(), payload.to_vec()))
-                        .collect(),
-                },
-                _ => return None,
-            };
-            Some(rue_air::DurableNominal {
-                name: Arc::from(decl.key.name()),
-                module_path: Arc::from(decl.key.module().logical_path()),
-                is_public: decl.is_public,
-                // A user nominal in the durable set: builtin/lang-item/`@repr(c)`
-                // are trusted-provenance / declaration side facts the durable
-                // payload does not carry, so this differential's user corpora
-                // leave them at their non-set defaults.
-                is_builtin: false,
-                lang_item: None,
-                is_repr_c: false,
-                body,
-            })
-        }
-    }
-
-    impl rue_air::DurableCallableSource<StableDefinitionKey, ModuleId> for DurableDeclSource {
-        fn function(
-            &self,
-            key: &StableDefinitionKey,
-        ) -> Option<rue_air::DurableFunction<StableDefinitionKey, ModuleId>> {
-            use crate::durable_semantics::DurableDeclarationPayload as Payload;
-            let decl = self.by_key.get(key)?;
-            let Payload::Callable {
-                parameters,
-                result,
-                has_self,
-                is_unchecked,
-            } = &decl.payload
-            else {
-                return None;
-            };
-            // A `self`-taking callable is a method, not a free function.
-            if *has_self {
-                return None;
-            }
-            Some(rue_air::DurableFunction {
-                parameters: parameters.iter().map(provider_durable_param).collect(),
-                result: result.clone(),
-                is_public: decl.is_public,
-                is_unchecked: *is_unchecked,
-            })
-        }
-
-        fn method(
-            &self,
-            key: &StableDefinitionKey,
-        ) -> Option<rue_air::DurableMethod<StableDefinitionKey, ModuleId>> {
-            // r4b-3: the durable method key's receiver preimage is its owner
-            // nominal. The `Callable` payload carries the explicit parameters and
-            // result (self is separate, tracked by `has_self`); the receiver type
-            // is the owner nominal, recovered by joining the method key's
-            // `owner()` (module + kind + name) back to the owner nominal's own
-            // durable key in this set, so the pool resolves it through the same 2a
-            // nominal machinery as any parameter type.
-            use crate::durable_semantics::DurableDeclarationPayload as Payload;
-            let decl = self.by_key.get(key)?;
-            let Payload::Callable {
-                parameters,
-                result,
-                has_self,
-                ..
-            } = &decl.payload
-            else {
-                return None;
-            };
-            // A free function (no self) is not a method.
-            if !*has_self {
-                return None;
-            }
-            let owner = key.owner()?;
-            let owner_key = self
-                .by_key
-                .keys()
-                .find(|candidate| {
-                    candidate.owner().is_none()
-                        && candidate.module() == owner.module()
-                        && candidate.kind() == owner.kind()
-                        && candidate.name() == owner.name()
-                })?
-                .clone();
-            Some(rue_air::DurableMethod {
-                receiver: rue_air::SemanticImportType::Nominal(owner_key),
-                parameters: parameters.iter().map(provider_durable_param).collect(),
-                result: result.clone(),
-                has_self: *has_self,
-            })
-        }
-    }
-
-    impl rue_air::DurableConstSource<StableDefinitionKey, ModuleId> for DurableDeclSource {
-        fn constant(
-            &self,
-            key: &StableDefinitionKey,
-        ) -> Option<rue_air::DurableConst<StableDefinitionKey, ModuleId>> {
-            use crate::durable_semantics::DurableDeclarationPayload as Payload;
-            let decl = self.by_key.get(key)?;
-            let Payload::Const { ty, value } = &decl.payload else {
-                // Module bindings deliberately STOP here: their durable target
-                // is real, but the body pool has no module-registry identity arm
-                // from which to mint the epoch-local `Type::Module`.
-                return None;
-            };
-            Some(rue_air::DurableConst {
-                is_public: decl.is_public,
-                ty: ty.clone(),
-                value: value.clone(),
-            })
-        }
-
-        fn function_name(&self, key: &StableDefinitionKey) -> Option<Arc<str>> {
-            use crate::durable_semantics::DurableDeclarationPayload as Payload;
-            matches!(self.by_key.get(key)?.payload, Payload::Callable { .. })
-                .then(|| Arc::from(key.name()))
-        }
-    }
-
     /// Render a pool `Type` to a comparable display through the minted pool, the
     /// index-independent parity the 2a/2b contract asserts (never a pool-relative
     /// index).
@@ -21503,111 +21623,6 @@ mod tests {
     // and well-known `Option` → r6; builtin / slice names beyond the pool's
     // pre-registered `BUILTIN_ENUMS` + `str` set → r6; the `(StructId, name)`
     // endpoint-trait seam → r4b-3.
-
-    /// The index-independent render of a nominal pool [`rue_air::Type`]: the
-    /// display, copyability, visibility, mangled symbol, and member vocabulary a
-    /// differential compares across two independently-minted pools (the pool
-    /// mints its own ids; parity is a display/metadata property).
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    struct EndpointNominalRender {
-        display: String,
-        is_copy: bool,
-        is_pub: bool,
-        symbol: String,
-        members: Vec<(String, String)>,
-    }
-
-    /// Render any pool [`rue_air::Type`] to its display, recursing through pool
-    /// indices so it is index-independent and safe to compare across two pools.
-    fn endpoint_display(pool: &rue_air::TypeInternPool, ty: rue_air::Type) -> String {
-        use rue_air::TypeKind;
-        match ty.kind() {
-            TypeKind::I8 => "i8".into(),
-            TypeKind::I16 => "i16".into(),
-            TypeKind::I32 => "i32".into(),
-            TypeKind::I64 => "i64".into(),
-            TypeKind::U8 => "u8".into(),
-            TypeKind::U16 => "u16".into(),
-            TypeKind::U32 => "u32".into(),
-            TypeKind::U64 => "u64".into(),
-            TypeKind::Bool => "bool".into(),
-            TypeKind::Unit => "()".into(),
-            TypeKind::Never => "!".into(),
-            TypeKind::ComptimeType => "type".into(),
-            TypeKind::Struct(id) => pool.struct_def(id).name,
-            TypeKind::Enum(id) => pool.enum_def(id).name,
-            TypeKind::Array(id) => {
-                let (element, len) = pool.array_def(id);
-                format!("[{}; {}]", endpoint_display(pool, element), len)
-            }
-            TypeKind::PtrConst(id) => {
-                format!(
-                    "ptr const {}",
-                    endpoint_display(pool, pool.ptr_const_def(id))
-                )
-            }
-            TypeKind::PtrMut(id) => {
-                format!("ptr mut {}", endpoint_display(pool, pool.ptr_mut_def(id)))
-            }
-            other => format!("{other:?}"),
-        }
-    }
-
-    /// Index-independent copyability, mirroring `Sema::is_type_copy`.
-    fn endpoint_is_copy(pool: &rue_air::TypeInternPool, ty: rue_air::Type) -> bool {
-        use rue_air::TypeKind;
-        match ty.kind() {
-            TypeKind::Struct(id) => pool.struct_def(id).is_copy,
-            TypeKind::Enum(id) => pool
-                .enum_def(id)
-                .variant_payloads
-                .iter()
-                .flatten()
-                .all(|&ty| endpoint_is_copy(pool, ty)),
-            TypeKind::Array(id) => endpoint_is_copy(pool, pool.array_def(id).0),
-            _ => true,
-        }
-    }
-
-    /// Render a nominal (struct or enum) pool [`rue_air::Type`] to its
-    /// index-independent metadata.
-    fn endpoint_nominal_render(
-        pool: &rue_air::TypeInternPool,
-        ty: rue_air::Type,
-    ) -> EndpointNominalRender {
-        use rue_air::TypeKind;
-        match ty.kind() {
-            TypeKind::Struct(id) => {
-                let def = pool.struct_def(id);
-                EndpointNominalRender {
-                    display: def.name.clone(),
-                    is_copy: def.is_copy,
-                    is_pub: def.is_pub,
-                    symbol: pool.struct_symbol_name(id),
-                    members: def
-                        .fields
-                        .iter()
-                        .map(|field| (field.name.clone(), endpoint_display(pool, field.ty)))
-                        .collect(),
-                }
-            }
-            TypeKind::Enum(id) => {
-                let def = pool.enum_def(id);
-                EndpointNominalRender {
-                    display: def.name.clone(),
-                    is_copy: endpoint_is_copy(pool, ty),
-                    is_pub: def.is_pub,
-                    symbol: pool.enum_symbol_name(id),
-                    members: def
-                        .variants
-                        .iter()
-                        .map(|variant| (variant.clone(), String::new()))
-                        .collect(),
-                }
-            }
-            other => panic!("endpoint_nominal_render expects a nominal, got {other:?}"),
-        }
-    }
 
     #[test]
     fn provider_endpoint_facts_resolve_instance_type_matches_epoch() {

--- a/crates/rue-compiler/src/session/tests/rfinal_harness.rs
+++ b/crates/rue-compiler/src/session/tests/rfinal_harness.rs
@@ -1,9 +1,28 @@
-//! RUE-1091 rFinal whole-body differential scaffolding.
+//! RUE-1091 rFinal whole-body differential harness.
 //!
-//! This module is deliberately test-only. It captures the production
-//! `BodyTransaction` path today and leaves exactly one explicit slot for the
-//! future ProviderFacts + overlay implementation. No production path selects
-//! between analyzers.
+//! Side A is the production `BodyTransaction` path. Side B — previously an
+//! explicit unimplemented slot — is now the provider-driven fact replay: for
+//! every body in the shape corpus it re-supplies each fact the production
+//! analysis consumed through the five real provider drivers
+//! (`ProviderTypeFacts`, `SignatureFacts` via the comptime-call arms,
+//! `ProviderCallFacts`, `ProviderEndpointFacts`, `ProviderAggregateFacts`)
+//! plus the body-local `BodySemanticOverlay`, and records exactly the query
+//! edges those drivers observe.
+//!
+//! Side B consumes NO epoch table: its fact sources are the durable
+//! declaration set (`bind_canonical_declaration_semantics` — the r4b-3
+//! sanctioned fill source), the shared whole-program RIR (a body-query input),
+//! the `CompilerBodyFactProvider` boundary, and the drivers' own pools and
+//! overlays. The production side's published `BodyTransaction` serves only as
+//! the differential's DEMAND ORACLE (which facts a body consumes) — the fact
+//! VALUES on side B always come from the drivers.
+//!
+//! Divergences are never silently tolerated: every fact side B cannot yet
+//! supply lands in the named [`SIDE_B_FACT_EXCEPTIONS`] table, and every
+//! edge-family difference between the two sides lands in the named
+//! [`EDGE_FAMILY_EXCEPTIONS`] table (r4a-1: provider edges are the post-flip
+//! truth — the finer materialization edges are the more-correct behavior).
+//! No production path selects between analyzers; everything here is test-only.
 
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -12,35 +31,34 @@ use std::{
 };
 
 use super::*;
+use crate::body_query::BodyReference;
+use crate::declaration_candidate::{
+    DeclarationCandidateCategory, DeclarationCandidateKey, DeclarationCandidateOwner,
+};
+use crate::revisioned_query_database::test_support::{
+    DurableDeclSource, endpoint_display, endpoint_nominal_render,
+};
+use crate::revisioned_query_database::{
+    CompilerBodyFactProvider, ProviderTypeFacts, ReceiverTypeIdentity, RevisionedQueryDatabase,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DifferentialSide {
     Production,
-    /// Replaced by the r2-r6 slices once the ProviderFacts analyzer exists.
-    FutureProviderFactsOverlay,
+    /// The provider-driven side, filled by the r2-r6 drivers (RUE-1091 rFinal).
+    ProviderFactsOverlay,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum HarnessError {
     Compile(String),
     BodyNotFound(String),
-    /// Intentional: this is the plug-compatible slot the provider slices fill.
-    ProviderFactsAnalyzerNotImplemented,
-}
-
-trait WholeBodyAnalyzer {
-    fn side(&self) -> DifferentialSide;
-
-    fn capture(
-        &self,
-        case: &HarnessCase,
-        requested_body_order: &[&str],
-    ) -> Result<Vec<CapturedBody>, HarnessError>;
 }
 
 struct ProductionAnalyzer;
 
-struct FutureProviderFactsOverlayAnalyzer;
+/// Side B: the provider-driven fact replay over the five drivers + overlay.
+struct ProviderFactsOverlayAnalyzer;
 
 struct DirectProductionInputs {
     merged: crate::CanonicalMergedProgram,
@@ -122,26 +140,15 @@ impl DirectProductionInputs {
     }
 }
 
-impl WholeBodyAnalyzer for FutureProviderFactsOverlayAnalyzer {
-    fn side(&self) -> DifferentialSide {
-        DifferentialSide::FutureProviderFactsOverlay
-    }
-
-    fn capture(
-        &self,
-        _case: &HarnessCase,
-        _requested_body_order: &[&str],
-    ) -> Result<Vec<CapturedBody>, HarnessError> {
-        Err(HarnessError::ProviderFactsAnalyzerNotImplemented)
-    }
-}
-
 #[derive(Debug, Clone)]
 struct HarnessCase {
     name: &'static str,
     source: &'static str,
     bodies: &'static [&'static str],
     expected_failure: bool,
+    /// Names the failing body consulted and found absent — the demand data the
+    /// side-B replay drives through the lookup boundary for failure cases.
+    absent_lookups: &'static [&'static str],
 }
 
 const SHAPE_CORPUS: &[HarnessCase] = &[
@@ -150,6 +157,7 @@ const SHAPE_CORPUS: &[HarnessCase] = &[
         source: "fn helper() -> i32 { 40 } fn main() -> i32 { helper() + 2 }",
         bodies: &["helper", "main"],
         expected_failure: false,
+        absent_lookups: &[],
     },
     HarnessCase {
         name: "three_body_permutation",
@@ -157,6 +165,7 @@ const SHAPE_CORPUS: &[HarnessCase] = &[
                  fn main() -> i32 { first() + second() }",
         bodies: &["first", "second", "main"],
         expected_failure: false,
+        absent_lookups: &[],
     },
     HarnessCase {
         name: "method",
@@ -164,6 +173,7 @@ const SHAPE_CORPUS: &[HarnessCase] = &[
                  fn main() -> i32 { Counter { value: 3 }.get() }",
         bodies: &["get", "main"],
         expected_failure: false,
+        absent_lookups: &[],
     },
     HarnessCase {
         name: "associated_function",
@@ -172,6 +182,7 @@ const SHAPE_CORPUS: &[HarnessCase] = &[
                  fn main() -> i32 { Counter.make(3).value }",
         bodies: &["make", "main"],
         expected_failure: false,
+        absent_lookups: &[],
     },
     HarnessCase {
         name: "named_destructor",
@@ -180,6 +191,7 @@ const SHAPE_CORPUS: &[HarnessCase] = &[
                  fn main() { let resource = Resource { value: 1 }; }",
         bodies: &["Resource", "main"],
         expected_failure: false,
+        absent_lookups: &[],
     },
     HarnessCase {
         name: "specialization",
@@ -187,6 +199,7 @@ const SHAPE_CORPUS: &[HarnessCase] = &[
                  fn main() -> i32 { choose(42) }",
         bodies: &["choose", "main"],
         expected_failure: false,
+        absent_lookups: &[],
     },
     HarnessCase {
         name: "anonymous_producer",
@@ -195,38 +208,42 @@ const SHAPE_CORPUS: &[HarnessCase] = &[
                  p.a + p.b }",
         bodies: &["Pair", "main"],
         expected_failure: false,
+        absent_lookups: &[],
     },
     HarnessCase {
         name: "well_known_option_shape",
         // The trusted-toolchain Option registry needs a multi-file continuation
-        // protocol that this no-provider scaffolding must not duplicate. This
+        // protocol whose production-path gap stays recorded below. This
         // freestanding structural Option shape still exercises the production
-        // anonymous-enum/fallible path; the trusted registry case is recorded
-        // below as a carry-forward.
+        // anonymous-enum/fallible path and, on side B, the r6b anonymous arm.
         source: "fn Option(comptime T: type) -> type { enum { Some(T), None } } \
                  fn main() { let O = Option(i32); }",
         bodies: &["main"],
         expected_failure: false,
+        absent_lookups: &[],
     },
     HarnessCase {
         name: "absent_lookup",
         source: "fn main() -> i32 { missing() }",
         bodies: &["main"],
         expected_failure: true,
+        absent_lookups: &["missing"],
     },
     HarnessCase {
         name: "private_lookup",
-        // A same-module private item is legal; the cross-module form needs the
-        // import-fixture protocol and is retained as an explicit gap below.
+        // A same-module private item is legal; the cross-module form is closed
+        // by `side_b_cross_module_private_lookup_is_driver_supplied`.
         source: "fn hidden() -> i32 { 1 } fn main() -> i32 { hidden() }",
         bodies: &["hidden", "main"],
         expected_failure: false,
+        absent_lookups: &[],
     },
     HarnessCase {
         name: "multi_diagnostic_body",
         source: "fn main() -> i32 { missing_one(); missing_two(); true }",
         bodies: &["main"],
         expected_failure: true,
+        absent_lookups: &["missing_one", "missing_two"],
     },
 ];
 
@@ -362,14 +379,17 @@ const CANONICAL_ARGUMENT_VALUE_COVERAGE: &[NamedCoverage] = &[
     },
 ];
 
-// Review carry-forwards that require ProviderFacts or a coordination-owned
-// production hook. They remain named executable data, never prose hidden in a
-// review thread.
+// Review carry-forwards. An entry flips from `Gap` to `Constructed` exactly
+// when a live side-B assertion closes it (the closing test is named in
+// `CLOSED_GAP_LIVE_TESTS`); remaining gaps stay recorded — never deleted or
+// silently bypassed.
 const REVIEW_CARRY_FORWARDS: &[NamedCoverage] = &[
     NamedCoverage {
         name: "trusted_well_known_option_registry",
         status: CoverageStatus::Gap(
-            "needs the future ProviderFacts toolchain-fact side, not a second test registry",
+            "production-path gap (r6c rider d): the trusted StrBuf/Option module fixture is \
+             flip-corpus work; the pool install itself is proven by \
+             provider_well_known_option_install_matches_epoch",
         ),
     },
     NamedCoverage {
@@ -380,34 +400,204 @@ const REVIEW_CARRY_FORWARDS: &[NamedCoverage] = &[
     },
     NamedCoverage {
         name: "cross_module_private_lookup",
-        status: CoverageStatus::Gap("needs the future provider-side multi-module corpus adapter"),
+        status: CoverageStatus::Constructed,
     },
     NamedCoverage {
         name: "unrelated_same_named_const_preserves_recorded_edges",
-        status: CoverageStatus::Gap(
-            "r0 carry-forward: exact provider lookup edges are unavailable until side B exists",
-        ),
+        status: CoverageStatus::Constructed,
     },
     NamedCoverage {
         name: "e0481_candidate_hint_records_no_resolution_edges",
-        status: CoverageStatus::Gap(
-            "r0 carry-forward: requires provider-side diagnostic observation capture",
-        ),
+        status: CoverageStatus::Constructed,
     },
     NamedCoverage {
         name: "forced_eviction_and_cancellation",
+        status: CoverageStatus::Constructed,
+    },
+    NamedCoverage {
+        name: "const_candidate_facts",
         status: CoverageStatus::Gap(
-            "rFinal behavior test plugs into this capture after the provider analyzer exists",
+            "ConstInfo assembly needs the flip's const-declaration RIR handle (r4b-3 \
+             re-deferral); const-candidate-rooted producers stay outside the pool's minting \
+             scope (r6b rider c)",
+        ),
+    },
+    NamedCoverage {
+        name: "pool_drop_metadata_parity",
+        status: CoverageStatus::Gap(
+            "the pool mints destructor: None (r4a-2a scope); destructor-symbol/needs-drop \
+             parity is flip work — the freeze hook itself is live \
+             (side_b_finalize_containment_metadata_freeze_hook)",
+        ),
+    },
+    NamedCoverage {
+        name: "instance_keyed_producer_body_facts",
+        status: CoverageStatus::Gap(
+            "the producer-facts boundary op is definition-keyed, but the underlying \
+             body-produced-anonymous family keys producer identities in the WRAPPER instance \
+             form (the declaration-signature projection retains the empty-argument \
+             specialization wrapper, r6b rider b), so a cold database answers no \
+             definition-keyed producer; the flip owns the instance-keyed op and side B seeds \
+             shapes from the durable oracle until then",
         ),
     },
 ];
+
+/// Closed gap -> the live side-B test that closed it. Executable data so a
+/// reviewer can jump from the flipped row to its assertion.
+const CLOSED_GAP_LIVE_TESTS: &[(&str, &str)] = &[
+    (
+        "cross_module_private_lookup",
+        "side_b_cross_module_private_lookup_is_driver_supplied",
+    ),
+    (
+        "unrelated_same_named_const_preserves_recorded_edges",
+        "side_b_unrelated_same_named_const_preserves_recorded_edges",
+    ),
+    (
+        "e0481_candidate_hint_records_no_resolution_edges",
+        "side_b_absent_lookup_records_only_its_keyed_terminals",
+    ),
+    (
+        "forced_eviction_and_cancellation",
+        "side_b_forced_eviction_and_cancellation_leave_no_partial_state",
+    ),
+];
+
+// ---------------------------------------------------------------------------
+// Side-B exception tables (executable data, asserted non-vacuous)
+// ---------------------------------------------------------------------------
+
+/// A fact side B cannot yet supply from the drivers, named and justified. The
+/// replay records exactly which rows each body hit; the corpus test asserts the
+/// hit set equals [`EXPECTED_FACT_EXCEPTION_HITS`] — no silent tolerance, no
+/// stale rows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SideBFactException {
+    name: &'static str,
+    reason: &'static str,
+}
+
+const SIDE_B_FACT_EXCEPTIONS: &[SideBFactException] = &[
+    SideBFactException {
+        name: "comptime_call_reduces_to_anonymous_nominal",
+        reason: "r6b rider (d): the pool mints the identity; the type-syntax reduction result \
+                 is a body-level durable value with no declaration-level cross-path truth",
+    },
+    SideBFactException {
+        name: "instance_keyed_producer_body_facts",
+        reason: "the definition-keyed producer-facts op cannot answer wrapper/specialized \
+                 producer instances (the underlying family keys them in the wrapper form); \
+                 nominal shapes come from the durable oracle until the flip's instance-keyed \
+                 op",
+    },
+    SideBFactException {
+        name: "associated_function_pool_identity",
+        reason: "the boundary supplies the assoc-fn candidate + signature; member FunctionInfo \
+                 pool assembly is flip work (the durable callable source classifies \
+                 has_self=false members as free functions)",
+    },
+    SideBFactException {
+        name: "drop_glue_overlay_method_installation",
+        reason: "drop-glue instance keys belong to the flip's overlay method installation",
+    },
+    SideBFactException {
+        name: "pool_drop_metadata_parity",
+        reason: "the pool mints destructor: None; the freeze hook is live but destructor \
+                 parity for destructor-bearing nominals is flip work",
+    },
+];
+
+/// The materialization families a side-B edge may belong to — "edges at
+/// materialization, never at render".
+const SIDE_B_MATERIALIZATION_FAMILIES: &[&str] = &[
+    "compiler.lookup-name",
+    "compiler.lookup-import",
+    "compiler.semantic-nucleus",
+    // The producer-facts op reconstructs the producer's comptime call from its
+    // declaration shell — a declaration-level fact terminal.
+    "compiler.declaration-shell",
+    "compiler.body-produced-anonymous",
+    "compiler.body-toolchain-demands",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EdgeExceptionSide {
+    /// The epoch side records the family; side B does not (deleted or
+    /// re-pointed at the flip).
+    EpochOnly,
+    /// Side B records the family; the epoch side does not (r4a-1: the finer
+    /// provider materialization edges are the post-flip truth).
+    ProviderOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct EdgeFamilyException {
+    family: &'static str,
+    side: EdgeExceptionSide,
+    reason: &'static str,
+}
+
+const EDGE_FAMILY_EXCEPTIONS: &[EdgeFamilyException] = &[
+    EdgeFamilyException {
+        family: "compiler.raw-declaration-body",
+        side: EdgeExceptionSide::EpochOnly,
+        reason: "the body's own raw-source terminal; the flip re-points the compute closure, \
+                 keeping this input on the transaction, not on the fact drivers",
+    },
+    EdgeFamilyException {
+        family: "compiler.module-declaration-set",
+        side: EdgeExceptionSide::EpochOnly,
+        reason: "the conservative whole-program declaration-set edge the flip DELETES (plan \
+                 section 5 step 3) — exactly the no-whole-program-context locality delta",
+    },
+    EdgeFamilyException {
+        family: "compiler.lookup-name",
+        side: EdgeExceptionSide::ProviderOnly,
+        reason: "r4a-1 ruling: keyed name-lookup edges recorded at materialization are the \
+                 richer post-flip truth the epoch's table reads mask",
+    },
+    EdgeFamilyException {
+        family: "compiler.semantic-nucleus",
+        side: EdgeExceptionSide::ProviderOnly,
+        reason: "declaration identity/signature/const facts consulted through the boundary \
+                 record their nucleus terminals; the epoch reads the same facts from bound \
+                 tables edge-free",
+    },
+    EdgeFamilyException {
+        family: "compiler.semantic-nucleus",
+        side: EdgeExceptionSide::EpochOnly,
+        reason: "for bodies whose side-B facts are all pool-answered (r4b-1 P-ops record no \
+                 boundary edge), the production transaction still roots the nucleus terminals \
+                 of its declaration prefix; the flip re-points that prefix at the drivers",
+    },
+    EdgeFamilyException {
+        family: "compiler.declaration-shell",
+        side: EdgeExceptionSide::ProviderOnly,
+        reason: "the definition-keyed producer-facts op consults the producer's declaration \
+                 shell to reconstruct its comptime call; the epoch transaction reads shells \
+                 through its declaration prefix without a per-body edge",
+    },
+    EdgeFamilyException {
+        family: "compiler.body-produced-anonymous",
+        side: EdgeExceptionSide::EpochOnly,
+        reason: "the production transaction roots the WRAPPER-instance producer terminal; \
+                 the definition-keyed boundary op defers on a cold database \
+                 (instance_keyed_producer_body_facts), so side B seeds shapes from the \
+                 durable oracle — the flip's instance-keyed op restores this edge on side B",
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Side A (production) capture
+// ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct ObservationCounters {
     declaration_context: rue_air::PerBodyDeclarationContextWork,
     // These session-owned metrics are captured once after case setup. Direct
     // production body analysis does not mutate them, so they are deliberately
-    // framed as case snapshots rather than per-body work until side B lands.
+    // framed as case snapshots rather than per-body work.
     case_provider_snapshot: crate::unstable::ProviderObservationMetrics,
     case_overlay_snapshot: crate::unstable::OverlayMaterializationMetrics,
 }
@@ -420,6 +610,18 @@ struct CapturedBody {
     diagnostics: Vec<u8>,
     dependency_edges: Vec<u8>,
     observation_counters: Vec<u8>,
+}
+
+/// The durable demand oracle side B replays: WHAT the production body consumed
+/// (durable-keyed references + produced anonymous nominals) and the edge
+/// families its retained terminal recorded. Fact VALUES never come from here.
+#[derive(Debug, Clone)]
+struct BodyDemandOracle {
+    body: String,
+    references: Vec<BodyReference>,
+    produced: Vec<crate::durable_semantics::DurableAnonymousNominal>,
+    failed: bool,
+    edge_families: BTreeSet<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -571,7 +773,7 @@ fn capture_terminal(
     body_name: &str,
     counters: ObservationCounters,
     directly_analyzed: &crate::body_query::BodyTransaction,
-) -> Result<CapturedBody, HarnessError> {
+) -> Result<(CapturedBody, BTreeSet<String>), HarnessError> {
     let revision = session
         .queries
         .revisioned
@@ -631,17 +833,25 @@ fn capture_terminal(
         .collect::<Vec<_>>()
         .join("\n")
         .into_bytes();
-    Ok(CapturedBody {
-        case,
-        body: body_name.to_owned(),
-        artifact,
-        diagnostics,
-        dependency_edges,
-        observation_counters: format!("{counters:?}").into_bytes(),
-    })
+    let edge_families = terminal
+        .dependencies()
+        .iter()
+        .map(|dependency| dependency.node.family().to_owned())
+        .collect::<BTreeSet<_>>();
+    Ok((
+        CapturedBody {
+            case,
+            body: body_name.to_owned(),
+            artifact,
+            diagnostics,
+            dependency_edges,
+            observation_counters: format!("{counters:?}").into_bytes(),
+        },
+        edge_families,
+    ))
 }
 
-impl WholeBodyAnalyzer for ProductionAnalyzer {
+impl ProductionAnalyzer {
     fn side(&self) -> DifferentialSide {
         DifferentialSide::Production
     }
@@ -651,6 +861,16 @@ impl WholeBodyAnalyzer for ProductionAnalyzer {
         case: &HarnessCase,
         requested_body_order: &[&str],
     ) -> Result<Vec<CapturedBody>, HarnessError> {
+        Ok(self.capture_with_oracle(case, requested_body_order)?.0)
+    }
+
+    /// Capture the production side AND the per-body durable demand oracle side
+    /// B replays through the drivers.
+    fn capture_with_oracle(
+        &self,
+        case: &HarnessCase,
+        requested_body_order: &[&str],
+    ) -> Result<(Vec<CapturedBody>, Vec<BodyDemandOracle>), HarnessError> {
         let source = SourceSnapshot::single("main.rue", case.source)
             .map_err(|error| HarnessError::Compile(error.to_string()))?;
         let options = CompileOptions::default();
@@ -692,6 +912,7 @@ impl WholeBodyAnalyzer for ProductionAnalyzer {
         let case_overlay_snapshot = crate::unstable::overlay_materialization_metrics(&session);
         let direct = DirectProductionInputs::build(case.source)?;
         let mut captured = Vec::new();
+        let mut oracles = Vec::new();
         // This is the actual body-analysis schedule permutation: each call
         // executes production `analyze_body_query` against one shared immutable
         // corpus input in the requested order. Terminal capture below supplies
@@ -709,16 +930,1273 @@ impl WholeBodyAnalyzer for ProductionAnalyzer {
                 case_provider_snapshot,
                 case_overlay_snapshot,
             };
-            captured.push(capture_terminal(
+            let (capture, edge_families) = capture_terminal(
                 &session,
                 &key,
                 case.name,
                 body,
                 counters,
                 &directly_analyzed,
-            )?);
+            )?;
+            let (references, produced, failed) = match &directly_analyzed {
+                crate::body_query::BodyTransaction::Success {
+                    references,
+                    produced_anonymous_nominals,
+                    ..
+                } => (
+                    references.0.to_vec(),
+                    produced_anonymous_nominals.0.to_vec(),
+                    false,
+                ),
+                crate::body_query::BodyTransaction::DeterministicFailure { references, .. } => {
+                    (references.0.to_vec(), Vec::new(), true)
+                }
+            };
+            oracles.push(BodyDemandOracle {
+                body: (*body).to_owned(),
+                references,
+                produced,
+                failed,
+                edge_families,
+            });
+            captured.push(capture);
         }
-        Ok(captured)
+        Ok((captured, oracles))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Side B (provider drivers + overlay) replay
+// ---------------------------------------------------------------------------
+
+/// One replayed body on side B: the canonical driver-fact lines, the named
+/// exception rows the body hit, and the exact recorded provider edges.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SideBBody {
+    case: &'static str,
+    body: String,
+    facts: Vec<String>,
+    exceptions: BTreeSet<&'static str>,
+    edge_families: BTreeSet<String>,
+    edge_identities: BTreeSet<String>,
+}
+
+/// Side-B durable inputs for one case: the parsed/merged program, the shared
+/// whole-program RIR (body-query inputs), and the durable declaration set (the
+/// r4b-3 sanctioned fill source). No bound epoch is constructed here.
+struct SideBCase {
+    snapshot: SourceSnapshot,
+    rir: crate::CanonicalRirOutput,
+    decls: Arc<[crate::durable_semantics::DurableDeclarationSemantic]>,
+    module_files: BTreeMap<ModuleId, FileId>,
+}
+
+impl SideBCase {
+    fn build_single(source: &str) -> Result<Self, HarnessError> {
+        let snapshot = SourceSnapshot::single("main.rue", source)
+            .map_err(|error| HarnessError::Compile(error.to_string()))?;
+        Self::build_from_snapshot(snapshot)
+    }
+
+    fn build_from_snapshot(snapshot: SourceSnapshot) -> Result<Self, HarnessError> {
+        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot)
+            .map_err(|errors| HarnessError::Compile(errors.to_string()))?;
+        let merged = crate::merge_parsed_modules(&parsed)
+            .map_err(|errors| HarnessError::Compile(errors.to_string()))?;
+        let rir = crate::lower_canonical_rir(&merged)
+            .map_err(|errors| HarnessError::Compile(errors.to_string()))?;
+        let options = CompileOptions::default();
+        let (_, decls, _) = crate::bound_definitions::bind_canonical_declaration_semantics(
+            &merged,
+            &rir,
+            options.preview_features.clone(),
+            options.target,
+        )
+        .map_err(|errors| HarnessError::Compile(errors.to_string()))?;
+        let module_files = merged
+            .ast()
+            .modules()
+            .iter()
+            .map(|module| (module.module_id().clone(), module.file_id()))
+            .collect();
+        Ok(Self {
+            snapshot,
+            rir,
+            decls,
+            module_files,
+        })
+    }
+
+    fn revision(&self, database: &mut RevisionedQueryDatabase) -> rue_query::Revision {
+        database.source_revision(&ExactSourceInput::new(&self.snapshot), &self.snapshot)
+    }
+}
+
+fn side_b_configuration() -> crate::semantic_query_nucleus::SemanticQueryConfiguration {
+    let options = CompileOptions::default();
+    crate::semantic_query_nucleus::SemanticQueryConfiguration {
+        target: options.target,
+        preview_features: StablePreviewFeatures::new(&options.preview_features),
+    }
+}
+
+fn candidate_category(kind: crate::StableDefinitionKind) -> Option<DeclarationCandidateCategory> {
+    use crate::StableDefinitionKind as K;
+    use DeclarationCandidateCategory as Cat;
+    Some(match kind {
+        K::Function => Cat::Function,
+        K::Struct => Cat::Struct,
+        K::Enum => Cat::Enum,
+        K::ValueConst | K::ModuleBinding => Cat::ConstCandidate,
+        K::Destructor => Cat::Destructor,
+        K::Method => Cat::Method,
+        K::AssociatedFunction => Cat::AssociatedFunction,
+    })
+}
+
+fn candidate_for(key: &crate::StableDefinitionKey) -> Option<DeclarationCandidateKey> {
+    let category = candidate_category(key.kind())?;
+    let owner = key.owner().map(|owner| DeclarationCandidateOwner {
+        category: candidate_category(owner.kind()).expect("owner kinds are nominal"),
+        name: Arc::from(owner.name()),
+    });
+    Some(DeclarationCandidateKey {
+        module: key.module().clone(),
+        category,
+        name: Arc::from(key.name()),
+        owner,
+        duplicate_discriminator: 0,
+    })
+}
+
+/// The type-syntax spelling of a durable primitive, or `None` for non-primitive
+/// arms (which route through the endpoint driver instead).
+fn primitive_syntax(key: &crate::TypeInstanceKey) -> Option<&'static str> {
+    use rue_air::TypeInstanceKey as T;
+    Some(match key {
+        T::I8 => "i8",
+        T::I16 => "i16",
+        T::I32 => "i32",
+        T::I64 => "i64",
+        T::U8 => "u8",
+        T::U16 => "u16",
+        T::U32 => "u32",
+        T::U64 => "u64",
+        T::Bool => "bool",
+        T::Unit => "()",
+        T::Never => "!",
+        T::ComptimeType => "type",
+        _ => return None,
+    })
+}
+
+/// Convert a durable type-instance key to the durable import-type algebra the
+/// pool's slice registration consumes. `None` for arms with no durable import
+/// form.
+fn durable_import_type(key: &crate::TypeInstanceKey) -> Option<crate::DurableType> {
+    use crate::DurableType as D;
+    use rue_air::NominalInstanceKey as N;
+    use rue_air::TypeInstanceKey as T;
+    Some(match key {
+        T::I8 => D::I8,
+        T::I16 => D::I16,
+        T::I32 => D::I32,
+        T::I64 => D::I64,
+        T::U8 => D::U8,
+        T::U16 => D::U16,
+        T::U32 => D::U32,
+        T::U64 => D::U64,
+        T::Bool => D::Bool,
+        T::Unit => D::Unit,
+        T::Never => D::Never,
+        T::Nominal(N::Named(named)) => D::Nominal(named.clone()),
+        T::BuiltinNominal { kind, name } | T::Nominal(N::Builtin { kind, name }) => {
+            D::BuiltinNominal {
+                kind: match kind {
+                    rue_air::AnonymousNominalKind::Struct => {
+                        rue_air::SemanticImportNominalKind::Struct
+                    }
+                    rue_air::AnonymousNominalKind::Enum => rue_air::SemanticImportNominalKind::Enum,
+                },
+                name: name.clone(),
+            }
+        }
+        T::Array { element, len } => D::Array {
+            element: Box::new(durable_import_type(element)?),
+            len: *len,
+        },
+        T::Slice { element, name } => D::Slice {
+            element: Box::new(durable_import_type(element)?),
+            name: name.clone(),
+        },
+        T::PtrConst(pointee) => D::PtrConst(Box::new(durable_import_type(pointee)?)),
+        T::PtrMut(pointee) => D::PtrMut(Box::new(durable_import_type(pointee)?)),
+        _ => return None,
+    })
+}
+
+fn collect_type_parts(
+    key: &crate::TypeInstanceKey,
+    named: &mut BTreeSet<crate::StableDefinitionKey>,
+    producers: &mut BTreeSet<crate::StableDefinitionKey>,
+    anonymous: &mut Vec<crate::AnonymousNominalKey>,
+    slices: &mut Vec<(crate::TypeInstanceKey, Arc<str>)>,
+    has_module: &mut bool,
+    has_generic: &mut bool,
+) {
+    use rue_air::NominalInstanceKey as N;
+    use rue_air::TypeInstanceKey as T;
+    match key {
+        T::Nominal(N::Named(definition)) => {
+            named.insert(definition.clone());
+        }
+        T::Nominal(N::Anonymous(anon)) => {
+            if !anonymous.contains(anon) {
+                anonymous.push(anon.clone());
+            }
+            collect_function_parts(
+                None,
+                Some(&anon.producer),
+                named,
+                producers,
+                anonymous,
+                slices,
+                has_module,
+                has_generic,
+            );
+            for ty in anon.arguments.types.iter() {
+                collect_type_parts(
+                    ty,
+                    named,
+                    producers,
+                    anonymous,
+                    slices,
+                    has_module,
+                    has_generic,
+                );
+            }
+        }
+        T::Array { element, .. } => collect_type_parts(
+            element,
+            named,
+            producers,
+            anonymous,
+            slices,
+            has_module,
+            has_generic,
+        ),
+        T::Slice { element, name } => {
+            slices.push(((**element).clone(), name.clone()));
+            collect_type_parts(
+                element,
+                named,
+                producers,
+                anonymous,
+                slices,
+                has_module,
+                has_generic,
+            );
+        }
+        T::PtrConst(pointee) | T::PtrMut(pointee) => collect_type_parts(
+            pointee,
+            named,
+            producers,
+            anonymous,
+            slices,
+            has_module,
+            has_generic,
+        ),
+        T::Module(_) => *has_module = true,
+        T::GenericParameter(_) => *has_generic = true,
+        _ => {}
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_function_parts(
+    function: Option<&crate::FunctionInstanceKey>,
+    producer: Option<&rue_air::StableProducerId<crate::StableDefinitionKey, ModuleId>>,
+    named: &mut BTreeSet<crate::StableDefinitionKey>,
+    producers: &mut BTreeSet<crate::StableDefinitionKey>,
+    anonymous: &mut Vec<crate::AnonymousNominalKey>,
+    slices: &mut Vec<(crate::TypeInstanceKey, Arc<str>)>,
+    has_module: &mut bool,
+    has_generic: &mut bool,
+) {
+    use crate::FunctionInstanceKey as F;
+    use rue_air::StableProducerId as P;
+    if let Some(producer) = producer {
+        match producer {
+            P::Definition(definition) => {
+                producers.insert(definition.clone());
+            }
+            P::Function(function) => collect_function_parts(
+                Some(function),
+                None,
+                named,
+                producers,
+                anonymous,
+                slices,
+                has_module,
+                has_generic,
+            ),
+        }
+    }
+    if let Some(function) = function {
+        match function {
+            F::Definition(definition) => {
+                producers.insert(definition.clone());
+            }
+            F::Specialization { base, arguments } => {
+                collect_function_parts(
+                    Some(base),
+                    None,
+                    named,
+                    producers,
+                    anonymous,
+                    slices,
+                    has_module,
+                    has_generic,
+                );
+                for ty in arguments.types.iter() {
+                    collect_type_parts(
+                        ty,
+                        named,
+                        producers,
+                        anonymous,
+                        slices,
+                        has_module,
+                        has_generic,
+                    );
+                }
+            }
+            F::AnonymousMember { owner, .. } => collect_type_parts(
+                owner,
+                named,
+                producers,
+                anonymous,
+                slices,
+                has_module,
+                has_generic,
+            ),
+            F::DropGlue(pointee) => collect_type_parts(
+                pointee,
+                named,
+                producers,
+                anonymous,
+                slices,
+                has_module,
+                has_generic,
+            ),
+        }
+    }
+}
+
+/// The comptime-call syntax a definition-rooted anonymous producer spells
+/// (`Pair()`, `Option(i32)`), or `None` when an argument has no primitive
+/// spelling.
+fn producer_call_syntax(anon: &crate::AnonymousNominalKey) -> Option<(ModuleId, String)> {
+    use crate::FunctionInstanceKey as F;
+    use rue_air::StableProducerId as P;
+    let canonical = anon.with_canonical_producer().into_owned();
+    let (base, arguments) = match &canonical.producer {
+        P::Definition(definition) => (definition.clone(), None),
+        P::Function(function) => match &**function {
+            F::Definition(definition) => (definition.clone(), None),
+            F::Specialization { base, arguments } => match &**base {
+                F::Definition(definition) => (definition.clone(), Some(arguments.clone())),
+                _ => return None,
+            },
+            _ => return None,
+        },
+    };
+    let mut rendered = Vec::new();
+    if let Some(arguments) = &arguments {
+        for ty in arguments.types.iter() {
+            rendered.push(primitive_syntax(ty)?.to_owned());
+        }
+        for value in arguments.values.iter() {
+            match value {
+                rue_air::CanonicalArgumentValue::Integer(value) => rendered.push(value.to_string()),
+                rue_air::CanonicalArgumentValue::Bool(value) => rendered.push(value.to_string()),
+                _ => return None,
+            }
+        }
+    }
+    Some((
+        base.module().clone(),
+        format!("{}({})", base.name(), rendered.join(", ")),
+    ))
+}
+
+/// The per-body replay context: the five drivers plus the body-local overlay,
+/// all constructed inside ONE provider probe so the probe's recorded edge set
+/// is exactly this body's side-B observation footprint.
+struct ReplayCtx<'a, 'db, 'r> {
+    provider: &'a CompilerBodyFactProvider<'db>,
+    endpoint: rue_air::ProviderEndpointFacts<
+        'a,
+        CompilerBodyFactProvider<'db>,
+        DurableDeclSource,
+        crate::StableDefinitionKey,
+        ModuleId,
+    >,
+    calls: rue_air::ProviderCallFacts<
+        'a,
+        CompilerBodyFactProvider<'db>,
+        DurableDeclSource,
+        crate::StableDefinitionKey,
+        ModuleId,
+    >,
+    overlay: crate::body_overlay::BodySemanticOverlay,
+    decls: &'r [crate::durable_semantics::DurableDeclarationSemantic],
+    module_files: &'r BTreeMap<ModuleId, FileId>,
+    tokens: BTreeMap<crate::StableDefinitionKey, rue_air::SemanticDefinitionToken>,
+    replayed_nominals: BTreeSet<crate::StableDefinitionKey>,
+    replayed_functions: BTreeSet<crate::StableDefinitionKey>,
+    checked_producers: BTreeSet<crate::StableDefinitionKey>,
+    minted: Vec<(String, rue_air::Type)>,
+    agg_seed: Vec<(crate::StableDefinitionKey, String)>,
+    facts: Vec<String>,
+    exceptions: BTreeSet<&'static str>,
+}
+
+impl<'a, 'db, 'r> ReplayCtx<'a, 'db, 'r> {
+    fn file_of(&self, module: &ModuleId) -> FileId {
+        *self
+            .module_files
+            .get(module)
+            .unwrap_or_else(|| panic!("module {module:?} has no file in the merged program"))
+    }
+
+    fn token_for(&mut self, key: &crate::StableDefinitionKey) -> rue_air::SemanticDefinitionToken {
+        if let Some(token) = self.tokens.get(key) {
+            return *token;
+        }
+        let file = self.file_of(key.module());
+        let token =
+            self.endpoint
+                .register_named_nominal(key.clone(), file.index(), key.name(), key.kind());
+        self.tokens.insert(key.clone(), token);
+        token
+    }
+
+    /// Resolve the name of a durable nominal as TYPE SYNTAX through
+    /// `ProviderTypeFacts` (r2) into the body-local overlay, asserting the
+    /// resolved durable identity and the overlay-materialized metadata equal
+    /// the durable declaration truth.
+    fn replay_named_nominal(&mut self, key: &crate::StableDefinitionKey) {
+        if !self.replayed_nominals.insert(key.clone()) {
+            return;
+        }
+        // r2: type-syntax resolution through the boundary + overlay
+        // materialization, byte-compared against the durable declaration.
+        let scope = key.module().clone();
+        let mut type_facts = ProviderTypeFacts::new(self.provider, &mut self.overlay);
+        let resolved = rue_air::resolve_semantic_type_syntax(&mut type_facts, &scope, key.name());
+        match resolved {
+            Ok(resolved) => {
+                assert_eq!(
+                    resolved,
+                    crate::DurableType::Nominal(key.clone()),
+                    "ProviderTypeFacts resolved `{}` to a different durable identity",
+                    key.name()
+                );
+            }
+            Err(error) => panic!(
+                "ProviderTypeFacts failed to resolve nominal `{}`: {error:?}",
+                key.name()
+            ),
+        }
+        let durable = self
+            .decls
+            .iter()
+            .find(|decl| decl.key == *key)
+            .unwrap_or_else(|| panic!("nominal `{}` missing from the durable set", key.name()));
+        let materialized = self
+            .overlay
+            .materialized_nominal(key)
+            .unwrap_or_else(|| panic!("`{}` was not materialized into the overlay", key.name()));
+        assert_eq!(
+            materialized,
+            &durable.payload,
+            "overlay materialization for `{}` diverged from the durable declaration",
+            key.name()
+        );
+        self.facts.push(format!(
+            "type-facts nominal `{}` resolved + overlay-materialized (durable-equal)",
+            key.name()
+        ));
+
+        // r4b-2: the endpoint driver mints the pool identity for the same key.
+        let token = self.token_for(key);
+        let instance = rue_air::TypeInstanceKey::Nominal(rue_air::NominalInstanceKey::Named(token));
+        let minted = self
+            .endpoint
+            .resolve_instance_type(&instance)
+            .unwrap_or_else(|error| {
+                panic!("endpoint driver failed to mint `{}`: {error:?}", key.name())
+            });
+        let render = self
+            .endpoint
+            .with_type_pool(|pool| endpoint_nominal_render(pool, minted));
+        self.facts
+            .push(format!("endpoint nominal {} => {render:?}", key.name()));
+        self.minted.push((key.name().to_owned(), minted));
+        self.agg_seed.push((key.clone(), key.name().to_owned()));
+
+        // If the durable set carries a destructor for this nominal, the pool's
+        // drop metadata (destructor: None) cannot match production yet — the
+        // named parity gap, recorded per hit.
+        let has_destructor = self.decls.iter().any(|decl| {
+            decl.key.kind() == crate::StableDefinitionKind::Destructor
+                && decl
+                    .key
+                    .owner()
+                    .is_some_and(|owner| owner.name() == key.name())
+        });
+        if has_destructor {
+            self.exceptions.insert("pool_drop_metadata_parity");
+        }
+    }
+
+    fn replay_reference(&mut self, reference: &BodyReference) {
+        match reference {
+            BodyReference::Callable(instance) => self.replay_callable(instance),
+            BodyReference::Definition(key) => self.replay_definition(key),
+            BodyReference::Type(instance) => self.replay_type(instance),
+        }
+    }
+
+    fn replay_callable(&mut self, instance: &crate::FunctionInstanceKey) {
+        use crate::FunctionInstanceKey as F;
+        match instance {
+            F::Definition(key) => self.replay_definition(key),
+            F::Specialization { base, arguments } => {
+                self.facts
+                    .push(format!("specialization arguments {arguments:?}"));
+                self.replay_callable(base);
+            }
+            F::AnonymousMember { owner, .. } => {
+                self.exceptions
+                    .insert("drop_glue_overlay_method_installation");
+                self.replay_type(owner);
+            }
+            F::DropGlue(pointee) => {
+                self.exceptions
+                    .insert("drop_glue_overlay_method_installation");
+                self.replay_type(pointee);
+            }
+        }
+    }
+
+    fn replay_definition(&mut self, key: &crate::StableDefinitionKey) {
+        use crate::StableDefinitionKind as K;
+        use rue_air::BodyFactProvider;
+        match key.kind() {
+            K::Function => {
+                if !self.replayed_functions.insert(key.clone()) {
+                    return;
+                }
+                let module = key.module().clone();
+                let present = self.calls.function_contains_in_module(&module, key.name());
+                assert!(
+                    present,
+                    "the lookup boundary must classify `{}` as a declared free function",
+                    key.name()
+                );
+                let file = self.file_of(&module);
+                let info = self
+                    .calls
+                    .function_info(&key.clone(), key.name(), file)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "ProviderCallFacts must assemble FunctionInfo for `{}`",
+                            key.name()
+                        )
+                    });
+                let mut params = Vec::new();
+                {
+                    let arena = self.calls.param_arena();
+                    let names = arena.names(info.params).to_vec();
+                    let types = arena.types(info.params).to_vec();
+                    for (name, ty) in names.iter().zip(types.iter()) {
+                        params.push(format!(
+                            "{}: {}",
+                            self.calls.resolve_symbol(*name).to_owned(),
+                            endpoint_display(self.calls.type_pool(), *ty)
+                        ));
+                    }
+                }
+                let ret = endpoint_display(self.calls.type_pool(), info.return_type);
+                self.facts.push(format!(
+                    "call-facts fn `{}`({}) -> {} generic={} pub={}",
+                    key.name(),
+                    params.join(", "),
+                    ret,
+                    info.is_generic,
+                    info.is_pub,
+                ));
+            }
+            K::Method | K::AssociatedFunction => {
+                let owner = key
+                    .owner()
+                    .expect("method-namespace keys carry their owner");
+                let receiver = ReceiverTypeIdentity::new(
+                    key.module().clone(),
+                    owner.name(),
+                    candidate_category(owner.kind()).expect("nominal owner"),
+                );
+                let candidates = self.provider.method_candidates(&receiver, key.name());
+                let want = match key.kind() {
+                    K::Method => rue_air::MemberKind::Method,
+                    _ => rue_air::MemberKind::AssociatedFunction,
+                };
+                let mut matching = candidates.iter().filter(|candidate| candidate.kind == want);
+                let member = matching.next().unwrap_or_else(|| {
+                    panic!(
+                        "the boundary must supply the member candidate `{}.{}`",
+                        owner.name(),
+                        key.name()
+                    )
+                });
+                assert!(matching.next().is_none(), "unique member candidate");
+                let signature = self.provider.signature(&member.declaration);
+                assert!(
+                    signature.is_some(),
+                    "the member candidate handle fetches its signature"
+                );
+                self.facts.push(format!(
+                    "member `{}.{}` kind={:?} has_self={} pub={} signature=present",
+                    owner.name(),
+                    key.name(),
+                    member.kind,
+                    member.has_self_receiver,
+                    member.is_public,
+                ));
+                if key.kind() == K::Method {
+                    let owner_file = self.file_of(key.module());
+                    let info = self
+                        .calls
+                        .method_info(&key.clone(), owner_file, owner.name(), key.name())
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "ProviderCallFacts must assemble MethodInfo for `{}.{}`",
+                                owner.name(),
+                                key.name()
+                            )
+                        });
+                    let receiver_display =
+                        endpoint_display(self.calls.type_pool(), info.struct_type);
+                    let return_display = endpoint_display(self.calls.type_pool(), info.return_type);
+                    self.facts.push(format!(
+                        "call-facts method `{}.{}` receiver={} -> {} self_mode={:?}",
+                        owner.name(),
+                        key.name(),
+                        receiver_display,
+                        return_display,
+                        info.self_mode,
+                    ));
+                } else {
+                    self.exceptions.insert("associated_function_pool_identity");
+                }
+            }
+            K::Destructor => {
+                let owner = key.owner().expect("destructor keys carry their owner");
+                let file = self.file_of(key.module());
+                let declaration = self.endpoint.destructor(file, owner.name());
+                assert!(
+                    declaration.is_some(),
+                    "the endpoint driver locates the `{}` destructor declaration",
+                    owner.name()
+                );
+                let receiver = ReceiverTypeIdentity::new(
+                    key.module().clone(),
+                    owner.name(),
+                    candidate_category(owner.kind()).expect("nominal owner"),
+                );
+                let metadata = self
+                    .provider
+                    .drop_copy_metadata(&receiver)
+                    .expect("drop/copy metadata is supplied by the boundary");
+                assert!(
+                    metadata.has_destructor,
+                    "the boundary observes the `{}` destructor",
+                    owner.name()
+                );
+                self.facts.push(format!(
+                    "destructor `{}` located; boundary has_destructor=true is_copy={}",
+                    owner.name(),
+                    metadata.is_copy,
+                ));
+            }
+            K::ValueConst | K::ModuleBinding => {
+                let resolution = self.provider.lookup_unqualified(
+                    key.module(),
+                    rue_air::ProviderNamespace::ModuleItem,
+                    key.name(),
+                );
+                let present = matches!(
+                    resolution.of_kind(rue_air::ProviderDefinitionKind::Const),
+                    rue_air::NameResolution::Unique(_) | rue_air::NameResolution::Ambiguous(_)
+                );
+                assert!(
+                    present,
+                    "the lookup boundary classifies const candidate `{}`",
+                    key.name()
+                );
+                self.facts.push(format!(
+                    "const-candidate `{}` present (ConstInfo assembly deferred)",
+                    key.name()
+                ));
+                self.exceptions.insert("const_candidate_facts");
+            }
+            K::Struct | K::Enum => self.replay_named_nominal(key),
+        }
+    }
+
+    /// Cross-check an anonymous producer through the boundary's producer-facts
+    /// op. The op is definition-keyed while the underlying family keys producer
+    /// identities in the WRAPPER instance form (the declaration-signature
+    /// projection retains the empty-argument specialization wrapper — the r6b
+    /// rider (b) form), so on a cold database it answers `None` for every
+    /// producer: the recorded `instance_keyed_producer_body_facts` exception.
+    /// If it ever answers `Some`, the identities must cover the consumed one.
+    fn replay_producer(&mut self, anon: &crate::AnonymousNominalKey) {
+        use crate::FunctionInstanceKey as F;
+        use rue_air::StableProducerId as P;
+        let canonical = anon.with_canonical_producer().into_owned();
+        let producer_key = match &canonical.producer {
+            P::Definition(definition) => Some(definition.clone()),
+            P::Function(function) => match &**function {
+                F::Definition(definition) => Some(definition.clone()),
+                _ => None,
+            },
+        };
+        let Some(producer_key) = producer_key else {
+            self.exceptions.insert("instance_keyed_producer_body_facts");
+            return;
+        };
+        if producer_key.kind() != crate::StableDefinitionKind::Function
+            || !self.checked_producers.insert(producer_key.clone())
+        {
+            if producer_key.kind() != crate::StableDefinitionKind::Function {
+                self.exceptions.insert("instance_keyed_producer_body_facts");
+            }
+            return;
+        }
+        use rue_air::BodyFactProvider;
+        let candidate = candidate_for(&producer_key).expect("function candidates are derivable");
+        match self.provider.producer_body_facts(&candidate) {
+            Some(crate::body_query::ProducedAnonymous::Produced(produced)) => {
+                let boundary: BTreeSet<_> = produced
+                    .0
+                    .iter()
+                    .map(|nominal| nominal.identity.with_canonical_producer().into_owned())
+                    .collect();
+                assert!(
+                    boundary.contains(&canonical),
+                    "the boundary producer facts for `{}` must include the consumed identity",
+                    producer_key.name()
+                );
+                self.facts.push(format!(
+                    "producer-facts `{}` supplied {} anonymous nominal(s) via the boundary",
+                    producer_key.name(),
+                    produced.0.len()
+                ));
+            }
+            Some(crate::body_query::ProducedAnonymous::ProducerFailed(failure)) => {
+                panic!("producer `{}` failed: {failure:?}", producer_key.name())
+            }
+            None => {
+                self.facts.push(format!(
+                    "producer-facts `{}` deferred by the definition-keyed op; shape supplied \
+                     by the durable oracle",
+                    producer_key.name()
+                ));
+                self.exceptions.insert("instance_keyed_producer_body_facts");
+            }
+        }
+    }
+
+    fn replay_type(&mut self, instance: &crate::TypeInstanceKey) {
+        use rue_air::NominalInstanceKey as N;
+        use rue_air::TypeInstanceKey as T;
+
+        // r2: primitives resolve through the type-syntax boundary with no edge.
+        if let Some(syntax) = primitive_syntax(instance) {
+            let scope = self.any_module();
+            let mut type_facts = ProviderTypeFacts::new(self.provider, &mut self.overlay);
+            let resolved = rue_air::resolve_semantic_type_syntax(&mut type_facts, &scope, syntax)
+                .unwrap_or_else(|error| panic!("primitive `{syntax}` resolves: {error:?}"));
+            assert_eq!(
+                Some(&resolved),
+                durable_import_type(instance).as_ref(),
+                "primitive `{syntax}` durable identity"
+            );
+            self.facts.push(format!("type-facts primitive `{syntax}`"));
+        }
+
+        // Collect the durable parts of this key.
+        let mut named = BTreeSet::new();
+        let mut producers = BTreeSet::new();
+        let mut anonymous = Vec::new();
+        let mut slices = Vec::new();
+        let mut has_module = false;
+        let mut has_generic = false;
+        collect_type_parts(
+            instance,
+            &mut named,
+            &mut producers,
+            &mut anonymous,
+            &mut slices,
+            &mut has_module,
+            &mut has_generic,
+        );
+        for key in &named {
+            self.replay_named_nominal(key);
+        }
+        for key in &producers {
+            self.token_for(key);
+        }
+        for (element, name) in &slices {
+            match durable_import_type(element) {
+                Some(element) => {
+                    let registered = self.endpoint.register_generated_slice(&element, name);
+                    assert!(registered.is_some(), "slice `{name}` mints its struct");
+                    self.facts.push(format!("endpoint slice `{name}` minted"));
+                }
+                None => panic!("slice element for `{name}` has no durable import form"),
+            }
+        }
+        for anon in &anonymous {
+            // The boundary supplies the producer's published nominals for
+            // definition-keyed producers (specialized: recorded exception).
+            self.replay_producer(anon);
+            // r5a wiring: the constructor head + argument + reduction arms run
+            // through SignatureFacts; a reduction to an anonymous nominal is
+            // the pinned r6b deferral, recorded per hit.
+            if let Some((scope, syntax)) = producer_call_syntax(anon) {
+                let mut type_facts = ProviderTypeFacts::new(self.provider, &mut self.overlay);
+                match rue_air::resolve_semantic_type_syntax(&mut type_facts, &scope, &syntax) {
+                    Ok(resolved) => self
+                        .facts
+                        .push(format!("comptime-call `{syntax}` reduced to {resolved:?}")),
+                    Err(error) => {
+                        let rendered = format!("{error:?}");
+                        assert!(
+                            rendered.contains("Deferred"),
+                            "comptime call `{syntax}` failed for a non-deferral reason: {rendered}"
+                        );
+                        self.facts.push(format!(
+                            "comptime-call `{syntax}` head+arguments driven; anonymous \
+                             reduction deferred (r6b)"
+                        ));
+                        self.exceptions
+                            .insert("comptime_call_reduces_to_anonymous_nominal");
+                    }
+                }
+            }
+            // r6b arm: seed the issued->durable seam and mint through the pool.
+            let tokens = &self.tokens;
+            let issued = anon.try_map_identities(
+                &|key: &crate::StableDefinitionKey| {
+                    tokens
+                        .get(key)
+                        .copied()
+                        .ok_or("module_identity_deferred_to_flip")
+                },
+                &|_module: &ModuleId| Err("module_identity_deferred_to_flip"),
+            );
+            match issued {
+                Ok(issued) => {
+                    self.endpoint
+                        .register_anonymous_nominal(issued, anon.clone());
+                }
+                Err(_) => {
+                    // A module-typed argument has no token relocation yet; the
+                    // direct durable mint below still covers the identity.
+                }
+            }
+            let minted = self
+                .endpoint
+                .mint_anonymous(anon)
+                .unwrap_or_else(|| panic!("the pool must mint the anonymous nominal {anon:?}"));
+            let render = self
+                .endpoint
+                .with_type_pool(|pool| endpoint_nominal_render(pool, minted));
+            self.facts.push(format!("endpoint anonymous => {render:?}"));
+            self.minted.push((format!("{render:?}"), minted));
+        }
+
+        if has_generic || has_module {
+            // Module identity / generic parameters are pool-refused arms; the
+            // full-key resolve below would fail closed, which is the recorded
+            // behavior, not a silent divergence.
+            if has_generic {
+                self.facts
+                    .push("generic-parameter arm fails closed (r5 substitution)".to_owned());
+            }
+            if has_module {
+                self.exceptions.insert("module_identity_deferred_to_flip");
+            }
+            return;
+        }
+
+        // r4b-2: the endpoint driver resolves the WHOLE relocated key through
+        // the shared `resolve_instance_type` algebra over the pool.
+        let tokens = &self.tokens;
+        let relocated = instance.try_map_identities(
+            &|key: &crate::StableDefinitionKey| {
+                tokens.get(key).copied().ok_or("unminted definition token")
+            },
+            &|_module: &ModuleId| Err("module identity unreachable here"),
+        );
+        let relocated = relocated.expect("every definition identity was minted above");
+        // The anonymous arm of the relocated key resolves only when the issued
+        // relocation succeeded; a bare anonymous key already minted above.
+        let contains_unseeded_anonymous = matches!(
+            &relocated,
+            T::Nominal(N::Anonymous(_))
+        ) && anonymous.iter().any(|anon| {
+            anon.try_map_identities::<rue_air::SemanticDefinitionToken, rue_air::SemanticModuleToken, ()>(
+                &|key: &crate::StableDefinitionKey| tokens.get(key).copied().ok_or(()),
+                &|_module: &ModuleId| Err(()),
+            )
+            .is_err()
+        });
+        if contains_unseeded_anonymous {
+            return;
+        }
+        let resolved = self
+            .endpoint
+            .resolve_instance_type(&relocated)
+            .unwrap_or_else(|error| panic!("endpoint resolve of {instance:?} failed: {error:?}"));
+        let display = self
+            .endpoint
+            .with_type_pool(|pool| endpoint_display(pool, resolved));
+        self.facts
+            .push(format!("endpoint type {instance:?} => {display}"));
+        self.minted.push((display, resolved));
+    }
+
+    fn any_module(&self) -> ModuleId {
+        self.module_files
+            .keys()
+            .next()
+            .expect("the merged program has a module")
+            .clone()
+    }
+
+    /// The rFinal freeze-hook exercise (r4a-2a rider): drop/linearity reads are
+    /// un-finalized until the pool-side freeze runs at the same point
+    /// production freezes; afterwards every minted type answers.
+    fn exercise_finalize_seam(&mut self) {
+        if let Some((display, ty)) = self.minted.first().cloned() {
+            assert_eq!(
+                self.endpoint.type_needs_drop(ty),
+                None,
+                "drop metadata must be un-finalized before the freeze hook"
+            );
+            let _ = display;
+        }
+        self.endpoint
+            .finalize_containment_metadata()
+            .expect("the minted universe has no containment cycle");
+        let mut lines = Vec::new();
+        for (display, ty) in &self.minted {
+            let needs_drop = self
+                .endpoint
+                .type_needs_drop(*ty)
+                .expect("finalized pool answers needs-drop");
+            let carries_linear = self
+                .endpoint
+                .type_carries_linear(*ty)
+                .expect("finalized pool answers linearity");
+            lines.push(format!(
+                "containment {display}: needs_drop={needs_drop} carries_linear={carries_linear}"
+            ));
+        }
+        self.facts.extend(lines);
+        if !self.minted.is_empty() {
+            self.facts
+                .push("finalize_containment_metadata seam exercised".to_owned());
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_body_replay(
+    provider: &CompilerBodyFactProvider<'_>,
+    decls: &[crate::durable_semantics::DurableDeclarationSemantic],
+    module_files: &BTreeMap<ModuleId, FileId>,
+    references: &[BodyReference],
+    produced_union: &[crate::durable_semantics::DurableAnonymousNominal],
+    absent_lookups: &[&str],
+    body_key: Option<&crate::StableDefinitionKey>,
+    rir: &rue_rir::Rir,
+    rir_interner: &lasso::ThreadedRodeo,
+) -> (
+    Vec<String>,
+    BTreeSet<&'static str>,
+    Vec<(crate::StableDefinitionKey, String)>,
+) {
+    use rue_air::BodyFactProvider;
+    let endpoint = rue_air::ProviderEndpointFacts::new(
+        provider,
+        DurableDeclSource::from_declarations(decls).with_anonymous_nominals(produced_union),
+        rir,
+        rir_interner,
+    );
+    let calls = rue_air::ProviderCallFacts::new(
+        provider,
+        DurableDeclSource::from_declarations(decls),
+        rir,
+        rir_interner,
+    );
+    let mut ctx = ReplayCtx {
+        provider,
+        endpoint,
+        calls,
+        overlay: crate::body_overlay::BodySemanticOverlay::new(),
+        decls,
+        module_files,
+        tokens: BTreeMap::new(),
+        replayed_nominals: BTreeSet::new(),
+        replayed_functions: BTreeSet::new(),
+        checked_producers: BTreeSet::new(),
+        minted: Vec::new(),
+        agg_seed: Vec::new(),
+        facts: Vec::new(),
+        exceptions: BTreeSet::new(),
+    };
+
+    for reference in references {
+        ctx.replay_reference(reference);
+    }
+
+    // Failure-body demands: the driver classifies each consulted-and-absent
+    // name through the keyed lookup boundary — the provider-era observation the
+    // production diagnostic path masks.
+    for name in absent_lookups {
+        let module = ctx.any_module();
+        let present = ctx.calls.function_contains_in_module(&module, name);
+        assert!(!present, "`{name}` must be absent through the boundary");
+        let mut type_facts = ProviderTypeFacts::new(ctx.provider, &mut ctx.overlay);
+        let resolved = rue_air::resolve_semantic_type_syntax(&mut type_facts, &module, name);
+        assert!(
+            resolved.is_err(),
+            "`{name}` must not resolve as a type either"
+        );
+        ctx.facts.push(format!(
+            "absent `{name}` classified Absent via keyed lookup"
+        ));
+    }
+
+    // The body's own trusted-toolchain demand set, observed through the
+    // boundary op (function bodies carry the derivable candidate key).
+    if let Some(body_key) = body_key
+        && body_key.kind() == crate::StableDefinitionKind::Function
+        && let Some(candidate) = candidate_for(body_key)
+    {
+        let demand = provider.trusted_toolchain_facts(&candidate);
+        ctx.facts.push(format!(
+            "toolchain-demands kinds={}",
+            demand.payload_kinds().len()
+        ));
+    }
+
+    ctx.exercise_finalize_seam();
+
+    let ReplayCtx {
+        facts,
+        exceptions,
+        agg_seed,
+        ..
+    } = ctx;
+    (facts, exceptions, agg_seed)
+}
+
+/// Replay the aggregate facts for every named nominal the body consumed —
+/// OUTSIDE any provider probe: `ProviderAggregateFacts` takes no provider
+/// handle, so it records zero provider edges by construction (the r4b-3
+/// property, structurally enforced here).
+fn aggregate_replay(
+    inputs: &SideBCase,
+    seed: &[(crate::StableDefinitionKey, String)],
+) -> Vec<String> {
+    let mut facts = vec![
+        "aggregate driver constructed with no provider handle: zero provider edges by \
+         construction"
+            .to_owned(),
+    ];
+    let mut aggregate =
+        rue_air::ProviderAggregateFacts::<crate::StableDefinitionKey, ModuleId, _>::new(
+            DurableDeclSource::from_declarations(&inputs.decls),
+        );
+    for (key, _) in seed {
+        let file = inputs.module_files[key.module()];
+        aggregate.register_named_nominal(key.clone(), file, key.name());
+    }
+    for (key, endpoint_display_name) in seed {
+        let file = inputs.module_files[key.module()];
+        match (
+            key.kind(),
+            aggregate.select_qualified_type(file, key.name()),
+        ) {
+            (crate::StableDefinitionKind::Struct, rue_air::ProviderQualifiedType::Struct(ty)) => {
+                let display = aggregate.with_type_pool(|pool| endpoint_display(pool, ty));
+                assert_eq!(
+                    &display,
+                    endpoint_display_name,
+                    "aggregate and endpoint drivers agree on `{}`",
+                    key.name()
+                );
+                facts.push(format!("aggregate qualified `{}` => struct", key.name()));
+            }
+            (crate::StableDefinitionKind::Enum, rue_air::ProviderQualifiedType::Enum(ty)) => {
+                let display = aggregate.with_type_pool(|pool| endpoint_display(pool, ty));
+                assert_eq!(
+                    &display,
+                    endpoint_display_name,
+                    "aggregate and endpoint drivers agree on `{}`",
+                    key.name()
+                );
+                facts.push(format!("aggregate qualified `{}` => enum", key.name()));
+            }
+            (kind, _) => panic!(
+                "aggregate driver could not select `{}` as {kind:?}",
+                key.name()
+            ),
+        }
+        if key.kind() == crate::StableDefinitionKind::Struct {
+            match aggregate.select_struct_literal_head(file, key.name()) {
+                rue_air::ProviderStructHead::Named(_) => {
+                    facts.push(format!("aggregate literal head `{}` => Named", key.name()));
+                }
+                _ => panic!("aggregate literal head for `{}`", key.name()),
+            }
+        }
+    }
+    facts
+}
+
+impl ProviderFactsOverlayAnalyzer {
+    fn side(&self) -> DifferentialSide {
+        DifferentialSide::ProviderFactsOverlay
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn replay_body(
+        &self,
+        inputs: &SideBCase,
+        database: &RevisionedQueryDatabase,
+        revision: rue_query::Revision,
+        case_name: &'static str,
+        body: &str,
+        oracle: &BodyDemandOracle,
+        produced_union: &[crate::durable_semantics::DurableAnonymousNominal],
+        absent_lookups: &[&str],
+        run_tag: &str,
+    ) -> SideBBody {
+        let decls = inputs.decls.clone();
+        let module_files = inputs.module_files.clone();
+        let mut references = oracle.references.clone();
+        references.sort();
+        references.dedup();
+        let produced_union = produced_union.to_vec();
+        let body_key = decls
+            .iter()
+            .map(|decl| decl.key.clone())
+            .find(|key| key.kind().owns_body() && key.name() == body);
+        let absent: Vec<&str> = absent_lookups.to_vec();
+        let rir = inputs.rir.rir();
+        let interner = inputs.rir.semantic_symbols().interner();
+        let label = format!("side-b:{run_tag}:{case_name}:{body}");
+        let outcome =
+            database.probe_body_facts(revision, side_b_configuration(), &label, move |provider| {
+                run_body_replay(
+                    provider,
+                    &decls,
+                    &module_files,
+                    &references,
+                    &produced_union,
+                    &absent,
+                    body_key.as_ref(),
+                    rir,
+                    interner,
+                )
+            });
+        let (mut facts, exceptions, agg_seed) = outcome.result;
+        if oracle.failed {
+            facts.push(
+                "production body failed deterministically; side B classified its absences \
+                 through the keyed lookup boundary"
+                    .to_owned(),
+            );
+        }
+        facts.extend(aggregate_replay(inputs, &agg_seed));
+        facts.sort();
+        facts.dedup();
+        let edge_families = outcome
+            .dependencies
+            .iter()
+            .map(|node| node.family().to_owned())
+            .collect::<BTreeSet<_>>();
+        let edge_identities = outcome
+            .dependencies
+            .iter()
+            .map(|node| format!("{}::{}", node.family(), node.key()))
+            .collect::<BTreeSet<_>>();
+        SideBBody {
+            case: case_name,
+            body: body.to_owned(),
+            facts,
+            exceptions,
+            edge_families,
+            edge_identities,
+        }
+    }
+
+    fn replay_case(
+        &self,
+        case: &HarnessCase,
+        inputs: &SideBCase,
+        oracles: &[BodyDemandOracle],
+        requested_body_order: &[&str],
+        database: &RevisionedQueryDatabase,
+        revision: rue_query::Revision,
+        run_tag: &str,
+    ) -> Vec<SideBBody> {
+        let produced_union: Vec<_> = {
+            let mut union: BTreeMap<crate::AnonymousNominalKey, _> = BTreeMap::new();
+            for oracle in oracles {
+                for nominal in &oracle.produced {
+                    union.insert(nominal.identity.clone(), nominal.clone());
+                }
+            }
+            union.into_values().collect()
+        };
+        requested_body_order
+            .iter()
+            .map(|body| {
+                let oracle = oracles
+                    .iter()
+                    .find(|oracle| oracle.body == *body)
+                    .unwrap_or_else(|| panic!("no oracle for body `{body}`"));
+                self.replay_body(
+                    inputs,
+                    database,
+                    revision,
+                    case.name,
+                    body,
+                    oracle,
+                    &produced_union,
+                    case.absent_lookups,
+                    run_tag,
+                )
+            })
+            .collect()
     }
 }
 
@@ -736,6 +2214,10 @@ fn corpus_permutations(case: &HarnessCase) -> Vec<Vec<&'static str>> {
     };
     vec![forward, reverse, rotated]
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[test]
 fn side_a_is_self_equal_across_full_shape_corpus_and_schedule_permutations() {
@@ -759,17 +2241,569 @@ fn side_a_is_self_equal_across_full_shape_corpus_and_schedule_permutations() {
     }
 }
 
+/// The corpus-wide expected fact-exception hit set: every row a body hit must
+/// be a named table row, and every table row must be hit — no silent
+/// tolerance, no stale rows.
+// `drop_glue_overlay_method_installation` is deliberately absent: this corpus
+// publishes no drop-glue/anonymous-member instance reference, so the row is a
+// documented reserve for the arm that would hit it, not an expected hit.
+const EXPECTED_FACT_EXCEPTION_HITS: &[&str] = &[
+    "associated_function_pool_identity",
+    "comptime_call_reduces_to_anonymous_nominal",
+    "instance_keyed_producer_body_facts",
+    "pool_drop_metadata_parity",
+];
+
 #[test]
-fn future_provider_facts_side_is_an_explicit_unimplemented_slot() {
-    let analyzer = FutureProviderFactsOverlayAnalyzer;
+fn side_b_provider_drivers_supply_previously_stubbed_facts() {
+    let analyzer = ProviderFactsOverlayAnalyzer;
+    assert_eq!(analyzer.side(), DifferentialSide::ProviderFactsOverlay);
+    let production = ProductionAnalyzer;
+    let table_names: BTreeSet<&str> = SIDE_B_FACT_EXCEPTIONS.iter().map(|row| row.name).collect();
     assert_eq!(
-        analyzer.side(),
-        DifferentialSide::FutureProviderFactsOverlay
+        table_names.len(),
+        SIDE_B_FACT_EXCEPTIONS.len(),
+        "exception rows are uniquely named"
+    );
+    let mut hit: BTreeSet<&'static str> = BTreeSet::new();
+    for case in SHAPE_CORPUS {
+        let (_, oracles) = production
+            .capture_with_oracle(case, case.bodies)
+            .unwrap_or_else(|error| panic!("oracle capture failed for {}: {error:?}", case.name));
+        let inputs = SideBCase::build_single(case.source)
+            .unwrap_or_else(|error| panic!("side-b inputs failed for {}: {error:?}", case.name));
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = inputs.revision(&mut database);
+
+        let forward = analyzer.replay_case(
+            case,
+            &inputs,
+            &oracles,
+            case.bodies,
+            &database,
+            revision,
+            "fwd",
+        );
+        // Warm/cold invariance across the schedule permutation: the reversed
+        // replay runs against the SAME database (warm terminals) and must
+        // produce identical facts, exceptions, and edge identities.
+        let reversed_order: Vec<&str> = case.bodies.iter().rev().copied().collect();
+        let mut reverse = analyzer.replay_case(
+            case,
+            &inputs,
+            &oracles,
+            &reversed_order,
+            &database,
+            revision,
+            "rev",
+        );
+        reverse.reverse();
+        assert_eq!(
+            forward, reverse,
+            "side-B replay diverged across schedule permutations for {}",
+            case.name
+        );
+
+        for body in &forward {
+            assert!(
+                !body.facts.is_empty(),
+                "side B supplied no facts for {}::{}",
+                case.name,
+                body.body
+            );
+            for exception in &body.exceptions {
+                assert!(
+                    table_names.contains(exception),
+                    "unnamed side-B exception `{exception}` for {}::{}",
+                    case.name,
+                    body.body
+                );
+                hit.insert(exception);
+            }
+            // Edges land only at materialization families.
+            for family in &body.edge_families {
+                assert!(
+                    SIDE_B_MATERIALIZATION_FAMILIES.contains(&family.as_str()),
+                    "side-B edge outside the materialization families for {}::{}: {family}",
+                    case.name,
+                    body.body
+                );
+            }
+        }
+    }
+    let expected: BTreeSet<&str> = EXPECTED_FACT_EXCEPTION_HITS.iter().copied().collect();
+    assert_eq!(
+        hit, expected,
+        "the corpus-wide exception hit set drifted from the recorded expectation"
+    );
+}
+
+#[test]
+fn side_b_edge_sets_match_production_with_recorded_exceptions() {
+    let analyzer = ProviderFactsOverlayAnalyzer;
+    let production = ProductionAnalyzer;
+    let mut hit_rows: BTreeSet<&'static str> = BTreeSet::new();
+    for case in SHAPE_CORPUS {
+        let (_, oracles) = production
+            .capture_with_oracle(case, case.bodies)
+            .unwrap_or_else(|error| panic!("oracle capture failed for {}: {error:?}", case.name));
+        let inputs = SideBCase::build_single(case.source).unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = inputs.revision(&mut database);
+        let side_b = analyzer.replay_case(
+            case,
+            &inputs,
+            &oracles,
+            case.bodies,
+            &database,
+            revision,
+            "edge",
+        );
+
+        let side_a_families: BTreeSet<&str> = oracles
+            .iter()
+            .flat_map(|oracle| oracle.edge_families.iter().map(String::as_str))
+            .collect();
+        let side_b_families: BTreeSet<&str> = side_b
+            .iter()
+            .flat_map(|body| body.edge_families.iter().map(String::as_str))
+            .collect();
+
+        for family in side_a_families.difference(&side_b_families) {
+            let row = EDGE_FAMILY_EXCEPTIONS
+                .iter()
+                .find(|row| row.family == *family && row.side == EdgeExceptionSide::EpochOnly);
+            let row = row.unwrap_or_else(|| {
+                panic!(
+                    "case {}: epoch-only edge family `{family}` has no recorded exception; \
+                     side A={side_a_families:?} side B={side_b_families:?}",
+                    case.name
+                )
+            });
+            hit_rows.insert(row.family);
+        }
+        for family in side_b_families.difference(&side_a_families) {
+            let row = EDGE_FAMILY_EXCEPTIONS
+                .iter()
+                .find(|row| row.family == *family && row.side == EdgeExceptionSide::ProviderOnly);
+            let row = row.unwrap_or_else(|| {
+                panic!(
+                    "case {}: provider-only edge family `{family}` has no recorded exception; \
+                     side A={side_a_families:?} side B={side_b_families:?}",
+                    case.name
+                )
+            });
+            hit_rows.insert(row.family);
+        }
+    }
+    // Every recorded exception row is live somewhere in the corpus — the table
+    // cannot silently go stale.
+    let all_rows: BTreeSet<&str> = EDGE_FAMILY_EXCEPTIONS
+        .iter()
+        .map(|row| row.family)
+        .collect();
+    assert_eq!(
+        hit_rows, all_rows,
+        "an edge-family exception row was never hit by the corpus (stale row?)"
+    );
+}
+
+#[test]
+fn side_b_unrelated_same_named_const_preserves_recorded_edges() {
+    // The r0-carried structural locality assertion, now expressible with side
+    // B live: adding a same-named constant in an UNRELATED module changes
+    // neither the recorded side-B dependency-edge set nor the supplied facts
+    // for an untouched body — no whole-program context path exists on side B.
+    let case = &SHAPE_CORPUS[0];
+    assert_eq!(case.name, "plain_functions");
+    let production = ProductionAnalyzer;
+    let (_, oracles) = production.capture_with_oracle(case, case.bodies).unwrap();
+    let analyzer = ProviderFactsOverlayAnalyzer;
+
+    let baseline_inputs = SideBCase::build_single(case.source).unwrap();
+    let mut baseline_db = RevisionedQueryDatabase::default();
+    let baseline_revision = baseline_inputs.revision(&mut baseline_db);
+    let baseline = analyzer.replay_case(
+        case,
+        &baseline_inputs,
+        &oracles,
+        case.bodies,
+        &baseline_db,
+        baseline_revision,
+        "locality-a",
+    );
+
+    // The same program plus an UNRELATED module declaring a `pub const` that
+    // shares the free function's name.
+    let root = FileId::new(0);
+    let unrelated = FileId::new(1);
+    let metadata = SourceMetadata::new(
+        root,
+        HashMap::from([
+            (root, "main.rue".to_owned()),
+            (unrelated, "unrelated.rue".to_owned()),
+        ]),
+        HashMap::from([
+            (root, "main.rue".to_owned()),
+            (unrelated, "unrelated.rue".to_owned()),
+        ]),
+    )
+    .expect("two-file metadata");
+    let snapshot = SourceSnapshot::new(
+        metadata,
+        vec![
+            (root, Arc::new(case.source.to_owned())),
+            (
+                unrelated,
+                Arc::new("pub const helper: i64 = 40;".to_owned()),
+            ),
+        ],
+    )
+    .expect("two-file snapshot");
+    let extended_inputs = SideBCase::build_from_snapshot(snapshot).unwrap();
+    let mut extended_db = RevisionedQueryDatabase::default();
+    let extended_revision = extended_inputs.revision(&mut extended_db);
+    let extended = analyzer.replay_case(
+        case,
+        &extended_inputs,
+        &oracles,
+        case.bodies,
+        &extended_db,
+        extended_revision,
+        "locality-b",
+    );
+
+    for (before, after) in baseline.iter().zip(extended.iter()) {
+        assert_eq!(
+            before.facts, after.facts,
+            "an unrelated same-named const changed the supplied facts for {}",
+            before.body
+        );
+        assert_eq!(
+            before.edge_identities, after.edge_identities,
+            "an unrelated same-named const changed the recorded edge set for {}",
+            before.body
+        );
+        assert_eq!(before.exceptions, after.exceptions);
+    }
+}
+
+#[test]
+fn side_b_absent_lookup_records_only_its_keyed_terminals() {
+    // The r0/E0481 carry-forward: a failing body's provider-side observation
+    // capture records ONLY the keyed lookup terminals of the names it
+    // consulted — no candidate-scan or whole-universe edge exists on side B.
+    let case = SHAPE_CORPUS
+        .iter()
+        .find(|case| case.name == "absent_lookup")
+        .unwrap();
+    let inputs = SideBCase::build_single(case.source).unwrap();
+    let mut database = RevisionedQueryDatabase::default();
+    let revision = inputs.revision(&mut database);
+    let module = inputs
+        .module_files
+        .keys()
+        .next()
+        .expect("one module")
+        .clone();
+    let decls = inputs.decls.clone();
+    let rir = inputs.rir.rir();
+    let interner = inputs.rir.semantic_symbols().interner();
+    let outcome = database.probe_body_facts(
+        revision,
+        side_b_configuration(),
+        "side-b:e0481:absent",
+        move |provider| {
+            let calls = rue_air::ProviderCallFacts::new(
+                provider,
+                DurableDeclSource::from_declarations(&decls),
+                rir,
+                interner,
+            );
+            assert!(!calls.function_contains_in_module(&module, "missing"));
+        },
+    );
+    assert!(
+        !outcome.dependencies.is_empty(),
+        "the absent lookup records its keyed terminal"
+    );
+    for node in &outcome.dependencies {
+        assert_eq!(
+            node.family(),
+            "compiler.lookup-name",
+            "an absent lookup observes only the name-lookup family: {node:?}"
+        );
+        assert!(
+            node.key().contains("missing"),
+            "an absent lookup records only the consulted name's terminal, no candidate \
+             scan: {node:?}"
+        );
+    }
+}
+
+#[test]
+fn side_b_forced_eviction_and_cancellation_leave_no_partial_state() {
+    // The rFinal behavior slot, following the slice-2b overlay cancellation
+    // model: a canceled side-B request promotes nothing (never-promote) and a
+    // subsequent replay is untainted; forced eviction pressure re-derives
+    // invisibly (identical facts + edge identities).
+    let case = &SHAPE_CORPUS[0];
+    let production = ProductionAnalyzer;
+    let (_, oracles) = production.capture_with_oracle(case, case.bodies).unwrap();
+    let analyzer = ProviderFactsOverlayAnalyzer;
+    let inputs = SideBCase::build_single(case.source).unwrap();
+    // A tiny retention floor so filler pressure genuinely evicts.
+    let mut database = RevisionedQueryDatabase::with_declaration_memo_retention(4);
+    let revision = inputs.revision(&mut database);
+
+    let baseline = analyzer.replay_case(
+        case,
+        &inputs,
+        &oracles,
+        case.bodies,
+        &database,
+        revision,
+        "cancel-baseline",
+    );
+
+    // CANCELLATION: drive the same lookups under a rooted request that aborts
+    // before publishing — nothing is promoted and no lease pin escapes.
+    let module = inputs.module_files.keys().next().unwrap().clone();
+    let decls = inputs.decls.clone();
+    let rir = inputs.rir.rir();
+    let interner = inputs.rir.semantic_symbols().interner();
+    let published = database.publish_lookup_root(
+        revision,
+        side_b_configuration(),
+        "side-b:cancel:probe",
+        "side-b:cancel:root",
+        true,
+        move |provider| {
+            let calls = rue_air::ProviderCallFacts::new(
+                provider,
+                DurableDeclSource::from_declarations(&decls),
+                rir,
+                interner,
+            );
+            let _ = calls.function_contains_in_module(&module, "helper");
+            let _ = calls.function_contains_in_module(&module, "main");
+        },
+    );
+    assert!(!published, "a canceled side-B request publishes no root");
+    let metrics = database.lookup_pressure_metrics();
+    assert_eq!(
+        metrics.published_roots, 0,
+        "a canceled side-B request promotes nothing (never-promote)"
     );
     assert_eq!(
-        analyzer.capture(&SHAPE_CORPUS[0], SHAPE_CORPUS[0].bodies),
-        Err(HarnessError::ProviderFactsAnalyzerNotImplemented)
+        metrics.leased_terminals, 0,
+        "a canceled side-B request leases no terminal"
     );
+
+    // The cancellation left no partial state: the replay is byte-identical.
+    let after_cancel = analyzer.replay_case(
+        case,
+        &inputs,
+        &oracles,
+        case.bodies,
+        &database,
+        revision,
+        "cancel-after",
+    );
+    assert_eq!(baseline, after_cancel, "cancellation left partial state");
+
+    // FORCED EVICTION: drive the lookup family far past its floor of 4 so the
+    // replay's warm terminals evict, then replay again — the re-derivation is
+    // invisible: identical facts and identical edge identities.
+    let module = inputs.module_files.keys().next().unwrap().clone();
+    let decls = inputs.decls.clone();
+    for index in 0..24 {
+        let name = format!("Filler{index}");
+        let decls = decls.clone();
+        let module = module.clone();
+        let label = format!("side-b:evict:{index}");
+        let outcome =
+            database.probe_body_facts(revision, side_b_configuration(), &label, move |provider| {
+                let calls = rue_air::ProviderCallFacts::new(
+                    provider,
+                    DurableDeclSource::from_declarations(&decls),
+                    rir,
+                    interner,
+                );
+                calls.function_contains_in_module(&module, &name)
+            });
+        assert!(!outcome.result, "filler names are absent");
+    }
+    let after_eviction = analyzer.replay_case(
+        case,
+        &inputs,
+        &oracles,
+        case.bodies,
+        &database,
+        revision,
+        "evict-after",
+    );
+    assert_eq!(
+        baseline, after_eviction,
+        "forced eviction changed the side-B replay (re-derivation must be invisible)"
+    );
+}
+
+#[test]
+fn side_b_cross_module_private_lookup_is_driver_supplied() {
+    // The cross-module private form, closed by a side-B multi-module corpus:
+    // the boundary supplies the candidate WITH its visibility fact, and the
+    // aggregate driver's visibility-domain computation hides a cross-directory
+    // private item while admitting the public one.
+    let root = FileId::new(0);
+    let leaf = FileId::new(1);
+    let metadata = SourceMetadata::new(
+        root,
+        HashMap::from([
+            (root, "/project/main.rue".to_owned()),
+            (leaf, "/project/sub/leaf.rue".to_owned()),
+        ]),
+        HashMap::from([
+            (root, "main.rue".to_owned()),
+            (leaf, "sub/leaf.rue".to_owned()),
+        ]),
+    )
+    .expect("two-file metadata");
+    let snapshot = SourceSnapshot::new(
+        metadata,
+        vec![
+            (root, Arc::new("fn main() -> i32 { 0 }".to_owned())),
+            (
+                leaf,
+                Arc::new(
+                    "fn hidden_helper() -> i32 { 1 }\npub fn shown_helper() -> i32 { 2 }\n"
+                        .to_owned(),
+                ),
+            ),
+        ],
+    )
+    .expect("two-file snapshot");
+    let inputs = SideBCase::build_from_snapshot(snapshot).unwrap();
+    let mut database = RevisionedQueryDatabase::default();
+    let revision = inputs.revision(&mut database);
+    let leaf_module = ModuleId::from_logical_path("sub/leaf.rue").unwrap();
+
+    let outcome = database.probe_body_facts(
+        revision,
+        side_b_configuration(),
+        "side-b:cross-module-private",
+        move |provider| {
+            use rue_air::BodyFactProvider;
+            let hidden = provider.lookup_unqualified(
+                &leaf_module,
+                rue_air::ProviderNamespace::ModuleItem,
+                "hidden_helper",
+            );
+            let shown = provider.lookup_unqualified(
+                &leaf_module,
+                rue_air::ProviderNamespace::ModuleItem,
+                "shown_helper",
+            );
+            let hidden_public = match &hidden {
+                rue_air::NameResolution::Unique(candidate) => candidate.is_public,
+                other => panic!("hidden_helper must be a unique candidate: {other:?}"),
+            };
+            let shown_public = match &shown {
+                rue_air::NameResolution::Unique(candidate) => candidate.is_public,
+                other => panic!("shown_helper must be a unique candidate: {other:?}"),
+            };
+            (hidden_public, shown_public)
+        },
+    );
+    let (hidden_public, shown_public) = outcome.result;
+    assert!(!hidden_public, "the boundary supplies the private fact");
+    assert!(shown_public, "the boundary supplies the public fact");
+
+    // The aggregate driver's visibility-domain computation over the SAME
+    // request-local physical paths: cross-directory private is hidden, public
+    // crosses, same-file sees private.
+    let mut aggregate =
+        rue_air::ProviderAggregateFacts::<crate::StableDefinitionKey, ModuleId, _>::new(
+            DurableDeclSource::from_declarations(&inputs.decls),
+        );
+    aggregate.register_file_path(root, "/project/main.rue");
+    aggregate.register_file_path(leaf, "/project/sub/leaf.rue");
+    assert!(
+        aggregate.is_accessible(leaf, leaf, false),
+        "same file sees private"
+    );
+    assert!(
+        !aggregate.is_accessible(root, leaf, false),
+        "cross-directory private is hidden"
+    );
+    assert!(
+        aggregate.is_accessible(root, leaf, true),
+        "public crosses directories"
+    );
+}
+
+#[test]
+fn side_b_finalize_containment_metadata_freeze_hook() {
+    // The r4a-2a rider's seam hook, exercised at the point production freezes:
+    // before the freeze the pool's drop/linearity reads are un-finalized;
+    // after it every minted nominal answers.
+    let case = SHAPE_CORPUS
+        .iter()
+        .find(|case| case.name == "method")
+        .unwrap();
+    let inputs = SideBCase::build_single(case.source).unwrap();
+    let mut database = RevisionedQueryDatabase::default();
+    let revision = inputs.revision(&mut database);
+    let counter = inputs
+        .decls
+        .iter()
+        .find(|decl| decl.key.name() == "Counter")
+        .expect("Counter is declared")
+        .key
+        .clone();
+    let decls = inputs.decls.clone();
+    let file = inputs.module_files[counter.module()];
+    let rir = inputs.rir.rir();
+    let interner = inputs.rir.semantic_symbols().interner();
+    let outcome = database.probe_body_facts(
+        revision,
+        side_b_configuration(),
+        "side-b:freeze-hook",
+        move |provider| {
+            let endpoint = rue_air::ProviderEndpointFacts::new(
+                provider,
+                DurableDeclSource::from_declarations(&decls),
+                rir,
+                interner,
+            );
+            let token = endpoint.register_named_nominal(
+                counter.clone(),
+                file.index(),
+                counter.name(),
+                counter.kind(),
+            );
+            let ty = endpoint
+                .resolve_instance_type(&rue_air::TypeInstanceKey::Nominal(
+                    rue_air::NominalInstanceKey::Named(token),
+                ))
+                .expect("Counter mints");
+            let before = endpoint.type_needs_drop(ty);
+            endpoint
+                .finalize_containment_metadata()
+                .expect("no containment cycle");
+            let after_drop = endpoint.type_needs_drop(ty);
+            let after_linear = endpoint.type_carries_linear(ty);
+            // Repeat freeze is a pure re-finalization.
+            endpoint
+                .finalize_containment_metadata()
+                .expect("repeat freeze");
+            (before, after_drop, after_linear)
+        },
+    );
+    let (before, after_drop, after_linear) = outcome.result;
+    assert_eq!(before, None, "un-finalized before the freeze hook");
+    assert_eq!(after_drop, Some(false), "Counter needs no drop");
+    assert_eq!(after_linear, Some(false), "Counter carries no linear");
 }
 
 #[test]
@@ -977,12 +3011,7 @@ fn identity_variant_inventory_is_exhaustive_and_constructible() {
 }
 
 #[test]
-fn review_carry_forwards_are_named_documented_gaps() {
-    assert!(
-        REVIEW_CARRY_FORWARDS.iter().all(|case| {
-            matches!(case.status, CoverageStatus::Gap(reason) if !reason.is_empty())
-        })
-    );
+fn review_carry_forwards_are_named_documented_gaps_or_closed_by_live_tests() {
     assert_eq!(
         REVIEW_CARRY_FORWARDS
             .iter()
@@ -995,6 +3024,37 @@ fn review_carry_forwards_are_named_documented_gaps() {
             "unrelated_same_named_const_preserves_recorded_edges",
             "e0481_candidate_hint_records_no_resolution_edges",
             "forced_eviction_and_cancellation",
+            "const_candidate_facts",
+            "pool_drop_metadata_parity",
+            "instance_keyed_producer_body_facts",
         ]
     );
+    let closed: BTreeMap<&str, &str> = CLOSED_GAP_LIVE_TESTS.iter().copied().collect();
+    for case in REVIEW_CARRY_FORWARDS {
+        match case.status {
+            CoverageStatus::Constructed => {
+                assert!(
+                    closed.contains_key(case.name),
+                    "closed gap `{}` must name its live side-B test",
+                    case.name
+                );
+            }
+            CoverageStatus::Gap(reason) => {
+                assert!(!reason.is_empty());
+                assert!(
+                    !closed.contains_key(case.name),
+                    "gap `{}` cannot both remain recorded and claim a closing test",
+                    case.name
+                );
+            }
+        }
+    }
+    // Every named closing test corresponds to a flipped entry.
+    for (name, _test) in CLOSED_GAP_LIVE_TESTS {
+        let entry = REVIEW_CARRY_FORWARDS
+            .iter()
+            .find(|case| case.name == *name)
+            .expect("closing tests reference recorded rows");
+        assert_eq!(entry.status, CoverageStatus::Constructed);
+    }
 }


### PR DESCRIPTION
Refs RUE-1091.

## Summary

- replace the stubbed `FutureProviderFactsOverlayAnalyzer` with a real `ProviderFactsOverlayAnalyzer` in the rFinal harness: for every body in the shape corpus, the body's durable demand set is replayed through the five real drivers (type-syntax, signature, call, endpoint, aggregate) inside one provider probe per body, so the probe's recorded query edges are exactly that body's side-B observation footprint; fact values come only from the drivers plus `BodySemanticOverlay`, with production's published `BodyTransaction` serving solely as the demand oracle
- make edge-completeness a live per-family differential: side-B edges must fall within the materialization families, and every A/B family difference must match a row of the executable `EDGE_FAMILY_EXCEPTIONS` table (including the flip-deleted `module-declaration-set` whole-program edge), with a non-vacuity assertion that every row is hit
- carry the structural-locality assertion live, and cover cancellation (never-promote: no root, no lease, byte-identical replay after) and forced eviction (retention floor plus filler lookups; invisible re-derivation)
- add the pool-side containment freeze hook the r4a-2a rider demanded: `BodyIdentityPool::finalize_containment_metadata` / `type_needs_drop` / `type_carries_linear`, surfaced on `ProviderEndpointFacts`, unit-pinned and exercised per body (None before freeze, Some after, repeat-freeze pure)
- flip four recorded gaps to live assertions via the executable `CLOSED_GAP_LIVE_TESTS` map: cross-module private lookup, unrelated same-named const edge preservation, E0481 candidate-hint edge minimalism, and forced eviction/cancellation; keep `trusted_well_known_option_registry` and `ambiguous_body_lookup` recorded, and add named gaps `const_candidate_facts`, `pool_drop_metadata_parity`, and `instance_keyed_producer_body_facts`
- record one finding for the flip: the definition-keyed `producer_body_facts` boundary op cannot answer producers on a cold database because the `body-produced-anonymous` family filter compares the collapsed producer form while the nucleus projection retains the empty-arg `Specialization` wrapper (production works because consuming transactions query with the wrapper instance); side B names the exception and the flip's instance-keyed producer op, or a canonical-form comparison in the family filter, closes it
- move the shared `DurableDeclSource` adapter and render helpers into a cfg(test) `test_support` module; `probe_body_facts` / `publish_lookup_root` / `ProviderProbeOutcome` / `with_declaration_memo_retention` become pub(crate) for the harness

Everything remains cfg(test)-only; no inventory change was owed (no epoch reads added to inventoried files).

## Validation

- `//crates/rue-compiler:rue-compiler-test` — 825 passed (11 harness tests)
- `//crates/rue-air:rue-air-test` — pass
- `//:body-analysis-capability-inventory-validation`, `//:body-analysis-capability-inventory-tool-tests` — pass
- `./clippy.sh` — clean
- `scripts/rue fmt` — clean