### PR TITLE
RUE-1129: focus required release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
         # rustfmt target's platform-specific runtime environment.
         run: ./buck2 test //:fmt-check
 
+      - name: Check production debug assertions
+        run: scripts/validate-debug-assert-policy.py
+
   clippy:
     runs-on: ubuntu-latest
     steps:
@@ -506,14 +509,13 @@ jobs:
         if: steps.sel.outputs.run == 'true'
         run: scripts/ci-timed "${{ matrix.check_name }} corpus" -- scripts/ci-heavy-suite "${{ matrix.target }}"
 
-  # Release-mode build + test (RUE-45). Every other job builds the compiler in
-  # debug, so release-only miscompiles — the ones previously masked by a
-  # `debug_assert!` that vanishes when `cfg(debug_assertions)` is off (RUE-24 is
-  # the precedent) — never ran anywhere. This job builds the whole workspace
-  # optimized via `//platforms:release` (RUE-277 made that a genuinely
-  # optimized, byte-distinct build) and runs the full suite against it, so
-  # release codegen is exercised. Bounded to linux-x64 to keep CI time in check;
-  # the debug matrix above still covers arm64/macOS.
+  # Focused release-mode coverage (RUE-1129). Correctness-critical compiler
+  # invariants are enforced independently by validate-debug-assert-policy.py;
+  # this job proves Buck selects the real optimization flags and runs a bounded
+  # end-to-end corpus through the release-built compiler. The scheduled
+  # release.yml workflow retains exhaustive release //... coverage without
+  # putting every optimized target and ThinLTO link on the required critical
+  # path. Debug CI above still covers arm64/macOS.
   release:
     runs-on: ubuntu-latest
     name: release (linux-x64)
@@ -536,11 +538,7 @@ jobs:
             dotslash-linux-x64-
 
       # BuildBuddy remote action cache (RUE-316/RUE-1006); see the clippy job
-      # for the secret-availability contract. This job is the workflow's
-      # critical path (~16 min cold, dominated by the full release build), so
-      # it benefits the most. The RUE-277 debug-vs-release assertion below is
-      # a byte comparison of two separately keyed configurations and is
-      # unaffected by where the artifacts were produced.
+      # for the secret-availability contract.
       - name: Provision remote build cache
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
@@ -552,30 +550,14 @@ jobs:
           scripts/provision-build-cache install
           scripts/provision-build-cache apply
 
-      # Build every crate optimized (catches build breaks that only surface with
-      # optimizations on). Do this before the debug comparison: on cache-miss
-      # changes it gives the parallel sanitizer job time to publish the Linux
-      # debug compiler instead of racing two cold builds of the same graph.
-      - name: Build all targets (release)
-        run: scripts/ci-timed "release build" -- ./buck2 build //crates/... --target-platforms //platforms:release
+      # Direct RUE-277 guard: inspect Buck's analyzed rustc_cfg actions instead
+      # of inferring optimization from complete binary bytes. This performs no
+      # compilation and also pins the release callers to the target platform.
+      - name: Validate release configuration
+        run: scripts/ci-timed "release configuration" -- scripts/validate-release-configuration.py
 
-      # Regression guard for RUE-277: `//platforms:release` must produce a
-      # genuinely-optimized binary that differs from the debug build. The
-      # release artifact is already materialized above; the debug artifact may
-      # now be served by the shared cache after another required job uploads it.
-      - name: Assert release build is distinct from debug
-        run: |
-          debug_bin="$(./scripts/rue-bin --target-platforms //platforms:debug)"
-          release_bin="$(./scripts/rue-bin --target-platforms //platforms:release)"
-          if cmp -s "$debug_bin" "$release_bin"; then
-            echo "::error::release build is byte-identical to debug — //platforms:release opt-level is a no-op (RUE-277 regression)"
-            exit 1
-          fi
-          echo "release build differs from debug build (optimized) — OK"
-
-      # Run the full suite — including the spec/UI/CLI sh_tests, which spawn
-      # the release-configured rue binary — so cfg(debug_assertions)-off and
-      # ThinLTO miscompiles remain required coverage.
-
-      - name: Run tests (release)
-        run: scripts/ci-timed "release tests" -- ./buck2 test //... --target-platforms //platforms:release
+      # Builds only the Rue driver and CLI harness under the release platform,
+      # then runs the 24 representative differential-opt cases (96 produced
+      # programs across -O0/-O1/-O2/-O3) through the release-built compiler.
+      - name: Run focused release smoke
+        run: scripts/ci-timed "release smoke" -- ./buck2 test //:release-smoke --target-platforms //platforms:release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Full release suite
+
+# Exhaustive release-mode defense in depth lives off the required PR critical
+# path (RUE-1129). Required CI still analyzes the exact release rustc flags and
+# runs a focused end-to-end release smoke on every PR and merge-group commit.
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    name: full release suite (linux-x64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dotslash
+        uses: facebook/install-dotslash@v2
+
+      - name: Cache dotslash artifacts
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/dotslash
+          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          restore-keys: |
+            dotslash-linux-x64-
+
+      - name: Provision remote build cache
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          if [ -z "${BUILDBUDDY_API_KEY:-}" ]; then
+            echo "BUILDBUDDY_API_KEY unavailable; building without the remote cache."
+            exit 0
+          fi
+          scripts/provision-build-cache install
+          scripts/provision-build-cache apply
+
+      # The monolithic //:cli-tests target owns the complete CLI corpus here.
+      # Exclude its CI-only hash shards so the same corpus is not repeated four
+      # additional times by the //... expansion.
+      - name: Run full release suite
+        run: >-
+          scripts/ci-timed "full release suite" --
+          ./buck2 test //... --exclude rue_cli_shard
+          --target-platforms //platforms:release

--- a/BUCK
+++ b/BUCK
@@ -240,6 +240,18 @@ sh_test(
     env = _CLI_TEST_ENV,
 )
 
+# Required release coverage is deliberately bounded: compile the real driver
+# and CLI harness under //platforms:release, then run the representative
+# differential-opt corpus through that release-built compiler. The scheduled
+# full-release workflow owns exhaustive //... coverage off the PR critical
+# path (RUE-1129).
+sh_test(
+    name = "release-smoke",
+    test = "//crates/rue-cli-tests:rue-cli-tests",
+    args = ["--quiet", "differential_opt"],
+    env = _CLI_TEST_ENV,
+)
+
 # RUE-1116: parallel CI shards of the CLI corpus. Same harness and declared
 # inputs as //:cli-tests, but each sets RUE_CLI_TEST_SHARD=k/N so it runs a
 # stable hash-partitioned 1/N slice; the shards' union is the full corpus. They
@@ -360,6 +372,22 @@ sh_test(
     name = "required-ci-container-pin-tool-tests",
     test = "scripts/test-required-ci-container-pins.py",
     resources = ["scripts/validate-required-ci-container-pins.py"],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+    },
+)
+
+sh_test(
+    name = "debug-assert-policy-tool-tests",
+    test = "scripts/test-debug-assert-policy.py",
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+    },
+)
+
+sh_test(
+    name = "release-configuration-tool-tests",
+    test = "scripts/test-release-configuration.py",
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
     },

--- a/crates/rue-cfg/src/opt/forward.rs
+++ b/crates/rue-cfg/src/opt/forward.rs
@@ -209,9 +209,8 @@ pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
     // `last_store` table.
     // ------------------------------------------------------------------
     let mut subst: Vec<Option<CfgValue>> = vec![None; cfg.value_count()];
-    // (single-write block, forwarded load block) pairs for the debug dominance
-    // check.
-    #[cfg(debug_assertions)]
+    // (single-write block, forwarded load block) pairs for the dominance
+    // correctness check.
     let mut rule1_dominance_checks: Vec<(BlockId, BlockId)> = Vec::new();
     // Rule 2 last whole-slot store per local, reset per block.
     let mut last_store: Vec<Option<CfgValue>> = vec![None; num_locals];
@@ -247,9 +246,7 @@ pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
                         // Rule 1: global single-write forwarding.
                         subst[value.as_u32() as usize] = Some(write_value);
                         stats.loads_forwarded_single_write += 1;
-                        #[cfg(debug_assertions)]
                         rule1_dominance_checks.push((write_block, block_id));
-                        let _ = write_block;
                     } else if !cfg.is_address_taken(slot) {
                         // Rule 2: block-local forwarding for multi-write slots.
                         if let Some(&Some(stored)) = last_store.get(slot as usize) {
@@ -310,20 +307,17 @@ pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
         return Ok(stats);
     }
 
-    // Turn the definite-initialization argument for Rule 1 into a checked
-    // invariant: the single write's block must dominate every load it feeds.
-    // Only computed when debug assertions are on and Rule 1 actually fired.
-    #[cfg(debug_assertions)]
-    {
-        if !rule1_dominance_checks.is_empty() {
-            let dom = crate::dominators::DominatorTree::compute(cfg);
-            for (write_block, load_block) in &rule1_dominance_checks {
-                debug_assert!(
-                    dom.dominates(*write_block, *load_block),
-                    "Rule 1 forwarded a load in {load_block} whose single write \
-                     block {write_block} does not dominate it",
-                );
-            }
+    // Turn the definite-initialization argument for Rule 1 into an always-on
+    // invariant: violating it would make the substitution below silently use a
+    // value before its definition in release builds.
+    if !rule1_dominance_checks.is_empty() {
+        let dom = crate::dominators::DominatorTree::compute(cfg);
+        for (write_block, load_block) in &rule1_dominance_checks {
+            assert!(
+                dom.dominates(*write_block, *load_block),
+                "Rule 1 forwarded a load in {load_block} whose single write \
+                 block {write_block} does not dominate it",
+            );
         }
     }
 

--- a/crates/rue-cfg/src/opt/simplify.rs
+++ b/crates/rue-cfg/src/opt/simplify.rs
@@ -355,7 +355,11 @@ fn merge_chains(cfg: &mut Cfg, stats: &mut Stats) -> Result<(), crate::CfgEditEr
             // Record param -> arg substitutions for the edge being erased.
             let args: Vec<CfgValue> = cfg.goto_args(args).to_vec();
             let params = std::mem::take(&mut cfg.get_block_mut(target).params);
-            debug_assert_eq!(params.len(), args.len(), "verified edge arity");
+            assert_eq!(
+                params.len(),
+                args.len(),
+                "edge arity must remain valid while merging blocks"
+            );
             for ((param, _ty), arg) in params.into_iter().zip(args) {
                 subst[param.as_u32() as usize] = Some(arg);
             }

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1080,7 +1080,10 @@ impl<'a> CfgLower<'a> {
         }
         // The dedicated indirect-result register x8 holds the sret pointer.
         if let Some(p) = sret_ptr {
-            debug_assert!(abi.sret_pointer_in_dedicated_register());
+            assert!(
+                abi.sret_pointer_in_dedicated_register(),
+                "AAPCS64 must pass the sret pointer in dedicated register x8"
+            );
             self.mir.push(Aarch64Inst::MovRR {
                 dst: Operand::Physical(Reg::X8),
                 src: Operand::Virtual(p),

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -299,7 +299,7 @@ pub(crate) fn narrow_scalar_access(
         // i64/u64/pointers occupy a full slot; aggregates never take this path.
         _ => return None,
     };
-    debug_assert_eq!(
+    assert_eq!(
         u64::from(width),
         type_pool.layout(ty).size,
         "narrow scalar width must equal the compact physical size"

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -1511,7 +1511,10 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
             Some(ValueKind::Call)
         }
         CfgInstData::Intrinsic { runtime, name, .. } => {
-            debug_assert!(runtime.is_none_or(|runtime| runtime.validate()));
+            assert!(
+                runtime.is_none_or(|runtime| runtime.validate()),
+                "intrinsic runtime metadata must be valid before codegen"
+            );
             let args = ctx.cfg.get_intrinsic_args(&inst.data);
             let name_string = adapter.resolve_intrinsic_symbol(*name);
             let values: Vec<IntrinsicArgPlan> = args

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1189,7 +1189,10 @@ impl<'a> CfgLower<'a> {
         let mut int_ops: Vec<VReg> = Vec::new();
         let mut stack_ops: Vec<VReg> = Vec::new();
         if let Some(p) = sret_ptr {
-            debug_assert!(!abi.sret_pointer_in_dedicated_register());
+            assert!(
+                !abi.sret_pointer_in_dedicated_register(),
+                "x86-64 SysV must pass the sret pointer as the first integer argument"
+            );
             int_ops.push(p);
         }
 

--- a/crates/rue-linker/src/emit.rs
+++ b/crates/rue-linker/src/emit.rs
@@ -62,7 +62,7 @@ impl ElfSectionLayout {
 
     /// .rodata section index (2 if present, otherwise unused).
     fn rodata(&self) -> u16 {
-        debug_assert!(
+        assert!(
             self.has_rodata,
             "rodata index requested but rodata not present"
         );

--- a/docs/development.md
+++ b/docs/development.md
@@ -170,8 +170,10 @@ scripts/rue test
 ```
 
 CI additionally runs Clippy, workflow linting, rust-project.json validation,
-debug tests on Linux x86-64, Linux AArch64, and macOS, plus a release-mode Linux
-suite. Fuzz, sanitizer, website, and benchmark workflows run separately.
+debug tests on Linux x86-64, Linux AArch64, and macOS, plus a focused
+release-mode Linux smoke. The exhaustive release suite runs nightly and can be
+dispatched manually. Fuzz, sanitizer, website, and benchmark workflows run
+separately.
 
 ## Editor / IDE support
 

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -20,6 +20,26 @@ compiler-reproducibility job is the deliberate exception: its two independently
 materialized compiler builds stay local and cache-free, while the ordinary
 linux-x64 test lane may use BuildBuddy.
 
+Required release coverage is intentionally focused (RUE-1129). The
+`release (linux-x64)` job analyzes Buck's configured `rustc_cfg` actions and
+fails unless `//platforms:release` supplies `-Copt-level=3 -Clto=thin` while
+`//platforms:debug` supplies neither. It then runs `//:release-smoke`, the 24
+representative differential-opt cases, through a release-built Rue compiler.
+It does not build every crate target or run the exhaustive suite.
+
+`.github/workflows/release.yml` runs the complete release-configured `//...`
+suite nightly and on manual dispatch. Its `rue_cli_shard` exclusion is
+intentional: the monolithic `//:cli-tests` target owns the full CLI corpus, so
+also running the four CI-only hash shards would execute that corpus twice.
+
+Production `debug_assert*` use is governed by
+`scripts/validate-debug-assert-policy.py`, run by required formatting CI and
+`scripts/rue quick`. Every surviving call has an exact per-file allowance and
+rationale; changing the count requires reviewing the ledger. CFG optimization,
+code generation, and linking have no allowances: an invariant whose violation
+could change emitted code must be an always-on assertion or a real compiler
+diagnostic.
+
 The platform test lanes all retain broad target discovery. Every platform
 (linux-x64, linux-arm64, macOS) defers its three heaviest corpora —
 `//:cli-tests`, `//:cli-tests-caldera`, and `//:spec-tests` — to explicit

--- a/quick-test.sh
+++ b/quick-test.sh
@@ -12,6 +12,9 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
+echo "Checking production debug-assertion policy..."
+scripts/validate-debug-assert-policy.py
+
 echo "Running unit tests (quick mode)..."
 # Run every crate's unit tests; //... avoids a hand-maintained list that
 # silently goes stale as crates are added; scoping to //crates/ keeps vendored

--- a/scripts/test-debug-assert-policy.py
+++ b/scripts/test-debug-assert-policy.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Focused tests for the production debug-assertion policy."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("validate-debug-assert-policy.py")
+SPEC = importlib.util.spec_from_file_location("debug_assert_policy", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+policy = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(policy)
+
+
+class DebugAssertPolicyTests(unittest.TestCase):
+    def validate(
+        self, files: dict[str, str], allowances: dict[str, policy.Allowance]
+    ) -> list[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for relative, contents in files.items():
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(contents)
+            return policy.validate(root, allowances)
+
+    def test_accepts_exact_reviewed_allowance(self) -> None:
+        path = "crates/rue-air/src/lib.rs"
+        self.assertEqual(
+            self.validate(
+                {path: "fn f() { debug_assert!(true); }\n"},
+                {path: policy.Allowance(1, "redundant test invariant")},
+            ),
+            [],
+        )
+
+    def test_rejects_unreviewed_assertion(self) -> None:
+        errors = self.validate(
+            {"crates/rue-codegen/src/lib.rs": "debug_assert_eq!(1, 1);\n"}, {}
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("unreviewed", errors[0])
+
+    def test_rejects_ledger_drift_in_either_direction(self) -> None:
+        path = "crates/rue-air/src/lib.rs"
+        allowance = {path: policy.Allowance(2, "two redundant checks")}
+        too_few = self.validate({path: "debug_assert!(true);\n"}, allowance)
+        too_many = self.validate(
+            {path: "debug_assert!(true);\ndebug_assert!(true);\ndebug_assert!(true);\n"},
+            allowance,
+        )
+        self.assertIn("expects 2, found 1", too_few[0])
+        self.assertIn("expects 2, found 3", too_many[0])
+
+    def test_ignores_comments_and_string_literals(self) -> None:
+        source = """\
+// debug_assert!(false);
+/* debug_assert_eq!(1, 2); */
+const TEXT: &str = "debug_assert_ne!(1, 1);";
+const RAW: &str = r#"debug_assert!(false);"#;
+"""
+        self.assertEqual(
+            self.validate({"crates/rue-codegen/src/lib.rs": source}, {}), []
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-release-configuration.py
+++ b/scripts/test-release-configuration.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Focused tests for release-configuration validation."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("validate-release-configuration.py")
+SPEC = importlib.util.spec_from_file_location("release_configuration", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+release_configuration = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(release_configuration)
+
+
+def payload(platform: str, command: str) -> str:
+    return json.dumps(
+        {
+            f"(target: `prelude//rust/tools:rustc_cfg "
+            f"(root//platforms:{platform}#abc)`, id: `0`)": {"cmd": command}
+        }
+    )
+
+
+class ReleaseConfigurationTests(unittest.TestCase):
+    def test_extracts_configured_rustc_action(self) -> None:
+        command = "[rustc, -Copt-level=3, -Clto=thin]"
+        self.assertEqual(
+            release_configuration.rustc_cfg_command(
+                payload("release", command), "release"
+            ),
+            command,
+        )
+
+    def test_requires_release_flags_and_forbids_them_in_debug(self) -> None:
+        self.assertEqual(
+            release_configuration.validate_commands(
+                "[rustc]", "[rustc, -Copt-level=3, -Clto=thin]"
+            ),
+            [],
+        )
+        errors = release_configuration.validate_commands(
+            "[rustc, -Clto=thin]", "[rustc, -Copt-level=3]"
+        )
+        self.assertIn("debug rustc_cfg unexpectedly contains -Clto=thin", errors)
+        self.assertIn("release rustc_cfg is missing -Clto=thin", errors)
+
+    def test_rejects_old_modifier_and_missing_platform(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for relative, expected in release_configuration.RELEASE_CALLERS.items():
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(f"--target-platforms {expected}\n")
+
+            self.assertEqual(release_configuration.validate_callers(root), [])
+
+            (root / "bench.sh").write_text("--modifier //constraints:release\n")
+            errors = release_configuration.validate_callers(root)
+            self.assertTrue(any("RUE-277 no-op" in error for error in errors))
+            self.assertTrue(any("no longer names" in error for error in errors))
+
+    def test_rejects_missing_or_ambiguous_rustc_action(self) -> None:
+        with self.assertRaisesRegex(ValueError, "0 matching"):
+            release_configuration.rustc_cfg_command("{}", "release")
+        duplicate = json.loads(payload("release", "[rustc]"))
+        duplicate[
+            "(target: `prelude//rust/tools:rustc_cfg "
+            "(root//platforms:release#def)`, id: `0`)"
+        ] = {"cmd": "[rustc]"}
+        with self.assertRaisesRegex(ValueError, "2 matching"):
+            release_configuration.rustc_cfg_command(
+                json.dumps(duplicate), "release"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-debug-assert-policy.py
+++ b/scripts/validate-debug-assert-policy.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Enforce Rue's reviewed production debug-assertion budget.
+
+`debug_assert!` is useful for redundant development checks, but it must never
+be the only barrier between malformed compiler state and wrong generated code.
+Every surviving production use is therefore an explicit reviewed exception.
+Changing, adding, or removing one requires updating this ledger with its
+rationale; the lowering, codegen, and linker crates intentionally have none.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEBUG_ASSERT = re.compile(r"\bdebug_assert(?:_eq|_ne)?!\s*\(")
+RAW_STRING_START = re.compile(r"(?:br|r)(?P<hashes>#{0,255})\"")
+CHARACTER_LITERAL_START = re.compile(r"'(?:\\.|[^'\\\n])+'")
+
+
+class Allowance(NamedTuple):
+    count: int
+    rationale: str
+
+
+# Exact per-file counts make this a ratchet rather than a blanket exemption:
+# even deleting an old use requires reviewing and reducing the ledger.
+ALLOWANCES = {
+    "crates/rue-air/src/inst.rs": Allowance(1, "redundant fixed-width AIR encoding check"),
+    "crates/rue-air/src/intern_pool.rs": Allowance(3, "redundant arena and traversal bookkeeping checks"),
+    "crates/rue-air/src/sema/analysis.rs": Allowance(20, "redundant semantic index and phase-state coherence checks"),
+    "crates/rue-air/src/sema/analysis/builtin_ops.rs": Allowance(1, "redundant error-recovery state check"),
+    "crates/rue-air/src/sema/analysis/calls.rs": Allowance(1, "redundant parameter metadata width check"),
+    "crates/rue-air/src/sema/analysis/functions.rs": Allowance(2, "redundant parameter-mode and ABI accounting checks"),
+    "crates/rue-air/src/sema/analysis/intrinsics.rs": Allowance(1, "redundant intrinsic signature inventory check"),
+    "crates/rue-air/src/sema/analysis/ownership.rs": Allowance(1, "redundant non-negative arena-index check"),
+    "crates/rue-air/src/sema/binding_manifest.rs": Allowance(2, "redundant binding-manifest construction checks"),
+    "crates/rue-air/src/sema/comptime_eval.rs": Allowance(2, "redundant semantic phase preconditions"),
+    "crates/rue-air/src/sema/declaration_index.rs": Allowance(4, "redundant declaration indexing counters"),
+    "crates/rue-air/src/sema/declarations.rs": Allowance(7, "redundant declaration-resolution lifecycle checks"),
+    "crates/rue-air/src/sema/typeck.rs": Allowance(1, "redundant parameter flag cardinality check"),
+    "crates/rue-compiler/src/artifact_views.rs": Allowance(7, "redundant typed-view owner and bounds checks"),
+    "crates/rue-compiler/src/definition_snapshot.rs": Allowance(1, "redundant definition arena identity check"),
+    "crates/rue-compiler/src/diagnostic_attempt_store.rs": Allowance(2, "redundant diagnostic retention accounting"),
+    "crates/rue-compiler/src/parsed_modules.rs": Allowance(2, "redundant source ownership checks"),
+    "crates/rue-compiler/src/query_graph.rs": Allowance(3, "redundant query-node lifecycle checks"),
+    "crates/rue-compiler/src/revisioned_query_database.rs": Allowance(1, "redundant memo-retention accounting"),
+    "crates/rue-compiler/src/semantic_query_nucleus.rs": Allowance(1, "redundant semantic query category check"),
+    "crates/rue-compiler/src/session.rs": Allowance(8, "redundant canonical-session phase and provenance checks"),
+    "crates/rue-compiler/src/source_identity.rs": Allowance(4, "redundant normalized-path representation checks"),
+    "crates/rue-compiler/src/source_snapshot.rs": Allowance(1, "redundant source arena identity check"),
+    "crates/rue-compiler/src/typed_query_store.rs": Allowance(1, "redundant typed-query key check"),
+    "crates/rue-error/src/lib.rs": Allowance(1, "redundant diagnostic rendering bounds check"),
+    "crates/rue-oracle/src/lib.rs": Allowance(2, "oracle harness bookkeeping checks, not compiler correctness gates"),
+    "crates/rue-parser/src/parser/shared.rs": Allowance(2, "redundant parser entry preconditions"),
+    "crates/rue-parser/src/parser/statements.rs": Allowance(1, "redundant parser entry precondition"),
+    "crates/rue-rir/src/inst.rs": Allowance(2, "redundant RIR variable-width encoding checks"),
+    "crates/rue-span/src/lib.rs": Allowance(1, "redundant span construction bounds check"),
+    "crates/rue/src/emit.rs": Allowance(6, "presentation-mode phase accounting checks"),
+    "crates/rue/src/source_loader.rs": Allowance(1, "redundant source-plan revision check"),
+}
+
+
+def strip_non_code(source: str) -> str:
+    """Replace Rust comments and string/character contents with whitespace."""
+
+    result = list(source)
+    index = 0
+    block_depth = 0
+    state = "code"
+    raw_hashes = 0
+
+    def blank(position: int) -> None:
+        if result[position] != "\n":
+            result[position] = " "
+
+    while index < len(source):
+        if state == "line_comment":
+            if source[index] == "\n":
+                state = "code"
+            else:
+                blank(index)
+            index += 1
+            continue
+
+        if state == "block_comment":
+            if source.startswith("/*", index):
+                blank(index)
+                blank(index + 1)
+                block_depth += 1
+                index += 2
+            elif source.startswith("*/", index):
+                blank(index)
+                blank(index + 1)
+                block_depth -= 1
+                index += 2
+                if block_depth == 0:
+                    state = "code"
+            else:
+                blank(index)
+                index += 1
+            continue
+
+        if state == "quoted":
+            if source[index] == "\\":
+                blank(index)
+                if index + 1 < len(source):
+                    blank(index + 1)
+                index += 2
+            else:
+                character = source[index]
+                blank(index)
+                index += 1
+                if character == '"':
+                    state = "code"
+            continue
+
+        if state == "character":
+            if source[index] == "\\":
+                blank(index)
+                if index + 1 < len(source):
+                    blank(index + 1)
+                index += 2
+            else:
+                character = source[index]
+                blank(index)
+                index += 1
+                if character == "'":
+                    state = "code"
+            continue
+
+        if state == "raw":
+            terminator = '"' + ("#" * raw_hashes)
+            if source.startswith(terminator, index):
+                for offset in range(len(terminator)):
+                    blank(index + offset)
+                index += len(terminator)
+                state = "code"
+            else:
+                blank(index)
+                index += 1
+            continue
+
+        if source.startswith("//", index):
+            blank(index)
+            blank(index + 1)
+            index += 2
+            state = "line_comment"
+            continue
+        if source.startswith("/*", index):
+            blank(index)
+            blank(index + 1)
+            index += 2
+            block_depth = 1
+            state = "block_comment"
+            continue
+
+        raw_match = RAW_STRING_START.match(source, index)
+        if raw_match:
+            token = raw_match.group(0)
+            raw_hashes = len(raw_match.group("hashes"))
+            for offset in range(len(token)):
+                blank(index + offset)
+            index += len(token)
+            state = "raw"
+            continue
+
+        if source.startswith('b"', index):
+            blank(index)
+            blank(index + 1)
+            index += 2
+            state = "quoted"
+            continue
+        if source[index] == '"':
+            blank(index)
+            index += 1
+            state = "quoted"
+            continue
+
+        # Treat a quote as a character literal only when it has a closing quote
+        # on this line; this avoids mistaking Rust lifetimes for literals.
+        if source[index] == "'" and CHARACTER_LITERAL_START.match(source, index):
+            blank(index)
+            index += 1
+            state = "character"
+            continue
+
+        index += 1
+
+    return "".join(result)
+
+
+def count_debug_asserts(path: Path) -> int:
+    return len(DEBUG_ASSERT.findall(strip_non_code(path.read_text())))
+
+
+def validate(root: Path, allowances: dict[str, Allowance] = ALLOWANCES) -> list[str]:
+    actual = {
+        path.relative_to(root).as_posix(): count_debug_asserts(path)
+        for path in sorted((root / "crates").glob("**/*.rs"))
+    }
+    actual = {path: count for path, count in actual.items() if count}
+
+    errors: list[str] = []
+    for path in sorted(set(actual) | set(allowances)):
+        observed = actual.get(path, 0)
+        allowance = allowances.get(path)
+        if allowance is None:
+            errors.append(
+                f"{path}: found {observed} unreviewed debug assertion(s); "
+                "use an always-on assertion/diagnostic, or add a justified allowance"
+            )
+        elif observed != allowance.count:
+            errors.append(
+                f"{path}: debug-assertion ledger expects {allowance.count}, found {observed}; "
+                "review the change and update or remove its allowance"
+            )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", type=Path, default=ROOT)
+    args = parser.parse_args()
+
+    errors = validate(args.root)
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    total = sum(allowance.count for allowance in ALLOWANCES.values())
+    print(
+        "debug-assertion policy valid: "
+        f"{total} reviewed debug-only assertion(s), none in CFG/codegen/linker"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-release-configuration.py
+++ b/scripts/validate-release-configuration.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Verify that Buck analyzes Rue's debug and release Rust flags correctly."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+TARGET = "//crates/rue:rue"
+PLATFORMS = {
+    "debug": "//platforms:debug",
+    "release": "//platforms:release",
+}
+RELEASE_FLAGS = ("-Copt-level=3", "-Clto=thin")
+RELEASE_CALLERS = {
+    "bench.sh": "//platforms:$BUILD_MODE",
+    "scripts/parser-profile.py": "//platforms:release",
+    "scripts/perf-baseline.py": "//platforms:release",
+}
+
+
+def rustc_cfg_command(payload: str, platform: str) -> str:
+    try:
+        actions = json.loads(payload)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"{platform} aquery returned invalid JSON: {error}") from error
+
+    matches = [
+        attributes.get("cmd", "")
+        for key, attributes in actions.items()
+        if "prelude//rust/tools:rustc_cfg" in key and f"root//platforms:{platform}#" in key
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"{platform} aquery exposed {len(matches)} matching rustc_cfg actions, expected 1"
+        )
+    return matches[0]
+
+
+def validate_commands(debug: str, release: str) -> list[str]:
+    errors: list[str] = []
+    for flag in RELEASE_FLAGS:
+        if flag not in release:
+            errors.append(f"release rustc_cfg is missing {flag}")
+        if flag in debug:
+            errors.append(f"debug rustc_cfg unexpectedly contains {flag}")
+    return errors
+
+
+def validate_callers(root: Path) -> list[str]:
+    errors: list[str] = []
+    for relative, expected_platform in RELEASE_CALLERS.items():
+        source = (root / relative).read_text()
+        if "--modifier //constraints:release" in source:
+            errors.append(
+                f"{relative}: uses the RUE-277 no-op release modifier; "
+                "use --target-platforms //platforms:release"
+            )
+        if expected_platform not in source:
+            errors.append(
+                f"{relative}: release caller no longer names {expected_platform}"
+            )
+    return errors
+
+
+def query(buck2: Path, platform: str) -> str:
+    command = [
+        str(buck2),
+        "aquery",
+        f"deps({TARGET})",
+        "--target-platforms",
+        PLATFORMS[platform],
+        "--output-attribute",
+        "^cmd$",
+        "--json",
+    ]
+    result = subprocess.run(
+        command,
+        cwd=ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return rustc_cfg_command(result.stdout, platform)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--buck2", type=Path, default=ROOT / "buck2")
+    args = parser.parse_args()
+
+    try:
+        debug = query(args.buck2, "debug")
+        release = query(args.buck2, "release")
+    except (OSError, subprocess.CalledProcessError, ValueError) as error:
+        print(f"error: could not inspect Buck release configuration: {error}", file=sys.stderr)
+        return 1
+
+    errors = validate_commands(debug, release) + validate_callers(ROOT)
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "release configuration valid: release has "
+        f"{' '.join(RELEASE_FLAGS)}; debug does not"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- replace the required full release build/test graph with direct Buck configuration validation and a 24-case differential release smoke
- enforce a reviewed production `debug_assert*` ledger and promote correctness-critical CFG, codegen, and linker guards to always-on assertions
- retain exhaustive release coverage in a nightly/manual workflow without re-running the four CI-only CLI shards

## Validation

- `scripts/rue quick`
- `./buck2 test //:release-smoke --target-platforms //platforms:release`
- `scripts/validate-release-configuration.py`
- `scripts/validate-debug-assert-policy.py`
- `./buck2 test //:required-ci-container-pin-validation //:required-ci-container-pin-tool-tests //:debug-assert-policy-tool-tests //:release-configuration-tool-tests //:wrapper-script-tests`
- `./buck2 test //:fmt-check`
- actionlint 1.7.12

Fixes RUE-1129.

Refs RUE-45, RUE-277, RUE-236, RUE-1006.
