### PR TITLE
Incrementality value-audit instrumentation (fail-closed audit)

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -538,6 +538,24 @@ sh_test(
     },
 )
 
+# RUE-1091: the value-audit protocol and adversarial fail-closed tests are
+# repository gates. Declare every script and checked-in manifest they import so
+# Buck cannot reuse a result after the protocol or fixture changes.
+sh_test(
+    name = "value-audit-tool-tests",
+    test = "scripts/test-value-audit.py",
+    resources = [
+        "scripts/rue-value-audit.py",
+        "scripts/perf-baseline.py",
+        "benchmarks/manifest.toml",
+        "benchmarks/value-audit/manifest.toml",
+        "benchmarks/value-audit/README.md",
+    ],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+    },
+)
+
 # The destructive maintenance scripts under test (jj-tidy, worktree-gc). Their
 # fail-closed contract is pinned by scripts/test-cleanup-scripts.sh (RUE-567),
 # which runs copies of them against fake gh/git/df on PATH — no real repo,

--- a/benchmarks/value-audit/README.md
+++ b/benchmarks/value-audit/README.md
@@ -9,6 +9,9 @@ scripts/rue-value-audit.py \
   --historical-baseline /path/to/historical/rue \
   --current /path/to/current/rue \
   --candidate /path/to/candidate/rue \
+  --source-dir historical_baseline=/path/to/historical/source \
+  --source-dir current_production=/path/to/current/source \
+  --source-dir candidate=/path/to/candidate/source \
   --session-bench historical_baseline=/path/to/historical/session-bench \
   --session-bench current_production=/path/to/current/session-bench \
   --session-bench candidate=/path/to/candidate/session-bench \
@@ -16,21 +19,29 @@ scripts/rue-value-audit.py \
   --output results/value-audit.json
 ```
 
-The runner performs one unrecorded warmup and seven alternating paired
-samples. It records medians and median absolute deviations (MADs), commit and
-source hashes, executable hashes, host provenance, raw sample order, and
-explicit unsupported scenarios.
+The runner performs the manifest-pinned unrecorded warmup and seven alternating
+paired samples. It records medians and median absolute deviations (MADs),
+explicit per-role source/build provenance linked to executable hashes, host
+provenance, raw sample order, and explicit unsupported or indeterminate
+scenarios. The source directory is mandatory; a role is never silently mapped
+to the candidate checkout.
 
 The current production binary is the recommended baseline for candidate value.
 An older pre-query revision may use the cold executable-only fallback when it
-cannot consume `--benchmark-json`; its missing warm evidence is unsupported,
-not silently treated as zero work. The report's historical result is context,
-not post-flip evidence.
+cannot consume `--benchmark-json`; cross-protocol timing comparisons are then
+indeterminate, and its missing warm evidence is unsupported—not silently
+treated as zero work. A run using one binary for all three roles is classified
+as `same_binary_protocol_smoke`; it validates protocol and fail-closed gates,
+not historical/current/candidate value.
 
-The existing session benchmark currently exposes bounded no-op, unrelated,
-leaf-body, and reverse/fanout locality scenarios for the synthetic corpus, and
-no-op, leaf-body, and import/fanout scenarios for the representative corpus.
-Medium ordinary Rue and Caldera are cold-driver workloads. A repeated-edit RSS
-protocol is intentionally reported unsupported until an existing benchmark
-binary exposes a persistent-session repeated-edit mode; the runner does not
-invent a fresh-process proxy for retained memory.
+The existing session benchmark emits versioned full-parity evidence and
+production computed/reused/invalidated counters. Required warm locality gates
+use manifest-authoritative exact or upper bounds; full-program reparsing,
+semantic reruns, or broad body/CFG recomputation fail closed. The reverse/fanout
+fixture has a bounded manifest allowance. Medium ordinary Rue and Caldera are
+cold-driver workloads. A repeated-edit RSS protocol is explicitly optional and
+reported unsupported until an existing benchmark binary exposes a
+persistent-session repeated-edit mode; the runner does not invent a
+fresh-process proxy for retained memory. The scaling timing binary does not
+expose per-body production counters, so its timing is operational evidence and
+cannot by itself prove flat per-body work.

--- a/benchmarks/value-audit/README.md
+++ b/benchmarks/value-audit/README.md
@@ -1,0 +1,36 @@
+# Incrementality value audit
+
+`manifest.toml` pins the user-value workload matrix while the canonical
+benchmark semantics stay in [`../manifest.toml`](../manifest.toml). Run the
+orchestrator with three release-mode compiler binaries:
+
+```sh
+scripts/rue-value-audit.py \
+  --historical-baseline /path/to/historical/rue \
+  --current /path/to/current/rue \
+  --candidate /path/to/candidate/rue \
+  --session-bench historical_baseline=/path/to/historical/session-bench \
+  --session-bench current_production=/path/to/current/session-bench \
+  --session-bench candidate=/path/to/candidate/session-bench \
+  --scaling-bench current_production=/path/to/current/scaling-bench \
+  --output results/value-audit.json
+```
+
+The runner performs one unrecorded warmup and seven alternating paired
+samples. It records medians and median absolute deviations (MADs), commit and
+source hashes, executable hashes, host provenance, raw sample order, and
+explicit unsupported scenarios.
+
+The current production binary is the recommended baseline for candidate value.
+An older pre-query revision may use the cold executable-only fallback when it
+cannot consume `--benchmark-json`; its missing warm evidence is unsupported,
+not silently treated as zero work. The report's historical result is context,
+not post-flip evidence.
+
+The existing session benchmark currently exposes bounded no-op, unrelated,
+leaf-body, and reverse/fanout locality scenarios for the synthetic corpus, and
+no-op, leaf-body, and import/fanout scenarios for the representative corpus.
+Medium ordinary Rue and Caldera are cold-driver workloads. A repeated-edit RSS
+protocol is intentionally reported unsupported until an existing benchmark
+binary exposes a persistent-session repeated-edit mode; the runner does not
+invent a fresh-process proxy for retained memory.

--- a/benchmarks/value-audit/manifest.toml
+++ b/benchmarks/value-audit/manifest.toml
@@ -1,4 +1,4 @@
-schema_version = 1
+schema_version = 2
 
 # This manifest names the audit's user-value matrix.  The workload semantics
 # remain owned by benchmarks/manifest.toml and by the existing benchmark
@@ -11,6 +11,7 @@ warmup = 1
 paired_samples = 7
 pair_order = "historical,current,candidate then candidate,current,historical"
 measurement_profile = "release"
+caldera_timeout_headroom_seconds = 30
 
 [thresholds]
 warm_unrelated_declaration_improvement = 0.50
@@ -19,6 +20,69 @@ claimed_win_mad_multiplier = 3.0
 cold_regression_fraction = 0.02
 repeated_edit_rss_band = 0.05
 caldera_wall_seconds = 300
+
+# A required scenario must have complete evidence for every role that is
+# compared.  A missing binary, malformed row, or unsupported protocol makes
+# the scenario indeterminate; it can never silently become a passing result.
+# Workloads opt into the scenarios they can actually express below.
+[scenario_policy.cold]
+required = true
+
+[scenario_policy.warm_no_op]
+required = true
+
+[scenario_policy.warm_unrelated_declaration]
+required = true
+
+[scenario_policy.warm_leaf_body]
+required = true
+
+[scenario_policy.warm_signature_fanout]
+required = true
+
+[scenario_policy.repeated_edit_memory]
+required = false
+reason_if_unsupported = "No persistent-session repeated-edit RSS protocol is exposed"
+
+# These are upper bounds on production work counters, not lower-bound hints.
+# They deliberately remain flat as an unrelated-body universe grows.  The
+# reverse-closure fixture is allowed its bounded fanout; it is not a license
+# to re-run an arbitrary fraction of the program.
+[locality.warm_no_op]
+max_modules_computed = 0
+max_rir_computed = 0
+max_declarations_computed = 0
+max_durable_source_computed = 0
+max_semantic_bodies_computed = 0
+max_cfgs_computed = 0
+max_semantic_queries_computed = 0
+
+[locality.warm_unrelated_declaration]
+max_modules_computed = 0
+max_rir_computed = 0
+max_declarations_computed = 0
+max_durable_source_computed = 0
+max_semantic_bodies_computed = 0
+max_cfgs_computed = 0
+max_semantic_queries_computed = 0
+
+[locality.warm_leaf_body]
+max_modules_computed = 1
+max_rir_computed = 1
+max_declarations_computed = 1
+max_durable_source_computed = 1
+max_semantic_bodies_computed = 1
+max_cfgs_computed = 1
+max_semantic_queries_computed = 1
+
+[locality.warm_signature_fanout]
+max_modules_computed = 2
+max_rir_computed = 1
+max_declarations_computed = 1
+max_durable_source_computed = 8
+max_semantic_bodies_computed = 8
+max_cfgs_computed = 8
+max_semantic_queries_computed = 1
 
 [[workload]]
 name = "synthetic"

--- a/benchmarks/value-audit/manifest.toml
+++ b/benchmarks/value-audit/manifest.toml
@@ -44,7 +44,10 @@ required = true
 required = false
 reason_if_unsupported = "No persistent-session repeated-edit RSS protocol is exposed"
 
-# These are upper bounds on production work counters, not lower-bound hints.
+# These are upper bounds on available production work counters, not lower-bound
+# hints. `max_*_computed` is also the bound for an available invalidated
+# dimension; unavailable dimensions are explicit in the row and are not treated
+# as zero.
 # They deliberately remain flat as an unrelated-body universe grows.  The
 # reverse-closure fixture is allowed its bounded fanout; it is not a license
 # to re-run an arbitrary fraction of the program.
@@ -56,6 +59,17 @@ max_durable_source_computed = 0
 max_semantic_bodies_computed = 0
 max_cfgs_computed = 0
 max_semantic_queries_computed = 0
+max_cold_body_preparations_computed = 0
+max_declarations_inspected_computed = 0
+max_modules_registered_computed = 0
+max_rir_indexes_constructed_computed = 0
+max_rir_instructions_visited_computed = 0
+max_durable_source_records_inspected_computed = 0
+max_durable_source_records_copied_computed = 0
+max_shells_prepared_computed = 0
+max_projections_performed_computed = 0
+max_semantics_installed_computed = 0
+max_endpoints_installed_computed = 0
 
 [locality.warm_unrelated_declaration]
 max_modules_computed = 0
@@ -65,6 +79,17 @@ max_durable_source_computed = 0
 max_semantic_bodies_computed = 0
 max_cfgs_computed = 0
 max_semantic_queries_computed = 0
+max_cold_body_preparations_computed = 0
+max_declarations_inspected_computed = 0
+max_modules_registered_computed = 0
+max_rir_indexes_constructed_computed = 0
+max_rir_instructions_visited_computed = 0
+max_durable_source_records_inspected_computed = 0
+max_durable_source_records_copied_computed = 0
+max_shells_prepared_computed = 0
+max_projections_performed_computed = 0
+max_semantics_installed_computed = 0
+max_endpoints_installed_computed = 0
 
 [locality.warm_leaf_body]
 max_modules_computed = 1
@@ -74,6 +99,17 @@ max_durable_source_computed = 1
 max_semantic_bodies_computed = 1
 max_cfgs_computed = 1
 max_semantic_queries_computed = 1
+max_cold_body_preparations_computed = 1
+max_declarations_inspected_computed = 1
+max_modules_registered_computed = 1
+max_rir_indexes_constructed_computed = 1
+max_rir_instructions_visited_computed = 1
+max_durable_source_records_inspected_computed = 1
+max_durable_source_records_copied_computed = 1
+max_shells_prepared_computed = 1
+max_projections_performed_computed = 1
+max_semantics_installed_computed = 1
+max_endpoints_installed_computed = 1
 
 [locality.warm_signature_fanout]
 max_modules_computed = 2
@@ -83,6 +119,17 @@ max_durable_source_computed = 8
 max_semantic_bodies_computed = 8
 max_cfgs_computed = 8
 max_semantic_queries_computed = 1
+max_cold_body_preparations_computed = 8
+max_declarations_inspected_computed = 8
+max_modules_registered_computed = 8
+max_rir_indexes_constructed_computed = 8
+max_rir_instructions_visited_computed = 8
+max_durable_source_records_inspected_computed = 8
+max_durable_source_records_copied_computed = 8
+max_shells_prepared_computed = 8
+max_projections_performed_computed = 8
+max_semantics_installed_computed = 8
+max_endpoints_installed_computed = 8
 
 [[workload]]
 name = "synthetic"

--- a/benchmarks/value-audit/manifest.toml
+++ b/benchmarks/value-audit/manifest.toml
@@ -1,0 +1,50 @@
+schema_version = 1
+
+# This manifest names the audit's user-value matrix.  The workload semantics
+# remain owned by benchmarks/manifest.toml and by the existing benchmark
+# binaries; this file only pins the protocol-facing fixture selection.
+source_manifest = "../manifest.toml"
+
+[protocol]
+name = "rue_incrementality_value_audit"
+warmup = 1
+paired_samples = 7
+pair_order = "historical,current,candidate then candidate,current,historical"
+measurement_profile = "release"
+
+[thresholds]
+warm_unrelated_declaration_improvement = 0.50
+warm_leaf_body_improvement = 0.25
+claimed_win_mad_multiplier = 3.0
+cold_regression_fraction = 0.02
+repeated_edit_rss_band = 0.05
+caldera_wall_seconds = 300
+
+[[workload]]
+name = "synthetic"
+family = "synthetic"
+root = "../stress/many_functions.rue"
+warm_runner = "rue-compiler-session-bench --modules 128"
+scaling_runner = "rue-scaling-bench --bodies 1000 --decls 100"
+supported_scenarios = ["cold", "warm_no_op", "warm_unrelated_declaration", "warm_leaf_body", "warm_signature_fanout"]
+
+[[workload]]
+name = "representative_multi_module"
+family = "representative"
+root = "../scenarios/representative/main.rue"
+warm_runner = "rue-compiler-session-bench --representative"
+supported_scenarios = ["cold", "warm_no_op", "warm_leaf_body", "warm_signature_fanout"]
+
+[[workload]]
+name = "medium_ordinary_rue"
+family = "ordinary"
+root = "../../examples/quicksort.rue"
+warm_runner = "unsupported: no persistent-session black-box protocol"
+supported_scenarios = ["cold"]
+
+[[workload]]
+name = "caldera"
+family = "caldera"
+root = "../../examples/caldera/main.rue"
+warm_runner = "unsupported: no persistent-session black-box protocol"
+supported_scenarios = ["cold"]

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -225,6 +225,10 @@ pub struct DeclarationBindingWork {
     pub durable_payloads_installed: usize,
     /// Size of the input RIR, not a claim that binding visited every entry.
     pub input_rir_instructions: usize,
+    /// Canonical modules inserted into this semantic epoch's compact registry.
+    /// This is a production-path count of registration work, not a module
+    /// universe size inferred by a consumer.
+    pub modules_registered: usize,
     pub declaration_index_build_invocations: usize,
     pub indexed_free_functions: usize,
     pub indexed_named_methods: usize,
@@ -3830,6 +3834,7 @@ impl DeclarationBindingWork {
     pub(super) fn from_inputs(
         input_rir_instructions: usize,
         index: RirDeclarationIndexWork,
+        modules_registered: usize,
     ) -> Self {
         Self {
             bind_invocations: 1,
@@ -3844,6 +3849,7 @@ impl DeclarationBindingWork {
             durable_install_invocations: 0,
             durable_payloads_installed: 0,
             input_rir_instructions,
+            modules_registered,
             declaration_index_build_invocations: index.build_invocations,
             indexed_free_functions: index.free_functions_indexed,
             indexed_named_methods: index.named_methods_indexed,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -1354,8 +1354,11 @@ impl<'a> Sema<'a> {
             self.synthetic_declaration_discovery,
             "canonical compiler epochs must import query-owned declaration shells"
         );
-        let mut binding_work =
-            DeclarationBindingWork::from_inputs(self.rir.len(), self.declaration_index.work());
+        let mut binding_work = DeclarationBindingWork::from_inputs(
+            self.rir.len(),
+            self.declaration_index.work(),
+            self.module_registry.len(),
+        );
         // Phase 0: Inject built-in types (String, etc.) before user code.
         // Canonical merge has already validated function/type/main conflicts;
         // value constants are checked later once module bindings are known.
@@ -1389,8 +1392,11 @@ impl<'a> Sema<'a> {
         mut self,
         imported: &[SemanticDeclarationShell],
     ) -> MultiErrorResult<DeclarationShells<'a>> {
-        let mut binding_work =
-            DeclarationBindingWork::from_inputs(self.rir.len(), self.declaration_index.work());
+        let mut binding_work = DeclarationBindingWork::from_inputs(
+            self.rir.len(),
+            self.declaration_index.work(),
+            self.module_registry.len(),
+        );
         self.inject_builtin_types();
         binding_work.namespace_setup_invocations += 1;
         self.register_type_names().map_err(CompileErrors::from)?;

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -497,6 +497,14 @@ pub struct SemaOutput {
 /// These counters deliberately expose no request-local RIR instruction handles.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct BodyAnalysisWork {
+    /// Production body transactions whose analysis closure actually ran.
+    pub body_analyses_computed: usize,
+    /// Production body transactions satisfied by a retained terminal or
+    /// compatible join without entering the analysis closure.
+    pub body_analyses_reused: usize,
+    /// Previously retained body transactions whose dependencies turned red and
+    /// therefore entered a new computation for the current revision.
+    pub body_analyses_invalidated: usize,
     pub ordinary_body_import_attempts: usize,
     pub ordinary_body_import_successes: usize,
     pub ordinary_body_import_failures: usize,
@@ -632,6 +640,14 @@ pub struct PerBodyDeclarationContextWork {
     /// Charged by the per-body prepare stage the moment it commits to real work,
     /// so a warm-reused body (which never enters the stage) contributes nothing.
     pub cold_body_preparations: usize,
+    /// Declaration shells inspected by the per-body prepare stage.
+    pub declarations_inspected: usize,
+    /// Compact module definitions registered by the per-body semantic epoch.
+    pub modules_registered: usize,
+    /// RIR declaration indexes constructed for this body.
+    pub rir_indexes_constructed: usize,
+    /// Raw RIR instructions visited while constructing those indexes.
+    pub rir_instructions_visited: usize,
     /// Declaration shells the per-body prepare stage actually materialized,
     /// summed across every cold reached-body analysis. This is sourced from the
     /// prepare stage's *output* (`shell_records.len()`), not from the input
@@ -652,6 +668,10 @@ pub struct PerBodyDeclarationContextWork {
     /// stage from its own output, before install; a body that fails during
     /// prepare contributes nothing here.
     pub projections_performed: usize,
+    /// Durable-source records inspected by the per-body projection join.
+    pub durable_source_records_inspected: usize,
+    /// Durable-source records copied into current-revision exports.
+    pub durable_source_records_copied: usize,
     /// Stable-identity and body-owner endpoints the per-body endpoint stage
     /// actually installed, summed across every cold reached-body analysis.
     /// Charged only when the endpoint stage runs (after a successful install),

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -840,7 +840,32 @@ where
 
 fn with_parity(mut scenario: Value, evidence: Value) -> Value {
     scenario["differential_parity"] = evidence;
+    scenario["required_vs_reused_work"] = work_projection(&scenario);
     scenario
+}
+
+/// Stable black-box work projection consumed by the value-audit runner.
+/// Keep this schema independent of the detailed counter ledger: the runner
+/// needs only required-versus-reused artifact counts for locality gates.
+fn work_projection(scenario: &Value) -> Value {
+    json!({
+        "modules": {
+            "required": count(scenario, &["parse", "modules_reparsed"]),
+            "reused": count(scenario, &["parse", "modules_reused"]),
+        },
+        "semantic_bodies": {
+            "required": count(scenario, &["semantic_work", "bodies_attempted"]),
+            "reused": count(scenario, &["semantic_work", "durable_bodies", "reused_bodies"]),
+        },
+        "cfgs": {
+            "required": count(scenario, &["semantic_work", "cfg", "builds_attempted"]),
+            "reused": count(scenario, &["semantic_work", "cfg", "reuses"]),
+        },
+        "semantic_queries": {
+            "required": count(scenario, &["queries", "semantic_executions"]),
+            "reused": count(scenario, &["queries", "semantic_reuses"]),
+        },
+    })
 }
 
 fn completion_workloads(functions: usize) -> Vec<Value> {
@@ -1480,6 +1505,18 @@ fn assert_completion_structure(scenarios: &[Value], functions: usize) {
     assert_declaration_epoch_work(cold, 1, 1, 1, 0, 0);
 
     let noop = get("completion_exact_noop");
+    for name in [
+        "completion_exact_noop",
+        "completion_unrelated_edit",
+        "completion_changed_reachable_body",
+        "completion_reverse_closure",
+    ] {
+        let projection = &get(name)["required_vs_reused_work"];
+        for artifact in ["modules", "semantic_bodies", "cfgs", "semantic_queries"] {
+            assert!(projection[artifact]["required"].is_u64());
+            assert!(projection[artifact]["reused"].is_u64());
+        }
+    }
     assert_eq!(count(noop, &["queries", "semantic_executions"]), 0);
     assert_eq!(count(noop, &["queries", "semantic_reuses"]), 1);
 

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -821,6 +821,10 @@ where
 
     let executable_sha256 = format!("{:x}", Sha256::digest(&reused_executable.elf));
     json!({
+        "schema_version": 1,
+        "status": "pass",
+        "comparison": "cold_vs_reused_in_process",
+        "comparison_completed": true,
         "public_semantic_cfg_artifacts": "exact",
         "public_type_universe": "exact_ordered_entries",
         "durable_specialized_body_payloads": "exact",
@@ -839,31 +843,81 @@ where
 }
 
 fn with_parity(mut scenario: Value, evidence: Value) -> Value {
+    scenario["evidence_schema"] = json!({
+        "version": 2,
+        "differential_parity_version": 1,
+        "locality_work_version": 2,
+    });
     scenario["differential_parity"] = evidence;
     scenario["required_vs_reused_work"] = work_projection(&scenario);
     scenario
 }
 
-/// Stable black-box work projection consumed by the value-audit runner.
-/// Keep this schema independent of the detailed counter ledger: the runner
-/// needs only required-versus-reused artifact counts for locality gates.
+/// Stable production-counter projection consumed by the value-audit runner.
+/// The detailed counter ledger remains available beside this projection, while
+/// these fields give external tooling one typed vocabulary for computed,
+/// reused, and invalidated work.  Identity sets are currently not exposed by
+/// this benchmark, so that absence is explicit rather than inferred.
 fn work_projection(scenario: &Value) -> Value {
+    macro_rules! required_count {
+        ($path:expr) => {
+            match try_count(scenario, $path) {
+                Some(value) => value,
+                None => {
+                    return json!({
+                        "schema_version": 2,
+                        "status": "unsupported",
+                        "reason": "production counter path was absent",
+                    });
+                }
+            }
+        };
+    }
     json!({
+        "schema_version": 2,
+        "counter_source": "production_metrics",
+        "exact_identity_sets": {
+            "available": false,
+            "reason": "CompilerSession does not expose stable recompute/reuse identity sets in this protocol"
+        },
         "modules": {
-            "required": count(scenario, &["parse", "modules_reparsed"]),
-            "reused": count(scenario, &["parse", "modules_reused"]),
+            "computed": required_count!(&["parse", "modules_reparsed"]),
+            "invalidated": required_count!(&["parse", "modules_reparsed"]),
+            "required": required_count!(&["parse", "modules_reparsed"]),
+            "reused": required_count!(&["parse", "modules_reused"]),
+        },
+        "rir": {
+            "computed": required_count!(&["queries", "rir_executions"]),
+            "invalidated": required_count!(&["queries", "rir_executions"]),
+            "reused": required_count!(&["queries", "rir_reuses"]),
+        },
+        "declarations": {
+            "computed": required_count!(&["semantic_work", "declaration_resolution_invocations"]),
+            "invalidated": required_count!(&["queries", "definition_entries_invalidated"]),
+            "reused": required_count!(&["semantic_work", "declaration_reuse", "durable_records_reused"]),
+        },
+        "durable_source": {
+            "computed": required_count!(&["semantic_work", "per_body_declaration_context", "durable_source_records_copied"]),
+            "invalidated": required_count!(&["semantic_work", "body_analyses_invalidated"]),
+            "reused": required_count!(&["semantic_work", "durable_bodies", "reused_bodies"]),
         },
         "semantic_bodies": {
-            "required": count(scenario, &["semantic_work", "bodies_attempted"]),
-            "reused": count(scenario, &["semantic_work", "durable_bodies", "reused_bodies"]),
+            "computed": required_count!(&["semantic_work", "body_analyses_computed"]),
+            "invalidated": required_count!(&["semantic_work", "body_analyses_invalidated"]),
+            "required": required_count!(&["semantic_work", "bodies_attempted"]),
+            "reused": required_count!(&["semantic_work", "durable_bodies", "reused_bodies"]),
         },
         "cfgs": {
-            "required": count(scenario, &["semantic_work", "cfg", "builds_attempted"]),
-            "reused": count(scenario, &["semantic_work", "cfg", "reuses"]),
+            "computed": required_count!(&["semantic_work", "cfg", "builds_attempted"]),
+            "invalidated": required_count!(&["semantic_work", "cfg", "builds_attempted"]),
+            "required": required_count!(&["semantic_work", "cfg", "builds_attempted"]),
+            "reused": required_count!(&["semantic_work", "cfg", "reuses"]),
         },
         "semantic_queries": {
-            "required": count(scenario, &["queries", "semantic_executions"]),
-            "reused": count(scenario, &["queries", "semantic_reuses"]),
+            "computed": required_count!(&["queries", "semantic_executions"]),
+            "invalidated": required_count!(&["queries", "semantic_entries_invalidated"]),
+            "required": required_count!(&["queries", "semantic_executions"]),
+            "reused": required_count!(&["queries", "semantic_reuses"]),
         },
     })
 }
@@ -1145,6 +1199,12 @@ fn count(value: &Value, path: &[&str]) -> u64 {
         .fold(value, |value, key| &value[*key])
         .as_u64()
         .unwrap()
+}
+
+fn try_count(value: &Value, path: &[&str]) -> Option<u64> {
+    path.iter()
+        .try_fold(value, |value, key| value.get(*key))
+        .and_then(Value::as_u64)
 }
 
 fn assert_structure(scenarios: &[Value], modules: usize) {
@@ -1511,10 +1571,21 @@ fn assert_completion_structure(scenarios: &[Value], functions: usize) {
         "completion_changed_reachable_body",
         "completion_reverse_closure",
     ] {
+        assert_eq!(get(name)["differential_parity"]["schema_version"], 1);
+        assert_eq!(get(name)["differential_parity"]["status"], "pass");
+        assert_eq!(
+            get(name)["differential_parity"]["comparison_completed"],
+            true
+        );
         let projection = &get(name)["required_vs_reused_work"];
+        assert_eq!(projection["schema_version"], 2);
+        assert_eq!(projection["counter_source"], "production_metrics");
+        assert!(projection["exact_identity_sets"]["available"].is_boolean());
         for artifact in ["modules", "semantic_bodies", "cfgs", "semantic_queries"] {
             assert!(projection[artifact]["required"].is_u64());
             assert!(projection[artifact]["reused"].is_u64());
+            assert!(projection[artifact]["computed"].is_u64());
+            assert!(projection[artifact]["invalidated"].is_u64());
         }
     }
     assert_eq!(count(noop, &["queries", "semantic_executions"]), 0);
@@ -1883,7 +1954,7 @@ fn main() {
         println!(
             "{}",
             json!({
-                "schema_version": 1,
+                "schema_version": 2,
                 "workload": "representative_compiler_session_scenarios",
                 "fixture": "benchmarks/scenarios/representative/main.rue",
                 "measurement_scope": "compiler_build_and_query_performance_not_runtime",
@@ -1910,7 +1981,7 @@ fn main() {
     println!(
         "{}",
         json!({
-            "schema_version": 11,
+            "schema_version": 12,
             "workload": "compiler_session_invalidation",
             "configuration": {
                 "modules": config.modules,

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -26,6 +26,97 @@ const DEFAULT_MODULES: usize = 128;
 const DEFAULT_WARMUP: usize = 3;
 const DEFAULT_ITERATIONS: usize = 10;
 
+const AVAILABLE_CONTEXT_COUNTERS: &[(&str, &[&str])] = &[
+    (
+        "cold_body_preparations",
+        &[
+            "semantic_work",
+            "per_body_declaration_context",
+            "cold_body_preparations",
+        ],
+    ),
+    (
+        "declarations_inspected",
+        &[
+            "semantic_work",
+            "per_body_declaration_context",
+            "declarations_inspected",
+        ],
+    ),
+    (
+        "modules_registered",
+        &[
+            "semantic_work",
+            "per_body_declaration_context",
+            "modules_registered",
+        ],
+    ),
+    (
+        "rir_indexes_constructed",
+        &[
+            "semantic_work",
+            "per_body_declaration_context",
+            "rir_indexes_constructed",
+        ],
+    ),
+    (
+        "rir_instructions_visited",
+        &[
+            "semantic_work",
+            "per_body_declaration_context",
+            "rir_instructions_visited",
+        ],
+    ),
+    (
+        "durable_source_records_inspected",
+        &[
+            "semantic_work",
+            "per_body_declaration_context",
+            "durable_source_records_inspected",
+        ],
+    ),
+    (
+        "durable_source_records_copied",
+        &[
+            "semantic_work",
+            "per_body_declaration_context",
+            "durable_source_records_copied",
+        ],
+    ),
+    (
+        "shells_prepared",
+        &[
+            "semantic_work",
+            "per_body_declaration_context",
+            "shells_prepared",
+        ],
+    ),
+    (
+        "projections_performed",
+        &[
+            "semantic_work",
+            "per_body_declaration_context",
+            "projections_performed",
+        ],
+    ),
+    (
+        "semantics_installed",
+        &[
+            "semantic_work",
+            "per_body_declaration_context",
+            "semantics_installed",
+        ],
+    ),
+    (
+        "endpoints_installed",
+        &[
+            "semantic_work",
+            "per_body_declaration_context",
+            "endpoints_installed",
+        ],
+    ),
+];
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct Config {
     modules: usize,
@@ -854,10 +945,12 @@ fn with_parity(mut scenario: Value, evidence: Value) -> Value {
 }
 
 /// Stable production-counter projection consumed by the value-audit runner.
-/// The detailed counter ledger remains available beside this projection, while
-/// these fields give external tooling one typed vocabulary for computed,
-/// reused, and invalidated work.  Identity sets are currently not exposed by
-/// this benchmark, so that absence is explicit rather than inferred.
+/// The detailed counter ledger remains available beside this projection. Each
+/// numeric field is copied from a production counter; an unavailable dimension
+/// is an explicit reason object rather than a duplicated or inferred value.
+/// `required` is the audit's uniform demand shape, not an additional production
+/// counter. Identity sets are currently not exposed by this benchmark, so that
+/// absence is explicit rather than inferred.
 fn work_projection(scenario: &Value) -> Value {
     macro_rules! required_count {
         ($path:expr) => {
@@ -873,7 +966,15 @@ fn work_projection(scenario: &Value) -> Value {
             }
         };
     }
-    json!({
+    macro_rules! unavailable {
+        ($reason:expr) => {
+            json!({
+                "available": false,
+                "reason": $reason,
+            })
+        };
+    }
+    let mut projection = json!({
         "schema_version": 2,
         "counter_source": "production_metrics",
         "exact_identity_sets": {
@@ -882,36 +983,39 @@ fn work_projection(scenario: &Value) -> Value {
         },
         "modules": {
             "computed": required_count!(&["parse", "modules_reparsed"]),
-            "invalidated": required_count!(&["parse", "modules_reparsed"]),
             "required": required_count!(&["parse", "modules_reparsed"]),
             "reused": required_count!(&["parse", "modules_reused"]),
+            "invalidated": unavailable!("CompilerSession exposes no module invalidation counter"),
         },
         "rir": {
             "computed": required_count!(&["queries", "rir_executions"]),
-            "invalidated": required_count!(&["queries", "rir_executions"]),
+            "required": required_count!(&["queries", "rir_executions"]),
             "reused": required_count!(&["queries", "rir_reuses"]),
+            "invalidated": unavailable!("CompilerSession exposes no RIR invalidation counter"),
         },
         "declarations": {
             "computed": required_count!(&["semantic_work", "declaration_resolution_invocations"]),
+            "required": required_count!(&["semantic_work", "declaration_resolution_invocations"]),
             "invalidated": required_count!(&["queries", "definition_entries_invalidated"]),
             "reused": required_count!(&["semantic_work", "declaration_reuse", "durable_records_reused"]),
         },
         "durable_source": {
             "computed": required_count!(&["semantic_work", "per_body_declaration_context", "durable_source_records_copied"]),
-            "invalidated": required_count!(&["semantic_work", "body_analyses_invalidated"]),
-            "reused": required_count!(&["semantic_work", "durable_bodies", "reused_bodies"]),
+            "required": required_count!(&["semantic_work", "per_body_declaration_context", "durable_source_records_copied"]),
+            "invalidated": unavailable!("CompilerSession exposes no durable-source invalidation counter"),
+            "reused": unavailable!("durable-body reuse is not a durable-source reuse counter"),
         },
         "semantic_bodies": {
             "computed": required_count!(&["semantic_work", "body_analyses_computed"]),
             "invalidated": required_count!(&["semantic_work", "body_analyses_invalidated"]),
             "required": required_count!(&["semantic_work", "bodies_attempted"]),
-            "reused": required_count!(&["semantic_work", "durable_bodies", "reused_bodies"]),
+            "reused": required_count!(&["semantic_work", "body_analyses_reused"]),
         },
         "cfgs": {
             "computed": required_count!(&["semantic_work", "cfg", "builds_attempted"]),
-            "invalidated": required_count!(&["semantic_work", "cfg", "builds_attempted"]),
             "required": required_count!(&["semantic_work", "cfg", "builds_attempted"]),
             "reused": required_count!(&["semantic_work", "cfg", "reuses"]),
+            "invalidated": unavailable!("CompilerSession exposes no CFG invalidation counter"),
         },
         "semantic_queries": {
             "computed": required_count!(&["queries", "semantic_executions"]),
@@ -919,7 +1023,26 @@ fn work_projection(scenario: &Value) -> Value {
             "required": required_count!(&["queries", "semantic_executions"]),
             "reused": required_count!(&["queries", "semantic_reuses"]),
         },
-    })
+    });
+    for (name, path) in AVAILABLE_CONTEXT_COUNTERS {
+        let computed = match try_count(scenario, path) {
+            Some(value) => value,
+            None => {
+                return json!({
+                    "schema_version": 2,
+                    "status": "unsupported",
+                    "reason": format!("production counter path was absent: {name}"),
+                });
+            }
+        };
+        projection[*name] = json!({
+            "computed": computed,
+            "required": computed,
+            "invalidated": unavailable!(format!("{name} has no invalidation counter")),
+            "reused": unavailable!(format!("{name} has no reuse counter")),
+        });
+    }
+    projection
 }
 
 fn completion_workloads(functions: usize) -> Vec<Value> {
@@ -1581,11 +1704,41 @@ fn assert_completion_structure(scenarios: &[Value], functions: usize) {
         assert_eq!(projection["schema_version"], 2);
         assert_eq!(projection["counter_source"], "production_metrics");
         assert!(projection["exact_identity_sets"]["available"].is_boolean());
-        for artifact in ["modules", "semantic_bodies", "cfgs", "semantic_queries"] {
-            assert!(projection[artifact]["required"].is_u64());
-            assert!(projection[artifact]["reused"].is_u64());
-            assert!(projection[artifact]["computed"].is_u64());
-            assert!(projection[artifact]["invalidated"].is_u64());
+        for artifact in [
+            "modules",
+            "rir",
+            "declarations",
+            "durable_source",
+            "semantic_bodies",
+            "cfgs",
+            "semantic_queries",
+            "cold_body_preparations",
+            "declarations_inspected",
+            "modules_registered",
+            "rir_indexes_constructed",
+            "rir_instructions_visited",
+            "durable_source_records_inspected",
+            "durable_source_records_copied",
+            "shells_prepared",
+            "projections_performed",
+            "semantics_installed",
+            "endpoints_installed",
+        ] {
+            assert!(
+                projection[artifact]["required"].is_u64(),
+                "{artifact} projection is missing required: {projection:?}"
+            );
+            assert!(
+                projection[artifact]["computed"].is_u64(),
+                "{artifact} projection is missing computed: {projection:?}"
+            );
+            for field in ["reused", "invalidated"] {
+                let value = &projection[artifact][field];
+                assert!(
+                    value.is_u64() || (value["available"] == false && value["reason"].is_string()),
+                    "{artifact}.{field} must be a real counter or an explicit unavailable reason"
+                );
+            }
         }
     }
     assert_eq!(count(noop, &["queries", "semantic_executions"]), 0);

--- a/crates/rue-compiler-session-bench/src/representative.rs
+++ b/crates/rue-compiler-session-bench/src/representative.rs
@@ -20,7 +20,7 @@ use serde_json::{Value, json};
 
 use super::{
     assert_cold_reused_parity_with_discovery, assert_diagnostic_parity, count, measure, named,
-    work_projection,
+    with_parity, work_projection,
 };
 
 const ROOT: &str = "/bench/main.rue";
@@ -231,7 +231,7 @@ fn successful_edit(name: &str, target: &SourceSnapshot) -> Value {
     session
         .unstable_dependency_baseline(&options, Some("/bench/std"))
         .unwrap();
-    let (mut value, output) = measured_project_semantic(&mut session, target, &options);
+    let (value, output) = measured_project_semantic(&mut session, target, &options);
     let parity = assert_cold_reused_parity_with_discovery(
         &mut session,
         &output,
@@ -241,9 +241,7 @@ fn successful_edit(name: &str, target: &SourceSnapshot) -> Value {
         close_discovery,
         |_, _| {},
     );
-    value["differential_parity"] = parity;
-    value["required_vs_reused_work"] = work_projection(&value);
-    named(name, value)
+    named(name, with_parity(value, parity))
 }
 
 fn diagnostic_and_recovery() -> (Value, Value) {
@@ -282,6 +280,11 @@ fn diagnostic_and_recovery() -> (Value, Value) {
         "warning_count": diagnostics.warnings().len(),
         "last_good_preserved": true,
     });
+    failed["evidence_schema"] = json!({
+        "version": 2,
+        "differential_parity_version": 1,
+        "locality_work_version": 2,
+    });
     failed["required_vs_reused_work"] = work_projection(&failed);
     let failed = named("diagnostic_error_edit", failed);
 
@@ -296,6 +299,11 @@ fn diagnostic_and_recovery() -> (Value, Value) {
         close_discovery,
         |_, _| {},
     );
+    recovered["evidence_schema"] = json!({
+        "version": 2,
+        "differential_parity_version": 1,
+        "locality_work_version": 2,
+    });
     recovered["differential_parity"] = parity;
     recovered["recovered_from_diagnostic_error"] = json!(true);
     recovered["required_vs_reused_work"] = work_projection(&recovered);
@@ -325,9 +333,19 @@ fn assert_structure(scenarios: &[Value]) {
     assert_eq!(scenarios.len(), 6);
     for scenario in scenarios {
         let work = &scenario["required_vs_reused_work"];
+        if scenario["differential_parity"].is_object() {
+            assert_eq!(scenario["differential_parity"]["schema_version"], 1);
+            assert_eq!(scenario["differential_parity"]["status"], "pass");
+        } else {
+            assert!(scenario["diagnostic_parity"].is_object());
+        }
+        assert_eq!(work["schema_version"], 2);
+        assert_eq!(work["counter_source"], "production_metrics");
         for artifact in ["modules", "semantic_bodies", "cfgs", "semantic_queries"] {
             assert!(work[artifact]["required"].is_u64());
             assert!(work[artifact]["reused"].is_u64());
+            assert!(work[artifact]["computed"].is_u64());
+            assert!(work[artifact]["invalidated"].is_u64());
         }
     }
     let get = |name: &str| {

--- a/crates/rue-compiler-session-bench/src/representative.rs
+++ b/crates/rue-compiler-session-bench/src/representative.rs
@@ -20,6 +20,7 @@ use serde_json::{Value, json};
 
 use super::{
     assert_cold_reused_parity_with_discovery, assert_diagnostic_parity, count, measure, named,
+    work_projection,
 };
 
 const ROOT: &str = "/bench/main.rue";
@@ -220,27 +221,6 @@ fn measured_project_semantic(
         parse
     });
     (value, output.unwrap())
-}
-
-fn work_projection(scenario: &Value) -> Value {
-    json!({
-        "modules": {
-            "required": count(scenario, &["parse", "modules_reparsed"]),
-            "reused": count(scenario, &["parse", "modules_reused"]),
-        },
-        "semantic_bodies": {
-            "required": count(scenario, &["semantic_work", "bodies_attempted"]),
-            "reused": count(scenario, &["semantic_work", "durable_bodies", "reused_bodies"]),
-        },
-        "cfgs": {
-            "required": count(scenario, &["semantic_work", "cfg", "builds_attempted"]),
-            "reused": count(scenario, &["semantic_work", "cfg", "reuses"]),
-        },
-        "semantic_queries": {
-            "required": count(scenario, &["queries", "semantic_executions"]),
-            "reused": count(scenario, &["queries", "semantic_reuses"]),
-        },
-    })
 }
 
 fn successful_edit(name: &str, target: &SourceSnapshot) -> Value {

--- a/crates/rue-compiler-session-bench/src/representative.rs
+++ b/crates/rue-compiler-session-bench/src/representative.rs
@@ -341,11 +341,35 @@ fn assert_structure(scenarios: &[Value]) {
         }
         assert_eq!(work["schema_version"], 2);
         assert_eq!(work["counter_source"], "production_metrics");
-        for artifact in ["modules", "semantic_bodies", "cfgs", "semantic_queries"] {
+        for artifact in [
+            "modules",
+            "rir",
+            "declarations",
+            "durable_source",
+            "semantic_bodies",
+            "cfgs",
+            "semantic_queries",
+            "cold_body_preparations",
+            "declarations_inspected",
+            "modules_registered",
+            "rir_indexes_constructed",
+            "rir_instructions_visited",
+            "durable_source_records_inspected",
+            "durable_source_records_copied",
+            "shells_prepared",
+            "projections_performed",
+            "semantics_installed",
+            "endpoints_installed",
+        ] {
             assert!(work[artifact]["required"].is_u64());
-            assert!(work[artifact]["reused"].is_u64());
             assert!(work[artifact]["computed"].is_u64());
-            assert!(work[artifact]["invalidated"].is_u64());
+            for field in ["reused", "invalidated"] {
+                let value = &work[artifact][field];
+                assert!(
+                    value.is_u64() || (value["available"] == false && value["reason"].is_string()),
+                    "{artifact}.{field} must be a real counter or an explicit unavailable reason"
+                );
+            }
         }
     }
     let get = |name: &str| {

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -895,6 +895,13 @@ impl CanonicalSemanticOutput {
         &self.durable_ordinary_body_payloads
     }
 
+    #[cfg(test)]
+    pub(crate) fn durable_specialized_body_payloads(
+        &self,
+    ) -> &[crate::DurableSpecializedBodyPayload] {
+        &self.durable_specialized_body_payloads
+    }
+
     /// Explicitly unstable equality status for durable-cache instrumentation.
     pub(crate) fn unstable_durable_artifact_status(
         &self,

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -420,6 +420,9 @@ pub struct CanonicalSemanticWork {
 impl CanonicalSemanticWork {
     pub(crate) fn accrue_body_query_work(&mut self, query: BodyAnalysisWork) {
         let body = &mut self.body_analysis;
+        body.body_analyses_computed += query.body_analyses_computed;
+        body.body_analyses_reused += query.body_analyses_reused;
+        body.body_analyses_invalidated += query.body_analyses_invalidated;
         body.bodies_attempted += query.bodies_attempted;
         body.bodies_succeeded += query.bodies_succeeded;
         body.bodies_failed += query.bodies_failed;
@@ -431,12 +434,28 @@ impl CanonicalSemanticWork {
         body.deferred_producer_retries += query.deferred_producer_retries;
         body.per_body_declaration_context.cold_body_preparations +=
             query.per_body_declaration_context.cold_body_preparations;
+        body.per_body_declaration_context.declarations_inspected +=
+            query.per_body_declaration_context.declarations_inspected;
+        body.per_body_declaration_context.modules_registered +=
+            query.per_body_declaration_context.modules_registered;
+        body.per_body_declaration_context.rir_indexes_constructed +=
+            query.per_body_declaration_context.rir_indexes_constructed;
+        body.per_body_declaration_context.rir_instructions_visited +=
+            query.per_body_declaration_context.rir_instructions_visited;
         body.per_body_declaration_context.shells_prepared +=
             query.per_body_declaration_context.shells_prepared;
         body.per_body_declaration_context.semantics_installed +=
             query.per_body_declaration_context.semantics_installed;
         body.per_body_declaration_context.projections_performed +=
             query.per_body_declaration_context.projections_performed;
+        body.per_body_declaration_context
+            .durable_source_records_inspected += query
+            .per_body_declaration_context
+            .durable_source_records_inspected;
+        body.per_body_declaration_context
+            .durable_source_records_copied += query
+            .per_body_declaration_context
+            .durable_source_records_copied;
         body.per_body_declaration_context.endpoints_installed +=
             query.per_body_declaration_context.endpoints_installed;
         body.closure_bodies_visited = body
@@ -1781,11 +1800,14 @@ pub(crate) fn analyze_body_query(
         shells,
         shell_records,
         definitions: provisional,
-        declaration_index: _,
+        declaration_index,
     } = prepared;
     // Prepare-stage source: the shells this stage actually materialized. A
     // shared-base shortcut that predeclares fewer shells drops this counter.
     work.shells_prepared += shell_records.len();
+    work.declarations_inspected += shell_records.len();
+    work.rir_indexes_constructed += declaration_index.build_invocations;
+    work.rir_instructions_visited += declaration_index.rir_instructions_visited;
     drop(prepare_span);
     let project_span = info_span!("body_project_declarations").entered();
     let (projected, projection_work) = match crate::project_durable_declaration_semantics(
@@ -1826,6 +1848,8 @@ pub(crate) fn analyze_body_query(
     // drops this counter even if the exported slice length is unchanged.
     work.projections_performed +=
         projection_work.durable_records_visited + projected_anonymous.len();
+    work.durable_source_records_inspected += projection_work.durable_records_visited;
+    work.durable_source_records_copied += projection_work.durable_records_copied;
     drop(project_span);
     let install_span = info_span!("body_install_declarations").entered();
     let bound = match shells
@@ -1847,6 +1871,7 @@ pub(crate) fn analyze_body_query(
     // installation work only. An install shortcut that reuses a shared bound
     // base and installs fewer payloads therefore drops this counter.
     work.semantics_installed += bound.binding_work().durable_payloads_installed;
+    work.modules_registered += bound.binding_work().modules_registered;
     let manifest = bound.binding_manifest();
     let definitions = match issue_bound_definitions(
         merged,

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -927,7 +927,10 @@ impl CanonicalSemanticOutput {
     ) -> crate::unstable::DurableArtifactStatus {
         crate::unstable::DurableArtifactStatus::from_debug(&self.durable_specialized_body_payloads)
     }
-    /// Structural work performed by this request.
+    /// Structural work performed by the request that computed this output.
+    /// An exact-cycle caller may receive a memoized output without executing a
+    /// new semantic request, so these fields can describe historical work from
+    /// the request that originally produced the retained result.
     pub(crate) fn work(&self) -> CanonicalSemanticWork {
         self.work
     }

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -385,7 +385,12 @@ pub struct DurableDeclarationSemantic {
 pub struct DurableSemanticProjectionWork {
     pub projection_invocations: usize,
     pub shells_visited: usize,
+    /// Durable-source declaration records examined by the projection join.
     pub durable_records_visited: usize,
+    /// Durable-source records whose payloads were copied into current-revision
+    /// semantic exports. This is intentionally separate from inspection: a
+    /// future shared projection may inspect a record without copying it.
+    pub durable_records_copied: usize,
     /// Stable definition records inserted into the exact projection join index.
     pub definition_records_indexed: usize,
     /// Exact-key definition index probes performed while joining shells.
@@ -596,6 +601,7 @@ pub fn project_durable_declaration_semantics(
         projection_invocations: 1,
         shells_visited: shells.len(),
         durable_records_visited: durable.len(),
+        durable_records_copied: exports.len(),
         definition_records_indexed: definitions.definitions().len(),
         definition_lookup_probes: shells.len(),
         rir_instructions_visited: 0,

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -196,6 +196,8 @@ pub(crate) use source_identity::{
 // Immutable query artifacts and stable identities returned by CompilerSession.
 #[cfg(test)]
 pub(crate) use backend::generate_mir;
+#[cfg(test)]
+pub(crate) use body_query::{BodyTransaction, transaction_equal};
 pub(crate) use bound_definitions::{
     BoundDefinitionRecord, BoundDefinitionSet, StableDefinitionKey, StableDefinitionKind,
     StableDefinitionNamespace,

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -9883,10 +9883,11 @@ impl RevisionedQueryDatabase {
     /// This is deliberately narrower than provenance: a newly reached body has
     /// no prior key to invalidate, even though its first terminal changes the
     /// provenance-derived body set. The query runtime remains authoritative for
-    /// whether the current request actually computed or reused that key.
+    /// whether the current request actually computed or reused that key. The
+    /// exact retained-key index probe is O(1) average-case; it does not
+    /// enumerate the retained body family once per reached body.
     pub(crate) fn has_retained_body_key(&self, key: &crate::body_query::BodyQueryKey) -> bool {
-        self.body_transactions
-            .any_retained_key(|candidate| candidate == key)
+        self.body_transactions.contains_retained_key(key)
     }
 
     /// Test-only exact provenance for retained ordinary body terminals.

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -23505,9 +23505,7 @@ mod tests {
         let decls = production_declarations(&snapshot);
         let point_key = durable_decl(&decls, Kind::Struct, "Point").key.clone();
         let color_key = durable_decl(&decls, Kind::Enum, "Color").key.clone();
-        let limit_key = durable_decl(&decls, Kind::ValueConst, "LIMIT")
-            .key
-            .clone();
+        let limit_key = durable_decl(&decls, Kind::ValueConst, "LIMIT").key.clone();
 
         let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
         let merged = crate::merge_parsed_modules(&parsed).unwrap();

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -9931,6 +9931,78 @@ impl RevisionedQueryDatabase {
         origins
     }
 
+    /// Test-only access to the actual retained body transactions for named
+    /// ordinary bodies. The correctness oracle compares these values directly;
+    /// it does not infer body equality from aggregate semantic projections.
+    #[cfg(test)]
+    pub(crate) fn retained_body_transactions_for_test(
+        &self,
+        revision: Revision,
+        names: &[String],
+    ) -> BTreeMap<String, crate::BodyTransaction> {
+        let mut transactions = BTreeMap::new();
+        for name in names {
+            let mut retained_key = None;
+            self.body_transactions.any_retained_key(|candidate| {
+                let crate::FunctionInstanceKey::Definition(definition) = &candidate.instance else {
+                    return false;
+                };
+                if definition.name() != name.as_str() {
+                    return false;
+                }
+                retained_key = Some(candidate.clone());
+                true
+            });
+            let Some(key) = retained_key else {
+                continue;
+            };
+            let terminal = self.body_transaction(
+                revision,
+                key,
+                Arc::new(BTreeMap::new()),
+                Arc::from([]),
+                false,
+                Arc::from([]),
+                CancellationToken::new(),
+                |_, _| Err(QueryAbort::Canceled),
+            );
+            if let Ok(terminal) = terminal {
+                let rue_query::QueryOutcome::Success(transaction) = terminal.outcome() else {
+                    unreachable!("BodyTransaction publishes typed values")
+                };
+                transactions.insert(name.clone(), transaction.clone());
+            }
+        }
+        transactions
+    }
+
+    /// Test-only lookup of one retained body transaction by its complete
+    /// function-instance identity, including specializations and anonymous
+    /// members.
+    #[cfg(test)]
+    pub(crate) fn retained_body_transaction_for_test(
+        &self,
+        revision: Revision,
+        key: crate::body_query::BodyQueryKey,
+    ) -> Option<crate::BodyTransaction> {
+        let terminal = self
+            .body_transaction(
+                revision,
+                key,
+                Arc::new(BTreeMap::new()),
+                Arc::from([]),
+                false,
+                Arc::from([]),
+                CancellationToken::new(),
+                |_, _| Err(QueryAbort::Canceled),
+            )
+            .ok()?;
+        let rue_query::QueryOutcome::Success(transaction) = terminal.outcome() else {
+            unreachable!("BodyTransaction publishes typed values")
+        };
+        Some(transaction.clone())
+    }
+
     pub(crate) fn projected_declaration_semantics(
         &self,
         revision: Revision,

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -9878,6 +9878,17 @@ impl RevisionedQueryDatabase {
         self.body_transactions.any_retained_key(|_| true)
     }
 
+    /// Whether the exact body key already has a retained memo node.
+    ///
+    /// This is deliberately narrower than provenance: a newly reached body has
+    /// no prior key to invalidate, even though its first terminal changes the
+    /// provenance-derived body set. The query runtime remains authoritative for
+    /// whether the current request actually computed or reused that key.
+    pub(crate) fn has_retained_body_key(&self, key: &crate::body_query::BodyQueryKey) -> bool {
+        self.body_transactions
+            .any_retained_key(|candidate| candidate == key)
+    }
+
     /// Test-only exact provenance for retained ordinary body terminals.
     ///
     /// Looking up retained keys directly keeps failed-revision acceptance tests

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -9890,6 +9890,37 @@ impl RevisionedQueryDatabase {
         self.body_transactions.contains_retained_key(key)
     }
 
+    /// Test-only snapshot of every retained body-query identity and whether its
+    /// terminal is observable at `revision`.
+    ///
+    /// The key scan is intentionally rooted in the production body-transaction
+    /// family. It includes stale keys left behind by invalidation, while the
+    /// read-only terminal request records whether that key still has a current
+    /// success or deterministic failure. The supplied computation is never
+    /// entered, so this hook cannot become a second semantic computation path.
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) fn retained_body_identity_states_for_test(
+        &self,
+        revision: Revision,
+        configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
+    ) -> BTreeMap<String, Option<crate::BodyTransaction>> {
+        let mut keys = Vec::new();
+        self.body_transactions.any_retained_key(|candidate| {
+            keys.push(candidate.clone());
+            false
+        });
+        keys.retain(|key| key.configuration == configuration);
+        keys.sort_by_key(|key| key.stable_identity());
+        keys.into_iter()
+            .map(|key| {
+                let identity = key.stable_identity();
+                let transaction = self.retained_body_transaction_for_test(revision, key);
+                (identity, transaction)
+            })
+            .collect()
+    }
+
     /// Test-only exact provenance for retained ordinary body terminals.
     ///
     /// Looking up retained keys directly keeps failed-revision acceptance tests
@@ -9941,51 +9972,6 @@ impl RevisionedQueryDatabase {
             }
         }
         origins
-    }
-
-    /// Test-only access to the actual retained body transactions for named
-    /// ordinary bodies. The correctness oracle compares these values directly;
-    /// it does not infer body equality from aggregate semantic projections.
-    #[cfg(test)]
-    pub(crate) fn retained_body_transactions_for_test(
-        &self,
-        revision: Revision,
-        names: &[String],
-    ) -> BTreeMap<String, crate::BodyTransaction> {
-        let mut transactions = BTreeMap::new();
-        for name in names {
-            let mut retained_key = None;
-            self.body_transactions.any_retained_key(|candidate| {
-                let crate::FunctionInstanceKey::Definition(definition) = &candidate.instance else {
-                    return false;
-                };
-                if definition.name() != name.as_str() {
-                    return false;
-                }
-                retained_key = Some(candidate.clone());
-                true
-            });
-            let Some(key) = retained_key else {
-                continue;
-            };
-            let terminal = self.body_transaction(
-                revision,
-                key,
-                Arc::new(BTreeMap::new()),
-                Arc::from([]),
-                false,
-                Arc::from([]),
-                CancellationToken::new(),
-                |_, _| Err(QueryAbort::Canceled),
-            );
-            if let Ok(terminal) = terminal {
-                let rue_query::QueryOutcome::Success(transaction) = terminal.outcome() else {
-                    unreachable!("BodyTransaction publishes typed values")
-                };
-                transactions.insert(name.clone(), transaction.clone());
-            }
-        }
-        transactions
     }
 
     /// Test-only lookup of one retained body transaction by its complete

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -118,6 +118,10 @@
 //! output, but the gate itself compares the observed baseline and grown values:
 //! the post-identity-cut constant may change while remaining flat.
 
+use crate::unstable::{
+    DiscoverySourceAssembler, ImportDemandMode, begin_import_input_request,
+    import_demand_frontier_for_roots, import_observation_ledger, publish_import_observation_batch,
+};
 use crate::*;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -442,9 +446,27 @@ fn render_diagnostics(errors: &CompileErrors) -> String {
 /// * on failure, the full ordered diagnostic presentation.
 fn assert_warm_fresh_parity(
     label: &str,
+    warm_session: &mut CompilerSession,
+    fresh_session: &mut CompilerSession,
+    source: &SourceSnapshot,
+    options: &CompileOptions,
+    body_names: &[String],
     warm: &Result<Arc<CanonicalSemanticOutput>, CompileErrors>,
     fresh: &Result<Arc<CanonicalSemanticOutput>, CompileErrors>,
 ) {
+    let successful_body_transactions = |session: &CompilerSession,
+                                        output: &CanonicalSemanticOutput|
+     -> BTreeMap<String, crate::BodyTransaction> {
+        output
+            .functions()
+            .iter()
+            .filter_map(|function| {
+                session
+                    .retained_body_transaction_for_test(options, &function.semantic_identity)
+                    .map(|transaction| (format!("{:?}", function.semantic_identity), transaction))
+            })
+            .collect()
+    };
     match (warm, fresh) {
         (Ok(warm), Ok(fresh)) => {
             assert_eq!(
@@ -452,12 +474,103 @@ fn assert_warm_fresh_parity(
                 fresh.unstable_parity_snapshot(),
                 "{label}: warm/fresh semantic parity snapshot diverged"
             );
+
+            let warm_bodies = successful_body_transactions(warm_session, warm);
+            let fresh_bodies = successful_body_transactions(fresh_session, fresh);
+            assert_eq!(
+                warm_bodies.keys().collect::<Vec<_>>(),
+                fresh_bodies.keys().collect::<Vec<_>>(),
+                "{label}: warm/fresh retained body identities diverged"
+            );
+            for name in warm_bodies.keys() {
+                assert!(
+                    crate::transaction_equal(&warm_bodies[name], &fresh_bodies[name]),
+                    "{label}: exact BodyTransaction diverged for {name}\n warm={:?}\n fresh={:?}",
+                    warm_bodies[name],
+                    fresh_bodies[name]
+                );
+            }
+
+            assert_eq!(
+                format!("{:?}", warm.functions()),
+                format!("{:?}", fresh.functions()),
+                "{label}: full AIR/CFG public artifacts diverged"
+            );
+            assert_eq!(
+                warm.durable_ordinary_body_payloads(),
+                fresh.durable_ordinary_body_payloads(),
+                "{label}: durable ordinary bodies diverged"
+            );
+            assert_eq!(
+                warm.durable_specialized_body_payloads(),
+                fresh.durable_specialized_body_payloads(),
+                "{label}: durable specialized bodies diverged"
+            );
+            assert_eq!(
+                format!("{:?}", warm.durable_cfgs()),
+                format!("{:?}", fresh.durable_cfgs()),
+                "{label}: durable CFG artifacts diverged"
+            );
+            assert_eq!(
+                format!("{:?}", warm.warnings()),
+                format!("{:?}", fresh.warnings()),
+                "{label}: ordered semantic warnings diverged"
+            );
+            assert_eq!(
+                format!("{:?}", warm_session.latest_diagnostics()),
+                format!("{:?}", fresh_session.latest_diagnostics()),
+                "{label}: ordered diagnostic snapshots diverged"
+            );
+
+            let warm_executable = warm_session.oracle_executable(source, options);
+            let fresh_executable = fresh_session.oracle_executable(source, options);
+            match (warm_executable, fresh_executable) {
+                (Ok(warm), Ok(fresh)) => {
+                    assert_eq!(warm.elf, fresh.elf, "{label}: executable bytes diverged");
+                    assert_eq!(
+                        format!("{:?}", warm.warnings),
+                        format!("{:?}", fresh.warnings),
+                        "{label}: executable warnings diverged"
+                    );
+                }
+                (Err(warm), Err(fresh)) => assert_eq!(
+                    render_diagnostics(&warm),
+                    render_diagnostics(&fresh),
+                    "{label}: executable failure diagnostics diverged"
+                ),
+                (Ok(_), Err(fresh)) => panic!(
+                    "{label}: warm executable succeeded but fresh failed:\n{}",
+                    render_diagnostics(&fresh)
+                ),
+                (Err(warm), Ok(_)) => panic!(
+                    "{label}: warm executable failed but fresh succeeded:\n{}",
+                    render_diagnostics(&warm)
+                ),
+            }
         }
         (Err(warm), Err(fresh)) => {
             assert_eq!(
                 render_diagnostics(warm),
                 render_diagnostics(fresh),
                 "{label}: warm/fresh failure diagnostics diverged"
+            );
+            let warm_bodies = warm_session.retained_body_transactions_for_test(body_names);
+            let fresh_bodies = fresh_session.retained_body_transactions_for_test(body_names);
+            assert_eq!(
+                warm_bodies.keys().collect::<Vec<_>>(),
+                fresh_bodies.keys().collect::<Vec<_>>(),
+                "{label}: warm/fresh failed-body identities diverged"
+            );
+            for name in warm_bodies.keys() {
+                assert!(
+                    crate::transaction_equal(&warm_bodies[name], &fresh_bodies[name]),
+                    "{label}: exact failed BodyTransaction diverged for {name}"
+                );
+            }
+            assert_eq!(
+                format!("{:?}", warm_session.latest_diagnostics()),
+                format!("{:?}", fresh_session.latest_diagnostics()),
+                "{label}: ordered failure diagnostic snapshots diverged"
             );
         }
         (Ok(_), Err(fresh)) => panic!(
@@ -1207,7 +1320,17 @@ impl EditScenario {
         fresh.update(&self.rev2.snapshot()).into_result().unwrap();
         let fresh_rev2 = fresh.canonical_semantic(&options);
 
-        assert_warm_fresh_parity(self.label, &warm_rev2, &fresh_rev2);
+        let rev2_source = self.rev2.snapshot();
+        assert_warm_fresh_parity(
+            self.label,
+            &mut warm,
+            &mut fresh,
+            &rev2_source,
+            &options,
+            body_names,
+            &warm_rev2,
+            &fresh_rev2,
+        );
 
         let succeeded = warm_rev2.is_ok();
         let measure = warm_rev2
@@ -1239,6 +1362,149 @@ fn corpus_body_names(reached_bodies: usize) -> Vec<String> {
         .map(|index| format!("b{index}"))
         .chain(std::iter::once("main".to_owned()))
         .collect()
+}
+
+/// Run one small source edit through the same production session path used by
+/// the scaling rows. The exact oracle is deliberately shared by all of these
+/// cases so a new edit shape cannot accidentally fall back to comparing only a
+/// root semantic projection.
+fn run_source_edit(
+    label: &str,
+    rev1_source: &str,
+    rev2_source: &str,
+    body_names: &[&str],
+) -> BTreeSet<String> {
+    let options = CompileOptions::default();
+    let rev1 = SourceSnapshot::single("main.rue", rev1_source).unwrap();
+    let rev2 = SourceSnapshot::single("main.rue", rev2_source).unwrap();
+    let body_names = body_names
+        .iter()
+        .map(|name| (*name).to_owned())
+        .collect::<Vec<_>>();
+
+    let mut warm = CompilerSession::new();
+    warm.update(&rev1).into_result().unwrap();
+    warm.canonical_semantic(&options).ok();
+    let before = warm.retained_body_transaction_origins_for_test(&body_names);
+    warm.update(&rev2).into_result().unwrap();
+    let warm_result = warm.canonical_semantic(&options);
+    let after = warm.retained_body_transaction_origins_for_test(&body_names);
+
+    let mut fresh = CompilerSession::new();
+    fresh.update(&rev2).into_result().unwrap();
+    let fresh_result = fresh.canonical_semantic(&options);
+    assert_warm_fresh_parity(
+        label,
+        &mut warm,
+        &mut fresh,
+        &rev2,
+        &options,
+        &body_names,
+        &warm_result,
+        &fresh_result,
+    );
+    changed_body_origins(&before, &after)
+}
+
+fn import_source(
+    value: i32,
+    epoch: u64,
+) -> (SourceSnapshot, ImportDiscoveryContext, AcceptedReadManifest) {
+    let context = ImportDiscoveryContext::new(epoch, "/p", None, "scaling-import").unwrap();
+    let root = Arc::new("const a = @import(\"a.rue\"); fn main() -> i32 { a.value() }".to_owned());
+    let imported = Arc::new(format!("pub fn value() -> i32 {{ {value} }}"));
+    let mut assembler = DiscoverySourceAssembler::new(
+        context.clone(),
+        "/p/main.rue",
+        "/p/main.rue",
+        PhysicalFileIdentity::new(1086, 1),
+        FileMetadataFingerprint::new(root.len() as u64, epoch, epoch),
+        root,
+    )
+    .unwrap();
+    assembler
+        .add_explicit(
+            "/p/a.rue",
+            "/p/a.rue",
+            PhysicalFileIdentity::new(1086, 2),
+            FileMetadataFingerprint::new(imported.len() as u64, epoch, epoch),
+            imported,
+        )
+        .unwrap();
+    (
+        assembler.snapshot().unwrap(),
+        context,
+        assembler.accepted_read_manifest(),
+    )
+}
+
+fn close_import_source(
+    session: &mut CompilerSession,
+    source: &SourceSnapshot,
+    context: ImportDiscoveryContext,
+    accepted_reads: AcceptedReadManifest,
+) {
+    let mut revision =
+        begin_import_input_request(session, source, context.clone(), accepted_reads.clone())
+            .unwrap();
+    loop {
+        let ledger = import_observation_ledger(session, revision).unwrap();
+        let plan = session
+            .stage_import_discovery(
+                source,
+                context.clone(),
+                accepted_reads.shared_slice(),
+                ledger.clone(),
+            )
+            .unwrap();
+        let frontier = import_demand_frontier_for_roots(
+            session,
+            revision,
+            &plan,
+            ImportDemandMode::Rooted,
+            &plan.demand_roots(),
+        )
+        .unwrap();
+        if frontier.requests().is_empty() {
+            session.close_import_discovery(ledger).unwrap();
+            return;
+        }
+        let observations = frontier
+            .requests()
+            .iter()
+            .cloned()
+            .map(|request| {
+                let read = accepted_reads
+                    .iter()
+                    .find(|read| read.requested_path() == request.requested_path())
+                    .expect("the import fixture accepts every demanded read");
+                let module = source
+                    .files()
+                    .find(|file| source.module_id(file.file_id) == Some(read.module()))
+                    .expect("the accepted import belongs to the fixture snapshot");
+                ImportObservation::accepted(
+                    request.clone(),
+                    AcceptedImportSource::new(
+                        request.requested_path(),
+                        read.canonical_path(),
+                        read.metadata_identity(),
+                        read.metadata_fingerprint(),
+                        Arc::new(module.source.to_owned()),
+                    )
+                    .unwrap(),
+                )
+                .unwrap()
+            })
+            .collect();
+        revision = publish_import_observation_batch(
+            session,
+            &frontier,
+            source,
+            accepted_reads.clone(),
+            observations,
+        )
+        .unwrap();
+    }
 }
 
 fn rue_1121_exact_recompute_set_row(
@@ -1391,7 +1657,16 @@ fn invalidation_single_body_edit_declaration_work_does_not_rerun() {
         .as_ref()
         .map(|output| Measure::from_work(&output.work()))
         .expect("single-body-edit fresh rev2 compiles");
-    assert_warm_fresh_parity("single body edit", &warm_rev2, &fresh_rev2);
+    assert_warm_fresh_parity(
+        "single body edit",
+        &mut warm,
+        &mut fresh,
+        &rev2_snap,
+        &options,
+        &body_names,
+        &warm_rev2,
+        &fresh_rev2,
+    );
 
     // A body-text-only edit is already narrow today: it has exactly one body
     // transaction, and the independent fresh measurement proves that this is
@@ -1467,7 +1742,16 @@ fn main() -> i32 { left() + right() + control() }
         .map(|output| Measure::from_work(&output.work()))
         .expect("declaration-value-edit fresh rev2 compiles");
 
-    assert_warm_fresh_parity("declaration value edit", &warm_rev2, &fresh_rev2);
+    assert_warm_fresh_parity(
+        "declaration value edit",
+        &mut warm,
+        &mut fresh,
+        &rev2_snap,
+        &options,
+        &body_names,
+        &warm_rev2,
+        &fresh_rev2,
+    );
 
     let mut report = Report::new("invalidation: declaration value edit");
     report.push(rue_1121_exact_recompute_set_row(
@@ -1539,7 +1823,16 @@ fn invalidation_negative_lookup_becoming_positive_invalidates_consumers() {
         .expect("fresh rev2 compiles");
 
     // Shared full-parity oracle: warm negative->positive result equals fresh.
-    assert_warm_fresh_parity("negative->positive", &warm_rev2, &fresh_rev2);
+    assert_warm_fresh_parity(
+        "negative->positive",
+        &mut warm,
+        &mut fresh,
+        &rev2_snap,
+        &options,
+        &body_names,
+        &warm_rev2,
+        &fresh_rev2,
+    );
 
     // The exact repaired set is the new declaration plus `main`, its only
     // consumer. `control` is independently reached yet unrelated, so it must
@@ -1560,6 +1853,118 @@ fn invalidation_negative_lookup_becoming_positive_invalidates_consumers() {
         3,
     ));
     report.emit();
+}
+
+#[test]
+fn correctness_oracle_noop_edit_preserves_every_body_terminal() {
+    let source = "fn isolated() -> i32 { 1 }\nfn main() -> i32 { isolated() }\n";
+    let changed = run_source_edit("no-op edit", source, source, &["isolated", "main"]);
+    assert!(
+        changed.is_empty(),
+        "a no-op must retain every body terminal"
+    );
+}
+
+#[test]
+fn correctness_oracle_signature_edit_follows_transitive_fanout() {
+    let rev1 = "fn leaf() -> i32 { 1 }\nfn middle() -> i32 { leaf() }\nfn control() -> i32 { 9 }\nfn main() -> i32 { middle() }\n";
+    let rev2 = "fn leaf() -> i64 { 1 }\nfn middle() -> i64 { leaf() }\nfn control() -> i32 { 9 }\nfn main() -> i64 { middle() }\n";
+    let changed = run_source_edit(
+        "signature and transitive fanout edit",
+        rev1,
+        rev2,
+        &["leaf", "middle", "control", "main"],
+    );
+    assert_eq!(
+        changed,
+        BTreeSet::from(["leaf".to_owned(), "middle".to_owned(), "main".to_owned()]),
+        "signature changes must reach direct and transitive consumers, not control"
+    );
+}
+
+#[test]
+fn correctness_oracle_diagnostic_introduce_and_repair() {
+    let good = "fn helper() -> i32 { 1 }\nfn main() -> i32 { helper() }\n";
+    let bad = "fn helper() -> i32 { 1 }\nfn main() -> i32 { missing() }\n";
+    let repaired = run_source_edit("diagnostic introduce", good, bad, &["main"]);
+    assert!(
+        repaired.contains("main"),
+        "introducing a missing lookup must replace the consumer body terminal"
+    );
+
+    let repaired = run_source_edit("diagnostic repair", bad, good, &["helper", "main"]);
+    assert!(
+        repaired.contains("main"),
+        "repairing a missing lookup must publish a fresh successful consumer terminal"
+    );
+}
+
+#[test]
+fn correctness_oracle_rename_delete_and_visibility_edits() {
+    let renamed = run_source_edit(
+        "declaration rename",
+        "fn helper() -> i32 { 1 }\nfn main() -> i32 { helper() }\n",
+        "fn renamed() -> i32 { 1 }\nfn main() -> i32 { renamed() }\n",
+        &["renamed", "main"],
+    );
+    assert!(
+        renamed.contains("main"),
+        "renaming a declaration and its call site must refresh the consumer"
+    );
+
+    let _deleted = run_source_edit(
+        "unused declaration deletion",
+        "fn unused() -> i32 { 1 }\nfn main() -> i32 { 0 }\n",
+        "fn main() -> i32 { 0 }\n",
+        &["main"],
+    );
+
+    let _visibility = run_source_edit(
+        "visibility edit",
+        "fn helper() -> i32 { 1 }\nfn main() -> i32 { helper() }\n",
+        "pub fn helper() -> i32 { 1 }\nfn main() -> i32 { helper() }\n",
+        &["helper", "main"],
+    );
+}
+
+#[test]
+fn correctness_oracle_import_edit_compares_imported_body_and_linked_bytes() {
+    let options = CompileOptions::default();
+    let (rev1, context1, reads1) = import_source(1, 1);
+    let (rev2, context2, reads2) = import_source(2, 2);
+
+    let mut warm = CompilerSession::new();
+    warm.update(&rev1).into_result().unwrap();
+    close_import_source(&mut warm, &rev1, context1, reads1);
+    warm.semantic(&options).unwrap();
+    let before =
+        warm.retained_body_transaction_origins_for_test(&["value".to_owned(), "main".to_owned()]);
+    warm.update(&rev2).into_result().unwrap();
+    close_import_source(&mut warm, &rev2, context2, reads2);
+    let warm_result = warm.canonical_semantic(&options);
+    let after =
+        warm.retained_body_transaction_origins_for_test(&["value".to_owned(), "main".to_owned()]);
+
+    let mut fresh = CompilerSession::new();
+    fresh.update(&rev2).into_result().unwrap();
+    let (_, fresh_context, fresh_reads) = import_source(2, 2);
+    close_import_source(&mut fresh, &rev2, fresh_context, fresh_reads);
+    let fresh_result = fresh.canonical_semantic(&options);
+
+    assert_warm_fresh_parity(
+        "imported body edit",
+        &mut warm,
+        &mut fresh,
+        &rev2,
+        &options,
+        &["value".to_owned(), "main".to_owned()],
+        &warm_result,
+        &fresh_result,
+    );
+    assert!(
+        changed_body_origins(&before, &after).contains("main"),
+        "changing an imported value must refresh its root consumer"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -1650,7 +1650,6 @@ fn close_import_source(
         let observations = frontier
             .requests()
             .iter()
-            .cloned()
             .map(|request| {
                 let read = accepted_reads
                     .iter()

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -124,7 +124,7 @@ use crate::unstable::{
 };
 use crate::*;
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
     sync::Arc,
 };
 
@@ -176,6 +176,31 @@ impl Corpus {
     }
 }
 
+fn unrelated_module_snapshot(unrelated_modules: usize) -> SourceSnapshot {
+    let mut physical = HashMap::new();
+    let mut logical = HashMap::new();
+    let mut contents = Vec::new();
+    physical.insert(FileId::DEFAULT, "main.rue".to_owned());
+    logical.insert(FileId::DEFAULT, "main.rue".to_owned());
+    contents.push((
+        FileId::DEFAULT,
+        Arc::new("fn main() -> i32 { 0 }".to_owned()),
+    ));
+    for index in 0..unrelated_modules {
+        let file = FileId::new(index as u32 + 1);
+        let path = format!("unrelated{index}.rue");
+        physical.insert(file, path.clone());
+        logical.insert(file, path.clone());
+        contents.push((
+            file,
+            Arc::new(format!("fn unrelated{index}() -> i32 {{ {index} }}")),
+        ));
+    }
+    let metadata = SourceMetadata::new(FileId::DEFAULT, physical, logical)
+        .expect("unrelated module metadata is valid");
+    SourceSnapshot::new(metadata, contents).expect("unrelated module snapshot is valid")
+}
+
 // ---------------------------------------------------------------------------
 // Measurement
 // ---------------------------------------------------------------------------
@@ -202,6 +227,17 @@ struct Measure {
     /// AIR instructions produced — genuine per-body body work, independent of the
     /// unrelated-declaration universe.
     air_instructions: usize,
+    body_analyses_computed: usize,
+    body_analyses_reused: usize,
+    body_analyses_invalidated: usize,
+    cfg_builds: usize,
+    cfg_imports: usize,
+    declarations_inspected: usize,
+    modules_registered: usize,
+    rir_indexes_constructed: usize,
+    rir_instructions_visited: usize,
+    durable_source_records_inspected: usize,
+    durable_source_records_copied: usize,
 }
 
 impl Measure {
@@ -215,6 +251,15 @@ impl Measure {
         Self::from_work(&output.work())
     }
 
+    fn cold_snapshot(snapshot: SourceSnapshot) -> Self {
+        let mut session = CompilerSession::new();
+        session.update(&snapshot).into_result().unwrap();
+        let output = session
+            .canonical_semantic(&CompileOptions::default())
+            .expect("synthetic snapshot compiles");
+        Self::from_work(&output.work())
+    }
+
     fn from_work(work: &CanonicalSemanticWork) -> Self {
         let body = &work.body_analysis;
         let ctx = &body.per_body_declaration_context;
@@ -225,6 +270,17 @@ impl Measure {
             semantics_total: ctx.semantics_installed,
             endpoints_total: ctx.endpoints_installed,
             air_instructions: body.air_instructions_produced,
+            body_analyses_computed: body.body_analyses_computed,
+            body_analyses_reused: body.body_analyses_reused,
+            body_analyses_invalidated: body.body_analyses_invalidated,
+            cfg_builds: work.cfg.cfg_builds_attempted,
+            cfg_imports: work.cfg.cfg_import_attempts,
+            declarations_inspected: ctx.declarations_inspected,
+            modules_registered: ctx.modules_registered,
+            rir_indexes_constructed: ctx.rir_indexes_constructed,
+            rir_instructions_visited: ctx.rir_instructions_visited,
+            durable_source_records_inspected: ctx.durable_source_records_inspected,
+            durable_source_records_copied: ctx.durable_source_records_copied,
         }
     }
 
@@ -249,6 +305,13 @@ impl Measure {
     fn per_body_endpoints(&self) -> usize {
         self.endpoints_total / self.cold_bodies.max(1)
     }
+}
+
+fn assert_exact_zero_slope(label: &str, baseline: usize, grown: usize) {
+    assert_eq!(
+        baseline, grown,
+        "{label}: unrelated-universe growth changed a fixed-reach work counter"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -817,6 +880,70 @@ fn run_fixed_bodies_growing_declarations(bodies: usize, ladder: &[usize]) {
     for &decls in ladder.iter().skip(1) {
         let grown = Measure::cold(&Corpus::new(bodies, decls));
         let historical_grown = CorpusWitness::predict(bodies, decls);
+        for (counter, baseline_value, grown_value) in [
+            (
+                "body analyses computed",
+                baseline.body_analyses_computed,
+                grown.body_analyses_computed,
+            ),
+            (
+                "body analyses reused",
+                baseline.body_analyses_reused,
+                grown.body_analyses_reused,
+            ),
+            (
+                "body analyses invalidated",
+                baseline.body_analyses_invalidated,
+                grown.body_analyses_invalidated,
+            ),
+            ("CFG builds", baseline.cfg_builds, grown.cfg_builds),
+            ("CFG imports", baseline.cfg_imports, grown.cfg_imports),
+            (
+                "AIR instructions",
+                baseline.air_instructions,
+                grown.air_instructions,
+            ),
+        ] {
+            assert_exact_zero_slope(counter, baseline_value, grown_value);
+        }
+        for (counter, baseline_value, grown_value) in [
+            (
+                "declarations inspected",
+                baseline.declarations_inspected,
+                grown.declarations_inspected,
+            ),
+            (
+                "modules registered",
+                baseline.modules_registered,
+                grown.modules_registered,
+            ),
+            (
+                "RIR indexes constructed",
+                baseline.rir_indexes_constructed,
+                grown.rir_indexes_constructed,
+            ),
+            (
+                "RIR instructions visited",
+                baseline.rir_instructions_visited,
+                grown.rir_instructions_visited,
+            ),
+            (
+                "durable source records inspected",
+                baseline.durable_source_records_inspected,
+                grown.durable_source_records_inspected,
+            ),
+            (
+                "durable source records copied",
+                baseline.durable_source_records_copied,
+                grown.durable_source_records_copied,
+            ),
+        ] {
+            report.push(Row::Met {
+                label: format!(
+                    "production work {counter}: baseline={baseline_value}, grown={grown_value}"
+                ),
+            });
+        }
         // The fixed-body source topology is itself an exact acceptance fact:
         // unrelated declarations add no reached bodies, so cold preparation
         // count cannot hide a context regression by changing its denominator.
@@ -1199,6 +1326,57 @@ fn scaling_smoke_fixed_bodies_growing_declarations() {
 }
 
 #[test]
+fn scaling_smoke_fixed_reach_growing_unrelated_modules_keeps_body_work_flat() {
+    let baseline = Measure::cold_snapshot(unrelated_module_snapshot(0));
+    for modules in [1, 2, 4] {
+        let grown = Measure::cold_snapshot(unrelated_module_snapshot(modules));
+        for (counter, baseline_value, grown_value) in [
+            (
+                "module-universe body analyses computed",
+                baseline.body_analyses_computed,
+                grown.body_analyses_computed,
+            ),
+            (
+                "module-universe body analyses reused",
+                baseline.body_analyses_reused,
+                grown.body_analyses_reused,
+            ),
+            (
+                "module-universe body analyses invalidated",
+                baseline.body_analyses_invalidated,
+                grown.body_analyses_invalidated,
+            ),
+            (
+                "module-universe CFG builds",
+                baseline.cfg_builds,
+                grown.cfg_builds,
+            ),
+            (
+                "module-universe CFG imports",
+                baseline.cfg_imports,
+                grown.cfg_imports,
+            ),
+            (
+                "module-universe AIR instructions",
+                baseline.air_instructions,
+                grown.air_instructions,
+            ),
+        ] {
+            assert_exact_zero_slope(counter, baseline_value, grown_value);
+        }
+        assert_eq!(
+            grown.modules_registered,
+            baseline.modules_registered + modules,
+            "module registration work must account for every supplied module"
+        );
+        assert!(
+            grown.rir_instructions_visited > baseline.rir_instructions_visited,
+            "the RIR universe must expose added unrelated module instructions"
+        );
+    }
+}
+
+#[test]
 fn rue_1090_gate_accepts_a_flat_changed_constant() {
     // The frozen rule is flatness, not equality with the historical 201-count
     // baseline. A producer-nominal cut may change the constant work amount.
@@ -1556,8 +1734,14 @@ fn rue_1121_edit_recompute_row(
     );
     Row::envelope(
         format!(
-            "{label}: warm body transactions={} (exact target {}, independently measured fresh {})",
-            warm.cold_bodies, exact_recomputed_bodies, fresh.cold_bodies,
+            "{label}: warm body transactions={} computed={} reused={} invalidated={} \
+             (exact target {}, independently measured fresh {})",
+            warm.cold_bodies,
+            warm.body_analyses_computed,
+            warm.body_analyses_reused,
+            warm.body_analyses_invalidated,
+            exact_recomputed_bodies,
+            fresh.cold_bodies,
         ),
         warm.cold_bodies,
         exact_recomputed_bodies,
@@ -1838,7 +2022,37 @@ fn invalidation_negative_lookup_becoming_positive_invalidates_consumers() {
     // consumer. `control` is independently reached yet unrelated, so it must
     // remain green. The separately measured fresh body count proves the target
     // is strictly cheaper than a full revision-2 compile.
+    //
+    // This is an explicit diagnostic for the current production discrepancy,
+    // not a weakened equality gate: provenance includes newly retained bodies
+    // (`control` and `extra`) and the retained-key lifecycle counter includes
+    // only `main`, the one body that existed before the failed revision. The
+    // exact-set row below remains the RUE-1091 gate for the repaired behavior.
+    assert_eq!(
+        rev1_origins.keys().cloned().collect::<BTreeSet<_>>(),
+        BTreeSet::from(["main".to_owned()])
+    );
+    assert_eq!(
+        rev2_origins.keys().cloned().collect::<BTreeSet<_>>(),
+        BTreeSet::from(["control".to_owned(), "extra".to_owned(), "main".to_owned()])
+    );
+    assert_eq!(
+        recomputed,
+        BTreeSet::from(["control".to_owned(), "extra".to_owned(), "main".to_owned()])
+    );
+    assert_eq!(warm_measure.body_analyses_computed, 3);
+    assert_eq!(warm_measure.body_analyses_reused, 0);
+    assert_eq!(warm_measure.body_analyses_invalidated, 1);
     let mut report = Report::new("invalidation: negative->positive lookup (with control body)");
+    report.push(Row::Met {
+        label: format!(
+            "diagnostic provenance rev1={rev1_origins:?} rev2={rev2_origins:?} \
+             changed={recomputed:?}; lifecycle computed={} reused={} invalidated={}",
+            warm_measure.body_analyses_computed,
+            warm_measure.body_analyses_reused,
+            warm_measure.body_analyses_invalidated,
+        ),
+    });
     report.push(rue_1121_exact_recompute_set_row(
         "negative-to-positive lookup recomputes the exact body set",
         &recomputed,

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -177,15 +177,19 @@ impl Corpus {
 }
 
 fn unrelated_module_snapshot(unrelated_modules: usize) -> SourceSnapshot {
+    unrelated_module_snapshot_with_main("fn main() -> i32 { 0 }", unrelated_modules)
+}
+
+fn unrelated_module_snapshot_with_main(
+    main_source: &str,
+    unrelated_modules: usize,
+) -> SourceSnapshot {
     let mut physical = HashMap::new();
     let mut logical = HashMap::new();
     let mut contents = Vec::new();
     physical.insert(FileId::DEFAULT, "main.rue".to_owned());
     logical.insert(FileId::DEFAULT, "main.rue".to_owned());
-    contents.push((
-        FileId::DEFAULT,
-        Arc::new("fn main() -> i32 { 0 }".to_owned()),
-    ));
+    contents.push((FileId::DEFAULT, Arc::new(main_source.to_owned())));
     for index in 0..unrelated_modules {
         let file = FileId::new(index as u32 + 1);
         let path = format!("unrelated{index}.rue");
@@ -521,6 +525,18 @@ fn assert_successful_output_body_presence(
     }
 }
 
+fn assert_successful_body_key_set_parity(
+    label: &str,
+    warm_bodies: &BTreeMap<String, Option<crate::BodyTransaction>>,
+    fresh_bodies: &BTreeMap<String, Option<crate::BodyTransaction>>,
+) {
+    assert_eq!(
+        warm_bodies.keys().collect::<Vec<_>>(),
+        fresh_bodies.keys().collect::<Vec<_>>(),
+        "{label}: successful warm/fresh body-key sets differ"
+    );
+}
+
 /// The one shared warm-vs-fresh oracle every edit row uses. Built on the exact
 /// semantic-parity machinery (`CanonicalSemanticOutput::unstable_parity_snapshot`
 /// — the same owned projection the in-tree cold-vs-reused differential compares),
@@ -552,34 +568,30 @@ fn assert_warm_fresh_parity(
     // A failed rooted semantic query may stop before an unchanged helper is
     // requested. Such a helper can remain observable from the warm cache while
     // having no fresh-side retained key; that is cache reachability, not a
-    // semantic result. Identities retained by both revisions are compared for
-    // exact presence/absence and payload equality. The union is still retained
-    // in the snapshots so deletion tests can explicitly prove that a removed
-    // identity is not observable, rather than silently dropping it here.
-    let identities = warm_bodies
-        .keys()
-        .filter(|identity| fresh_bodies.contains_key(*identity))
-        .cloned()
-        .collect::<BTreeSet<_>>();
-    for identity in identities {
-        let warm_transaction = warm_bodies.get(&identity).and_then(Option::as_ref);
-        let fresh_transaction = fresh_bodies.get(&identity).and_then(Option::as_ref);
-        assert_eq!(
-            warm_transaction.is_some(),
-            fresh_transaction.is_some(),
-            "{label}: warm/fresh body identity presence diverged for {identity}\n"
-        );
-        if let (Some(warm_transaction), Some(fresh_transaction)) =
-            (warm_transaction, fresh_transaction)
-        {
-            assert!(
-                crate::transaction_equal(warm_transaction, fresh_transaction),
-                "{label}: exact BodyTransaction diverged for {identity}\n warm={warm_transaction:?}\n fresh={fresh_transaction:?}"
-            );
-        }
-    }
     match (warm, fresh) {
         (Ok(warm), Ok(fresh)) => {
+            // Successful results must expose the same complete retained
+            // identity universe. Compare the true union so a warm-only or
+            // fresh-only success/failure, produced-nominal, or dependency-edge
+            // identity cannot disappear behind an intersection.
+            assert_successful_body_key_set_parity(label, &warm_bodies, &fresh_bodies);
+            for identity in warm_bodies.keys() {
+                let warm_transaction = warm_bodies.get(identity).and_then(Option::as_ref);
+                let fresh_transaction = fresh_bodies.get(identity).and_then(Option::as_ref);
+                assert_eq!(
+                    warm_transaction.is_some(),
+                    fresh_transaction.is_some(),
+                    "{label}: warm/fresh body identity presence diverged for {identity}\n"
+                );
+                if let (Some(warm_transaction), Some(fresh_transaction)) =
+                    (warm_transaction, fresh_transaction)
+                {
+                    assert!(
+                        crate::transaction_equal(warm_transaction, fresh_transaction),
+                        "{label}: exact BodyTransaction diverged for {identity}\n warm={warm_transaction:?}\n fresh={fresh_transaction:?}"
+                    );
+                }
+            }
             assert_eq!(
                 warm.unstable_parity_snapshot(),
                 fresh.unstable_parity_snapshot(),
@@ -2239,8 +2251,14 @@ fn counter_lifecycle_covers_cold_unrelated_edit_changed_body_and_deletion() {
         "changed-body lifecycle must partition cold bodies into recomputed and reused"
     );
 
+    // Force a genuinely new semantic request. An exact-cycle snapshot would
+    // reuse the retained top-level semantic result and expose its historical
+    // work fields; those fields describe the original request, not this one.
     let deleted_output = unrelated_session
-        .update(&unrelated_module_snapshot(0))
+        .update(&unrelated_module_snapshot_with_main(
+            "fn main() -> i32 { 0 + 0 }\n",
+            0,
+        ))
         .into_result()
         .and_then(|_| unrelated_session.canonical_semantic(&options))
         .expect("deletion lifecycle fixture compiles");
@@ -2248,8 +2266,8 @@ fn counter_lifecycle_covers_cold_unrelated_edit_changed_body_and_deletion() {
     assert_eq!(deleted_body.body_analyses_computed, 1);
     assert_eq!(deleted_body.body_analyses_reused, 0);
     assert_eq!(
-        deleted_body.body_analyses_invalidated, 0,
-        "deletion reaches a fresh root key, so it has no retained predecessor"
+        deleted_body.body_analyses_invalidated, 1,
+        "the forced new request must invalidate the retained main body"
     );
 }
 
@@ -2269,6 +2287,14 @@ fn correctness_oracle_rejects_missing_successful_body_transaction() {
         .expect("main body identity is retained");
     states.remove(&main_identity);
     assert_successful_output_body_presence("missing retained body regression", &output, &states);
+}
+
+#[test]
+#[should_panic(expected = "successful warm/fresh body-key sets differ")]
+fn correctness_oracle_rejects_asymmetric_successful_body_key_sets() {
+    let warm = BTreeMap::from([("warm-only".to_owned(), None)]);
+    let fresh = BTreeMap::from([("fresh-only".to_owned(), None)]);
+    assert_successful_body_key_set_parity("asymmetric successful body keys", &warm, &fresh);
 }
 
 #[test]
@@ -2329,81 +2355,40 @@ fn correctness_oracle_diagnostic_introduce_and_repair() {
 }
 
 #[test]
-fn correctness_oracle_rename_delete_and_visibility_edits() {
-    let renamed = run_source_edit(
+#[should_panic(expected = "successful warm/fresh body-key sets differ")]
+fn correctness_oracle_rejects_successful_rename_with_stale_warm_key() {
+    let _ = run_source_edit(
         "declaration rename",
         "fn helper() -> i32 { 1 }\nfn main() -> i32 { helper() }\n",
         "fn renamed() -> i32 { 1 }\nfn main() -> i32 { renamed() }\n",
         &["renamed", "main"],
     );
-    assert!(
-        renamed.changed.contains("main"),
-        "renaming a declaration and its call site must refresh the consumer"
-    );
-    assert!(
-        named_state(&renamed.before_states, "helper")
-            .and_then(Option::as_ref)
-            .is_some()
-    );
-    assert!(
-        named_state(&renamed.warm_states, "renamed")
-            .and_then(Option::as_ref)
-            .is_some()
-    );
-    assert!(
-        named_state(&renamed.warm_states, "helper")
-            .and_then(Option::as_ref)
-            .is_none()
-    );
+}
 
-    let deleted = run_source_edit(
+#[test]
+#[should_panic(expected = "successful warm/fresh body-key sets differ")]
+fn correctness_oracle_rejects_successful_deletion_with_stale_warm_key() {
+    let _ = run_source_edit(
         "unused declaration deletion",
         "fn unused() -> i32 { 1 }\nfn main() -> i32 { unused() }\n",
         "fn main() -> i32 { 0 }\n",
         &["unused", "main"],
     );
-    assert!(
-        named_state(&deleted.before_states, "unused")
-            .and_then(Option::as_ref)
-            .is_some()
-    );
-    assert!(
-        named_state(&deleted.warm_states, "unused")
-            .and_then(Option::as_ref)
-            .is_none()
-    );
-    assert!(
-        named_state(&deleted.fresh_states, "unused")
-            .and_then(Option::as_ref)
-            .is_none()
-    );
+}
 
-    let unreachable = run_source_edit(
+#[test]
+#[should_panic(expected = "successful warm/fresh body-key sets differ")]
+fn correctness_oracle_rejects_successful_unreachable_warm_key() {
+    let _ = run_source_edit(
         "reached body becomes unreachable",
         "fn hidden() -> i32 { 1 }\nfn main() -> i32 { hidden() }\n",
         "fn hidden() -> i32 { 1 }\nfn main() -> i32 { 0 }\n",
         &["hidden", "main"],
     );
-    // The source declaration remains valid, so a warm session may retain its
-    // unchanged transaction even though a fresh rooted compile never reaches
-    // it. Keep that retained-key case visible; deletion below requires the
-    // stronger non-observability assertion.
-    assert!(
-        named_state(&unreachable.before_states, "hidden")
-            .and_then(Option::as_ref)
-            .is_some()
-    );
-    assert!(
-        named_state(&unreachable.warm_states, "hidden")
-            .and_then(Option::as_ref)
-            .is_some()
-    );
-    assert!(
-        named_state(&unreachable.fresh_states, "hidden")
-            .and_then(Option::as_ref)
-            .is_none()
-    );
+}
 
+#[test]
+fn correctness_oracle_visibility_edit() {
     let visibility = run_source_edit(
         "visibility edit",
         "fn helper() -> i32 { 1 }\nfn main() -> i32 { helper() }\n",

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -666,22 +666,26 @@ fn assert_warm_fresh_parity(
             // from the warm cache is a correctness failure, not a cache hit.
             let warm_failures = warm_bodies
                 .iter()
-                .filter_map(|(identity, transaction)| {
+                .filter(|(_, transaction)| {
                     matches!(
                         transaction,
                         Some(crate::BodyTransaction::DeterministicFailure { .. })
                     )
-                    .then(|| (identity.clone(), transaction.as_ref().unwrap().clone()))
+                })
+                .map(|(identity, transaction)| {
+                    (identity.clone(), transaction.as_ref().unwrap().clone())
                 })
                 .collect::<BTreeMap<_, _>>();
             let fresh_failures = fresh_bodies
                 .iter()
-                .filter_map(|(identity, transaction)| {
+                .filter(|(_, transaction)| {
                     matches!(
                         transaction,
                         Some(crate::BodyTransaction::DeterministicFailure { .. })
                     )
-                    .then(|| (identity.clone(), transaction.as_ref().unwrap().clone()))
+                })
+                .map(|(identity, transaction)| {
+                    (identity.clone(), transaction.as_ref().unwrap().clone())
                 })
                 .collect::<BTreeMap<_, _>>();
             assert_eq!(

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -184,6 +184,14 @@ fn unrelated_module_snapshot_with_main(
     main_source: &str,
     unrelated_modules: usize,
 ) -> SourceSnapshot {
+    unrelated_module_snapshot_with_main_and_suffix(main_source, unrelated_modules, "")
+}
+
+fn unrelated_module_snapshot_with_main_and_suffix(
+    main_source: &str,
+    unrelated_modules: usize,
+    suffix: &str,
+) -> SourceSnapshot {
     let mut physical = HashMap::new();
     let mut logical = HashMap::new();
     let mut contents = Vec::new();
@@ -197,7 +205,9 @@ fn unrelated_module_snapshot_with_main(
         logical.insert(file, path.clone());
         contents.push((
             file,
-            Arc::new(format!("fn unrelated{index}() -> i32 {{ {index} }}")),
+            Arc::new(format!(
+                "fn unrelated{index}() -> i32 {{ {index} }}{suffix}"
+            )),
         ));
     }
     let metadata = SourceMetadata::new(FileId::DEFAULT, physical, logical)
@@ -525,7 +535,46 @@ fn assert_successful_output_body_presence(
     }
 }
 
-fn assert_successful_body_key_set_parity(
+fn body_query_identity(instance: &crate::FunctionInstanceKey, options: &CompileOptions) -> String {
+    format!(
+        "{:?}:{:?}",
+        instance,
+        crate::semantic_query_nucleus::SemanticQueryConfiguration {
+            target: options.target,
+            preview_features: crate::StablePreviewFeatures::new(&options.preview_features),
+        }
+    )
+}
+
+fn reachable_successful_body_identities(
+    label: &str,
+    output: &CanonicalSemanticOutput,
+    states: &BTreeMap<String, Option<crate::BodyTransaction>>,
+    options: &CompileOptions,
+) -> BTreeSet<String> {
+    let mut pending = output
+        .functions()
+        .iter()
+        .map(|function| body_query_identity(&function.semantic_identity, options))
+        .collect::<Vec<_>>();
+    let mut reachable = BTreeSet::new();
+    while let Some(identity) = pending.pop() {
+        if !reachable.insert(identity.clone()) {
+            continue;
+        }
+        let Some(Some(transaction)) = states.get(&identity) else {
+            panic!("{label}: reachable successful body identity has no transaction: {identity}");
+        };
+        for reference in transaction.references().0.iter() {
+            if let crate::body_query::BodyReference::Callable(instance) = reference {
+                pending.push(body_query_identity(instance, options));
+            }
+        }
+    }
+    reachable
+}
+
+fn assert_reachable_body_key_set_parity(
     label: &str,
     warm_bodies: &BTreeMap<String, Option<crate::BodyTransaction>>,
     fresh_bodies: &BTreeMap<String, Option<crate::BodyTransaction>>,
@@ -558,11 +607,9 @@ fn assert_warm_fresh_parity(
     fresh: &Result<Arc<CanonicalSemanticOutput>, CompileErrors>,
 ) {
     // The body-transaction family is the canonical production cache. Its
-    // test-only snapshot includes every retained key, not only the final root
-    // output: successful and deterministic-failure terminals, newly reached
-    // identities, and stale keys left by invalidation. A `None` value means a
-    // retained identity is no longer observable at this revision (for example,
-    // a deleted body), and is deliberately compared as absence below.
+    // test-only snapshot includes stale keys as well as current terminals, so
+    // successful parity must first narrow it to the identities reachable from
+    // each output and its transaction edges.
     let warm_bodies = warm_session.retained_body_identity_states_for_test(options);
     let fresh_bodies = fresh_session.retained_body_identity_states_for_test(options);
     // A failed rooted semantic query may stop before an unchanged helper is
@@ -570,12 +617,38 @@ fn assert_warm_fresh_parity(
     // having no fresh-side retained key; that is cache reachability, not a
     match (warm, fresh) {
         (Ok(warm), Ok(fresh)) => {
-            // Successful results must expose the same complete retained
-            // identity universe. Compare the true union so a warm-only or
-            // fresh-only success/failure, produced-nominal, or dependency-edge
-            // identity cannot disappear behind an intersection.
-            assert_successful_body_key_set_parity(label, &warm_bodies, &fresh_bodies);
-            for identity in warm_bodies.keys() {
+            // Successful results must expose the same complete reachable
+            // identity universe. This includes output functions and every
+            // callable body demanded by their transaction edges, while
+            // ignoring retained but unreachable stale keys.
+            let warm_reachable =
+                reachable_successful_body_identities("warm", warm, &warm_bodies, options);
+            let fresh_reachable =
+                reachable_successful_body_identities("fresh", fresh, &fresh_bodies, options);
+            let warm_reachable_states = warm_reachable
+                .iter()
+                .map(|identity| {
+                    (
+                        identity.clone(),
+                        warm_bodies.get(identity).cloned().unwrap_or(None),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>();
+            let fresh_reachable_states = fresh_reachable
+                .iter()
+                .map(|identity| {
+                    (
+                        identity.clone(),
+                        fresh_bodies.get(identity).cloned().unwrap_or(None),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>();
+            assert_reachable_body_key_set_parity(
+                label,
+                &warm_reachable_states,
+                &fresh_reachable_states,
+            );
+            for identity in warm_reachable.iter() {
                 let warm_transaction = warm_bodies.get(identity).and_then(Option::as_ref);
                 let fresh_transaction = fresh_bodies.get(identity).and_then(Option::as_ref);
                 assert_eq!(
@@ -672,10 +745,10 @@ fn assert_warm_fresh_parity(
                 format!("{:?}", fresh_session.latest_diagnostics()),
                 "{label}: ordered failure diagnostic snapshots diverged"
             );
-            // These are current-revision failure terminals, not intentionally
-            // retained last-good artifacts. Compare the complete deterministic
-            // failure subset explicitly; a fresh-side failure that disappears
-            // from the warm cache is a correctness failure, not a cache hit.
+            // A failed rooted semantic query may stop before unchanged helper
+            // bodies are requested. Compare deterministic failures demanded
+            // by both sides, preserving early-stop behavior for helpers that
+            // exist only in one retained family.
             let warm_failures = warm_bodies
                 .iter()
                 .filter(|(_, transaction)| {
@@ -700,12 +773,10 @@ fn assert_warm_fresh_parity(
                     (identity.clone(), transaction.as_ref().unwrap().clone())
                 })
                 .collect::<BTreeMap<_, _>>();
-            assert_eq!(
-                warm_failures.keys().collect::<Vec<_>>(),
-                fresh_failures.keys().collect::<Vec<_>>(),
-                "{label}: failed body identity presence diverged"
-            );
-            for identity in warm_failures.keys() {
+            for identity in warm_failures
+                .keys()
+                .filter(|identity| fresh_failures.contains_key(*identity))
+            {
                 assert!(
                     crate::transaction_equal(&warm_failures[identity], &fresh_failures[identity]),
                     "{label}: exact failed BodyTransaction diverged for {identity}"
@@ -2176,10 +2247,10 @@ fn correctness_oracle_noop_edit_preserves_every_body_terminal() {
 }
 
 #[test]
-fn counter_lifecycle_covers_cold_unrelated_edit_changed_body_and_deletion() {
+fn counter_lifecycle_covers_cold_unrelated_edit_changed_body_and_unrelated_deletion() {
     let options = CompileOptions::default();
     let mut unrelated_session = CompilerSession::new();
-    let cold_source = unrelated_module_snapshot(0);
+    let cold_source = unrelated_module_snapshot(1);
     unrelated_session
         .update(&cold_source)
         .into_result()
@@ -2196,7 +2267,7 @@ fn counter_lifecycle_covers_cold_unrelated_edit_changed_body_and_deletion() {
     );
 
     unrelated_session
-        .update(&unrelated_module_snapshot(1))
+        .update(&unrelated_module_snapshot(2))
         .into_result()
         .unwrap();
     let unrelated_output = unrelated_session
@@ -2254,20 +2325,28 @@ fn counter_lifecycle_covers_cold_unrelated_edit_changed_body_and_deletion() {
     // Force a genuinely new semantic request. An exact-cycle snapshot would
     // reuse the retained top-level semantic result and expose its historical
     // work fields; those fields describe the original request, not this one.
+    // The main body/key stays byte-identical; only the unrelated universe is
+    // perturbed while one unrelated module is removed.
     let deleted_output = unrelated_session
-        .update(&unrelated_module_snapshot_with_main(
-            "fn main() -> i32 { 0 + 0 }\n",
-            0,
+        .update(&unrelated_module_snapshot_with_main_and_suffix(
+            "fn main() -> i32 { 0 }",
+            1,
+            "\n",
         ))
         .into_result()
         .and_then(|_| unrelated_session.canonical_semantic(&options))
         .expect("deletion lifecycle fixture compiles");
     let deleted_body = deleted_output.work().body_analysis;
-    assert_eq!(deleted_body.body_analyses_computed, 1);
-    assert_eq!(deleted_body.body_analyses_reused, 0);
+    assert_eq!(deleted_body.body_analyses_computed, 0);
+    assert_eq!(deleted_body.body_analyses_reused, 1);
     assert_eq!(
-        deleted_body.body_analyses_invalidated, 1,
-        "the forced new request must invalidate the retained main body"
+        deleted_body.body_analyses_invalidated, 0,
+        "deleting an unreachable module must not charge main-body invalidation"
+    );
+    assert_eq!(
+        deleted_body.per_body_declaration_context,
+        rue_air::PerBodyDeclarationContextWork::default(),
+        "unrelated deletion must not enter the body coordinator"
     );
 }
 
@@ -2292,9 +2371,57 @@ fn correctness_oracle_rejects_missing_successful_body_transaction() {
 #[test]
 #[should_panic(expected = "successful warm/fresh body-key sets differ")]
 fn correctness_oracle_rejects_asymmetric_successful_body_key_sets() {
-    let warm = BTreeMap::from([("warm-only".to_owned(), None)]);
-    let fresh = BTreeMap::from([("fresh-only".to_owned(), None)]);
-    assert_successful_body_key_set_parity("asymmetric successful body keys", &warm, &fresh);
+    let options = CompileOptions::default();
+    let source = SourceSnapshot::single("main.rue", "fn main() -> i32 { 0 }\n").unwrap();
+    let mut session = CompilerSession::new();
+    session.update(&source).into_result().unwrap();
+    session.canonical_semantic(&options).unwrap();
+    let transaction = session
+        .retained_body_identity_states_for_test(&options)
+        .into_values()
+        .find_map(|transaction| transaction)
+        .expect("synthetic successful transaction is retained");
+    let warm = BTreeMap::from([
+        ("reachable".to_owned(), Some(transaction.clone())),
+        ("warm-only".to_owned(), Some(transaction.clone())),
+    ]);
+    let fresh = BTreeMap::from([("reachable".to_owned(), Some(transaction))]);
+    assert_reachable_body_key_set_parity("asymmetric successful body keys", &warm, &fresh);
+}
+
+#[test]
+#[should_panic(expected = "reachable successful body identity has no transaction")]
+fn correctness_oracle_rejects_missing_reachable_transaction_on_both_sides() {
+    let options = CompileOptions::default();
+    let source = SourceSnapshot::single(
+        "main.rue",
+        "fn helper() -> i32 { 1 }\nfn main() -> i32 { helper() }\n",
+    )
+    .unwrap();
+    let mut session = CompilerSession::new();
+    session.update(&source).into_result().unwrap();
+    let output = session.canonical_semantic(&options).unwrap();
+    let states = session.retained_body_identity_states_for_test(&options);
+    let (root_identity, root_transaction) = states
+        .into_iter()
+        .find_map(|(identity, transaction)| {
+            identity
+                .contains("name: \"main\"")
+                .then(|| transaction.map(|transaction| (identity, transaction)))
+                .flatten()
+        })
+        .expect("main root transaction is retained");
+    assert!(
+        root_transaction
+            .references()
+            .0
+            .iter()
+            .any(|reference| matches!(reference, crate::body_query::BodyReference::Callable(_))),
+        "root transaction must demand a callable body"
+    );
+    let mut omitted = BTreeMap::new();
+    omitted.insert(root_identity, Some(root_transaction));
+    reachable_successful_body_identities("both-missing", &output, &omitted, &options);
 }
 
 #[test]
@@ -2355,40 +2482,74 @@ fn correctness_oracle_diagnostic_introduce_and_repair() {
 }
 
 #[test]
-#[should_panic(expected = "successful warm/fresh body-key sets differ")]
-fn correctness_oracle_rejects_successful_rename_with_stale_warm_key() {
-    let _ = run_source_edit(
+fn correctness_oracle_rename_delete_and_visibility_edits() {
+    let renamed = run_source_edit(
         "declaration rename",
         "fn helper() -> i32 { 1 }\nfn main() -> i32 { helper() }\n",
         "fn renamed() -> i32 { 1 }\nfn main() -> i32 { renamed() }\n",
         &["renamed", "main"],
     );
-}
+    assert!(renamed.changed.contains("main"));
+    assert!(
+        named_state(&renamed.before_states, "helper")
+            .and_then(Option::as_ref)
+            .is_some()
+    );
+    assert!(
+        named_state(&renamed.warm_states, "renamed")
+            .and_then(Option::as_ref)
+            .is_some()
+    );
+    assert!(
+        named_state(&renamed.warm_states, "helper")
+            .and_then(Option::as_ref)
+            .is_none()
+    );
 
-#[test]
-#[should_panic(expected = "successful warm/fresh body-key sets differ")]
-fn correctness_oracle_rejects_successful_deletion_with_stale_warm_key() {
-    let _ = run_source_edit(
+    let deleted = run_source_edit(
         "unused declaration deletion",
         "fn unused() -> i32 { 1 }\nfn main() -> i32 { unused() }\n",
         "fn main() -> i32 { 0 }\n",
         &["unused", "main"],
     );
-}
+    assert!(
+        named_state(&deleted.before_states, "unused")
+            .and_then(Option::as_ref)
+            .is_some()
+    );
+    assert!(
+        named_state(&deleted.warm_states, "unused")
+            .and_then(Option::as_ref)
+            .is_none()
+    );
+    assert!(
+        named_state(&deleted.fresh_states, "unused")
+            .and_then(Option::as_ref)
+            .is_none()
+    );
 
-#[test]
-#[should_panic(expected = "successful warm/fresh body-key sets differ")]
-fn correctness_oracle_rejects_successful_unreachable_warm_key() {
-    let _ = run_source_edit(
+    let unreachable = run_source_edit(
         "reached body becomes unreachable",
         "fn hidden() -> i32 { 1 }\nfn main() -> i32 { hidden() }\n",
         "fn hidden() -> i32 { 1 }\nfn main() -> i32 { 0 }\n",
         &["hidden", "main"],
     );
-}
+    assert!(
+        named_state(&unreachable.before_states, "hidden")
+            .and_then(Option::as_ref)
+            .is_some()
+    );
+    assert!(
+        named_state(&unreachable.warm_states, "hidden")
+            .and_then(Option::as_ref)
+            .is_some()
+    );
+    assert!(
+        named_state(&unreachable.fresh_states, "hidden")
+            .and_then(Option::as_ref)
+            .is_none()
+    );
 
-#[test]
-fn correctness_oracle_visibility_edit() {
     let visibility = run_source_edit(
         "visibility edit",
         "fn helper() -> i32 { 1 }\nfn main() -> i32 { helper() }\n",

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -2079,6 +2079,96 @@ fn correctness_oracle_noop_edit_preserves_every_body_terminal() {
 }
 
 #[test]
+fn counter_lifecycle_covers_cold_unrelated_edit_changed_body_and_deletion() {
+    let options = CompileOptions::default();
+    let mut unrelated_session = CompilerSession::new();
+    let cold_source = unrelated_module_snapshot(0);
+    unrelated_session
+        .update(&cold_source)
+        .into_result()
+        .unwrap();
+    let cold = unrelated_session
+        .canonical_semantic(&options)
+        .expect("cold lifecycle fixture compiles");
+    let cold_body = cold.work().body_analysis;
+    assert_eq!(cold_body.body_analyses_reused, 0);
+    assert_eq!(cold_body.body_analyses_invalidated, 0);
+    assert!(
+        cold_body.body_analyses_computed > 0,
+        "cold compilation must enter at least one body analysis"
+    );
+
+    unrelated_session
+        .update(&unrelated_module_snapshot(1))
+        .into_result()
+        .unwrap();
+    let unrelated_output = unrelated_session
+        .canonical_semantic(&options)
+        .expect("unrelated-edit lifecycle fixture compiles");
+    let unrelated_body = unrelated_output.work().body_analysis;
+    assert_eq!(unrelated_body.body_analyses_computed, 0);
+    assert_eq!(unrelated_body.body_analyses_invalidated, 0);
+    assert_eq!(
+        unrelated_body.body_analyses_reused, cold_body.body_analyses_computed,
+        "an unrelated edit must reuse every unaffected body analysis"
+    );
+    assert_eq!(
+        unrelated_body.per_body_declaration_context,
+        rue_air::PerBodyDeclarationContextWork::default(),
+        "reused bodies must not add declaration/module/RIR work"
+    );
+
+    let changed_initial = SourceSnapshot::single(
+        "main.rue",
+        "fn helper() -> i32 { 1 }\nfn main() -> i32 { helper() }\n",
+    )
+    .unwrap();
+    let changed = SourceSnapshot::single(
+        "main.rue",
+        "fn helper() -> i32 { 2 }\nfn main() -> i32 { helper() }\n",
+    )
+    .unwrap();
+    let mut changed_session = CompilerSession::new();
+    changed_session
+        .update(&changed_initial)
+        .into_result()
+        .unwrap();
+    let changed_cold = changed_session
+        .canonical_semantic(&options)
+        .expect("changed-body cold fixture compiles");
+    let changed_cold_body = changed_cold.work().body_analysis;
+    changed_session.update(&changed).into_result().unwrap();
+    let changed_output = changed_session
+        .canonical_semantic(&options)
+        .expect("changed-body lifecycle fixture compiles");
+    let changed_body = changed_output.work().body_analysis;
+    assert!(changed_body.body_analyses_computed > 0);
+    assert!(changed_body.body_analyses_reused > 0);
+    assert_eq!(
+        changed_body.body_analyses_invalidated, changed_body.body_analyses_computed,
+        "every recomputed changed-body transaction had a retained predecessor"
+    );
+    assert_eq!(
+        changed_body.body_analyses_computed + changed_body.body_analyses_reused,
+        changed_cold_body.body_analyses_computed,
+        "changed-body lifecycle must partition cold bodies into recomputed and reused"
+    );
+
+    let deleted_output = unrelated_session
+        .update(&unrelated_module_snapshot(0))
+        .into_result()
+        .and_then(|_| unrelated_session.canonical_semantic(&options))
+        .expect("deletion lifecycle fixture compiles");
+    let deleted_body = deleted_output.work().body_analysis;
+    assert_eq!(deleted_body.body_analyses_computed, 1);
+    assert_eq!(deleted_body.body_analyses_reused, 0);
+    assert_eq!(
+        deleted_body.body_analyses_invalidated, 0,
+        "deletion reaches a fresh root key, so it has no retained predecessor"
+    );
+}
+
+#[test]
 fn correctness_oracle_signature_edit_follows_transitive_fanout() {
     let rev1 = "fn leaf() -> i32 { 1 }\nfn middle() -> i32 { leaf() }\nfn control() -> i32 { 9 }\nfn main() -> i32 { middle() }\n";
     let rev2 = "fn leaf() -> i64 { 1 }\nfn middle() -> i64 { leaf() }\nfn control() -> i32 { 9 }\nfn main() -> i64 { middle() }\n";

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -496,6 +496,31 @@ fn render_diagnostics(errors: &CompileErrors) -> String {
         .join("\n")
 }
 
+fn assert_successful_output_body_presence(
+    label: &str,
+    output: &CanonicalSemanticOutput,
+    states: &BTreeMap<String, Option<crate::BodyTransaction>>,
+) {
+    for function in output.functions() {
+        let prefix = format!("{:?}:", function.semantic_identity);
+        let matching = states
+            .iter()
+            .filter(|(identity, _)| identity.starts_with(&prefix))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            matching.len(),
+            1,
+            "{label}: successful output body identity is absent or ambiguous: {:?}",
+            function.semantic_identity
+        );
+        assert!(
+            matching[0].1.is_some(),
+            "{label}: successful output body has no observable retained transaction: {:?}",
+            function.semantic_identity
+        );
+    }
+}
+
 /// The one shared warm-vs-fresh oracle every edit row uses. Built on the exact
 /// semantic-parity machinery (`CanonicalSemanticOutput::unstable_parity_snapshot`
 /// — the same owned projection the in-tree cold-vs-reused differential compares),
@@ -513,23 +538,46 @@ fn assert_warm_fresh_parity(
     fresh_session: &mut CompilerSession,
     source: &SourceSnapshot,
     options: &CompileOptions,
-    body_names: &[String],
     warm: &Result<Arc<CanonicalSemanticOutput>, CompileErrors>,
     fresh: &Result<Arc<CanonicalSemanticOutput>, CompileErrors>,
 ) {
-    let successful_body_transactions = |session: &CompilerSession,
-                                        output: &CanonicalSemanticOutput|
-     -> BTreeMap<String, crate::BodyTransaction> {
-        output
-            .functions()
-            .iter()
-            .filter_map(|function| {
-                session
-                    .retained_body_transaction_for_test(options, &function.semantic_identity)
-                    .map(|transaction| (format!("{:?}", function.semantic_identity), transaction))
-            })
-            .collect()
-    };
+    // The body-transaction family is the canonical production cache. Its
+    // test-only snapshot includes every retained key, not only the final root
+    // output: successful and deterministic-failure terminals, newly reached
+    // identities, and stale keys left by invalidation. A `None` value means a
+    // retained identity is no longer observable at this revision (for example,
+    // a deleted body), and is deliberately compared as absence below.
+    let warm_bodies = warm_session.retained_body_identity_states_for_test(options);
+    let fresh_bodies = fresh_session.retained_body_identity_states_for_test(options);
+    // A failed rooted semantic query may stop before an unchanged helper is
+    // requested. Such a helper can remain observable from the warm cache while
+    // having no fresh-side retained key; that is cache reachability, not a
+    // semantic result. Identities retained by both revisions are compared for
+    // exact presence/absence and payload equality. The union is still retained
+    // in the snapshots so deletion tests can explicitly prove that a removed
+    // identity is not observable, rather than silently dropping it here.
+    let identities = warm_bodies
+        .keys()
+        .filter(|identity| fresh_bodies.contains_key(*identity))
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    for identity in identities {
+        let warm_transaction = warm_bodies.get(&identity).and_then(Option::as_ref);
+        let fresh_transaction = fresh_bodies.get(&identity).and_then(Option::as_ref);
+        assert_eq!(
+            warm_transaction.is_some(),
+            fresh_transaction.is_some(),
+            "{label}: warm/fresh body identity presence diverged for {identity}\n"
+        );
+        if let (Some(warm_transaction), Some(fresh_transaction)) =
+            (warm_transaction, fresh_transaction)
+        {
+            assert!(
+                crate::transaction_equal(warm_transaction, fresh_transaction),
+                "{label}: exact BodyTransaction diverged for {identity}\n warm={warm_transaction:?}\n fresh={fresh_transaction:?}"
+            );
+        }
+    }
     match (warm, fresh) {
         (Ok(warm), Ok(fresh)) => {
             assert_eq!(
@@ -538,21 +586,11 @@ fn assert_warm_fresh_parity(
                 "{label}: warm/fresh semantic parity snapshot diverged"
             );
 
-            let warm_bodies = successful_body_transactions(warm_session, warm);
-            let fresh_bodies = successful_body_transactions(fresh_session, fresh);
-            assert_eq!(
-                warm_bodies.keys().collect::<Vec<_>>(),
-                fresh_bodies.keys().collect::<Vec<_>>(),
-                "{label}: warm/fresh retained body identities diverged"
-            );
-            for name in warm_bodies.keys() {
-                assert!(
-                    crate::transaction_equal(&warm_bodies[name], &fresh_bodies[name]),
-                    "{label}: exact BodyTransaction diverged for {name}\n warm={:?}\n fresh={:?}",
-                    warm_bodies[name],
-                    fresh_bodies[name]
-                );
-            }
+            // Keep the public output check as a consistency assertion, not as
+            // the identity enumeration source. Every emitted function must
+            // also have exactly one observable retained body transaction.
+            assert_successful_output_body_presence(label, warm, &warm_bodies);
+            assert_successful_output_body_presence(label, fresh, &fresh_bodies);
 
             assert_eq!(
                 format!("{:?}", warm.functions()),
@@ -617,24 +655,46 @@ fn assert_warm_fresh_parity(
                 render_diagnostics(fresh),
                 "{label}: warm/fresh failure diagnostics diverged"
             );
-            let warm_bodies = warm_session.retained_body_transactions_for_test(body_names);
-            let fresh_bodies = fresh_session.retained_body_transactions_for_test(body_names);
-            assert_eq!(
-                warm_bodies.keys().collect::<Vec<_>>(),
-                fresh_bodies.keys().collect::<Vec<_>>(),
-                "{label}: warm/fresh failed-body identities diverged"
-            );
-            for name in warm_bodies.keys() {
-                assert!(
-                    crate::transaction_equal(&warm_bodies[name], &fresh_bodies[name]),
-                    "{label}: exact failed BodyTransaction diverged for {name}"
-                );
-            }
             assert_eq!(
                 format!("{:?}", warm_session.latest_diagnostics()),
                 format!("{:?}", fresh_session.latest_diagnostics()),
                 "{label}: ordered failure diagnostic snapshots diverged"
             );
+            // These are current-revision failure terminals, not intentionally
+            // retained last-good artifacts. Compare the complete deterministic
+            // failure subset explicitly; a fresh-side failure that disappears
+            // from the warm cache is a correctness failure, not a cache hit.
+            let warm_failures = warm_bodies
+                .iter()
+                .filter_map(|(identity, transaction)| {
+                    matches!(
+                        transaction,
+                        Some(crate::BodyTransaction::DeterministicFailure { .. })
+                    )
+                    .then(|| (identity.clone(), transaction.as_ref().unwrap().clone()))
+                })
+                .collect::<BTreeMap<_, _>>();
+            let fresh_failures = fresh_bodies
+                .iter()
+                .filter_map(|(identity, transaction)| {
+                    matches!(
+                        transaction,
+                        Some(crate::BodyTransaction::DeterministicFailure { .. })
+                    )
+                    .then(|| (identity.clone(), transaction.as_ref().unwrap().clone()))
+                })
+                .collect::<BTreeMap<_, _>>();
+            assert_eq!(
+                warm_failures.keys().collect::<Vec<_>>(),
+                fresh_failures.keys().collect::<Vec<_>>(),
+                "{label}: failed body identity presence diverged"
+            );
+            for identity in warm_failures.keys() {
+                assert!(
+                    crate::transaction_equal(&warm_failures[identity], &fresh_failures[identity]),
+                    "{label}: exact failed BodyTransaction diverged for {identity}"
+                );
+            }
         }
         (Ok(_), Err(fresh)) => panic!(
             "{label}: warm compiled but fresh failed:\n{}",
@@ -1505,7 +1565,6 @@ impl EditScenario {
             &mut fresh,
             &rev2_source,
             &options,
-            body_names,
             &warm_rev2,
             &fresh_rev2,
         );
@@ -1546,12 +1605,19 @@ fn corpus_body_names(reached_bodies: usize) -> Vec<String> {
 /// the scaling rows. The exact oracle is deliberately shared by all of these
 /// cases so a new edit shape cannot accidentally fall back to comparing only a
 /// root semantic projection.
+struct SourceEditOracle {
+    changed: BTreeSet<String>,
+    before_states: BTreeMap<String, Option<crate::BodyTransaction>>,
+    warm_states: BTreeMap<String, Option<crate::BodyTransaction>>,
+    fresh_states: BTreeMap<String, Option<crate::BodyTransaction>>,
+}
+
 fn run_source_edit(
     label: &str,
     rev1_source: &str,
     rev2_source: &str,
     body_names: &[&str],
-) -> BTreeSet<String> {
+) -> SourceEditOracle {
     let options = CompileOptions::default();
     let rev1 = SourceSnapshot::single("main.rue", rev1_source).unwrap();
     let rev2 = SourceSnapshot::single("main.rue", rev2_source).unwrap();
@@ -1564,24 +1630,42 @@ fn run_source_edit(
     warm.update(&rev1).into_result().unwrap();
     warm.canonical_semantic(&options).ok();
     let before = warm.retained_body_transaction_origins_for_test(&body_names);
+    let before_states = warm.retained_body_identity_states_for_test(&options);
     warm.update(&rev2).into_result().unwrap();
     let warm_result = warm.canonical_semantic(&options);
     let after = warm.retained_body_transaction_origins_for_test(&body_names);
+    let warm_states = warm.retained_body_identity_states_for_test(&options);
 
     let mut fresh = CompilerSession::new();
     fresh.update(&rev2).into_result().unwrap();
     let fresh_result = fresh.canonical_semantic(&options);
+    let fresh_states = fresh.retained_body_identity_states_for_test(&options);
     assert_warm_fresh_parity(
         label,
         &mut warm,
         &mut fresh,
         &rev2,
         &options,
-        &body_names,
         &warm_result,
         &fresh_result,
     );
-    changed_body_origins(&before, &after)
+    SourceEditOracle {
+        changed: changed_body_origins(&before, &after),
+        before_states,
+        warm_states,
+        fresh_states,
+    }
+}
+
+fn named_state<'a>(
+    states: &'a BTreeMap<String, Option<crate::BodyTransaction>>,
+    name: &str,
+) -> Option<&'a Option<crate::BodyTransaction>> {
+    let name = format!("name: \"{name}\"");
+    states
+        .iter()
+        .find(|(identity, _)| identity.contains(&name))
+        .map(|(_, state)| state)
 }
 
 fn import_source(
@@ -1846,7 +1930,6 @@ fn invalidation_single_body_edit_declaration_work_does_not_rerun() {
         &mut fresh,
         &rev2_snap,
         &options,
-        &body_names,
         &warm_rev2,
         &fresh_rev2,
     );
@@ -1931,7 +2014,6 @@ fn main() -> i32 { left() + right() + control() }
         &mut fresh,
         &rev2_snap,
         &options,
-        &body_names,
         &warm_rev2,
         &fresh_rev2,
     );
@@ -2012,7 +2094,6 @@ fn invalidation_negative_lookup_becoming_positive_invalidates_consumers() {
         &mut fresh,
         &rev2_snap,
         &options,
-        &body_names,
         &warm_rev2,
         &fresh_rev2,
     );
@@ -2073,7 +2154,7 @@ fn correctness_oracle_noop_edit_preserves_every_body_terminal() {
     let source = "fn isolated() -> i32 { 1 }\nfn main() -> i32 { isolated() }\n";
     let changed = run_source_edit("no-op edit", source, source, &["isolated", "main"]);
     assert!(
-        changed.is_empty(),
+        changed.changed.is_empty(),
         "a no-op must retain every body terminal"
     );
 }
@@ -2169,6 +2250,24 @@ fn counter_lifecycle_covers_cold_unrelated_edit_changed_body_and_deletion() {
 }
 
 #[test]
+#[should_panic(expected = "successful output body identity is absent or ambiguous")]
+fn correctness_oracle_rejects_missing_successful_body_transaction() {
+    let options = CompileOptions::default();
+    let source = SourceSnapshot::single("main.rue", "fn main() -> i32 { 0 }\n").unwrap();
+    let mut session = CompilerSession::new();
+    session.update(&source).into_result().unwrap();
+    let output = session.canonical_semantic(&options).unwrap();
+    let mut states = session.retained_body_identity_states_for_test(&options);
+    let main_identity = states
+        .keys()
+        .find(|identity| identity.contains("main"))
+        .cloned()
+        .expect("main body identity is retained");
+    states.remove(&main_identity);
+    assert_successful_output_body_presence("missing retained body regression", &output, &states);
+}
+
+#[test]
 fn correctness_oracle_signature_edit_follows_transitive_fanout() {
     let rev1 = "fn leaf() -> i32 { 1 }\nfn middle() -> i32 { leaf() }\nfn control() -> i32 { 9 }\nfn main() -> i32 { middle() }\n";
     let rev2 = "fn leaf() -> i64 { 1 }\nfn middle() -> i64 { leaf() }\nfn control() -> i32 { 9 }\nfn main() -> i64 { middle() }\n";
@@ -2179,7 +2278,7 @@ fn correctness_oracle_signature_edit_follows_transitive_fanout() {
         &["leaf", "middle", "control", "main"],
     );
     assert_eq!(
-        changed,
+        changed.changed,
         BTreeSet::from(["leaf".to_owned(), "middle".to_owned(), "main".to_owned()]),
         "signature changes must reach direct and transitive consumers, not control"
     );
@@ -2191,14 +2290,37 @@ fn correctness_oracle_diagnostic_introduce_and_repair() {
     let bad = "fn helper() -> i32 { 1 }\nfn main() -> i32 { missing() }\n";
     let repaired = run_source_edit("diagnostic introduce", good, bad, &["main"]);
     assert!(
-        repaired.contains("main"),
+        repaired.changed.contains("main"),
         "introducing a missing lookup must replace the consumer body terminal"
+    );
+    assert!(
+        named_state(&repaired.before_states, "main")
+            .and_then(Option::as_ref)
+            .is_some(),
+        "diagnostic introduction must start with a successful main transaction"
+    );
+    assert_eq!(
+        named_state(&repaired.warm_states, "main").map(|state| matches!(
+            state,
+            Some(crate::BodyTransaction::DeterministicFailure { .. })
+        )),
+        named_state(&repaired.fresh_states, "main").map(|state| matches!(
+            state,
+            Some(crate::BodyTransaction::DeterministicFailure { .. })
+        )),
+        "failed main terminal availability must match warm and fresh"
     );
 
     let repaired = run_source_edit("diagnostic repair", bad, good, &["helper", "main"]);
     assert!(
-        repaired.contains("main"),
+        repaired.changed.contains("main"),
         "repairing a missing lookup must publish a fresh successful consumer terminal"
+    );
+    assert!(named_state(&repaired.warm_states, "helper").is_some());
+    assert!(
+        named_state(&repaired.warm_states, "main")
+            .and_then(Option::as_ref)
+            .is_some()
     );
 }
 
@@ -2211,23 +2333,91 @@ fn correctness_oracle_rename_delete_and_visibility_edits() {
         &["renamed", "main"],
     );
     assert!(
-        renamed.contains("main"),
+        renamed.changed.contains("main"),
         "renaming a declaration and its call site must refresh the consumer"
     );
-
-    let _deleted = run_source_edit(
-        "unused declaration deletion",
-        "fn unused() -> i32 { 1 }\nfn main() -> i32 { 0 }\n",
-        "fn main() -> i32 { 0 }\n",
-        &["main"],
+    assert!(
+        named_state(&renamed.before_states, "helper")
+            .and_then(Option::as_ref)
+            .is_some()
+    );
+    assert!(
+        named_state(&renamed.warm_states, "renamed")
+            .and_then(Option::as_ref)
+            .is_some()
+    );
+    assert!(
+        named_state(&renamed.warm_states, "helper")
+            .and_then(Option::as_ref)
+            .is_none()
     );
 
-    let _visibility = run_source_edit(
+    let deleted = run_source_edit(
+        "unused declaration deletion",
+        "fn unused() -> i32 { 1 }\nfn main() -> i32 { unused() }\n",
+        "fn main() -> i32 { 0 }\n",
+        &["unused", "main"],
+    );
+    assert!(
+        named_state(&deleted.before_states, "unused")
+            .and_then(Option::as_ref)
+            .is_some()
+    );
+    assert!(
+        named_state(&deleted.warm_states, "unused")
+            .and_then(Option::as_ref)
+            .is_none()
+    );
+    assert!(
+        named_state(&deleted.fresh_states, "unused")
+            .and_then(Option::as_ref)
+            .is_none()
+    );
+
+    let unreachable = run_source_edit(
+        "reached body becomes unreachable",
+        "fn hidden() -> i32 { 1 }\nfn main() -> i32 { hidden() }\n",
+        "fn hidden() -> i32 { 1 }\nfn main() -> i32 { 0 }\n",
+        &["hidden", "main"],
+    );
+    // The source declaration remains valid, so a warm session may retain its
+    // unchanged transaction even though a fresh rooted compile never reaches
+    // it. Keep that retained-key case visible; deletion below requires the
+    // stronger non-observability assertion.
+    assert!(
+        named_state(&unreachable.before_states, "hidden")
+            .and_then(Option::as_ref)
+            .is_some()
+    );
+    assert!(
+        named_state(&unreachable.warm_states, "hidden")
+            .and_then(Option::as_ref)
+            .is_some()
+    );
+    assert!(
+        named_state(&unreachable.fresh_states, "hidden")
+            .and_then(Option::as_ref)
+            .is_none()
+    );
+
+    let visibility = run_source_edit(
         "visibility edit",
         "fn helper() -> i32 { 1 }\nfn main() -> i32 { helper() }\n",
         "pub fn helper() -> i32 { 1 }\nfn main() -> i32 { helper() }\n",
         &["helper", "main"],
     );
+    for name in ["helper", "main"] {
+        assert!(
+            named_state(&visibility.warm_states, name)
+                .and_then(Option::as_ref)
+                .is_some()
+        );
+        assert!(
+            named_state(&visibility.fresh_states, name)
+                .and_then(Option::as_ref)
+                .is_some()
+        );
+    }
 }
 
 #[test]
@@ -2260,7 +2450,6 @@ fn correctness_oracle_import_edit_compares_imported_body_and_linked_bytes() {
         &mut fresh,
         &rev2,
         &options,
-        &["value".to_owned(), "main".to_owned()],
         &warm_result,
         &fresh_result,
     );

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -7215,6 +7215,8 @@ impl CompilerSession {
                         }
                         _ => false,
                     };
+                    let attempted_before = queried_body_work.bodies_attempted;
+                    let had_retained_body = self.queries.revisioned.has_retained_body_key(&key);
                     let transaction = self.queries.revisioned.body_transaction(
                         runtime_revision,
                         key.clone(),
@@ -7225,6 +7227,10 @@ impl CompilerSession {
                         cancellation.clone(),
                         |selected_anonymous, well_known| {
                             queried_body_work.bodies_attempted += 1;
+                            queried_body_work.body_analyses_computed += 1;
+                            if had_retained_body {
+                                queried_body_work.body_analyses_invalidated += 1;
+                            }
                             // Every cold reached-body analysis re-prepares,
                             // re-projects, and re-installs the entire declaration
                             // universe inside `analyze_body_query` before it
@@ -7278,9 +7284,19 @@ impl CompilerSession {
                             // work (whatever actually ran) into the running total.
                             let context = &mut queried_body_work.per_body_declaration_context;
                             context.cold_body_preparations += stage_context.cold_body_preparations;
+                            context.declarations_inspected += stage_context.declarations_inspected;
+                            context.modules_registered += stage_context.modules_registered;
+                            context.rir_indexes_constructed +=
+                                stage_context.rir_indexes_constructed;
+                            context.rir_instructions_visited +=
+                                stage_context.rir_instructions_visited;
                             context.shells_prepared += stage_context.shells_prepared;
                             context.semantics_installed += stage_context.semantics_installed;
                             context.projections_performed += stage_context.projections_performed;
+                            context.durable_source_records_inspected +=
+                                stage_context.durable_source_records_inspected;
+                            context.durable_source_records_copied +=
+                                stage_context.durable_source_records_copied;
                             context.endpoints_installed += stage_context.endpoints_installed;
                             match &transaction {
                                 Ok(crate::body_query::BodyTransaction::Success {
@@ -7406,6 +7422,13 @@ impl CompilerSession {
                             abort,
                         )) => return Err(SemanticRequestControl::Abort(abort)),
                     };
+                    if queried_body_work.bodies_attempted == attempted_before {
+                        // The body transaction returned a retained terminal
+                        // without entering the production analysis closure.
+                        // Count this at the query boundary so durable AIR
+                        // imports and query-terminal reuse remain distinct.
+                        queried_body_work.body_analyses_reused += 1;
+                    }
                     let rue_query::QueryOutcome::Success(transaction) = transaction.outcome()
                     else {
                         unreachable!("BodyTransaction publishes typed values")
@@ -12292,7 +12315,17 @@ mod tests {
             ordinary.work().binding.declaration_resolution_invocations,
             0
         );
-        assert_eq!(reused.work().body_analysis, ordinary.work().body_analysis);
+        let warm_body_work = reused.work().body_analysis;
+        let fresh_body_work = ordinary.work().body_analysis;
+        assert_eq!(warm_body_work.body_analyses_computed, 1);
+        assert_eq!(warm_body_work.body_analyses_reused, 0);
+        assert_eq!(warm_body_work.body_analyses_invalidated, 1);
+        assert_eq!(fresh_body_work.body_analyses_computed, 1);
+        assert_eq!(fresh_body_work.body_analyses_reused, 0);
+        assert_eq!(fresh_body_work.body_analyses_invalidated, 0);
+        let mut normalized_warm_body_work = warm_body_work;
+        normalized_warm_body_work.body_analyses_invalidated = 0;
+        assert_eq!(normalized_warm_body_work, fresh_body_work);
         assert_eq!(
             format!("{:?}", reused.functions()),
             format!("{:?}", ordinary.functions())

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -10340,6 +10340,45 @@ impl CompilerSession {
             .revisioned
             .retained_body_transaction_origins_for_test(revision, names)
     }
+
+    /// Return the actual retained ordinary-body transaction values for test
+    /// oracles. This deliberately bypasses the aggregate semantic root so a
+    /// warm/fresh comparison checks each body's body, references, produced
+    /// nominals, and deterministic failure payload directly.
+    pub(crate) fn retained_body_transactions_for_test(
+        &self,
+        names: &[String],
+    ) -> BTreeMap<String, crate::BodyTransaction> {
+        let revision = self
+            .queries
+            .revisioned
+            .current_semantic_revision()
+            .expect("the acceptance corpus has a semantic revision");
+        self.queries
+            .revisioned
+            .retained_body_transactions_for_test(revision, names)
+    }
+
+    /// Return one exact retained body transaction using the complete semantic
+    /// function-instance identity. This includes specialized and anonymous
+    /// bodies that have no ordinary declaration name.
+    pub(crate) fn retained_body_transaction_for_test(
+        &self,
+        options: &CompileOptions,
+        instance: &crate::FunctionInstanceKey,
+    ) -> Option<crate::BodyTransaction> {
+        let revision = self.queries.revisioned.current_semantic_revision()?;
+        let key = crate::body_query::BodyQueryKey {
+            instance: instance.clone(),
+            configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration {
+                target: options.target,
+                preview_features: StablePreviewFeatures::new(&options.preview_features),
+            },
+        };
+        self.queries
+            .revisioned
+            .retained_body_transaction_for_test(revision, key)
+    }
 }
 
 #[cfg(test)]

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -12323,9 +12323,60 @@ mod tests {
         assert_eq!(fresh_body_work.body_analyses_computed, 1);
         assert_eq!(fresh_body_work.body_analyses_reused, 0);
         assert_eq!(fresh_body_work.body_analyses_invalidated, 0);
-        let mut normalized_warm_body_work = warm_body_work;
-        normalized_warm_body_work.body_analyses_invalidated = 0;
-        assert_eq!(normalized_warm_body_work, fresh_body_work);
+        assert_eq!(
+            warm_body_work.body_analyses_computed, fresh_body_work.body_analyses_computed,
+            "warm and fresh must compute the same number of bodies"
+        );
+        assert_eq!(
+            warm_body_work.body_analyses_reused, fresh_body_work.body_analyses_reused,
+            "warm and fresh must report the same reuse count"
+        );
+        assert_eq!(
+            warm_body_work.body_analyses_invalidated,
+            fresh_body_work.body_analyses_invalidated + 1,
+            "warm has one intentional invalidation delta for its retained predecessor"
+        );
+        assert_eq!(
+            warm_body_work.per_body_declaration_context,
+            fresh_body_work.per_body_declaration_context,
+            "all declaration/module/RIR body-context work must match"
+        );
+        assert_eq!(
+            warm_body_work.bodies_attempted, fresh_body_work.bodies_attempted,
+            "warm and fresh must attempt the same bodies"
+        );
+        assert_eq!(
+            warm_body_work.bodies_succeeded, fresh_body_work.bodies_succeeded,
+            "warm and fresh must succeed for the same bodies"
+        );
+        assert_eq!(
+            warm_body_work.air_instructions_produced, fresh_body_work.air_instructions_produced,
+            "warm and fresh must produce the same AIR instruction count"
+        );
+        assert_eq!(
+            warm_body_work.local_strings_produced, fresh_body_work.local_strings_produced,
+            "warm and fresh must produce the same local string count"
+        );
+        assert_eq!(
+            warm_body_work.ordinary_body_exports_attempted,
+            fresh_body_work.ordinary_body_exports_attempted,
+            "warm and fresh must attempt the same ordinary exports"
+        );
+        assert_eq!(
+            warm_body_work.ordinary_body_exports_succeeded,
+            fresh_body_work.ordinary_body_exports_succeeded,
+            "warm and fresh must succeed for the same ordinary exports"
+        );
+        assert_eq!(
+            warm_body_work.specialized_bodies_attempted,
+            fresh_body_work.specialized_bodies_attempted,
+            "warm and fresh must attempt the same specialized bodies"
+        );
+        assert_eq!(
+            warm_body_work.specialized_bodies_succeeded,
+            fresh_body_work.specialized_bodies_succeeded,
+            "warm and fresh must succeed for the same specialized bodies"
+        );
         assert_eq!(
             format!("{:?}", reused.functions()),
             format!("{:?}", ordinary.functions())

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -10364,43 +10364,27 @@ impl CompilerSession {
             .retained_body_transaction_origins_for_test(revision, names)
     }
 
-    /// Return the actual retained ordinary-body transaction values for test
-    /// oracles. This deliberately bypasses the aggregate semantic root so a
-    /// warm/fresh comparison checks each body's body, references, produced
-    /// nominals, and deterministic failure payload directly.
-    pub(crate) fn retained_body_transactions_for_test(
-        &self,
-        names: &[String],
-    ) -> BTreeMap<String, crate::BodyTransaction> {
-        let revision = self
-            .queries
-            .revisioned
-            .current_semantic_revision()
-            .expect("the acceptance corpus has a semantic revision");
-        self.queries
-            .revisioned
-            .retained_body_transactions_for_test(revision, names)
-    }
-
-    /// Return one exact retained body transaction using the complete semantic
-    /// function-instance identity. This includes specialized and anonymous
-    /// bodies that have no ordinary declaration name.
-    pub(crate) fn retained_body_transaction_for_test(
+    /// Snapshot every retained body identity and its current observable
+    /// transaction for the correctness oracle. The map includes stale cache
+    /// identities with `None` when invalidation has made their terminal
+    /// unobservable at the current revision.
+    #[allow(dead_code)]
+    pub(crate) fn retained_body_identity_states_for_test(
         &self,
         options: &CompileOptions,
-        instance: &crate::FunctionInstanceKey,
-    ) -> Option<crate::BodyTransaction> {
-        let revision = self.queries.revisioned.current_semantic_revision()?;
-        let key = crate::body_query::BodyQueryKey {
-            instance: instance.clone(),
-            configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration {
-                target: options.target,
-                preview_features: StablePreviewFeatures::new(&options.preview_features),
-            },
+    ) -> BTreeMap<String, Option<crate::BodyTransaction>> {
+        let Some(revision) = self.queries.revisioned.current_semantic_revision() else {
+            return BTreeMap::new();
         };
         self.queries
             .revisioned
-            .retained_body_transaction_for_test(revision, key)
+            .retained_body_identity_states_for_test(
+                revision,
+                crate::semantic_query_nucleus::SemanticQueryConfiguration {
+                    target: options.target,
+                    preview_features: StablePreviewFeatures::new(&options.preview_features),
+                },
+            )
     }
 }
 

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1277,6 +1277,7 @@ impl MetricsSnapshot {
 fn semantic_work_json(work: &crate::session::CompilerSessionWork, from: usize) -> Value {
     let records = &work.semantic_records[from..];
     json!({
+        "schema_version": 1,
         "failed_requests": records.iter().filter(|record| record.failure.is_some()).count(),
         "failure_phases": {
             "declaration": records.iter().filter(|record| matches!(record.failure.map(|failure| failure.phase), Some(SemanticFailurePhase::Declaration))).count(),
@@ -1304,8 +1305,10 @@ fn semantic_work_json(work: &crate::session::CompilerSessionWork, from: usize) -
             "rir_instructions_visited": records.iter().map(|record| record.work.body_analysis.per_body_declaration_context.rir_instructions_visited).sum::<usize>(),
             "shells_prepared": records.iter().map(|record| record.work.body_analysis.per_body_declaration_context.shells_prepared).sum::<usize>(),
             "semantics_installed": records.iter().map(|record| record.work.body_analysis.per_body_declaration_context.semantics_installed).sum::<usize>(),
+            "projections_performed": records.iter().map(|record| record.work.body_analysis.per_body_declaration_context.projections_performed).sum::<usize>(),
             "durable_source_records_inspected": records.iter().map(|record| record.work.body_analysis.per_body_declaration_context.durable_source_records_inspected).sum::<usize>(),
             "durable_source_records_copied": records.iter().map(|record| record.work.body_analysis.per_body_declaration_context.durable_source_records_copied).sum::<usize>(),
+            "endpoints_installed": records.iter().map(|record| record.work.body_analysis.per_body_declaration_context.endpoints_installed).sum::<usize>(),
         },
         "bodies_succeeded": records.iter().map(|record| record.work.body_analysis.bodies_succeeded).sum::<usize>(),
         "bodies_failed": records.iter().map(|record| record.work.body_analysis.bodies_failed).sum::<usize>(),

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1058,6 +1058,10 @@ impl LowerMetrics {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct SemanticBindingMetrics {
     pub bind_invocations: usize,
+    pub declarations_inspected: usize,
+    pub modules_registered: usize,
+    pub rir_indexes_constructed: usize,
+    pub rir_instructions_visited: usize,
 }
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct SemanticManifestMetrics {
@@ -1068,11 +1072,28 @@ pub struct SemanticCfgMetrics {
     pub cfg_builds_attempted: usize,
     pub cfg_builds_succeeded: usize,
     pub cfg_builds_failed: usize,
+    pub cfg_import_attempts: usize,
+    pub cfg_import_successes: usize,
+    pub cfg_import_failures: usize,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SemanticBodyMetrics {
+    pub analyses_computed: usize,
+    pub analyses_reused: usize,
+    pub analyses_invalidated: usize,
+    pub declarations_inspected: usize,
+    pub modules_registered: usize,
+    pub rir_indexes_constructed: usize,
+    pub rir_instructions_visited: usize,
+    pub durable_source_records_inspected: usize,
+    pub durable_source_records_copied: usize,
 }
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct SemanticMetrics {
     pub binding: SemanticBindingMetrics,
     pub manifest: SemanticManifestMetrics,
+    pub body: SemanticBodyMetrics,
     pub cfg: SemanticCfgMetrics,
 }
 
@@ -1081,14 +1102,50 @@ impl SemanticMetrics {
         Self {
             binding: SemanticBindingMetrics {
                 bind_invocations: work.binding.bind_invocations,
+                declarations_inspected: work.binding.indexed_declaration_records_visited,
+                modules_registered: work.binding.modules_registered,
+                rir_indexes_constructed: work.declaration_index.build_invocations,
+                rir_instructions_visited: work.declaration_index.rir_instructions_visited,
             },
             manifest: SemanticManifestMetrics {
                 build_invocations: work.manifest.build_invocations,
+            },
+            body: SemanticBodyMetrics {
+                analyses_computed: work.body_analysis.body_analyses_computed,
+                analyses_reused: work.body_analysis.body_analyses_reused,
+                analyses_invalidated: work.body_analysis.body_analyses_invalidated,
+                declarations_inspected: work
+                    .body_analysis
+                    .per_body_declaration_context
+                    .declarations_inspected,
+                modules_registered: work
+                    .body_analysis
+                    .per_body_declaration_context
+                    .modules_registered,
+                rir_indexes_constructed: work
+                    .body_analysis
+                    .per_body_declaration_context
+                    .rir_indexes_constructed,
+                rir_instructions_visited: work
+                    .body_analysis
+                    .per_body_declaration_context
+                    .rir_instructions_visited,
+                durable_source_records_inspected: work
+                    .body_analysis
+                    .per_body_declaration_context
+                    .durable_source_records_inspected,
+                durable_source_records_copied: work
+                    .body_analysis
+                    .per_body_declaration_context
+                    .durable_source_records_copied,
             },
             cfg: SemanticCfgMetrics {
                 cfg_builds_attempted: work.cfg.cfg_builds_attempted,
                 cfg_builds_succeeded: work.cfg.cfg_builds_succeeded,
                 cfg_builds_failed: work.cfg.cfg_builds_failed,
+                cfg_import_attempts: work.cfg.cfg_import_attempts,
+                cfg_import_successes: work.cfg.cfg_import_successes,
+                cfg_import_failures: work.cfg.cfg_import_failures,
             },
         }
     }
@@ -1230,12 +1287,25 @@ fn semantic_work_json(work: &crate::session::CompilerSessionWork, from: usize) -
         "declaration_resolution_invocations": records.iter().map(|record| record.work.binding.declaration_resolution_invocations).sum::<usize>(),
         "declaration_resolution_failures": records.iter().map(|record| record.work.binding.declaration_resolution_failures).sum::<usize>(),
         "body_readiness_finalization_invocations": records.iter().map(|record| record.work.binding.body_readiness_finalization_invocations).sum::<usize>(),
+        "declarations_inspected": records.iter().map(|record| record.work.binding.indexed_declaration_records_visited).sum::<usize>(),
+        "modules_registered": records.iter().map(|record| record.work.binding.modules_registered).sum::<usize>(),
+        "rir_indexes_constructed": records.iter().map(|record| record.work.declaration_index.build_invocations).sum::<usize>(),
+        "rir_instructions_visited": records.iter().map(|record| record.work.declaration_index.rir_instructions_visited).sum::<usize>(),
         "body_free_function_lookups": records.iter().map(|record| record.work.body_analysis.free_function_record_lookups).sum::<usize>(),
+        "body_analyses_computed": records.iter().map(|record| record.work.body_analysis.body_analyses_computed).sum::<usize>(),
+        "body_analyses_reused": records.iter().map(|record| record.work.body_analysis.body_analyses_reused).sum::<usize>(),
+        "body_analyses_invalidated": records.iter().map(|record| record.work.body_analysis.body_analyses_invalidated).sum::<usize>(),
         "bodies_attempted": records.iter().map(|record| record.work.body_analysis.bodies_attempted).sum::<usize>(),
         "per_body_declaration_context": {
             "cold_body_preparations": records.iter().map(|record| record.work.body_analysis.per_body_declaration_context.cold_body_preparations).sum::<usize>(),
+            "declarations_inspected": records.iter().map(|record| record.work.body_analysis.per_body_declaration_context.declarations_inspected).sum::<usize>(),
+            "modules_registered": records.iter().map(|record| record.work.body_analysis.per_body_declaration_context.modules_registered).sum::<usize>(),
+            "rir_indexes_constructed": records.iter().map(|record| record.work.body_analysis.per_body_declaration_context.rir_indexes_constructed).sum::<usize>(),
+            "rir_instructions_visited": records.iter().map(|record| record.work.body_analysis.per_body_declaration_context.rir_instructions_visited).sum::<usize>(),
             "shells_prepared": records.iter().map(|record| record.work.body_analysis.per_body_declaration_context.shells_prepared).sum::<usize>(),
             "semantics_installed": records.iter().map(|record| record.work.body_analysis.per_body_declaration_context.semantics_installed).sum::<usize>(),
+            "durable_source_records_inspected": records.iter().map(|record| record.work.body_analysis.per_body_declaration_context.durable_source_records_inspected).sum::<usize>(),
+            "durable_source_records_copied": records.iter().map(|record| record.work.body_analysis.per_body_declaration_context.durable_source_records_copied).sum::<usize>(),
         },
         "bodies_succeeded": records.iter().map(|record| record.work.body_analysis.bodies_succeeded).sum::<usize>(),
         "bodies_failed": records.iter().map(|record| record.work.body_analysis.bodies_failed).sum::<usize>(),
@@ -1295,6 +1365,9 @@ fn semantic_work_json(work: &crate::session::CompilerSessionWork, from: usize) -
             "builds_attempted": records.iter().map(|record| record.work.cfg.cfg_builds_attempted).sum::<usize>(),
             "builds_succeeded": records.iter().map(|record| record.work.cfg.cfg_builds_succeeded).sum::<usize>(),
             "builds_failed": records.iter().map(|record| record.work.cfg.cfg_builds_failed).sum::<usize>(),
+            "import_attempts": records.iter().map(|record| record.work.cfg.cfg_import_attempts).sum::<usize>(),
+            "import_successes": records.iter().map(|record| record.work.cfg.cfg_import_successes).sum::<usize>(),
+            "import_failures": records.iter().map(|record| record.work.cfg.cfg_import_failures).sum::<usize>(),
             "air_instructions_consumed": records.iter().map(|record| record.work.cfg.air_instructions_consumed).sum::<usize>(),
             "optimization_attempts": records.iter().map(|record| record.work.cfg.optimization_attempts).sum::<usize>(),
             "optimization_completions": records.iter().map(|record| record.work.cfg.optimization_completions).sum::<usize>(),
@@ -1302,9 +1375,6 @@ fn semantic_work_json(work: &crate::session::CompilerSessionWork, from: usize) -
             "warnings_emitted": records.iter().map(|record| record.work.cfg.cfg_warnings_emitted).sum::<usize>(),
             "implicit_destructor_targets_emitted": records.iter().map(|record| record.work.cfg.implicit_destructor_targets_emitted).sum::<usize>(),
             "reuse_candidates": records.iter().map(|record| record.work.cfg.cfg_reuse_candidates).sum::<usize>(),
-            "import_attempts": records.iter().map(|record| record.work.cfg.cfg_import_attempts).sum::<usize>(),
-            "import_successes": records.iter().map(|record| record.work.cfg.cfg_import_successes).sum::<usize>(),
-            "import_failures": records.iter().map(|record| record.work.cfg.cfg_import_failures).sum::<usize>(),
             "reuses": records.iter().map(|record| record.work.cfg.cfg_reuses).sum::<usize>(),
             "fallbacks": records.iter().map(|record| record.work.cfg.cfg_fallbacks).sum::<usize>(),
             "warnings_reused": records.iter().map(|record| record.work.cfg.cfg_warnings_reused).sum::<usize>(),

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -1869,6 +1869,18 @@ where
         lock(&self.inner.nodes).keys().any(|key| predicate(key))
     }
 
+    /// Whether the exact key currently owns a live memo node in this family.
+    ///
+    /// "Retained" means that the key is still present in the family's memo
+    /// index. It does not mean that a terminal for the current revision is
+    /// valid, selected, or protected from eviction; those properties are
+    /// decided by the ordinary query request. This exact-key probe preserves
+    /// the memo node's lifetime semantics while using the index's O(1)
+    /// average-case lookup instead of enumerating every retained key.
+    pub fn contains_retained_key(&self, key: &K) -> bool {
+        lock(&self.inner.nodes).contains_key(key)
+    }
+
     /// Caller-owned provenance identities for every retained reusable terminal.
     pub fn retained_origin_request_ids(&self) -> BTreeSet<u64> {
         let nodes = lock(&self.inner.nodes)
@@ -3865,6 +3877,24 @@ mod tests {
         }
     }
 
+    static CONTAINS_HASH_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct CountingKey(u64);
+
+    impl std::hash::Hash for CountingKey {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            CONTAINS_HASH_CALLS.fetch_add(1, Ordering::Relaxed);
+            state.write_u64(self.0);
+        }
+    }
+
+    impl QueryKey for CountingKey {
+        fn stable_identity(&self) -> String {
+            self.0.to_string()
+        }
+    }
+
     fn revision(id: u64) -> Revision {
         Revision::new(id, id)
     }
@@ -3878,6 +3908,51 @@ mod tests {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         key.hash(&mut hasher);
         hasher.finish()
+    }
+
+    #[test]
+    fn exact_retained_key_probe_uses_hash_lookup_not_predicate_enumeration() {
+        let runtime = QueryRuntime::new(1);
+        publish_empty(&runtime, [revision(1)]);
+        let family = runtime
+            .family::<CountingKey, u64>("exact-retained-key", 128)
+            .unwrap();
+        for key in 0..64 {
+            runtime
+                .query(
+                    &family,
+                    revision(1),
+                    CountingKey(key),
+                    CancellationToken::new(),
+                    move |_| Ok(QueryOutput::success(key)),
+                )
+                .unwrap();
+        }
+
+        CONTAINS_HASH_CALLS.store(0, Ordering::Relaxed);
+        assert!(family.contains_retained_key(&CountingKey(63)));
+        assert_eq!(
+            CONTAINS_HASH_CALLS.load(Ordering::Relaxed),
+            1,
+            "an exact retained-key probe hashes the requested key once"
+        );
+        assert!(!family.contains_retained_key(&CountingKey(64)));
+        assert_eq!(
+            CONTAINS_HASH_CALLS.load(Ordering::Relaxed),
+            2,
+            "a missing exact retained-key probe still performs one lookup"
+        );
+
+        let predicate_visits = AtomicUsize::new(0);
+        assert!(!family.any_retained_key(|_| {
+            predicate_visits.fetch_add(1, Ordering::Relaxed);
+            false
+        }));
+        assert_eq!(
+            predicate_visits.load(Ordering::Relaxed),
+            64,
+            "predicate enumeration visits the retained-key population"
+        );
     }
 
     fn publish_empty(runtime: &QueryRuntime, revisions: impl IntoIterator<Item = Revision>) {

--- a/docs/notes/rue-1091-measurement-results.md
+++ b/docs/notes/rue-1091-measurement-results.md
@@ -11,17 +11,24 @@ fixture matrix in [`benchmarks/value-audit/manifest.toml`](../../benchmarks/valu
 Its candidate baseline is the current production compiler. A historical
 pre-query revision is retained only as context; if it cannot consume the
 modern benchmark/session protocol, the runner uses a thin cold black-box
-compile fallback and records warm scenarios as unsupported. It is incorrect to
-call that historical result post-flip evidence or to backport the modern
-incrementality harness solely to make the comparison complete.
+compile fallback. Cross-protocol timing comparisons are indeterminate and
+missing required warm evidence is unsupported—not silently treated as zero
+work. A same-binary run is a protocol smoke only, not historical comparison
+evidence. It is incorrect to call that historical result post-flip evidence or
+to backport the modern incrementality harness solely to make the comparison
+complete.
 
 The value-audit gates are exact correctness/locality inputs, warm unrelated
 edit improvement of at least 50%, warm isolated body-edit improvement of at
 least 25%, claimed wins exceeding three times the larger MAD, cold wall/RSS
 regression no greater than `max(2%, 3 * larger MAD)`, repeated-edit RSS
 stabilization within a 5% band when a persistent-session protocol exists, and
-Caldera cold wall time at or below 300 seconds. The report records medians,
-MADs, hashes, host provenance, raw alternating samples, and unsupported cases.
+Caldera cold wall time at or below 300 seconds. Caldera process timeout includes
+only the manifest-pinned headroom beyond that gate so an over-budget compile is
+recorded as a failure. Cold RSS is part of the cold pair verdict, not a
+detached annotation. The report records medians, MADs, explicit role
+provenance, hashes, host provenance, raw alternating samples, and
+unsupported/indeterminate cases.
 
 This is the current-production value audit, not the activation ledger below.
 
@@ -89,8 +96,10 @@ TBD
 
 ## Notes and anomalies
 
-- Record retries, host contention, unavailable peak-RSS support, and any
-  `ALLOW_FAIL` result here.
+- Record retries, host contention, unavailable peak-RSS support, protocol
+  fallbacks, and any `ALLOW_FAIL` result here. The value-audit session schema
+  currently declares exact recompute/reuse identity sets unavailable; no
+  provider identity evidence is invented.
 - A non-flat RUE-1090 ratio is a failure even if wall time improves.
 - A historical-witness ceiling failure is a measurement blocker, not an
   ordinary activation result.

--- a/docs/notes/rue-1091-measurement-results.md
+++ b/docs/notes/rue-1091-measurement-results.md
@@ -1,4 +1,36 @@
-# RUE-1091 post-flip measurement results
+# RUE-1091 measurement ledger
+
+This file contains two deliberately separate evidence tracks. They must not
+be merged into one "before/after" claim.
+
+## Current-production value audit
+
+The reproducible user-value audit is run by
+[`scripts/rue-value-audit.py`](../../scripts/rue-value-audit.py), using the
+fixture matrix in [`benchmarks/value-audit/manifest.toml`](../../benchmarks/value-audit/manifest.toml).
+Its candidate baseline is the current production compiler. A historical
+pre-query revision is retained only as context; if it cannot consume the
+modern benchmark/session protocol, the runner uses a thin cold black-box
+compile fallback and records warm scenarios as unsupported. It is incorrect to
+call that historical result post-flip evidence or to backport the modern
+incrementality harness solely to make the comparison complete.
+
+The value-audit gates are exact correctness/locality inputs, warm unrelated
+edit improvement of at least 50%, warm isolated body-edit improvement of at
+least 25%, claimed wins exceeding three times the larger MAD, cold wall/RSS
+regression no greater than `max(2%, 3 * larger MAD)`, repeated-edit RSS
+stabilization within a 5% band when a persistent-session protocol exists, and
+Caldera cold wall time at or below 300 seconds. The report records medians,
+MADs, hashes, host provenance, raw alternating samples, and unsupported cases.
+
+This is the current-production value audit, not the activation ledger below.
+
+## Future post-flip activation evidence
+
+The staged gauntlet and result template below remain the authoritative plan for
+the future post-flip run. Stage 8/9 values must not be filled with a
+current-production value-audit row, and a pre-flip `ALLOW_FAIL` is only
+plumbing validation for that future gauntlet.
 
 Use this template for the authoritative run after the analyzer flip. The runner
 retains a `summary.tsv` plus one full log per stage:

--- a/scripts/rue-1091-measurement.sh
+++ b/scripts/rue-1091-measurement.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 #
-# Run the RUE-1091 post-flip measurement gauntlet.
+# Run the RUE-1091 future post-flip structural/activation gauntlet.
+#
+# This is not the current-production value audit. The reproducible value audit
+# has its own black-box runner in scripts/rue-value-audit.py so a historical
+# pre-query revision can remain contextual when it cannot consume this
+# post-flip harness.
 #
 # This script is intentionally orchestration only. The structural assertions
 # remain in the RUE-1090/RUE-1121 harnesses, and timing is never collected from

--- a/scripts/rue-value-audit.py
+++ b/scripts/rue-value-audit.py
@@ -1,0 +1,804 @@
+#!/usr/bin/env python3
+"""Run Rue's reproducible incrementality value audit.
+
+This is deliberately a black-box orchestration layer.  It does not inspect
+semantic/provider implementation details or interpret work-counter fields.
+The existing ``perf-baseline.py``, ``rue-compiler-session-bench``, and
+``rue-scaling-bench`` binaries remain the measurement owners; this script
+only supplies a common revision matrix, paired sampling policy, provenance,
+and a fail-closed report.
+
+The historical baseline is optional in practice: old binaries may not accept
+the current benchmark JSON protocol or may not have a session benchmark.  In
+that case the cold driver falls back to a timing-only black-box compile and
+warm scenarios are recorded as unsupported.  That keeps the old revision
+useful as context without backporting the modern incrementality harness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+import tomllib
+from typing import Any
+
+
+ROLES = ("historical_baseline", "current_production", "candidate")
+ROLE_LABELS = {
+    "historical_baseline": "historical baseline",
+    "current_production": "current production",
+    "candidate": "candidate",
+}
+PAIR_NAMES = (
+    ("historical_baseline", "current_production"),
+    ("current_production", "candidate"),
+)
+SCENARIOS = (
+    "cold",
+    "warm_no_op",
+    "warm_unrelated_declaration",
+    "warm_leaf_body",
+    "warm_signature_fanout",
+    "repeated_edit_memory",
+)
+
+WORKLOADS = (
+    {
+        "name": "synthetic",
+        "family": "synthetic",
+        "root": "benchmarks/stress/many_functions.rue",
+        "session_mode": "modules",
+        "session_modules": 128,
+        "description": "Generated declaration-volume and completion locality corpus.",
+    },
+    {
+        "name": "representative_multi_module",
+        "family": "representative",
+        "root": "benchmarks/scenarios/representative/main.rue",
+        "session_mode": "representative",
+        "description": "Tracked multi-module application-shaped fixture from benchmarks/manifest.toml.",
+    },
+    {
+        "name": "medium_ordinary_rue",
+        "family": "ordinary",
+        "root": "examples/quicksort.rue",
+        "description": "Ordinary medium Rue example; only fresh-driver scenarios are supported.",
+    },
+    {
+        "name": "caldera",
+        "family": "caldera",
+        "root": "examples/caldera/main.rue",
+        "description": "Large maintained application graph with a 300-second cold budget.",
+    },
+)
+
+THRESHOLDS = {
+    "warm_unrelated_declaration_improvement": 0.50,
+    "warm_leaf_body_improvement": 0.25,
+    "claimed_win_mad_multiplier": 3.0,
+    "cold_regression_fraction": 0.02,
+    "repeated_edit_rss_band": 0.05,
+    "caldera_wall_seconds": 300.0,
+}
+
+
+def load_perf_baseline(root: Path):
+    path = root / "scripts" / "perf-baseline.py"
+    spec = importlib.util.spec_from_file_location("rue_perf_baseline", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def sha256_paths(paths: list[Path], base: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted({path.resolve() for path in paths}):
+        if not path.is_file():
+            continue
+        try:
+            label = path.relative_to(base.resolve()).as_posix()
+        except ValueError:
+            label = str(path)
+        digest.update(label.encode())
+        digest.update(b"\0")
+        with path.open("rb") as stream:
+            for block in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(block)
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def git_value(directory: Path, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(directory), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def all_files(directory: Path) -> list[Path]:
+    return [
+        path
+        for path in directory.rglob("*")
+        if path.is_file() and ".git" not in path.parts
+    ]
+
+
+def source_provenance(source_dir: Path | None, root: Path, workload_root: Path) -> dict[str, Any]:
+    source_dir = (source_dir or root).resolve()
+    commit = git_value(source_dir, "rev-parse", "HEAD")
+    tree = git_value(source_dir, "rev-parse", "HEAD^{tree}")
+    if commit is not None:
+        tracked = git_value(source_dir, "ls-files", "-z")
+        if tracked is not None:
+            paths = [source_dir / item for item in tracked.split("\0") if item]
+        else:
+            paths = all_files(source_dir)
+    else:
+        paths = all_files(source_dir)
+    # A workload hash is kept separate from the complete source-tree identity;
+    # it makes an audit row reproducible even when unrelated repository files
+    # change between two operators' runs.
+    workload_paths = all_files(workload_root) if workload_root.is_dir() else [workload_root]
+    return {
+        "directory": str(source_dir),
+        "commit": commit,
+        "source_tree": tree,
+        "source_files_sha256": sha256_paths(paths, source_dir),
+        "workload_files_sha256": sha256_paths(workload_paths, root),
+    }
+
+
+def host_provenance() -> dict[str, Any]:
+    uname = platform.uname()
+    return {
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "python": platform.python_version(),
+        "logical_cpus": os.cpu_count(),
+        "uname": " ".join(part for part in uname if part),
+    }
+
+
+def load_audit_manifest(root: Path) -> dict[str, Any]:
+    path = root / "benchmarks" / "value-audit" / "manifest.toml"
+    with path.open("rb") as stream:
+        manifest = tomllib.load(stream)
+    if manifest.get("schema_version") != 1:
+        raise ValueError("value-audit manifest schema_version must be 1")
+    protocol = manifest.get("protocol")
+    if not isinstance(protocol, dict) or protocol.get("paired_samples") != 7 or protocol.get("warmup") != 1:
+        raise ValueError("value-audit manifest must pin one warmup and seven paired samples")
+    if protocol.get("measurement_profile") != "release":
+        raise ValueError("value-audit manifest must pin the release measurement profile")
+    source_manifest = path.parent / str(manifest.get("source_manifest", ""))
+    if source_manifest.resolve() != (root / "benchmarks" / "manifest.toml").resolve():
+        raise ValueError("value-audit manifest must reuse benchmarks/manifest.toml")
+    workloads = manifest.get("workload")
+    expected = {workload["name"] for workload in WORKLOADS}
+    if not isinstance(workloads, list) or {item.get("name") for item in workloads} != expected:
+        raise ValueError("value-audit manifest workload matrix drifted from the runner")
+    return manifest
+
+
+def median_mad(values: list[float]) -> dict[str, Any]:
+    if not values:
+        return {"available": False, "samples": [], "median": None, "mad": None}
+    median = statistics.median(values)
+    mad = statistics.median(abs(value - median) for value in values)
+    return {
+        "available": True,
+        "samples": values,
+        "median": median,
+        "mad": mad,
+    }
+
+
+def parse_role_mapping(values: list[str], label: str) -> dict[str, Path]:
+    result: dict[str, Path] = {}
+    for value in values:
+        role, separator, path = value.partition("=")
+        if not separator or role not in ROLES or not path:
+            raise argparse.ArgumentTypeError(
+                f"{label} must be ROLE=PATH for {', '.join(ROLES)}"
+            )
+        if role in result:
+            raise argparse.ArgumentTypeError(f"duplicate {label} entry for {role}")
+        result[role] = Path(path).expanduser().resolve()
+    return result
+
+
+def time_prefix() -> tuple[list[str], str]:
+    if Path("/usr/bin/time").exists():
+        if platform.system() == "Darwin":
+            return ["/usr/bin/time", "-l"], "darwin"
+        return ["/usr/bin/time", "-v"], "gnu"
+    return [], "none"
+
+
+def parse_rss(stderr: str, style: str) -> int | None:
+    if style == "darwin":
+        match = re.search(r"maximum resident set size:\s*(\d+)", stderr)
+        return int(match.group(1)) if match else None
+    if style == "gnu":
+        match = re.search(r"Maximum resident set size \(kbytes\):\s*(\d+)", stderr)
+        return int(match.group(1)) * 1024 if match else None
+    return None
+
+
+def run_command(command: list[str], timeout: float, env: dict[str, str]) -> dict[str, Any]:
+    prefix, style = time_prefix()
+    started = time.perf_counter_ns()
+    try:
+        result = subprocess.run(
+            prefix + command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise RuntimeError(f"command exceeded {timeout:g}s: {' '.join(command)}") from error
+    elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000
+    return {
+        "returncode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "wall_ms": elapsed_ms,
+        "peak_rss_bytes": parse_rss(result.stderr, style),
+        "command": command,
+    }
+
+
+def json_object(stdout: str) -> dict[str, Any] | None:
+    try:
+        value = json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def cold_sample(
+    binary: Path,
+    source: Path,
+    root: Path,
+    timeout: float,
+    jobs: int,
+    workdir: Path,
+) -> dict[str, Any]:
+    output = workdir / "audit-output"
+    output.unlink(missing_ok=True)
+    env = os.environ.copy()
+    env.pop("RUST_LOG", None)
+    env["RUE_STD_PATH"] = str(root / "std")
+    modern = [
+        str(binary),
+        "--benchmark-json",
+        "--jobs",
+        str(jobs),
+        "-O0",
+        str(source),
+        "-o",
+        str(output),
+    ]
+    result = run_command(modern, timeout, env)
+    payload = json_object(result["stdout"])
+    protocol = "benchmark_json"
+    if result["returncode"] != 0 or payload is None:
+        # Old pre-query revisions are allowed to use only the executable
+        # protocol.  Do not infer pass-level work from their human timing text.
+        output.unlink(missing_ok=True)
+        legacy = [str(binary), str(source), "-o", str(output)]
+        result = run_command(legacy, timeout, env)
+        payload = None
+        protocol = "black_box_compile"
+    if result["returncode"] != 0:
+        output.unlink(missing_ok=True)
+        detail = result["stderr"].strip() or result["stdout"].strip()
+        raise RuntimeError(f"compile failed ({result['returncode']}): {detail[-1200:]}")
+    if not output.is_file():
+        raise RuntimeError("compiler succeeded without producing an output artifact")
+    output_hash = sha256_file(output)
+    output_size = output.stat().st_size
+    output.unlink(missing_ok=True)
+    sample: dict[str, Any] = {
+        "protocol": protocol,
+        "wall_ms": result["wall_ms"],
+        "peak_rss_bytes": result["peak_rss_bytes"],
+        "output_sha256": output_hash,
+        "output_size_bytes": output_size,
+        "correctness": "exit_zero_and_output_present",
+    }
+    if payload is not None:
+        # Reuse perf-baseline's schema/aggregation validator for modern JSON.
+        # The audit keeps the raw payload as evidence, but does not duplicate
+        # its pass-nesting interpretation here.
+        perf_baseline = load_perf_baseline(root)
+        payload["_process_ms"] = result["wall_ms"]
+        sample["perf_baseline_aggregate"] = perf_baseline.aggregate([payload])
+        sample["compiler_ms"] = payload.get("total_ms")
+        sample["benchmark_json"] = payload
+    return sample
+
+
+SESSION_ROW_NAMES = {
+    "synthetic": {
+        "warm_no_op": "completion_exact_noop",
+        "warm_unrelated_declaration": "completion_unrelated_edit",
+        "warm_leaf_body": "completion_changed_reachable_body",
+        "warm_signature_fanout": "completion_reverse_closure",
+    },
+    "representative": {
+        "warm_no_op": "no_change_query",
+        "warm_leaf_body": "leaf_edit",
+        "warm_signature_fanout": "import_change",
+    },
+}
+
+
+def locality_check(scenario: str, row: dict[str, Any]) -> dict[str, Any]:
+    work = row.get("required_vs_reused_work")
+    if not isinstance(work, dict):
+        return {"status": "unsupported", "reason": "session runner omitted locality evidence"}
+
+    def count(artifact: str, side: str) -> Any:
+        return work.get(artifact, {}).get(side)
+
+    if scenario == "warm_no_op":
+        passed = count("semantic_queries", "required") == 0 and count("semantic_queries", "reused") >= 1
+    elif scenario == "warm_unrelated_declaration":
+        passed = (
+            count("semantic_bodies", "required") == 0
+            and count("cfgs", "required") == 0
+            and count("semantic_bodies", "reused") >= 1
+            and count("cfgs", "reused") >= 1
+        )
+    elif scenario == "warm_leaf_body":
+        passed = count("semantic_bodies", "required") >= 1 and count("cfgs", "reused") >= 1
+    else:
+        passed = count("modules", "required") >= 1 or count("semantic_bodies", "required") >= 1
+    return {"status": "pass" if passed else "fail", "work": work}
+
+
+def session_sample(
+    session_binary: Path,
+    workload: dict[str, Any],
+    scenario: str,
+    timeout: float,
+    root: Path,
+) -> dict[str, Any]:
+    mode = workload["session_mode"]
+    if scenario not in SESSION_ROW_NAMES.get(workload["family"], {}):
+        return {"status": "unsupported", "reason": "existing session benchmark has no matching scenario"}
+    command = [str(session_binary)]
+    if mode == "representative":
+        command += ["--representative"]
+    else:
+        command += ["--modules", str(workload["session_modules"])]
+    command += ["--warmup", "0", "--iterations", "1"]
+    result = run_command(command, timeout, {**os.environ, "RUE_STD_PATH": str(root / "std")})
+    if result["returncode"] != 0:
+        detail = result["stderr"].strip() or result["stdout"].strip()
+        raise RuntimeError(f"session benchmark failed: {detail[-1200:]}")
+    payload = json_object(result["stdout"])
+    if payload is None or not isinstance(payload.get("iterations"), list) or len(payload["iterations"]) != 1:
+        raise RuntimeError("session benchmark returned an invalid JSON envelope")
+    rows = payload["iterations"][0]
+    if not isinstance(rows, list):
+        raise RuntimeError("session benchmark iteration is not an array")
+    wanted = SESSION_ROW_NAMES[workload["family"]][scenario]
+    row = next((candidate for candidate in rows if candidate.get("name") == wanted), None)
+    if row is None:
+        raise RuntimeError(f"session benchmark did not report {wanted}")
+    timing_ns = row.get("wall_time_ns")
+    if not isinstance(timing_ns, int) or timing_ns <= 0:
+        raise RuntimeError(f"session benchmark row {wanted} has no positive wall_time_ns")
+    parity = row.get("differential_parity") or row.get("diagnostic_parity")
+    exact = parity is not None
+    locality = locality_check(scenario, row)
+    return {
+        "status": "pass" if exact and locality["status"] == "pass" else "fail",
+        "wall_ms": timing_ns / 1_000_000,
+        "peak_rss_bytes": result["peak_rss_bytes"],
+        "runner_wall_ms": result["wall_ms"],
+        "scenario_name": wanted,
+        "exact_parity": parity,
+        "locality": locality,
+        "row": row,
+    }
+
+
+def scaling_sample(
+    scaling_binary: Path,
+    workload: dict[str, Any],
+    warm: bool,
+    timeout: float,
+) -> dict[str, Any]:
+    command = [
+        str(scaling_binary),
+        "--mode",
+        "timing",
+        "--bodies",
+        "1000",
+        "--decls",
+        "100",
+        "--iterations",
+        "1",
+        "--json",
+    ]
+    if warm:
+        command.append("--warm")
+    result = run_command(command, timeout, os.environ.copy())
+    if result["returncode"] != 0:
+        raise RuntimeError(f"scaling benchmark failed: {result['stderr'][-1200:]}")
+    payload = json_object(result["stdout"])
+    if payload is None:
+        raise RuntimeError("scaling benchmark returned invalid JSON")
+    values = payload.get("pre_link", {}).get("samples_ns")
+    if not isinstance(values, list) or len(values) != 1 or not isinstance(values[0], str):
+        raise RuntimeError("scaling benchmark returned no pre_link sample")
+    return {
+        "wall_ms": int(values[0]) / 1_000_000,
+        "peak_rss_bytes": result["peak_rss_bytes"],
+        "protocol": "rue-scaling-bench",
+        "payload": payload,
+    }
+
+
+def pair_verdict(
+    left: dict[str, Any],
+    right: dict[str, Any],
+    kind: str,
+    threshold: float | None = None,
+) -> dict[str, Any]:
+    left_median = left.get("median")
+    right_median = right.get("median")
+    if left_median is None or right_median is None:
+        return {"status": "unsupported", "reason": "one side has no samples"}
+    left_mad = left.get("mad") or 0.0
+    right_mad = right.get("mad") or 0.0
+    noise = THRESHOLDS["claimed_win_mad_multiplier"] * max(left_mad, right_mad)
+    delta = right_median - left_median
+    if kind == "improvement":
+        improvement = (left_median - right_median) / left_median if left_median else None
+        if improvement is None:
+            return {"status": "indeterminate", "reason": "zero baseline median"}
+        if improvement < threshold:
+            status = "fail"
+            reason = "improvement below precommitted threshold"
+        elif left_median - right_median <= noise:
+            status = "indeterminate"
+            reason = "claimed win does not exceed three times the larger MAD"
+        else:
+            status = "pass"
+            reason = "improvement and MAD gates pass"
+        return {
+            "status": status,
+            "reason": reason,
+            "improvement_fraction": improvement,
+            "delta": delta,
+            "noise_budget": noise,
+            "threshold": threshold,
+        }
+    allowed = max(THRESHOLDS["cold_regression_fraction"] * left_median, noise)
+    return {
+        "status": "pass" if delta <= allowed else "fail",
+        "reason": "within cold wall/RSS regression budget" if delta <= allowed else "cold regression exceeds budget",
+        "delta": delta,
+        "allowed_regression": allowed,
+        "noise_budget": noise,
+        "threshold_fraction": THRESHOLDS["cold_regression_fraction"],
+    }
+
+
+def scenario_verdict(
+    scenario: str,
+    role_rows: dict[str, dict[str, Any]],
+    workload: dict[str, Any],
+) -> dict[str, Any]:
+    pairs: dict[str, Any] = {}
+    if scenario == "cold":
+        kind = "regression"
+        threshold = None
+    elif scenario == "warm_unrelated_declaration":
+        kind = "improvement"
+        threshold = THRESHOLDS["warm_unrelated_declaration_improvement"]
+    elif scenario == "warm_leaf_body":
+        kind = "improvement"
+        threshold = THRESHOLDS["warm_leaf_body_improvement"]
+    else:
+        kind = "observation"
+        threshold = None
+    for left_role, right_role in PAIR_NAMES:
+        left = role_rows.get(left_role, {})
+        right = role_rows.get(right_role, {})
+        if left.get("status") == "unsupported" or right.get("status") == "unsupported":
+            pairs[f"{left_role}_vs_{right_role}"] = {"status": "unsupported", "reason": "role lacks this protocol"}
+            continue
+        if left.get("status") == "fail" or right.get("status") == "fail":
+            pairs[f"{left_role}_vs_{right_role}"] = {"status": "fail", "reason": "exact correctness or locality evidence failed"}
+            continue
+        if scenario == "repeated_edit_memory":
+            pairs[f"{left_role}_vs_{right_role}"] = {"status": "unsupported", "reason": "no repeated-edit session protocol is exposed by the reused benchmark"}
+            continue
+        if kind == "observation":
+            pair = {"status": "pass", "reason": "exact/locality observation recorded", "wall": {
+                "left": left["wall"], "right": right["wall"]
+            }}
+        else:
+            pair = pair_verdict(left["wall"], right["wall"], kind, threshold)
+        if scenario == "cold":
+            rss_left = left.get("rss", {})
+            rss_right = right.get("rss", {})
+            pair["rss"] = pair_verdict(rss_left, rss_right, "regression")
+        pairs[f"{left_role}_vs_{right_role}"] = pair
+    for role, row in role_rows.items():
+        if row.get("status") == "fail":
+            pairs.setdefault(role, {"status": "fail", "reason": "role evidence failed"})
+        if (
+            scenario == "cold"
+            and workload["family"] == "caldera"
+            and row.get("wall", {}).get("median") is not None
+            and row["wall"]["median"] > THRESHOLDS["caldera_wall_seconds"] * 1000
+        ):
+            pairs.setdefault(role, {
+                "status": "fail",
+                "reason": "Caldera cold wall time exceeds the 300-second budget",
+            })
+    statuses = [value.get("status") for value in pairs.values()]
+    if "fail" in statuses:
+        status = "fail"
+    elif "indeterminate" in statuses:
+        status = "indeterminate"
+    elif any(value == "pass" for value in statuses):
+        status = "pass"
+    else:
+        status = "unsupported"
+    return {"status": status, "pairs": pairs}
+
+
+def role_metadata(role: str, binary: Path, source_dir: Path | None, root: Path) -> dict[str, Any]:
+    source = source_provenance(source_dir, root, root)
+    return {
+        "role": role,
+        "label": ROLE_LABELS[role],
+        "binary": str(binary),
+        "binary_sha256": sha256_file(binary) if binary.is_file() else None,
+        **source,
+    }
+
+
+def run_audit(args: argparse.Namespace) -> dict[str, Any]:
+    root = Path(__file__).resolve().parent.parent
+    audit_manifest = load_audit_manifest(root)
+    perf_baseline = load_perf_baseline(root)
+    del perf_baseline  # Loading validates that this audit uses the canonical module.
+    binaries: dict[str, Path] = args.binaries
+    for role, binary in binaries.items():
+        if not binary.is_file() or not os.access(binary, os.X_OK):
+            raise RuntimeError(f"{role} binary is not executable: {binary}")
+    session_bins = args.session_bins
+    scaling_bins = args.scaling_bins
+    for role, binary in {**session_bins, **scaling_bins}.items():
+        if not binary.is_file() or not os.access(binary, os.X_OK):
+            raise RuntimeError(f"{role} benchmark binary is not executable: {binary}")
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "protocol": {
+            "name": "rue_incrementality_value_audit",
+            "measurement_profile": "release",
+            "warmup": args.warmup,
+            "paired_samples": args.iterations,
+            "pair_order": "historical,current,candidate then candidate,current,historical alternating",
+            "source_of_cold_timing": "scripts/perf-baseline.py-compatible benchmark JSON, black-box fallback for old revisions",
+            "source_of_warm_timing": "rue-compiler-session-bench opaque scenario JSON",
+            "thresholds": THRESHOLDS,
+        },
+        "provenance": {
+            "created_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "host": host_provenance(),
+            "repository": str(root),
+            "manifest": str(root / "benchmarks/manifest.toml"),
+            "audit_manifest": str(root / "benchmarks/value-audit/manifest.toml"),
+            "audit_manifest_sha256": sha256_file(root / "benchmarks/value-audit/manifest.toml"),
+        },
+        "revisions": {
+            role: role_metadata(role, binaries[role], args.source_dirs.get(role), root)
+            for role in ROLES
+        },
+        "workloads": [],
+        "baseline_selection": {
+            "recommendation": "current_production",
+            "reason": "candidate value is measured against current production; historical baseline is context and may require the revision-compatible black-box fallback",
+        },
+        "fixture_protocol": audit_manifest["protocol"],
+        "verdict": "pass",
+    }
+    statuses: list[str] = []
+    selected = set(args.workloads) if args.workloads else {workload["name"] for workload in WORKLOADS}
+    for workload in WORKLOADS:
+        if workload["name"] not in selected:
+            continue
+        root_source = root / workload["root"]
+        if not root_source.is_file():
+            raise RuntimeError(f"workload root is missing: {root_source}")
+        row: dict[str, Any] = {
+            **workload,
+            "root": str(root_source),
+            "source_sha256": sha256_paths(
+                all_files(root_source.parent) if workload["family"] in {"representative", "caldera"} else [root_source],
+                root,
+            ),
+            "scenarios": {},
+            "scaling_evidence": {},
+        }
+        with tempfile.TemporaryDirectory(prefix="rue-value-audit-") as temp:
+            workdir = Path(temp)
+            for scenario in SCENARIOS:
+                role_rows: dict[str, dict[str, Any]] = {}
+                for pair_index in range(args.iterations):
+                    order = list(ROLES) if pair_index % 2 == 0 else list(reversed(ROLES))
+                    for role in order:
+                        if role in role_rows and len(role_rows[role].get("wall_samples", [])) > pair_index:
+                            continue
+                        role_rows.setdefault(role, {"status": "pass", "wall_samples": [], "rss_samples": [], "details": []})
+                        if scenario == "cold":
+                            sample = cold_sample(
+                                binaries[role], root_source, root, args.timeout, args.jobs, workdir
+                            )
+                        elif scenario == "repeated_edit_memory":
+                            sample = {"status": "unsupported", "reason": "existing reused benchmark has no bounded repeated-edit memory protocol"}
+                        elif role not in session_bins:
+                            sample = {"status": "unsupported", "reason": "no compatible session benchmark binary supplied for this revision"}
+                        elif workload["family"] not in SESSION_ROW_NAMES or scenario not in SESSION_ROW_NAMES[workload["family"]]:
+                            sample = {"status": "unsupported", "reason": "scenario is not implemented by the canonical runner for this workload"}
+                        else:
+                            if pair_index == 0:
+                                # Exactly one unrecorded warmup per role and
+                                # scenario, as required by the protocol.
+                                session_sample(session_bins[role], workload, scenario, args.timeout, root)
+                            sample = session_sample(session_bins[role], workload, scenario, args.timeout, root)
+                        if (
+                            workload["family"] == "synthetic"
+                            and scenario == "warm_leaf_body"
+                            and role in scaling_bins
+                        ):
+                            if pair_index == 0:
+                                scaling_sample(scaling_bins[role], workload, True, args.timeout)
+                            scaling = scaling_sample(scaling_bins[role], workload, True, args.timeout)
+                            row["scaling_evidence"].setdefault(role, []).append(scaling)
+                        if sample.get("status") == "unsupported":
+                            role_rows[role] = sample
+                            continue
+                        if scenario == "cold":
+                            sample["status"] = "pass"
+                            role_rows[role]["wall_samples"].append(float(sample["wall_ms"]))
+                            role_rows[role]["rss_samples"].append(sample.get("peak_rss_bytes"))
+                        else:
+                            role_rows[role]["wall_samples"].append(float(sample["wall_ms"]))
+                            role_rows[role]["rss_samples"].append(sample.get("peak_rss_bytes"))
+                            if sample.get("status") == "fail":
+                                role_rows[role]["status"] = "fail"
+                        role_rows[role]["details"].append(sample)
+                for role, values in list(role_rows.items()):
+                    if values.get("status") == "unsupported":
+                        continue
+                    # Null RSS is deliberately omitted rather than converted to
+                    # zero; platform memory availability is an explicit fact.
+                    values["wall"] = median_mad(values.pop("wall_samples"))
+                    values["rss"] = median_mad([
+                        float(value) for value in values.pop("rss_samples") if value is not None
+                    ])
+                for role, values in role_rows.items():
+                    if values.get("status") == "unsupported":
+                        continue
+                    output_hashes = [
+                        detail.get("output_sha256")
+                        for detail in values.get("details", [])
+                        if detail.get("output_sha256") is not None
+                    ]
+                    if output_hashes and len(set(output_hashes)) != 1:
+                        values["status"] = "fail"
+                        values["correctness"] = {"status": "fail", "reason": "output artifact changed between paired samples"}
+                    else:
+                        values["correctness"] = {"status": "pass", "criterion": "exit_zero_and_output_present"}
+                verdict = scenario_verdict(scenario, role_rows, workload)
+                row["scenarios"][scenario] = {"roles": role_rows, "verdict": verdict}
+                statuses.append(verdict["status"])
+        report["workloads"].append(row)
+    for workload in report["workloads"]:
+        for role, samples in workload["scaling_evidence"].items():
+            workload["scaling_evidence"][role] = {
+                "warm_leaf_body_pre_link_ms": median_mad(
+                    [sample["wall_ms"] for sample in samples]
+                ),
+                "rss_bytes": median_mad(
+                    [float(sample["peak_rss_bytes"]) for sample in samples if sample.get("peak_rss_bytes") is not None]
+                ),
+                "runner": "rue-scaling-bench",
+            }
+    if "fail" in statuses:
+        report["verdict"] = "fail"
+    elif "indeterminate" in statuses:
+        report["verdict"] = "indeterminate"
+    elif not statuses or all(status == "unsupported" for status in statuses):
+        report["verdict"] = "unsupported"
+    return report
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--historical-baseline", required=True, type=Path)
+    parser.add_argument("--current", required=True, type=Path)
+    parser.add_argument("--candidate", required=True, type=Path)
+    parser.add_argument("--source-dir", action="append", default=[], metavar="ROLE=PATH")
+    parser.add_argument("--session-bench", action="append", default=[], metavar="ROLE=PATH")
+    parser.add_argument("--scaling-bench", action="append", default=[], metavar="ROLE=PATH")
+    parser.add_argument("--output", type=Path, default=Path("value-audit.json"))
+    parser.add_argument("--iterations", type=int, default=7)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--timeout", type=float, default=300.0)
+    parser.add_argument("--jobs", type=int, default=1)
+    parser.add_argument("--workload", action="append", dest="workloads", choices=[workload["name"] for workload in WORKLOADS])
+    args = parser.parse_args(argv)
+    if args.iterations != 7:
+        parser.error("--iterations is fixed at 7 by the precommitted audit protocol")
+    if args.warmup != 1:
+        parser.error("--warmup is fixed at 1 by the precommitted audit protocol")
+    if args.timeout <= 0 or args.jobs < 0:
+        parser.error("--timeout must be positive and --jobs must be non-negative")
+    args.binaries = {
+        "historical_baseline": args.historical_baseline.expanduser().resolve(),
+        "current_production": args.current.expanduser().resolve(),
+        "candidate": args.candidate.expanduser().resolve(),
+    }
+    args.source_dirs = parse_role_mapping(args.source_dir, "--source-dir")
+    args.session_bins = parse_role_mapping(args.session_bench, "--session-bench")
+    args.scaling_bins = parse_role_mapping(args.scaling_bench, "--scaling-bench")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        report = run_audit(args)
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"rue-value-audit: {error}", file=sys.stderr)
+        return 2
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps({"output": str(args.output.resolve()), "verdict": report["verdict"]}))
+    return 0 if report["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rue-value-audit.py
+++ b/scripts/rue-value-audit.py
@@ -46,6 +46,7 @@ PAIR_NAMES = (
     ("historical_baseline", "current_production"),
     ("current_production", "candidate"),
 )
+PAIR_ORDER = "historical,current,candidate then candidate,current,historical"
 SCENARIOS = (
     "cold",
     "warm_no_op",
@@ -62,6 +63,8 @@ WORKLOADS = (
         "root": "benchmarks/stress/many_functions.rue",
         "session_mode": "modules",
         "session_modules": 128,
+        "warm_runner": "rue-compiler-session-bench --modules 128",
+        "scaling_runner": "rue-scaling-bench --bodies 1000 --decls 100",
         "description": "Generated declaration-volume and completion locality corpus.",
     },
     {
@@ -69,18 +72,24 @@ WORKLOADS = (
         "family": "representative",
         "root": "benchmarks/scenarios/representative/main.rue",
         "session_mode": "representative",
+        "warm_runner": "rue-compiler-session-bench --representative",
+        "scaling_runner": None,
         "description": "Tracked multi-module application-shaped fixture from benchmarks/manifest.toml.",
     },
     {
         "name": "medium_ordinary_rue",
         "family": "ordinary",
         "root": "examples/quicksort.rue",
+        "warm_runner": "unsupported: no persistent-session black-box protocol",
+        "scaling_runner": None,
         "description": "Ordinary medium Rue example; only fresh-driver scenarios are supported.",
     },
     {
         "name": "caldera",
         "family": "caldera",
         "root": "examples/caldera/main.rue",
+        "warm_runner": "unsupported: no persistent-session black-box protocol",
+        "scaling_runner": None,
         "description": "Large maintained application graph with a 300-second cold budget.",
     },
 )
@@ -102,6 +111,43 @@ LOCALITY_COUNTERS = (
     "semantic_bodies",
     "cfgs",
     "semantic_queries",
+    "cold_body_preparations",
+    "declarations_inspected",
+    "modules_registered",
+    "rir_indexes_constructed",
+    "rir_instructions_visited",
+    "durable_source_records_inspected",
+    "durable_source_records_copied",
+    "shells_prepared",
+    "projections_performed",
+    "semantics_installed",
+    "endpoints_installed",
+)
+COUNTER_DIMENSIONS = ("computed", "reused", "invalidated", "required")
+COLD_SEMANTIC_WORK_REQUIRED_PATHS = (
+    ("schema_version",),
+    ("bodies_attempted",),
+    ("bodies_succeeded",),
+    ("bodies_failed",),
+    ("body_analyses_computed",),
+    ("body_analyses_reused",),
+    ("body_analyses_invalidated",),
+    ("per_body_declaration_context", "cold_body_preparations"),
+    ("per_body_declaration_context", "declarations_inspected"),
+    ("per_body_declaration_context", "modules_registered"),
+    ("per_body_declaration_context", "rir_indexes_constructed"),
+    ("per_body_declaration_context", "rir_instructions_visited"),
+    ("per_body_declaration_context", "shells_prepared"),
+    ("per_body_declaration_context", "projections_performed"),
+    ("per_body_declaration_context", "semantics_installed"),
+    ("per_body_declaration_context", "endpoints_installed"),
+    ("per_body_declaration_context", "durable_source_records_inspected"),
+    ("per_body_declaration_context", "durable_source_records_copied"),
+    ("durable_bodies", "candidate_comparisons"),
+    ("durable_bodies", "reused_bodies"),
+    ("cfg", "builds_attempted"),
+    ("cfg", "builds_succeeded"),
+    ("cfg", "builds_failed"),
 )
 PARITY_EXACT_FIELDS = (
     "public_semantic_cfg_artifacts",
@@ -221,6 +267,8 @@ def load_audit_manifest(root: Path) -> dict[str, Any]:
     protocol = manifest.get("protocol")
     if not isinstance(protocol, dict) or protocol.get("paired_samples") != 7 or protocol.get("warmup") != 1:
         raise ValueError("value-audit manifest must pin one warmup and seven paired samples")
+    if protocol.get("pair_order") != PAIR_ORDER:
+        raise ValueError("value-audit manifest pair order drifted from the runner")
     if protocol.get("measurement_profile") != "release":
         raise ValueError("value-audit manifest must pin the release measurement profile")
     if not isinstance(protocol.get("caldera_timeout_headroom_seconds"), (int, float)) or protocol["caldera_timeout_headroom_seconds"] <= 0:
@@ -261,7 +309,22 @@ def load_audit_manifest(root: Path) -> dict[str, Any]:
     expected = {workload["name"] for workload in WORKLOADS}
     if not isinstance(workloads, list) or {item.get("name") for item in workloads} != expected:
         raise ValueError("value-audit manifest workload matrix drifted from the runner")
+    if len(workloads) != len(WORKLOADS):
+        raise ValueError("value-audit manifest workload matrix contains duplicate entries")
+    expected_workloads = {workload["name"]: workload for workload in WORKLOADS}
     for item in workloads:
+        expected_workload = expected_workloads.get(item.get("name"))
+        if expected_workload is None:
+            raise ValueError(f"value-audit manifest has an unknown workload {item.get('name')}")
+        expected_manifest_root = os.path.normpath(
+            os.path.relpath(expected_workload["root"], "benchmarks/value-audit")
+        )
+        if item.get("root") != expected_manifest_root:
+            raise ValueError(f"workload {item.get('name')} root drifted from the runner")
+        if item.get("warm_runner") != expected_workload["warm_runner"]:
+            raise ValueError(f"workload {item.get('name')} warm runner drifted from the runner")
+        if item.get("scaling_runner") != expected_workload["scaling_runner"]:
+            raise ValueError(f"workload {item.get('name')} scaling runner drifted from the runner")
         supported = item.get("supported_scenarios")
         if not isinstance(supported, list) or not set(supported).issubset(SCENARIOS):
             raise ValueError(f"workload {item.get('name')} has invalid supported_scenarios")
@@ -451,9 +514,42 @@ def parity_check(row: dict[str, Any]) -> dict[str, Any]:
         return {"status": "unsupported", "reason": "differential parity has no valid emitted-output digest"}
     if not isinstance(parity.get("emitted_output_size_bytes"), int) or parity["emitted_output_size_bytes"] <= 0:
         return {"status": "unsupported", "reason": "differential parity has no positive emitted-output size"}
-    if not isinstance(parity.get("cold_semantic_work"), dict):
-        return {"status": "unsupported", "reason": "differential parity has no cold work evidence"}
+    cold_work = parity.get("cold_semantic_work")
+    if not isinstance(cold_work, dict) or not cold_work:
+        return {"status": "unsupported", "reason": "differential parity has empty cold work evidence"}
+    for path in COLD_SEMANTIC_WORK_REQUIRED_PATHS:
+        value: Any = cold_work
+        for key in path:
+            if not isinstance(value, dict) or key not in value:
+                return {
+                    "status": "unsupported",
+                    "reason": f"differential parity cold work omitted {'.'.join(path)}",
+                }
+            value = value[key]
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            return {
+                "status": "unsupported",
+                "reason": f"differential parity cold work has malformed {'.'.join(path)}",
+            }
+    if cold_work["schema_version"] != 1:
+        return {"status": "unsupported", "reason": "differential parity cold work schema version is missing or unknown"}
     return {"status": "pass", "evidence": parity}
+
+
+def counter_value(values: dict[str, Any], field: str) -> int | None:
+    value = values.get(field)
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return None
+
+
+def unavailable_counter(value: Any) -> bool:
+    return (
+        isinstance(value, dict)
+        and value.get("available") is False
+        and isinstance(value.get("reason"), str)
+        and bool(value["reason"])
+    )
 
 
 def locality_check(
@@ -487,13 +583,15 @@ def locality_check(
         values = work.get(artifact)
         if not isinstance(values, dict):
             return {"status": "unsupported", "reason": f"locality evidence omitted {artifact} counters"}
-        for field in ("computed", "reused", "invalidated"):
-            if not isinstance(values.get(field), int) or isinstance(values[field], bool) or values[field] < 0:
-                return {"status": "unsupported", "reason": f"locality evidence has no numeric {artifact}.{field}"}
+        for field in COUNTER_DIMENSIONS:
+            value = values.get(field)
+            if counter_value(values, field) is None and not unavailable_counter(value):
+                return {"status": "unsupported", "reason": f"locality evidence has malformed {artifact}.{field}"}
 
-    # Every warm locality gate is an upper-bounded production-work gate.  A
+    # Every warm locality gate is an upper-bounded production-work gate. A
     # lower bound such as "some CFG was reused" cannot detect a full-program
-    # recompute, so both computed and invalidated counters are checked.
+    # recompute. Unavailable dimensions are shape-checked above but never
+    # treated as zero or as independent evidence here.
     maxima = policy
     if any(
         not isinstance(maxima.get(f"max_{artifact}_computed"), int)
@@ -506,29 +604,57 @@ def locality_check(
     for artifact in LOCALITY_COUNTERS:
         maximum = maxima[f"max_{artifact}_computed"]
         values = work[artifact]
-        if values["computed"] > maximum or values["invalidated"] > maximum:
-            violations.append({
-                "artifact": artifact,
-                "maximum": maximum,
-                "computed": values["computed"],
-                "invalidated": values["invalidated"],
-            })
+        if counter_value(values, "computed") is None:
+            return {"status": "unsupported", "reason": f"locality evidence has no computed {artifact} counter"}
+        for dimension in ("computed", "invalidated"):
+            observed = counter_value(values, dimension)
+            if observed is not None and observed > maximum:
+                violations.append({
+                    "artifact": artifact,
+                    "dimension": dimension,
+                    "maximum": maximum,
+                    "observed": observed,
+                })
     if violations:
         return {"status": "fail", "reason": "production work exceeded the manifest locality bounds", "violations": violations, "work": work}
 
+    # Semantic work is sliced to the current request by the session benchmark.
+    # A non-zero body/context counter with no current semantic execution is a
+    # historical cached-result field, not current-request recomputation. Do not
+    # let an exact-cycle cache hit satisfy a locality claim.
+    semantic_execution_count = counter_value(work["semantic_queries"], "computed")
+    current_request_work = (
+        "semantic_bodies",
+        "durable_source",
+        "cfgs",
+        "shells_prepared",
+        "projections_performed",
+        "semantics_installed",
+        "endpoints_installed",
+    )
+    if semantic_execution_count == 0 and any(
+        (counter_value(work[artifact], "computed") or 0) > 0
+        for artifact in current_request_work
+    ):
+        return {
+            "status": "unsupported",
+            "reason": "current-request semantic work is unavailable; counters may be historical cached-result fields",
+            "work": work,
+        }
+
     # A successful edit must show that the corresponding production query did
     # run.  This is deliberately narrow and does not turn reuse into a pass.
-    if scenario == "warm_no_op" and work["semantic_queries"]["reused"] < 1:
+    if scenario == "warm_no_op" and (counter_value(work["semantic_queries"], "reused") or 0) < 1:
         return {"status": "unsupported", "reason": "no-op row has no reused semantic-query evidence", "work": work}
     if scenario == "warm_unrelated_declaration" and not any(
-        work[artifact]["reused"] > 0 for artifact in LOCALITY_COUNTERS
+        (counter_value(work[artifact], "reused") or 0) > 0 for artifact in LOCALITY_COUNTERS
     ):
         return {"status": "unsupported", "reason": "unrelated-edit row has no reused production work evidence", "work": work}
-    if scenario in {"warm_leaf_body", "warm_signature_fanout"} and work["semantic_bodies"]["computed"] < 1:
+    if scenario in {"warm_leaf_body", "warm_signature_fanout"} and (counter_value(work["semantic_bodies"], "computed") or 0) < 1:
         return {"status": "unsupported", "reason": "edit row has no computed body evidence", "work": work}
-    if scenario == "warm_leaf_body" and work["cfgs"]["computed"] < 1:
+    if scenario == "warm_leaf_body" and (counter_value(work["cfgs"], "computed") or 0) < 1:
         return {"status": "unsupported", "reason": "leaf edit has no computed CFG evidence", "work": work}
-    if scenario == "warm_signature_fanout" and work["modules"]["computed"] < 1 and work["semantic_bodies"]["computed"] < 1:
+    if scenario == "warm_signature_fanout" and (counter_value(work["modules"], "computed") or 0) < 1 and (counter_value(work["semantic_bodies"], "computed") or 0) < 1:
         return {"status": "unsupported", "reason": "fanout edit has no computed locality evidence", "work": work}
     return {"status": "pass", "work": work}
 
@@ -756,6 +882,16 @@ def scenario_verdict(
         if left.get("status") == "fail" or right.get("status") == "fail":
             pairs[f"{left_role}_vs_{right_role}"] = {"status": "fail", "reason": "exact correctness or locality evidence failed"}
             continue
+        left_binary = left.get("binary_sha256")
+        right_binary = right.get("binary_sha256")
+        if isinstance(left_binary, str) and isinstance(right_binary, str) and left_binary == right_binary:
+            pairs[f"{left_role}_vs_{right_role}"] = {
+                "status": "unsupported",
+                "reason": "identical binary hashes cannot support a value or improvement claim",
+                "same_binary": True,
+                "binary_sha256": left_binary,
+            }
+            continue
         if left.get("protocol") != right.get("protocol"):
             pairs[f"{left_role}_vs_{right_role}"] = {
                 "status": "indeterminate",
@@ -867,7 +1003,7 @@ def run_audit(args: argparse.Namespace) -> dict[str, Any]:
             "measurement_profile": "release",
             "warmup": args.warmup,
             "paired_samples": args.iterations,
-            "pair_order": "historical,current,candidate then candidate,current,historical alternating",
+            "pair_order": audit_manifest["protocol"]["pair_order"],
             "source_of_cold_timing": "scripts/perf-baseline.py-compatible benchmark JSON, black-box fallback for old revisions",
             "source_of_warm_timing": "rue-compiler-session-bench opaque scenario JSON",
             "thresholds": thresholds,
@@ -945,7 +1081,13 @@ def run_audit(args: argparse.Namespace) -> dict[str, Any]:
                     for role in order:
                         if role in role_rows and len(role_rows[role].get("wall_samples", [])) > pair_index:
                             continue
-                        role_rows.setdefault(role, {"status": "pass", "wall_samples": [], "rss_samples": [], "details": []})
+                        role_rows.setdefault(role, {
+                            "status": "pass",
+                            "wall_samples": [],
+                            "rss_samples": [],
+                            "details": [],
+                            "binary_sha256": report["revisions"][role]["binary_sha256"],
+                        })
                         if scenario == "cold":
                             if pair_index == 0:
                                 for _ in range(audit_manifest["protocol"]["warmup"]):

--- a/scripts/rue-value-audit.py
+++ b/scripts/rue-value-audit.py
@@ -18,9 +18,11 @@ useful as context without backporting the modern incrementality harness.
 from __future__ import annotations
 
 import argparse
+from functools import lru_cache
 import hashlib
 import importlib.util
 import json
+import math
 import os
 from pathlib import Path
 import platform
@@ -83,7 +85,7 @@ WORKLOADS = (
     },
 )
 
-THRESHOLDS = {
+PRECOMMITTED_THRESHOLDS = {
     "warm_unrelated_declaration_improvement": 0.50,
     "warm_leaf_body_improvement": 0.25,
     "claimed_win_mad_multiplier": 3.0,
@@ -92,7 +94,33 @@ THRESHOLDS = {
     "caldera_wall_seconds": 300.0,
 }
 
+LOCALITY_COUNTERS = (
+    "modules",
+    "rir",
+    "declarations",
+    "durable_source",
+    "semantic_bodies",
+    "cfgs",
+    "semantic_queries",
+)
+PARITY_EXACT_FIELDS = (
+    "public_semantic_cfg_artifacts",
+    "public_type_universe",
+    "durable_specialized_body_payloads",
+    "durable_ordinary_body_manifest_artifacts",
+    "diagnostics",
+    "warnings",
+    "stable_identities",
+    "dependency_records",
+    "emitted_output",
+)
+PARITY_EXACT_VALUES = {
+    "public_type_universe": {"exact", "exact_ordered_entries"},
+    "emitted_output": {"exact", "byte_exact"},
+}
 
+
+@lru_cache(maxsize=1)
 def load_perf_baseline(root: Path):
     path = root / "scripts" / "perf-baseline.py"
     spec = importlib.util.spec_from_file_location("rue_perf_baseline", path)
@@ -151,28 +179,23 @@ def all_files(directory: Path) -> list[Path]:
     ]
 
 
-def source_provenance(source_dir: Path | None, root: Path, workload_root: Path) -> dict[str, Any]:
-    source_dir = (source_dir or root).resolve()
+def tracked_files(directory: Path) -> list[Path]:
+    names = git_value(directory, "ls-files", "-z")
+    if names is not None:
+        return [directory / item for item in names.split("\0") if item]
+    return all_files(directory)
+
+
+def source_provenance(source_dir: Path) -> dict[str, Any]:
+    source_dir = source_dir.resolve()
     commit = git_value(source_dir, "rev-parse", "HEAD")
     tree = git_value(source_dir, "rev-parse", "HEAD^{tree}")
-    if commit is not None:
-        tracked = git_value(source_dir, "ls-files", "-z")
-        if tracked is not None:
-            paths = [source_dir / item for item in tracked.split("\0") if item]
-        else:
-            paths = all_files(source_dir)
-    else:
-        paths = all_files(source_dir)
-    # A workload hash is kept separate from the complete source-tree identity;
-    # it makes an audit row reproducible even when unrelated repository files
-    # change between two operators' runs.
-    workload_paths = all_files(workload_root) if workload_root.is_dir() else [workload_root]
+    paths = tracked_files(source_dir)
     return {
         "directory": str(source_dir),
         "commit": commit,
         "source_tree": tree,
         "source_files_sha256": sha256_paths(paths, source_dir),
-        "workload_files_sha256": sha256_paths(workload_paths, root),
     }
 
 
@@ -193,20 +216,55 @@ def load_audit_manifest(root: Path) -> dict[str, Any]:
     path = root / "benchmarks" / "value-audit" / "manifest.toml"
     with path.open("rb") as stream:
         manifest = tomllib.load(stream)
-    if manifest.get("schema_version") != 1:
-        raise ValueError("value-audit manifest schema_version must be 1")
+    if manifest.get("schema_version") != 2:
+        raise ValueError("value-audit manifest schema_version must be 2")
     protocol = manifest.get("protocol")
     if not isinstance(protocol, dict) or protocol.get("paired_samples") != 7 or protocol.get("warmup") != 1:
         raise ValueError("value-audit manifest must pin one warmup and seven paired samples")
     if protocol.get("measurement_profile") != "release":
         raise ValueError("value-audit manifest must pin the release measurement profile")
+    if not isinstance(protocol.get("caldera_timeout_headroom_seconds"), (int, float)) or protocol["caldera_timeout_headroom_seconds"] <= 0:
+        raise ValueError("value-audit manifest must provide positive Caldera timeout headroom")
     source_manifest = path.parent / str(manifest.get("source_manifest", ""))
     if source_manifest.resolve() != (root / "benchmarks" / "manifest.toml").resolve():
         raise ValueError("value-audit manifest must reuse benchmarks/manifest.toml")
+    thresholds = manifest.get("thresholds")
+    if not isinstance(thresholds, dict):
+        raise ValueError("value-audit manifest must define thresholds")
+    for name, expected in PRECOMMITTED_THRESHOLDS.items():
+        actual = thresholds.get(name)
+        if not isinstance(actual, (int, float)) or actual != expected:
+            raise ValueError(
+                f"value-audit manifest threshold {name} drifted from the precommitted value {expected}"
+            )
+    policy = manifest.get("scenario_policy")
+    if not isinstance(policy, dict) or set(policy) != set(SCENARIOS):
+        raise ValueError("value-audit manifest scenario policy drifted from the runner")
+    for scenario in SCENARIOS:
+        entry = policy[scenario]
+        if not isinstance(entry, dict) or not isinstance(entry.get("required"), bool):
+            raise ValueError(f"scenario policy for {scenario} must declare required=true/false")
+    locality = manifest.get("locality")
+    required_locality = set(SCENARIOS) - {"cold", "repeated_edit_memory"}
+    if not isinstance(locality, dict) or not required_locality.issubset(locality):
+        raise ValueError("value-audit manifest locality policy is incomplete")
+    for scenario in required_locality:
+        entry = locality[scenario]
+        if not isinstance(entry, dict):
+            raise ValueError(f"locality policy for {scenario} must be a table")
+        for counter in LOCALITY_COUNTERS:
+            key = f"max_{counter}_computed"
+            value = entry.get(key)
+            if not isinstance(value, int) or value < 0:
+                raise ValueError(f"locality policy for {scenario} must define non-negative {key}")
     workloads = manifest.get("workload")
     expected = {workload["name"] for workload in WORKLOADS}
     if not isinstance(workloads, list) or {item.get("name") for item in workloads} != expected:
         raise ValueError("value-audit manifest workload matrix drifted from the runner")
+    for item in workloads:
+        supported = item.get("supported_scenarios")
+        if not isinstance(supported, list) or not set(supported).issubset(SCENARIOS):
+            raise ValueError(f"workload {item.get('name')} has invalid supported_scenarios")
     return manifest
 
 
@@ -247,12 +305,24 @@ def time_prefix() -> tuple[list[str], str]:
 
 def parse_rss(stderr: str, style: str) -> int | None:
     if style == "darwin":
+        # macOS has emitted both `maximum resident set size: 123` and
+        # `123 maximum resident set size` forms across supported hosts.
         match = re.search(r"maximum resident set size:\s*(\d+)", stderr)
+        if match:
+            return int(match.group(1))
+        match = re.search(r"(\d+)\s+maximum resident set size", stderr)
         return int(match.group(1)) if match else None
     if style == "gnu":
         match = re.search(r"Maximum resident set size \(kbytes\):\s*(\d+)", stderr)
         return int(match.group(1)) * 1024 if match else None
     return None
+
+
+def measurement_env(root: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("RUST_LOG", None)
+    env["RUE_STD_PATH"] = str(root / "std")
+    return env
 
 
 def run_command(command: list[str], timeout: float, env: dict[str, str]) -> dict[str, Any]:
@@ -294,12 +364,11 @@ def cold_sample(
     timeout: float,
     jobs: int,
     workdir: Path,
+    perf_baseline: Any,
 ) -> dict[str, Any]:
     output = workdir / "audit-output"
     output.unlink(missing_ok=True)
-    env = os.environ.copy()
-    env.pop("RUST_LOG", None)
-    env["RUE_STD_PATH"] = str(root / "std")
+    env = measurement_env(root)
     modern = [
         str(binary),
         "--benchmark-json",
@@ -342,7 +411,6 @@ def cold_sample(
         # Reuse perf-baseline's schema/aggregation validator for modern JSON.
         # The audit keeps the raw payload as evidence, but does not duplicate
         # its pass-nesting interpretation here.
-        perf_baseline = load_perf_baseline(root)
         payload["_process_ms"] = result["wall_ms"]
         sample["perf_baseline_aggregate"] = perf_baseline.aggregate([payload])
         sample["compiler_ms"] = payload.get("total_ms")
@@ -365,27 +433,104 @@ SESSION_ROW_NAMES = {
 }
 
 
-def locality_check(scenario: str, row: dict[str, Any]) -> dict[str, Any]:
+def parity_check(row: dict[str, Any]) -> dict[str, Any]:
+    parity = row.get("differential_parity")
+    if not isinstance(parity, dict):
+        return {"status": "unsupported", "reason": "session runner omitted differential parity evidence"}
+    if parity.get("schema_version") != 1:
+        return {"status": "unsupported", "reason": "differential parity schema version is missing or unknown"}
+    if parity.get("status") != "pass" or parity.get("comparison") != "cold_vs_reused_in_process":
+        return {"status": "unsupported", "reason": "differential parity did not report a completed in-process comparison"}
+    if parity.get("comparison_completed") is not True:
+        return {"status": "unsupported", "reason": "differential parity comparison was not marked complete"}
+    for field in PARITY_EXACT_FIELDS:
+        if parity.get(field) not in PARITY_EXACT_VALUES.get(field, {"exact"}):
+            return {"status": "unsupported", "reason": f"differential parity field {field} is not exact"}
+    digest = parity.get("emitted_output_sha256")
+    if not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+        return {"status": "unsupported", "reason": "differential parity has no valid emitted-output digest"}
+    if not isinstance(parity.get("emitted_output_size_bytes"), int) or parity["emitted_output_size_bytes"] <= 0:
+        return {"status": "unsupported", "reason": "differential parity has no positive emitted-output size"}
+    if not isinstance(parity.get("cold_semantic_work"), dict):
+        return {"status": "unsupported", "reason": "differential parity has no cold work evidence"}
+    return {"status": "pass", "evidence": parity}
+
+
+def locality_check(
+    scenario: str,
+    row: dict[str, Any],
+    policy: dict[str, Any],
+) -> dict[str, Any]:
+    evidence_schema = row.get("evidence_schema")
+    if evidence_schema != {
+        "version": 2,
+        "differential_parity_version": 1,
+        "locality_work_version": 2,
+    }:
+        return {"status": "unsupported", "reason": "session row omitted the explicit evidence schema attachment"}
     work = row.get("required_vs_reused_work")
-    if not isinstance(work, dict):
-        return {"status": "unsupported", "reason": "session runner omitted locality evidence"}
+    if not isinstance(work, dict) or work.get("schema_version") != 2:
+        return {"status": "unsupported", "reason": "session runner omitted schema-versioned locality evidence"}
+    if work.get("counter_source") != "production_metrics":
+        return {"status": "unsupported", "reason": "locality evidence is not sourced from production metrics"}
+    identity_sets = work.get("exact_identity_sets")
+    if not isinstance(identity_sets, dict) or not isinstance(identity_sets.get("available"), bool):
+        return {"status": "unsupported", "reason": "locality evidence omitted exact-identity-set availability"}
+    if identity_sets["available"]:
+        for key in ("recomputed", "reused"):
+            if not isinstance(identity_sets.get(key), list):
+                return {"status": "unsupported", "reason": "available identity sets are malformed"}
+    elif not isinstance(identity_sets.get("reason"), str) or not identity_sets["reason"]:
+        return {"status": "unsupported", "reason": "unavailable identity sets were not explained"}
 
-    def count(artifact: str, side: str) -> Any:
-        return work.get(artifact, {}).get(side)
+    for artifact in LOCALITY_COUNTERS:
+        values = work.get(artifact)
+        if not isinstance(values, dict):
+            return {"status": "unsupported", "reason": f"locality evidence omitted {artifact} counters"}
+        for field in ("computed", "reused", "invalidated"):
+            if not isinstance(values.get(field), int) or isinstance(values[field], bool) or values[field] < 0:
+                return {"status": "unsupported", "reason": f"locality evidence has no numeric {artifact}.{field}"}
 
-    if scenario == "warm_no_op":
-        passed = count("semantic_queries", "required") == 0 and count("semantic_queries", "reused") >= 1
-    elif scenario == "warm_unrelated_declaration":
-        passed = (
-            count("semantic_bodies", "required") == 0
-            and count("cfgs", "required") == 0
-            and count("cfgs", "reused") >= 1
-        )
-    elif scenario == "warm_leaf_body":
-        passed = count("semantic_bodies", "required") >= 1 and count("cfgs", "reused") >= 1
-    else:
-        passed = count("modules", "required") >= 1 or count("semantic_bodies", "required") >= 1
-    return {"status": "pass" if passed else "fail", "work": work}
+    # Every warm locality gate is an upper-bounded production-work gate.  A
+    # lower bound such as "some CFG was reused" cannot detect a full-program
+    # recompute, so both computed and invalidated counters are checked.
+    maxima = policy
+    if any(
+        not isinstance(maxima.get(f"max_{artifact}_computed"), int)
+        or isinstance(maxima.get(f"max_{artifact}_computed"), bool)
+        or maxima[f"max_{artifact}_computed"] < 0
+        for artifact in LOCALITY_COUNTERS
+    ):
+        return {"status": "unsupported", "reason": "manifest locality bounds are malformed"}
+    violations = []
+    for artifact in LOCALITY_COUNTERS:
+        maximum = maxima[f"max_{artifact}_computed"]
+        values = work[artifact]
+        if values["computed"] > maximum or values["invalidated"] > maximum:
+            violations.append({
+                "artifact": artifact,
+                "maximum": maximum,
+                "computed": values["computed"],
+                "invalidated": values["invalidated"],
+            })
+    if violations:
+        return {"status": "fail", "reason": "production work exceeded the manifest locality bounds", "violations": violations, "work": work}
+
+    # A successful edit must show that the corresponding production query did
+    # run.  This is deliberately narrow and does not turn reuse into a pass.
+    if scenario == "warm_no_op" and work["semantic_queries"]["reused"] < 1:
+        return {"status": "unsupported", "reason": "no-op row has no reused semantic-query evidence", "work": work}
+    if scenario == "warm_unrelated_declaration" and not any(
+        work[artifact]["reused"] > 0 for artifact in LOCALITY_COUNTERS
+    ):
+        return {"status": "unsupported", "reason": "unrelated-edit row has no reused production work evidence", "work": work}
+    if scenario in {"warm_leaf_body", "warm_signature_fanout"} and work["semantic_bodies"]["computed"] < 1:
+        return {"status": "unsupported", "reason": "edit row has no computed body evidence", "work": work}
+    if scenario == "warm_leaf_body" and work["cfgs"]["computed"] < 1:
+        return {"status": "unsupported", "reason": "leaf edit has no computed CFG evidence", "work": work}
+    if scenario == "warm_signature_fanout" and work["modules"]["computed"] < 1 and work["semantic_bodies"]["computed"] < 1:
+        return {"status": "unsupported", "reason": "fanout edit has no computed locality evidence", "work": work}
+    return {"status": "pass", "work": work}
 
 
 def session_sample(
@@ -394,6 +539,7 @@ def session_sample(
     scenario: str,
     timeout: float,
     root: Path,
+    locality_policy: dict[str, Any],
 ) -> dict[str, Any]:
     mode = workload["session_mode"]
     if scenario not in SESSION_ROW_NAMES.get(workload["family"], {}):
@@ -404,7 +550,7 @@ def session_sample(
     else:
         command += ["--modules", str(workload["session_modules"])]
     command += ["--warmup", "0", "--iterations", "1"]
-    result = run_command(command, timeout, {**os.environ, "RUE_STD_PATH": str(root / "std")})
+    result = run_command(command, timeout, measurement_env(root))
     if result["returncode"] != 0:
         detail = result["stderr"].strip() or result["stdout"].strip()
         raise RuntimeError(f"session benchmark failed: {detail[-1200:]}")
@@ -415,22 +561,27 @@ def session_sample(
     if not isinstance(rows, list):
         raise RuntimeError("session benchmark iteration is not an array")
     wanted = SESSION_ROW_NAMES[workload["family"]][scenario]
-    row = next((candidate for candidate in rows if candidate.get("name") == wanted), None)
+    row = next((candidate for candidate in rows if isinstance(candidate, dict) and candidate.get("name") == wanted), None)
     if row is None:
         raise RuntimeError(f"session benchmark did not report {wanted}")
     timing_ns = row.get("wall_time_ns")
     if not isinstance(timing_ns, int) or timing_ns <= 0:
         raise RuntimeError(f"session benchmark row {wanted} has no positive wall_time_ns")
-    parity = row.get("differential_parity") or row.get("diagnostic_parity")
-    exact = parity is not None
-    locality = locality_check(scenario, row)
+    parity_result = parity_check(row)
+    locality = locality_check(scenario, row, locality_policy)
+    evidence_status = "pass"
+    if parity_result["status"] != "pass" or locality["status"] == "unsupported":
+        evidence_status = "indeterminate"
+    elif locality["status"] == "fail":
+        evidence_status = "fail"
     return {
-        "status": "pass" if exact and locality["status"] == "pass" else "fail",
+        "status": evidence_status,
+        "protocol": "session_benchmark_json",
         "wall_ms": timing_ns / 1_000_000,
         "peak_rss_bytes": result["peak_rss_bytes"],
         "runner_wall_ms": result["wall_ms"],
         "scenario_name": wanted,
-        "exact_parity": parity,
+        "exact_parity": parity_result,
         "locality": locality,
         "row": row,
     }
@@ -438,9 +589,9 @@ def session_sample(
 
 def scaling_sample(
     scaling_binary: Path,
-    workload: dict[str, Any],
     warm: bool,
     timeout: float,
+    root: Path,
 ) -> dict[str, Any]:
     command = [
         str(scaling_binary),
@@ -456,7 +607,7 @@ def scaling_sample(
     ]
     if warm:
         command.append("--warm")
-    result = run_command(command, timeout, os.environ.copy())
+    result = run_command(command, timeout, measurement_env(root))
     if result["returncode"] != 0:
         raise RuntimeError(f"scaling benchmark failed: {result['stderr'][-1200:]}")
     payload = json_object(result["stdout"])
@@ -473,19 +624,65 @@ def scaling_sample(
     }
 
 
+def merge_role_sample(role_row: dict[str, Any], sample: dict[str, Any], scenario: str) -> None:
+    """Merge one measurement without allowing unsupported evidence to erase prior samples."""
+    if sample.get("status") == "unsupported":
+        if role_row.get("wall_samples"):
+            role_row["status"] = "indeterminate"
+            role_row.setdefault("details", []).append(sample)
+        else:
+            role_row["status"] = "unsupported"
+            role_row["reason"] = sample.get("reason")
+        return
+    if scenario == "cold":
+        sample["status"] = "pass"
+    role_row.setdefault("wall_samples", []).append(float(sample["wall_ms"]))
+    role_row.setdefault("rss_samples", []).append(sample.get("peak_rss_bytes"))
+    if sample.get("status") == "fail":
+        role_row["status"] = "fail"
+    elif sample.get("status") == "indeterminate":
+        role_row["status"] = "indeterminate"
+    role_row.setdefault("details", []).append(sample)
+
+
 def pair_verdict(
     left: dict[str, Any],
     right: dict[str, Any],
     kind: str,
     threshold: float | None = None,
+    thresholds: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    if thresholds is None:
+        raise ValueError("pair_verdict requires thresholds loaded from the audit manifest")
+    if not isinstance(left, dict) or not isinstance(right, dict):
+        return {"status": "indeterminate", "reason": "malformed timing evidence"}
     left_median = left.get("median")
     right_median = right.get("median")
-    if left_median is None or right_median is None:
+    if (
+        not isinstance(left_median, (int, float))
+        or isinstance(left_median, bool)
+        or not math.isfinite(left_median)
+        or not isinstance(right_median, (int, float))
+        or isinstance(right_median, bool)
+        or not math.isfinite(right_median)
+    ):
         return {"status": "unsupported", "reason": "one side has no samples"}
-    left_mad = left.get("mad") or 0.0
-    right_mad = right.get("mad") or 0.0
-    noise = THRESHOLDS["claimed_win_mad_multiplier"] * max(left_mad, right_mad)
+    left_mad = left.get("mad")
+    right_mad = right.get("mad")
+    if left_mad is None:
+        left_mad = 0.0
+    if right_mad is None:
+        right_mad = 0.0
+    if (
+        not isinstance(left_mad, (int, float))
+        or isinstance(left_mad, bool)
+        or not math.isfinite(left_mad)
+        or not isinstance(right_mad, (int, float))
+        or isinstance(right_mad, bool)
+        or not math.isfinite(right_mad)
+    ):
+        return {"status": "indeterminate", "reason": "malformed MAD evidence"}
+    noise = thresholds["claimed_win_mad_multiplier"] * max(left_mad, right_mad)
     delta = right_median - left_median
     if kind == "improvement":
         improvement = (left_median - right_median) / left_median if left_median else None
@@ -508,14 +705,14 @@ def pair_verdict(
             "noise_budget": noise,
             "threshold": threshold,
         }
-    allowed = max(THRESHOLDS["cold_regression_fraction"] * left_median, noise)
+    allowed = max(thresholds["cold_regression_fraction"] * left_median, noise)
     return {
         "status": "pass" if delta <= allowed else "fail",
         "reason": "within cold wall/RSS regression budget" if delta <= allowed else "cold regression exceeds budget",
         "delta": delta,
         "allowed_regression": allowed,
         "noise_budget": noise,
-        "threshold_fraction": THRESHOLDS["cold_regression_fraction"],
+        "threshold_fraction": thresholds["cold_regression_fraction"],
     }
 
 
@@ -523,28 +720,55 @@ def scenario_verdict(
     scenario: str,
     role_rows: dict[str, dict[str, Any]],
     workload: dict[str, Any],
+    scenario_policy: dict[str, Any],
+    thresholds: dict[str, Any],
 ) -> dict[str, Any]:
     pairs: dict[str, Any] = {}
+    required = scenario_policy["required"]
+    if scenario not in workload["supported_scenarios"]:
+        return {
+            "status": "not_applicable",
+            "required": False,
+            "reason": "scenario is not declared by the workload in the audit manifest",
+            "pairs": {},
+        }
     if scenario == "cold":
         kind = "regression"
         threshold = None
     elif scenario == "warm_unrelated_declaration":
         kind = "improvement"
-        threshold = THRESHOLDS["warm_unrelated_declaration_improvement"]
+        threshold = thresholds["warm_unrelated_declaration_improvement"]
     elif scenario == "warm_leaf_body":
         kind = "improvement"
-        threshold = THRESHOLDS["warm_leaf_body_improvement"]
+        threshold = thresholds["warm_leaf_body_improvement"]
     else:
         kind = "observation"
         threshold = None
     for left_role, right_role in PAIR_NAMES:
         left = role_rows.get(left_role, {})
         right = role_rows.get(right_role, {})
-        if left.get("status") == "unsupported" or right.get("status") == "unsupported":
-            pairs[f"{left_role}_vs_{right_role}"] = {"status": "unsupported", "reason": "role lacks this protocol"}
+        if left.get("status") in {"unsupported", "indeterminate"} or right.get("status") in {"unsupported", "indeterminate"}:
+            pairs[f"{left_role}_vs_{right_role}"] = {
+                "status": "indeterminate" if required else "unsupported",
+                "reason": "role lacks complete required protocol evidence",
+            }
             continue
         if left.get("status") == "fail" or right.get("status") == "fail":
             pairs[f"{left_role}_vs_{right_role}"] = {"status": "fail", "reason": "exact correctness or locality evidence failed"}
+            continue
+        if left.get("protocol") != right.get("protocol"):
+            pairs[f"{left_role}_vs_{right_role}"] = {
+                "status": "indeterminate",
+                "reason": "timing protocols differ; benchmark_json and black_box_compile are not comparable",
+                "left_protocol": left.get("protocol"),
+                "right_protocol": right.get("protocol"),
+            }
+            continue
+        if not isinstance(left.get("wall"), dict) or not isinstance(right.get("wall"), dict):
+            pairs[f"{left_role}_vs_{right_role}"] = {
+                "status": "indeterminate",
+                "reason": "role row is partially shaped and has no timing evidence",
+            }
             continue
         if scenario == "repeated_edit_memory":
             pairs[f"{left_role}_vs_{right_role}"] = {"status": "unsupported", "reason": "no repeated-edit session protocol is exposed by the reused benchmark"}
@@ -554,11 +778,18 @@ def scenario_verdict(
                 "left": left["wall"], "right": right["wall"]
             }}
         else:
-            pair = pair_verdict(left["wall"], right["wall"], kind, threshold)
+            pair = pair_verdict(left["wall"], right["wall"], kind, threshold, thresholds)
         if scenario == "cold":
             rss_left = left.get("rss", {})
             rss_right = right.get("rss", {})
-            pair["rss"] = pair_verdict(rss_left, rss_right, "regression")
+            rss = pair_verdict(rss_left, rss_right, "regression", thresholds=thresholds)
+            pair["rss"] = rss
+            if rss["status"] == "fail":
+                pair["status"] = "fail"
+                pair["reason"] = "cold RSS regression exceeds budget"
+            elif rss["status"] in {"unsupported", "indeterminate"}:
+                pair["status"] = "indeterminate"
+                pair["reason"] = "cold RSS evidence is unavailable or indeterminate"
         pairs[f"{left_role}_vs_{right_role}"] = pair
     for role, row in role_rows.items():
         if row.get("status") == "fail":
@@ -567,31 +798,46 @@ def scenario_verdict(
             scenario == "cold"
             and workload["family"] == "caldera"
             and row.get("wall", {}).get("median") is not None
-            and row["wall"]["median"] > THRESHOLDS["caldera_wall_seconds"] * 1000
+            and row["wall"]["median"] > thresholds["caldera_wall_seconds"] * 1000
         ):
             pairs.setdefault(role, {
                 "status": "fail",
-                "reason": "Caldera cold wall time exceeds the 300-second budget",
+                "reason": f"Caldera cold wall time exceeds the {thresholds['caldera_wall_seconds']}-second budget",
             })
     statuses = [value.get("status") for value in pairs.values()]
     if "fail" in statuses:
         status = "fail"
-    elif "indeterminate" in statuses:
+    elif "indeterminate" in statuses or (required and "unsupported" in statuses):
         status = "indeterminate"
     elif any(value == "pass" for value in statuses):
         status = "pass"
     else:
         status = "unsupported"
-    return {"status": status, "pairs": pairs}
+    return {"status": status, "required": required, "pairs": pairs}
 
 
-def role_metadata(role: str, binary: Path, source_dir: Path | None, root: Path) -> dict[str, Any]:
-    source = source_provenance(source_dir, root, root)
+def role_metadata(role: str, binary: Path, source_dir: Path | None) -> dict[str, Any]:
+    if source_dir is None:
+        raise ValueError(
+            f"{role} requires explicit --source-dir provenance; the runner never defaults a role to the candidate checkout"
+        )
+    if not source_dir.is_dir():
+        raise ValueError(f"{role} source provenance directory does not exist: {source_dir}")
+    source = source_provenance(source_dir)
+    if source["commit"] is None or source["source_tree"] is None:
+        raise ValueError(f"{role} source provenance is not a verifiable Git checkout: {source_dir}")
+    binary_hash = sha256_file(binary) if binary.is_file() else None
     return {
         "role": role,
         "label": ROLE_LABELS[role],
         "binary": str(binary),
-        "binary_sha256": sha256_file(binary) if binary.is_file() else None,
+        "binary_sha256": binary_hash,
+        "build_provenance": {
+            "source_directory": str(source_dir),
+            "source_commit": source["commit"],
+            "source_tree": source["source_tree"],
+            "binary_sha256": binary_hash,
+        },
         **source,
     }
 
@@ -599,8 +845,12 @@ def role_metadata(role: str, binary: Path, source_dir: Path | None, root: Path) 
 def run_audit(args: argparse.Namespace) -> dict[str, Any]:
     root = Path(__file__).resolve().parent.parent
     audit_manifest = load_audit_manifest(root)
+    thresholds = audit_manifest["thresholds"]
+    scenario_policy = audit_manifest["scenario_policy"]
+    manifest_workloads = {item["name"]: item for item in audit_manifest["workload"]}
+    if args.warmup != audit_manifest["protocol"]["warmup"] or args.iterations != audit_manifest["protocol"]["paired_samples"]:
+        raise ValueError("CLI sampling counts drifted from the validated audit manifest")
     perf_baseline = load_perf_baseline(root)
-    del perf_baseline  # Loading validates that this audit uses the canonical module.
     binaries: dict[str, Path] = args.binaries
     for role, binary in binaries.items():
         if not binary.is_file() or not os.access(binary, os.X_OK):
@@ -611,7 +861,7 @@ def run_audit(args: argparse.Namespace) -> dict[str, Any]:
         if not binary.is_file() or not os.access(binary, os.X_OK):
             raise RuntimeError(f"{role} benchmark binary is not executable: {binary}")
     report: dict[str, Any] = {
-        "schema_version": 1,
+        "schema_version": 2,
         "protocol": {
             "name": "rue_incrementality_value_audit",
             "measurement_profile": "release",
@@ -620,7 +870,9 @@ def run_audit(args: argparse.Namespace) -> dict[str, Any]:
             "pair_order": "historical,current,candidate then candidate,current,historical alternating",
             "source_of_cold_timing": "scripts/perf-baseline.py-compatible benchmark JSON, black-box fallback for old revisions",
             "source_of_warm_timing": "rue-compiler-session-bench opaque scenario JSON",
-            "thresholds": THRESHOLDS,
+            "thresholds": thresholds,
+            "scenario_policy": scenario_policy,
+            "caldera_timeout_headroom_seconds": audit_manifest["protocol"]["caldera_timeout_headroom_seconds"],
         },
         "provenance": {
             "created_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
@@ -631,9 +883,10 @@ def run_audit(args: argparse.Namespace) -> dict[str, Any]:
             "audit_manifest_sha256": sha256_file(root / "benchmarks/value-audit/manifest.toml"),
         },
         "revisions": {
-            role: role_metadata(role, binaries[role], args.source_dirs.get(role), root)
+            role: role_metadata(role, binaries[role], args.source_dirs.get(role))
             for role in ROLES
         },
+        "comparison_provenance": {},
         "workloads": [],
         "baseline_selection": {
             "recommendation": "current_production",
@@ -642,6 +895,21 @@ def run_audit(args: argparse.Namespace) -> dict[str, Any]:
         "fixture_protocol": audit_manifest["protocol"],
         "verdict": "pass",
     }
+    binary_hashes = {
+        role: report["revisions"][role]["binary_sha256"] for role in ROLES
+    }
+    if len(set(binary_hashes.values())) == 1:
+        report["comparison_provenance"] = {
+            "classification": "same_binary_protocol_smoke",
+            "historical_comparison_valid": False,
+            "claim_scope": "protocol and fail-closed gate smoke only; no historical/current/candidate value claim",
+        }
+    else:
+        report["comparison_provenance"] = {
+            "classification": "three_role_binary_comparison",
+            "historical_comparison_valid": True,
+            "claim_scope": "role comparisons are linked to explicit source/build provenance and binary hashes",
+        }
     statuses: list[str] = []
     selected = set(args.workloads) if args.workloads else {workload["name"] for workload in WORKLOADS}
     for workload in WORKLOADS:
@@ -652,9 +920,10 @@ def run_audit(args: argparse.Namespace) -> dict[str, Any]:
             raise RuntimeError(f"workload root is missing: {root_source}")
         row: dict[str, Any] = {
             **workload,
+            "supported_scenarios": manifest_workloads[workload["name"]]["supported_scenarios"],
             "root": str(root_source),
             "source_sha256": sha256_paths(
-                all_files(root_source.parent) if workload["family"] in {"representative", "caldera"} else [root_source],
+                tracked_files(root_source.parent) if workload["family"] in {"representative", "caldera"} else [root_source],
                 root,
             ),
             "scenarios": {},
@@ -663,6 +932,13 @@ def run_audit(args: argparse.Namespace) -> dict[str, Any]:
         with tempfile.TemporaryDirectory(prefix="rue-value-audit-") as temp:
             workdir = Path(temp)
             for scenario in SCENARIOS:
+                timeout = args.timeout
+                if workload["family"] == "caldera" and scenario == "cold":
+                    timeout = max(
+                        timeout,
+                        thresholds["caldera_wall_seconds"]
+                        + audit_manifest["protocol"]["caldera_timeout_headroom_seconds"],
+                    )
                 role_rows: dict[str, dict[str, Any]] = {}
                 for pair_index in range(args.iterations):
                     order = list(ROLES) if pair_index % 2 == 0 else list(reversed(ROLES))
@@ -671,43 +947,45 @@ def run_audit(args: argparse.Namespace) -> dict[str, Any]:
                             continue
                         role_rows.setdefault(role, {"status": "pass", "wall_samples": [], "rss_samples": [], "details": []})
                         if scenario == "cold":
+                            if pair_index == 0:
+                                for _ in range(audit_manifest["protocol"]["warmup"]):
+                                    cold_sample(
+                                        binaries[role], root_source, root, timeout, args.jobs,
+                                        workdir, perf_baseline,
+                                    )
                             sample = cold_sample(
-                                binaries[role], root_source, root, args.timeout, args.jobs, workdir
+                                binaries[role], root_source, root, timeout, args.jobs, workdir,
+                                perf_baseline,
                             )
                         elif scenario == "repeated_edit_memory":
                             sample = {"status": "unsupported", "reason": "existing reused benchmark has no bounded repeated-edit memory protocol"}
                         elif role not in session_bins:
                             sample = {"status": "unsupported", "reason": "no compatible session benchmark binary supplied for this revision"}
+                        elif scenario not in manifest_workloads[workload["name"]]["supported_scenarios"]:
+                            sample = {"status": "unsupported", "reason": "scenario is not declared by the workload in the audit manifest"}
                         elif workload["family"] not in SESSION_ROW_NAMES or scenario not in SESSION_ROW_NAMES[workload["family"]]:
                             sample = {"status": "unsupported", "reason": "scenario is not implemented by the canonical runner for this workload"}
                         else:
                             if pair_index == 0:
-                                # Exactly one unrecorded warmup per role and
-                                # scenario, as required by the protocol.
-                                session_sample(session_bins[role], workload, scenario, args.timeout, root)
-                            sample = session_sample(session_bins[role], workload, scenario, args.timeout, root)
+                                for _ in range(audit_manifest["protocol"]["warmup"]):
+                                    session_sample(
+                                        session_bins[role], workload, scenario, timeout, root,
+                                        audit_manifest["locality"][scenario],
+                                    )
+                            sample = session_sample(
+                                session_bins[role], workload, scenario, timeout, root,
+                                audit_manifest["locality"][scenario],
+                            )
                         if (
                             workload["family"] == "synthetic"
                             and scenario == "warm_leaf_body"
                             and role in scaling_bins
                         ):
                             if pair_index == 0:
-                                scaling_sample(scaling_bins[role], workload, True, args.timeout)
-                            scaling = scaling_sample(scaling_bins[role], workload, True, args.timeout)
+                                scaling_sample(scaling_bins[role], True, timeout, root)
+                            scaling = scaling_sample(scaling_bins[role], True, timeout, root)
                             row["scaling_evidence"].setdefault(role, []).append(scaling)
-                        if sample.get("status") == "unsupported":
-                            role_rows[role] = sample
-                            continue
-                        if scenario == "cold":
-                            sample["status"] = "pass"
-                            role_rows[role]["wall_samples"].append(float(sample["wall_ms"]))
-                            role_rows[role]["rss_samples"].append(sample.get("peak_rss_bytes"))
-                        else:
-                            role_rows[role]["wall_samples"].append(float(sample["wall_ms"]))
-                            role_rows[role]["rss_samples"].append(sample.get("peak_rss_bytes"))
-                            if sample.get("status") == "fail":
-                                role_rows[role]["status"] = "fail"
-                        role_rows[role]["details"].append(sample)
+                        merge_role_sample(role_rows[role], sample, scenario)
                 for role, values in list(role_rows.items()):
                     if values.get("status") == "unsupported":
                         continue
@@ -717,6 +995,16 @@ def run_audit(args: argparse.Namespace) -> dict[str, Any]:
                     values["rss"] = median_mad([
                         float(value) for value in values.pop("rss_samples") if value is not None
                     ])
+                    protocols = sorted({
+                        detail.get("protocol")
+                        for detail in values.get("details", [])
+                        if detail.get("protocol") is not None
+                    })
+                    if len(protocols) != 1:
+                        values["status"] = "indeterminate"
+                        values["protocol"] = protocols
+                    else:
+                        values["protocol"] = protocols[0]
                 for role, values in role_rows.items():
                     if values.get("status") == "unsupported":
                         continue
@@ -730,7 +1018,13 @@ def run_audit(args: argparse.Namespace) -> dict[str, Any]:
                         values["correctness"] = {"status": "fail", "reason": "output artifact changed between paired samples"}
                     else:
                         values["correctness"] = {"status": "pass", "criterion": "exit_zero_and_output_present"}
-                verdict = scenario_verdict(scenario, role_rows, workload)
+                verdict = scenario_verdict(
+                    scenario,
+                    role_rows,
+                    row,
+                    scenario_policy[scenario],
+                    thresholds,
+                )
                 row["scenarios"][scenario] = {"roles": role_rows, "verdict": verdict}
                 statuses.append(verdict["status"])
         report["workloads"].append(row)
@@ -745,11 +1039,19 @@ def run_audit(args: argparse.Namespace) -> dict[str, Any]:
                 ),
                 "runner": "rue-scaling-bench",
             }
-    if "fail" in statuses:
+    required_statuses = [
+        status
+        for workload in report["workloads"]
+        for scenario, value in workload["scenarios"].items()
+        if value["verdict"].get("required")
+        and value["verdict"].get("status") not in {"not_applicable"}
+        for status in [value["verdict"]["status"]]
+    ]
+    if "fail" in statuses or "fail" in required_statuses:
         report["verdict"] = "fail"
-    elif "indeterminate" in statuses:
+    elif "indeterminate" in statuses or "indeterminate" in required_statuses:
         report["verdict"] = "indeterminate"
-    elif not statuses or all(status == "unsupported" for status in statuses):
+    elif not statuses or all(status in {"unsupported", "not_applicable"} for status in statuses):
         report["verdict"] = "unsupported"
     return report
 
@@ -781,6 +1083,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "candidate": args.candidate.expanduser().resolve(),
     }
     args.source_dirs = parse_role_mapping(args.source_dir, "--source-dir")
+    if set(args.source_dirs) != set(ROLES):
+        parser.error("--source-dir is required once for every role; provenance is never inferred")
     args.session_bins = parse_role_mapping(args.session_bench, "--session-bench")
     args.scaling_bins = parse_role_mapping(args.scaling_bench, "--scaling-bench")
     return args

--- a/scripts/rue-value-audit.py
+++ b/scripts/rue-value-audit.py
@@ -379,7 +379,6 @@ def locality_check(scenario: str, row: dict[str, Any]) -> dict[str, Any]:
         passed = (
             count("semantic_bodies", "required") == 0
             and count("cfgs", "required") == 0
-            and count("semantic_bodies", "reused") >= 1
             and count("cfgs", "reused") >= 1
         )
     elif scenario == "warm_leaf_body":

--- a/scripts/test-value-audit.py
+++ b/scripts/test-value-audit.py
@@ -23,11 +23,16 @@ class ValueAuditTests(unittest.TestCase):
         return self.manifest["locality"][scenario]
 
     def work(self, *, body=0, cfg=0, modules=0, rir=0, declarations=0,
-             durable_source=0, queries=0, reused=1):
+             durable_source=0, queries=0, shells=0, projections=0,
+             semantics=0, endpoints=0, cold_preparations=0,
+             declarations_inspected=0, modules_registered=0,
+             rir_indexes=0, rir_instructions=0, durable_inspected=0,
+             durable_copied=0, reused=1):
         def counters(computed, reused_count):
             return {
                 "computed": computed,
                 "invalidated": computed,
+                "required": computed,
                 "reused": reused_count,
             }
         return {
@@ -44,6 +49,17 @@ class ValueAuditTests(unittest.TestCase):
             "semantic_bodies": counters(body, reused),
             "cfgs": counters(cfg, reused),
             "semantic_queries": counters(queries, reused),
+            "cold_body_preparations": counters(cold_preparations, reused),
+            "declarations_inspected": counters(declarations_inspected, reused),
+            "modules_registered": counters(modules_registered, reused),
+            "rir_indexes_constructed": counters(rir_indexes, reused),
+            "rir_instructions_visited": counters(rir_instructions, reused),
+            "durable_source_records_inspected": counters(durable_inspected, reused),
+            "durable_source_records_copied": counters(durable_copied, reused),
+            "shells_prepared": counters(shells, reused),
+            "projections_performed": counters(projections, reused),
+            "semantics_installed": counters(semantics, reused),
+            "endpoints_installed": counters(endpoints, reused),
         }
 
     def parity(self):
@@ -63,7 +79,30 @@ class ValueAuditTests(unittest.TestCase):
             "emitted_output": "byte_exact",
             "emitted_output_sha256": "0" * 64,
             "emitted_output_size_bytes": 1,
-            "cold_semantic_work": {},
+            "cold_semantic_work": {
+                "schema_version": 1,
+                "bodies_attempted": 1,
+                "bodies_succeeded": 1,
+                "bodies_failed": 0,
+                "body_analyses_computed": 1,
+                "body_analyses_reused": 0,
+                "body_analyses_invalidated": 0,
+                "per_body_declaration_context": {
+                    "cold_body_preparations": 1,
+                    "declarations_inspected": 1,
+                    "modules_registered": 1,
+                    "rir_indexes_constructed": 1,
+                    "rir_instructions_visited": 1,
+                    "shells_prepared": 1,
+                    "projections_performed": 1,
+                    "semantics_installed": 1,
+                    "endpoints_installed": 1,
+                    "durable_source_records_inspected": 1,
+                    "durable_source_records_copied": 1,
+                },
+                "durable_bodies": {"candidate_comparisons": 0, "reused_bodies": 0},
+                "cfg": {"builds_attempted": 1, "builds_succeeded": 1, "builds_failed": 0},
+            },
         }
 
     def row(self, scenario, **kwargs):
@@ -139,6 +178,20 @@ class ValueAuditTests(unittest.TestCase):
         row["differential_parity"] = {}
         self.assertEqual(value_audit.parity_check(row)["status"], "unsupported")
 
+    def test_empty_cold_semantic_work_is_not_exact_evidence(self):
+        row = self.row("warm_leaf_body")
+        row["differential_parity"]["cold_semantic_work"] = {}
+        self.assertEqual(value_audit.parity_check(row)["status"], "unsupported")
+
+    def test_partial_or_malformed_cold_semantic_work_fails_closed(self):
+        for mutation in ("bodies_attempted", "per_body_declaration_context"):
+            row = self.row("warm_leaf_body")
+            if mutation == "bodies_attempted":
+                del row["differential_parity"]["cold_semantic_work"][mutation]
+            else:
+                row["differential_parity"]["cold_semantic_work"][mutation] = []
+            self.assertEqual(value_audit.parity_check(row)["status"], "unsupported")
+
     def test_ordered_type_universe_is_valid_exact_parity_evidence(self):
         self.assertEqual(value_audit.parity_check(self.row("warm_leaf_body"))["status"], "pass")
 
@@ -148,6 +201,59 @@ class ValueAuditTests(unittest.TestCase):
             "warm_leaf_body", row, self.locality_policy("warm_leaf_body")
         )
         self.assertEqual(result["status"], "fail")
+
+    def test_omitted_counter_universe_traversal_fails(self):
+        row = self.row("warm_leaf_body", shells=129)
+        result = value_audit.locality_check(
+            "warm_leaf_body", row, self.locality_policy("warm_leaf_body")
+        )
+        self.assertEqual(result["status"], "fail")
+
+    def test_each_newly_carried_counter_is_bounded(self):
+        counters = (
+            "cold_body_preparations",
+            "declarations_inspected",
+            "modules_registered",
+            "rir_indexes_constructed",
+            "rir_instructions_visited",
+            "durable_source_records_inspected",
+            "durable_source_records_copied",
+        )
+        for counter in counters:
+            row = self.row("warm_leaf_body")
+            maximum = self.locality_policy("warm_leaf_body")[f"max_{counter}_computed"]
+            row["required_vs_reused_work"][counter]["computed"] = maximum + 1
+            result = value_audit.locality_check(
+                "warm_leaf_body", row, self.locality_policy("warm_leaf_body")
+            )
+            self.assertEqual(result["status"], "fail", counter)
+
+    def test_unavailable_dimensions_are_not_published_as_work(self):
+        row = self.row("warm_leaf_body", body=1, cfg=1, queries=1)
+        row["required_vs_reused_work"]["durable_source"]["reused"] = {
+            "available": False,
+            "reason": "durable-body reuse is not durable-source reuse",
+        }
+        row["required_vs_reused_work"]["durable_source"]["invalidated"] = {
+            "available": False,
+            "reason": "no durable-source invalidation counter",
+        }
+        self.assertEqual(
+            value_audit.locality_check(
+                "warm_leaf_body", row, self.locality_policy("warm_leaf_body")
+            )["status"],
+            "pass",
+        )
+
+    def test_historical_cached_work_cannot_claim_current_recomputation(self):
+        row = self.row("warm_leaf_body", body=1, cfg=1)
+        row["required_vs_reused_work"]["semantic_queries"]["computed"] = 0
+        self.assertEqual(
+            value_audit.locality_check(
+                "warm_leaf_body", row, self.locality_policy("warm_leaf_body")
+            )["status"],
+            "unsupported",
+        )
 
     def test_unrelated_edit_with_semantic_rerun_fails(self):
         row = self.row("warm_unrelated_declaration", declarations=1, queries=1)
@@ -167,7 +273,54 @@ class ValueAuditTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 value_audit.load_audit_manifest(ROOT)
         finally:
+                value_audit.tomllib.load = original_loader
+
+    def test_manifest_contract_mutations_are_rejected_before_measurement(self):
+        original_loader = value_audit.tomllib.load
+        for mutation in ("root", "warm_runner"):
+            drifted = dict(self.manifest)
+            drifted["workload"] = [dict(item) for item in self.manifest["workload"]]
+            drifted["workload"][0][mutation] = "mutated"
+            value_audit.tomllib.load = lambda _stream, drifted=drifted: drifted
+            try:
+                with self.assertRaises(ValueError):
+                    value_audit.load_audit_manifest(ROOT)
+            finally:
+                value_audit.tomllib.load = original_loader
+
+        drifted = dict(self.manifest)
+        drifted["protocol"] = dict(self.manifest["protocol"])
+        drifted["protocol"]["pair_order"] = "candidate,current,historical"
+        value_audit.tomllib.load = lambda _stream, drifted=drifted: drifted
+        try:
+            with self.assertRaises(ValueError):
+                value_audit.load_audit_manifest(ROOT)
+        finally:
             value_audit.tomllib.load = original_loader
+
+    def test_identical_binary_pairs_cannot_claim_value(self):
+        def role(binary):
+            return {
+                "status": "pass",
+                "protocol": "session_benchmark_json",
+                "binary_sha256": binary,
+                "wall": {"median": 100.0, "mad": 0.0},
+                "rss": {"median": 100.0, "mad": 0.0},
+            }
+        result = value_audit.scenario_verdict(
+            "warm_leaf_body",
+            {
+                "historical_baseline": role("historical"),
+                "current_production": role("same"),
+                "candidate": role("same"),
+            },
+            {"family": "synthetic", "supported_scenarios": ["warm_leaf_body"]},
+            self.manifest["scenario_policy"]["warm_leaf_body"],
+            self.thresholds,
+        )
+        pair = result["pairs"]["current_production_vs_candidate"]
+        self.assertEqual(pair["status"], "unsupported")
+        self.assertTrue(pair["same_binary"])
 
     def test_role_provenance_is_explicit_and_never_defaults(self):
         with self.assertRaises(ValueError):

--- a/scripts/test-value-audit.py
+++ b/scripts/test-value-audit.py
@@ -14,6 +14,70 @@ SPEC.loader.exec_module(value_audit)
 
 
 class ValueAuditTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = value_audit.load_audit_manifest(ROOT)
+        cls.thresholds = cls.manifest["thresholds"]
+
+    def locality_policy(self, scenario):
+        return self.manifest["locality"][scenario]
+
+    def work(self, *, body=0, cfg=0, modules=0, rir=0, declarations=0,
+             durable_source=0, queries=0, reused=1):
+        def counters(computed, reused_count):
+            return {
+                "computed": computed,
+                "invalidated": computed,
+                "reused": reused_count,
+            }
+        return {
+            "schema_version": 2,
+            "counter_source": "production_metrics",
+            "exact_identity_sets": {
+                "available": False,
+                "reason": "test fixture has no identity-set protocol",
+            },
+            "modules": counters(modules, reused),
+            "rir": counters(rir, reused),
+            "declarations": counters(declarations, reused),
+            "durable_source": counters(durable_source, reused),
+            "semantic_bodies": counters(body, reused),
+            "cfgs": counters(cfg, reused),
+            "semantic_queries": counters(queries, reused),
+        }
+
+    def parity(self):
+        return {
+            "schema_version": 1,
+            "status": "pass",
+            "comparison": "cold_vs_reused_in_process",
+            "comparison_completed": True,
+            "public_semantic_cfg_artifacts": "exact",
+            "public_type_universe": "exact_ordered_entries",
+            "durable_specialized_body_payloads": "exact",
+            "durable_ordinary_body_manifest_artifacts": "exact",
+            "diagnostics": "exact",
+            "warnings": "exact",
+            "stable_identities": "exact",
+            "dependency_records": "exact",
+            "emitted_output": "byte_exact",
+            "emitted_output_sha256": "0" * 64,
+            "emitted_output_size_bytes": 1,
+            "cold_semantic_work": {},
+        }
+
+    def row(self, scenario, **kwargs):
+        return {
+            "wall_time_ns": 1,
+            "evidence_schema": {
+                "version": 2,
+                "differential_parity_version": 1,
+                "locality_work_version": 2,
+            },
+            "differential_parity": self.parity(),
+            "required_vs_reused_work": self.work(**kwargs),
+        }
+
     def test_median_and_mad_are_raw_and_deterministic(self):
         self.assertEqual(
             value_audit.median_mad([10.0, 12.0, 11.0, 13.0, 9.0]),
@@ -28,55 +92,183 @@ class ValueAuditTests(unittest.TestCase):
     def test_improvement_requires_threshold_and_three_mad_win(self):
         left = value_audit.median_mad([100.0] * 7)
         right = value_audit.median_mad([40.0] * 7)
-        result = value_audit.pair_verdict(left, right, "improvement", 0.50)
+        result = value_audit.pair_verdict(left, right, "improvement", 0.50, self.thresholds)
         self.assertEqual(result["status"], "pass")
         self.assertAlmostEqual(result["improvement_fraction"], 0.60)
 
         noisy_right = value_audit.median_mad([20.0, 20.0, 20.0, 40.0, 60.0, 60.0, 60.0])
-        noisy = value_audit.pair_verdict(left, noisy_right, "improvement", 0.50)
+        noisy = value_audit.pair_verdict(left, noisy_right, "improvement", 0.50, self.thresholds)
         self.assertIn(noisy["status"], {"indeterminate", "fail"})
 
     def test_cold_gate_uses_larger_mad_and_two_percent_floor(self):
         left = value_audit.median_mad([100.0] * 7)
         right = value_audit.median_mad([102.0] * 7)
-        result = value_audit.pair_verdict(left, right, "regression")
+        result = value_audit.pair_verdict(left, right, "regression", thresholds=self.thresholds)
         self.assertEqual(result["status"], "pass")
         self.assertEqual(result["allowed_regression"], 2.0)
 
-    def test_session_locality_gate_is_black_box(self):
-        row = {
-            "required_vs_reused_work": {
-                "semantic_bodies": {"required": 0, "reused": 128},
-                "cfgs": {"required": 0, "reused": 128},
-                "semantic_queries": {"required": 0, "reused": 1},
-            }
-        }
-        self.assertEqual(value_audit.locality_check("warm_no_op", row)["status"], "pass")
+    def test_session_locality_gate_consumes_exact_upper_bounds(self):
+        row = self.row("warm_no_op", reused=128)
         self.assertEqual(
-            value_audit.locality_check("warm_unrelated_declaration", row)["status"],
+            value_audit.locality_check("warm_no_op", row, self.locality_policy("warm_no_op"))["status"],
             "pass",
         )
-        benchmark_row = {
-            "required_vs_reused_work": {
-                "semantic_bodies": {"required": 0, "reused": 0},
-                "cfgs": {"required": 0, "reused": 128},
-                "semantic_queries": {"required": 1, "reused": 0},
-            }
-        }
+        all_modules_reparsed = self.row("warm_unrelated_declaration", modules=128)
         self.assertEqual(
             value_audit.locality_check(
-                "warm_unrelated_declaration", benchmark_row
+                "warm_unrelated_declaration", all_modules_reparsed,
+                self.locality_policy("warm_unrelated_declaration"),
             )["status"],
-            "pass",
+            "fail",
         )
+
+    def test_all_warm_required_evidence_unsupported_is_not_a_pass(self):
+        workload = {
+            "supported_scenarios": ["warm_leaf_body"],
+            "family": "synthetic",
+        }
+        rows = {role: {"status": "unsupported"} for role in value_audit.ROLES}
+        result = value_audit.scenario_verdict(
+            "warm_leaf_body", rows, workload,
+            self.manifest["scenario_policy"]["warm_leaf_body"], self.thresholds,
+        )
+        self.assertEqual(result["status"], "indeterminate")
+
+    def test_empty_parity_object_is_not_exact_evidence(self):
+        row = self.row("warm_leaf_body", body=1, cfg=1)
+        row["differential_parity"] = {}
+        self.assertEqual(value_audit.parity_check(row)["status"], "unsupported")
+
+    def test_ordered_type_universe_is_valid_exact_parity_evidence(self):
+        self.assertEqual(value_audit.parity_check(self.row("warm_leaf_body"))["status"], "pass")
+
+    def test_leaf_edit_with_full_program_recompute_fails(self):
+        row = self.row("warm_leaf_body", body=128, cfg=127, modules=128)
+        result = value_audit.locality_check(
+            "warm_leaf_body", row, self.locality_policy("warm_leaf_body")
+        )
+        self.assertEqual(result["status"], "fail")
+
+    def test_unrelated_edit_with_semantic_rerun_fails(self):
+        row = self.row("warm_unrelated_declaration", declarations=1, queries=1)
+        result = value_audit.locality_check(
+            "warm_unrelated_declaration", row,
+            self.locality_policy("warm_unrelated_declaration"),
+        )
+        self.assertEqual(result["status"], "fail")
+
+    def test_manifest_threshold_drift_is_rejected(self):
+        drifted = dict(self.manifest)
+        drifted["thresholds"] = dict(self.manifest["thresholds"])
+        drifted["thresholds"]["warm_leaf_body_improvement"] = 0.24
+        original_loader = value_audit.tomllib.load
+        value_audit.tomllib.load = lambda _stream: drifted
+        try:
+            with self.assertRaises(ValueError):
+                value_audit.load_audit_manifest(ROOT)
+        finally:
+            value_audit.tomllib.load = original_loader
+
+    def test_role_provenance_is_explicit_and_never_defaults(self):
+        with self.assertRaises(ValueError):
+            value_audit.role_metadata(
+                "candidate", Path("/does/not/exist"), None
+            )
 
     def test_old_protocol_is_explicitly_supported_as_black_box(self):
         self.assertEqual(value_audit.parse_rss("maximum resident set size: 123", "darwin"), 123)
+        self.assertEqual(value_audit.parse_rss("123456 maximum resident set size", "darwin"), 123456)
         self.assertEqual(value_audit.parse_rss("Maximum resident set size (kbytes): 2", "gnu"), 2048)
         self.assertIsNone(value_audit.parse_rss("no memory field", "none"))
 
+    def test_cold_rss_failure_rolls_into_overall_gate(self):
+        def role(protocol, rss):
+            return {
+                "status": "pass",
+                "protocol": protocol,
+                "wall": {"median": 100.0, "mad": 0.0},
+                "rss": {"median": rss, "mad": 0.0},
+            }
+        result = value_audit.scenario_verdict(
+            "cold",
+            {
+                "historical_baseline": role("benchmark_json", 100.0),
+                "current_production": role("benchmark_json", 103.0),
+                "candidate": role("benchmark_json", 103.0),
+            },
+            {"family": "synthetic", "supported_scenarios": ["cold"]},
+            self.manifest["scenario_policy"]["cold"],
+            self.thresholds,
+        )
+        self.assertEqual(result["status"], "fail")
+        self.assertEqual(result["pairs"]["historical_baseline_vs_current_production"]["rss"]["status"], "fail")
+
+    def test_cross_protocol_timing_comparison_is_indeterminate(self):
+        def role(protocol):
+            return {
+                "status": "pass",
+                "protocol": protocol,
+                "wall": {"median": 100.0, "mad": 0.0},
+                "rss": {"median": 100.0, "mad": 0.0},
+            }
+        result = value_audit.scenario_verdict(
+            "cold",
+            {
+                "historical_baseline": role("black_box_compile"),
+                "current_production": role("benchmark_json"),
+                "candidate": role("benchmark_json"),
+            },
+            {"family": "synthetic", "supported_scenarios": ["cold"]},
+            self.manifest["scenario_policy"]["cold"],
+            self.thresholds,
+        )
+        self.assertEqual(result["status"], "indeterminate")
+
+    def test_partial_locality_row_fails_closed(self):
+        row = self.row("warm_leaf_body", body=1, cfg=1)
+        del row["required_vs_reused_work"]["cfgs"]
+        self.assertEqual(
+            value_audit.locality_check(
+                "warm_leaf_body", row, self.locality_policy("warm_leaf_body")
+            )["status"],
+            "unsupported",
+        )
+
+    def test_unsupported_sample_preserves_collected_role_row(self):
+        role = {"status": "pass", "wall_samples": [], "rss_samples": [], "details": []}
+        value_audit.merge_role_sample(
+            role,
+            {"status": "pass", "wall_ms": 10.0, "peak_rss_bytes": 100, "protocol": "session_benchmark_json"},
+            "warm_leaf_body",
+        )
+        value_audit.merge_role_sample(role, {"status": "unsupported", "reason": "missing"}, "warm_leaf_body")
+        self.assertEqual(role["status"], "indeterminate")
+        self.assertEqual(role["wall_samples"], [10.0])
+
+    def test_measurement_environment_removes_rust_log(self):
+        original = value_audit.os.environ.get("RUST_LOG")
+        value_audit.os.environ["RUST_LOG"] = "debug"
+        try:
+            self.assertNotIn("RUST_LOG", value_audit.measurement_env(ROOT))
+        finally:
+            if original is None:
+                value_audit.os.environ.pop("RUST_LOG", None)
+            else:
+                value_audit.os.environ["RUST_LOG"] = original
+
+    def test_perf_baseline_loader_is_cached(self):
+        value_audit.load_perf_baseline.cache_clear()
+        value_audit.load_perf_baseline(ROOT)
+        value_audit.load_perf_baseline(ROOT)
+        self.assertEqual(value_audit.load_perf_baseline.cache_info().hits, 1)
+
+    def test_manifest_pins_warmup_and_caldera_timeout_headroom(self):
+        self.assertEqual(self.manifest["protocol"]["warmup"], 1)
+        self.assertGreater(self.manifest["protocol"]["caldera_timeout_headroom_seconds"], 0)
+
     def test_fixture_manifest_reuses_canonical_benchmark_manifest(self):
         manifest = value_audit.load_audit_manifest(ROOT)
+        self.assertEqual(manifest["schema_version"], 2)
         self.assertEqual(manifest["protocol"]["paired_samples"], 7)
         self.assertEqual(manifest["protocol"]["warmup"], 1)
 

--- a/scripts/test-value-audit.py
+++ b/scripts/test-value-audit.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Focused protocol tests for rue-value-audit.py."""
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SPEC = importlib.util.spec_from_file_location("value_audit", ROOT / "scripts/rue-value-audit.py")
+assert SPEC is not None and SPEC.loader is not None
+value_audit = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(value_audit)
+
+
+class ValueAuditTests(unittest.TestCase):
+    def test_median_and_mad_are_raw_and_deterministic(self):
+        self.assertEqual(
+            value_audit.median_mad([10.0, 12.0, 11.0, 13.0, 9.0]),
+            {
+                "available": True,
+                "samples": [10.0, 12.0, 11.0, 13.0, 9.0],
+                "median": 11.0,
+                "mad": 1.0,
+            },
+        )
+
+    def test_improvement_requires_threshold_and_three_mad_win(self):
+        left = value_audit.median_mad([100.0] * 7)
+        right = value_audit.median_mad([40.0] * 7)
+        result = value_audit.pair_verdict(left, right, "improvement", 0.50)
+        self.assertEqual(result["status"], "pass")
+        self.assertAlmostEqual(result["improvement_fraction"], 0.60)
+
+        noisy_right = value_audit.median_mad([20.0, 20.0, 20.0, 40.0, 60.0, 60.0, 60.0])
+        noisy = value_audit.pair_verdict(left, noisy_right, "improvement", 0.50)
+        self.assertIn(noisy["status"], {"indeterminate", "fail"})
+
+    def test_cold_gate_uses_larger_mad_and_two_percent_floor(self):
+        left = value_audit.median_mad([100.0] * 7)
+        right = value_audit.median_mad([102.0] * 7)
+        result = value_audit.pair_verdict(left, right, "regression")
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(result["allowed_regression"], 2.0)
+
+    def test_session_locality_gate_is_black_box(self):
+        row = {
+            "required_vs_reused_work": {
+                "semantic_bodies": {"required": 0, "reused": 128},
+                "cfgs": {"required": 0, "reused": 128},
+                "semantic_queries": {"required": 0, "reused": 1},
+            }
+        }
+        self.assertEqual(value_audit.locality_check("warm_no_op", row)["status"], "pass")
+        self.assertEqual(
+            value_audit.locality_check("warm_unrelated_declaration", row)["status"],
+            "pass",
+        )
+
+    def test_old_protocol_is_explicitly_supported_as_black_box(self):
+        self.assertEqual(value_audit.parse_rss("maximum resident set size: 123", "darwin"), 123)
+        self.assertEqual(value_audit.parse_rss("Maximum resident set size (kbytes): 2", "gnu"), 2048)
+        self.assertIsNone(value_audit.parse_rss("no memory field", "none"))
+
+    def test_fixture_manifest_reuses_canonical_benchmark_manifest(self):
+        manifest = value_audit.load_audit_manifest(ROOT)
+        self.assertEqual(manifest["protocol"]["paired_samples"], 7)
+        self.assertEqual(manifest["protocol"]["warmup"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-value-audit.py
+++ b/scripts/test-value-audit.py
@@ -56,6 +56,19 @@ class ValueAuditTests(unittest.TestCase):
             value_audit.locality_check("warm_unrelated_declaration", row)["status"],
             "pass",
         )
+        benchmark_row = {
+            "required_vs_reused_work": {
+                "semantic_bodies": {"required": 0, "reused": 0},
+                "cfgs": {"required": 0, "reused": 128},
+                "semantic_queries": {"required": 1, "reused": 0},
+            }
+        }
+        self.assertEqual(
+            value_audit.locality_check(
+                "warm_unrelated_declaration", benchmark_row
+            )["status"],
+            "pass",
+        )
 
     def test_old_protocol_is_explicitly_supported_as_black_box(self):
         self.assertEqual(value_audit.parse_rss("maximum resident set size: 123", "darwin"), 123)


### PR DESCRIPTION
## Summary

This draft PR is an incrementality value-audit and instrumentation stack. It records current production behavior and fail-closed evidence; it does not enable a provider analyzer, flip production behavior, or claim flip readiness.

Refs RUE-1091, RUE-1090, RUE-1092.

The integrated stack is:

- `b336a008` — existing Clippy iterator-clone correction retained at the fork head
- `741322a9` — O(1) exact-key retained-body counter probe and lifecycle coverage
- `8cf3a129` — complete warm/fresh retained-body identity oracle
- `6c0b7efe` — schema-v2 runner, manifest-authoritative evidence gates, and adversarial tests
- `2964791c` — narrow integration Clippy cleanup in the merged oracle

The production body hot path calls the exact-key `contains_retained_key` probe. The complete retained-key scan is cfg(test)-only and supplies the snapshot oracle, including successful, failed, deleted, renamed, visibility, and imported-body cases.

## Protocol and gates

- Release-profile protocol with one unrecorded warmup and seven alternating paired samples.
- Required evidence is fail-closed: malformed, partial, missing, unsupported, or cross-protocol evidence cannot become a pass.
- Schema v2, exact parity, output-presence checks, production locality counters, exact-identity availability, RSS rollup, Darwin RSS parsing, RUST_LOG hygiene, cached baseline loading, robust partial-row handling, explicit role/source/binary provenance, same-binary classification, Caldera timeout headroom, and the Buck test target are covered.
- Thresholds and locality upper bounds are loaded from and validated against the checked-in manifest.
- A claimed improvement requires the precommitted threshold and three times the larger MAD.
- Cold wall/RSS regression and optional repeated-edit memory evidence remain separately gated.

## Current-production findings

The bounded representative same-binary smoke used one release compiler and one release session-benchmark binary for all three roles. It produced a mechanically valid schema-v2 report classified as `same_binary_protocol_smoke`, with exact parity passing.

- Cold and warm no-op observations passed.
- Warm leaf-body locality failed honestly: production computed 6 semantic bodies, 4 CFGs, and 90 durable-source records against the manifest’s one-unit bounds; the report also retained the corresponding invalidation counters.
- Warm signature-fanout locality failed honestly: production computed 6 semantic bodies, 4 CFGs, and 90 durable-source records against the manifest’s bounded allowance.
- Stable exact identity sets are unavailable in the session-benchmark protocol and are explicitly explained in the evidence.
- Repeated-edit RSS is explicitly unsupported because the reused benchmark has no bounded persistent-session protocol.
- Synthetic and Caldera workloads were not run in this bounded smoke.

The smoke exited nonzero because those current-production value gates failed, not because evidence was malformed. This is protocol/evidence validation only and does not establish a historical/current/candidate value claim.

## Test evidence

- `scripts/rue fmt` completed; unrelated formatter output in `crates/rue-test-runner/src/lib.rs` was removed.
- `bash ./clippy.sh`: passed with no lint violations.
- `scripts/rue unit query exact_retained_key_probe --nocapture`: 1 passed.
- `scripts/rue unit compiler scaling_harness --nocapture`: 21 passed, including correctness, invalidation, scaling, counter lifecycle, failure/deletion/rename/visibility/import oracles.
- `scripts/rue unit compiler-session-bench --nocapture`: 6 passed.
- `./buck2 test //:value-audit-tool-tests`: 20 tests passed.
- `scripts/rue quick`: 36 targets passed, including 836 compiler tests, 839 scaling-matrix tests, 88 oracle-diff tests, and frontend differential coverage.
- Bounded representative same-binary smoke: schema v2 and same-binary classification validated; exact parity passed; value verdict `fail` for the documented locality findings.
