### PR TITLE
Gate the regressed large examples, and isolate what decides warm body locality

### DIFF
--- a/benchmarks/value-audit/README.md
+++ b/benchmarks/value-audit/README.md
@@ -34,6 +34,36 @@ treated as zero work. A run using one binary for all three roles is classified
 as `same_binary_protocol_smoke`; it validates protocol and fail-closed gates,
 not historical/current/candidate value.
 
+## Regressed-example cold workloads
+
+`rill`, `mosaic`, `harbor`, `lattice`, and `meridian` are the five large example
+programs the RUE-1026/RUE-1027 query cutover regressed. All five are `--skip`ped
+from `//:cli-tests` and the large-example compile guard is stubbed, so this audit
+is currently the only place their cold cost is gated.
+
+Each carries an absolute `cold_wall_seconds` gate derived from the checked-in
+`[historical_reference]` table, which transcribes the pre-cutover and
+post-cutover figures from
+[`docs/notes/rue-1083-closure-evidence.md`](../../docs/notes/rue-1083-closure-evidence.md).
+That reference is prose evidence from a local release-build comparison on the
+maintainer's host — it is not a run of this protocol, it is not attributable to
+a role binary, and the runner refuses to let it be declared role evidence.
+
+Two properties make these rows useful before a historical baseline binary
+exists:
+
+- The gate is **per-role and absolute**, so it produces a real verdict even in a
+  `same_binary_protocol_smoke` where every pair is `unsupported`. Role-vs-role
+  cold comparison still needs the pre-cutover binary; the gate does not.
+- `cold_timeout_seconds` is deliberately far above the gate, so an over-budget
+  compile is recorded as a gate failure instead of raising out of the run.
+
+Cost: these are cold-driver workloads under the same one-warmup, seven-paired-
+sample protocol as every other row, and `meridian` currently compiles in minutes
+rather than seconds. Expect the full matrix to run for hours on one host, in the
+same class as the existing Caldera row. Use `--workloads` to select a subset
+while iterating.
+
 The existing session benchmark emits versioned full-parity evidence and
 production computed/reused/invalidated counters. Required warm locality gates
 use manifest-authoritative exact or upper bounds; full-program reparsing,

--- a/benchmarks/value-audit/README.md
+++ b/benchmarks/value-audit/README.md
@@ -38,8 +38,15 @@ not historical/current/candidate value.
 
 `rill`, `mosaic`, `harbor`, `lattice`, and `meridian` are the five large example
 programs the RUE-1026/RUE-1027 query cutover regressed. All five are `--skip`ped
-from `//:cli-tests` and the large-example compile guard is stubbed, so this audit
-is currently the only place their cold cost is gated.
+from `//:cli-tests`, so their compile cost is not part of the required corpus.
+
+The large-example compile guard
+([`.github/workflows/large-examples.yml`](../../.github/workflows/large-examples.yml))
+does compile all six programs, but it deliberately answers a different question:
+it proves they still compile at all, under a 3600-second timeout, and a Caldera
+timeout is downgraded to a warning because pure slowness is a tracked
+performance follow-up rather than a compile-correctness regression. It makes no
+performance claim. These rows are where cold *cost* is gated.
 
 Each carries an absolute `cold_wall_seconds` gate derived from the checked-in
 `[historical_reference]` table, which transcribes the pre-cutover and

--- a/benchmarks/value-audit/manifest.toml
+++ b/benchmarks/value-audit/manifest.toml
@@ -21,6 +21,49 @@ cold_regression_fraction = 0.02
 repeated_edit_rss_band = 0.05
 caldera_wall_seconds = 300
 
+# Pre-cutover compile times for the five large example programs the
+# RUE-1026/RUE-1027 declaration/body query cutover regressed, transcribed from
+# the reproduction table in docs/notes/rue-1083-closure-evidence.md.
+#
+# Provenance discipline: these are local release-build measurements against
+# pre-cutover trunk on the maintainer's host.  They were NOT produced by this
+# audit protocol, they are not attributable to a role binary, and the runner
+# must never surface them as a measured role row.  They exist to give the
+# absolute cold gates below a checked-in reference instead of leaving the only
+# numbers the project must beat in prose.
+[historical_reference]
+source = "docs/notes/rue-1083-closure-evidence.md"
+kind = "local_release_build_comparison"
+produced_by_this_protocol = false
+usable_as_role_evidence = false
+# `cold_wall_seconds` on each regressed_example workload below is
+# `cold_gate_multiplier * pre_cutover_seconds`.  The multiplier is a
+# host-variance allowance over a reference measured on a different machine, not
+# a performance target: the target is the reference value itself.  Every one of
+# these programs is currently 20x to 77x its reference, so the allowance cannot
+# mask the regression it exists to measure.
+cold_gate_multiplier = 4.0
+
+[historical_reference.programs.rill]
+pre_cutover_seconds = 0.32
+post_cutover_seconds = 6.4
+
+[historical_reference.programs.mosaic]
+pre_cutover_seconds = 0.49
+post_cutover_seconds = 14.5
+
+[historical_reference.programs.harbor]
+pre_cutover_seconds = 0.89
+post_cutover_seconds = 65.0
+
+[historical_reference.programs.lattice]
+pre_cutover_seconds = 1.15
+post_cutover_seconds = 69.0
+
+[historical_reference.programs.meridian]
+pre_cutover_seconds = 5.7
+post_cutover_seconds = 438.0
+
 # A required scenario must have complete evidence for every role that is
 # compared.  A missing binary, malformed row, or unsupported protocol makes
 # the scenario indeterminate; it can never silently become a passing result.
@@ -159,3 +202,65 @@ family = "caldera"
 root = "../../examples/caldera/main.rue"
 warm_runner = "unsupported: no persistent-session black-box protocol"
 supported_scenarios = ["cold"]
+# Restated from `thresholds.caldera_wall_seconds` and
+# `protocol.caldera_timeout_headroom_seconds`; the runner rejects drift between
+# them so there is one source of truth and one cold-budget code path.
+cold_wall_seconds = 300
+cold_timeout_seconds = 330
+
+# The five large example programs the query cutover regressed.  Each is
+# `--skip`ped from //:cli-tests today (BUCK), so the audit is currently the only
+# place their cold cost is gated at all.  They are cold-driver workloads with no
+# persistent-session protocol, exactly like `medium_ordinary_rue`.
+#
+# `cold_wall_seconds` is the absolute per-role gate and is checked without any
+# role-vs-role pairing, so these rows produce a real verdict even in a
+# same-binary protocol smoke where no historical binary exists.
+# `cold_timeout_seconds` is only the process bound: it is deliberately far above
+# the gate so an over-budget compile is recorded as a gate failure rather than
+# crashing the run.
+
+[[workload]]
+name = "rill"
+family = "regressed_example"
+root = "../../examples/rill/main.rue"
+warm_runner = "unsupported: no persistent-session black-box protocol"
+supported_scenarios = ["cold"]
+cold_wall_seconds = 1.28
+cold_timeout_seconds = 120
+
+[[workload]]
+name = "mosaic"
+family = "regressed_example"
+root = "../../examples/mosaic/main.rue"
+warm_runner = "unsupported: no persistent-session black-box protocol"
+supported_scenarios = ["cold"]
+cold_wall_seconds = 1.96
+cold_timeout_seconds = 120
+
+[[workload]]
+name = "harbor"
+family = "regressed_example"
+root = "../../examples/harbor/main.rue"
+warm_runner = "unsupported: no persistent-session black-box protocol"
+supported_scenarios = ["cold"]
+cold_wall_seconds = 3.56
+cold_timeout_seconds = 300
+
+[[workload]]
+name = "lattice"
+family = "regressed_example"
+root = "../../examples/lattice/main.rue"
+warm_runner = "unsupported: no persistent-session black-box protocol"
+supported_scenarios = ["cold"]
+cold_wall_seconds = 4.6
+cold_timeout_seconds = 300
+
+[[workload]]
+name = "meridian"
+family = "regressed_example"
+root = "../../examples/meridian/main.rue"
+warm_runner = "unsupported: no persistent-session black-box protocol"
+supported_scenarios = ["cold"]
+cold_wall_seconds = 22.8
+cold_timeout_seconds = 900

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -20,9 +20,16 @@ use rue_span::FileId;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
+mod module_axis;
 mod representative;
 
 const DEFAULT_MODULES: usize = 128;
+/// The module axis holds this many reached bodies fixed across every row, so a
+/// counter difference between rows is attributable to module count alone.
+const DEFAULT_MODULE_AXIS_BODIES: usize = 128;
+/// One module is the single-file shape the existing completion corpus measures;
+/// the larger counts spread the same bodies over a module graph.
+const DEFAULT_MODULE_AXIS_COUNTS: &[usize] = &[1, 2, 8, 32, 128];
 const DEFAULT_WARMUP: usize = 3;
 const DEFAULT_ITERATIONS: usize = 10;
 
@@ -117,12 +124,18 @@ const AVAILABLE_CONTEXT_COUNTERS: &[(&str, &[&str])] = &[
     ),
 ];
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct Config {
     modules: usize,
     warmup: usize,
     iterations: usize,
     representative: bool,
+    /// Run the diagnostic module-count axis instead of the timing workloads.
+    /// `module_axis_bodies` is held fixed while `--module-counts` varies, so a
+    /// difference between rows is attributable to module count alone.
+    module_axis: bool,
+    module_axis_bodies: usize,
+    module_axis_counts: Vec<usize>,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -2064,6 +2077,9 @@ fn parse_config_args(args: impl IntoIterator<Item = String>) -> Result<Config, S
         warmup: DEFAULT_WARMUP,
         iterations: DEFAULT_ITERATIONS,
         representative: false,
+        module_axis: false,
+        module_axis_bodies: DEFAULT_MODULE_AXIS_BODIES,
+        module_axis_counts: DEFAULT_MODULE_AXIS_COUNTS.to_vec(),
     };
     let mut args = args.into_iter();
     while let Some(arg) = args.next() {
@@ -2071,18 +2087,46 @@ fn parse_config_args(args: impl IntoIterator<Item = String>) -> Result<Config, S
             config.representative = true;
             continue;
         }
-        let value = args
+        if arg == "--module-axis" {
+            config.module_axis = true;
+            continue;
+        }
+        let raw = args
             .next()
             .ok_or_else(|| format!("missing value for {arg}"))?;
-        let value = value
+        if arg == "--module-counts" {
+            let counts = raw
+                .split(',')
+                .map(|part| part.trim().parse::<usize>())
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| format!("invalid value for {arg}"))?;
+            if counts.is_empty() || counts.contains(&0) {
+                return Err(format!("unknown option or invalid value: {arg}"));
+            }
+            config.module_axis_counts = counts;
+            continue;
+        }
+        let value = raw
             .parse::<usize>()
             .map_err(|_| format!("invalid value for {arg}"))?;
         match arg.as_str() {
             "--modules" if value >= 4 => config.modules = value,
             "--warmup" => config.warmup = value,
             "--iterations" if value > 0 => config.iterations = value,
+            "--bodies" if value >= 2 => config.module_axis_bodies = value,
             _ => return Err(format!("unknown option or invalid value: {arg}")),
         }
+    }
+    if config.module_axis
+        && let Some(count) = config
+            .module_axis_counts
+            .iter()
+            .find(|count| **count > config.module_axis_bodies)
+    {
+        return Err(format!(
+            "cannot spread {} bodies across {count} modules",
+            config.module_axis_bodies
+        ));
     }
     Ok(config)
 }
@@ -2090,13 +2134,20 @@ fn parse_config_args(args: impl IntoIterator<Item = String>) -> Result<Config, S
 fn usage(message: &str) -> ! {
     eprintln!("error: {message}");
     eprintln!(
-        "usage: rue-compiler-session-bench [--representative] [--modules N>=4] [--warmup N] [--iterations N>=1]"
+        "usage: rue-compiler-session-bench [--representative] [--modules N>=4] [--warmup N] [--iterations N>=1]\n       rue-compiler-session-bench --module-axis [--bodies N>=2] [--module-counts N,N,...]"
     );
     process::exit(2)
 }
 
 fn main() {
     let config = parse_config();
+    if config.module_axis {
+        println!(
+            "{}",
+            module_axis::run(config.module_axis_bodies, &config.module_axis_counts)
+        );
+        return;
+    }
     if config.representative {
         for _ in 0..config.warmup {
             representative::run_iteration();
@@ -2196,6 +2247,9 @@ mod tests {
                 warmup: DEFAULT_WARMUP,
                 iterations: DEFAULT_ITERATIONS,
                 representative: false,
+                module_axis: false,
+                module_axis_bodies: DEFAULT_MODULE_AXIS_BODIES,
+                module_axis_counts: DEFAULT_MODULE_AXIS_COUNTS.to_vec(),
             }
         );
     }

--- a/crates/rue-compiler-session-bench/src/module_axis.rs
+++ b/crates/rue-compiler-session-bench/src/module_axis.rs
@@ -1,0 +1,567 @@
+//! Module-count axis for the completion locality workload (RUE-1091).
+//!
+//! # Why this exists
+//!
+//! Two checked-in workloads disagree about warm body locality:
+//!
+//! * the `--modules N` completion scenarios reanalyze exactly the edited leaf
+//!   after a reachable-body edit (`bodies_attempted == 1` at N=128); and
+//! * the `--representative` fixture reanalyzes every body after a leaf edit
+//!   (`bodies_attempted == 6` of 6), including three bodies that are provably
+//!   outside the edit's reverse closure.
+//!
+//! Those two fixtures differ on more than one axis at once. The completion
+//! corpus is a single file assembled by `single_root_snapshot`; the
+//! representative fixture is seven files reached through import discovery. Body
+//! count and module count are therefore confounded, and the existing benchmarks
+//! cannot say whether the representative result is caused by the program being
+//! small enough that its reverse closure covers everything, or by something
+//! about the multi-module import path defeating durable body reuse.
+//!
+//! This corpus holds the call graph, the body count, and the edit shape fixed
+//! and varies two things independently: how many modules the bodies are spread
+//! across, and which protocol commits import discovery. That separates the two
+//! candidate causes without authoring a second hand-maintained fixture.
+//!
+//! # What it found
+//!
+//! Module count is not the variable — one module and eight behave identically.
+//! The discovery protocol is: the same program under the same edit reanalyzes
+//! one body when discovery is staged and every body under the rooted
+//! import-demand protocol, which is the protocol any program with an import must
+//! use. See `docs/notes/module-axis-locality-findings.md`.
+//!
+//! # What it is not
+//!
+//! This is a diagnostic workload, not a value gate. It reports the production
+//! counters for each configuration and asserts the invariants that must hold
+//! regardless of the answer — reached body count, warm/fresh parity for every
+//! measured edit, and the staged locality result the existing audit claim rests
+//! on. The rooted-demand locality numbers are the observation being collected,
+//! so this module deliberately does not encode an expected value for them: a
+//! repair must not read as a failure.
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use rue_compiler::unstable::{
+    DiscoverySourceAssembler, ImportDemandMode, begin_import_input_request,
+    committed_import_discovery, import_demand_frontier_for_roots, import_observation_ledger,
+    publish_import_observation_batch,
+};
+use rue_compiler::{
+    AcceptedImportSource, AcceptedReadManifest, CompileOptions, CompilerSession,
+    FileMetadataFingerprint, ImportDiscoveryContext, ImportObservation, ImportObservationLedger,
+    PhysicalFileIdentity, SemanticView, SourceSnapshot,
+};
+use serde_json::{Value, json};
+
+use super::{assert_cold_reused_parity_with_discovery, count, measure, named, with_parity};
+
+const ROOT: &str = "/bench/main.rue";
+
+/// Which body the corpus edits, relative to the base revision.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Variant {
+    /// The unmodified program.
+    Base,
+    /// Change the body of `f000`, the first reached leaf. Under exact reverse
+    /// invalidation this reanalyzes `f000` and `main` and nothing else.
+    LeafEdit,
+    /// Change the body of `dead`, which nothing calls. Under exact reverse
+    /// invalidation this reanalyzes no reached body at all.
+    UnrelatedEdit,
+}
+
+/// One point on the module axis: `bodies` reached leaves spread across
+/// `modules` files, all called directly from `main`.
+///
+/// `modules == 1` places every leaf in the root module, so the generated program
+/// is shaped like the existing single-file completion corpus. It is the only
+/// configuration that can run both discovery protocols, because a program with
+/// no imports is the only one whose observation ledger closes without a demand
+/// round; that makes it the control point where the two protocols are compared
+/// on an identical program.
+#[derive(Clone, Copy)]
+pub(crate) struct Corpus {
+    bodies: usize,
+    modules: usize,
+}
+
+impl Corpus {
+    pub(crate) fn new(bodies: usize, modules: usize) -> Self {
+        assert!(bodies >= 2, "the corpus needs at least one leaf plus main");
+        assert!(modules >= 1, "the corpus needs at least the root module");
+        assert!(
+            modules <= bodies,
+            "a module must own at least one leaf; {modules} modules cannot hold {bodies} bodies"
+        );
+        Self { bodies, modules }
+    }
+
+    /// Leaves owned by module `index`, as a contiguous block. Block ownership
+    /// (rather than round-robin) keeps `f000` — the leaf the edit targets — in
+    /// the root module at every module count, so a leaf edit always dirties
+    /// exactly one source file and the edit's blast radius does not itself vary
+    /// along the axis.
+    fn leaves_for(&self, index: usize) -> std::ops::Range<usize> {
+        let leaves = self.bodies - 1;
+        let base = leaves / self.modules;
+        let extra = leaves % self.modules;
+        let start = index * base + index.min(extra);
+        let len = base + usize::from(index < extra);
+        start..start + len
+    }
+
+    fn module_path(index: usize) -> String {
+        format!("/bench/m{index:03}.rue")
+    }
+
+    fn sources(&self, variant: Variant) -> BTreeMap<String, Arc<String>> {
+        let mut sources = BTreeMap::new();
+        let leaf_body = |leaf: usize| {
+            if leaf == 0 && variant == Variant::LeafEdit {
+                1
+            } else {
+                leaf
+            }
+        };
+        // Module 0 is the root: it owns `main`, the unrelated `dead` body, and
+        // its own share of the leaves.
+        let mut root = String::new();
+        for index in 1..self.modules {
+            root.push_str(&format!(
+                "const m{index:03} = @import(\"m{index:03}.rue\");\n"
+            ));
+        }
+        for leaf in self.leaves_for(0) {
+            root.push_str(&format!(
+                "fn f{leaf:03}() -> i32 {{ {} }}\n",
+                leaf_body(leaf)
+            ));
+        }
+        root.push_str(&format!(
+            "fn dead() -> i32 {{ {} }}\n",
+            i32::from(variant == Variant::UnrelatedEdit)
+        ));
+        let calls = (0..self.modules)
+            .flat_map(|index| {
+                self.leaves_for(index).map(move |leaf| {
+                    if index == 0 {
+                        format!("f{leaf:03}()")
+                    } else {
+                        format!("m{index:03}.f{leaf:03}()")
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        root.push_str(&format!("fn main() -> i32 {{ {} }}\n", calls.join(" + ")));
+        sources.insert(ROOT.to_owned(), Arc::new(root));
+
+        for index in 1..self.modules {
+            let mut module = String::new();
+            for leaf in self.leaves_for(index) {
+                module.push_str(&format!(
+                    "pub fn f{leaf:03}() -> i32 {{ {} }}\n",
+                    leaf_body(leaf)
+                ));
+            }
+            sources.insert(Self::module_path(index), Arc::new(module));
+        }
+        sources
+    }
+
+    fn snapshot(&self, variant: Variant) -> SourceSnapshot {
+        assemble(&self.sources(variant)).0
+    }
+}
+
+/// Stable per-path physical identity. Discovery requires each file to carry a
+/// distinct identity, and it must not shift between revisions or an unrelated
+/// edit would look like a file replacement.
+fn identity_for_path(path: &str) -> u64 {
+    if path == ROOT {
+        return 1;
+    }
+    let index: u64 = path
+        .trim_start_matches("/bench/m")
+        .trim_end_matches(".rue")
+        .parse()
+        .expect("generated module paths are /bench/mNNN.rue");
+    index + 2
+}
+
+fn assemble(
+    sources: &BTreeMap<String, Arc<String>>,
+) -> (SourceSnapshot, ImportDiscoveryContext, AcceptedReadManifest) {
+    let context = ImportDiscoveryContext::new(1, "/bench", None, "rue-1091-module-axis").unwrap();
+    let root = sources.get(ROOT).unwrap().clone();
+    let mut assembler = DiscoverySourceAssembler::new(
+        context.clone(),
+        ROOT,
+        ROOT,
+        PhysicalFileIdentity::new(1091, 1),
+        FileMetadataFingerprint::new(root.len() as u64, 0, 1),
+        root,
+    )
+    .unwrap();
+    for (path, source) in sources.iter().filter(|(path, _)| path.as_str() != ROOT) {
+        let identity = identity_for_path(path);
+        assembler
+            .add_explicit(
+                path,
+                path,
+                PhysicalFileIdentity::new(1091, identity),
+                FileMetadataFingerprint::new(source.len() as u64, 0, identity),
+                source.clone(),
+            )
+            .unwrap();
+    }
+    (
+        assembler.snapshot().unwrap(),
+        context,
+        assembler.accepted_read_manifest(),
+    )
+}
+
+/// How a revision's import discovery is driven to a committed artifact.
+///
+/// The two checked-in workloads do not agree here either, and the difference is
+/// not incidental: it decides whether the session observes one revision or a
+/// chain of successor revisions per edit.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Discovery {
+    /// Stage the already-assembled snapshot and commit it, with no import-input
+    /// request and no successor revisions. This is what the single-file
+    /// completion corpus does (`close_completion_discovery`).
+    Staged,
+    /// Open a rooted import-input request and drain the demand frontier,
+    /// publishing an observation batch per round. This is what the
+    /// representative fixture does, and what the real driver does when it reads
+    /// imports from a filesystem.
+    Demand,
+}
+
+impl Discovery {
+    fn name(self) -> &'static str {
+        match self {
+            Discovery::Staged => "staged",
+            Discovery::Demand => "rooted_demand",
+        }
+    }
+}
+
+/// Stage an already-complete snapshot without opening an import-input request.
+///
+/// Every module is present in the assembled snapshot, so the demand frontier
+/// would be empty; this protocol simply never asks. It is the multi-file
+/// generalization of the completion corpus's helper.
+fn close_staged_discovery(session: &mut CompilerSession, source: &SourceSnapshot) {
+    if committed_import_discovery(session)
+        .is_some_and(|artifact| artifact.source_revision() == source.source_revision())
+    {
+        return;
+    }
+    let sources = path_keyed_sources(source);
+    let (discovered, context, accepted_reads) = assemble(&sources);
+    assert_eq!(discovered.source_revision(), source.source_revision());
+    session
+        .stage_import_discovery(
+            &discovered,
+            context,
+            accepted_reads.shared_slice(),
+            ImportObservationLedger::default(),
+        )
+        .unwrap();
+    session
+        .close_import_discovery(ImportObservationLedger::default())
+        .unwrap();
+}
+
+fn path_keyed_sources(source: &SourceSnapshot) -> BTreeMap<String, Arc<String>> {
+    source
+        .files()
+        .map(|file| {
+            let path = if file.path.starts_with('/') {
+                file.path.to_owned()
+            } else {
+                format!("/bench/{}", file.path)
+            };
+            (path, Arc::new(file.source.to_owned()))
+        })
+        .collect()
+}
+
+/// Drive the rooted import-demand protocol to completion for `source`, matching
+/// what the representative fixture does. The completion corpus's single-file
+/// helper cannot be reused here: it assumes exactly one file and never issues a
+/// demand frontier.
+fn close_discovery(session: &mut CompilerSession, source: &SourceSnapshot) {
+    if committed_import_discovery(session)
+        .is_some_and(|artifact| artifact.source_revision() == source.source_revision())
+    {
+        return;
+    }
+    let sources = path_keyed_sources(source);
+    let (discovered, context, accepted_reads) = assemble(&sources);
+    assert_eq!(discovered.source_revision(), source.source_revision());
+    let mut revision = begin_import_input_request(
+        session,
+        &discovered,
+        context.clone(),
+        accepted_reads.clone(),
+    )
+    .unwrap();
+    loop {
+        let ledger = import_observation_ledger(session, revision).unwrap();
+        let plan = session
+            .stage_import_discovery(
+                &discovered,
+                context.clone(),
+                accepted_reads.shared_slice(),
+                ledger.clone(),
+            )
+            .unwrap();
+        let frontier = import_demand_frontier_for_roots(
+            session,
+            revision,
+            &plan,
+            ImportDemandMode::Rooted,
+            &plan.demand_roots(),
+        )
+        .unwrap();
+        if frontier.requests().is_empty() {
+            session.close_import_discovery(ledger).unwrap();
+            break;
+        }
+        let observations = frontier
+            .requests()
+            .iter()
+            .cloned()
+            .map(|request| {
+                let requested_path = request.requested_path().to_owned();
+                if let Some(source) = sources.get(&requested_path) {
+                    let identity = identity_for_path(&requested_path);
+                    ImportObservation::accepted(
+                        request,
+                        AcceptedImportSource::new(
+                            requested_path.as_str(),
+                            requested_path.as_str(),
+                            PhysicalFileIdentity::new(1091, identity),
+                            FileMetadataFingerprint::new(source.len() as u64, 0, identity),
+                            source.clone(),
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap()
+                } else {
+                    ImportObservation::absent(request)
+                }
+            })
+            .collect();
+        revision = publish_import_observation_batch(
+            session,
+            &frontier,
+            &discovered,
+            accepted_reads.clone(),
+            observations,
+        )
+        .unwrap();
+    }
+}
+
+fn close(discovery: Discovery, session: &mut CompilerSession, source: &SourceSnapshot) {
+    match discovery {
+        Discovery::Staged => close_staged_discovery(session, source),
+        Discovery::Demand => close_discovery(session, source),
+    }
+}
+
+fn measured_semantic(
+    session: &mut CompilerSession,
+    source: &SourceSnapshot,
+    options: &CompileOptions,
+    discovery: Discovery,
+) -> (Value, Arc<SemanticView>) {
+    let mut output = None;
+    let value = measure(session, |session| {
+        let update = session.update(source);
+        let parse = update.unstable_metrics();
+        update.into_result().unwrap();
+        close(discovery, session, source);
+        output = Some(session.semantic(options).unwrap());
+        parse
+    });
+    (value, output.unwrap())
+}
+
+/// Prime a session on the base revision, apply `variant`, and report the
+/// production counters for the warm request.
+fn warm_edit(corpus: &Corpus, discovery: Discovery, variant: Variant, name: &str) -> Value {
+    let options = CompileOptions::default();
+    let base = corpus.snapshot(Variant::Base);
+    let edited = corpus.snapshot(variant);
+    let mut session = CompilerSession::new();
+    measured_semantic(&mut session, &base, &options, discovery);
+    let (value, output) = measured_semantic(&mut session, &edited, &options, discovery);
+    let parity = assert_cold_reused_parity_with_discovery(
+        &mut session,
+        &output,
+        &edited,
+        &options,
+        None,
+        |session, source| close(discovery, session, source),
+        |session, source| close(discovery, session, source),
+    );
+    named(name, with_parity(value, parity))
+}
+
+fn cold(corpus: &Corpus, discovery: Discovery) -> Value {
+    let options = CompileOptions::default();
+    let base = corpus.snapshot(Variant::Base);
+    let mut session = CompilerSession::new();
+    let (value, _) = measured_semantic(&mut session, &base, &options, discovery);
+    named("cold", value)
+}
+
+/// One row of the axis: every scenario at a single `(bodies, modules)` point.
+fn configuration(bodies: usize, modules: usize, discovery: Discovery) -> Value {
+    let corpus = Corpus::new(bodies, modules);
+    let scenarios = vec![
+        cold(&corpus, discovery),
+        warm_edit(&corpus, discovery, Variant::LeafEdit, "warm_leaf_body"),
+        warm_edit(
+            &corpus,
+            discovery,
+            Variant::UnrelatedEdit,
+            "warm_unrelated_body",
+        ),
+    ];
+    let cold_bodies = count(&scenarios[0], &["semantic_work", "bodies_attempted"]);
+    assert_eq!(
+        cold_bodies, bodies as u64,
+        "the corpus must reach exactly {bodies} bodies at {modules} modules"
+    );
+    if discovery == Discovery::Staged {
+        // The staged protocol is the one the N=128 completion scenarios use, and
+        // exact reverse invalidation under it is the claim
+        // `docs/notes/body-analysis-cfg-incrementality-audit.md` makes. Pin it
+        // here so a regression in the behavior that claim rests on fails loudly.
+        //
+        // The rooted-demand rows are deliberately left unasserted: they are the
+        // observation this workload exists to collect, and encoding today's
+        // value would make a repair look like a failure.
+        let leaf = &scenarios[1];
+        assert_eq!(
+            count(leaf, &["semantic_work", "body_analyses_computed"]),
+            1,
+            "a staged leaf edit reanalyzes exactly the edited body"
+        );
+        let unrelated = &scenarios[2];
+        assert_eq!(
+            count(unrelated, &["semantic_work", "body_analyses_computed"]),
+            0,
+            "a staged unrelated edit reanalyzes no reached body"
+        );
+    }
+    json!({
+        "bodies": bodies,
+        "modules": modules,
+        "discovery": discovery.name(),
+        "scenarios": scenarios,
+    })
+}
+
+pub(crate) fn run(bodies: usize, module_counts: &[usize]) -> Value {
+    // `Staged` is only a legal protocol for a program with no imports: with any
+    // import present the observation ledger is incomplete and the attempted
+    // revision refuses to close. That is itself part of the finding — the
+    // shortcut the single-file completion corpus takes is unavailable to every
+    // multi-module program, including every real one.
+    let configurations = module_counts
+        .iter()
+        .flat_map(|modules| {
+            let protocols: &[Discovery] = if *modules == 1 {
+                &[Discovery::Staged, Discovery::Demand]
+            } else {
+                &[Discovery::Demand]
+            };
+            protocols
+                .iter()
+                .map(move |discovery| configuration(bodies, *modules, *discovery))
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "schema_version": 1,
+        "workload": "completion_module_axis",
+        "measurement_scope": "structural_counters_only_not_wall_time",
+        "question": "which of module count and import-discovery protocol decides warm body locality",
+        "configuration": {
+            "bodies": bodies,
+            "module_counts": module_counts,
+            "call_graph": "direct: main calls every leaf once",
+            "discovery_protocols": ["staged", "rooted_demand"],
+        },
+        "configurations": configurations,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leaf_blocks_partition_the_reached_bodies() {
+        for modules in [1, 2, 3, 7, 16] {
+            let corpus = Corpus::new(64, modules);
+            let owned = (0..modules)
+                .flat_map(|index| corpus.leaves_for(index))
+                .collect::<Vec<_>>();
+            assert_eq!(
+                owned,
+                (0..63).collect::<Vec<_>>(),
+                "{modules} modules must partition the 63 leaves in order"
+            );
+        }
+    }
+
+    #[test]
+    fn the_edited_leaf_stays_in_the_root_module_at_every_count() {
+        for modules in [1, 2, 16, 63] {
+            let corpus = Corpus::new(64, modules);
+            assert!(
+                corpus.leaves_for(0).contains(&0),
+                "f000 must stay in the root module at {modules} modules so the \
+                 edit dirties exactly one source at every point on the axis"
+            );
+        }
+    }
+
+    #[test]
+    fn every_module_count_generates_the_same_reached_body_count() {
+        for modules in [1, 2, 4] {
+            let corpus = Corpus::new(16, modules);
+            let sources = corpus.sources(Variant::Base);
+            let bodies = sources
+                .values()
+                .map(|source| source.matches("fn f").count())
+                .sum::<usize>();
+            assert_eq!(bodies, 15, "{modules} modules must still declare 15 leaves");
+            assert_eq!(sources.len(), modules, "one file per module");
+        }
+    }
+
+    #[test]
+    fn only_the_edited_body_text_changes() {
+        let corpus = Corpus::new(16, 4);
+        let base = corpus.sources(Variant::Base);
+        let leaf = corpus.sources(Variant::LeafEdit);
+        let changed = base
+            .iter()
+            .filter(|(path, source)| leaf.get(*path) != Some(source))
+            .count();
+        assert_eq!(
+            changed, 1,
+            "a leaf edit changes exactly one module's source"
+        );
+    }
+}

--- a/docs/notes/body-analysis-cfg-incrementality-audit.md
+++ b/docs/notes/body-analysis-cfg-incrementality-audit.md
@@ -117,6 +117,16 @@ The schema-11 session benchmark hard-gates supported N=128 workloads:
 - cold analysis populates declaration, body, and CFG caches from its one
   canonical pass, without duplicate cache-population analysis.
 
+Those hard gates measure a single-file corpus committed through the staged
+discovery protocol. `rue-compiler-session-bench --module-axis` holds the corpus
+and edit fixed and varies only the protocol: under the rooted import-demand
+protocol that every multi-module program must use, the same leaf edit reanalyzes
+every reached body rather than the leaf and its direct reverse caller. Module
+count is not the variable — one module and eight behave identically. See
+[`module-axis-locality-findings.md`](module-axis-locality-findings.md). The
+scenarios below remain accurate about the corpus they measure; they are not
+evidence of exact reverse invalidation for programs with imports.
+
 Every reused scenario is compared against a fresh session for exact public
 semantic/CFG artifacts, ordered type-pool entries, strings, warnings, stable
 identities, specialized durable-body payloads, durable ordinary bodies exposed

--- a/docs/notes/module-axis-locality-findings.md
+++ b/docs/notes/module-axis-locality-findings.md
@@ -1,0 +1,114 @@
+# Warm body locality is decided by the discovery protocol, not module count
+
+Status: diagnostic measurement. Produced by
+`rue-compiler-session-bench --module-axis`, which holds the call graph, reached
+body count, and edit shape fixed and varies only the number of modules the
+bodies are spread across and the protocol used to commit import discovery.
+
+## The disagreement this resolves
+
+Two checked-in workloads reported incompatible warm body locality:
+
+- the N=128 completion scenarios reanalyze exactly the edited leaf after a
+  reachable-body edit (`bodies_attempted == 1`), which is the evidence
+  [`body-analysis-cfg-incrementality-audit.md`](body-analysis-cfg-incrementality-audit.md)
+  cites for exact reverse invalidation; and
+- the seven-file representative fixture reanalyzes all six of its bodies after a
+  leaf edit with zero durable reuse, including three bodies that are provably
+  outside the edit's reverse closure.
+
+Those fixtures differ in body count, module count, standard-library use, and
+discovery protocol simultaneously, so neither result could be attributed to a
+cause. The obvious hypothesis was that the representative program is simply too
+small for locality to be visible — that its reverse closure covers the whole
+program. That hypothesis is wrong.
+
+## Result
+
+The module axis holds everything constant except module count and discovery
+protocol. `staged` commits an already-complete snapshot; `rooted_demand` opens an
+import-input request and drains the demand frontier, which is what the
+representative fixture does and what the driver does when it reads imports from a
+filesystem.
+
+| modules | discovery | leaf edit: computed | reused | unrelated edit: computed | reused |
+|---:|---|---:|---:|---:|---:|
+| 1 | staged | 1 | 15 | 0 | 16 |
+| 1 | rooted_demand | 16 | 0 | 16 | 0 |
+| 2 | rooted_demand | 16 | 0 | 16 | 0 |
+| 4 | rooted_demand | 16 | 0 | 16 | 0 |
+| 8 | rooted_demand | 16 | 0 | 16 | 0 |
+
+(16 reached bodies; `computed` is `semantic_work.body_analyses_computed`.)
+
+The same shape holds at the completion workload's own N=128, where the
+declaration-context cost is visible as well:
+
+| modules | discovery | scenario | computed | reused | durable source records copied |
+|---:|---|---|---:|---:|---:|
+| 1 | staged | cold | 128 | 0 | 16512 |
+| 1 | staged | leaf edit | 1 | 127 | 129 |
+| 1 | staged | unrelated edit | 0 | 128 | 0 |
+| 1 | rooted_demand | cold | 128 | 0 | 16512 |
+| 1 | rooted_demand | leaf edit | 128 | 0 | 16512 |
+| 1 | rooted_demand | unrelated edit | 128 | 0 | 16512 |
+| 8 | rooted_demand | leaf edit | 128 | 0 | 17408 |
+| 128 | rooted_demand | leaf edit | 128 | 0 | 32768 |
+
+Under the rooted-demand protocol a one-line edit to a single leaf performs
+*exactly* the declaration-context work of a cold build — 16512 records at one
+module, identical to the cold row. Under the staged protocol the same edit costs
+129. The warm path is not a reduced cold path on that protocol; it is the cold
+path.
+
+Two readings follow directly:
+
+1. **Module count changes nothing.** Every `rooted_demand` row is identical from
+   one module to eight. Spreading the same bodies across a module graph does not
+   degrade locality, and the representative fixture's size was never the cause.
+2. **The discovery protocol changes everything.** The first two rows are the same
+   program, the same module count, and the same edit. Under `staged` a leaf edit
+   reanalyzes one body; under `rooted_demand` it reanalyzes all sixteen, and an
+   edit to an unreachable body reanalyzes all sixteen as well.
+
+Durable CFG reuse is unaffected in every row: a leaf edit rebuilds one CFG and
+reuses the rest under both protocols. Only body-query reuse collapses.
+
+## Why this matters for the claimed evidence
+
+`staged` is not a protocol a real program can use. With any import present the
+observation ledger is incomplete and the attempted revision refuses to close —
+the workload asserts this by construction, which is why the axis only runs
+`staged` at one module. So the exact-reverse-invalidation result rests on a
+discovery shortcut available only to single-file programs with no imports.
+
+Every multi-module program takes the `rooted_demand` path. On that path, warm
+body reuse is currently zero regardless of program size.
+
+This does not contradict any individual assertion in the completion workload;
+those assertions are accurate about the corpus they measure. It qualifies what
+that corpus is evidence *for*.
+
+## Consequences for RUE-1091
+
+The per-body context repair addresses the O(bodies x declarations) cost inside
+`analyze_body_query` — the work a body performs once it has been chosen for
+analysis. The behavior measured here decides *how many* bodies are chosen. They
+are different layers, and the numbers above suggest the second one is not
+addressed by the first.
+
+Worth confirming before the provider flip rather than after: if the flip lands
+and warm rebuilds on multi-module programs are still recomputing every body, the
+cause will be here rather than in the repaired per-body path.
+
+## Reproducing
+
+```sh
+./buck2 run //crates/rue-compiler-session-bench:rue-compiler-session-bench -- \
+  --module-axis --bodies 16 --module-counts 1,2,4,8
+```
+
+The workload gates on structural counters only and asserts warm/fresh parity for
+every measured edit. It pins the `staged` locality result, because that is the
+behavior the existing audit claim rests on; the `rooted_demand` rows are
+deliberately left unasserted so a repair does not read as a failure.

--- a/docs/notes/module-axis-locality-findings.md
+++ b/docs/notes/module-axis-locality-findings.md
@@ -89,17 +89,92 @@ This does not contradict any individual assertion in the completion workload;
 those assertions are accurate about the corpus they measure. It qualifies what
 that corpus is evidence *for*.
 
+## Mechanism
+
+The measurement above narrows the cause to a single call. At one module the
+demand path performs the same work as the staged path plus
+`begin_import_input_request`, and locality is already gone. Reading that path
+gives the exact mechanism, and it is not an oversight.
+
+`rue_query::Revision` is a pair of an id and a *compatibility token*, and
+retained work is validated across revisions by comparing the token alone
+(`crates/rue-query/src/lib.rs:87`, consumed at `lib.rs:3609`):
+
+```rust
+pub const fn is_compatible_with(self, other: Self) -> bool {
+    self.compatibility == other.compatibility
+}
+```
+
+The two publication paths choose that token differently:
+
+- an ordinary source update publishes `Revision::new(self.next_revision, 1)` —
+  a **constant** token, so every retained terminal stays validatable across
+  edits (`revisioned_query_database.rs:11053`);
+- import discovery publishes `Revision::new(self.next_revision, generation)`
+  (`revisioned_query_database.rs:10644`), where `generation` is incremented by
+  every `begin_import_inputs` call (`revisioned_query_database.rs:10224`).
+
+So each import-input request mints a fresh compatibility token, and no terminal
+retained under the previous token can be validated against it. Every body is
+recomputed — not because its inputs changed, but because the token it was
+retained under no longer matches.
+
+This is deliberate, and the code says so at the increment:
+
+> A new request generation is a fresh filesystem observation epoch. Reuse
+> requires a future explicit watch/read-policy proof token. The API deliberately
+> has no carried-ledger input that could be mistaken for freshness authority.
+
+That is a sound conservatism in isolation: without evidence that the filesystem
+has not changed underneath it, the compiler refuses to trust anything it
+retained. The finding here is not that the rule is wrong. It is that **nobody
+had measured what it costs**, and the cost is the entire warm-rebuild benefit
+for every program that reaches its sources through import discovery.
+
+## The design question this raises
+
+ADR-0063 §2 states:
+
+> Terminals from the previous attempt are validated or red/green reused against
+> the successor; an unchanged input leaf carried into the successor does not
+> become different merely because its revision number advanced.
+
+The epoch reset and that sentence are in tension. Both are defensible; they
+cannot both be fully honored without the "future explicit watch/read-policy
+proof token" the comment names, which does not exist yet.
+
+Resolving this is a design decision, not a repair — it decides when the compiler
+is entitled to believe the filesystem has not moved. It is deliberately not
+changed here. The candidate directions, for whoever picks it up:
+
+1. Introduce the proof token the comment anticipates, so a request that can
+   demonstrate unchanged inputs carries its predecessor's compatibility token
+   instead of minting a new one.
+2. Separate "filesystem freshness" from "semantic input identity" so that a new
+   observation epoch invalidates only the leaves it actually re-observed, rather
+   than every terminal in the graph.
+3. Accept the cost and state plainly that warm incremental rebuild is available
+   only to in-process hosts that manage their own source snapshots — which would
+   make the north-star interactive rebuild unreachable for the CLI driver.
+
+Option 3 is the status quo by default, and it is worth being explicit that it is
+the status quo rather than arriving there without deciding.
+
 ## Consequences for RUE-1091
 
 The per-body context repair addresses the O(bodies x declarations) cost inside
 `analyze_body_query` — the work a body performs once it has been chosen for
 analysis. The behavior measured here decides *how many* bodies are chosen. They
-are different layers, and the numbers above suggest the second one is not
-addressed by the first.
+are different layers, and the mechanism above confirms the second is untouched by
+the first: the compatibility token is chosen in the import-input publication
+path, which the provider rewire does not go near.
 
-Worth confirming before the provider flip rather than after: if the flip lands
-and warm rebuilds on multi-module programs are still recomputing every body, the
-cause will be here rather than in the repaired per-body path.
+So the flip can proceed without waiting on this. What must not happen is reading
+the post-flip warm numbers as a verdict on the flip. If multi-module warm
+rebuilds still recompute every body afterward, that is the epoch reset, not a
+failed repair — and the post-flip measurement should say which rows it expects
+to move before it is run rather than after.
 
 ## Reproducing
 

--- a/docs/notes/rue-1091-measurement-results.md
+++ b/docs/notes/rue-1091-measurement-results.md
@@ -23,12 +23,22 @@ edit improvement of at least 50%, warm isolated body-edit improvement of at
 least 25%, claimed wins exceeding three times the larger MAD, cold wall/RSS
 regression no greater than `max(2%, 3 * larger MAD)`, repeated-edit RSS
 stabilization within a 5% band when a persistent-session protocol exists, and
-Caldera cold wall time at or below 300 seconds. Caldera process timeout includes
-only the manifest-pinned headroom beyond that gate so an over-budget compile is
-recorded as a failure. Cold RSS is part of the cold pair verdict, not a
-detached annotation. The report records medians, MADs, explicit role
-provenance, hashes, host provenance, raw alternating samples, and
+and per-workload absolute cold wall budgets. Caldera keeps its 300-second
+budget; `rill`, `mosaic`, `harbor`, `lattice`, and `meridian` carry budgets
+derived from the pre-cutover figures recorded in
+[`rue-1083-closure-evidence.md`](rue-1083-closure-evidence.md). Each workload's
+process timeout sits above its own budget so an over-budget compile is recorded
+as a gate failure rather than raising out of the run. Those budgets are checked
+per role without pairing, so they return a verdict even when no historical
+baseline binary exists and every pair is unsupported. Cold RSS is part of the
+cold pair verdict, not a detached annotation. The report records medians, MADs,
+explicit role provenance, hashes, host provenance, raw alternating samples, and
 unsupported/indeterminate cases.
+
+The pre-cutover figures are transcribed prose evidence from a local
+release-build comparison, not a run of this protocol. They give the absolute
+gates a checked-in reference; they are never reported as a measured role row,
+and the runner rejects a manifest that claims otherwise.
 
 This is the current-production value audit, not the activation ledger below.
 

--- a/scripts/rue-value-audit.py
+++ b/scripts/rue-value-audit.py
@@ -90,9 +90,70 @@ WORKLOADS = (
         "root": "examples/caldera/main.rue",
         "warm_runner": "unsupported: no persistent-session black-box protocol",
         "scaling_runner": None,
+        "cold_wall_seconds": 300.0,
+        "cold_timeout_seconds": 330.0,
         "description": "Large maintained application graph with a 300-second cold budget.",
     },
+    # The five programs the RUE-1026/RUE-1027 query cutover regressed.  Their
+    # cold gates come from the checked-in `[historical_reference]` table; see the
+    # manifest for how `cold_wall_seconds` is derived and why the process timeout
+    # is far looser than the gate.
+    {
+        "name": "rill",
+        "family": "regressed_example",
+        "root": "examples/rill/main.rue",
+        "warm_runner": "unsupported: no persistent-session black-box protocol",
+        "scaling_runner": None,
+        "cold_wall_seconds": 1.28,
+        "cold_timeout_seconds": 120.0,
+        "description": "Bytecode language and VM; 0.32s pre-cutover reference.",
+    },
+    {
+        "name": "mosaic",
+        "family": "regressed_example",
+        "root": "examples/mosaic/main.rue",
+        "warm_runner": "unsupported: no persistent-session black-box protocol",
+        "scaling_runner": None,
+        "cold_wall_seconds": 1.96,
+        "cold_timeout_seconds": 120.0,
+        "description": "Medium multi-module application; 0.49s pre-cutover reference.",
+    },
+    {
+        "name": "harbor",
+        "family": "regressed_example",
+        "root": "examples/harbor/main.rue",
+        "warm_runner": "unsupported: no persistent-session black-box protocol",
+        "scaling_runner": None,
+        "cold_wall_seconds": 3.56,
+        "cold_timeout_seconds": 300.0,
+        "description": "52-module application graph; 0.89s pre-cutover reference.",
+    },
+    {
+        "name": "lattice",
+        "family": "regressed_example",
+        "root": "examples/lattice/main.rue",
+        "warm_runner": "unsupported: no persistent-session black-box protocol",
+        "scaling_runner": None,
+        "cold_wall_seconds": 4.6,
+        "cold_timeout_seconds": 300.0,
+        "description": "131-module application graph; 1.15s pre-cutover reference.",
+    },
+    {
+        "name": "meridian",
+        "family": "regressed_example",
+        "root": "examples/meridian/main.rue",
+        "warm_runner": "unsupported: no persistent-session black-box protocol",
+        "scaling_runner": None,
+        "cold_wall_seconds": 22.8,
+        "cold_timeout_seconds": 900.0,
+        "description": "265-module application graph; 5.7s pre-cutover reference.",
+    },
 )
+
+# Workload families whose root names a directory-shaped program, so the recorded
+# source digest must cover the whole tracked module graph rather than the root
+# file alone.
+DIRECTORY_ROOTED_FAMILIES = {"representative", "caldera", "regressed_example"}
 
 PRECOMMITTED_THRESHOLDS = {
     "warm_unrelated_declaration_improvement": 0.50,
@@ -328,7 +389,84 @@ def load_audit_manifest(root: Path) -> dict[str, Any]:
         supported = item.get("supported_scenarios")
         if not isinstance(supported, list) or not set(supported).issubset(SCENARIOS):
             raise ValueError(f"workload {item.get('name')} has invalid supported_scenarios")
+        for key in ("cold_wall_seconds", "cold_timeout_seconds"):
+            expected_budget = expected_workload.get(key)
+            actual_budget = item.get(key)
+            if expected_budget is None:
+                if actual_budget is not None:
+                    raise ValueError(f"workload {item.get('name')} declares an unexpected {key}")
+                continue
+            if not isinstance(actual_budget, (int, float)) or float(actual_budget) != expected_budget:
+                raise ValueError(f"workload {item.get('name')} {key} drifted from the runner")
+        gate = item.get("cold_wall_seconds")
+        bound = item.get("cold_timeout_seconds")
+        if gate is not None and (bound is None or bound <= gate):
+            raise ValueError(
+                f"workload {item.get('name')} must bound its process timeout above its cold gate "
+                "so an over-budget compile fails the gate instead of crashing the run"
+            )
+    caldera = next(item for item in workloads if item.get("name") == "caldera")
+    if caldera.get("cold_wall_seconds") != thresholds["caldera_wall_seconds"]:
+        raise ValueError("the Caldera cold gate must restate thresholds.caldera_wall_seconds exactly")
+    if caldera.get("cold_timeout_seconds") != (
+        thresholds["caldera_wall_seconds"] + protocol["caldera_timeout_headroom_seconds"]
+    ):
+        raise ValueError(
+            "the Caldera process timeout must be its gate plus the manifest-pinned headroom"
+        )
+    _validate_historical_reference(manifest, expected_workloads)
     return manifest
+
+
+def _validate_historical_reference(
+    manifest: dict[str, Any], expected_workloads: dict[str, dict[str, Any]]
+) -> None:
+    """Cross-check the checked-in pre-cutover reference against the cold gates.
+
+    The reference is prose evidence transcribed from
+    `docs/notes/rue-1083-closure-evidence.md`, not a run of this protocol. It is
+    validated here for exactly two properties: that it cannot be mistaken for
+    role evidence, and that every `regressed_example` cold gate is the declared
+    multiple of its reference rather than a hand-tuned number that drifted away
+    from the regression it is supposed to measure.
+    """
+    reference = manifest.get("historical_reference")
+    if not isinstance(reference, dict):
+        raise ValueError("value-audit manifest must carry the historical reference table")
+    if reference.get("produced_by_this_protocol") is not False:
+        raise ValueError("the historical reference must declare that this protocol did not produce it")
+    if reference.get("usable_as_role_evidence") is not False:
+        raise ValueError("the historical reference must declare that it is not role evidence")
+    multiplier = reference.get("cold_gate_multiplier")
+    if not isinstance(multiplier, (int, float)) or multiplier <= 1:
+        raise ValueError("the historical reference must declare a cold gate multiplier above one")
+    programs = reference.get("programs")
+    if not isinstance(programs, dict):
+        raise ValueError("the historical reference must name its per-program measurements")
+    regressed = {
+        name for name, workload in expected_workloads.items()
+        if workload["family"] == "regressed_example"
+    }
+    if set(programs) != regressed:
+        raise ValueError("the historical reference programs drifted from the regressed_example workloads")
+    for name, entry in programs.items():
+        pre = entry.get("pre_cutover_seconds") if isinstance(entry, dict) else None
+        post = entry.get("post_cutover_seconds") if isinstance(entry, dict) else None
+        if not isinstance(pre, (int, float)) or pre <= 0:
+            raise ValueError(f"historical reference for {name} needs a positive pre-cutover value")
+        if not isinstance(post, (int, float)) or post <= pre:
+            raise ValueError(
+                f"historical reference for {name} must record a post-cutover regression above its reference"
+            )
+        gate = expected_workloads[name]["cold_wall_seconds"]
+        if abs(gate - pre * multiplier) > 0.005:
+            raise ValueError(
+                f"cold gate for {name} is not {multiplier}x its pre-cutover reference"
+            )
+        if post <= gate:
+            raise ValueError(
+                f"cold gate for {name} does not separate the reference from the recorded regression"
+            )
 
 
 def median_mad(values: list[float]) -> dict[str, Any]:
@@ -930,15 +1068,21 @@ def scenario_verdict(
     for role, row in role_rows.items():
         if row.get("status") == "fail":
             pairs.setdefault(role, {"status": "fail", "reason": "role evidence failed"})
+        # Absolute cold budgets are per-role and need no pairing, so a workload
+        # that declares one still returns a real verdict in a same-binary smoke
+        # where no historical role binary exists.
+        budget = workload.get("cold_wall_seconds")
         if (
             scenario == "cold"
-            and workload["family"] == "caldera"
+            and budget is not None
             and row.get("wall", {}).get("median") is not None
-            and row["wall"]["median"] > thresholds["caldera_wall_seconds"] * 1000
+            and row["wall"]["median"] > budget * 1000
         ):
             pairs.setdefault(role, {
                 "status": "fail",
-                "reason": f"Caldera cold wall time exceeds the {thresholds['caldera_wall_seconds']}-second budget",
+                "reason": f"cold wall time exceeds the {budget:g}-second budget for {workload['name']}",
+                "budget_seconds": budget,
+                "observed_seconds": row["wall"]["median"] / 1000,
             })
     statuses = [value.get("status") for value in pairs.values()]
     if "fail" in statuses:
@@ -1059,7 +1203,7 @@ def run_audit(args: argparse.Namespace) -> dict[str, Any]:
             "supported_scenarios": manifest_workloads[workload["name"]]["supported_scenarios"],
             "root": str(root_source),
             "source_sha256": sha256_paths(
-                tracked_files(root_source.parent) if workload["family"] in {"representative", "caldera"} else [root_source],
+                tracked_files(root_source.parent) if workload["family"] in DIRECTORY_ROOTED_FAMILIES else [root_source],
                 root,
             ),
             "scenarios": {},
@@ -1069,12 +1213,8 @@ def run_audit(args: argparse.Namespace) -> dict[str, Any]:
             workdir = Path(temp)
             for scenario in SCENARIOS:
                 timeout = args.timeout
-                if workload["family"] == "caldera" and scenario == "cold":
-                    timeout = max(
-                        timeout,
-                        thresholds["caldera_wall_seconds"]
-                        + audit_manifest["protocol"]["caldera_timeout_headroom_seconds"],
-                    )
+                if scenario == "cold" and workload.get("cold_timeout_seconds") is not None:
+                    timeout = max(timeout, workload["cold_timeout_seconds"])
                 role_rows: dict[str, dict[str, Any]] = {}
                 for pair_index in range(args.iterations):
                     order = list(ROLES) if pair_index % 2 == 0 else list(reversed(ROLES))

--- a/scripts/test-value-audit.py
+++ b/scripts/test-value-audit.py
@@ -425,6 +425,132 @@ class ValueAuditTests(unittest.TestCase):
         self.assertEqual(manifest["protocol"]["paired_samples"], 7)
         self.assertEqual(manifest["protocol"]["warmup"], 1)
 
+    def regressed_workloads(self):
+        return [
+            workload for workload in value_audit.WORKLOADS
+            if workload["family"] == "regressed_example"
+        ]
+
+    def cold_role(self, median_ms):
+        return {
+            "status": "pass",
+            "protocol": "black_box_compile",
+            "wall": {"median": median_ms, "mad": 0.0},
+            "rss": {"median": 100.0, "mad": 0.0},
+        }
+
+    def test_every_regressed_example_is_a_cold_only_workload_with_a_budget(self):
+        names = {workload["name"] for workload in self.regressed_workloads()}
+        self.assertEqual(names, {"rill", "mosaic", "harbor", "lattice", "meridian"})
+        manifest_workloads = {item["name"]: item for item in self.manifest["workload"]}
+        for workload in self.regressed_workloads():
+            entry = manifest_workloads[workload["name"]]
+            self.assertEqual(entry["supported_scenarios"], ["cold"])
+            self.assertGreater(workload["cold_wall_seconds"], 0)
+            self.assertGreater(workload["cold_timeout_seconds"], workload["cold_wall_seconds"])
+            self.assertIn(workload["family"], value_audit.DIRECTORY_ROOTED_FAMILIES)
+
+    def test_absolute_cold_budget_fails_a_same_binary_run(self):
+        """The gate is per-role, so it verdicts without a historical binary.
+
+        Every pair is `unsupported` here because all three roles share one
+        binary hash. The workload must still fail on its own observed wall time,
+        otherwise the regressed-example rows would report nothing until a
+        pre-cutover baseline binary exists.
+        """
+        rill = next(item for item in self.regressed_workloads() if item["name"] == "rill")
+        roles = {
+            role: {**self.cold_role(rill["cold_wall_seconds"] * 1000 * 5), "binary_sha256": "same"}
+            for role in ("historical_baseline", "current_production", "candidate")
+        }
+        result = value_audit.scenario_verdict(
+            "cold", roles,
+            {**rill, "supported_scenarios": ["cold"]},
+            self.manifest["scenario_policy"]["cold"], self.thresholds,
+        )
+        self.assertEqual(result["status"], "fail")
+        self.assertTrue(all(
+            pair["status"] == "unsupported"
+            for name, pair in result["pairs"].items() if "_vs_" in name
+        ))
+        self.assertEqual(
+            result["pairs"]["current_production"]["budget_seconds"],
+            rill["cold_wall_seconds"],
+        )
+
+    def test_cold_budget_under_gate_does_not_fail(self):
+        rill = next(item for item in self.regressed_workloads() if item["name"] == "rill")
+        roles = {
+            role: {**self.cold_role(rill["cold_wall_seconds"] * 1000 * 0.5), "binary_sha256": "same"}
+            for role in ("historical_baseline", "current_production", "candidate")
+        }
+        result = value_audit.scenario_verdict(
+            "cold", roles,
+            {**rill, "supported_scenarios": ["cold"]},
+            self.manifest["scenario_policy"]["cold"], self.thresholds,
+        )
+        self.assertNotEqual(result["status"], "fail")
+
+    def reject_mutation(self, mutate):
+        drifted = {key: value for key, value in self.manifest.items()}
+        mutate(drifted)
+        original_loader = value_audit.tomllib.load
+        value_audit.tomllib.load = lambda _stream, drifted=drifted: drifted
+        try:
+            with self.assertRaises(ValueError):
+                value_audit.load_audit_manifest(ROOT)
+        finally:
+            value_audit.tomllib.load = original_loader
+
+    def test_caldera_budget_drift_from_thresholds_is_rejected(self):
+        def mutate(drifted):
+            drifted["workload"] = [dict(item) for item in self.manifest["workload"]]
+            caldera = next(item for item in drifted["workload"] if item["name"] == "caldera")
+            caldera["cold_wall_seconds"] = 299
+        self.reject_mutation(mutate)
+
+    def test_cold_gate_above_its_process_timeout_is_rejected(self):
+        def mutate(drifted):
+            drifted["workload"] = [dict(item) for item in self.manifest["workload"]]
+            rill = next(item for item in drifted["workload"] if item["name"] == "rill")
+            rill["cold_timeout_seconds"] = rill["cold_wall_seconds"]
+        self.reject_mutation(mutate)
+
+    def test_historical_reference_cannot_be_promoted_to_role_evidence(self):
+        def mutate(drifted):
+            drifted["historical_reference"] = dict(self.manifest["historical_reference"])
+            drifted["historical_reference"]["usable_as_role_evidence"] = True
+        self.reject_mutation(mutate)
+
+        def mutate_protocol(drifted):
+            drifted["historical_reference"] = dict(self.manifest["historical_reference"])
+            drifted["historical_reference"]["produced_by_this_protocol"] = True
+        self.reject_mutation(mutate_protocol)
+
+    def test_cold_gate_detached_from_its_reference_is_rejected(self):
+        def mutate(drifted):
+            drifted["historical_reference"] = dict(self.manifest["historical_reference"])
+            drifted["historical_reference"]["cold_gate_multiplier"] = 8.0
+        self.reject_mutation(mutate)
+
+    def test_reference_that_does_not_separate_regression_from_gate_is_rejected(self):
+        def mutate(drifted):
+            reference = dict(self.manifest["historical_reference"])
+            programs = {name: dict(entry) for name, entry in reference["programs"].items()}
+            programs["rill"]["post_cutover_seconds"] = programs["rill"]["pre_cutover_seconds"] * 1.1
+            reference["programs"] = programs
+            drifted["historical_reference"] = reference
+        self.reject_mutation(mutate)
+
+    def test_reference_programs_must_match_the_regressed_workloads(self):
+        def mutate(drifted):
+            reference = dict(self.manifest["historical_reference"])
+            programs = {name: dict(entry) for name, entry in reference["programs"].items()}
+            del programs["meridian"]
+            reference["programs"] = programs
+            drifted["historical_reference"] = reference
+        self.reject_mutation(mutate)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Scope

Two independent changes, both follow-ups to the value-audit work. Rebased onto
trunk now that #1960 has merged, so this is just the two commits.

Refs RUE-1091, RUE-1083.

## 1. Gate the regressed large examples

`rill`, `mosaic`, `harbor`, `lattice`, and `meridian` are `--skip`ped from
`//:cli-tests`, so their compile cost is not part of the required corpus.

The large-example compile guard (now un-stubbed on trunk) answers a different
question: it proves the six programs still *compile*, under a 3600s timeout,
with a Caldera timeout downgraded to a warning because pure slowness is a
tracked performance follow-up. It makes no performance claim. These rows are
where cold *cost* gets gated.

- Add all five as cold-only audit workloads with absolute per-role wall budgets.
- Check in the pre-cutover and post-cutover figures from
  `rue-1083-closure-evidence.md` as a `[historical_reference]` table, so the
  numbers the project has to beat live in the manifest rather than in prose.
- Generalize the Caldera-only cold budget into per-workload
  `cold_wall_seconds` / `cold_timeout_seconds`. Caldera restates the existing
  threshold and headroom, and the loader rejects drift between them.

The absolute budget is checked **per role, without pairing**, so these rows
return a real verdict in a same-binary protocol smoke where every pair is
`unsupported`. That matters: it means the cold question gets an answer before a
pre-cutover baseline binary exists. Each workload's process timeout sits above
its own budget so an over-budget compile is recorded as a gate failure rather
than raising out of the run.

The loader also rejects a reference that claims to be role evidence, a gate
detached from its declared multiple of the reference, and a gate that fails to
separate the reference from the recorded regression.

Cost: these run under the same 1-warmup/7-paired-sample protocol as every other
row, and `meridian` currently compiles in minutes. The full matrix is an
hours-long run, in the same class as the existing Caldera row. Noted in the
README; `--workloads` selects a subset.

## 2. Isolate what decides warm body locality

Two checked-in workloads reported incompatible results. The N=128 completion
scenarios reanalyze exactly the edited leaf. The seven-file representative
fixture reanalyzes **all six** of its bodies after a leaf edit — including three
that are provably outside the edit's reverse closure (`worker.compute`,
`model.weight`, `std.math.abs` are unaffected by editing `labels.adjustment`).

Those fixtures differ in body count, module count, std use, and discovery
protocol simultaneously, so neither result could be attributed to a cause. The
natural hypothesis was that the representative program is too small for locality
to be visible. That hypothesis is wrong.

`rue-compiler-session-bench --module-axis` holds the call graph, reached body
count, and edit shape fixed and varies two things independently: module count,
and the protocol that commits import discovery.

| modules | discovery | leaf edit: computed | reused | durable source records copied |
|---:|---|---:|---:|---:|
| 1 | staged | 1 | 127 | 129 |
| 1 | rooted_demand | 128 | 0 | 16512 |
| 8 | rooted_demand | 128 | 0 | 17408 |
| 128 | rooted_demand | 128 | 0 | 32768 |

(128 reached bodies. The cold row copies 16512 records at one module.)

- **Module count changes nothing.** One module and 128 are identical.
- **The discovery protocol changes everything.** Same program, same module
  count, same edit: one body reanalyzed under staged discovery, all 128 under
  rooted demand. A one-line leaf edit under rooted demand performs *exactly* the
  declaration-context work of its own cold build.
- Durable CFG reuse is unaffected in every row — a leaf edit rebuilds 1 CFG and
  reuses 127 under both protocols. Only body-query reuse collapses.

Staged discovery is not available to any program with an import: the observation
ledger is incomplete and the attempted revision refuses to close. The axis
asserts this by construction, which is why staged only runs at one module. So
the exact-reverse-invalidation evidence rests on a shortcut only single-file
programs can take, and every multi-module program takes the other path.

This does not contradict any assertion in the completion workload — those are
accurate about the corpus they measure. It qualifies what that corpus is
evidence *for*, and the qualification is now recorded next to the claim in
`body-analysis-cfg-incrementality-audit.md`.

The workload pins the staged locality result, since that is what the existing
claim rests on, and deliberately leaves the rooted-demand numbers unasserted so
a repair does not read as a failure.

### Why this is worth knowing before the flip

The per-body context repair targets the O(bodies × declarations) cost *inside*
`analyze_body_query` — what a body pays once chosen. The behavior measured here
decides *how many* bodies get chosen. Those are different layers. If the flip
lands and multi-module warm rebuilds still recompute every body, the cause is
here rather than in the repaired path.

## Test evidence

Run before the rebase onto post-#1960 trunk; CI covers the current base.

- `scripts/rue fmt`: clean. Unrelated formatter churn in
  `crates/rue-test-runner/src/lib.rs` was reverted, not committed.
- `bash ./clippy.sh`: 66 targets, no violations.
- `scripts/rue unit compiler-session-bench`: 10 passed (6 existing + 4 new).
- `python3 scripts/test-value-audit.py` and `./buck2 test //:value-audit-tool-tests`:
  37 passed (28 existing + 9 new).
- `scripts/rue quick`: 36 targets passed.
- Module axis run at `--bodies 16 --module-counts 1,2,4,8` and
  `--bodies 128 --module-counts 1,8,128`; both tables above are from those runs.

The value-audit runner itself was not executed end-to-end — it needs three
release binaries with distinct source provenance, which this environment does
not have. The new workloads are covered by the loader validation and unit tests
only.
