### PR TITLE
Make drop-flag slot allocation deterministic

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -2643,12 +2643,20 @@ impl<'a> CfgBuilder<'a> {
     /// field path of `key` that is moved somewhere in this function
     /// (RUE-156). Called at the slot's (re)initialization sites.
     fn arm_field_drop_flags(&mut self, key: MovedSlot, span: rue_span::Span) {
-        let paths: Vec<FieldPath> = self
+        let mut paths: Vec<FieldPath> = self
             .ever_field_moved
             .iter()
             .filter(|(s, _)| *s == key)
             .map(|(_, p)| p.clone())
             .collect();
+        // `ever_field_moved` is a `HashSet`, so its iteration order varies per
+        // process. `set_field_drop_flag` allocates a hidden local the first time
+        // it sees a path, which would make the flag slots — and therefore every
+        // frame offset after them — depend on hash order. Sorting pins the
+        // allocation order to the field path itself. Emitted output must be a
+        // function of the source, and several parity gates compare artifacts
+        // byte-for-byte.
+        paths.sort();
         for path in paths {
             self.set_field_drop_flag(key, path, true, span);
         }


### PR DESCRIPTION
## Summary

Compiling `examples/rill/main.rue` three times produced three different
executables. `examples/lattice/main.rue` did the same. Mosaic and harbor were
byte-stable. One-line root cause; the fix is a sort.

This predates the RUE-1026/RUE-1027 query cutover — the pre-cutover compiler
shows the same instability — so it is not caused by the incremental work. It was
surfaced by the value audit's fail-closed correctness gate on the first run that
had real programs to compare.

Refs RUE-1083.

## Finding

Bisected with `--emit` rather than by reading code:

| stage | stable? |
|---|---|
| `rir`, `air` | stable |
| **`cfg`** | **differs** |
| `lowering`, `mir` | differs (downstream) |

It enters at CFG construction. The CFG diff was pairs of adjacent slot numbers
swapping — `store $158` ↔ `store $159`. In the linked binary that surfaced as 14
bytes across 7 sites, every one a stack displacement 8 apart
(`mov %r12,-0x528(%rbp)` vs `-0x530(%rbp)`), with identical file size.

`crates/rue-cfg/src/build.rs`, `arm_field_drop_flags`:

```rust
let paths: Vec<FieldPath> = self
    .ever_field_moved      // HashSet<(MovedSlot, FieldPath)>
    .iter()                // per-process hash order
    .filter(|(s, _)| *s == key)
    .map(|(_, p)| p.clone())
    .collect();
for path in paths {
    self.set_field_drop_flag(key, path, true, span);  // allocates a local on first sight
}
```

`set_field_drop_flag` allocates a hidden local the first time it sees a path, so
the flag slots followed hash order and every frame offset after them moved with
it. Sorting pins allocation order to the field path. `FieldPath` is `Vec<u32>`,
already `Ord`.

I checked the sibling helpers — `moved_paths_of` and `maybe_moved_paths_of`
return `HashSet`s consumed only via `.contains()`, so order does not matter
there. This was the only order-sensitive site.

## Why it matters beyond one example

Several gates compare artifacts byte-for-byte: the session benchmark's
`executable_sha256`, the cold-versus-reused parity assertions, and the value
audit's correctness gate. Those checks were only meaningful on programs that
happened to hash stably, and nothing identified which programs those were.

## Verification

Three compiles each, same binary:

| program | before | after |
|---|---|---|
| rill | 3 distinct | **1 distinct** |
| lattice | 3 distinct | **1 distinct** |
| mosaic | 1 distinct | 1 distinct, **digest unchanged** |
| harbor | 1 distinct | 1 distinct, **digest unchanged** |

Mosaic and harbor keeping their exact prior digests is the evidence that this
reorders allocation without altering behavior.

Suites, all on this change:

- `scripts/rue test`: 2178 unit + `//:spec-tests` + `//:ui-tests` (209) — passed.
- `//:cli-tests-shard-{0,1,2,3}` run **serially**: 421 + 391 + 442 + 443 = 1697
  passed, 0 failed. Running all four concurrently fails on this 4-core host from
  contention, which is the timeout-under-parallel-load case `AGENTS.md` describes;
  each shard passes in isolation.
- `//:reproducible-programs`: passed.
- `scripts/rue quick`: 36 targets.

## Note on scope

This fixes the nondeterminism. It does **not** widen the output-reproducibility
corpus — `scripts/test-reproducible-output.sh` still checks only
`reproducibility/fixture`, so a future regression in a real multi-module program
would still go unnoticed. Adding rill there is cheap (~1 s pre-cutover) and worth
doing; I left it out of this PR to keep the fix reviewable on its own.


---
_Generated by [Claude Code](https://claude.ai/code/session_012LsHBgTP9eKtFWf2hPgcQ8)_