### PR TITLE
Enforce the absolute cold budget only when there is no baseline binary

### DIFF
--- a/benchmarks/value-audit/README.md
+++ b/benchmarks/value-audit/README.md
@@ -65,6 +65,33 @@ exists:
 - `cold_timeout_seconds` is deliberately far above the gate, so an over-budget
   compile is recorded as a gate failure instead of raising out of the run.
 
+### The absolute gate is enforced only without a baseline
+
+An absolute budget compares a wall time on whatever host is running against a
+constant calibrated on a different one. There is no multiplier that is
+simultaneously tight enough to mean something and loose enough to be safe
+everywhere: a measured host ran 2.4x the reference figures and left as little as
+1.2x headroom over its own pre-cutover cost
+([`docs/notes/pre-cutover-baseline-binary.md`](../../docs/notes/pre-cutover-baseline-binary.md)).
+
+So the runner decides per run, using the same distinct-binary test that
+classifies the comparison:
+
+| historical baseline binary | absolute cold budget |
+|---|---|
+| absent, or identical to current | **enforced** — a breach fails the scenario |
+| distinct | **advisory** — reported, does not decide the verdict |
+
+With a distinct baseline the role-vs-role pair comparison is available and is
+host-independent by construction, because both roles run on the same machine in
+the same run. The absolute budget then adds nothing the pairs do not already
+carry and can only contribute a false failure on a slow host. The run records
+which mode applied in `comparison_provenance.absolute_cold_budget`.
+
+An advisory is an observation, never a verdict: it cannot fail a scenario, and
+it cannot manufacture a pass for a scenario that has no passing evidence of its
+own. A genuine pair failure still fails.
+
 Cost: these are cold-driver workloads under the same one-warmup, seven-paired-
 sample protocol as every other row, and `meridian` currently compiles in minutes
 rather than seconds. Expect the full matrix to run for hours on one host, in the

--- a/docs/notes/pre-cutover-baseline-binary.md
+++ b/docs/notes/pre-cutover-baseline-binary.md
@@ -151,11 +151,25 @@ headroom on this host while leaving today's failures unambiguous:
 Nothing about the verdict changes: every program still fails, by 4x to 14x. The
 change buys robustness on slower hosts, which is what an absolute gate is for.
 
-That said, the absolute gate was always the fallback, and it is no longer the
-only option. With a buildable baseline binary the role-vs-role pair comparison is
-available, and it is host-independent by construction because both roles run on
-the same machine in the same run. A run that supplies the baseline should be read
-pair-first; the absolute gate is what reports when no baseline is supplied.
+### The multiplier is no longer the thing standing between you and a false failure
+
+Raising 4x to 6x bought headroom but did not fix the shape of the problem: an
+absolute budget compares a wall time on an unknown host against a constant
+calibrated elsewhere, and no multiplier is simultaneously tight enough to mean
+something and loose enough to be safe everywhere. Picking a better constant just
+moves the failure mode.
+
+The runner now decides per run instead. When a distinct historical baseline
+binary is supplied, the role-vs-role pair comparison is available and is
+host-independent by construction — both roles run on the same machine in the
+same run — so the absolute budget is reported as `advisory` and does not decide
+the scenario. With no baseline it stays the hard gate it was designed to be,
+because then it is the only thing that reports at all. The run records which
+mode applied in `comparison_provenance.absolute_cold_budget`.
+
+That makes the 6x multiplier a fallback calibration rather than a load-bearing
+threshold. It still matters for a bare run; it no longer stands between a
+repaired compiler and a false failure on a slow host.
 
 ## Reproducing
 

--- a/docs/notes/rue-1091-measurement-results.md
+++ b/docs/notes/rue-1091-measurement-results.md
@@ -30,7 +30,11 @@ derived from the pre-cutover figures recorded in
 process timeout sits above its own budget so an over-budget compile is recorded
 as a gate failure rather than raising out of the run. Those budgets are checked
 per role without pairing, so they return a verdict even when no historical
-baseline binary exists and every pair is unsupported. Cold RSS is part of the
+baseline binary exists and every pair is unsupported. When a distinct historical
+baseline IS supplied the absolute budget becomes advisory and the
+host-independent pair comparison decides the scenario, because an absolute
+budget calibrated on another host can otherwise fail a repaired compiler; see
+[`pre-cutover-baseline-binary.md`](pre-cutover-baseline-binary.md). Cold RSS is part of the
 cold pair verdict, not a detached annotation. The report records medians, MADs,
 explicit role provenance, hashes, host provenance, raw alternating samples, and
 unsupported/indeterminate cases.

--- a/scripts/rue-value-audit.py
+++ b/scripts/rue-value-audit.py
@@ -1037,7 +1037,14 @@ def scenario_verdict(
     workload: dict[str, Any],
     scenario_policy: dict[str, Any],
     thresholds: dict[str, Any],
+    baseline_available: bool = False,
 ) -> dict[str, Any]:
+    """Decide one scenario.
+
+    `baseline_available` says whether this run supplied a genuinely distinct
+    historical baseline binary. It decides how an absolute `cold_wall_seconds`
+    breach is reported — see the gate below for why.
+    """
     pairs: dict[str, Any] = {}
     required = scenario_policy["required"]
     if scenario not in workload["supported_scenarios"]:
@@ -1119,9 +1126,25 @@ def scenario_verdict(
     for role, row in role_rows.items():
         if row.get("status") == "fail":
             pairs.setdefault(role, {"status": "fail", "reason": "role evidence failed"})
-        # Absolute cold budgets are per-role and need no pairing, so a workload
-        # that declares one still returns a real verdict in a same-binary smoke
-        # where no historical role binary exists.
+        # The absolute cold budget is per-role and needs no pairing, which is
+        # what makes it useful with no baseline binary: it is the only thing
+        # that reports at all when every pair is unsupported.
+        #
+        # It is also intrinsically host-sensitive. It compares a wall time on
+        # whatever machine is running against a constant calibrated on a
+        # different one, so no multiplier is simultaneously tight enough to mean
+        # something and loose enough to be safe everywhere. A measured host ran
+        # 2.4x the reference figures and left as little as 1.2x headroom over
+        # its OWN pre-cutover cost; see
+        # docs/notes/pre-cutover-baseline-binary.md.
+        #
+        # When a distinct historical baseline IS supplied, the role-vs-role pair
+        # comparison above is available and is host-independent by construction
+        # — both roles run on the same machine in the same run. The absolute
+        # budget then adds no evidence the pairs do not already carry, and can
+        # only contribute a false failure on a slow host. So it is reported as
+        # `advisory` and does not decide the verdict. Without a baseline it
+        # remains the hard gate it was designed to be.
         budget = workload.get("cold_wall_seconds")
         if (
             scenario == "cold"
@@ -1129,17 +1152,27 @@ def scenario_verdict(
             and row.get("wall", {}).get("median") is not None
             and row["wall"]["median"] > budget * 1000
         ):
-            pairs.setdefault(role, {
-                "status": "fail",
+            over_budget = {
                 "reason": f"cold wall time exceeds the {budget:g}-second budget for {workload['name']}",
                 "budget_seconds": budget,
                 "observed_seconds": row["wall"]["median"] / 1000,
-            })
+            }
+            if baseline_available:
+                over_budget["status"] = "advisory"
+                over_budget["advisory_because"] = (
+                    "a distinct historical baseline is present, so the host-independent "
+                    "pair comparison decides this scenario"
+                )
+            else:
+                over_budget["status"] = "fail"
+            pairs.setdefault(role, over_budget)
     statuses = [value.get("status") for value in pairs.values()]
     if "fail" in statuses:
         status = "fail"
     elif "indeterminate" in statuses or (required and "unsupported" in statuses):
         status = "indeterminate"
+    # `advisory` is an observation, never a verdict: it neither fails a scenario
+    # nor manufactures a pass for one that has no passing evidence of its own.
     elif any(value == "pass" for value in statuses):
         status = "pass"
     else:
@@ -1229,6 +1262,13 @@ def run_audit(args: argparse.Namespace) -> dict[str, Any]:
     binary_hashes = {
         role: report["revisions"][role]["binary_sha256"] for role in ROLES
     }
+    # A distinct historical binary is exactly what makes the pair comparison
+    # real, so the same test that classifies the run also decides whether the
+    # absolute cold budget is a gate or an advisory.
+    baseline_available = (
+        binary_hashes["historical_baseline"] is not None
+        and binary_hashes["historical_baseline"] != binary_hashes["current_production"]
+    )
     if len(set(binary_hashes.values())) == 1:
         report["comparison_provenance"] = {
             "classification": "same_binary_protocol_smoke",
@@ -1241,6 +1281,11 @@ def run_audit(args: argparse.Namespace) -> dict[str, Any]:
             "historical_comparison_valid": True,
             "claim_scope": "role comparisons are linked to explicit source/build provenance and binary hashes",
         }
+    report["comparison_provenance"]["absolute_cold_budget"] = (
+        "advisory; the host-independent pair comparison decides cold scenarios"
+        if baseline_available
+        else "enforced; no distinct historical baseline binary was supplied"
+    )
     statuses: list[str] = []
     selected = set(args.workloads) if args.workloads else {workload["name"] for workload in WORKLOADS}
     for workload in WORKLOADS:
@@ -1357,6 +1402,7 @@ def run_audit(args: argparse.Namespace) -> dict[str, Any]:
                     row,
                     scenario_policy[scenario],
                     thresholds,
+                    baseline_available,
                 )
                 row["scenarios"][scenario] = {"roles": role_rows, "verdict": verdict}
                 statuses.append(verdict["status"])

--- a/scripts/test-value-audit.py
+++ b/scripts/test-value-audit.py
@@ -491,6 +491,85 @@ class ValueAuditTests(unittest.TestCase):
         )
         self.assertNotEqual(result["status"], "fail")
 
+    def cold_roles(self, median_ms, *, distinct_baseline):
+        """Three cold role rows, optionally with a genuinely distinct baseline."""
+        rows = {}
+        for role in ("historical_baseline", "current_production", "candidate"):
+            rows[role] = {
+                **self.cold_role(median_ms),
+                "binary_sha256": (
+                    "historical" if distinct_baseline and role == "historical_baseline" else "same"
+                ),
+            }
+        return rows
+
+    def test_over_budget_is_advisory_when_a_real_baseline_is_present(self):
+        """With a baseline, the host-independent pair comparison decides.
+
+        The absolute budget is calibrated on a different machine, so once a
+        distinct historical binary makes the pair comparison available, an
+        over-budget row must not be able to fail the scenario on its own.
+        """
+        rill = next(item for item in self.regressed_workloads() if item["name"] == "rill")
+        roles = self.cold_roles(rill["cold_wall_seconds"] * 1000 * 5, distinct_baseline=True)
+        result = value_audit.scenario_verdict(
+            "cold", roles,
+            {**rill, "supported_scenarios": ["cold"]},
+            self.manifest["scenario_policy"]["cold"], self.thresholds,
+            True,
+        )
+        self.assertNotEqual(result["status"], "fail")
+        advisory = [
+            pair for name, pair in result["pairs"].items()
+            if "_vs_" not in name and pair.get("status") == "advisory"
+        ]
+        self.assertTrue(advisory, f"expected an advisory row: {result['pairs']}")
+        self.assertEqual(advisory[0]["budget_seconds"], rill["cold_wall_seconds"])
+        self.assertIn("advisory_because", advisory[0])
+
+    def test_over_budget_still_fails_without_a_baseline(self):
+        """No baseline means no pair evidence, so the budget stays a hard gate."""
+        rill = next(item for item in self.regressed_workloads() if item["name"] == "rill")
+        roles = self.cold_roles(rill["cold_wall_seconds"] * 1000 * 5, distinct_baseline=False)
+        result = value_audit.scenario_verdict(
+            "cold", roles,
+            {**rill, "supported_scenarios": ["cold"]},
+            self.manifest["scenario_policy"]["cold"], self.thresholds,
+            False,
+        )
+        self.assertEqual(result["status"], "fail")
+
+    def test_advisory_alone_never_manufactures_a_pass(self):
+        """An advisory is an observation, not passing evidence.
+
+        Every pair here is unsupported, so the scenario must not become a pass
+        merely because the only other row present is an advisory.
+        """
+        rill = next(item for item in self.regressed_workloads() if item["name"] == "rill")
+        roles = self.cold_roles(rill["cold_wall_seconds"] * 1000 * 5, distinct_baseline=True)
+        for role in roles:
+            roles[role]["status"] = "unsupported"
+        result = value_audit.scenario_verdict(
+            "cold", roles,
+            {**rill, "supported_scenarios": ["cold"]},
+            self.manifest["scenario_policy"]["cold"], self.thresholds,
+            True,
+        )
+        self.assertNotEqual(result["status"], "pass")
+
+    def test_a_real_pair_failure_still_fails_with_a_baseline(self):
+        """Downgrading the absolute gate must not soften the pair verdict."""
+        rill = next(item for item in self.regressed_workloads() if item["name"] == "rill")
+        roles = self.cold_roles(rill["cold_wall_seconds"] * 1000 * 5, distinct_baseline=True)
+        roles["current_production"]["status"] = "fail"
+        result = value_audit.scenario_verdict(
+            "cold", roles,
+            {**rill, "supported_scenarios": ["cold"]},
+            self.manifest["scenario_policy"]["cold"], self.thresholds,
+            True,
+        )
+        self.assertEqual(result["status"], "fail")
+
     def reject_mutation(self, mutate):
         drifted = {key: value for key, value in self.manifest.items()}
         mutate(drifted)


### PR DESCRIPTION
## Summary

Straight off trunk, independent of #1964. Fixes the shape of the cold-gate
problem rather than its constant.

Refs RUE-1083, RUE-1091.

## The problem with the gate, not the number

An absolute `cold_wall_seconds` budget compares a wall time on whatever host is
running against a constant calibrated on a different one. There is no multiplier
that is simultaneously tight enough to mean something and loose enough to be safe
everywhere.

The measurement in #1963 showed this concretely: a host running 2.4× the
reference figures left as little as **1.22× headroom over its own pre-cutover
cost** on the rill row. A host a quarter slower than that would have failed a
*fully repaired* compiler — the exact false failure the multiplier exists to
prevent. Raising 4× → 6× bought headroom but only moved the failure mode.

## The change

Decide per run, using the same distinct-binary test that already classifies the
comparison:

| historical baseline binary | absolute cold budget |
|---|---|
| absent, or identical to current | **enforced** — a breach fails the scenario |
| distinct | **advisory** — reported, does not decide the verdict |

With a distinct baseline the role-vs-role pair comparison is available and is
**host-independent by construction**, because both roles run on the same machine
in the same run. The absolute budget then adds nothing the pairs do not already
carry, and can only contribute a false failure. Without a baseline it stays the
hard gate it was designed to be — it is the only thing that reports at all when
every pair is `unsupported`.

Each run records which mode applied in
`comparison_provenance.absolute_cold_budget`, so a report is never ambiguous
about how its cold rows were judged.

## What an advisory is not

Downgrading a gate is exactly where a fail-closed design can spring a leak, so
all four properties are tested:

- an over-budget row with a baseline is `advisory` and does **not** fail;
- an over-budget row without a baseline still **fails**;
- an advisory **cannot manufacture a pass** for a scenario whose pairs are all
  unsupported;
- a genuine pair failure still **fails** with a baseline present.

## Effect on the multiplier

This leaves the 6× multiplier from #1963 as a fallback calibration rather than a
load-bearing threshold. It still governs bare runs; it no longer stands between
a repaired compiler and a false failure on a slow host. Nothing about today's
verdicts changes — every regressed program is 4–14× over gate.

## Test evidence

- `python3 scripts/test-value-audit.py` and `./buck2 test //:value-audit-tool-tests`:
  **46 passed** (42 before, +4 for the advisory semantics).
- Python-only change; no compiler code touched, so the Rust suites are
  unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_012LsHBgTP9eKtFWf2hPgcQ8)_