### PR TITLE
RUE-1132: share the declaration projection across a request's bodies

### DIFF
--- a/crates/rue-compiler/src/body_overlay.rs
+++ b/crates/rue-compiler/src/body_overlay.rs
@@ -693,6 +693,11 @@ mod tests {
             cancellation: &rue_query::CancellationToken,
         ) -> Result<crate::body_query::BodyTransaction, rue_query::QueryAbort> {
             let mut work = rue_air::PerBodyDeclarationContextWork::default();
+            // A fresh memo per call: this differential compares one production
+            // body against one overlay body, so each side projects for itself
+            // exactly as it did before RUE-1132 shared the projection across the
+            // bodies of a request.
+            let shared_projection = crate::canonical_semantic::SharedDeclarationProjection::new();
             crate::canonical_semantic::analyze_body_query(
                 &self.merged,
                 &self.rir,
@@ -704,6 +709,7 @@ mod tests {
                 &crate::body_query::WellKnownOptionResolution::default(),
                 key,
                 cancellation,
+                &shared_projection,
                 &mut work,
             )
         }

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -12,6 +12,118 @@ use rue_air::{
 };
 use tracing::info_span;
 
+/// Request-scoped memo for the body-invariant durable declaration projection
+/// (RUE-1132).
+///
+/// `project_durable_declaration_semantics` is a pure function of inputs that are
+/// all revision-scoped — the merged program, the prepared shell records and
+/// their provisional definition universe, and the query-owned durable
+/// declarations. None of them carries a body key, so every reached body used to
+/// recompute a bit-for-bit identical value. This memo computes it once per
+/// semantic request and hands the shared `Arc` to each body.
+///
+/// It is **not** a dependency authority and holds no lease: it is created inside
+/// one rooted attempt, dropped with it, and pins the revision and configuration
+/// it was filled for. A request presenting a different revision/configuration is
+/// a programming error, not a cache miss — the body fails closed rather than
+/// recomputing into a slot that belongs to another revision. Because the value
+/// is owned data (`Arc<[SemanticDeclarationExport]>`) rather than a semantic
+/// epoch, sharing it retains no mutable declaration state across bodies.
+///
+/// The projection lock is never held across the projection itself: a miss
+/// releases the lock, projects, then re-locks to publish. Two concurrent misses
+/// may therefore both project — deterministically producing equal values — and
+/// the first writer wins, mirroring `recipe_cache`'s claim discipline.
+pub(crate) struct SharedDeclarationProjection {
+    filled: std::sync::Mutex<Option<FilledDeclarationProjection>>,
+}
+
+struct FilledDeclarationProjection {
+    revision: crate::SourceRevision,
+    configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
+    exports: Arc<[rue_air::SemanticDeclarationExport]>,
+}
+
+/// Why a body's projection request did not reuse the shared value. The stage
+/// charges its projection work only on a `Computed` outcome, so a reused
+/// projection drops the per-body counter at the stage's own source rather than
+/// being subtracted afterwards.
+enum SharedProjectionOutcome {
+    Computed(
+        Arc<[rue_air::SemanticDeclarationExport]>,
+        crate::durable_semantics::DurableSemanticProjectionWork,
+    ),
+    Reused(Arc<[rue_air::SemanticDeclarationExport]>),
+}
+
+impl SharedDeclarationProjection {
+    pub(crate) fn new() -> Self {
+        Self {
+            filled: std::sync::Mutex::new(None),
+        }
+    }
+
+    /// The declaration projection for this request, computing it on first
+    /// demand. `project` runs outside the lock.
+    fn get_or_project(
+        &self,
+        revision: &crate::SourceRevision,
+        configuration: &crate::semantic_query_nucleus::SemanticQueryConfiguration,
+        project: impl FnOnce() -> Result<
+            (
+                Arc<[rue_air::SemanticDeclarationExport]>,
+                crate::durable_semantics::DurableSemanticProjectionWork,
+            ),
+            crate::durable_semantics::DurableSemanticProjectionFailure,
+        >,
+    ) -> Result<SharedProjectionOutcome, SharedProjectionFailure> {
+        {
+            let filled = self
+                .filled
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(filled) = filled.as_ref() {
+                if filled.revision != *revision || filled.configuration != *configuration {
+                    return Err(SharedProjectionFailure::ForeignRequest);
+                }
+                return Ok(SharedProjectionOutcome::Reused(filled.exports.clone()));
+            }
+        }
+        let (exports, work) = project().map_err(SharedProjectionFailure::Projection)?;
+        let mut filled = self
+            .filled
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match filled.as_ref() {
+            // A concurrent miss published first. Its value is equal by
+            // construction, so adopt it and keep one shared identity.
+            Some(existing)
+                if existing.revision == *revision && existing.configuration == *configuration =>
+            {
+                let exports = existing.exports.clone();
+                drop(filled);
+                Ok(SharedProjectionOutcome::Computed(exports, work))
+            }
+            Some(_) => Err(SharedProjectionFailure::ForeignRequest),
+            None => {
+                *filled = Some(FilledDeclarationProjection {
+                    revision: revision.clone(),
+                    configuration: configuration.clone(),
+                    exports: exports.clone(),
+                });
+                drop(filled);
+                Ok(SharedProjectionOutcome::Computed(exports, work))
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum SharedProjectionFailure {
+    Projection(crate::durable_semantics::DurableSemanticProjectionFailure),
+    ForeignRequest,
+}
+
 pub(crate) struct PreparedDurableBodyCandidate {
     pub owner: crate::StableDefinitionKey,
     pub body_span: rue_span::Span,
@@ -1746,6 +1858,10 @@ pub(crate) fn analyze_body_query(
     well_known: &crate::body_query::WellKnownOptionResolution,
     key: &crate::body_query::BodyQueryKey,
     cancellation: &rue_query::CancellationToken,
+    // The request-scoped memo for the body-invariant declaration projection
+    // (RUE-1132). The first reached body of a request projects and publishes;
+    // every later body reuses the shared exports and charges no projection work.
+    shared_projection: &SharedDeclarationProjection,
     // Per-body declaration-context work is accrued here, at the stage sources,
     // as each stage actually performs it — never from the coordinator's input
     // slice lengths. The out-parameter carries partial work when a stage fails
@@ -1813,17 +1929,34 @@ pub(crate) fn analyze_body_query(
     work.rir_instructions_visited += declaration_index.rir_instructions_visited;
     drop(prepare_span);
     let project_span = info_span!("body_project_declarations").entered();
-    let (projected, projection_work) = match crate::project_durable_declaration_semantics(
-        merged,
-        &provisional,
-        &shell_records,
-        query_declarations,
-    ) {
-        Ok(projected) => projected,
-        Err(failure) => {
+    // RUE-1132: the declaration projection is body-invariant, so it is computed
+    // once per request and shared. The stage still runs in full for the first
+    // reached body — including its failure classification — so a projection
+    // failure is reported identically regardless of which body demanded it.
+    let projection =
+        shared_projection.get_or_project(rir.source_revision(), &key.configuration, || {
+            crate::project_durable_declaration_semantics(
+                merged,
+                &provisional,
+                &shell_records,
+                query_declarations,
+            )
+        });
+    let (projected, projection_work) = match projection {
+        Ok(SharedProjectionOutcome::Computed(projected, work)) => (projected, Some(work)),
+        Ok(SharedProjectionOutcome::Reused(projected)) => (projected, None),
+        Err(SharedProjectionFailure::Projection(failure)) => {
             return Ok(deterministic_failure(
                 "project_durable_declaration_semantics",
                 format!("{failure:?}"),
+            ));
+        }
+        Err(SharedProjectionFailure::ForeignRequest) => {
+            return Ok(deterministic_failure(
+                "shared_declaration_projection_revision",
+                "the shared declaration projection belongs to a different revision or \
+                 configuration than this body's request"
+                    .into(),
             ));
         }
     };
@@ -1849,10 +1982,16 @@ pub(crate) fn analyze_body_query(
     // than `projected.len()` means a projection shortcut that visits fewer
     // records — e.g. a shared base that skips already-projected declarations —
     // drops this counter even if the exported slice length is unchanged.
+    //
+    // RUE-1132 is exactly that shortcut: a body that reused the request's shared
+    // projection visited and copied no durable record, so it charges only the
+    // anonymous-nominal term it did project. The declaration term is charged
+    // once per request, by whichever body computed it.
+    let declaration_projection_work = projection_work.unwrap_or_default();
     work.projections_performed +=
-        projection_work.durable_records_visited + projected_anonymous.len();
-    work.durable_source_records_inspected += projection_work.durable_records_visited;
-    work.durable_source_records_copied += projection_work.durable_records_copied;
+        declaration_projection_work.durable_records_visited + projected_anonymous.len();
+    work.durable_source_records_inspected += declaration_projection_work.durable_records_visited;
+    work.durable_source_records_copied += declaration_projection_work.durable_records_copied;
     drop(project_span);
     let install_span = info_span!("body_install_declarations").entered();
     let bound = match shells
@@ -3672,5 +3811,165 @@ mod tests {
         assert_eq!(o1.optimization_attempts, 2);
         assert_eq!(o1.optimization_completions, 2);
         assert_eq!(o1.optimized_level_attempts, 2);
+    }
+
+    mod shared_declaration_projection {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use super::super::{
+            SharedDeclarationProjection, SharedProjectionFailure, SharedProjectionOutcome,
+        };
+        use crate::durable_semantics::{
+            DurableSemanticProjectionFailure, DurableSemanticProjectionWork,
+        };
+        use crate::source_identity::{ModuleRevision, SourceId, SourceRevision};
+
+        fn revision(text: &str) -> SourceRevision {
+            let module = crate::ModuleId::from_logical_path("main")
+                .expect("`main` is a valid logical module path");
+            SourceRevision::new(
+                module.clone(),
+                vec![ModuleRevision {
+                    module,
+                    source: SourceId::from_shared_text(Arc::new(text.to_owned())),
+                }],
+            )
+            .expect("a single-module revision is well formed")
+        }
+
+        fn configuration() -> crate::semantic_query_nucleus::SemanticQueryConfiguration {
+            crate::semantic_query_nucleus::SemanticQueryConfiguration {
+                target: crate::Target::X86_64Linux,
+                preview_features: crate::StablePreviewFeatures::new(
+                    &crate::PreviewFeatures::default(),
+                ),
+            }
+        }
+
+        /// The memo is agnostic to the projection payload — it shares whatever
+        /// the projector returned — so an empty export set is sufficient to
+        /// exercise compute/reuse/fail-closed. Payload equivalence is covered by
+        /// the projector's own tests and by the corpus differentials.
+        fn exports() -> Arc<[rue_air::SemanticDeclarationExport]> {
+            Arc::from(Vec::new())
+        }
+
+        /// The first body of a request projects; every later body reuses the
+        /// exact same allocation rather than reprojecting. This is the whole
+        /// point of RUE-1132, so it is asserted on `Arc` identity, not equality.
+        #[test]
+        fn later_bodies_reuse_the_first_body_s_projection() {
+            let shared = SharedDeclarationProjection::new();
+            let revision = revision("fn main() {}");
+            let configuration = configuration();
+            let projections = AtomicUsize::new(0);
+            let project = || {
+                projections.fetch_add(1, Ordering::Relaxed);
+                Ok((exports(), DurableSemanticProjectionWork::default()))
+            };
+
+            let first = shared
+                .get_or_project(&revision, &configuration, project)
+                .expect("the first request projects");
+            let SharedProjectionOutcome::Computed(first, _) = first else {
+                panic!("the first request must compute");
+            };
+            let second = shared
+                .get_or_project(&revision, &configuration, project)
+                .expect("the second request reuses");
+            let SharedProjectionOutcome::Reused(second) = second else {
+                panic!("the second request must reuse, not recompute");
+            };
+
+            assert_eq!(
+                projections.load(Ordering::Relaxed),
+                1,
+                "the projection must run exactly once per request"
+            );
+            assert!(
+                Arc::ptr_eq(&first, &second),
+                "every body must share one projection allocation"
+            );
+        }
+
+        /// A memo that outlived its revision is a programming error, not a miss.
+        /// It must never silently reproject into a slot owned by another
+        /// revision, because the body would then observe a projection that does
+        /// not belong to its own source.
+        #[test]
+        fn a_foreign_revision_fails_closed_instead_of_reprojecting() {
+            let shared = SharedDeclarationProjection::new();
+            let configuration = configuration();
+            shared
+                .get_or_project(&revision("fn main() {}"), &configuration, || {
+                    Ok((exports(), DurableSemanticProjectionWork::default()))
+                })
+                .expect("the first request projects");
+
+            let foreign = shared.get_or_project(
+                &revision("fn main() { let x = 1; }"),
+                &configuration,
+                || panic!("a foreign revision must not be given the chance to reproject"),
+            );
+
+            assert!(matches!(
+                foreign,
+                Err(SharedProjectionFailure::ForeignRequest)
+            ));
+        }
+
+        /// The same fail-closed rule applies to configuration: a body compiled
+        /// for another target or preview-feature set must not adopt this
+        /// request's exports.
+        #[test]
+        fn a_foreign_configuration_fails_closed() {
+            let shared = SharedDeclarationProjection::new();
+            let revision = revision("fn main() {}");
+            shared
+                .get_or_project(&revision, &configuration(), || {
+                    Ok((exports(), DurableSemanticProjectionWork::default()))
+                })
+                .expect("the first request projects");
+
+            let mut foreign_configuration = configuration();
+            foreign_configuration.target = crate::Target::Aarch64Linux;
+            let foreign = shared.get_or_project(&revision, &foreign_configuration, || {
+                panic!("a foreign configuration must not be given the chance to reproject")
+            });
+
+            assert!(matches!(
+                foreign,
+                Err(SharedProjectionFailure::ForeignRequest)
+            ));
+        }
+
+        /// A failed projection must not fill the memo: the failure is
+        /// deterministic and every body must observe it, rather than the first
+        /// body failing and later bodies reusing a half-filled slot.
+        #[test]
+        fn a_failed_projection_leaves_the_memo_empty() {
+            let shared = SharedDeclarationProjection::new();
+            let revision = revision("fn main() {}");
+            let configuration = configuration();
+
+            let failed = shared.get_or_project(&revision, &configuration, || {
+                Err(DurableSemanticProjectionFailure::AmbiguousDefinition)
+            });
+            assert!(matches!(
+                failed,
+                Err(SharedProjectionFailure::Projection(_))
+            ));
+
+            let retried = shared
+                .get_or_project(&revision, &configuration, || {
+                    Ok((exports(), DurableSemanticProjectionWork::default()))
+                })
+                .expect("a later body reprojects after a failure");
+            assert!(
+                matches!(retried, SharedProjectionOutcome::Computed(..)),
+                "a failure must not be cached as a reusable projection"
+            );
+        }
     }
 }

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -944,7 +944,7 @@ fn rue_1090_historical_witness_ceiling_line(
     )
 }
 
-/// RUE-1121's post-repair acceptance row for a counter charged once per body.
+/// RUE-1121's post-repair acceptance row for a declaration-context counter.
 ///
 /// The RUE-1090 decision remains its exact-ratio verdict below. This row is the
 /// complementary acceptance assertion: with the same reached-body topology,
@@ -952,21 +952,25 @@ fn rue_1090_historical_witness_ceiling_line(
 /// flat. Until RUE-1091 repairs the shared declaration context, the current
 /// whole-universe witness records a controlled expected failure. Once repaired,
 /// the same row becomes a hard target pass without duplicating the test.
+///
+/// `witness` is the documented known-bad TOTAL, which differs by counter
+/// because the counters are no longer charged the same way. A counter still
+/// paid per body witnesses at `universe · cold_bodies`; the RUE-1132 projection
+/// is charged once per request and witnesses at `universe`. Passing the total
+/// rather than a per-body value keeps that difference explicit at each call
+/// site instead of hiding it in a uniform multiply here.
 fn rue_1121_exact_flat_context_row(
     counter: &str,
     baseline_total: usize,
     baseline_bodies: usize,
     grown_total: usize,
     grown_bodies: usize,
-    historical_grown_per_body_witness: usize,
+    witness: usize,
 ) -> Row {
     assert_eq!(
         grown_bodies, baseline_bodies,
         "RUE-1121 fixed-body corpus changed its body-preparation topology"
     );
-    let witness = historical_grown_per_body_witness
-        .checked_mul(grown_bodies)
-        .expect("RUE-1121 context witness overflow");
     Row::envelope(
         format!(
             "RUE-1121 exact-flat {counter}: warm-independent cold {} -> {} \
@@ -1109,12 +1113,25 @@ fn run_fixed_bodies_growing_declarations(bodies: usize, ladder: &[usize]) {
         // RUE-1121 acceptance rows consume only stage-sourced counters. The
         // RUE-1090 verdict below deliberately remains limited to its original
         // project/install/endpoint exact-ratio decision.
-        for (counter, baseline_total, grown_total, historical_grown_per_body_witness) in [
+        // Each witness is the known-bad TOTAL for that counter's charging shape:
+        // `universe · cold_bodies` for the counters still paid per body, and a
+        // single `universe` for the RUE-1132 projection, which is computed once
+        // per request and shared. The projection row therefore remains a tracked
+        // RUE-1091 expected-failure — one whole-universe projection is still not
+        // exactly flat in unrelated declarations — but its witness now records
+        // the repaired shape, so a regression back to per-body projection blows
+        // past the band and panics instead of being absorbed.
+        let per_body_witness = |per_body: usize| {
+            per_body
+                .checked_mul(grown.cold_bodies)
+                .expect("RUE-1121 context witness overflow")
+        };
+        for (counter, baseline_total, grown_total, witness) in [
             (
                 "shells prepared",
                 baseline.shells_total,
                 grown.shells_total,
-                historical_grown.per_body_shells,
+                per_body_witness(historical_grown.per_body_shells),
             ),
             (
                 "projections",
@@ -1126,13 +1143,13 @@ fn run_fixed_bodies_growing_declarations(bodies: usize, ladder: &[usize]) {
                 "semantics installed",
                 baseline.semantics_total,
                 grown.semantics_total,
-                historical_grown.per_body_semantics,
+                per_body_witness(historical_grown.per_body_semantics),
             ),
             (
                 "endpoints",
                 baseline.endpoints_total,
                 grown.endpoints_total,
-                historical_grown.per_body_endpoints,
+                per_body_witness(historical_grown.per_body_endpoints),
             ),
         ] {
             report.push(rue_1121_exact_flat_context_row(
@@ -1141,7 +1158,7 @@ fn run_fixed_bodies_growing_declarations(bodies: usize, ladder: &[usize]) {
                 baseline.cold_bodies,
                 grown_total,
                 grown.cold_bodies,
-                historical_grown_per_body_witness,
+                witness,
             ));
         }
         // A worsening beyond the historical unrepaired witness is a regression,
@@ -1356,13 +1373,21 @@ fn run_fixed_declarations_growing_bodies(decls: usize, ladder: &[usize]) {
             predicted.per_body_shells,
             1,
         ));
+        // RUE-1132 changed the SHAPE of this counter, so it is no longer a
+        // per-body linear row. The declaration projection is body-invariant and
+        // is now computed once per request and shared, so total projection work
+        // must stay at one universe REGARDLESS of how many bodies are reached.
+        // Asserting the total (not the per-body quotient) is strictly stronger
+        // than the old linear row: a regression to per-body projection lands at
+        // `U · cold_bodies` and fails here immediately, and the row cannot be
+        // satisfied by an integer-division artifact at large body counts.
         report.push(Row::linear_hard(
             format!(
-                "per-body project @ {decls} decls: {bodies} bodies={} (corpus U={})",
-                grown.per_body_projections(),
-                predicted.per_body_projections
+                "RUE-1132 shared projection @ {decls} decls: {bodies} bodies \
+                 total={} (corpus U={}, charged once per request)",
+                grown.projections_total, predicted.per_body_projections
             ),
-            grown.per_body_projections(),
+            grown.projections_total,
             predicted.per_body_projections,
             1,
         ));

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -6984,6 +6984,12 @@ impl CompilerSession {
                 // host driver after the worklist; the demanding body's transaction
                 // never runs on an unsatisfied prerequisite.
                 let mut parked_toolchain: Option<crate::ParkedToolchainModules> = None;
+                // RUE-1132: the durable declaration projection is body-invariant,
+                // so this rooted attempt projects once and every reached body
+                // reuses the shared exports. The memo is created here and dropped
+                // with the attempt, so it can never outlive its revision.
+                let shared_projection =
+                    crate::canonical_semantic::SharedDeclarationProjection::new();
                 while let Some(instance) = priority_pending.pop().or_else(|| pending.pop_first()) {
                     let popped_depth = instance_depth.get(&instance).copied().unwrap_or(0);
                     // Producer-nominal identity is exact: a reached anonymous
@@ -7278,6 +7284,7 @@ impl CompilerSession {
                                 &well_known,
                                 &key,
                                 cancellation,
+                                &shared_projection,
                                 &mut stage_context,
                             );
                             // Fold the stage-sourced per-body declaration-context

--- a/crates/rue-compiler/src/session/tests/rfinal_harness.rs
+++ b/crates/rue-compiler/src/session/tests/rfinal_harness.rs
@@ -122,6 +122,10 @@ impl DirectProductionInputs {
         HarnessError,
     > {
         let mut work = rue_air::PerBodyDeclarationContextWork::default();
+        // A fresh memo per analyzed body: this harness captures each body's own
+        // declaration-context work in isolation, so it must not inherit a
+        // projection another body already paid for (RUE-1132).
+        let shared_projection = crate::canonical_semantic::SharedDeclarationProjection::new();
         let transaction = crate::canonical_semantic::analyze_body_query(
             &self.merged,
             &self.rir,
@@ -133,6 +137,7 @@ impl DirectProductionInputs {
             &crate::body_query::WellKnownOptionResolution::default(),
             key,
             &rue_query::CancellationToken::new(),
+            &shared_projection,
             &mut work,
         )
         .map_err(|abort| HarnessError::Compile(format!("{abort:?}")))?;


### PR DESCRIPTION
## Summary

`analyze_body_query` projected the whole durable declaration universe once per reached body. Every input to that projection is revision-scoped — the merged program, the prepared shell records and their provisional definition universe, and the query-owned durable declarations — and none carries a body key, so each body recomputed a bit-for-bit identical value.

This projects once per rooted attempt and shares the resulting `Arc<[SemanticDeclarationExport]>` with every body of the request.

Refs RUE-1132, RUE-1091, RUE-1083.

## What the memo is, and is not

It is not a dependency authority. It holds no lease, observes no terminal, is created inside one rooted attempt and dropped with it, and pins the revision and configuration it was filled for. A request presenting a different revision or configuration fails closed rather than reprojecting into a slot owned by another revision, so no body can observe a projection that is not its own. A failed projection leaves the memo empty, so the deterministic failure reaches every body rather than one body failing and the rest reusing a half-filled slot. Invalidation semantics are unchanged.

The anonymous-nominal projection is body-varying and deliberately stays per body. The projection lock is never held across the projection itself, mirroring `recipe_cache`'s claim discipline.

Projection work counters are charged only when a body actually projects, at the stage's own source, so a reusing body drops the counter rather than having it subtracted afterwards.

## Structural effect

Exact, deterministic, reproduced by the scaling harness on every run:

| bodies × decls | `per_body_project` | `projections_total` |
|---|---:|---:|
| 100 × 100 | 201 → **1** | 20,301 → **201** |
| 1000 × 100 | 1101 → **1** | 1,102,101 → **1,101** |
| 100 × 1000 | 1101 → **1** | 111,201 → **1,101** |

## Cold wall time (value-audit protocol)

`scripts/rue-value-audit.py` under its standard protocol — 1 warmup, 7 paired alternating samples, medians and MADs — with pre-change trunk `fb54de6` as `current_production` and this revision as `candidate`. Both binaries built at `//platforms:release` on one host (4-core Xeon 2.1GHz), distinct SHA-256 verified before measuring.

| workload | base ms (MAD) | candidate ms (MAD) | delta | 3×MAD bar | significant |
|---|---:|---:|---:|---:|:--:|
| synthetic (1000 bodies) | 9465.8 (79.5) | 6960.3 (178.8) | **−26.5%** | 536.4 | yes |
| representative_multi_module | 281.3 (5.9) | 239.0 (2.6) | **−15.1%** | 17.8 | yes |
| medium_ordinary_rue | 21.0 (0.8) | 19.5 (0.6) | −7.1% | 2.5 | no |

`medium_ordinary_rue` (quicksort, 73 lines) does not clear the bar and is reported as **no measurable change**. That is the expected shape rather than a disappointment: the saving scales with reached bodies, and quicksort has too few to share a projection across.

Cold peak RSS is unchanged on every workload, far inside the audit's budget (largest delta 24 KiB against a 1.5 MiB allowance).

**Scope of the claim.** The `current_production_vs_candidate` cold pair **passes** on all three workloads. The audit's *overall* verdict is `indeterminate`, for two structural reasons that are not about this change: its historical-baseline pair is a deliberate same-binary smoke (no pre-cutover binary was supplied — that is #1963's concern), and the warm scenarios are `unsupported` without per-role session-benchmark binaries. **Warm behavior is not claimed here.** `caldera` was not run; it is cold-only at ~45 min per sample, so seven paired samples is an hours-long run.

A second, independent protocol run gave synthetic −22.8% and representative −4.6%. Both runs agree on direction everywhere. Synthetic is robust across both (−23% to −27%); the representative workload sits closer to its noise floor and cleared the bar in one run of two. The table above is the run with complete wall+RSS evidence.

## What this does not do

Compile remains O(declarations × bodies): prepare and install are still paid per body, and together they are the larger share. This removes the ×bodies factor from one of the four stages. It does not move the RUE-1090 gate, which correctly still reads `ACTIVATE RUE-1091` — the projection slope drops ~100× without flattening.

## Harness rows

The RUE-1121/RUE-1090 rows record the new charging shape rather than being loosened. The projection row remains a tracked RUE-1091 expected-failure — one whole-universe projection is still not exactly flat in unrelated declarations — but its witness moves from `universe × bodies` to `universe`, so a regression back to per-body projection blows past the band and panics. The growing-bodies row becomes a hard total-work invariant on total projection work, strictly stronger than the per-body linear row it replaces.

## Test evidence

- `./test.sh`: PASSED (exit 0).
- `scripts/rue quick`: 36 targets.
- `//crates/rue-compiler:rue-compiler-test`: 842 passed, including 4 new memo tests — reuse asserted on `Arc` identity, fail-closed on foreign revision and on foreign configuration, and no caching of a failed projection.
- `//crates/rue-compiler:scaling-matrix-test`: 841 passed.
- `bash ./clippy.sh`: 66 targets, no violations. `scripts/rue fmt`: clean (unrelated formatter churn in `crates/rue-test-runner/src/lib.rs` was reverted, not committed).
