### PR TITLE
Check a real maintained program for byte-stable output

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -315,12 +315,16 @@ sh_test(
     },
 )
 
+# RUE-1083: `examples/` is a declared input because this suite now also checks a
+# real maintained program (rill) for byte-stable output, not just the
+# purpose-built fixture. An edit under examples/ must therefore re-run it.
 sh_test(
     name = "reproducible-programs",
     labels = ["rue_heavy_suite"],
     test = "scripts/test-reproducible-output.sh",
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_EXAMPLES_DIR": "$(location :examples)/examples",
         "RUE_REPRO_FIXTURE": "$(location :reproducibility-fixture)/reproducibility/fixture",
         "RUE_STD_DIR": "$(location :std)/std",
     },

--- a/scripts/test-reproducible-output.sh
+++ b/scripts/test-reproducible-output.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 : "${RUE_BINARY:?RUE_BINARY must point to the Rue compiler}"
 : "${RUE_REPRO_FIXTURE:?RUE_REPRO_FIXTURE must point to the reproducibility fixture}"
 : "${RUE_STD_DIR:?RUE_STD_DIR must point to the Rue standard library}"
+: "${RUE_EXAMPLES_DIR:?RUE_EXAMPLES_DIR must point to the examples directory}"
 export RUE_STD_PATH="$RUE_STD_DIR"
 
 scratch="$(mktemp -d)"
@@ -383,6 +384,66 @@ compile_semantic_order_pair() {
     assert_macos_signature "$output_b"
 }
 
+# RUE-1083: a real, maintained multi-module program, checked the same way.
+#
+# Everything above compiles `reproducibility/fixture`, a corpus built for this
+# test. That left a gap: no program anyone actually maintains was checked for
+# byte-stable output, and a genuine nondeterminism bug lived in drop-flag slot
+# allocation without any suite noticing. It surfaced only when the incrementality
+# value audit compared two compiles of `examples/rill/main.rue` and got different
+# executables.
+#
+# Rill is the cheap end of the regressed-example set and exercises what the
+# purpose-built fixture does not: a 19-file import graph with real destructors
+# and moved-out struct fields, which is exactly the shape that drives
+# `arm_field_drop_flags`. This deliberately reuses the same perturbations as
+# `compile_pair` — root-path length, mtimes, manifest spelling, parallelism,
+# umask, TMPDIR, TZ, and SOURCE_DATE_EPOCH — so a failure means the compiler,
+# not the environment.
+assert_example_reproducible() {
+    local name="$1" opt="$2"
+    local src="$RUE_EXAMPLES_DIR/$name"
+    if [ ! -d "$src" ]; then
+        printf 'FAIL: example corpus %s is missing at %s\n' "$name" "$src" >&2
+        return 1
+    fi
+
+    local dir_a="$root_a/examples/$name"
+    local dir_b="$root_b/examples/$name"
+    rm -rf "$dir_a" "$dir_b"
+    mkdir -p "$dir_a" "$dir_b"
+    cp -R "$src/." "$dir_a/"
+    cp -R "$src/." "$dir_b/"
+    find "$dir_a" -type f -name '*.rue' -exec touch -t 200001010000 {} +
+    find "$dir_b" -type f -name '*.rue' -exec touch -t 203001010000 {} +
+
+    local output_a="$root_a/tmp/example-$name-o$opt"
+    local output_b="$root_b/tmp/example-$name-o$opt"
+    (
+        umask 022
+        cd "$dir_a"
+        env \
+            LC_ALL=C \
+            SOURCE_DATE_EPOCH=1 \
+            TMPDIR="$root_a/tmp" \
+            TZ=UTC \
+            "$RUE_BINARY" "-O$opt" -j1 main.rue -o "$output_a"
+    )
+    (
+        umask 077
+        env \
+            LC_ALL=C \
+            SOURCE_DATE_EPOCH=2000000000 \
+            TMPDIR="$root_b/tmp" \
+            TZ=Pacific/Honolulu \
+            "$RUE_BINARY" "-O$opt" -j32 "$dir_b/./main.rue" -o "$output_b"
+    )
+
+    assert_identical "example $name native -O$opt program" "$output_a" "$output_b"
+    assert_macos_signature "$output_a"
+    assert_macos_signature "$output_b"
+}
+
 assert_relocated_symbol_names
 assert_source_order_independent_ir
 
@@ -424,3 +485,6 @@ compile_pair 0
 compile_pair 2
 compile_semantic_order_pair 0
 compile_semantic_order_pair 2
+
+assert_example_reproducible rill 0
+assert_example_reproducible rill 2


### PR DESCRIPTION
## Summary

Closes the coverage gap that let #1964's bug through. Off trunk, which now
contains that fix.

Everything `//:reproducible-programs` compiled was `reproducibility/fixture`, a
corpus built for this test. No program anyone actually maintains was checked for
byte-stable output — so a real nondeterminism bug in drop-flag slot allocation
lived there with every suite green, and surfaced only when the incrementality
value audit compared two compiles of `examples/rill/main.rue` and got different
executables.

Refs RUE-1083.

## Change

Compile `examples/rill` at `-O0` and `-O2` under the same perturbations
`compile_pair` already uses — root-path length, mtimes, parallelism, umask,
`TMPDIR`, `TZ`, `SOURCE_DATE_EPOCH` — and require the two artifacts to be byte
identical. `examples/` becomes a declared input so an edit there re-runs the
suite.

Rill is the cheap end of the regressed-example set and exercises what the
purpose-built fixture does not: a 19-file import graph with real destructors and
moved-out struct fields — the shape that drives `arm_field_drop_flags`.

The existing fixture logic is untouched. It asserts exact AIR symbols, exact
program output and exact exit codes, all specific to that corpus, so generalizing
it into a loop would have been a rewrite for no benefit. This is additive.

## The check is demonstrably non-vacuous

A reproducibility test that cannot catch the bug it was written for is worse than
none, so I verified rather than assumed. I rebuilt the compiler with #1964's
`paths.sort()` removed and ran the suite:

```
ok: native -O0 program (371ef742…)
ok: native -O2 program (faf54ee6…)
ok: semantic-order native -O0 program (9ed289b9…)
ok: semantic-order native -O2 program (a4b4bb93…)
FAIL: example rill native -O0 program is not byte-reproducible
  first differing byte offset (1-based): 14432
```

**Every pre-existing assertion passed on a compiler with a real nondeterminism
bug.** Only the new row failed. That is precisely the gap, shown rather than
claimed.

## Test evidence

- `./buck2 test //:reproducible-programs` on this branch: passed.
- Script run directly, showing the new assertions execute:
  `ok: example rill native -O0 program (b6cc0038…)` and
  `ok: example rill native -O2 program (a11f1f15…)`. The `-O0` digest matches the
  one recorded in #1964 after the fix.
- Negative control above.

## Cost

Two extra rill compiles. About 16 s today at rill's regressed cost, and under 2 s
once the regression is repaired. `lattice` is the other program known to have been
unstable; at ~58 s a compile it is too expensive to add now, and it is worth
revisiting when the regressed-example cold budgets come back into range.


---
_Generated by [Claude Code](https://claude.ai/code/session_012LsHBgTP9eKtFWf2hPgcQ8)_