### PR TITLE
RUE-1134: publish exact body lookup dependencies

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -74,8 +74,9 @@ pub use runtime_call::{
 };
 pub use sema::{
     AnalyzedBodyOwnerEvent, AnalyzedCallableKind, AnalyzedFunction, BodyAnalysisFailure,
-    BodyAnalysisWork, BodyFactProvider, BodyNamedDependencyEvent, BodyOwnerEndpoint, BodyOwnerKind,
-    BodyOwnerToken, BoundSema, BuiltinTypeCallHead, ConstInfo, ConstValue, DeclarationBindingWork,
+    BodyAnalysisWork, BodyFactProvider, BodyLookupCollector, BodyLookupObservation,
+    BodyNamedDependencyEvent, BodyOwnerEndpoint, BodyOwnerKind, BodyOwnerToken, BoundSema,
+    BuiltinTypeCallHead, ConstInfo, ConstValue, DeclarationBindingWork,
     DeclarationBuiltinTypeCallHeadDependencyEvent, DeclarationInstallFailure,
     DeclarationResolutionFailure, DeclarationShells, DeclarationTypeCallHeadDependencyEvent,
     DeclarationTypeDependencyEvent, DeclarationTypeDependencyKind,

--- a/crates/rue-air/src/sema/aggregate_resolution.rs
+++ b/crates/rue-air/src/sema/aggregate_resolution.rs
@@ -58,18 +58,22 @@ impl<'s, 'a, D: DeclarationPhase> EpochFacts<'s, 'a, D> {
 
 impl<D: DeclarationPhase> AggregateFacts for EpochFacts<'_, '_, D> {
     fn value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
+        self.sema.record_body_module_item_lookup(file, name);
         self.sema.value_const(&(file, name)).cloned()
     }
 
     fn module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
+        self.sema.record_body_module_item_lookup(file, name);
         self.sema.module_binding(&(file, name)).cloned()
     }
 
     fn struct_in_file(&self, file: FileId, name: Spur) -> Option<StructId> {
+        self.sema.record_body_module_item_lookup(file, name);
         self.sema.structs_by_file_name.get(&(file, name)).copied()
     }
 
     fn enum_in_file(&self, file: FileId, name: Spur) -> Option<EnumId> {
+        self.sema.record_body_module_item_lookup(file, name);
         self.sema.enums_by_file_name.get(&(file, name)).copied()
     }
 

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -2119,6 +2119,42 @@ impl<'a> BoundSema<'a> {
         )
     }
 
+    /// Analyze one callable body while publishing every exact declaration
+    /// candidate-set lookup through `collector`.
+    ///
+    /// The collector is installed only after declaration installation has
+    /// completed, so it records body-resolution demand rather than the
+    /// whole-epoch preparation prefix.
+    pub fn analyze_one_body_instance_recording_lookups<K, M>(
+        mut self,
+        instance: &crate::FunctionInstanceKey<K, M>,
+        definition: impl Fn(
+            &K,
+        ) -> Result<
+            crate::SemanticDefinitionToken,
+            crate::SemanticStableResolutionFailure,
+        >,
+        module: impl Fn(
+            &M,
+        )
+            -> Result<crate::SemanticModuleToken, crate::SemanticStableResolutionFailure>,
+        interruption: Option<super::OneBodyInterruption>,
+        collector: super::BodyLookupCollector,
+    ) -> super::OneBodyTransactionOutcome
+    where
+        K: Clone,
+        M: Clone,
+    {
+        self.sema.body_lookup_collector = Some(collector);
+        super::one_body::analyze_one_body_instance(
+            self.sema,
+            instance,
+            definition,
+            module,
+            interruption,
+        )
+    }
+
     #[cfg(test)]
     pub(crate) fn analyze_one_body_for_test(
         self,

--- a/crates/rue-air/src/sema/body_endpoint.rs
+++ b/crates/rue-air/src/sema/body_endpoint.rs
@@ -158,14 +158,17 @@ impl BodyEndpointProvider for EpochFacts<'_, '_> {
     }
 
     fn function_by_file_name(&self, file: FileId, name: Spur) -> Option<Spur> {
+        self.sema.record_body_module_item_lookup(file, name);
         self.sema.functions_by_file_name.get(&(file, name)).copied()
     }
 
     fn struct_by_file_name(&self, file: FileId, name: Spur) -> Option<StructId> {
+        self.sema.record_body_module_item_lookup(file, name);
         self.sema.structs_by_file_name.get(&(file, name)).copied()
     }
 
     fn enum_by_file_name(&self, file: FileId, name: Spur) -> Option<EnumId> {
+        self.sema.record_body_module_item_lookup(file, name);
         self.sema.enums_by_file_name.get(&(file, name)).copied()
     }
 
@@ -207,6 +210,7 @@ impl BodyEndpointProvider for EpochFacts<'_, '_> {
     }
 
     fn method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
+        self.sema.record_body_member_lookup(struct_id, name);
         self.sema.method_info((struct_id, name)).copied()
     }
 
@@ -215,6 +219,7 @@ impl BodyEndpointProvider for EpochFacts<'_, '_> {
     }
 
     fn first_free_function(&self, source: Spur, file_id: FileId) -> Option<InstRef> {
+        self.sema.record_body_module_item_lookup(file_id, source);
         self.sema
             .declaration_index
             .first_free_function(source, Some(file_id))
@@ -226,10 +231,13 @@ impl BodyEndpointProvider for EpochFacts<'_, '_> {
         owner_type_name: Spur,
         method_name: Spur,
     ) -> Option<InstRef> {
+        self.sema
+            .record_body_module_item_lookup(owner_file, owner_type_name);
         let struct_id = self
             .sema
             .structs_by_file_name
             .get(&(owner_file, owner_type_name))?;
+        self.sema.record_body_member_lookup(*struct_id, method_name);
         self.sema
             .named_method_declarations
             .get(&(*struct_id, method_name))
@@ -237,6 +245,8 @@ impl BodyEndpointProvider for EpochFacts<'_, '_> {
     }
 
     fn destructor(&self, file: u32, type_name: Spur) -> Option<RirDestructorDeclaration> {
+        self.sema
+            .record_body_destructor_lookup(FileId::new(file), type_name);
         self.sema
             .declaration_index
             .destructors()

--- a/crates/rue-air/src/sema/call_resolution.rs
+++ b/crates/rue-air/src/sema/call_resolution.rs
@@ -138,26 +138,32 @@ impl CallResolutionFacts for EpochFacts<'_, '_> {
     }
 
     fn resolve_function_name_local(&self, name: Spur, file: FileId) -> Option<Spur> {
+        self.sema.record_body_module_item_lookup(file, name);
         self.sema.resolve_function_name_local(name, file)
     }
 
     fn resolve_const_info_in_file(&self, name: Spur, file: FileId) -> Option<ConstInfo> {
+        self.sema.record_body_module_item_lookup(file, name);
         self.sema.resolve_const_info_in_file(name, file).cloned()
     }
 
     fn value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
+        self.sema.record_body_module_item_lookup(file, name);
         self.sema.value_const(&(file, name)).cloned()
     }
 
     fn module_binding(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
+        self.sema.record_body_module_item_lookup(file, name);
         self.sema.module_binding(&(file, name)).cloned()
     }
 
     fn method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
+        self.sema.record_body_member_lookup(struct_id, name);
         self.sema.method_info((struct_id, name)).copied()
     }
 
     fn named_method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
+        self.sema.record_body_member_lookup(struct_id, name);
         self.sema.methods.get(&(struct_id, name)).copied()
     }
 
@@ -173,10 +179,13 @@ impl CallResolutionFacts for EpochFacts<'_, '_> {
         owner_type_name: Spur,
         method_name: Spur,
     ) -> Option<InstRef> {
+        self.sema
+            .record_body_module_item_lookup(owner_file, owner_type_name);
         let struct_id = self
             .sema
             .structs_by_file_name
             .get(&(owner_file, owner_type_name))?;
+        self.sema.record_body_member_lookup(*struct_id, method_name);
         self.sema
             .named_method_declarations
             .get(&(*struct_id, method_name))

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -82,16 +82,16 @@ pub use one_body::{
 };
 pub use output::{
     AnalyzedBodyOwnerEvent, AnalyzedCallableKind, AnalyzedFunction, BodyAnalysisFailure,
-    BodyAnalysisWork, BodyNamedDependencyEvent, BodyOwnerEndpoint, BodyOwnerKind, BodyOwnerToken,
-    BuiltinTypeCallHead, DeclarationBuiltinTypeCallHeadDependencyEvent,
-    DeclarationTypeCallHeadDependencyEvent, DeclarationTypeDependencyEvent,
-    DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind,
-    DeclarationTypeDependencyTargetKind, ImplicitDropDependencySourceEvent,
-    ImplicitNamedDestructorDependencyEvent, NamedConstDependencyEvent,
-    NamedConstDependencyTargetEvent, NamedDestructorDependencyEvent, NamedMethodDependencyEvent,
-    NamedMethodDependencyTargetEvent, OrdinaryFreeFunctionDependencyEvent, ParamSlotModes,
-    PerBodyDeclarationContextWork, SemaOutput, SourceParamAbi,
-    SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
+    BodyAnalysisWork, BodyLookupCollector, BodyLookupObservation, BodyNamedDependencyEvent,
+    BodyOwnerEndpoint, BodyOwnerKind, BodyOwnerToken, BuiltinTypeCallHead,
+    DeclarationBuiltinTypeCallHeadDependencyEvent, DeclarationTypeCallHeadDependencyEvent,
+    DeclarationTypeDependencyEvent, DeclarationTypeDependencyKind,
+    DeclarationTypeDependencySourceKind, DeclarationTypeDependencyTargetKind,
+    ImplicitDropDependencySourceEvent, ImplicitNamedDestructorDependencyEvent,
+    NamedConstDependencyEvent, NamedConstDependencyTargetEvent, NamedDestructorDependencyEvent,
+    NamedMethodDependencyEvent, NamedMethodDependencyTargetEvent,
+    OrdinaryFreeFunctionDependencyEvent, ParamSlotModes, PerBodyDeclarationContextWork, SemaOutput,
+    SourceParamAbi, SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
 };
 pub use provider::{
     BodyFactProvider, DropCopyMetadata, ImportResolution, MemberCandidate, MemberKind,
@@ -381,6 +381,7 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
     pub(crate) body_owner_tokens:
         HashMap<(u32, String, Option<String>, BodyOwnerKind), BodyOwnerToken>,
     pub(crate) body_named_dependencies: Vec<BodyNamedDependencyEvent>,
+    pub(crate) body_lookup_collector: Option<BodyLookupCollector>,
     pub(crate) one_body_error_recovery: bool,
     pub(crate) one_body_recovered_errors: Vec<rue_error::CompileError>,
     pub(crate) one_body_inference_failure_incomplete: bool,
@@ -581,6 +582,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             body_dependency_observer,
             body_owner_tokens,
             body_named_dependencies,
+            body_lookup_collector,
             one_body_error_recovery,
             one_body_recovered_errors,
             one_body_inference_failure_incomplete,
@@ -664,6 +666,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             body_dependency_observer,
             body_owner_tokens,
             body_named_dependencies,
+            body_lookup_collector,
             one_body_error_recovery,
             one_body_recovered_errors,
             one_body_inference_failure_incomplete,
@@ -923,6 +926,46 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         self.body_analysis_work.named_const_dependency_events += 1;
     }
 
+    pub(crate) fn record_body_module_item_lookup(&self, file: FileId, name: Spur) {
+        let Some(collector) = &self.body_lookup_collector else {
+            return;
+        };
+        collector.record(BodyLookupObservation::ModuleItem {
+            file: file.index(),
+            name: std::sync::Arc::from(self.interner.resolve(&name)),
+        });
+    }
+
+    pub(crate) fn record_body_destructor_lookup(&self, file: FileId, type_name: Spur) {
+        let Some(collector) = &self.body_lookup_collector else {
+            return;
+        };
+        collector.record(BodyLookupObservation::Destructor {
+            file: file.index(),
+            type_name: std::sync::Arc::from(self.interner.resolve(&type_name)),
+        });
+    }
+
+    pub(crate) fn record_body_member_lookup(&self, owner: StructId, member: Spur) {
+        let Some(collector) = &self.body_lookup_collector else {
+            return;
+        };
+        if self.anonymous_struct_ids.contains(&owner) {
+            return;
+        }
+        let Some(definition) = self.type_pool.try_struct_def(owner) else {
+            return;
+        };
+        if definition.is_builtin {
+            return;
+        }
+        collector.record(BodyLookupObservation::Member {
+            owner_file: definition.file_id.index(),
+            owner_name: std::sync::Arc::from(definition.name),
+            member_name: std::sync::Arc::from(self.interner.resolve(&member)),
+        });
+    }
+
     pub(crate) fn record_body_callable_dependency(&mut self, symbol: Spur) {
         let Some(source) = self.body_dependency_observer.clone() else {
             return;
@@ -1179,6 +1222,7 @@ impl<'a> Sema<'a> {
             body_dependency_observer: None,
             body_owner_tokens: HashMap::new(),
             body_named_dependencies: Vec::new(),
+            body_lookup_collector: None,
             one_body_error_recovery: false,
             one_body_recovered_errors: Vec::new(),
             one_body_inference_failure_incomplete: false,

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -239,6 +239,68 @@ pub struct BodyNamedDependencyEvent {
     pub target: NamedConstDependencyTargetEvent,
 }
 
+/// One exact declaration candidate-set lookup performed while analyzing a
+/// single body.
+///
+/// These observations deliberately carry source-level file/name identities,
+/// never epoch-local compact type or symbol ids. The compiler projects them to
+/// its registered lookup and semantic-nucleus query keys while the body query
+/// task is still live. Empty and ambiguous results are observations too: the
+/// event records the consulted key, not a selected declaration.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BodyLookupObservation {
+    /// A top-level value/type/module-binding lookup in one module.
+    ModuleItem {
+        file: u32,
+        name: std::sync::Arc<str>,
+    },
+    /// A destructor lookup for one named type in one module.
+    Destructor {
+        file: u32,
+        type_name: std::sync::Arc<str>,
+    },
+    /// A method or associated-function candidate-set lookup on one named owner.
+    Member {
+        owner_file: u32,
+        owner_name: std::sync::Arc<str>,
+        member_name: std::sync::Arc<str>,
+    },
+}
+
+/// Thread-safe sink for one body's exact lookup observations.
+///
+/// A collector is installed only for the duration of an exact-one-body
+/// analysis. The fact seams accept `&self`, so the shared set provides explicit
+/// interior mutability without making the semantic epoch itself a query-runtime
+/// authority. Observations are deterministically deduplicated and sorted.
+#[derive(Clone, Default)]
+pub struct BodyLookupCollector(
+    std::sync::Arc<std::sync::Mutex<std::collections::BTreeSet<BodyLookupObservation>>>,
+);
+
+impl BodyLookupCollector {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn record(&self, observation: BodyLookupObservation) {
+        self.0
+            .lock()
+            .expect("body lookup collector is not poisoned")
+            .insert(observation);
+    }
+
+    pub fn observations(&self) -> std::sync::Arc<[BodyLookupObservation]> {
+        self.0
+            .lock()
+            .expect("body lookup collector is not poisoned")
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>()
+            .into()
+    }
+}
+
 /// Stable-capable owner of an analyzed body or synthesized named-type glue.
 ///
 /// This deliberately contains no request-local symbols or type IDs. CFG

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -74,6 +74,7 @@ impl<D: DeclarationPhase> crate::SemanticModulePathProvider<FileId, crate::types
             return Ok(None);
         };
         let name = self.sema.interner.get_or_intern(name);
+        self.sema.record_body_module_item_lookup(root_file, name);
         let binding = provider_failure(self.sema.resolve_module_binding_in_file(root_file, name))?;
         Ok(binding.and_then(|binding| self.module_binding_fact(binding)))
     }
@@ -89,6 +90,7 @@ impl<D: DeclarationPhase> crate::SemanticModulePathProvider<FileId, crate::types
         }
         let file = self.sema.module_registry.get_def(*module).file_id;
         let name = self.sema.interner.get_or_intern(name);
+        self.sema.record_body_module_item_lookup(file, name);
         let binding = provider_failure(self.sema.resolve_module_binding_in_file(file, name))?;
         Ok(binding.and_then(|binding| self.module_binding_fact(binding)))
     }
@@ -157,14 +159,17 @@ impl<D: DeclarationPhase>
     ) -> SemaProviderResult<Option<crate::SemanticTypeFact<Type, FileId>>> {
         let symbol = self.sema.interner.get_or_intern(name);
         let (id, bypass_visibility) = match self.root_authority {
-            SemaTypeRootAuthority::KnownFile(root_file) => (
-                self.sema
-                    .structs_by_file_name
-                    .get(&(root_file, symbol))
-                    .copied()
-                    .or_else(|| self.sema.resolve_builtin_struct_name(symbol)),
-                false,
-            ),
+            SemaTypeRootAuthority::KnownFile(root_file) => {
+                self.sema.record_body_module_item_lookup(root_file, symbol);
+                (
+                    self.sema
+                        .structs_by_file_name
+                        .get(&(root_file, symbol))
+                        .copied()
+                        .or_else(|| self.sema.resolve_builtin_struct_name(symbol)),
+                    false,
+                )
+            }
             SemaTypeRootAuthority::GlobalSpeculative => (
                 self.sema
                     .struct_id_for_name(symbol)
@@ -194,14 +199,17 @@ impl<D: DeclarationPhase>
     ) -> SemaProviderResult<Option<crate::SemanticTypeFact<Type, FileId>>> {
         let symbol = self.sema.interner.get_or_intern(name);
         let (id, bypass_visibility) = match self.root_authority {
-            SemaTypeRootAuthority::KnownFile(root_file) => (
-                self.sema
-                    .enums_by_file_name
-                    .get(&(root_file, symbol))
-                    .copied()
-                    .or_else(|| self.sema.resolve_builtin_enum_name(symbol)),
-                false,
-            ),
+            SemaTypeRootAuthority::KnownFile(root_file) => {
+                self.sema.record_body_module_item_lookup(root_file, symbol);
+                (
+                    self.sema
+                        .enums_by_file_name
+                        .get(&(root_file, symbol))
+                        .copied()
+                        .or_else(|| self.sema.resolve_builtin_enum_name(symbol)),
+                    false,
+                )
+            }
             SemaTypeRootAuthority::GlobalSpeculative => (
                 self.sema
                     .enum_id_for_name(symbol)
@@ -233,6 +241,7 @@ impl<D: DeclarationPhase>
             return Ok(None);
         };
         let symbol = self.sema.interner.get_or_intern(name);
+        self.sema.record_body_module_item_lookup(root_file, symbol);
         let mut value = self
             .sema
             .resolve_const_info_in_file(symbol, root_file)
@@ -260,6 +269,7 @@ impl<D: DeclarationPhase>
     ) -> SemaProviderResult<Option<crate::SemanticTypeFact<Type, FileId>>> {
         let file = self.sema.module_registry.get_def(*module).file_id;
         let symbol = self.sema.interner.get_or_intern(name);
+        self.sema.record_body_module_item_lookup(file, symbol);
         let Some(id) = self.sema.structs_by_file_name.get(&(file, symbol)).copied() else {
             return Ok(None);
         };
@@ -282,6 +292,7 @@ impl<D: DeclarationPhase>
     ) -> SemaProviderResult<Option<crate::SemanticTypeFact<Type, FileId>>> {
         let file = self.sema.module_registry.get_def(*module).file_id;
         let symbol = self.sema.interner.get_or_intern(name);
+        self.sema.record_body_module_item_lookup(file, symbol);
         let Some(id) = self.sema.enums_by_file_name.get(&(file, symbol)).copied() else {
             return Ok(None);
         };
@@ -304,6 +315,7 @@ impl<D: DeclarationPhase>
     ) -> SemaProviderResult<Option<crate::SemanticTypeFact<Type, FileId>>> {
         let file = self.sema.module_registry.get_def(*module).file_id;
         let symbol = self.sema.interner.get_or_intern(name);
+        self.sema.record_body_module_item_lookup(file, symbol);
         if self.sema.declaration_binding_active && self.sema.value_const(&(file, symbol)).is_none()
         {
             provider_failure(

--- a/crates/rue-compiler/src/body_query.rs
+++ b/crates/rue-compiler/src/body_query.rs
@@ -85,6 +85,26 @@ pub(crate) struct BodyProducedAnonymousNominals(
     pub(crate) Arc<[crate::durable_semantics::DurableAnonymousNominal]>,
 );
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum BodyLookupKey {
+    Name {
+        module: crate::ModuleId,
+        namespace: BodyLookupNamespace,
+        name: Arc<str>,
+    },
+    Member {
+        module: crate::ModuleId,
+        owner_name: Arc<str>,
+        member_name: Arc<str>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum BodyLookupNamespace {
+    ModuleItem,
+    Destructor,
+}
+
 /// The `body-produced-anonymous` family's terminal value.
 ///
 /// A producer either publishes the anonymous nominals it owns (`Produced`) or
@@ -121,10 +141,12 @@ pub(crate) enum BodyTransaction {
         body: Box<CanonicalBody>,
         references: BodyReferences,
         produced_anonymous_nominals: BodyProducedAnonymousNominals,
+        lookup_observations: Arc<[BodyLookupKey]>,
     },
     DeterministicFailure {
         errors: crate::CompileErrors,
         references: BodyReferences,
+        lookup_observations: Arc<[BodyLookupKey]>,
     },
 }
 
@@ -136,6 +158,32 @@ impl BodyTransaction {
             }
         }
     }
+
+    pub(crate) fn lookup_observations(&self) -> &[BodyLookupKey] {
+        match self {
+            Self::Success {
+                lookup_observations,
+                ..
+            }
+            | Self::DeterministicFailure {
+                lookup_observations,
+                ..
+            } => lookup_observations,
+        }
+    }
+
+    pub(crate) fn install_lookup_observations(&mut self, observations: Arc<[BodyLookupKey]>) {
+        match self {
+            Self::Success {
+                lookup_observations,
+                ..
+            }
+            | Self::DeterministicFailure {
+                lookup_observations,
+                ..
+            } => *lookup_observations = observations,
+        }
+    }
 }
 
 pub(crate) fn transaction_equal(left: &BodyTransaction, right: &BodyTransaction) -> bool {
@@ -145,11 +193,13 @@ pub(crate) fn transaction_equal(left: &BodyTransaction, right: &BodyTransaction)
                 body: left_body,
                 references: left_references,
                 produced_anonymous_nominals: left_produced,
+                ..
             },
             BodyTransaction::Success {
                 body: right_body,
                 references: right_references,
                 produced_anonymous_nominals: right_produced,
+                ..
             },
         ) => {
             left_body == right_body
@@ -160,10 +210,12 @@ pub(crate) fn transaction_equal(left: &BodyTransaction, right: &BodyTransaction)
             BodyTransaction::DeterministicFailure {
                 errors: left_errors,
                 references: left_references,
+                ..
             },
             BodyTransaction::DeterministicFailure {
                 errors: right_errors,
                 references: right_references,
+                ..
             },
         ) => {
             left_errors.to_string() == right_errors.to_string()

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -1888,6 +1888,7 @@ pub(crate) fn analyze_body_query(
                 )),
             )),
             references: BodyReferences(Arc::from(Vec::<BodyReference>::new())),
+            lookup_observations: Arc::from([]),
         }
     };
     #[cfg(test)]
@@ -2118,13 +2119,15 @@ pub(crate) fn analyze_body_query(
     };
     drop(install_span);
     let analyze_span = info_span!("body_analyze").entered();
-    let outcome = bound.analyze_one_body_instance(
+    let lookup_collector = rue_air::BodyLookupCollector::new();
+    let outcome = bound.analyze_one_body_instance_recording_lookups(
         &key.instance,
         |definition| definitions.semantic_token_for_key(definition),
         |module| definitions.module_token_for(merged, module),
         cancellation
             .is_canceled()
             .then_some(rue_air::OneBodyInterruption::Canceled),
+        lookup_collector.clone(),
     );
     drop(analyze_span);
     // Keep cancellation responsive across the synchronous AIR callback. The
@@ -2145,7 +2148,46 @@ pub(crate) fn analyze_body_query(
         definitions: &definitions,
         merged,
     };
-    publish_one_body_outcome(outcome, &resolver, &deterministic_failure)
+    let mut transaction = publish_one_body_outcome(outcome, &resolver, &deterministic_failure)?;
+    let module_for_file = |file| {
+        merged
+            .ast()
+            .modules()
+            .iter()
+            .find(|module| module.file_id().index() == file)
+            .map(|module| module.module_id().clone())
+    };
+    let lookup_observations = lookup_collector
+        .observations()
+        .iter()
+        .filter_map(|observation| {
+            use crate::body_query::{BodyLookupKey as Key, BodyLookupNamespace as Namespace};
+            Some(match observation {
+                rue_air::BodyLookupObservation::ModuleItem { file, name } => Key::Name {
+                    module: module_for_file(*file)?,
+                    namespace: Namespace::ModuleItem,
+                    name: name.clone(),
+                },
+                rue_air::BodyLookupObservation::Destructor { file, type_name } => Key::Name {
+                    module: module_for_file(*file)?,
+                    namespace: Namespace::Destructor,
+                    name: type_name.clone(),
+                },
+                rue_air::BodyLookupObservation::Member {
+                    owner_file,
+                    owner_name,
+                    member_name,
+                } => Key::Member {
+                    module: module_for_file(*owner_file)?,
+                    owner_name: owner_name.clone(),
+                    member_name: member_name.clone(),
+                },
+            })
+        })
+        .collect::<Vec<_>>()
+        .into();
+    transaction.install_lookup_observations(lookup_observations);
+    Ok(transaction)
 }
 
 /// The stable-identity back-projection publication needs to convert one
@@ -2396,6 +2438,7 @@ pub(crate) fn publish_one_body_outcome(
                 body: Box::new(body),
                 references,
                 produced_anonymous_nominals,
+                lookup_observations: Arc::from([]),
             })
         }
         rue_air::OneBodyTransactionOutcome::DeterministicFailure { errors, references } => {
@@ -2405,7 +2448,11 @@ pub(crate) fn publish_one_body_outcome(
             // invariant violation as a cancellation.
             let references = map_references(references)
                 .unwrap_or_else(|_| BodyReferences(Arc::from(Vec::<BodyReference>::new())));
-            Ok(BodyTransaction::DeterministicFailure { errors, references })
+            Ok(BodyTransaction::DeterministicFailure {
+                errors,
+                references,
+                lookup_observations: Arc::from([]),
+            })
         }
         // A non-terminal outcome is a request to observe a deferred producer, not
         // a deterministic failure; the coordinator reschedules it.
@@ -2453,6 +2500,7 @@ pub(crate) fn analyze_body_via_overlay(
                 )),
             )),
             references: BodyReferences(Arc::from(Vec::<BodyReference>::new())),
+            lookup_observations: Arc::from([]),
         }
     };
 

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -469,7 +469,6 @@ pub(crate) struct RevisionedQueryDatabase {
     test_import_store: Arc<Mutex<TestImportInputStore>>,
     parse_modules: QueryFamily<ModuleQueryKey, ParseModuleValue>,
     module_indexes: QueryFamily<ModuleQueryKey, ModuleIndexValue>,
-    module_declaration_sets: QueryFamily<ModuleQueryKey, ModuleDeclarationSetValue>,
     declaration_occurrence_indexes: QueryFamily<ModuleQueryKey, DeclarationOccurrenceIndexValue>,
     declaration_shells: QueryFamily<DeclarationShellQueryKey, DeclarationShellQueryValue>,
     #[cfg(test)]
@@ -508,10 +507,9 @@ pub(crate) struct RevisionedQueryDatabase {
     >,
     lookup_names: QueryFamily<LookupNameKey, LookupNameValue>,
     /// Per-`(module, import-path)` binding-resolution family. Registered query
-    /// machinery for the RUE-1091 exact provider boundary. No production consumer
-    /// exists until the step-4 flip adopts it, so — unlike `declaration_imports`,
-    /// whose family runs in production and only test-gates its field handle — both
-    /// this family's registration and its handle are `#[cfg(test)]` for now.
+    /// machinery for the exact provider boundary. Production body import
+    /// dependencies are mediated by module-binding name and semantic-nucleus
+    /// terminals; the direct provider remains a differential test adapter.
     #[cfg(test)]
     lookup_imports: QueryFamily<LookupImportKey, LookupImportValue>,
     /// Test-only log of every module whose immutable name index was built,
@@ -576,17 +574,14 @@ pub(crate) struct RevisionedQueryDatabase {
     provider_observation_meter: Arc<ProviderObservationCounters>,
     /// Session-held retention lease over the lookup families (RUE-1091,
     /// ADR-0066 §4). A rooted semantic publication promotes its exact observed
-    /// lookup-pin set here. Inert on the production path in this slice — a
-    /// production body observes no lookup terminals, so nothing is ever promoted;
-    /// the mechanism is production code the step-4 flip makes live. Behind a
-    /// `Mutex` because promotion is a `&self` operation on the shared database.
+    /// lookup-pin set here. Behind a `Mutex` because promotion is a `&self`
+    /// operation on the shared database.
     lookup_root_lease: Mutex<PublishedRootLookupLease>,
     /// Test-only witness that the rooted-publication promotion hook took its
     /// non-empty branch — i.e. entered the promotion path at all (RUE-1091). The
     /// hook checks the observed set for emptiness FIRST, before formatting the
     /// root identity or taking the lease lock, and increments this only past that
-    /// gate. A full production compile leaves it zero, mechanically proving the
-    /// empty path costs no identity format and no lock acquisition.
+    /// gate.
     #[cfg(test)]
     lookup_promotion_entries: std::sync::atomic::AtomicU64,
     /// Test-only probe family hosting one provider-observation task so a driven
@@ -641,10 +636,9 @@ const LOOKUP_INCARNATION_HISTORY_BOUND: usize = 4096;
 /// (the pin-under-lock discipline: no birth-eviction window). Promotion transfers
 /// this into the session-held [`PublishedRootLookupLease`].
 ///
-/// Production body analysis observes no lookup terminals in this slice — the
-/// exact body-fact provider that consults the lookup families is a test-only
-/// differential adapter until the RUE-1091 step-4 flip — so a production body's
-/// collected root is empty and its promotion is inert.
+/// Production body analysis records the candidate-set keys consulted by the
+/// epoch analyzer, then resolves and pins their exact query terminals before
+/// publishing the body transaction.
 pub(crate) struct ObservedLookupRoot {
     /// The exact pins, retained past the request through the batched-release set.
     pins: rue_query::RetainedPinSet,
@@ -673,9 +667,6 @@ impl ObservedLookupRoot {
     /// A terminal already present (same incarnation/stamp/revision) deduplicates:
     /// the redundant pin is dropped and no duplicate key is recorded.
     ///
-    /// Reachable in this slice only from the test-only exact provider — no
-    /// production body observes a lookup terminal until the step-4 flip.
-    #[cfg_attr(not(test), allow(dead_code))]
     fn record<K, V>(
         &mut self,
         family: &QueryFamily<K, V>,
@@ -848,23 +839,6 @@ pub(crate) struct ProjectedModuleIndex {
 
 #[derive(Debug, Clone)]
 struct ModuleIndexValue(Result<Arc<ModuleIndex>, crate::CompileErrors>);
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ModuleDeclarationSetFact {
-    namespace: DefinitionNamespace,
-    kind: DefinitionKind,
-    visibility: Option<rue_parser::ast::Visibility>,
-    name: Arc<str>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum ModuleDeclarationSetValue {
-    Available {
-        declarations: Arc<[ModuleDeclarationSetFact]>,
-        import_specifiers: Arc<[Arc<str>]>,
-    },
-    Unavailable,
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DeclarationOccurrenceIndex {
@@ -6434,66 +6408,6 @@ impl RevisionedQueryDatabase {
                 },
             )
             .expect("the ModuleIndex family has one canonical name");
-        let indexes_for_declaration_sets = module_indexes.clone();
-        let module_declaration_sets = runtime
-            .family_with_equality_and_evaluator(
-                "compiler.module-declaration-set",
-                MODULE_QUERY_MEMO_RETENTION,
-                |left: &ModuleDeclarationSetValue, right: &ModuleDeclarationSetValue| left == right,
-                move |context, _, key: &ModuleQueryKey| {
-                    let indexed =
-                        context.query_registered(&indexes_for_declaration_sets, key.clone())?;
-                    let rue_query::QueryOutcome::Success(indexed) = indexed.outcome() else {
-                        unreachable!("ModuleIndex publishes typed values")
-                    };
-                    let value = match &indexed.0 {
-                        Ok(index) => {
-                            let mut declarations = index
-                                .definitions
-                                .iter()
-                                .map(|entry| ModuleDeclarationSetFact {
-                                    namespace: entry.namespace,
-                                    kind: entry.kind,
-                                    visibility: entry.visibility,
-                                    name: entry.name.clone(),
-                                })
-                                .collect::<Vec<_>>();
-                            declarations.sort_by(|left, right| {
-                                let visibility_rank = |visibility| match visibility {
-                                    None => 0,
-                                    Some(rue_parser::ast::Visibility::Private) => 1,
-                                    Some(rue_parser::ast::Visibility::Public) => 2,
-                                };
-                                (
-                                    left.namespace,
-                                    left.kind,
-                                    visibility_rank(left.visibility),
-                                    left.name.as_ref(),
-                                )
-                                    .cmp(&(
-                                        right.namespace,
-                                        right.kind,
-                                        visibility_rank(right.visibility),
-                                        right.name.as_ref(),
-                                    ))
-                            });
-                            let mut import_specifiers = index
-                                .imports
-                                .iter()
-                                .map(|import| Arc::from(import.specifier()))
-                                .collect::<Vec<_>>();
-                            import_specifiers.sort();
-                            ModuleDeclarationSetValue::Available {
-                                declarations: declarations.into(),
-                                import_specifiers: import_specifiers.into(),
-                            }
-                        }
-                        Err(_) => ModuleDeclarationSetValue::Unavailable,
-                    };
-                    Ok(QueryOutput::success(value))
-                },
-            )
-            .expect("the ModuleDeclarationSet family has one canonical name");
         let parse_for_declaration_occurrences = parse_modules.clone();
         let parse_for_declaration_shells = parse_modules.clone();
         let declaration_occurrence_indexes = runtime
@@ -8967,7 +8881,6 @@ impl RevisionedQueryDatabase {
             test_import_store,
             parse_modules,
             module_indexes,
-            module_declaration_sets,
             declaration_occurrence_indexes,
             declaration_shells,
             #[cfg(test)]
@@ -9065,8 +8978,7 @@ impl RevisionedQueryDatabase {
     /// revalidation (or any publication that consulted no lookups) observes
     /// nothing, so it preserves the prior root's leased set by construction —
     /// which IS the §4 edit/error/fix warmth semantic. Promotion happens only on
-    /// publications that observed lookups. Inert on the production path: a
-    /// production body observes no lookup terminal, so this always returns early.
+    /// publications that observed lookups.
     pub(crate) fn promote_published_lookup_root(&self, root: String, observed: ObservedLookupRoot) {
         if observed.is_empty() {
             return;
@@ -9382,7 +9294,6 @@ impl RevisionedQueryDatabase {
                 crate::declaration_candidate::DeclarationCandidateKey,
             >,
         >,
-        declaration_modules: Arc<[ModuleId]>,
         producer_body_terminal_required: bool,
         well_known_demands: Arc<[crate::body_query::WellKnownOptionDemand]>,
         cancellation: CancellationToken,
@@ -9400,6 +9311,7 @@ impl RevisionedQueryDatabase {
         let candidate = declaration_candidate_for_stable_key(&definition)
             .ok_or(BodyTransactionRequestFailure::Query(QueryAbort::Canceled))?;
         let deferred_anonymous_producers = std::cell::RefCell::new(BTreeSet::new());
+        let observed_lookups = std::cell::RefCell::new(ObservedLookupRoot::new());
         // Set when a depended-on anonymous producer committed an anchor-transport
         // internal error (RUE-1089). It is carried out of the query closure — which
         // can only signal a bare `QueryAbort` — and mapped to a fatal
@@ -9436,21 +9348,6 @@ impl RevisionedQueryDatabase {
                     unreachable!("BodyToolchainDemands publishes typed values")
                 };
                 let body_payload_kinds = toolchain_demand.payload_kinds();
-                // The one-body resolver consumes declaration-set selection,
-                // including negative and qualified lookups that do not become
-                // positive BodyReferences. Until it publishes those exact
-                // lookup keys as a projection, conservatively observe the
-                // already-canonical, position-free declaration-set
-                // projections admitted by this body epoch. This is a query
-                // dependency only: no source/RIR rescanning or peer name
-                // resolver is introduced.
-                let _ = context.optional_input(accepted_import_topology_input());
-                for module in declaration_modules.iter().cloned() {
-                    let _ = context.query_registered(
-                        &self.module_declaration_sets,
-                        ModuleQueryKey(module),
-                    )?;
-                }
                 let mut selected_anonymous = BTreeMap::new();
                 let mut pending_anonymous = collect_instance_anonymous_nominals(&key.instance);
                 while let Some(identity) = pending_anonymous.pop_first() {
@@ -9580,6 +9477,83 @@ impl RevisionedQueryDatabase {
                         .into(),
                     well_known,
                 )?;
+                for lookup in transaction.lookup_observations() {
+                    match lookup {
+                        crate::body_query::BodyLookupKey::Name {
+                            module,
+                            namespace,
+                            name,
+                        } => {
+                            let namespace = match namespace {
+                                crate::body_query::BodyLookupNamespace::ModuleItem => {
+                                    DefinitionNamespace::ModuleItem
+                                }
+                                crate::body_query::BodyLookupNamespace::Destructor => {
+                                    DefinitionNamespace::Destructor
+                                }
+                            };
+                            let terminal = context.query_registered(
+                                &self.lookup_names,
+                                LookupNameKey {
+                                    module: module.clone(),
+                                    namespace,
+                                    name: name.clone(),
+                                },
+                            )?;
+                            observed_lookups
+                                .borrow_mut()
+                                .record(&self.lookup_names, &terminal);
+                        }
+                        crate::body_query::BodyLookupKey::Member {
+                            module,
+                            owner_name,
+                            member_name,
+                        } => {
+                            use crate::declaration_candidate::{
+                                DeclarationCandidateCategory as Category,
+                                DeclarationCandidateKey,
+                                DeclarationCandidateOwner,
+                            };
+                            for category in [Category::Method, Category::AssociatedFunction] {
+                                let query =
+                                    crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                                        declaration: DeclarationCandidateKey {
+                                            module: module.clone(),
+                                            category,
+                                            name: member_name.clone(),
+                                            owner: Some(DeclarationCandidateOwner {
+                                                category: Category::Struct,
+                                                name: owner_name.clone(),
+                                            }),
+                                            duplicate_discriminator: 0,
+                                        },
+                                        configuration: key.configuration.clone(),
+                                    };
+                                let identity = context.query_registered(
+                                    &self.semantic_nucleus,
+                                    crate::semantic_query_nucleus::SemanticNucleusKey::Identity(
+                                        query.clone(),
+                                    ),
+                                )?;
+                                if matches!(
+                                    identity.outcome(),
+                                    rue_query::QueryOutcome::Success(
+                                        crate::semantic_query_nucleus::SemanticNucleusValue::Identity(
+                                            _
+                                        )
+                                    )
+                                ) {
+                                    let _ = context.query_registered(
+                                        &self.semantic_nucleus,
+                                        crate::semantic_query_nucleus::SemanticNucleusKey::Signature(
+                                            query,
+                                        ),
+                                    )?;
+                                }
+                            }
+                        }
+                    }
+                }
                 let mut semantic_dependencies = BTreeSet::from([definition]);
                 let mut anonymous_dependencies = BTreeSet::new();
                 for reference in transaction.references().0.iter() {
@@ -9749,17 +9723,14 @@ impl RevisionedQueryDatabase {
                 //
                 // Empty observation is an unconditional no-op checked FIRST, with
                 // zero cost — no root-identity format, no lease lock, no map
-                // access. A production body observes no lookup terminals (the
-                // exact provider that consults the lookup families is a test-only
-                // differential adapter until the step-4 flip), and a warm green
-                // revalidation short-circuits with no observations either; both
-                // leave the empty set. So promotion never runs on the production
-                // path, and green reuse preserves the prior root's leased set by
-                // construction — the §4 edit/error/fix warmth semantic. Only a
-                // publication that actually observed lookups formats the identity,
-                // takes the lease, and supersedes. An attempt that aborts before
-                // publishing a root takes an `Err` arm below and is never promoted.
-                let observed = ObservedLookupRoot::new();
+                // access. A warm green revalidation short-circuits with no new
+                // observations and therefore preserves the prior root's leased
+                // set by construction — the §4 edit/error/fix warmth semantic.
+                // Only a publication that actually observed lookups formats the
+                // identity, takes the lease, and supersedes. An attempt that
+                // aborts before publishing a root takes an `Err` arm below and is
+                // never promoted.
+                let observed = observed_lookups.into_inner();
                 if !observed.is_empty() {
                     #[cfg(test)]
                     self.lookup_promotion_entries
@@ -9954,7 +9925,6 @@ impl RevisionedQueryDatabase {
                 revision,
                 key,
                 Arc::new(BTreeMap::new()),
-                Arc::from([]),
                 false,
                 Arc::from([]),
                 CancellationToken::new(),
@@ -9988,7 +9958,6 @@ impl RevisionedQueryDatabase {
                 revision,
                 key,
                 Arc::new(BTreeMap::new()),
-                Arc::from([]),
                 false,
                 Arc::from([]),
                 CancellationToken::new(),

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -3240,9 +3240,8 @@ impl CompilerSession {
     }
 
     /// A snapshot of the lookup-family pressure metrics (RUE-1091, ADR-0066 §4).
-    /// The lease-scoped and lease-attributed fields read zero on the production
-    /// path — no production body observes a lookup terminal, so the session
-    /// `PublishedRootLookupLease` promotes only empty sets until the step-4 flip.
+    /// Production body publications retain their exact observed lookup
+    /// terminals in the session's `PublishedRootLookupLease`.
     pub(crate) fn lookup_pressure_metrics(&self) -> crate::unstable::LookupPressureMetrics {
         self.queries.revisioned.lookup_pressure_metrics()
     }
@@ -6751,15 +6750,6 @@ impl CompilerSession {
                 }
             }
             let declaration_candidates = Arc::new(declaration_candidates);
-            let mut declaration_modules = BTreeSet::from([imports.root().clone()]);
-            for record in imports.records() {
-                declaration_modules.insert(record.importer().clone());
-                if let crate::CanonicalImportResolution::Resolved(target) = record.resolution() {
-                    declaration_modules.insert(target.clone());
-                }
-            }
-            let declaration_modules: Arc<[crate::ModuleId]> =
-                declaration_modules.into_iter().collect::<Vec<_>>().into();
             let configuration = crate::semantic_query_nucleus::SemanticQueryConfiguration {
                 target: options.target,
                 preview_features: StablePreviewFeatures::new(&options.preview_features),
@@ -7227,7 +7217,6 @@ impl CompilerSession {
                         runtime_revision,
                         key.clone(),
                         declaration_candidates.clone(),
-                        declaration_modules.clone(),
                         producer_body_terminal_required,
                         well_known_demands.clone(),
                         cancellation.clone(),
@@ -11678,14 +11667,10 @@ mod tests {
     }
 
     #[test]
-    fn published_lookup_root_lease_is_inert_on_the_production_path() {
-        // RUE-1091 slice 3c: the `PublishedRootLookupLease` promotion point is
-        // wired into the rooted semantic publication path, but a production body
-        // observes no lookup terminal (the exact provider that consults the lookup
-        // families is a test-only differential adapter until the step-4 flip), so
-        // every semantic-root publication promotes an EMPTY set — no root is
-        // installed and no lease-scoped or lease-attributed metric moves. The
-        // RUE-1090 recipe-cache and RUE-1091 provider counters stay unchanged too.
+    fn published_lookup_root_lease_retains_production_body_lookups() {
+        // Production one-body analysis publishes its exact lookup-name terminals
+        // into the session lease. This remains independent of the test-only fact
+        // provider and recipe cache.
         let source = snapshot(
             &[(
                 1,
@@ -11702,15 +11687,9 @@ mod tests {
             .expect("the program analyzes");
 
         let metrics = crate::unstable::lookup_pressure_metrics(&session);
-        assert_eq!(
-            metrics.published_roots, 0,
-            "no root is promoted on the production path"
-        );
-        assert_eq!(
-            metrics.leased_terminals, 0,
-            "the session lease holds no pin"
-        );
-        assert_eq!(metrics.retained_logical_keys, 0);
+        assert!(metrics.published_roots > 0, "{metrics:?}");
+        assert!(metrics.leased_terminals > 0, "{metrics:?}");
+        assert!(metrics.retained_logical_keys > 0, "{metrics:?}");
         assert_eq!(
             metrics.protected_growth, 0,
             "no lease supersession grew a family"
@@ -11720,18 +11699,12 @@ mod tests {
             "no lease supersession evicted a terminal"
         );
         assert_eq!(metrics.rederivations_after_eviction, 0);
-        // Mechanical (not inferred) proof that the empty path costs nothing: the
-        // promotion hook never entered its non-empty branch on any of this
-        // compile's body publications, so it formatted no root identity and took
-        // no lease lock.
-        assert_eq!(
-            session.queries.revisioned.lookup_promotion_entries(),
-            0,
-            "the promotion hook never entered the non-empty branch on the production path"
+        assert!(
+            session.queries.revisioned.lookup_promotion_entries() > 0,
+            "production bodies must promote their observed lookup terminals"
         );
-        // RUE-1090 recipe-cache and RUE-1091 provider inertness hold at the same
-        // time: wiring the lease promotion point did not perturb the production
-        // path.
+        // Exact lookup collection does not route production analysis through the
+        // differential provider or recipe cache.
         assert_eq!(
             crate::unstable::provider_observation_metrics(&session),
             crate::unstable::ProviderObservationMetrics::default(),
@@ -17909,7 +17882,6 @@ fn main() -> i32 { selected.value() }"#,
                 revision,
                 key.clone(),
                 Arc::new(BTreeMap::new()),
-                Arc::from([]),
                 false,
                 Arc::from([]),
                 cancellation.clone(),
@@ -17959,7 +17931,6 @@ fn main() -> i32 { selected.value() }"#,
                 revision,
                 key.clone(),
                 Arc::new(BTreeMap::new()),
-                Arc::from([]),
                 false,
                 Arc::from([]),
                 rue_query::CancellationToken::new(),
@@ -17988,7 +17959,6 @@ fn main() -> i32 { selected.value() }"#,
                 revision,
                 key.clone(),
                 Arc::new(BTreeMap::new()),
-                Arc::from([]),
                 false,
                 Arc::from([]),
                 rue_query::CancellationToken::new(),
@@ -18511,6 +18481,34 @@ fn main() -> i32 {
         let mut warm = CompilerSession::new();
         warm.update(&missing).into_result().unwrap();
         assert!(warm.canonical_semantic(&options).is_err());
+        let main = crate::body_query::BodyQueryKey {
+            instance: crate::FunctionInstanceKey::Definition(
+                crate::StableDefinitionKey::from_stable_parts(
+                    crate::ModuleId::from_logical_path("main.rue").unwrap(),
+                    crate::StableDefinitionNamespace::Value,
+                    crate::StableDefinitionKind::Function,
+                    "main",
+                    None,
+                ),
+            ),
+            configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration {
+                target: options.target,
+                preview_features: StablePreviewFeatures::new(&options.preview_features),
+            },
+        };
+        let dependencies = retained_body_dependency_nodes(&warm, &main);
+        assert!(
+            dependencies
+                .iter()
+                .any(|node| node.contains("lookup-name") && node.contains("helper")),
+            "{dependencies:?}"
+        );
+        assert!(
+            dependencies
+                .iter()
+                .all(|node| !node.contains("module-declaration-set")),
+            "{dependencies:?}"
+        );
 
         warm.update(&resolved).into_result().unwrap();
         let warm_output = warm.canonical_semantic(&options).unwrap();
@@ -18693,7 +18691,6 @@ fn main() -> i32 {
             revision,
             dead,
             Arc::new(BTreeMap::new()),
-            Arc::from([]),
             false,
             Arc::from([]),
             rue_query::CancellationToken::new(),

--- a/crates/rue-compiler/src/session/tests/rfinal_harness.rs
+++ b/crates/rue-compiler/src/session/tests/rfinal_harness.rs
@@ -530,18 +530,6 @@ const EDGE_FAMILY_EXCEPTIONS: &[EdgeFamilyException] = &[
                  keeping this input on the transaction, not on the fact drivers",
     },
     EdgeFamilyException {
-        family: "compiler.module-declaration-set",
-        side: EdgeExceptionSide::EpochOnly,
-        reason: "the conservative whole-program declaration-set edge the flip DELETES (plan \
-                 section 5 step 3) — exactly the no-whole-program-context locality delta",
-    },
-    EdgeFamilyException {
-        family: "compiler.lookup-name",
-        side: EdgeExceptionSide::ProviderOnly,
-        reason: "r4a-1 ruling: keyed name-lookup edges recorded at materialization are the \
-                 richer post-flip truth the epoch's table reads mask",
-    },
-    EdgeFamilyException {
         family: "compiler.semantic-nucleus",
         side: EdgeExceptionSide::ProviderOnly,
         reason: "declaration identity/signature/const facts consulted through the boundary \
@@ -755,7 +743,6 @@ fn capture_terminal(
             revision,
             key.clone(),
             Arc::new(BTreeMap::new()),
-            Arc::from([]),
             false,
             Arc::from([]),
             rue_query::CancellationToken::new(),
@@ -779,11 +766,14 @@ fn capture_terminal(
             body,
             references,
             produced_anonymous_nominals,
+            ..
         } => (
             format!("{body:?}\n{references:?}\n{produced_anonymous_nominals:?}").into_bytes(),
             Vec::new(),
         ),
-        crate::body_query::BodyTransaction::DeterministicFailure { errors, references } => (
+        crate::body_query::BodyTransaction::DeterministicFailure {
+            errors, references, ..
+        } => (
             format!("{references:?}").into_bytes(),
             // CompileErrors::to_string() is the production ordered rendered
             // diagnostic stream; do not sort it.


### PR DESCRIPTION
## Summary

- record exact positive and negative module-item, destructor, method, and associated-function lookups at AIR body-resolution fact seams
- publish those observations as lookup-name and semantic-nucleus dependencies, replacing conservative whole-module declaration-set edges
- retain production lookup terminals through the published-root lease and align the differential edge oracle with production
- add regression coverage proving unrelated declarations stay green while missing names becoming available invalidate consumers

Filesystem-observation authority for rooted-demand reuse remains a separate design decision tracked by RUE-1137.

## Validation

- `scripts/rue build`
- `scripts/rue quick`
- focused compiler invalidation, qualified lookup, lookup-root lease, and differential edge-set tests
- `scripts/rue test` (full serialized suite)

Fixes RUE-1134