### PR TITLE
RUE-1092: preserve exact provider body-instance identity

### DIFF
--- a/crates/rue-air/src/sema/provider.rs
+++ b/crates/rue-air/src/sema/provider.rs
@@ -307,6 +307,13 @@ pub trait BodyFactProvider {
     type ModuleRef: Clone;
     /// The implementation's owned handle for a consulted declaration.
     type DeclarationRef: Clone;
+    /// The implementation's owned identity for one exact body instance.
+    ///
+    /// Producer and trusted-toolchain facts are properties of the body that
+    /// actually runs, not merely of the declaration that supplied its source.
+    /// In particular, a specialization, anonymous member, or drop-glue body
+    /// must keep its wrapper identity when it crosses this boundary.
+    type BodyInstanceRef: Clone;
     /// The implementation's owned handle for a receiver type's identity.
     type ReceiverType: Clone;
 
@@ -453,9 +460,12 @@ pub trait BodyFactProvider {
     /// never guesses a winner. Winner-picking stays inside this point query.
     fn callable_symbol_method(&self, symbol: &str) -> Option<(Self::ReceiverType, Arc<str>)>;
 
-    /// Exact producer-body facts already required by the body.
-    fn producer_body_facts(&self, decl: &Self::DeclarationRef) -> Option<Self::ProducerBodyFacts>;
+    /// Exact producer-body facts for one body instance.
+    fn producer_body_facts(
+        &self,
+        instance: &Self::BodyInstanceRef,
+    ) -> Option<Self::ProducerBodyFacts>;
 
-    /// Exact trusted-toolchain facts already required by the body.
-    fn trusted_toolchain_facts(&self, decl: &Self::DeclarationRef) -> Self::ToolchainFacts;
+    /// Exact trusted-toolchain facts already required by one body instance.
+    fn trusted_toolchain_facts(&self, instance: &Self::BodyInstanceRef) -> Self::ToolchainFacts;
 }

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -11630,36 +11630,6 @@ fn import_resolution_from_value(value: &LookupImportValue) -> rue_air::ImportRes
     }
 }
 
-/// Build the body query key for a plain-function declaration candidate. Producer
-/// and toolchain facts are keyed by body instance; only a free function is
-/// derivable here, which is exactly what the representative differential bodies
-/// exercise. Non-function candidates yield `None`.
-#[cfg(test)]
-fn function_body_query_key_for_candidate(
-    candidate: &crate::declaration_candidate::DeclarationCandidateKey,
-    configuration: &crate::semantic_query_nucleus::SemanticQueryConfiguration,
-) -> Option<crate::body_query::BodyQueryKey> {
-    use crate::declaration_candidate::DeclarationCandidateCategory as Cat;
-    let (namespace, kind) = match candidate.category {
-        Cat::Function => (
-            crate::StableDefinitionNamespace::Value,
-            crate::StableDefinitionKind::Function,
-        ),
-        _ => return None,
-    };
-    let key = crate::StableDefinitionKey::from_stable_parts(
-        candidate.module.clone(),
-        namespace,
-        kind,
-        candidate.name.clone(),
-        None,
-    );
-    Some(crate::body_query::BodyQueryKey {
-        instance: crate::FunctionInstanceKey::Definition(key),
-        configuration: configuration.clone(),
-    })
-}
-
 /// The compiler-side implementation of the rue-air exact provider boundary.
 ///
 /// Bound entirely inside one query task: `context` records each edge, `database`
@@ -11732,32 +11702,13 @@ impl<'a> CompilerBodyFactProvider<'a> {
         &self.database.provider_observation_meter
     }
 
-    /// Observe producer facts under the producer's exact function-instance
-    /// identity. This preserves specialization wrappers carried by the
-    /// declaration projection instead of lossy definition-key reconstruction.
-    pub(crate) fn producer_instance_body_facts(
+    fn body_query_key(
         &self,
         instance: &crate::FunctionInstanceKey,
-    ) -> Option<crate::body_query::ProducedAnonymous> {
-        self.meter()
-            .producer_facts
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let body_key = crate::body_query::BodyQueryKey {
+    ) -> crate::body_query::BodyQueryKey {
+        crate::body_query::BodyQueryKey {
             instance: instance.clone(),
             configuration: self.configuration.clone(),
-        };
-        match self
-            .context
-            .query_registered(&self.database.body_produced_anonymous, body_key)
-        {
-            Ok(terminal) => match terminal.outcome() {
-                rue_query::QueryOutcome::Success(value) => Some(value.clone()),
-                _ => None,
-            },
-            Err(abort) => {
-                self.observe_abort(abort);
-                None
-            }
         }
     }
 
@@ -11927,6 +11878,7 @@ struct MemberObservation {
 impl rue_air::BodyFactProvider for CompilerBodyFactProvider<'_> {
     type ModuleRef = ModuleId;
     type DeclarationRef = crate::declaration_candidate::DeclarationCandidateKey;
+    type BodyInstanceRef = crate::FunctionInstanceKey;
     type ReceiverType = ReceiverTypeIdentity;
 
     type DeclarationIdentity = crate::semantic_query_nucleus::DeclarationIdentityProjection;
@@ -12336,16 +12288,15 @@ impl rue_air::BodyFactProvider for CompilerBodyFactProvider<'_> {
 
     fn producer_body_facts(
         &self,
-        decl: &crate::declaration_candidate::DeclarationCandidateKey,
+        instance: &crate::FunctionInstanceKey,
     ) -> Option<crate::body_query::ProducedAnonymous> {
         self.meter()
             .producer_facts
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let body_key = function_body_query_key_for_candidate(decl, &self.configuration)?;
-        match self
-            .context
-            .query_registered(&self.database.body_produced_anonymous, body_key)
-        {
+        match self.context.query_registered(
+            &self.database.body_produced_anonymous,
+            self.body_query_key(instance),
+        ) {
             Ok(terminal) => match terminal.outcome() {
                 rue_query::QueryOutcome::Success(value) => Some(value.clone()),
                 _ => None,
@@ -12364,20 +12315,16 @@ impl rue_air::BodyFactProvider for CompilerBodyFactProvider<'_> {
 
     fn trusted_toolchain_facts(
         &self,
-        decl: &crate::declaration_candidate::DeclarationCandidateKey,
+        instance: &crate::FunctionInstanceKey,
     ) -> crate::BodyToolchainDemand {
         self.meter()
             .toolchain_facts
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let empty = crate::BodyToolchainDemand::from_payload_kinds([], None);
-        let Some(body_key) = function_body_query_key_for_candidate(decl, &self.configuration)
-        else {
-            return empty;
-        };
-        match self
-            .context
-            .query_registered(&self.database.body_toolchain_demands, body_key)
-        {
+        match self.context.query_registered(
+            &self.database.body_toolchain_demands,
+            self.body_query_key(instance),
+        ) {
             Ok(terminal) => match terminal.outcome() {
                 rue_query::QueryOutcome::Success(value) => value.clone(),
                 _ => empty,
@@ -13889,6 +13836,16 @@ mod tests {
             target: rue_target::Target::X86_64Linux,
             preview_features: crate::StablePreviewFeatures::new(&crate::PreviewFeatures::default()),
         }
+    }
+
+    fn free_function_instance(module: &ModuleId, name: &str) -> crate::FunctionInstanceKey {
+        crate::FunctionInstanceKey::Definition(crate::StableDefinitionKey::from_stable_parts(
+            module.clone(),
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::Function,
+            Arc::from(name),
+            None,
+        ))
     }
 
     fn declaration_candidate(
@@ -20843,6 +20800,7 @@ mod tests {
         let config = semantic_configuration();
 
         let helper = declaration_candidate(&database, revision, &m, Cat::Function, "helper");
+        let helper_instance = free_function_instance(&m, "helper");
         let box_struct = declaration_candidate(&database, revision, &m, Cat::Struct, "Box");
         let copy_receiver = ReceiverTypeIdentity::new(m.clone(), "Box", Cat::Struct);
         let res_receiver = ReceiverTypeIdentity::new(m.clone(), "Res", Cat::Struct);
@@ -20862,7 +20820,7 @@ mod tests {
                     provider.language_item(&m, rue_air::ProviderNamespace::ModuleItem, "Box"),
                     provider.drop_copy_metadata(&copy_probe),
                     provider.drop_copy_metadata(&res_probe),
-                    provider.trusted_toolchain_facts(&helper_probe),
+                    provider.trusted_toolchain_facts(&helper_instance),
                 )
             });
         let (
@@ -23885,6 +23843,7 @@ mod tests {
         let bad = declaration_candidate(&database, revision, &m, Cat::Struct, "Bad");
         let good = declaration_candidate(&database, revision, &m, Cat::Struct, "Good");
         let plain = declaration_candidate(&database, revision, &m, Cat::Function, "plain");
+        let plain_instance = free_function_instance(&m, "plain");
 
         let bad_probe = bad.clone();
         let good_probe = good.clone();
@@ -23897,7 +23856,7 @@ mod tests {
                 (
                     provider.nominal_well_formedness(&bad_probe),
                     provider.nominal_well_formedness(&good_probe),
-                    provider.producer_body_facts(&plain_probe),
+                    provider.producer_body_facts(&plain_instance),
                     provider.signature(&plain_probe),
                 )
             },
@@ -23942,8 +23901,10 @@ mod tests {
         let epoch_produced = database.runtime.request_registered(
             &database.body_produced_anonymous,
             revision,
-            function_body_query_key_for_candidate(&plain, &config)
-                .expect("plain is a free function"),
+            crate::body_query::BodyQueryKey {
+                instance: free_function_instance(&m, "plain"),
+                configuration: config.clone(),
+            },
             CancellationToken::new(),
         );
         assert!(
@@ -23959,6 +23920,105 @@ mod tests {
             "a deferred producer publishes no terminal, so no producer edge is \
              recorded: {:?}",
             outcome.dependencies
+        );
+    }
+
+    #[test]
+    fn provider_producer_facts_preserve_specialization_instance_terminal() {
+        use rue_air::BodyFactProvider;
+        let snapshot = source_snapshot(
+            &[(
+                1,
+                "/m.rue",
+                "m.rue",
+                "fn Pair() -> type { struct { value: i32 } }\n\
+                 fn main() -> i32 { 0 }\n",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("m.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &snapshot);
+        let configuration = semantic_configuration();
+        let pair_instance = crate::FunctionInstanceKey::Specialization {
+            base: Box::new(free_function_instance(&module, "Pair")),
+            arguments: crate::CanonicalArguments::default(),
+        };
+        let registered_key = crate::body_query::BodyQueryKey {
+            instance: pair_instance.clone(),
+            configuration: configuration.clone(),
+        };
+
+        let provider_instance = pair_instance.clone();
+        let outcome = database.probe_body_facts(
+            revision,
+            configuration,
+            "producer-specialization-instance",
+            move |provider| {
+                (
+                    provider.producer_body_facts(&provider_instance),
+                    provider.trusted_toolchain_facts(&provider_instance),
+                )
+            },
+        );
+        let (provided, provider_toolchain) = outcome.result;
+        let provided = provided.expect("the Pair specialization publishes producer facts");
+
+        let direct = database.runtime.request_registered(
+            &database.body_produced_anonymous,
+            revision,
+            registered_key.clone(),
+            CancellationToken::new(),
+        );
+        let terminal = direct
+            .terminal()
+            .expect("the specialization-shaped registered terminal is retained");
+        let rue_query::QueryOutcome::Success(expected) = terminal.outcome() else {
+            panic!("the specialization-shaped registered terminal succeeds")
+        };
+        assert!(crate::body_query::produced_anonymous_equal(
+            &provided, expected
+        ));
+        assert!(matches!(
+            provided,
+            crate::body_query::ProducedAnonymous::Produced(ref produced) if !produced.0.is_empty()
+        ));
+        let producer_edges = outcome
+            .dependencies
+            .iter()
+            .filter(|node| node.family() == "compiler.body-produced-anonymous")
+            .map(|node| node.key().to_owned())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            producer_edges,
+            BTreeSet::from([registered_key.stable_identity()]),
+            "the provider must observe only the exact specialization body terminal"
+        );
+
+        let direct_toolchain = database.runtime.request_registered(
+            &database.body_toolchain_demands,
+            revision,
+            registered_key.clone(),
+            CancellationToken::new(),
+        );
+        let toolchain_terminal = direct_toolchain
+            .terminal()
+            .expect("the specialization-shaped toolchain terminal is retained");
+        let rue_query::QueryOutcome::Success(expected_toolchain) = toolchain_terminal.outcome()
+        else {
+            panic!("the specialization-shaped toolchain terminal succeeds")
+        };
+        assert_eq!(provider_toolchain, *expected_toolchain);
+        let toolchain_edges = outcome
+            .dependencies
+            .iter()
+            .filter(|node| node.family() == "compiler.body-toolchain-demands")
+            .map(|node| node.key().to_owned())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            toolchain_edges,
+            BTreeSet::from([registered_key.stable_identity()]),
+            "the provider must observe only the exact specialization toolchain terminal"
         );
     }
 

--- a/crates/rue-compiler/src/session/tests/rfinal_harness.rs
+++ b/crates/rue-compiler/src/session/tests/rfinal_harness.rs
@@ -32,9 +32,7 @@ use std::{
 
 use super::*;
 use crate::body_query::BodyReference;
-use crate::declaration_candidate::{
-    DeclarationCandidateCategory, DeclarationCandidateKey, DeclarationCandidateOwner,
-};
+use crate::declaration_candidate::DeclarationCandidateCategory;
 use crate::revisioned_query_database::test_support::{
     DurableDeclSource, endpoint_display, endpoint_nominal_render,
 };
@@ -579,6 +577,7 @@ struct CapturedBody {
 #[derive(Debug, Clone)]
 struct BodyDemandOracle {
     body: String,
+    body_instance: crate::FunctionInstanceKey,
     references: Vec<BodyReference>,
     produced: Vec<crate::durable_semantics::DurableAnonymousNominal>,
     failed: bool,
@@ -917,6 +916,7 @@ impl ProductionAnalyzer {
             };
             oracles.push(BodyDemandOracle {
                 body: (*body).to_owned(),
+                body_instance: key.instance.clone(),
                 references,
                 produced,
                 failed,
@@ -1014,21 +1014,6 @@ fn candidate_category(kind: crate::StableDefinitionKind) -> Option<DeclarationCa
         K::Destructor => Cat::Destructor,
         K::Method => Cat::Method,
         K::AssociatedFunction => Cat::AssociatedFunction,
-    })
-}
-
-fn candidate_for(key: &crate::StableDefinitionKey) -> Option<DeclarationCandidateKey> {
-    let category = candidate_category(key.kind())?;
-    let owner = key.owner().map(|owner| DeclarationCandidateOwner {
-        category: candidate_category(owner.kind()).expect("owner kinds are nominal"),
-        name: Arc::from(owner.name()),
-    });
-    Some(DeclarationCandidateKey {
-        module: key.module().clone(),
-        category,
-        name: Arc::from(key.name()),
-        owner,
-        duplicate_discriminator: 0,
     })
 }
 
@@ -1680,6 +1665,7 @@ impl<'a, 'db, 'r> ReplayCtx<'a, 'db, 'r> {
     /// producer-facts operation. Wrapper/specialization identity is preserved.
     fn replay_producer(&mut self, anon: &crate::AnonymousNominalKey) {
         use crate::FunctionInstanceKey as F;
+        use rue_air::BodyFactProvider;
         use rue_air::StableProducerId as P;
         let canonical = anon.with_canonical_producer().into_owned();
         let mut producer_instance = self
@@ -1712,10 +1698,7 @@ impl<'a, 'db, 'r> ReplayCtx<'a, 'db, 'r> {
         {
             return;
         }
-        match self
-            .provider
-            .producer_instance_body_facts(&producer_instance)
-        {
+        match self.provider.producer_body_facts(&producer_instance) {
             Some(crate::body_query::ProducedAnonymous::Produced(produced)) => {
                 let boundary: BTreeSet<_> = produced
                     .0
@@ -1966,7 +1949,7 @@ fn run_body_replay(
     references: &[BodyReference],
     produced_union: &[crate::durable_semantics::DurableAnonymousNominal],
     absent_lookups: &[&str],
-    body_key: Option<&crate::StableDefinitionKey>,
+    body_instance: Option<&crate::FunctionInstanceKey>,
     rir: &rue_rir::Rir,
     rir_interner: &lasso::ThreadedRodeo,
 ) -> (
@@ -2042,12 +2025,11 @@ fn run_body_replay(
     }
 
     // The body's own trusted-toolchain demand set, observed through the
-    // boundary op (function bodies carry the derivable candidate key).
-    if let Some(body_key) = body_key
-        && body_key.kind() == crate::StableDefinitionKind::Function
-        && let Some(candidate) = candidate_for(body_key)
-    {
-        let demand = provider.trusted_toolchain_facts(&candidate);
+    // boundary op under the exact instance analyzed by side A. A specialization
+    // must remain a specialization here; the provider owns any source-body
+    // projection behind its registered terminal.
+    if let Some(body_instance) = body_instance {
+        let demand = provider.trusted_toolchain_facts(body_instance);
         ctx.facts.push(format!(
             "toolchain-demands kinds={}",
             demand.payload_kinds().len()
@@ -2153,10 +2135,7 @@ impl ProviderFactsOverlayAnalyzer {
         references.sort();
         references.dedup();
         let produced_union = produced_union.to_vec();
-        let body_key = decls
-            .iter()
-            .map(|decl| decl.key.clone())
-            .find(|key| key.kind().owns_body() && key.name() == body);
+        let body_instance = oracle.body_instance.clone();
         let absent: Vec<&str> = absent_lookups.to_vec();
         let rir = inputs.rir.rir();
         let interner = inputs.rir.semantic_symbols().interner();
@@ -2170,7 +2149,7 @@ impl ProviderFactsOverlayAnalyzer {
                     &references,
                     &produced_union,
                     &absent,
-                    body_key.as_ref(),
+                    Some(&body_instance),
                     rir,
                     interner,
                 )


### PR DESCRIPTION
## What

- Add an explicit BodyInstanceRef to BodyFactProvider.
- Key producer-body and trusted-toolchain observations by the complete FunctionInstanceKey.
- Delete the free-function-only declaration reconstruction and direct producer helper bypass.
- Carry Side A exact body instance through the rFinal provider replay.
- Prove producer and toolchain dependency sets contain only the specialization-shaped registered terminal.

## Why

Producer and toolchain facts belong to the body instance that actually runs. Reconstructing a free-function key from its declaration erased specialization, anonymous-member, and drop-glue wrappers before the provider boundary could become production authority. This closes that correctness hole without activating a second production analyzer.

## Impact

This is a mergeable RUE-1092 prerequisite, not the production cutover itself. The single production epoch path is unchanged. The provider contract can now carry every FunctionInstanceKey variant losslessly into exact query dependencies, which the forthcoming provider-fed one-body entry point requires.

## Checks

- scripts/rue quick — 36 targets passed; compiler unit suite and 1,443-file frontend differential included
- exact specialization producer/toolchain terminal test
- exact rFinal provider-driver and edge-set tests
- git diff --check

Refs RUE-1092.