### PR TITLE
Centralize one-body semantic facts behind a mode

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -85,9 +85,9 @@ fn retired_whole_program_body_driver_is_an_explicit_test_oracle_only() {
         );
     }
     for oracle in [
-        "fn analyze_all_function_bodies_for_test(",
-        "fn analyze_all_function_bodies_with_work_for_test(",
-        "fn analyze_all_function_bodies_mut_for_test(",
+        "fn analyze_all_function_bodies_for_test<",
+        "fn analyze_all_function_bodies_with_work_for_test<",
+        "fn analyze_all_function_bodies_mut_for_test<",
         "fn analyze_all_bodies_for_test(",
     ] {
         assert!(

--- a/crates/rue-air/src/sema/aggregate_resolution.rs
+++ b/crates/rue-air/src/sema/aggregate_resolution.rs
@@ -46,17 +46,24 @@ impl AggregateModuleFact {
     }
 }
 
-pub(crate) struct EpochFacts<'s, 'a, D: DeclarationPhase> {
-    sema: &'s Sema<'a, D>,
+pub(crate) struct EpochFacts<
+    's,
+    'a,
+    D: DeclarationPhase,
+    F: super::BodyAnalysisFactMode = super::EpochFactMode,
+> {
+    sema: &'s Sema<'a, D, F>,
 }
 
-impl<'s, 'a, D: DeclarationPhase> EpochFacts<'s, 'a, D> {
-    pub(crate) fn new(sema: &'s Sema<'a, D>) -> Self {
+impl<'s, 'a, D: DeclarationPhase, F: crate::sema::BodyAnalysisFactMode> EpochFacts<'s, 'a, D, F> {
+    pub(crate) fn new(sema: &'s Sema<'a, D, F>) -> Self {
         Self { sema }
     }
 }
 
-impl<D: DeclarationPhase> AggregateFacts for EpochFacts<'_, '_, D> {
+impl<D: DeclarationPhase, F: crate::sema::BodyAnalysisFactMode> AggregateFacts
+    for EpochFacts<'_, '_, D, F>
+{
     fn value_const(&self, file: FileId, name: Spur) -> Option<ConstInfo> {
         self.sema.record_body_module_item_lookup(file, name);
         self.sema.value_const(&(file, name)).cloned()

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -12,7 +12,7 @@ use rue_span::Span;
 
 use super::BodySema;
 use super::aggregate_resolution::{
-    AggregateFacts, EpochFacts, ModuleTypeMember, QualifiedType, StructLiteralHead,
+    AggregateFacts, ModuleTypeMember, QualifiedType, StructLiteralHead,
     resolve_aggregate_module_ref, resolve_enum_type_name, resolve_struct_type_name,
     select_module_type_member, select_qualified_enum, select_qualified_type,
     select_struct_literal_head,
@@ -22,7 +22,7 @@ use super::context::{AnalysisContext, AnalysisResult, ConstValue};
 use crate::inst::{Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirRef};
 use crate::types::{Type, TypeKind};
 
-impl<'a> BodySema<'a> {
+impl<'a, Mode: crate::sema::BodyAnalysisFactMode> BodySema<'a, Mode> {
     /// Resolve a path/pattern enum type name that may be a comptime
     /// type-variable binding (`let O = Option(i32); O::Some(..)`), falling
     /// back to the named-enum table. Returns `(enum_id, via_comptime_binding)`,
@@ -36,7 +36,7 @@ impl<'a> BodySema<'a> {
         type_name: Spur,
         ctx: &AnalysisContext,
     ) -> Option<(crate::types::EnumId, bool)> {
-        let facts = EpochFacts::new(self);
+        let facts = self.aggregate_facts();
         resolve_enum_type_name(
             &facts,
             ctx.comptime_type_vars.get(&type_name).copied(),
@@ -62,7 +62,7 @@ impl<'a> BodySema<'a> {
         type_name: Spur,
         ctx: &AnalysisContext,
     ) -> Option<(crate::types::StructId, bool)> {
-        let facts = EpochFacts::new(self);
+        let facts = self.aggregate_facts();
         resolve_struct_type_name(
             &facts,
             ctx.comptime_type_vars.get(&type_name).copied(),
@@ -357,7 +357,7 @@ impl<'a> BodySema<'a> {
                 ));
             };
             let struct_id = {
-                let facts = EpochFacts::new(self);
+                let facts = self.aggregate_facts();
                 facts.struct_in_file(facts.module(module_id).file, type_name)
             }
             .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.to_string()), span)?;
@@ -377,7 +377,7 @@ impl<'a> BodySema<'a> {
             struct_id
         } else {
             let head = {
-                let facts = EpochFacts::new(self);
+                let facts = self.aggregate_facts();
                 select_struct_literal_head(
                     &facts,
                     ctx.comptime_type_vars.get(&type_name).copied(),
@@ -607,7 +607,7 @@ impl<'a> BodySema<'a> {
         // `module_file_path` is then that file's stored path, used for the
         // directory-based visibility checks below.
         let (module_fact, module_file_path) = {
-            let facts = EpochFacts::new(self);
+            let facts = self.aggregate_facts();
             let module = facts.module(module_id);
             let module_file_path = facts
                 .file_path(module.file)
@@ -617,9 +617,9 @@ impl<'a> BodySema<'a> {
         };
 
         // Get the accessing file's directory for visibility check
-        let accessing_file_path = EpochFacts::new(self).source_path(span).map(str::to_string);
+        let accessing_file_path = self.aggregate_facts().source_path(span).map(str::to_string);
         let member = {
-            let facts = EpochFacts::new(self);
+            let facts = self.aggregate_facts();
             select_module_type_member(&facts, module_fact.file, member_name)
         };
 
@@ -881,7 +881,7 @@ impl<'a> BodySema<'a> {
         span: Span,
         ctx: &AnalysisContext,
     ) -> Option<crate::types::ModuleId> {
-        let facts = EpochFacts::new(self);
+        let facts = self.aggregate_facts();
         resolve_aggregate_module_ref(&facts, self.rir, inst_ref, span.file_id, &ctx.locals)
     }
 
@@ -909,7 +909,7 @@ impl<'a> BodySema<'a> {
             return Ok(None);
         };
         let selected = {
-            let facts = EpochFacts::new(self);
+            let facts = self.aggregate_facts();
             let file = facts.module(module_id).file;
             select_qualified_type(&facts, file, type_name)
         };
@@ -1005,7 +1005,7 @@ impl<'a> BodySema<'a> {
             return Ok(None);
         };
         let Some(enum_id) = ({
-            let facts = EpochFacts::new(self);
+            let facts = self.aggregate_facts();
             let file = facts.module(module_id).file;
             select_qualified_enum(&facts, file, type_name)
         }) else {

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -22,8 +22,7 @@ use rue_span::{FileId, Span};
 use rue_target::{Arch, DataModel, Os};
 
 use super::call_resolution::{
-    CallResolutionFacts, StaticCallReference, call_facts, classify_static_call,
-    resolve_static_call_reference,
+    CallResolutionFacts, StaticCallReference, classify_static_call, resolve_static_call_reference,
 };
 use super::context::{AnalysisContext, AnalysisResult, CallLoanKind, ConstValue, ParamInfo};
 use super::{AnalyzedFunction, BodySema, InferenceContext, MethodInfo, ParamSlotModes, SemaOutput};
@@ -40,15 +39,15 @@ use crate::types::{ModuleId, StructField, StructId, Type, TypeKind};
 ///
 /// Called from Sema::analyze_all after declarations are collected.
 /// Uses the demand-driven driver for every program shape.
-pub(crate) fn analyze_all_function_bodies_for_test(
-    sema: BodySema<'_>,
+pub(crate) fn analyze_all_function_bodies_for_test<F: super::BodyAnalysisFactMode>(
+    sema: BodySema<'_, F>,
 ) -> MultiErrorResult<SemaOutput> {
     analyze_all_function_bodies_with_work_for_test(sema)
         .map_err(super::BodyAnalysisFailure::into_errors)
 }
 
-pub(crate) fn analyze_all_function_bodies_with_work_for_test(
-    mut sema: BodySema<'_>,
+pub(crate) fn analyze_all_function_bodies_with_work_for_test<F: super::BodyAnalysisFactMode>(
+    mut sema: BodySema<'_, F>,
 ) -> Result<SemaOutput, super::BodyAnalysisFailure> {
     let result = analyze_all_function_bodies_mut_for_test(&mut sema);
     let work = result
@@ -58,8 +57,8 @@ pub(crate) fn analyze_all_function_bodies_with_work_for_test(
     result.map_err(|errors| super::BodyAnalysisFailure::new(errors, work))
 }
 
-pub(crate) fn compose_queried_bodies(
-    mut sema: BodySema<'_>,
+pub(crate) fn compose_queried_bodies<F: super::BodyAnalysisFactMode>(
+    mut sema: BodySema<'_, F>,
     candidates: Vec<
         crate::SemanticQueriedBodyCandidate<
             crate::SemanticDefinitionToken,
@@ -75,8 +74,8 @@ pub(crate) fn compose_queried_bodies(
     result.map_err(|errors| super::BodyAnalysisFailure::new(errors, work))
 }
 
-fn compose_queried_bodies_inner(
-    sema: &mut BodySema<'_>,
+fn compose_queried_bodies_inner<F: super::BodyAnalysisFactMode>(
+    sema: &mut BodySema<'_, F>,
     candidates: Vec<
         crate::SemanticQueriedBodyCandidate<
             crate::SemanticDefinitionToken,
@@ -206,8 +205,8 @@ fn compose_queried_bodies_inner(
     )
 }
 
-fn canonical_composed_identity(
-    sema: &BodySema<'_>,
+fn canonical_composed_identity<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
     identity: &crate::FunctionInstanceKey<
         crate::SemanticDefinitionToken,
         crate::SemanticModuleToken,
@@ -233,8 +232,8 @@ fn canonical_composed_identity(
     })
 }
 
-fn composed_callable_metadata(
-    sema: &BodySema<'_>,
+fn composed_callable_metadata<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
     identity: &crate::FunctionInstanceKey<
         crate::SemanticDefinitionToken,
         crate::SemanticModuleToken,
@@ -338,7 +337,8 @@ fn composed_callable_metadata(
                 .interner
                 .get(member.name.as_ref())
                 .ok_or_else(missing)?;
-            let info = call_facts(sema)
+            let info = sema
+                .call_facts()
                 .method_info(struct_id, method)
                 .ok_or_else(missing)?;
             Ok((
@@ -390,8 +390,8 @@ fn composed_callable_metadata(
     }
 }
 
-pub(crate) fn import_staged_body(
-    sema: &mut BodySema<'_>,
+pub(crate) fn import_staged_body<F: super::BodyAnalysisFactMode>(
+    sema: &mut BodySema<'_, F>,
     body: &crate::SemanticBody<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
     body_span: Span,
 ) -> Result<
@@ -451,8 +451,8 @@ pub(crate) fn import_staged_body(
             .map_err(|_| BF::Semantic(F::InvalidStructuralType))?;
     }
 
-    fn definition_endpoint<'a>(
-        sema: &'a BodySema<'_>,
+    fn definition_endpoint<'a, Mode: super::BodyAnalysisFactMode>(
+        sema: &'a BodySema<'_, Mode>,
         token: &crate::SemanticDefinitionToken,
     ) -> Result<&'a crate::SemanticDefinitionEndpoint, BF> {
         if let Some(endpoint) = sema.stable_definition_endpoints.get(token) {
@@ -470,8 +470,8 @@ pub(crate) fn import_staged_body(
         Err(BF::StableResolution(failure))
     }
 
-    fn module_endpoint<'a>(
-        sema: &'a BodySema<'_>,
+    fn module_endpoint<'a, Mode: super::BodyAnalysisFactMode>(
+        sema: &'a BodySema<'_, Mode>,
         token: &crate::SemanticModuleToken,
     ) -> Result<&'a crate::SemanticModuleEndpoint, BF> {
         if let Some(endpoint) = sema.stable_module_endpoints.get(token) {
@@ -489,8 +489,8 @@ pub(crate) fn import_staged_body(
         Err(BF::StableResolution(failure))
     }
 
-    fn import_type(
-        sema: &BodySema<'_>,
+    fn import_type<Mode: super::BodyAnalysisFactMode>(
+        sema: &BodySema<'_, Mode>,
         pool: &crate::TypeInternPool,
         value: &T<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
     ) -> Result<Type, BF> {
@@ -632,8 +632,8 @@ pub(crate) fn import_staged_body(
         })
     }
 
-    fn resolve_struct_nominal(
-        sema: &BodySema<'_>,
+    fn resolve_struct_nominal<Mode: super::BodyAnalysisFactMode>(
+        sema: &BodySema<'_, Mode>,
         identity: &crate::NominalInstanceKey<
             crate::SemanticDefinitionToken,
             crate::SemanticModuleToken,
@@ -699,8 +699,8 @@ pub(crate) fn import_staged_body(
         }
     }
 
-    fn resolve_enum_nominal(
-        sema: &BodySema<'_>,
+    fn resolve_enum_nominal<Mode: super::BodyAnalysisFactMode>(
+        sema: &BodySema<'_, Mode>,
         identity: &crate::NominalInstanceKey<
             crate::SemanticDefinitionToken,
             crate::SemanticModuleToken,
@@ -765,8 +765,8 @@ pub(crate) fn import_staged_body(
         }
     }
 
-    fn resolve_body_function_definition(
-        sema: &BodySema<'_>,
+    fn resolve_body_function_definition<Mode: super::BodyAnalysisFactMode>(
+        sema: &BodySema<'_, Mode>,
         token: &crate::SemanticDefinitionToken,
     ) -> Result<Spur, BF> {
         let identity = definition_endpoint(sema, token)?;
@@ -791,7 +791,8 @@ pub(crate) fn import_staged_body(
             .get(&(FileId::new(identity.file), owner))
             .copied()
             .ok_or(BF::Semantic(F::MissingFunction))?;
-        let info = call_facts(sema)
+        let info = sema
+            .call_facts()
             .method_info(struct_id, name)
             .ok_or(BF::Semantic(F::MissingFunction))?;
         let expected = match identity.kind {
@@ -813,8 +814,8 @@ pub(crate) fn import_staged_body(
             .ok_or(BF::Semantic(F::MissingFunction))
     }
 
-    fn resolve_body_function(
-        sema: &BodySema<'_>,
+    fn resolve_body_function<Mode: super::BodyAnalysisFactMode>(
+        sema: &BodySema<'_, Mode>,
         identity: &crate::FunctionInstanceKey<
             crate::SemanticDefinitionToken,
             crate::SemanticModuleToken,
@@ -835,7 +836,8 @@ pub(crate) fn import_staged_body(
                     .interner
                     .get(member.name.as_ref())
                     .ok_or(BF::Semantic(F::MissingFunction))?;
-                let info = call_facts(sema)
+                let info = sema
+                    .call_facts()
                     .method_info(struct_id, name)
                     .ok_or(BF::Semantic(F::MissingFunction))?;
                 let expected = match member.kind {
@@ -936,8 +938,8 @@ pub(crate) fn import_staged_body(
     Ok(imported)
 }
 
-pub(crate) fn imported_body_references(
-    sema: &BodySema<'_>,
+pub(crate) fn imported_body_references<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
     air: &Air,
 ) -> (HashSet<Spur>, HashSet<(crate::StructId, Spur)>) {
     let mut functions = HashSet::new();
@@ -946,7 +948,7 @@ pub(crate) fn imported_body_references(
         let AirInstData::Call { name, .. } = instruction.data else {
             continue;
         };
-        match classify_static_call(&call_facts(sema), name) {
+        match classify_static_call(&sema.call_facts(), name) {
             Some(StaticCallReference::Free(name)) => {
                 functions.insert(name);
             }
@@ -960,8 +962,10 @@ pub(crate) fn imported_body_references(
 }
 
 #[cfg(test)]
-pub(crate) fn analyze_all_function_bodies_with_namespace_probe_for_test(
-    mut sema: BodySema<'_>,
+pub(crate) fn analyze_all_function_bodies_with_namespace_probe_for_test<
+    F: super::BodyAnalysisFactMode,
+>(
+    mut sema: BodySema<'_, F>,
 ) -> (
     MultiErrorResult<SemaOutput>,
     super::NamespaceBoundarySnapshot,
@@ -973,8 +977,8 @@ pub(crate) fn analyze_all_function_bodies_with_namespace_probe_for_test(
     (result, before, after)
 }
 
-fn analyze_all_function_bodies_mut_for_test(
-    sema: &mut BodySema<'_>,
+fn analyze_all_function_bodies_mut_for_test<F: super::BodyAnalysisFactMode>(
+    sema: &mut BodySema<'_, F>,
 ) -> MultiErrorResult<SemaOutput> {
     debug_assert!(!sema.declaration_binding_active);
     debug_assert!(sema.const_resolution_in_progress.is_empty());
@@ -1013,7 +1017,7 @@ fn analyze_all_function_bodies_mut_for_test(
 /// Materialize every qualified named callable symbol after declaration
 /// binding, before either fresh analysis or durable import can observe the
 /// body worklist. Hash-map iteration order must not affect Spur allocation.
-fn intern_named_callable_symbols(sema: &BodySema<'_>) {
+fn intern_named_callable_symbols<F: super::BodyAnalysisFactMode>(sema: &BodySema<'_, F>) {
     let mut symbols = sema
         .methods
         .iter()
@@ -1076,8 +1080,8 @@ fn find_undiagnosed_error_type(output: &SemaOutput) -> Option<CompileError> {
 }
 
 /// Shared finalization for demand-driven function-body analysis.
-fn finalize_function_body_analysis(
-    sema: &mut BodySema<'_>,
+fn finalize_function_body_analysis<F: super::BodyAnalysisFactMode>(
+    sema: &mut BodySema<'_, F>,
     functions_with_strings: Vec<(AnalyzedFunction, Vec<String>)>,
     active_aggregate_types: &HashSet<Type>,
     mut all_warnings: Vec<CompileWarning>,
@@ -1310,8 +1314,8 @@ fn finalize_function_body_analysis(
 ///
 /// This intentionally excludes methods/destructors; they have different
 /// reachability rules and are not covered by the current spec/UI cases.
-fn add_unused_function_warnings(
-    sema: &BodySema<'_>,
+fn add_unused_function_warnings<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
     referenced_functions: &HashSet<Spur>,
     warnings: &mut Vec<CompileWarning>,
 ) {
@@ -1338,13 +1342,15 @@ fn add_unused_function_warnings(
     }
 }
 
-fn collect_static_function_references(sema: &BodySema<'_>) -> HashSet<Spur> {
+fn collect_static_function_references<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
+) -> HashSet<Spur> {
     let mut referenced = HashSet::new();
 
     for (_, inst) in sema.rir.iter() {
         if let InstData::Call { name, .. } = &inst.data
             && let Some(function_key) =
-                resolve_static_call_reference(&call_facts(sema), *name, inst.span.file_id)
+                resolve_static_call_reference(&sema.call_facts(), *name, inst.span.file_id)
         {
             referenced.insert(function_key);
         }
@@ -1358,8 +1364,9 @@ fn collect_static_function_references(sema: &BodySema<'_>) -> HashSet<Spur> {
         let Some(name) = sema.interner.get(&event.callable_name) else {
             continue;
         };
-        if let Some(function) =
-            call_facts(sema).resolve_function_name_local(name, FileId::new(event.callable_file))
+        if let Some(function) = sema
+            .call_facts()
+            .resolve_function_name_local(name, FileId::new(event.callable_file))
         {
             referenced.insert(function);
         }
@@ -1403,14 +1410,15 @@ fn enqueue_references_sorted(
     pending_methods.extend(meths);
 }
 
-fn named_method_dependency_events(
-    sema: &BodySema<'_>,
+fn named_method_dependency_events<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
     caller_struct: StructId,
     caller_method: Spur,
     referenced_functions: &HashSet<Spur>,
     referenced_methods: &HashSet<(StructId, Spur)>,
 ) -> CompileResult<Vec<super::NamedMethodDependencyEvent>> {
-    let caller_info = call_facts(sema)
+    let caller_info = sema
+        .call_facts()
         .named_method_info(caller_struct, caller_method)
         .ok_or_else(|| {
             CompileError::new(
@@ -1424,7 +1432,7 @@ fn named_method_dependency_events(
     let caller_method_name = sema.interner.resolve(&caller_method).to_string();
     let mut events = Vec::new();
     for callee in referenced_functions {
-        let info = call_facts(sema).function_info(*callee).ok_or_else(|| {
+        let info = sema.call_facts().function_info(*callee).ok_or_else(|| {
             CompileError::new(
                 ErrorKind::InvalidCompilerInput(
                     "named method references a free function absent from semantic declarations"
@@ -1451,7 +1459,7 @@ fn named_method_dependency_events(
                 file: info.file_id.index(),
                 name: sema
                     .interner
-                    .resolve(&call_facts(sema).source_function_name(*callee))
+                    .resolve(&sema.call_facts().source_function_name(*callee))
                     .to_string(),
             },
         });
@@ -1461,7 +1469,8 @@ fn named_method_dependency_events(
         if owner_name.starts_with("__anon_struct_") {
             continue;
         }
-        let info = call_facts(sema)
+        let info = sema
+            .call_facts()
             .named_method_info(*callee_struct, *callee_method)
             .ok_or_else(|| {
                 CompileError::new(
@@ -1496,8 +1505,8 @@ fn named_method_dependency_events(
     Ok(events)
 }
 
-fn named_destructor_dependency_events(
-    sema: &BodySema<'_>,
+fn named_destructor_dependency_events<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
     caller_struct: StructId,
     caller_span: rue_span::Span,
     referenced_functions: &HashSet<Spur>,
@@ -1506,7 +1515,7 @@ fn named_destructor_dependency_events(
     let caller_owner_name = sema.type_pool.struct_def(caller_struct).name.clone();
     let mut events = Vec::new();
     for callee in referenced_functions {
-        let info = call_facts(sema).function_info(*callee).ok_or_else(|| {
+        let info = sema.call_facts().function_info(*callee).ok_or_else(|| {
             CompileError::new(
                 ErrorKind::InvalidCompilerInput(
                     "named destructor references an absent free function".into(),
@@ -1527,7 +1536,7 @@ fn named_destructor_dependency_events(
                 file: info.file_id.index(),
                 name: sema
                     .interner
-                    .resolve(&call_facts(sema).source_function_name(*callee))
+                    .resolve(&sema.call_facts().source_function_name(*callee))
                     .to_string(),
             },
         });
@@ -1537,7 +1546,8 @@ fn named_destructor_dependency_events(
         if owner_name.starts_with("__anon_struct_") {
             continue;
         }
-        let info = call_facts(sema)
+        let info = sema
+            .call_facts()
             .named_method_info(*callee_struct, *callee_method)
             .ok_or_else(|| {
                 CompileError::new(
@@ -1568,12 +1578,16 @@ fn named_destructor_dependency_events(
 
 /// Collect aggregate owners carried by committed AIR. Only owning aggregate
 /// edges recurse: raw pointers do not make their pointees live for drop glue.
-fn extend_owned_aggregate_types(
-    sema: &BodySema<'_>,
+fn extend_owned_aggregate_types<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
     roots: impl IntoIterator<Item = Type>,
     active: &mut HashSet<Type>,
 ) {
-    fn visit(sema: &BodySema<'_>, ty: Type, active: &mut HashSet<Type>) {
+    fn visit<F: super::BodyAnalysisFactMode>(
+        sema: &BodySema<'_, F>,
+        ty: Type,
+        active: &mut HashSet<Type>,
+    ) {
         match ty.kind() {
             TypeKind::Struct(id) => {
                 if !active.insert(ty) {
@@ -1622,8 +1636,8 @@ fn extend_owned_aggregate_types(
     }
 }
 
-fn extend_committed_air_aggregate_types(
-    sema: &BodySema<'_>,
+fn extend_committed_air_aggregate_types<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
     functions_with_strings: &[(AnalyzedFunction, Vec<String>)],
     active: &mut HashSet<Type>,
 ) {
@@ -1643,8 +1657,8 @@ fn extend_committed_air_aggregate_types(
 /// frontier drains. Declaration-time aggregates are eager roots; a type made
 /// during body analysis is a root only when the current attempt's AIR owns it.
 /// Persistent slots created only by an abandoned attempt therefore stay inert.
-fn enqueue_anonymous_destructors(
-    sema: &BodySema<'_>,
+fn enqueue_anonymous_destructors<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
     drop_marker_sym: Spur,
     active_aggregate_types: &HashSet<Type>,
     analyzed_methods: &HashSet<(StructId, Spur)>,
@@ -1672,7 +1686,9 @@ fn enqueue_anonymous_destructors(
 /// from the full type pool.
 ///
 /// This is the same trade-off Zig makes for faster builds and smaller binaries.
-fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<SemaOutput> {
+fn analyze_function_bodies_lazy<F: super::BodyAnalysisFactMode>(
+    sema: &mut BodySema<'_, F>,
+) -> MultiErrorResult<SemaOutput> {
     // Register core `str` before freezing the shared inference context even
     // when source never spells it, because every unconstrained literal uses
     // this canonical identity.
@@ -1684,7 +1700,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
 
     // Find main() - the reference root for executable body analysis.
     let main_sym = match sema.interner.get("main") {
-        Some(sym) if call_facts(sema).function_contains(sym) => sym,
+        Some(sym) if sema.call_facts().function_contains(sym) => sym,
         _ => {
             // No main function found - this is an error
             return Err(CompileErrors::from(CompileError::without_span(
@@ -1831,7 +1847,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                 analyzed_functions.insert(fn_name);
 
                 // Look up the function info
-                let fn_info = match call_facts(sema).function_info(fn_name) {
+                let fn_info = match sema.call_facts().function_info(fn_name) {
                     Some(info) => info,
                     None => continue, // Should not happen, but be defensive
                 };
@@ -1959,19 +1975,21 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                             },
                         );
                         for callee in &ordered_referenced_fns {
-                            let callee_info = call_facts(sema)
+                            let callee_info = sema
+                                .call_facts()
                                 .function_info(*callee)
                                 .expect("referenced free function is present in declarations");
+                            let callee_name = sema
+                                .interner
+                                .resolve(&sema.call_facts().source_function_name(*callee))
+                                .to_string();
                             sema.ordinary_free_function_dependencies.push(
                                 super::OrdinaryFreeFunctionDependencyEvent {
                                     caller_token: ordinary_owner,
                                     caller_file: fn_info.file_id.index(),
                                     caller_name: sema.interner.resolve(&source_name).to_string(),
                                     callee_file: callee_info.file_id.index(),
-                                    callee_name: sema
-                                        .interner
-                                        .resolve(&call_facts(sema).source_function_name(*callee))
-                                        .to_string(),
+                                    callee_name,
                                 },
                             );
                             sema.body_analysis_work
@@ -2116,7 +2134,12 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                                 name: sema.interner.resolve(&source_name).to_string(),
                             });
                         for callee in &referenced_fns {
-                            if let Some(callee_info) = call_facts(sema).function_info(*callee) {
+                            let callee_info = sema.call_facts().function_info(*callee);
+                            if let Some(callee_info) = callee_info {
+                                let callee_name = sema
+                                    .interner
+                                    .resolve(&sema.call_facts().source_function_name(*callee))
+                                    .to_string();
                                 sema.ordinary_free_function_dependencies.push(
                                     super::OrdinaryFreeFunctionDependencyEvent {
                                         caller_token: sema.body_owner_token(
@@ -2131,12 +2154,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                                             .resolve(&source_name)
                                             .to_string(),
                                         callee_file: callee_info.file_id.index(),
-                                        callee_name: sema
-                                            .interner
-                                            .resolve(
-                                                &call_facts(sema).source_function_name(*callee),
-                                            )
-                                            .to_string(),
+                                        callee_name,
                                     },
                                 );
                                 sema.body_analysis_work
@@ -2172,7 +2190,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                 analyzed_methods.insert((struct_id, method_name));
 
                 // Look up the method info
-                let method_info = match call_facts(sema).method_info(struct_id, method_name) {
+                let method_info = match sema.call_facts().method_info(struct_id, method_name) {
                     Some(info) => info,
                     None => continue,
                 };
@@ -2368,7 +2386,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                     .interner
                     .get(&type_name_str)
                     .expect("named struct definition must retain its interned source name");
-                let Some(method_ref) = call_facts(sema).named_method_declaration(
+                let Some(method_ref) = sema.call_facts().named_method_declaration(
                     struct_def.file_id,
                     owner_name,
                     method_name,
@@ -3428,7 +3446,7 @@ where
     Ok(())
 }
 
-impl<'a> BodySema<'a> {
+impl<'a, Mode: crate::sema::BodyAnalysisFactMode> BodySema<'a, Mode> {
     /// Create a type mismatch error with safe type name resolution.
     ///
     /// This helper method safely resolves type names even for anonymous structs

--- a/crates/rue-air/src/sema/analysis/anon_methods.rs
+++ b/crates/rue-air/src/sema/analysis/anon_methods.rs
@@ -5,7 +5,9 @@
 
 use super::*;
 
-impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
+impl<'a, D: crate::sema::DeclarationPhase, Mode: crate::sema::BodyAnalysisFactMode>
+    crate::sema::Sema<'a, D, Mode>
+{
     /// Register methods from an anonymous struct type.
     ///
     /// This is called when an anonymous struct with methods is encountered during
@@ -484,8 +486,8 @@ impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
         type_subst: &std::collections::HashMap<Spur, Type>,
         value_subst: &std::collections::HashMap<Spur, ConstValue>,
     ) -> Vec<super::super::AnonMethodSig> {
-        fn resolve(
-            sema: &mut crate::sema::Sema<'_, impl crate::sema::DeclarationPhase>,
+        fn resolve<D: crate::sema::DeclarationPhase, F: crate::sema::BodyAnalysisFactMode>(
+            sema: &mut crate::sema::Sema<'_, D, F>,
             symbol: Spur,
             type_subst: &std::collections::HashMap<Spur, Type>,
             value_subst: &std::collections::HashMap<Spur, ConstValue>,

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -3,7 +3,7 @@
 //! This category owns builtin operations within the canonical semantic-analysis
 //! implementation.
 
-use super::super::call_resolution::{CallResolutionFacts, call_facts};
+use super::super::call_resolution::CallResolutionFacts;
 use super::*;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -12,7 +12,7 @@ enum IntegerSentinel {
     NegativeOne,
 }
 
-impl<'a> BodySema<'a> {
+impl<'a, Mode: crate::sema::BodyAnalysisFactMode> BodySema<'a, Mode> {
     /// Convert RIR argument mode to AIR argument mode.
     pub(super) fn convert_arg_mode(mode: RirArgMode) -> AirArgMode {
         match mode {
@@ -99,7 +99,7 @@ impl<'a> BodySema<'a> {
             span,
         )?;
         let method = self.interner.get_or_intern("concat_borrowed");
-        if call_facts(self).method_info(struct_id, method).is_none() {
+        if self.call_facts().method_info(struct_id, method).is_none() {
             return Err(CompileError::new(
                 ErrorKind::InternalError("canonical StrBuf is missing concat_borrowed".to_string()),
                 span,

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -7,7 +7,7 @@
 //! `analysis::ownership`.
 
 use super::*;
-use crate::sema::call_resolution::{CallResolutionFacts, call_facts};
+use crate::sema::call_resolution::CallResolutionFacts;
 use crate::sema::{FunctionInfo, NamedConstDependencyTargetEvent};
 
 /// Validate membership and visibility for a module-member function call.
@@ -55,7 +55,7 @@ fn check_module_member_access(
     Ok(())
 }
 
-impl<'a> BodySema<'a> {
+impl<'a, Mode: crate::sema::BodyAnalysisFactMode> BodySema<'a, Mode> {
     /// Validate the source-level contract shared by every ordinary call form.
     /// Receiver exclusivity is checked separately for methods because their
     /// implicit `self` access participates in the same loan set as the explicit
@@ -224,7 +224,10 @@ impl<'a> BodySema<'a> {
         let source_name = name;
         let mut name = name;
         let mut resolved_alias = false;
-        if let Some(const_info) = call_facts(self).resolve_const_info_in_file(name, span.file_id)
+        let const_info = self
+            .call_facts()
+            .resolve_const_info_in_file(name, span.file_id);
+        if let Some(const_info) = const_info
             && let Some(callee) = const_info.value.as_function()
         {
             let alias_name = self.interner.resolve(&name).to_string();
@@ -244,7 +247,10 @@ impl<'a> BodySema<'a> {
         }
 
         let local_name = (!resolved_alias)
-            .then(|| call_facts(self).resolve_function_name_local(name, span.file_id))
+            .then(|| {
+                self.call_facts()
+                    .resolve_function_name_local(name, span.file_id)
+            })
             .flatten();
         if let Some(local_name) = local_name {
             name = local_name;
@@ -271,9 +277,10 @@ impl<'a> BodySema<'a> {
         }
 
         // Look up the function
-        let source_name = call_facts(self).source_function_name(name);
+        let source_name = self.call_facts().source_function_name(name);
         let fn_name_str = self.interner.resolve(&source_name).to_string();
-        let fn_info = call_facts(self)
+        let fn_info = self
+            .call_facts()
             .function_info(name)
             .ok_or_compile_error(ErrorKind::UndefinedFunction(fn_name_str.clone()), span)?;
 
@@ -301,7 +308,7 @@ impl<'a> BodySema<'a> {
         ctx: &mut AnalysisContext,
         check_unqualified_visibility: bool,
     ) -> CompileResult<AnalysisResult> {
-        let source_name = call_facts(self).source_function_name(name);
+        let source_name = self.call_facts().source_function_name(name);
         let fn_name_str = self.interner.resolve(&source_name).to_string();
 
         // Visibility (E0460, RUE-37/RUE-180): an unqualified call must not
@@ -812,7 +819,7 @@ impl<'a> BodySema<'a> {
                 let ty = self.peek_place_type(receiver, ctx)?;
                 let struct_id = ty.as_struct()?;
 
-                let info = call_facts(self).method_info(struct_id, method)?;
+                let info = self.call_facts().method_info(struct_id, method)?;
                 matches!(info.self_mode, RirParamMode::Inout | RirParamMode::Borrow).then_some(root)
             })
         };
@@ -905,7 +912,8 @@ impl<'a> BodySema<'a> {
 
         // Look up the method using StructId directly
         let method_key = (struct_id, method);
-        let method_info = call_facts(self)
+        let method_info = self
+            .call_facts()
             .method_info(struct_id, method)
             .ok_or_compile_error(
                 ErrorKind::UndefinedMethod {
@@ -1127,10 +1135,11 @@ impl<'a> BodySema<'a> {
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         let fn_name_str = self.interner.resolve(&function_name).to_string();
-        let module_def = call_facts(self).module_def(module_id);
+        let module_def = self.call_facts().module_def(module_id);
         let module_file_id = Some(module_def.file_id);
         let mut function_key = module_file_id.and_then(|file_id| {
-            call_facts(self).resolve_function_name_local(function_name, file_id)
+            self.call_facts()
+                .resolve_function_name_local(function_name, file_id)
         });
 
         // Fallback: a re-exported function member — `pub const f = @import("x").f;`
@@ -1144,7 +1153,8 @@ impl<'a> BodySema<'a> {
         if function_key.is_none()
             && let Some(mfile) = module_file_id
         {
-            let reexport = call_facts(self)
+            let reexport = self
+                .call_facts()
                 .value_const(mfile, function_name)
                 .and_then(|info| match info.value {
                     ConstValue::Function(fkey) => Some((fkey, info.is_pub)),
@@ -1179,7 +1189,8 @@ impl<'a> BodySema<'a> {
                 span,
             )
         })?;
-        let fn_info = call_facts(self)
+        let fn_info = self
+            .call_facts()
             .function_info(function_key)
             .ok_or_compile_error(
                 ErrorKind::UnknownModuleMember {
@@ -1289,7 +1300,9 @@ impl<'a> BodySema<'a> {
                     ));
                 }
             }
-        } else if let Some(info) = call_facts(self).value_const(ctx.current_file_id, type_name)
+        } else if let Some(info) = self
+            .call_facts()
+            .value_const(ctx.current_file_id, type_name)
             && let ConstValue::Type(ty) = info.value
         {
             // Module-level `const C = Counter(i32); C.zero()` (RUE-595): the
@@ -1339,7 +1352,8 @@ impl<'a> BodySema<'a> {
 
         // Look up the function using StructId
         let method_key = (struct_id, function);
-        let method_info = call_facts(self)
+        let method_info = self
+            .call_facts()
             .method_info(struct_id, function)
             .ok_or_compile_error(
                 ErrorKind::UndefinedAssocFn {

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -5,7 +5,7 @@
 
 use super::*;
 
-impl<'a> BodySema<'a> {
+impl<'a, Mode: crate::sema::BodyAnalysisFactMode> BodySema<'a, Mode> {
     pub(in crate::sema) fn analyze_single_function<P>(
         &mut self,
         infer_ctx: &InferenceContext,

--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -5,7 +5,7 @@
 
 use super::*;
 
-impl<'a> BodySema<'a> {
+impl<'a, Mode: crate::sema::BodyAnalysisFactMode> BodySema<'a, Mode> {
     /// Analyze an RIR instruction, producing AIR instructions.
     ///
     /// Types are determined by Hindley-Milner inference (stored in `resolved_types`).

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -8,7 +8,7 @@
 use super::*;
 use crate::sema::anon_structs::TrustedTryProducer;
 
-impl<'a> BodySema<'a> {
+impl<'a, Mode: crate::sema::BodyAnalysisFactMode> BodySema<'a, Mode> {
     // ========================================================================
     // Intrinsic operations: Intrinsic, TypeIntrinsic
     // ========================================================================

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -5,7 +5,7 @@
 //! them. It extends the canonical [`BodySema`] rather than introducing peer
 //! analysis state.
 
-use super::super::call_resolution::{CallResolutionFacts, call_facts};
+use super::super::call_resolution::CallResolutionFacts;
 use super::super::context::{LocalVar, VariableMoveState};
 use super::*;
 use crate::inst::AirPlaceRef;
@@ -143,7 +143,7 @@ impl PlaceTrace {
             .any(|p| matches!(p.proj, AirProjection::Index { .. }) && p.index_segment.is_none())
     }
 }
-impl<'a> BodySema<'a> {
+impl<'a, Mode: crate::sema::BodyAnalysisFactMode> BodySema<'a, Mode> {
     /// Read move state without exposing the move-state store to phase peers.
     pub(super) fn moved_state<'ctx>(
         &self,
@@ -371,7 +371,8 @@ impl<'a> BodySema<'a> {
         // owner backs both calls.
         let ptr_method = self.interner.get_or_intern("as_ptr");
         let len_method = self.interner.get_or_intern("len");
-        let Some(ptr_ty) = call_facts(self)
+        let Some(ptr_ty) = self
+            .call_facts()
             .method_info(struct_id, ptr_method)
             .map(|m| m.return_type)
         else {
@@ -382,7 +383,8 @@ impl<'a> BodySema<'a> {
                 span,
             ));
         };
-        let Some(len_ty) = call_facts(self)
+        let Some(len_ty) = self
+            .call_facts()
             .method_info(struct_id, len_method)
             .map(|m| m.return_type)
         else {
@@ -1393,7 +1395,8 @@ impl<'a> BodySema<'a> {
         // @import("math")`). Module bindings are per-file scoped (RUE-113),
         // so the lookup is keyed by the reference's own file and takes
         // precedence over file-local value constants.
-        if let Some(binding) = call_facts(self).module_binding(span.file_id, name) {
+        let module_binding = self.call_facts().module_binding(span.file_id, name);
+        if let Some(binding) = module_binding {
             self.record_body_named_dependency(
                 super::super::NamedConstDependencyTargetEvent::ModuleBinding {
                     file: span.file_id.index(),
@@ -1415,7 +1418,10 @@ impl<'a> BodySema<'a> {
         // checked above. The value was evaluated once during declaration
         // gathering (RUE-171); materialize it directly — the initializer is
         // never re-analyzed at use sites.
-        if let Some(const_info) = call_facts(self).resolve_const_info_in_file(name, span.file_id) {
+        let const_info = self
+            .call_facts()
+            .resolve_const_info_in_file(name, span.file_id);
+        if let Some(const_info) = const_info {
             // Apply the uniform privacy rule even though ordinary unqualified
             // lookup resolves in the reference file (spec 10.3:1, 10.3:7).
             self.check_unqualified_visibility(
@@ -2620,7 +2626,7 @@ impl<'a> BodySema<'a> {
             ));
         };
         let method = self.interner.get_or_intern("byte_at_borrowed");
-        if call_facts(self).method_info(struct_id, method).is_none() {
+        if self.call_facts().method_info(struct_id, method).is_none() {
             return Err(CompileError::new(
                 ErrorKind::InternalError(
                     "trusted std StrBuf is missing its source `byte_at_borrowed` method"

--- a/crates/rue-air/src/sema/analysis/pointers.rs
+++ b/crates/rue-air/src/sema/analysis/pointers.rs
@@ -5,7 +5,7 @@
 
 use super::*;
 
-impl<'a> BodySema<'a> {
+impl<'a, Mode: crate::sema::BodyAnalysisFactMode> BodySema<'a, Mode> {
     /// Analyze @ptr_read / @ptr_read_unaligned intrinsic: reads value through
     /// pointer. Signature: `@ptr_read(ptr: ptr const T) -> T`.
     ///

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -6,7 +6,7 @@
 use super::*;
 use crate::inference::LazyInferenceFacts;
 
-impl<'a> BodySema<'a> {
+impl<'a, Mode: crate::sema::BodyAnalysisFactMode> BodySema<'a, Mode> {
     fn inference_function_is_selected(
         &self,
         function: Spur,
@@ -203,7 +203,11 @@ impl<'a> BodySema<'a> {
             }
         }
 
-        fn record_concrete(sema: &mut BodySema<'_>, ty: &InferType, access_file: FileId) -> bool {
+        fn record_concrete<F: crate::sema::BodyAnalysisFactMode>(
+            sema: &mut BodySema<'_, F>,
+            ty: &InferType,
+            access_file: FileId,
+        ) -> bool {
             match ty {
                 InferType::Concrete(ty) => {
                     let accessible = match ty.kind() {
@@ -328,7 +332,7 @@ impl<'a> BodySema<'a> {
             type_var_count,
             inference_body_dependencies,
         ) = {
-            let facts = crate::sema::SemaInferenceFacts::new(infer_ctx, self);
+            let facts = self.inference_facts(infer_ctx);
 
             // Create constraint generator driven by the demand-population provider.
             let mut cgen = ConstraintGenerator::with_lazy_facts(

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -29,7 +29,7 @@ use crate::types::{Type, TypeKind};
 
 // ============================================================================
 
-impl<'a> BodySema<'a> {
+impl<'a, Mode: crate::sema::BodyAnalysisFactMode> BodySema<'a, Mode> {
     // ========================================================================
     // Literals: IntConst, BoolConst, StringConst, UnitConst
     // ========================================================================

--- a/crates/rue-air/src/sema/anon_structs.rs
+++ b/crates/rue-air/src/sema/anon_structs.rs
@@ -108,7 +108,7 @@ pub(crate) fn anonymous_producer_root(
     }
 }
 
-impl<D: DeclarationPhase> Sema<'_, D> {
+impl<D: DeclarationPhase, Mode: crate::sema::BodyAnalysisFactMode> Sema<'_, D, Mode> {
     /// Deterministic export/presentation ordering of two producer-nominal keys.
     ///
     /// This is a *presentation* order only — it decides how anonymous exports are
@@ -391,7 +391,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
     }
 }
 
-impl<D: DeclarationPhase> Sema<'_, D> {
+impl<D: DeclarationPhase, Mode: crate::sema::BodyAnalysisFactMode> Sema<'_, D, Mode> {
     /// Stable, allocation-order-independent digest of a producer-nominal
     /// anonymous identity (ADR-0066, RUE-1089).
     ///

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -384,11 +384,25 @@ impl SemanticBindingManifest {
     }
 }
 
-#[derive(Clone)]
-pub struct BoundSema<'a> {
-    pub(super) sema: super::BodySema<'a>,
+/// A bound semantic request.
+///
+/// `F` is a crate-internal/test-injection seam; downstream callers use the
+/// default epoch-backed mode. Splitting this into a separate public wrapper is
+/// outside this transitional refactor's scope.
+pub struct BoundSema<'a, F: super::BodyAnalysisFactMode = super::EpochFactMode> {
+    pub(super) sema: super::BodySema<'a, F>,
     manifest: OnceLock<SemanticBindingManifest>,
     binding_work: DeclarationBindingWork,
+}
+
+impl<'a, F: super::BodyAnalysisFactMode> Clone for BoundSema<'a, F> {
+    fn clone(&self) -> Self {
+        Self {
+            sema: self.sema.clone(),
+            manifest: self.manifest.clone(),
+            binding_work: self.binding_work.clone(),
+        }
+    }
 }
 
 /// A semantic request whose module-keyed declaration namespace and nominal shells
@@ -398,14 +412,18 @@ pub struct BoundSema<'a> {
 /// durable-declaration importer can populate that state here without making
 /// raw AIR handles part of the reusable representation.  Today the only
 /// transition performs the ordinary current-revision resolution pass.
-pub struct DeclarationShells<'a> {
-    pub(super) sema: Sema<'a>,
+///
+/// `F` is a crate-internal/test-injection seam; downstream callers use the
+/// default epoch-backed mode. Splitting this into a separate public wrapper is
+/// outside this transitional refactor's scope.
+pub struct DeclarationShells<'a, F: super::BodyAnalysisFactMode = super::EpochFactMode> {
+    pub(super) sema: Sema<'a, super::MutableDeclarations, F>,
     pub(super) binding_work: DeclarationBindingWork,
     pub(super) pending_payloads: Vec<PendingDeclarationPayload>,
     pub(super) pending_nominals: Vec<PendingNominalPayload>,
 }
 
-impl<'a> DeclarationShells<'a> {
+impl<'a, F: crate::sema::BodyAnalysisFactMode> DeclarationShells<'a, F> {
     pub fn install_stable_identity_endpoints(
         mut self,
         definitions: &[crate::SemanticDefinitionEndpoint],
@@ -463,13 +481,13 @@ impl<'a> DeclarationShells<'a> {
 
     /// Test-support adapter for resolving source-owned declaration payloads.
     #[doc(hidden)]
-    pub fn resolve_declarations_for_test(self) -> MultiErrorResult<BoundSema<'a>> {
+    pub fn resolve_declarations_for_test(self) -> MultiErrorResult<BoundSema<'a, F>> {
         self.resolve_declarations_with_work_for_test()
             .map_err(DeclarationResolutionFailure::into_errors)
     }
 
     #[cfg(test)]
-    pub fn resolve_declarations(self) -> MultiErrorResult<BoundSema<'a>> {
+    pub fn resolve_declarations(self) -> MultiErrorResult<BoundSema<'a, F>> {
         self.resolve_declarations_for_test()
     }
 
@@ -477,7 +495,7 @@ impl<'a> DeclarationShells<'a> {
     #[doc(hidden)]
     pub fn resolve_declarations_with_work_for_test(
         mut self,
-    ) -> Result<BoundSema<'a>, DeclarationResolutionFailure> {
+    ) -> Result<BoundSema<'a, F>, DeclarationResolutionFailure> {
         // This is the explicit payload-install boundary. Const resolution may
         // inspect only the exact occurrence set admitted by these shells. In a
         // canonical epoch that set came from keyed compiler queries; the RIR
@@ -526,7 +544,7 @@ impl<'a> DeclarationShells<'a> {
     #[cfg(test)]
     pub fn resolve_declarations_with_work(
         self,
-    ) -> Result<BoundSema<'a>, DeclarationResolutionFailure> {
+    ) -> Result<BoundSema<'a, F>, DeclarationResolutionFailure> {
         self.resolve_declarations_with_work_for_test()
     }
 
@@ -538,7 +556,7 @@ impl<'a> DeclarationShells<'a> {
     pub fn install_declaration_semantics(
         self,
         exports: &[SemanticDeclarationExport],
-    ) -> Result<BoundSema<'a>, DeclarationInstallFailure> {
+    ) -> Result<BoundSema<'a, F>, DeclarationInstallFailure> {
         self.install_declaration_semantics_with_anonymous(exports, &[])
     }
 
@@ -546,7 +564,7 @@ impl<'a> DeclarationShells<'a> {
         mut self,
         exports: &[SemanticDeclarationExport],
         anonymous_nominals: &[SemanticAnonymousNominalExport],
-    ) -> Result<BoundSema<'a>, DeclarationInstallFailure> {
+    ) -> Result<BoundSema<'a, F>, DeclarationInstallFailure> {
         use std::collections::BTreeMap;
 
         self.binding_work.durable_install_invocations += 1;
@@ -850,8 +868,8 @@ impl<'a> DeclarationShells<'a> {
             }
         }
 
-        fn import_capture_value(
-            sema: &mut Sema<'_>,
+        fn import_capture_value<F: super::BodyAnalysisFactMode>(
+            sema: &mut Sema<'_, super::MutableDeclarations, F>,
             value: &SemanticExportConstValue,
         ) -> Result<ConstValue, DeclarationInstallFailure> {
             Ok(match value {
@@ -879,8 +897,8 @@ impl<'a> DeclarationShells<'a> {
             })
         }
 
-        fn import_method_type(
-            sema: &mut Sema<'_>,
+        fn import_method_type<F: super::BodyAnalysisFactMode>(
+            sema: &mut Sema<'_, super::MutableDeclarations, F>,
             value: &SemanticAnonymousMethodType,
         ) -> Result<super::AnonMethodType, DeclarationInstallFailure> {
             Ok(match value {
@@ -1525,8 +1543,8 @@ impl<'a> DeclarationShells<'a> {
     }
 }
 
-fn install_const_candidate_endpoints<D: super::DeclarationPhase>(
-    sema: &mut super::Sema<'_, D>,
+fn install_const_candidate_endpoints<D: super::DeclarationPhase, F: super::BodyAnalysisFactMode>(
+    sema: &mut super::Sema<'_, D, F>,
     pending: &[PendingDeclarationPayload],
 ) -> Result<(), crate::SemanticStableResolutionFailure> {
     let issuer = sema
@@ -1593,7 +1611,7 @@ fn install_const_candidate_endpoints<D: super::DeclarationPhase>(
     Ok(())
 }
 
-impl<D: super::DeclarationPhase> Sema<'_, D> {
+impl<D: super::DeclarationPhase, Mode: crate::sema::BodyAnalysisFactMode> Sema<'_, D, Mode> {
     fn import_anonymous_identity(
         &self,
         identity: &SemanticAnonymousNominalIdentity,
@@ -1787,8 +1805,8 @@ impl<D: super::DeclarationPhase> Sema<'_, D> {
     }
 }
 
-fn install_stable_identity_endpoints<D: super::DeclarationPhase>(
-    sema: &mut super::Sema<'_, D>,
+fn install_stable_identity_endpoints<D: super::DeclarationPhase, F: super::BodyAnalysisFactMode>(
+    sema: &mut super::Sema<'_, D, F>,
     definitions: &[crate::SemanticDefinitionEndpoint],
     modules: &[crate::SemanticModuleEndpoint],
     expected_definitions: &[(u32, String, Option<String>, StableDefinitionKind)],
@@ -1986,7 +2004,9 @@ fn install_stable_identity_endpoints<D: super::DeclarationPhase>(
     Ok(())
 }
 
-fn stable_module_files<D: super::DeclarationPhase>(sema: &super::Sema<'_, D>) -> Vec<FileId> {
+fn stable_module_files<D: super::DeclarationPhase, F: super::BodyAnalysisFactMode>(
+    sema: &super::Sema<'_, D, F>,
+) -> Vec<FileId> {
     (0..sema.module_registry.len())
         .map(|index| {
             sema.module_registry
@@ -1996,7 +2016,7 @@ fn stable_module_files<D: super::DeclarationPhase>(sema: &super::Sema<'_, D>) ->
         .collect()
 }
 
-impl<'a> BoundSema<'a> {
+impl<'a, F: crate::sema::BodyAnalysisFactMode> BoundSema<'a, F> {
     /// Install a per-body well-known `Option(payload)` registry (RUE-1112)
     /// narrowly, outside this body's composition/import universe.
     ///
@@ -2449,7 +2469,7 @@ impl<'a> BoundSema<'a> {
     /// `MethodInfo` / RIR-index answers through this handle to compare against
     /// the provider-side pool + RIR index.
     #[cfg(test)]
-    pub(in crate::sema) fn body_sema(&self) -> &super::BodySema<'a> {
+    pub(in crate::sema) fn body_sema(&self) -> &super::BodySema<'a, F> {
         &self.sema
     }
 
@@ -2499,8 +2519,8 @@ impl<'a> BoundSema<'a> {
     /// index-independent render / metadata (via [`Self::with_type_pool`]), never
     /// the raw id.
     pub fn epoch_nominal_type(&self, file: FileId, name: Spur) -> Option<crate::types::Type> {
-        use super::body_endpoint::{BodyEndpointProvider, endpoint_facts};
-        let facts = endpoint_facts(&self.sema);
+        use super::body_endpoint::BodyEndpointProvider;
+        let facts = self.sema.endpoint_facts();
         facts
             .struct_by_file_name(file, name)
             .map(crate::types::Type::new_struct)
@@ -2517,13 +2537,13 @@ impl<'a> BoundSema<'a> {
     /// returned compact id is epoch-relative, so the differential compares the
     /// module endpoint/file relationship rather than raw indices.
     pub fn epoch_module_type(&self, file: FileId) -> Option<crate::types::Type> {
-        use super::body_endpoint::{endpoint_facts, resolve_instance_type};
+        use super::body_endpoint::resolve_instance_type;
         let endpoint = self
             .sema
             .stable_module_endpoints
             .values()
             .find(|endpoint| endpoint.file == file.index())?;
-        let facts = endpoint_facts(&self.sema);
+        let facts = self.sema.endpoint_facts();
         resolve_instance_type(&facts, &crate::TypeInstanceKey::Module(endpoint.token)).ok()
     }
 
@@ -2561,8 +2581,8 @@ impl<'a> BoundSema<'a> {
     /// caller compares its index-independent render / metadata via
     /// [`Self::with_type_pool`], never the raw id.
     pub fn epoch_generated_struct_type(&self, name: Spur) -> Option<crate::types::Type> {
-        use super::body_endpoint::{BodyEndpointProvider, endpoint_facts};
-        let facts = endpoint_facts(&self.sema);
+        use super::body_endpoint::BodyEndpointProvider;
+        let facts = self.sema.endpoint_facts();
         facts
             .generated_struct(name)
             .map(crate::types::Type::new_struct)
@@ -2683,8 +2703,8 @@ impl<'a> BoundSema<'a> {
         type_name: Spur,
         method: Spur,
     ) -> Option<super::info::MethodInfo> {
-        use super::body_endpoint::{BodyEndpointProvider, endpoint_facts};
-        let facts = endpoint_facts(&self.sema);
+        use super::body_endpoint::BodyEndpointProvider;
+        let facts = self.sema.endpoint_facts();
         let struct_id = facts.struct_by_file_name(file, type_name)?;
         facts.method_info(struct_id, method)
     }
@@ -2702,10 +2722,8 @@ impl<'a> BoundSema<'a> {
         file: FileId,
         name: Spur,
     ) -> crate::ProviderModuleMember {
-        use super::aggregate_resolution::{
-            EpochFacts, ModuleTypeMember, select_module_type_member,
-        };
-        let facts = EpochFacts::new(&self.sema);
+        use super::aggregate_resolution::{ModuleTypeMember, select_module_type_member};
+        let facts = self.sema.aggregate_facts();
         match select_module_type_member(&facts, file, name) {
             ModuleTypeMember::Struct(id) => {
                 crate::ProviderModuleMember::Struct(crate::types::Type::new_struct(id))
@@ -2722,8 +2740,8 @@ impl<'a> BoundSema<'a> {
     /// [`select_qualified_type`](super::aggregate_resolution::select_qualified_type)
     /// winner (enum→struct order) for `(file, name)`.
     pub fn epoch_qualified_type(&self, file: FileId, name: Spur) -> crate::ProviderQualifiedType {
-        use super::aggregate_resolution::{EpochFacts, QualifiedType, select_qualified_type};
-        let facts = EpochFacts::new(&self.sema);
+        use super::aggregate_resolution::{QualifiedType, select_qualified_type};
+        let facts = self.sema.aggregate_facts();
         match select_qualified_type(&facts, file, name) {
             QualifiedType::Enum(id) => {
                 crate::ProviderQualifiedType::Enum(crate::types::Type::new_enum(id))
@@ -2739,10 +2757,8 @@ impl<'a> BoundSema<'a> {
     /// [`select_struct_literal_head`](super::aggregate_resolution::select_struct_literal_head)
     /// winner for an unqualified head `(file, name)` (no local type).
     pub fn epoch_struct_literal_head(&self, file: FileId, name: Spur) -> crate::ProviderStructHead {
-        use super::aggregate_resolution::{
-            EpochFacts, StructLiteralHead, select_struct_literal_head,
-        };
-        let facts = EpochFacts::new(&self.sema);
+        use super::aggregate_resolution::{StructLiteralHead, select_struct_literal_head};
+        let facts = self.sema.aggregate_facts();
         match select_struct_literal_head(&facts, None, file, name) {
             StructLiteralHead::Bound(ty) => crate::ProviderStructHead::Bound(ty),
             StructLiteralHead::Named(id) => {
@@ -2763,8 +2779,8 @@ impl<'a> BoundSema<'a> {
         defining_file: FileId,
         is_public: bool,
     ) -> bool {
-        use super::aggregate_resolution::{EpochFacts, is_accessible};
-        let facts = EpochFacts::new(&self.sema);
+        use super::aggregate_resolution::is_accessible;
+        let facts = self.sema.aggregate_facts();
         is_accessible(&facts, accessing_file, defining_file, is_public)
     }
 
@@ -2890,7 +2906,7 @@ impl<'a> BoundSema<'a> {
     }
 }
 
-impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
+impl<'a, D: super::DeclarationPhase, Mode: crate::sema::BodyAnalysisFactMode> Sema<'a, D, Mode> {
     pub(super) fn attach_imported_declaration_shells(
         &self,
         imported: &[SemanticDeclarationShell],
@@ -3269,8 +3285,8 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
     }
 }
 
-fn validate_imported_shell<D: super::DeclarationPhase>(
-    sema: &Sema<'_, D>,
+fn validate_imported_shell<D: super::DeclarationPhase, F: super::BodyAnalysisFactMode>(
+    sema: &Sema<'_, D, F>,
     shell: &SemanticDeclarationShell,
     name: Spur,
     owner: Option<Spur>,
@@ -3317,7 +3333,7 @@ fn validate_imported_shell<D: super::DeclarationPhase>(
     Ok(())
 }
 
-impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
+impl<'a, D: super::DeclarationPhase, Mode: crate::sema::BodyAnalysisFactMode> Sema<'a, D, Mode> {
     fn export_type(
         &self,
         ty: Type,
@@ -3851,11 +3867,11 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
     }
 }
 
-impl<'a> Sema<'a> {
+impl<'a, Mode: crate::sema::BodyAnalysisFactMode> Sema<'a, super::MutableDeclarations, Mode> {
     pub(super) fn into_bound_with_work(
         mut self,
         binding_work: DeclarationBindingWork,
-    ) -> BoundSema<'a> {
+    ) -> BoundSema<'a, Mode> {
         // This updates source nominal definitions and therefore belongs on
         // the declaration side of the phase boundary. Body analysis receives
         // an immutable namespace with final destructor symbols.

--- a/crates/rue-air/src/sema/body_endpoint.rs
+++ b/crates/rue-air/src/sema/body_endpoint.rs
@@ -46,7 +46,7 @@ use crate::{
 /// `one_body.rs`. Every operation answers one point query against the
 /// declaration universe and returns owned/`Copy` data — no borrowed epoch table
 /// or live `Sema` handle escapes.
-pub(in crate::sema) trait BodyEndpointProvider {
+pub(crate) trait BodyEndpointProvider {
     /// Intern a source name to its symbol, or `None` if never interned. Mirrors
     /// `interner.get`.
     fn name_symbol(&self, name: &str) -> Option<Spur>;
@@ -131,17 +131,17 @@ pub(in crate::sema) trait BodyEndpointProvider {
 
 /// The production [`BodyEndpointProvider`]: every operation is the verbatim
 /// epoch-table read the inline `one_body.rs` code performed.
-pub(in crate::sema) struct EpochFacts<'s, 'a> {
-    sema: &'s BodySema<'a>,
+pub(crate) struct EpochFacts<'s, 'a, F: super::BodyAnalysisFactMode = super::EpochFactMode> {
+    sema: &'s BodySema<'a, F>,
 }
 
-/// Construct a short-lived [`EpochFacts`] borrowing `sema` for the duration of
-/// one endpoint resolution.
-pub(in crate::sema) fn endpoint_facts<'s, 'a>(sema: &'s BodySema<'a>) -> EpochFacts<'s, 'a> {
-    EpochFacts { sema }
+impl<'s, 'a, F: crate::sema::BodyAnalysisFactMode> EpochFacts<'s, 'a, F> {
+    pub(in crate::sema) fn new(sema: &'s BodySema<'a, F>) -> Self {
+        Self { sema }
+    }
 }
 
-impl BodyEndpointProvider for EpochFacts<'_, '_> {
+impl<F: super::BodyAnalysisFactMode> BodyEndpointProvider for EpochFacts<'_, '_, F> {
     fn name_symbol(&self, name: &str) -> Option<Spur> {
         self.sema.interner.get(name)
     }

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -4251,7 +4251,7 @@ mod tests {
     // (2c) + a durable signature (2b, resolving types through 2a) and proves it
     // equals production's populated info struct field-for-field.
 
-    use crate::sema::body_endpoint::{BodyEndpointProvider, endpoint_facts};
+    use crate::sema::body_endpoint::BodyEndpointProvider;
     use crate::sema::{BodySema, BoundSema, Sema};
 
     /// Lower one source file to `Rir` through the production frontend.
@@ -4354,7 +4354,7 @@ mod tests {
         let (rir, interner) = lower_rir(source, file);
         let index = BodyRirIndex::new(&rir);
         let bound = bind(&rir, &interner, "pkg/main.rue", file);
-        let facts = endpoint_facts(bound.body_sema());
+        let facts = bound.body_sema().endpoint_facts();
 
         for name in ["collide", "helper", "main", "nonexistent"] {
             let sym = interner.get(name);
@@ -4383,7 +4383,7 @@ mod tests {
         let (rir, interner) = lower_rir(source, file);
         let index = BodyRirIndex::new(&rir);
         let bound = bind(&rir, &interner, "pkg/main.rue", file);
-        let facts = endpoint_facts(bound.body_sema());
+        let facts = bound.body_sema().endpoint_facts();
 
         let foo = interner.get("Foo").unwrap();
         let pool_foo = index.destructor(file.index(), foo);
@@ -4414,7 +4414,7 @@ mod tests {
         let (rir, interner) = lower_rir(source, file);
         let index = BodyRirIndex::new(&rir);
         let bound = bind(&rir, &interner, "pkg/main.rue", file);
-        let facts = endpoint_facts(bound.body_sema());
+        let facts = bound.body_sema().endpoint_facts();
 
         for (type_name, method) in [
             ("Widget", "bump"),
@@ -4506,7 +4506,7 @@ mod tests {
         let index = BodyRirIndex::new(&rir);
         let bound = bind(&rir, &interner, "pkg/main.rue", file);
         let bs = bound.body_sema();
-        let facts = endpoint_facts(bs);
+        let facts = bs.endpoint_facts();
 
         // Production's populated FunctionInfo for `make`.
         let make_src = interner.get("make").unwrap();
@@ -4604,7 +4604,7 @@ mod tests {
         let index = BodyRirIndex::new(&rir);
         let bound = bind(&rir, &interner, "pkg/main.rue", file);
         let bs = bound.body_sema();
-        let facts = endpoint_facts(bs);
+        let facts = bs.endpoint_facts();
 
         let widget = interner.get("Widget").unwrap();
         let bump = interner.get("bump").unwrap();

--- a/crates/rue-air/src/sema/builtins.rs
+++ b/crates/rue-air/src/sema/builtins.rs
@@ -13,7 +13,7 @@ enum OwnershipProperty {
     Drop,
 }
 
-impl<'a> Sema<'a> {
+impl<'a, Mode: crate::sema::BodyAnalysisFactMode> Sema<'a, super::MutableDeclarations, Mode> {
     /// Phase 0: Inject compiler-provided enums.
     pub(crate) fn inject_builtin_types(&mut self) {
         // Inject built-in enum types (Arch, Os)
@@ -55,7 +55,7 @@ impl<'a> Sema<'a> {
     }
 }
 
-impl<'a, D: DeclarationPhase> Sema<'a, D> {
+impl<'a, D: DeclarationPhase, Mode: crate::sema::BodyAnalysisFactMode> Sema<'a, D, Mode> {
     // ========================================================================
     // Builtin type helper methods
     // ========================================================================

--- a/crates/rue-air/src/sema/call_resolution.rs
+++ b/crates/rue-air/src/sema/call_resolution.rs
@@ -52,7 +52,7 @@ use crate::types::{ModuleDef, ModuleId, StructId};
 /// family-1C analyzer sites. Every operation answers one point query against
 /// the declaration universe and returns owned/`Copy` data — no borrowed epoch
 /// table or live `Sema` handle escapes.
-pub(in crate::sema) trait CallResolutionFacts {
+pub(crate) trait CallResolutionFacts {
     /// The signature/binding info for an internal free-function symbol.
     /// Mirrors `Sema::function_info` (`functions.get`).
     fn function_info(&self, name: Spur) -> Option<FunctionInfo>;
@@ -114,17 +114,17 @@ pub(in crate::sema) trait CallResolutionFacts {
 
 /// The production [`CallResolutionFacts`]: every operation is the verbatim
 /// epoch-table read the inline analyzer code performed.
-pub(in crate::sema) struct EpochFacts<'s, 'a> {
-    sema: &'s BodySema<'a>,
+pub(crate) struct EpochFacts<'s, 'a, F: super::BodyAnalysisFactMode = super::EpochFactMode> {
+    sema: &'s BodySema<'a, F>,
 }
 
-/// Construct a short-lived [`EpochFacts`] borrowing `sema` for the duration of
-/// one call/method/operator resolution.
-pub(in crate::sema) fn call_facts<'s, 'a>(sema: &'s BodySema<'a>) -> EpochFacts<'s, 'a> {
-    EpochFacts { sema }
+impl<'s, 'a, F: crate::sema::BodyAnalysisFactMode> EpochFacts<'s, 'a, F> {
+    pub(in crate::sema) fn new(sema: &'s BodySema<'a, F>) -> Self {
+        Self { sema }
+    }
 }
 
-impl CallResolutionFacts for EpochFacts<'_, '_> {
+impl<F: super::BodyAnalysisFactMode> CallResolutionFacts for EpochFacts<'_, '_, F> {
     fn function_info(&self, name: Spur) -> Option<FunctionInfo> {
         self.sema.function_info(name).copied()
     }

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -300,7 +300,7 @@ fn comptime_panic_err(reason: String, span: Span) -> CompileError {
     CompileError::new(ErrorKind::ComptimeEvaluationFailed { reason }, span)
 }
 
-impl<D: DeclarationPhase> Sema<'_, D> {
+impl<D: DeclarationPhase, Mode: crate::sema::BodyAnalysisFactMode> Sema<'_, D, Mode> {
     /// Try to evaluate an RIR expression as a compile-time constant, with no
     /// substitutions or type context.
     ///

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -118,6 +118,7 @@ mod tests {
     const INSTRUCTIONS_SOURCE: &str = include_str!("analysis/instructions.rs");
     const OWNERSHIP_SOURCE: &str = include_str!("analysis/ownership.rs");
     const CONTROL_FLOW_SOURCE: &str = include_str!("control_flow.rs");
+    const FACT_MODE_SOURCE: &str = include_str!("fact_mode.rs");
     const CALL_INTRINSIC_PEER_SOURCE: &str = concat!(
         include_str!("mod.rs"),
         include_str!("aggregates.rs"),
@@ -348,8 +349,34 @@ mod tests {
             );
         }
 
-        assert!(CONTROL_FLOW_SOURCE.contains("impl<'a> BodySema<'a>"));
+        assert!(
+            CONTROL_FLOW_SOURCE
+                .contains("impl<'a, Mode: crate::sema::BodyAnalysisFactMode> BodySema<'a, Mode>")
+        );
         assert!(!CONTROL_FLOW_SOURCE.contains("struct BodySema"));
+    }
+
+    #[test]
+    fn one_body_fact_mode_has_one_epoch_backed_production_configuration() {
+        assert!(FACT_MODE_SOURCE.contains("pub struct EpochFactMode"));
+        assert!(FACT_MODE_SOURCE.contains("type EndpointFacts"));
+        assert!(FACT_MODE_SOURCE.contains("type CallFacts"));
+        assert!(FACT_MODE_SOURCE.contains("type AggregateFacts"));
+        assert!(FACT_MODE_SOURCE.contains("type InferenceFacts"));
+        assert!(FACT_MODE_SOURCE.contains("fn resolve_type_syntax_with_substitutions"));
+        assert!(FACT_MODE_SOURCE.contains("fn resolve_type_module_prefix"));
+        assert!(FACT_MODE_SOURCE.contains("fn resolve_array_length_fact"));
+        assert!(FACT_MODE_SOURCE.contains("fn validate_deferred_type_position"));
+        assert!(FACT_MODE_SOURCE.contains("fn validate_deferred_value_position"));
+        assert!(!FACT_MODE_SOURCE.contains("SemaTypeSyntaxProvider"));
+        assert!(!FACT_MODE_SOURCE.contains("DeferredSemaTypeSyntaxProvider"));
+        assert!(!FACT_MODE_SOURCE.contains("ProviderFactMode"));
+        assert!(!FACT_MODE_SOURCE.contains("analyze_one_body"));
+        assert!(SEMA_ROOT_SOURCE.contains("F = EpochFactMode"));
+        assert!(SEMA_ROOT_SOURCE.contains("fn endpoint_facts("));
+        assert!(SEMA_ROOT_SOURCE.contains("fn call_facts("));
+        assert!(SEMA_ROOT_SOURCE.contains("fn aggregate_facts("));
+        assert!(SEMA_ROOT_SOURCE.contains("fn inference_facts"));
     }
 
     #[test]
@@ -398,7 +425,10 @@ mod tests {
         assert!(OWNERSHIP_SOURCE.contains("struct PlaceTrace"));
         assert!(OWNERSHIP_SOURCE.contains("struct ProjectionInfo"));
         assert!(OWNERSHIP_SOURCE.contains("fn moved_state<'ctx>("));
-        assert!(OWNERSHIP_SOURCE.contains("impl<'a> BodySema<'a>"));
+        assert!(
+            OWNERSHIP_SOURCE
+                .contains("impl<'a, Mode: crate::sema::BodyAnalysisFactMode> BodySema<'a, Mode>")
+        );
         assert!(!OWNERSHIP_SOURCE.contains("struct BodySema"));
         assert!(!OWNERSHIP_SOURCE.contains("analyze_field_set_impl"));
         assert!(!OWNERSHIP_SOURCE.contains("analyze_index_set_impl"));

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -19,7 +19,7 @@ use crate::inst::{Air, AirInst, AirInstData, AirPattern, AirRef};
 use crate::scope::ScopedContext;
 use crate::types::{Type, TypeKind};
 
-impl<'a> BodySema<'a> {
+impl<'a, Mode: crate::sema::BodyAnalysisFactMode> BodySema<'a, Mode> {
     /// Analyze a control flow instruction.
     ///
     /// Handles: Branch, Loop, InfiniteLoop, Match, Break, Continue, Ret, Block

--- a/crates/rue-air/src/sema/declaration_base.rs
+++ b/crates/rue-air/src/sema/declaration_base.rs
@@ -106,7 +106,7 @@ impl EpochDerivationUnits {
     }
 }
 
-impl<D: DeclarationPhase> Sema<'_, D> {
+impl<D: DeclarationPhase, Mode: crate::sema::BodyAnalysisFactMode> Sema<'_, D, Mode> {
     /// Per-family unit counts for one derivation of this epoch, read from the
     /// live containers rather than from the inputs the epoch was built from.
     fn derivation_unit_sizes(&self) -> EpochDerivationUnits {
@@ -169,7 +169,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
     }
 }
 
-impl BoundSema<'_> {
+impl<F: crate::sema::BodyAnalysisFactMode> BoundSema<'_, F> {
     /// Seal this epoch as a request's declaration base (RUE-1135).
     ///
     /// The type pool and parameter arena are moved into shared immutable layers

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -24,7 +24,7 @@ use crate::path_norm::{mangle_symbol_component, normalize_module_path};
 use crate::types::StructField;
 use crate::types::{EnumDef, EnumId, StructDef, StructId, Type, TypeKind};
 
-impl<'a, D: DeclarationPhase> Sema<'a, D> {
+impl<'a, D: DeclarationPhase, Mode: crate::sema::BodyAnalysisFactMode> Sema<'a, D, Mode> {
     pub(crate) fn source_function_name(&self, internal_name: Spur) -> Spur {
         self.function_source_names
             .get(&internal_name)
@@ -198,7 +198,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     }
 }
 
-impl<'a> Sema<'a> {
+impl<'a, Mode: crate::sema::BodyAnalysisFactMode> Sema<'a, super::MutableDeclarations, Mode> {
     pub(crate) fn has_allow_directive<'r>(
         &self,
         mut directives: impl Iterator<Item = rue_rir::RirDirectiveView<'r>>,

--- a/crates/rue-air/src/sema/fact_mode.rs
+++ b/crates/rue-air/src/sema/fact_mode.rs
@@ -1,0 +1,267 @@
+//! Short-lived fact facades for canonical one-body semantic analysis.
+//!
+//! `EpochFactMode` is the only production mode. It preserves the current
+//! analyzer while making its existing fact seams explicit.
+
+use super::ConstValue;
+use super::aggregate_resolution::{AggregateFacts, EpochFacts as EpochAggregateFacts};
+use super::body_endpoint::{BodyEndpointProvider, EpochFacts as EpochEndpointFacts};
+use super::call_resolution::{CallResolutionFacts, EpochFacts as EpochCallFacts};
+use super::typeck::SemaTypeRootAuthority;
+use super::{BodySema, DeclarationPhase, InferenceContext, Sema, SemaInferenceFacts};
+use crate::inference::LazyInferenceFacts;
+use crate::types::{ArrayLen, ModuleId, Type};
+use lasso::Spur;
+use rue_span::Span;
+use std::collections::HashMap;
+
+/// Selects the short-lived endpoint and call-resolution facades used by the
+/// one-body engine. A facade borrows the analyzer only for one resolution.
+pub(crate) trait BodyAnalysisFactMode: Sized {
+    type EndpointFacts<'s, 'a>: BodyEndpointProvider
+    where
+        Self: 's,
+        'a: 's;
+
+    fn endpoint_facts<'s, 'a>(
+        &'s self,
+        sema: &'s BodySema<'a, Self>,
+    ) -> Self::EndpointFacts<'s, 'a>;
+
+    type CallFacts<'s, 'a>: CallResolutionFacts
+    where
+        Self: 's,
+        'a: 's;
+
+    fn call_facts<'s, 'a>(&'s self, sema: &'s BodySema<'a, Self>) -> Self::CallFacts<'s, 'a>;
+
+    type AggregateFacts<'s, 'a, D: DeclarationPhase>: AggregateFacts
+    where
+        Self: 's,
+        D: 's,
+        'a: 's;
+
+    fn aggregate_facts<'s, 'a, D: DeclarationPhase>(
+        &'s self,
+        sema: &'s Sema<'a, D, Self>,
+    ) -> Self::AggregateFacts<'s, 'a, D>;
+
+    type InferenceFacts<'s, 'a, D: DeclarationPhase>: LazyInferenceFacts
+    where
+        Self: 's,
+        D: 's,
+        'a: 's;
+
+    fn inference_facts<'s, 'a, D: DeclarationPhase>(
+        &'s self,
+        ctx: &'s InferenceContext,
+        sema: &'s Sema<'a, D, Self>,
+    ) -> Self::InferenceFacts<'s, 'a, D>;
+
+    fn resolve_type_syntax_with_substitutions<'a, D: DeclarationPhase>(
+        &self,
+        sema: &mut Sema<'a, D, Self>,
+        syntax: &str,
+        root_file: rue_span::FileId,
+        root_authority: SemaTypeRootAuthority,
+        span: Span,
+        type_substitutions: Option<&HashMap<Spur, Type>>,
+        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
+    ) -> Result<
+        Type,
+        crate::SemanticTypeSyntaxError<
+            std::convert::Infallible,
+            rue_error::CompileError,
+            rue_span::FileId,
+            Spur,
+        >,
+    >;
+
+    fn resolve_type_module_prefix<'a, D: DeclarationPhase>(
+        &self,
+        sema: &mut Sema<'a, D, Self>,
+        root_file: rue_span::FileId,
+        segments: &[&str],
+        span: Span,
+    ) -> rue_error::CompileResult<(ModuleId, Option<rue_span::FileId>, String)>;
+
+    fn resolve_array_length_fact<'a, D: DeclarationPhase>(
+        &self,
+        sema: &mut Sema<'a, D, Self>,
+        length: &ArrayLen,
+        span: Span,
+        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
+    ) -> rue_error::CompileResult<u64>;
+
+    fn validate_deferred_type_position<'a, D: DeclarationPhase>(
+        &self,
+        sema: &mut Sema<'a, D, Self>,
+        type_name: String,
+        type_params: &[Spur],
+        value_params: &[Spur],
+        value_param_type_syms: &[(Spur, Spur)],
+        span: Span,
+    ) -> rue_error::CompileResult<Option<Type>>;
+
+    #[allow(clippy::too_many_arguments)]
+    fn validate_deferred_value_position<'a, D: DeclarationPhase>(
+        &self,
+        sema: &mut Sema<'a, D, Self>,
+        value_name: &str,
+        type_params: &[Spur],
+        value_params: &[Spur],
+        value_param_type_syms: &[(Spur, Spur)],
+        expected: Option<Type>,
+        contract: Option<(Spur, Spur)>,
+        require_integer: bool,
+        span: Span,
+    ) -> rue_error::CompileResult<Option<ConstValue>>;
+}
+
+/// Epoch-backed facts are the sole production configuration.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct EpochFactMode;
+
+impl BodyAnalysisFactMode for EpochFactMode {
+    type EndpointFacts<'s, 'a>
+        = EpochEndpointFacts<'s, 'a>
+    where
+        Self: 's,
+        'a: 's;
+
+    fn endpoint_facts<'s, 'a>(
+        &'s self,
+        sema: &'s BodySema<'a, Self>,
+    ) -> Self::EndpointFacts<'s, 'a> {
+        EpochEndpointFacts::new(sema)
+    }
+
+    type CallFacts<'s, 'a>
+        = EpochCallFacts<'s, 'a>
+    where
+        Self: 's,
+        'a: 's;
+
+    fn call_facts<'s, 'a>(&'s self, sema: &'s BodySema<'a, Self>) -> Self::CallFacts<'s, 'a> {
+        EpochCallFacts::new(sema)
+    }
+
+    type AggregateFacts<'s, 'a, D: DeclarationPhase>
+        = EpochAggregateFacts<'s, 'a, D>
+    where
+        Self: 's,
+        D: 's,
+        'a: 's;
+
+    fn aggregate_facts<'s, 'a, D: DeclarationPhase>(
+        &'s self,
+        sema: &'s Sema<'a, D, Self>,
+    ) -> Self::AggregateFacts<'s, 'a, D> {
+        EpochAggregateFacts::new(sema)
+    }
+
+    type InferenceFacts<'s, 'a, D: DeclarationPhase>
+        = SemaInferenceFacts<'s, 'a, D>
+    where
+        Self: 's,
+        D: 's,
+        'a: 's;
+
+    fn inference_facts<'s, 'a, D: DeclarationPhase>(
+        &'s self,
+        ctx: &'s InferenceContext,
+        sema: &'s Sema<'a, D, Self>,
+    ) -> Self::InferenceFacts<'s, 'a, D> {
+        SemaInferenceFacts::new(ctx, sema)
+    }
+
+    fn resolve_type_syntax_with_substitutions<'a, D: DeclarationPhase>(
+        &self,
+        sema: &mut Sema<'a, D, Self>,
+        syntax: &str,
+        root_file: rue_span::FileId,
+        root_authority: SemaTypeRootAuthority,
+        span: Span,
+        type_substitutions: Option<&HashMap<Spur, Type>>,
+        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
+    ) -> Result<
+        Type,
+        crate::SemanticTypeSyntaxError<
+            std::convert::Infallible,
+            rue_error::CompileError,
+            rue_span::FileId,
+            Spur,
+        >,
+    > {
+        sema.resolve_type_syntax_with_epoch_facts(
+            syntax,
+            root_file,
+            root_authority,
+            span,
+            type_substitutions,
+            value_substitutions,
+        )
+    }
+
+    fn resolve_type_module_prefix<'a, D: DeclarationPhase>(
+        &self,
+        sema: &mut Sema<'a, D, Self>,
+        root_file: rue_span::FileId,
+        segments: &[&str],
+        span: Span,
+    ) -> rue_error::CompileResult<(ModuleId, Option<rue_span::FileId>, String)> {
+        sema.resolve_type_module_prefix_with_epoch_facts(root_file, segments, span)
+    }
+
+    fn resolve_array_length_fact<'a, D: DeclarationPhase>(
+        &self,
+        sema: &mut Sema<'a, D, Self>,
+        length: &ArrayLen,
+        span: Span,
+        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
+    ) -> rue_error::CompileResult<u64> {
+        sema.resolve_array_length_with_epoch_facts(length, span, value_substitutions)
+    }
+
+    fn validate_deferred_type_position<'a, D: DeclarationPhase>(
+        &self,
+        sema: &mut Sema<'a, D, Self>,
+        type_name: String,
+        type_params: &[Spur],
+        value_params: &[Spur],
+        value_param_type_syms: &[(Spur, Spur)],
+        span: Span,
+    ) -> rue_error::CompileResult<Option<Type>> {
+        sema.validate_deferred_type_position_with_epoch_facts(
+            type_name,
+            type_params,
+            value_params,
+            value_param_type_syms,
+            span,
+        )
+    }
+
+    fn validate_deferred_value_position<'a, D: DeclarationPhase>(
+        &self,
+        sema: &mut Sema<'a, D, Self>,
+        value_name: &str,
+        type_params: &[Spur],
+        value_params: &[Spur],
+        value_param_type_syms: &[(Spur, Spur)],
+        expected: Option<Type>,
+        contract: Option<(Spur, Spur)>,
+        require_integer: bool,
+        span: Span,
+    ) -> rue_error::CompileResult<Option<ConstValue>> {
+        sema.validate_deferred_value_position_with_epoch_facts(
+            value_name,
+            type_params,
+            value_params,
+            value_param_type_syms,
+            expected,
+            contract,
+            require_integer,
+            span,
+        )
+    }
+}

--- a/crates/rue-air/src/sema/file_paths.rs
+++ b/crates/rue-air/src/sema/file_paths.rs
@@ -12,7 +12,7 @@ use rue_span::{FileId, Span};
 
 use super::Sema;
 
-impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
+impl<'a, D: super::DeclarationPhase, Mode: crate::sema::BodyAnalysisFactMode> Sema<'a, D, Mode> {
     /// Install the complete resolved-import input for this semantic epoch.
     pub fn set_canonical_imports(
         &mut self,

--- a/crates/rue-air/src/sema/inference_ctx.rs
+++ b/crates/rue-air/src/sema/inference_ctx.rs
@@ -73,7 +73,9 @@ impl InferenceContext {
     /// Construct the context, snapshotting the generated-nominal overlays that
     /// the eager projection merged. The signature caches start empty and fill on
     /// demand.
-    pub(crate) fn new<D: DeclarationPhase>(sema: &Sema<'_, D>) -> Self {
+    pub(crate) fn new<D: DeclarationPhase, F: super::BodyAnalysisFactMode>(
+        sema: &Sema<'_, D, F>,
+    ) -> Self {
         let mut gen_builtin_struct_types = HashMap::new();
         let mut gen_struct_types_by_file = HashMap::new();
         for (name, id) in &sema.generated_structs {
@@ -109,13 +111,20 @@ impl InferenceContext {
 /// [`InferenceContext`] cache plus an immutable borrow of the analyzing `Sema`.
 /// The generator consults it through [`LazyInferenceFacts`]; every answer equals
 /// the value the eager projection would have held for that key.
-pub(crate) struct SemaInferenceFacts<'a, 'src, D: DeclarationPhase> {
+pub(crate) struct SemaInferenceFacts<
+    'a,
+    'src,
+    D: DeclarationPhase,
+    F: super::BodyAnalysisFactMode = super::EpochFactMode,
+> {
     ctx: &'a InferenceContext,
-    sema: &'a Sema<'src, D>,
+    sema: &'a Sema<'src, D, F>,
 }
 
-impl<'a, 'src, D: DeclarationPhase> SemaInferenceFacts<'a, 'src, D> {
-    pub(crate) fn new(ctx: &'a InferenceContext, sema: &'a Sema<'src, D>) -> Self {
+impl<'a, 'src, D: DeclarationPhase, F: crate::sema::BodyAnalysisFactMode>
+    SemaInferenceFacts<'a, 'src, D, F>
+{
+    pub(crate) fn new(ctx: &'a InferenceContext, sema: &'a Sema<'src, D, F>) -> Self {
         Self { ctx, sema }
     }
 
@@ -171,7 +180,9 @@ impl<'a, 'src, D: DeclarationPhase> SemaInferenceFacts<'a, 'src, D> {
     }
 }
 
-impl<D: DeclarationPhase> LazyInferenceFacts for SemaInferenceFacts<'_, '_, D> {
+impl<D: DeclarationPhase, F: crate::sema::BodyAnalysisFactMode> LazyInferenceFacts
+    for SemaInferenceFacts<'_, '_, D, F>
+{
     fn func_sig(&self, name: Spur) -> Option<Rc<FunctionSig>> {
         if let Some(cached) = self.ctx.func_sigs.borrow().get(&name) {
             return Some(Rc::clone(cached));

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -1,3 +1,9 @@
+// `Sema`, `BoundSema`, and `DeclarationShells` are public legacy wrappers,
+// while `F` is a crate-internal migration/test seam. Rust lints each generic
+// implementation independently, so a local alternative would require roughly
+// forty-four duplicate suppressions without changing the public API boundary.
+#![allow(private_bounds)]
+
 //! Semantic analysis - RIR to AIR conversion.
 //!
 //! Sema performs type checking and converts untyped RIR to typed AIR.
@@ -43,6 +49,7 @@ mod control_flow;
 mod declaration_base;
 mod declaration_index;
 mod declarations;
+mod fact_mode;
 mod file_paths;
 mod inference_ctx;
 mod info;
@@ -70,6 +77,8 @@ pub use binding_manifest::{
 pub use context::ConstValue;
 pub use declaration_base::EpochDerivationUnits;
 pub use declaration_index::RirDeclarationIndexWork;
+pub(crate) use fact_mode::BodyAnalysisFactMode;
+use fact_mode::EpochFactMode;
 pub use inference_ctx::InferenceContext;
 pub(crate) use inference_ctx::SemaInferenceFacts;
 use info::ConstResolution;
@@ -237,30 +246,30 @@ impl std::ops::Deref for SourceDeclarations {
 
 #[doc(hidden)]
 pub trait DeclarationPhase: std::ops::Deref<Target = DeclarationNamespace> + Sized {
-    fn resolve_indexed_const(
-        sema: &mut Sema<'_, Self>,
+    fn resolve_indexed_const<F: BodyAnalysisFactMode>(
+        sema: &mut Sema<'_, Self, F>,
         name: Spur,
         file_id: FileId,
     ) -> rue_error::CompileResult<Option<ConstValue>>;
 
-    fn collect_free_function_signature(
-        sema: &mut Sema<'_, Self>,
+    fn collect_free_function_signature<F: BodyAnalysisFactMode>(
+        sema: &mut Sema<'_, Self, F>,
         target: Spur,
         file_id: Option<FileId>,
     ) -> rue_error::CompileResult<Option<(FileId, bool)>>;
 }
 
 impl DeclarationPhase for MutableDeclarations {
-    fn resolve_indexed_const(
-        sema: &mut Sema<'_, Self>,
+    fn resolve_indexed_const<F: BodyAnalysisFactMode>(
+        sema: &mut Sema<'_, Self, F>,
         name: Spur,
         file_id: FileId,
     ) -> rue_error::CompileResult<Option<ConstValue>> {
         sema.resolve_indexed_const_binding_impl(name, file_id)
     }
 
-    fn collect_free_function_signature(
-        sema: &mut Sema<'_, Self>,
+    fn collect_free_function_signature<F: BodyAnalysisFactMode>(
+        sema: &mut Sema<'_, Self, F>,
         target: Spur,
         file_id: Option<FileId>,
     ) -> rue_error::CompileResult<Option<(FileId, bool)>> {
@@ -269,16 +278,16 @@ impl DeclarationPhase for MutableDeclarations {
 }
 
 impl DeclarationPhase for SourceDeclarations {
-    fn resolve_indexed_const(
-        _sema: &mut Sema<'_, Self>,
+    fn resolve_indexed_const<F: BodyAnalysisFactMode>(
+        _sema: &mut Sema<'_, Self, F>,
         _name: Spur,
         _file_id: FileId,
     ) -> rue_error::CompileResult<Option<ConstValue>> {
         Ok(None)
     }
 
-    fn collect_free_function_signature(
-        _sema: &mut Sema<'_, Self>,
+    fn collect_free_function_signature<F: BodyAnalysisFactMode>(
+        _sema: &mut Sema<'_, Self, F>,
         _target: Spur,
         _file_id: Option<FileId>,
     ) -> rue_error::CompileResult<Option<(FileId, bool)>> {
@@ -303,9 +312,23 @@ pub(crate) struct DeferredOwnershipGate {
 ///
 /// Cloning is confined to request-scoped body-epoch derivation. Immutable
 /// declaration data is shared by refcount; body-local mutable state is copied.
-#[derive(Clone)]
-pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
+///
+/// `F` is a crate-internal/test-injection seam; downstream callers use the
+/// default epoch-backed mode. Splitting this into a separate public wrapper is
+/// outside this transitional refactor's scope.
+pub struct Sema<
+    'a,
+    D: DeclarationPhase = MutableDeclarations,
+    F: BodyAnalysisFactMode = EpochFactMode,
+> {
     declarations: D,
+    /// The one-body fact facade mode. Production constructs `EpochFactMode` at
+    /// the external construction boundary; transitions retain the stored mode.
+    /// One mode instance is created at the construction boundary and shared
+    /// unchanged through every declaration/body phase transition. Mutable
+    /// operations clone this `Arc`, never the mode value, so stateful modes
+    /// observe the exact same identity for the whole request lineage.
+    fact_mode: Arc<F>,
     pub(crate) rir: &'a Rir,
     pub(crate) interner: &'a ThreadedRodeo,
     /// Request-local declaration candidates for this exact RIR arena.
@@ -561,7 +584,110 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
         std::collections::BTreeSet<anon_structs::IssuedAnonymousNominalKey>,
 }
 
-impl<D: DeclarationPhase> std::ops::Deref for Sema<'_, D> {
+impl<'a, D, F> Clone for Sema<'a, D, F>
+where
+    D: DeclarationPhase + Clone,
+    F: BodyAnalysisFactMode,
+{
+    fn clone(&self) -> Self {
+        Self {
+            declarations: self.declarations.clone(),
+            fact_mode: Arc::clone(&self.fact_mode),
+            rir: self.rir,
+            interner: self.interner,
+            declaration_index: self.declaration_index.clone(),
+            bound_const_candidates: self.bound_const_candidates.clone(),
+            synthetic_declaration_discovery: self.synthetic_declaration_discovery,
+            anonymous_methods: self.anonymous_methods.clone(),
+            named_callable_methods_by_symbol: self.named_callable_methods_by_symbol.clone(),
+            anonymous_callable_methods_by_symbol: self.anonymous_callable_methods_by_symbol.clone(),
+            generated_structs: self.generated_structs.clone(),
+            generated_enums: self.generated_enums.clone(),
+            anon_struct_identities: self.anon_struct_identities.clone(),
+            anon_enum_identities: self.anon_enum_identities.clone(),
+            anonymous_digest_owners: self.anonymous_digest_owners.clone(),
+            #[cfg(test)]
+            forced_anonymous_digests: self.forced_anonymous_digests.clone(),
+            anonymous_struct_ids: self.anonymous_struct_ids.clone(),
+            anonymous_enum_ids: self.anonymous_enum_ids.clone(),
+            canonical_anonymous_types: self.canonical_anonymous_types.clone(),
+            active_anonymous_producer: self.active_anonymous_producer.clone(),
+            body_analysis_work: self.body_analysis_work.clone(),
+            analyzed_body_owners: self.analyzed_body_owners.clone(),
+            ordinary_body_exports: self.ordinary_body_exports.clone(),
+            specialized_body_exports: self.specialized_body_exports.clone(),
+            reusable_ordinary_bodies: self.reusable_ordinary_bodies.clone(),
+            reusable_specialized_bodies: self.reusable_specialized_bodies.clone(),
+            stable_definition_tokens: self.stable_definition_tokens.clone(),
+            stable_definition_endpoints: self.stable_definition_endpoints.clone(),
+            const_candidate_tokens: self.const_candidate_tokens.clone(),
+            const_candidate_endpoints: self.const_candidate_endpoints.clone(),
+            stable_module_tokens: self.stable_module_tokens.clone(),
+            stable_module_endpoints: self.stable_module_endpoints.clone(),
+            body_dependency_observer: self.body_dependency_observer.clone(),
+            body_owner_tokens: self.body_owner_tokens.clone(),
+            body_named_dependencies: self.body_named_dependencies.clone(),
+            body_lookup_collector: self.body_lookup_collector.clone(),
+            one_body_error_recovery: self.one_body_error_recovery,
+            one_body_recovered_errors: self.one_body_recovered_errors.clone(),
+            one_body_inference_failure_incomplete: self.one_body_inference_failure_incomplete,
+            one_body_initial_anonymous_identities: self
+                .one_body_initial_anonymous_identities
+                .clone(),
+            one_body_requested_producer: self.one_body_requested_producer.clone(),
+            body_callable_dependencies: self.body_callable_dependencies.clone(),
+            body_specialization_dependencies: self.body_specialization_dependencies.clone(),
+            ordinary_free_function_dependencies: self.ordinary_free_function_dependencies.clone(),
+            specialized_free_function_origins: self.specialized_free_function_origins.clone(),
+            specialized_free_function_dependencies: self
+                .specialized_free_function_dependencies
+                .clone(),
+            named_method_dependencies: self.named_method_dependencies.clone(),
+            non_generic_named_method_dependencies_complete: self
+                .non_generic_named_method_dependencies_complete,
+            named_destructor_dependencies: self.named_destructor_dependencies.clone(),
+            declaration_type_dependencies: self.declaration_type_dependencies.clone(),
+            declaration_type_call_head_dependencies: self
+                .declaration_type_call_head_dependencies
+                .clone(),
+            declaration_builtin_type_call_head_dependencies: self
+                .declaration_builtin_type_call_head_dependencies
+                .clone(),
+            named_const_dependencies: self.named_const_dependencies.clone(),
+            named_const_dependency_source: self.named_const_dependency_source.clone(),
+            declaration_type_observer: self.declaration_type_observer.clone(),
+            const_resolution_in_progress: self.const_resolution_in_progress.clone(),
+            declaration_binding_active: self.declaration_binding_active,
+            preview_features: self.preview_features.clone(),
+            target: self.target.clone(),
+            builtin_arch_id: self.builtin_arch_id,
+            builtin_os_id: self.builtin_os_id,
+            builtin_data_model_id: self.builtin_data_model_id,
+            known: self.known.clone(),
+            type_pool: self.type_pool.clone(),
+            module_registry: self.module_registry.clone(),
+            canonical_imports: self.canonical_imports.clone(),
+            file_paths: self.file_paths.clone(),
+            symbol_paths: self.symbol_paths.clone(),
+            trusted_standard_library_files: self.trusted_standard_library_files.clone(),
+            root_file_id: self.root_file_id,
+            param_arena: self.param_arena.clone(),
+            anon_struct_method_sigs: self.anon_struct_method_sigs.clone(),
+            anon_struct_captured_values: self.anon_struct_captured_values.clone(),
+            anon_struct_type_subst: self.anon_struct_type_subst.clone(),
+            destructor_spans: self.destructor_spans.clone(),
+            infectious_linear: self.infectious_linear.clone(),
+            deferred_ownership_gates: self.deferred_ownership_gates.clone(),
+            comptime_type_call_depth: self.comptime_type_call_depth,
+            fn_signatures_in_flight: self.fn_signatures_in_flight.clone(),
+            ctor_type_displays: self.ctor_type_displays.clone(),
+            well_known_option_by_payload: self.well_known_option_by_payload.clone(),
+            well_known_option_identities: self.well_known_option_identities.clone(),
+        }
+    }
+}
+
+impl<D: DeclarationPhase, F: crate::sema::BodyAnalysisFactMode> std::ops::Deref for Sema<'_, D, F> {
     type Target = DeclarationNamespace;
 
     fn deref(&self) -> &Self::Target {
@@ -569,14 +695,15 @@ impl<D: DeclarationPhase> std::ops::Deref for Sema<'_, D> {
     }
 }
 
-impl<'a, D: DeclarationPhase> Sema<'a, D> {
+impl<'a, D: DeclarationPhase, F: crate::sema::BodyAnalysisFactMode> Sema<'a, D, F> {
     /// Change only the declaration-phase capability while preserving every
     /// other analyzer field by value. Keeping this conversion exhaustive makes
     /// additions to `Sema` fail to compile here until their phase-boundary
     /// semantics are reviewed.
-    fn map_declarations<E: DeclarationPhase>(self, map: impl FnOnce(D) -> E) -> Sema<'a, E> {
+    fn map_declarations<E: DeclarationPhase>(self, map: impl FnOnce(D) -> E) -> Sema<'a, E, F> {
         let Sema {
             declarations,
+            fact_mode,
             rir,
             interner,
             declaration_index,
@@ -661,6 +788,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         } = self;
         Sema {
             declarations: map(declarations),
+            fact_mode,
             rir,
             interner,
             declaration_index,
@@ -1062,13 +1190,13 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     }
 }
 
-impl std::ops::DerefMut for Sema<'_, MutableDeclarations> {
+impl<F: crate::sema::BodyAnalysisFactMode> std::ops::DerefMut for Sema<'_, MutableDeclarations, F> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.declarations
     }
 }
 
-pub(crate) type BodySema<'a> = Sema<'a, SourceDeclarations>;
+pub(crate) type BodySema<'a, F = EpochFactMode> = Sema<'a, SourceDeclarations, F>;
 
 #[cfg(test)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1080,8 +1208,37 @@ pub(crate) struct NamespaceBoundarySnapshot {
     pub(crate) anonymous_methods: usize,
 }
 
+impl<'a> Sema<'a, MutableDeclarations, EpochFactMode> {
+    /// Create the production epoch-backed semantic analyzer.
+    pub fn new_synthetic(
+        rir: &'a Rir,
+        interner: &'a ThreadedRodeo,
+        preview_features: PreviewFeatures,
+    ) -> Self {
+        Self::new_synthetic_with_mode(rir, interner, preview_features, EpochFactMode)
+    }
+
+    /// Create the production epoch-backed analyzer for an explicit target.
+    pub fn new_for_target(
+        rir: &'a Rir,
+        interner: &'a ThreadedRodeo,
+        preview_features: PreviewFeatures,
+        metadata: SemaMetadata,
+        target: Target,
+    ) -> Self {
+        Self::new_for_target_with_mode(
+            rir,
+            interner,
+            preview_features,
+            metadata,
+            target,
+            EpochFactMode,
+        )
+    }
+}
+
 #[cfg(test)]
-impl BodySema<'_> {
+impl<Mode: crate::sema::BodyAnalysisFactMode> BodySema<'_, Mode> {
     pub(crate) fn namespace_boundary_snapshot(&self) -> NamespaceBoundarySnapshot {
         use std::hash::{Hash, Hasher};
 
@@ -1128,7 +1285,18 @@ impl BodySema<'_> {
     }
 }
 
-impl<D: DeclarationPhase> Sema<'_, D> {
+impl<D: DeclarationPhase, F: crate::sema::BodyAnalysisFactMode> Sema<'_, D, F> {
+    pub(in crate::sema) fn aggregate_facts(&self) -> F::AggregateFacts<'_, '_, D> {
+        self.fact_mode.aggregate_facts(self)
+    }
+
+    pub(in crate::sema) fn inference_facts<'s>(
+        &'s self,
+        ctx: &'s InferenceContext,
+    ) -> F::InferenceFacts<'s, 's, D> {
+        self.fact_mode.inference_facts(ctx, self)
+    }
+
     pub(crate) fn body_owner_token(
         &self,
         file: FileId,
@@ -1155,8 +1323,18 @@ impl<D: DeclarationPhase> Sema<'_, D> {
     }
 }
 
-impl<'a> Sema<'a> {
-    fn freeze_declarations(mut self) -> BodySema<'a> {
+impl<F: crate::sema::BodyAnalysisFactMode> BodySema<'_, F> {
+    pub(in crate::sema) fn endpoint_facts(&self) -> F::EndpointFacts<'_, '_> {
+        self.fact_mode.endpoint_facts(self)
+    }
+
+    pub(in crate::sema) fn call_facts(&self) -> F::CallFacts<'_, '_> {
+        self.fact_mode.call_facts(self)
+    }
+}
+
+impl<'a, F: crate::sema::BodyAnalysisFactMode> Sema<'a, MutableDeclarations, F> {
+    fn freeze_declarations(mut self) -> BodySema<'a, F> {
         self.rebuild_callable_method_index();
         self.map_declarations(|MutableDeclarations(namespace)| {
             SourceDeclarations(Arc::new(namespace))
@@ -1169,18 +1347,20 @@ impl<'a> Sema<'a> {
     /// from the RIR and never participates in durable compiler joins. Supported
     /// compiler construction uses [`Self::new_for_target`] with canonical
     /// metadata.
-    pub fn new_synthetic(
+    pub(crate) fn new_synthetic_with_mode(
         rir: &'a Rir,
         interner: &'a ThreadedRodeo,
         preview_features: PreviewFeatures,
+        fact_mode: F,
     ) -> Self {
-        let mut sema = Self::new_for_target(
+        let mut sema = Self::new_for_target_with_mode(
             rir,
             interner,
             preview_features,
             SemaMetadata::synthetic_for_rir(rir),
             Target::host()
                 .expect("Rue cannot choose a default sema target on this unsupported host"),
+            fact_mode,
         );
         sema.synthetic_declaration_discovery = true;
         let synthetic_const_candidates = sema
@@ -1202,12 +1382,13 @@ impl<'a> Sema<'a> {
     }
 
     /// Create a new semantic analyzer for an explicit compilation target.
-    pub fn new_for_target(
+    pub(crate) fn new_for_target_with_mode(
         rir: &'a Rir,
         interner: &'a ThreadedRodeo,
         preview_features: PreviewFeatures,
         metadata: SemaMetadata,
         target: Target,
+        fact_mode: F,
     ) -> Self {
         let SemaMetadata {
             root_file_id,
@@ -1218,6 +1399,7 @@ impl<'a> Sema<'a> {
         type_pool.set_symbol_paths(logical_paths.clone());
         Self {
             declarations: MutableDeclarations(DeclarationNamespace::new()),
+            fact_mode: Arc::new(fact_mode),
             rir,
             interner,
             declaration_index: Arc::new(declaration_index::RirDeclarationIndex::new(rir)),
@@ -1408,13 +1590,13 @@ impl<'a> Sema<'a> {
 
     /// Test-support adapter for the retired source-owned declaration producer.
     #[doc(hidden)]
-    pub fn bind_declarations_for_test(self) -> MultiErrorResult<BoundSema<'a>> {
+    pub fn bind_declarations_for_test(self) -> MultiErrorResult<BoundSema<'a, F>> {
         self.predeclare_declaration_shells_for_test()?
             .resolve_declarations_for_test()
     }
 
     #[cfg(test)]
-    pub fn bind_declarations(self) -> MultiErrorResult<BoundSema<'a>> {
+    pub fn bind_declarations(self) -> MultiErrorResult<BoundSema<'a, F>> {
         self.bind_declarations_for_test()
     }
 
@@ -1423,7 +1605,7 @@ impl<'a> Sema<'a> {
     #[doc(hidden)]
     pub fn predeclare_declaration_shells_for_test(
         mut self,
-    ) -> MultiErrorResult<DeclarationShells<'a>> {
+    ) -> MultiErrorResult<DeclarationShells<'a, F>> {
         assert!(
             self.synthetic_declaration_discovery,
             "canonical compiler epochs must import query-owned declaration shells"
@@ -1465,7 +1647,7 @@ impl<'a> Sema<'a> {
     pub fn predeclare_imported_declaration_shells(
         mut self,
         imported: &[SemanticDeclarationShell],
-    ) -> MultiErrorResult<DeclarationShells<'a>> {
+    ) -> MultiErrorResult<DeclarationShells<'a, F>> {
         let mut binding_work = DeclarationBindingWork::from_inputs(
             self.rir.len(),
             self.declaration_index.work(),
@@ -1491,7 +1673,7 @@ impl<'a> Sema<'a> {
     }
 }
 
-impl BodySema<'_> {
+impl<Mode: crate::sema::BodyAnalysisFactMode> BodySema<'_, Mode> {
     /// Test-only oracle for the retired whole-program body driver.
     fn analyze_all_bodies_for_test(self) -> MultiErrorResult<SemaOutput> {
         analysis::analyze_all_function_bodies_for_test(self)

--- a/crates/rue-air/src/sema/one_body.rs
+++ b/crates/rue-air/src/sema/one_body.rs
@@ -16,7 +16,7 @@ use rue_error::{CompileError, CompileErrors, ErrorKind};
 use rue_rir::InstData;
 use rue_span::{FileId, Span};
 
-use super::body_endpoint::{BodyEndpointProvider, endpoint_facts};
+use super::body_endpoint::BodyEndpointProvider;
 use super::{AnalyzedBodyOwnerEvent, AnalyzedFunction, BodyOwnerKind, BodySema};
 use crate::{
     FunctionInstanceKey, NominalInstanceKey, SemanticBodyExport, SemanticDefinitionToken,
@@ -218,8 +218,8 @@ fn interruption_outcome(interruption: OneBodyInterruption) -> OneBodyTransaction
     }
 }
 
-fn stable_token(
-    sema: &BodySema<'_>,
+fn stable_token<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
     file: u32,
     name: &str,
     owner: Option<&str>,
@@ -228,8 +228,8 @@ fn stable_token(
     sema.stable_definition_token(file, name, owner, kind)
 }
 
-fn target_dependency(
-    sema: &BodySema<'_>,
+fn target_dependency<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
     target: &super::NamedConstDependencyTargetEvent,
 ) -> Result<OneBodyDependency, crate::SemanticBodyExportFailure> {
     use super::{DeclarationTypeDependencyTargetKind as TK, NamedConstDependencyTargetEvent as T};
@@ -244,7 +244,7 @@ fn target_dependency(
         }
         T::NamedType { file, name, kind } => {
             if let Some(symbol) = sema.interner.get(name.as_str()) {
-                let facts = endpoint_facts(sema);
+                let facts = sema.endpoint_facts();
                 let builtin_kind = if facts.is_builtin_enum(symbol) {
                     Some(crate::AnonymousNominalKind::Enum)
                 } else if facts.is_builtin_or_generated_struct(symbol) {
@@ -314,13 +314,13 @@ fn semantic_parameter_mode(mode: rue_rir::RirParamMode) -> crate::SemanticParame
     }
 }
 
-fn produced_method_type(
-    sema: &BodySema<'_>,
+fn produced_method_type<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
     ty: &super::AnonMethodType,
     owner: &crate::AnonymousNominalKey<SemanticDefinitionToken, SemanticModuleToken>,
 ) -> Result<SemanticProducedAnonymousMethodType, crate::SemanticBodyExportFailure> {
-    fn concrete(
-        sema: &BodySema<'_>,
+    fn concrete<F: super::BodyAnalysisFactMode>(
+        sema: &BodySema<'_, F>,
         ty: &super::AnonMethodType,
         owner: &crate::AnonymousNominalKey<SemanticDefinitionToken, SemanticModuleToken>,
     ) -> Result<
@@ -354,8 +354,8 @@ fn produced_method_type(
     })
 }
 
-fn produced_anonymous_nominals(
-    sema: &BodySema<'_>,
+fn produced_anonymous_nominals<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
 ) -> Result<Arc<[SemanticProducedAnonymousNominal]>, crate::SemanticBodyExportFailure> {
     let mut identities = sema
         .canonical_anonymous_types
@@ -369,7 +369,7 @@ fn produced_anonymous_nominals(
         .collect::<Vec<_>>();
     // Deterministic total order over the direct producer keys so the exported
     // nominal stream never depends on `HashMap` iteration order.
-    identities.sort_by(|(_, left), (_, right)| BodySema::anonymous_key_cmp(left, right));
+    identities.sort_by(|(_, left), (_, right)| BodySema::<F>::anonymous_key_cmp(left, right));
 
     identities
         .into_iter()
@@ -577,8 +577,8 @@ fn dependency_has_issuer(dependency: &OneBodyDependency, issuer: u64) -> bool {
     }
 }
 
-fn body_references(
-    sema: &BodySema<'_>,
+fn body_references<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
     owner: Option<super::BodyOwnerToken>,
     referenced_functions: &HashSet<Spur>,
     referenced_methods: &HashSet<(crate::StructId, Spur)>,
@@ -597,7 +597,7 @@ fn body_references(
         references.insert(OneBodyDependency::Callable(identity));
     }
     for (structure, method) in referenced_methods {
-        let Some(info) = endpoint_facts(sema).method_info(*structure, *method) else {
+        let Some(info) = sema.endpoint_facts().method_info(*structure, *method) else {
             return Err(ReferenceProjectionFailure::EngineAbort);
         };
         let symbol = sema.method_symbol(*structure, sema.interner.resolve(method), info.has_self);
@@ -643,7 +643,7 @@ fn body_references(
             continue;
         }
         if sema.interner.get(&event.target_name).is_some_and(|symbol| {
-            let facts = endpoint_facts(sema);
+            let facts = sema.endpoint_facts();
             facts.is_builtin_or_generated_struct(symbol) || facts.is_builtin_enum(symbol)
         }) {
             continue;
@@ -728,8 +728,8 @@ fn body_references(
     Ok(references)
 }
 
-fn fail(
-    sema: &BodySema<'_>,
+fn fail<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
     owner: Option<super::BodyOwnerToken>,
     error: CompileError,
 ) -> OneBodyTransactionOutcome {
@@ -769,8 +769,8 @@ fn fail(
     }
 }
 
-fn finalize_ordinary(
-    sema: &BodySema<'_>,
+fn finalize_ordinary<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
     owner: super::BodyOwnerToken,
     body_span: Span,
     function: AnalyzedFunction,
@@ -827,8 +827,8 @@ fn finalize_ordinary(
     }
 }
 
-pub(super) fn analyze_one_body(
-    mut sema: BodySema<'_>,
+pub(super) fn analyze_one_body<F: super::BodyAnalysisFactMode>(
+    mut sema: BodySema<'_, F>,
     request: OneBodyRequest,
     interruption: Option<OneBodyInterruption>,
 ) -> OneBodyTransactionOutcome {
@@ -866,7 +866,7 @@ pub(super) fn analyze_one_body(
             type_arguments,
             value_arguments,
         } => {
-            let Some(endpoint) = endpoint_facts(&sema).definition_endpoint(base) else {
+            let Some(endpoint) = sema.endpoint_facts().definition_endpoint(base) else {
                 return fail(
                     &sema,
                     None,
@@ -884,7 +884,8 @@ pub(super) fn analyze_one_body(
                     )),
                 );
             };
-            let Some(base_name) = endpoint_facts(&sema)
+            let Some(base_name) = sema
+                .endpoint_facts()
                 .function_by_file_name(FileId::new(endpoint.file), source_name)
             else {
                 return fail(
@@ -901,7 +902,7 @@ pub(super) fn analyze_one_body(
                 value_args: value_arguments,
             };
             let base_name = key.base_name;
-            let base_info = endpoint_facts(&sema).function_info(base_name);
+            let base_info = sema.endpoint_facts().function_info(base_name);
             let owner = base_info.as_ref().map(|info| {
                 sema.body_owner_token(
                     info.file_id,
@@ -987,8 +988,8 @@ pub(super) fn analyze_one_body(
     }
 }
 
-pub(super) fn analyze_one_body_instance<K, M>(
-    mut sema: BodySema<'_>,
+pub(super) fn analyze_one_body_instance<K, M, F: super::BodyAnalysisFactMode>(
+    mut sema: BodySema<'_, F>,
     instance: &FunctionInstanceKey<K, M>,
     definition: impl Fn(&K) -> Result<SemanticDefinitionToken, crate::SemanticStableResolutionFailure>,
     module: impl Fn(&M) -> Result<SemanticModuleToken, crate::SemanticStableResolutionFailure>,
@@ -1138,8 +1139,8 @@ fn function_instance_contains_str<D, M>(instance: &FunctionInstanceKey<D, M>) ->
     }
 }
 
-fn analyze_anonymous_member(
-    mut sema: BodySema<'_>,
+fn analyze_anonymous_member<F: super::BodyAnalysisFactMode>(
+    mut sema: BodySema<'_, F>,
     owner: TypeInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
     member: crate::AnonymousMemberKey,
     interruption: Option<OneBodyInterruption>,
@@ -1178,7 +1179,7 @@ fn analyze_anonymous_member(
             CompileError::without_span(ErrorKind::UndefinedFunction(member.name.to_string())),
         );
     };
-    let Some(method_info) = endpoint_facts(&sema).method_info(struct_id, method_name) else {
+    let Some(method_info) = sema.endpoint_facts().method_info(struct_id, method_name) else {
         return fail(
             &sema,
             None,
@@ -1347,12 +1348,12 @@ fn analyze_anonymous_member(
     }
 }
 
-pub(in crate::sema) fn materialize_argument_value(
-    sema: &BodySema<'_>,
+pub(in crate::sema) fn materialize_argument_value<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
     value: &crate::CanonicalArgumentValue<SemanticDefinitionToken, SemanticModuleToken>,
 ) -> Result<super::ConstValue, crate::SemanticBodyExportFailure> {
     use crate::CanonicalArgumentValue as V;
-    let facts = super::body_endpoint::endpoint_facts(sema);
+    let facts = sema.endpoint_facts();
     Ok(match value {
         V::Integer(value) => super::ConstValue::Integer(*value),
         V::Bool(value) => super::ConstValue::Bool(*value),
@@ -1372,20 +1373,20 @@ pub(in crate::sema) fn materialize_argument_value(
     })
 }
 
-pub(in crate::sema) fn materialize_instance_type(
-    sema: &BodySema<'_>,
+pub(in crate::sema) fn materialize_instance_type<F: super::BodyAnalysisFactMode>(
+    sema: &BodySema<'_, F>,
     value: &TypeInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
 ) -> Result<Type, crate::SemanticBodyExportFailure> {
-    super::body_endpoint::resolve_instance_type(&super::body_endpoint::endpoint_facts(sema), value)
+    super::body_endpoint::resolve_instance_type(&sema.endpoint_facts(), value)
 }
 
-fn analyze_definition(
-    sema: &mut BodySema<'_>,
+fn analyze_definition<F: super::BodyAnalysisFactMode>(
+    sema: &mut BodySema<'_, F>,
     infer_ctx: &super::InferenceContext,
     token: SemanticDefinitionToken,
     interruption: Option<OneBodyInterruption>,
 ) -> OneBodyTransactionOutcome {
-    let Some(endpoint) = endpoint_facts(sema).definition_endpoint(token) else {
+    let Some(endpoint) = sema.endpoint_facts().definition_endpoint(token) else {
         return fail(
             sema,
             None,
@@ -1405,8 +1406,9 @@ fn analyze_definition(
                     )),
                 );
             };
-            let Some(name) =
-                endpoint_facts(sema).function_by_file_name(FileId::new(endpoint.file), source_name)
+            let Some(name) = sema
+                .endpoint_facts()
+                .function_by_file_name(FileId::new(endpoint.file), source_name)
             else {
                 return fail(
                     sema,
@@ -1416,7 +1418,8 @@ fn analyze_definition(
                     )),
                 );
             };
-            let info = endpoint_facts(sema)
+            let info = sema
+                .endpoint_facts()
                 .function_info(name)
                 .expect("functions_by_file_name resolved to a registered function");
             if info.is_generic || info.is_extern {
@@ -1426,8 +1429,10 @@ fn analyze_definition(
                     ),
                 };
             }
-            let source = endpoint_facts(sema).source_function_name(name);
-            let Some(declaration) = endpoint_facts(sema).first_free_function(source, info.file_id)
+            let source = sema.endpoint_facts().source_function_name(name);
+            let Some(declaration) = sema
+                .endpoint_facts()
+                .first_free_function(source, info.file_id)
             else {
                 return fail(
                     sema,
@@ -1512,8 +1517,8 @@ fn analyze_definition(
     }
 }
 
-fn analyze_named_method(
-    sema: &mut BodySema<'_>,
+fn analyze_named_method<F: super::BodyAnalysisFactMode>(
+    sema: &mut BodySema<'_, F>,
     infer_ctx: &super::InferenceContext,
     endpoint: &crate::SemanticDefinitionEndpoint,
     interruption: Option<OneBodyInterruption>,
@@ -1536,8 +1541,9 @@ fn analyze_named_method(
             )),
         );
     };
-    let Some(struct_id) =
-        endpoint_facts(sema).struct_by_file_name(FileId::new(endpoint.file), owner_symbol)
+    let Some(struct_id) = sema
+        .endpoint_facts()
+        .struct_by_file_name(FileId::new(endpoint.file), owner_symbol)
     else {
         return fail(
             sema,
@@ -1554,14 +1560,14 @@ fn analyze_named_method(
             CompileError::without_span(ErrorKind::UndefinedFunction(endpoint.name.to_string())),
         );
     };
-    let Some(info) = endpoint_facts(sema).method_info(struct_id, method_name) else {
+    let Some(info) = sema.endpoint_facts().method_info(struct_id, method_name) else {
         return fail(
             sema,
             None,
             CompileError::without_span(ErrorKind::UndefinedFunction(endpoint.name.to_string())),
         );
     };
-    let Some(declaration) = endpoint_facts(sema).named_method_declaration(
+    let Some(declaration) = sema.endpoint_facts().named_method_declaration(
         FileId::new(endpoint.file),
         owner_symbol,
         method_name,
@@ -1653,8 +1659,8 @@ fn analyze_named_method(
     }
 }
 
-fn analyze_named_destructor(
-    sema: &mut BodySema<'_>,
+fn analyze_named_destructor<F: super::BodyAnalysisFactMode>(
+    sema: &mut BodySema<'_, F>,
     infer_ctx: &super::InferenceContext,
     endpoint: &crate::SemanticDefinitionEndpoint,
     interruption: Option<OneBodyInterruption>,
@@ -1677,8 +1683,9 @@ fn analyze_named_destructor(
             )),
         );
     };
-    let Some(struct_id) =
-        endpoint_facts(sema).struct_by_file_name(FileId::new(endpoint.file), owner_symbol)
+    let Some(struct_id) = sema
+        .endpoint_facts()
+        .struct_by_file_name(FileId::new(endpoint.file), owner_symbol)
     else {
         return fail(
             sema,
@@ -1688,7 +1695,10 @@ fn analyze_named_destructor(
             )),
         );
     };
-    let Some(record) = endpoint_facts(sema).destructor(endpoint.file, owner_symbol) else {
+    let Some(record) = sema
+        .endpoint_facts()
+        .destructor(endpoint.file, owner_symbol)
+    else {
         return fail(
             sema,
             None,

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -14,7 +14,7 @@ use crate::{
     TypeKind,
 };
 
-impl<D: DeclarationPhase> Sema<'_, D> {
+impl<D: DeclarationPhase, Mode: crate::sema::BodyAnalysisFactMode> Sema<'_, D, Mode> {
     pub(crate) fn export_specialized_body(
         &self,
         base_name: Spur,

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -2,6 +2,7 @@
 mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use crate::ConstValue;
     use crate::inst::{AirArgMode, AirInstData, AirRef};
@@ -3719,12 +3720,24 @@ fn main() -> i32 {
         crate::sema::BoundSema<'static>,
         Vec<crate::SemanticDefinitionEndpoint>,
     ) {
+        one_body_fixture_with_mode(source, crate::sema::EpochFactMode, |_| {})
+    }
+
+    fn one_body_fixture_with_mode<F: crate::sema::BodyAnalysisFactMode>(
+        source: &str,
+        fact_mode: F,
+        before_binding: impl FnOnce(&mut Sema<'static, crate::sema::MutableDeclarations, F>),
+    ) -> (
+        crate::sema::BoundSema<'static, F>,
+        Vec<crate::SemanticDefinitionEndpoint>,
+    ) {
         let (rir, interner) = lower_files(&[(source, FileId::DEFAULT)]);
         let rir = Box::leak(Box::new(rir));
         let interner = Box::leak(Box::new(interner));
-        let shells = Sema::new_synthetic(rir, interner, PreviewFeatures::new())
-            .predeclare_declaration_shells_for_test()
-            .unwrap();
+        let mut sema =
+            Sema::new_synthetic_with_mode(rir, interner, PreviewFeatures::new(), fact_mode);
+        before_binding(&mut sema);
+        let shells = sema.predeclare_declaration_shells_for_test().unwrap();
         let records = shells.declaration_shells().cloned().collect::<Vec<_>>();
         let (definitions, owners) = authoritative_test_endpoints(&records);
         let initial_definitions = definitions
@@ -3926,6 +3939,322 @@ fn main() -> i32 {
             "specialization transaction failed: {outcome:?}"
         );
         assert!(outcome.artifact_instruction_count().is_some());
+    }
+
+    /// A stateful mode proves the exact stored mode instance crosses the
+    /// declaration, binding, declaration-base derivation, and one-body
+    /// boundaries while exercising every mode operation through `Self`.
+    #[derive(Default)]
+    struct FactModeCounters {
+        mode_identity: AtomicUsize,
+        endpoint: AtomicUsize,
+        call: AtomicUsize,
+        aggregate: AtomicUsize,
+        inference: AtomicUsize,
+        type_syntax: AtomicUsize,
+        module_path: AtomicUsize,
+        array_length: AtomicUsize,
+        deferred_type: AtomicUsize,
+        deferred_value: AtomicUsize,
+    }
+
+    struct CountingFactMode {
+        counters: Arc<FactModeCounters>,
+    }
+
+    impl CountingFactMode {
+        fn hit(&self, counter: &AtomicUsize) {
+            let identity = self as *const Self as usize;
+            let observed = self
+                .counters
+                .mode_identity
+                .compare_exchange(0, identity, Ordering::Relaxed, Ordering::Relaxed)
+                .err();
+            if let Some(observed) = observed {
+                assert_eq!(observed, identity, "Sema replaced the stored fact mode");
+            }
+            counter.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    impl crate::sema::BodyAnalysisFactMode for CountingFactMode {
+        type EndpointFacts<'s, 'a>
+            = crate::sema::body_endpoint::EpochFacts<'s, 'a, Self>
+        where
+            Self: 's,
+            'a: 's;
+
+        fn endpoint_facts<'s, 'a>(
+            &'s self,
+            sema: &'s crate::sema::BodySema<'a, Self>,
+        ) -> Self::EndpointFacts<'s, 'a> {
+            self.hit(&self.counters.endpoint);
+            crate::sema::body_endpoint::EpochFacts::new(sema)
+        }
+
+        type CallFacts<'s, 'a>
+            = crate::sema::call_resolution::EpochFacts<'s, 'a, Self>
+        where
+            Self: 's,
+            'a: 's;
+
+        fn call_facts<'s, 'a>(
+            &'s self,
+            sema: &'s crate::sema::BodySema<'a, Self>,
+        ) -> Self::CallFacts<'s, 'a> {
+            self.hit(&self.counters.call);
+            crate::sema::call_resolution::EpochFacts::new(sema)
+        }
+
+        type AggregateFacts<'s, 'a, D: crate::sema::DeclarationPhase>
+            = crate::sema::aggregate_resolution::EpochFacts<'s, 'a, D, Self>
+        where
+            Self: 's,
+            D: 's,
+            'a: 's;
+
+        fn aggregate_facts<'s, 'a, D: crate::sema::DeclarationPhase>(
+            &'s self,
+            sema: &'s crate::sema::Sema<'a, D, Self>,
+        ) -> Self::AggregateFacts<'s, 'a, D> {
+            self.hit(&self.counters.aggregate);
+            crate::sema::aggregate_resolution::EpochFacts::new(sema)
+        }
+
+        type InferenceFacts<'s, 'a, D: crate::sema::DeclarationPhase>
+            = crate::sema::SemaInferenceFacts<'s, 'a, D, Self>
+        where
+            Self: 's,
+            D: 's,
+            'a: 's;
+
+        fn inference_facts<'s, 'a, D: crate::sema::DeclarationPhase>(
+            &'s self,
+            ctx: &'s crate::sema::InferenceContext,
+            sema: &'s crate::sema::Sema<'a, D, Self>,
+        ) -> Self::InferenceFacts<'s, 'a, D> {
+            self.hit(&self.counters.inference);
+            crate::sema::SemaInferenceFacts::new(ctx, sema)
+        }
+
+        fn resolve_type_syntax_with_substitutions<'a, D: crate::sema::DeclarationPhase>(
+            &self,
+            sema: &mut crate::sema::Sema<'a, D, Self>,
+            syntax: &str,
+            root_file: FileId,
+            root_authority: crate::sema::typeck::SemaTypeRootAuthority,
+            span: Span,
+            type_substitutions: Option<&HashMap<lasso::Spur, Type>>,
+            value_substitutions: Option<&HashMap<lasso::Spur, crate::ConstValue>>,
+        ) -> Result<
+            Type,
+            crate::SemanticTypeSyntaxError<
+                std::convert::Infallible,
+                rue_error::CompileError,
+                FileId,
+                lasso::Spur,
+            >,
+        > {
+            self.hit(&self.counters.type_syntax);
+            sema.resolve_type_syntax_with_epoch_facts(
+                syntax,
+                root_file,
+                root_authority,
+                span,
+                type_substitutions,
+                value_substitutions,
+            )
+        }
+
+        fn resolve_type_module_prefix<'a, D: crate::sema::DeclarationPhase>(
+            &self,
+            sema: &mut crate::sema::Sema<'a, D, Self>,
+            root_file: FileId,
+            segments: &[&str],
+            span: Span,
+        ) -> CompileResult<(crate::types::ModuleId, Option<FileId>, String)> {
+            self.hit(&self.counters.module_path);
+            sema.resolve_type_module_prefix_with_epoch_facts(root_file, segments, span)
+        }
+
+        fn resolve_array_length_fact<'a, D: crate::sema::DeclarationPhase>(
+            &self,
+            sema: &mut crate::sema::Sema<'a, D, Self>,
+            length: &crate::types::ArrayLen,
+            span: Span,
+            value_substitutions: Option<&HashMap<lasso::Spur, crate::ConstValue>>,
+        ) -> CompileResult<u64> {
+            self.hit(&self.counters.array_length);
+            sema.resolve_array_length_with_epoch_facts(length, span, value_substitutions)
+        }
+
+        fn validate_deferred_type_position<'a, D: crate::sema::DeclarationPhase>(
+            &self,
+            sema: &mut crate::sema::Sema<'a, D, Self>,
+            type_name: String,
+            type_params: &[lasso::Spur],
+            value_params: &[lasso::Spur],
+            value_param_type_syms: &[(lasso::Spur, lasso::Spur)],
+            span: Span,
+        ) -> CompileResult<Option<Type>> {
+            self.hit(&self.counters.deferred_type);
+            sema.validate_deferred_type_position_with_epoch_facts(
+                type_name,
+                type_params,
+                value_params,
+                value_param_type_syms,
+                span,
+            )
+        }
+
+        fn validate_deferred_value_position<'a, D: crate::sema::DeclarationPhase>(
+            &self,
+            sema: &mut crate::sema::Sema<'a, D, Self>,
+            value_name: &str,
+            type_params: &[lasso::Spur],
+            value_params: &[lasso::Spur],
+            value_param_type_syms: &[(lasso::Spur, lasso::Spur)],
+            expected: Option<Type>,
+            contract: Option<(lasso::Spur, lasso::Spur)>,
+            require_integer: bool,
+            span: Span,
+        ) -> CompileResult<Option<crate::ConstValue>> {
+            self.hit(&self.counters.deferred_value);
+            sema.validate_deferred_value_position_with_epoch_facts(
+                value_name,
+                type_params,
+                value_params,
+                value_param_type_syms,
+                expected,
+                contract,
+                require_integer,
+                span,
+            )
+        }
+    }
+
+    #[test]
+    fn non_epoch_fact_mode_survives_binding_and_analyzes_one_body() {
+        use crate::sema::{
+            OneBodyCanonicalArtifact as A, OneBodyRequest as R, OneBodyTransactionOutcome as O,
+        };
+
+        let source = r#"
+            struct Box { value: i32, fn get(borrow self) -> i32 { self.value } }
+            fn identity(comptime T: type, comptime N: i32, value: T) -> [T; N] { [value; N] }
+            fn first(value: [i32; 1]) -> i32 { value[0] }
+            fn helper() -> i32 { 7 }
+            fn main() -> i32 { helper() }
+        "#;
+        let counters = Arc::new(FactModeCounters::default());
+        let (mut bound, definitions) = one_body_fixture_with_mode(
+            source,
+            CountingFactMode {
+                counters: Arc::clone(&counters),
+            },
+            |sema| {
+                assert_eq!(
+                    sema.resolve_array_length(
+                        &crate::types::ArrayLen::Literal(1),
+                        Span::default(),
+                        None
+                    )
+                    .unwrap(),
+                    1
+                );
+                assert!(
+                    sema.resolve_type_module_prefix_in_file(
+                        FileId::DEFAULT,
+                        &["missing"],
+                        Span::default()
+                    )
+                    .is_err()
+                );
+            },
+        );
+
+        bound.seal_as_declaration_base();
+        let mut derivation_units = crate::sema::EpochDerivationUnits::default();
+        let derived = bound.derive_body_epoch(&mut derivation_units);
+        assert_eq!(derivation_units.bases_built, 0);
+        assert_eq!(derivation_units.epochs_derived, 1);
+
+        let main = endpoint(
+            &definitions,
+            "main",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let main_outcome = derived
+            .clone()
+            .analyze_one_body_for_test(R::Definition(main), None);
+        assert!(matches!(
+            main_outcome,
+            O::Success {
+                artifact: A::Ordinary(_),
+                ..
+            }
+        ));
+
+        let get = endpoint(
+            &definitions,
+            "get",
+            crate::StableDefinitionKind::Method,
+            Some("Box"),
+        );
+        let method_outcome = derived
+            .clone()
+            .analyze_one_body_for_test(R::Definition(get), None);
+        assert!(matches!(
+            method_outcome,
+            O::Success {
+                artifact: A::Ordinary(_),
+                ..
+            }
+        ));
+
+        let identity = endpoint(
+            &definitions,
+            "identity",
+            crate::StableDefinitionKind::Function,
+            None,
+        );
+        let outcome = derived.analyze_one_body_for_test(
+            R::Specialization {
+                base: identity,
+                type_arguments: vec![Type::I32],
+                value_arguments: vec![crate::ConstValue::Integer(1)],
+            },
+            None,
+        );
+        assert!(matches!(
+            outcome,
+            O::Success {
+                artifact: A::Specialization(_),
+                ..
+            }
+        ));
+        for (name, counter) in [
+            ("endpoint", &counters.endpoint),
+            ("call", &counters.call),
+            ("aggregate", &counters.aggregate),
+            ("inference", &counters.inference),
+            ("type syntax", &counters.type_syntax),
+            ("module path", &counters.module_path),
+            ("array length", &counters.array_length),
+            ("deferred type", &counters.deferred_type),
+            ("deferred value", &counters.deferred_value),
+        ] {
+            assert!(
+                counter.load(Ordering::Relaxed) > 0,
+                "{name} mode operation was skipped"
+            );
+        }
+        assert_ne!(
+            counters.mode_identity.load(Ordering::Relaxed),
+            0,
+            "declaration-base derivation must retain the stored fact mode"
+        );
     }
 
     #[test]

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -30,8 +30,8 @@ use crate::types::{
     parse_type_call_syntax,
 };
 
-struct SemaTypeSyntaxProvider<'s, 'a, 'c, D: DeclarationPhase> {
-    sema: &'s mut Sema<'a, D>,
+struct SemaTypeSyntaxProvider<'s, 'a, 'c, D: DeclarationPhase, F: super::BodyAnalysisFactMode> {
+    sema: &'s mut Sema<'a, D, F>,
     span: Span,
     root_authority: SemaTypeRootAuthority,
     resolution_context: SemaTypeResolutionContext,
@@ -41,7 +41,7 @@ struct SemaTypeSyntaxProvider<'s, 'a, 'c, D: DeclarationPhase> {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum SemaTypeRootAuthority {
+pub(crate) enum SemaTypeRootAuthority {
     KnownFile(FileId),
     GlobalSpeculative,
 }
@@ -58,8 +58,9 @@ fn provider_failure<T>(result: CompileResult<T>) -> SemaProviderResult<T> {
     result.map_err(crate::SemanticProviderError::Failure)
 }
 
-impl<D: DeclarationPhase> crate::SemanticModulePathProvider<FileId, crate::types::ModuleId, FileId>
-    for SemaTypeSyntaxProvider<'_, '_, '_, D>
+impl<D: DeclarationPhase, F: crate::sema::BodyAnalysisFactMode>
+    crate::SemanticModulePathProvider<FileId, crate::types::ModuleId, FileId>
+    for SemaTypeSyntaxProvider<'_, '_, '_, D, F>
 {
     type Abort = Infallible;
     type Failure = CompileError;
@@ -117,7 +118,7 @@ impl<D: DeclarationPhase> crate::SemanticModulePathProvider<FileId, crate::types
     }
 }
 
-impl<D: DeclarationPhase>
+impl<D: DeclarationPhase, F: crate::sema::BodyAnalysisFactMode>
     crate::SemanticTypeSyntaxProvider<
         FileId,
         crate::types::ModuleId,
@@ -126,7 +127,7 @@ impl<D: DeclarationPhase>
         Spur,
         Type,
         ConstValue,
-    > for SemaTypeSyntaxProvider<'_, '_, '_, D>
+    > for SemaTypeSyntaxProvider<'_, '_, '_, D, F>
 {
     fn substituted_type(
         &mut self,
@@ -570,7 +571,28 @@ impl<D: DeclarationPhase>
     }
 }
 
-impl<D: DeclarationPhase> SemaTypeSyntaxProvider<'_, '_, '_, D> {
+impl<'s, 'a, 'c, D: DeclarationPhase, F: crate::sema::BodyAnalysisFactMode>
+    SemaTypeSyntaxProvider<'s, 'a, 'c, D, F>
+{
+    fn new(
+        sema: &'s mut Sema<'a, D, F>,
+        span: Span,
+        root_authority: SemaTypeRootAuthority,
+        resolution_context: SemaTypeResolutionContext,
+        type_substitutions: Option<&'c HashMap<Spur, Type>>,
+        value_substitutions: Option<&'c HashMap<Spur, ConstValue>>,
+    ) -> Self {
+        Self {
+            sema,
+            span,
+            root_authority,
+            resolution_context,
+            type_substitutions,
+            value_substitutions,
+            observed_type_dependencies: Vec::new(),
+        }
+    }
+
     fn resolve_array_length_fact(
         &mut self,
         scope: FileId,
@@ -962,15 +984,52 @@ enum DeferredValueResolution {
     Pending,
 }
 
-struct DeferredSemaTypeSyntaxProvider<'s, 'a, 'c, D: DeclarationPhase> {
-    inner: SemaTypeSyntaxProvider<'s, 'a, 'c, D>,
+struct DeferredSemaTypeSyntaxProvider<
+    's,
+    'a,
+    'c,
+    D: DeclarationPhase,
+    F: super::BodyAnalysisFactMode,
+> {
+    inner: SemaTypeSyntaxProvider<'s, 'a, 'c, D, F>,
     type_params: &'c [Spur],
     value_params: &'c [Spur],
     value_param_type_syms: &'c [(Spur, Spur)],
 }
 
-impl<D: DeclarationPhase> crate::SemanticModulePathProvider<FileId, crate::types::ModuleId, FileId>
-    for DeferredSemaTypeSyntaxProvider<'_, '_, '_, D>
+impl<'s, 'a, 'c, D: DeclarationPhase, F: crate::sema::BodyAnalysisFactMode>
+    DeferredSemaTypeSyntaxProvider<'s, 'a, 'c, D, F>
+{
+    fn new(
+        sema: &'s mut Sema<'a, D, F>,
+        span: Span,
+        type_params: &'c [Spur],
+        value_params: &'c [Spur],
+        value_param_type_syms: &'c [(Spur, Spur)],
+    ) -> Self {
+        Self {
+            inner: SemaTypeSyntaxProvider::new(
+                sema,
+                span,
+                SemaTypeRootAuthority::KnownFile(span.file_id),
+                SemaTypeResolutionContext::Type,
+                None,
+                None,
+            ),
+            type_params,
+            value_params,
+            value_param_type_syms,
+        }
+    }
+
+    fn flush_observed_type_dependencies(&mut self) {
+        self.inner.flush_observed_type_dependencies();
+    }
+}
+
+impl<D: DeclarationPhase, F: crate::sema::BodyAnalysisFactMode>
+    crate::SemanticModulePathProvider<FileId, crate::types::ModuleId, FileId>
+    for DeferredSemaTypeSyntaxProvider<'_, '_, '_, D, F>
 {
     type Abort = Infallible;
     type Failure = CompileError;
@@ -1002,7 +1061,7 @@ impl<D: DeclarationPhase> crate::SemanticModulePathProvider<FileId, crate::types
     }
 }
 
-impl<D: DeclarationPhase>
+impl<D: DeclarationPhase, F: crate::sema::BodyAnalysisFactMode>
     crate::SemanticTypeSyntaxProvider<
         FileId,
         crate::types::ModuleId,
@@ -1011,7 +1070,7 @@ impl<D: DeclarationPhase>
         Spur,
         DeferredTypeResolution,
         DeferredValueResolution,
-    > for DeferredSemaTypeSyntaxProvider<'_, '_, '_, D>
+    > for DeferredSemaTypeSyntaxProvider<'_, '_, '_, D, F>
 {
     fn substituted_type(
         &mut self,
@@ -1535,7 +1594,7 @@ fn private_qualified_item_error(
     ))
 }
 
-impl<'a, D: DeclarationPhase> Sema<'a, D> {
+impl<'a, D: DeclarationPhase, Mode: crate::sema::BodyAnalysisFactMode> Sema<'a, D, Mode> {
     /// Get a human-readable name for a type.
     pub(crate) fn format_type_name(&self, ty: Type) -> String {
         // A constructor-produced anonymous type prints its instantiation
@@ -2078,15 +2137,35 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         type_substitutions: Option<&HashMap<Spur, Type>>,
         value_substitutions: Option<&HashMap<Spur, ConstValue>>,
     ) -> Result<Type, crate::SemanticTypeSyntaxError<Infallible, CompileError, FileId, Spur>> {
-        let mut provider = SemaTypeSyntaxProvider {
-            sema: self,
-            span,
+        let fact_mode = std::sync::Arc::clone(&self.fact_mode);
+        fact_mode.resolve_type_syntax_with_substitutions(
+            self,
+            syntax,
+            root_file,
             root_authority,
-            resolution_context: SemaTypeResolutionContext::Type,
+            span,
             type_substitutions,
             value_substitutions,
-            observed_type_dependencies: Vec::new(),
-        };
+        )
+    }
+
+    pub(crate) fn resolve_type_syntax_with_epoch_facts(
+        &mut self,
+        syntax: &str,
+        root_file: FileId,
+        root_authority: SemaTypeRootAuthority,
+        span: Span,
+        type_substitutions: Option<&HashMap<Spur, Type>>,
+        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
+    ) -> Result<Type, crate::SemanticTypeSyntaxError<Infallible, CompileError, FileId, Spur>> {
+        let mut provider = SemaTypeSyntaxProvider::new(
+            self,
+            span,
+            root_authority,
+            SemaTypeResolutionContext::Type,
+            type_substitutions,
+            value_substitutions,
+        );
         let result = crate::resolve_semantic_type_syntax(&mut provider, &root_file, syntax);
         provider.flush_observed_type_dependencies();
         result
@@ -2370,20 +2449,27 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         segments: &[&str],
         span: Span,
     ) -> CompileResult<(crate::types::ModuleId, Option<FileId>, String)> {
-        let resolved = crate::resolve_semantic_module_path(
-            &mut SemaTypeSyntaxProvider {
-                sema: self,
-                span,
-                root_authority: SemaTypeRootAuthority::KnownFile(root_file),
-                resolution_context: SemaTypeResolutionContext::Type,
-                type_substitutions: None,
-                value_substitutions: None,
-                observed_type_dependencies: Vec::new(),
-            },
-            &root_file,
-            segments,
-        )
-        .map_err(|failure| module_path_resolution_compile_error(failure, span))?;
+        let fact_mode = std::sync::Arc::clone(&self.fact_mode);
+        fact_mode.resolve_type_module_prefix(self, root_file, segments, span)
+    }
+
+    pub(crate) fn resolve_type_module_prefix_with_epoch_facts(
+        &mut self,
+        root_file: FileId,
+        segments: &[&str],
+        span: Span,
+    ) -> CompileResult<(crate::types::ModuleId, Option<FileId>, String)> {
+        let mut provider = SemaTypeSyntaxProvider::new(
+            self,
+            span,
+            SemaTypeRootAuthority::KnownFile(root_file),
+            SemaTypeResolutionContext::Type,
+            None,
+            None,
+        );
+        let resolved = crate::resolve_semantic_module_path(&mut provider, &root_file, segments)
+            .map_err(|failure| module_path_resolution_compile_error(failure, span))?;
+        provider.flush_observed_type_dependencies();
 
         let module_id = resolved.module;
         let module_def = self.module_registry.get_def(module_id);
@@ -2622,15 +2708,24 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         span: Span,
         value_substitutions: Option<&HashMap<Spur, ConstValue>>,
     ) -> CompileResult<u64> {
-        let mut provider = SemaTypeSyntaxProvider {
-            sema: self,
+        let fact_mode = std::sync::Arc::clone(&self.fact_mode);
+        fact_mode.resolve_array_length_fact(self, length, span, value_substitutions)
+    }
+
+    pub(crate) fn resolve_array_length_with_epoch_facts(
+        &mut self,
+        length: &ArrayLen,
+        span: Span,
+        value_substitutions: Option<&HashMap<Spur, ConstValue>>,
+    ) -> CompileResult<u64> {
+        let mut provider = SemaTypeSyntaxProvider::new(
+            self,
             span,
-            root_authority: SemaTypeRootAuthority::KnownFile(span.file_id),
-            resolution_context: SemaTypeResolutionContext::Type,
-            type_substitutions: None,
+            SemaTypeRootAuthority::KnownFile(span.file_id),
+            SemaTypeResolutionContext::Type,
+            None,
             value_substitutions,
-            observed_type_dependencies: Vec::new(),
-        };
+        );
         let result = provider.resolve_array_length_fact(span.file_id, length);
         provider.flush_observed_type_dependencies();
         result
@@ -2831,22 +2926,34 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         value_param_type_syms: &[(Spur, Spur)],
         span: Span,
     ) -> CompileResult<Option<Type>> {
-        let mut provider = DeferredSemaTypeSyntaxProvider {
-            inner: SemaTypeSyntaxProvider {
-                sema: self,
-                span,
-                root_authority: SemaTypeRootAuthority::KnownFile(span.file_id),
-                resolution_context: SemaTypeResolutionContext::Type,
-                type_substitutions: None,
-                value_substitutions: None,
-                observed_type_dependencies: Vec::new(),
-            },
+        let fact_mode = std::sync::Arc::clone(&self.fact_mode);
+        fact_mode.validate_deferred_type_position(
+            self,
+            type_name,
             type_params,
             value_params,
             value_param_type_syms,
-        };
+            span,
+        )
+    }
+
+    pub(crate) fn validate_deferred_type_position_with_epoch_facts(
+        &mut self,
+        type_name: String,
+        type_params: &[Spur],
+        value_params: &[Spur],
+        value_param_type_syms: &[(Spur, Spur)],
+        span: Span,
+    ) -> CompileResult<Option<Type>> {
+        let mut provider = DeferredSemaTypeSyntaxProvider::new(
+            self,
+            span,
+            type_params,
+            value_params,
+            value_param_type_syms,
+        );
         let result = crate::resolve_semantic_type_syntax(&mut provider, &span.file_id, &type_name);
-        provider.inner.flush_observed_type_dependencies();
+        provider.flush_observed_type_dependencies();
         match result {
             Ok(DeferredTypeResolution::Resolved(ty)) => Ok(Some(ty)),
             Ok(DeferredTypeResolution::Pending) => Ok(None),
@@ -2885,6 +2992,31 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     /// values are returned for partial binding; an enclosing comptime
     /// parameter is valid but remains `None` until specialization.
     fn validate_deferred_value_position(
+        &mut self,
+        value_name: &str,
+        type_params: &[Spur],
+        value_params: &[Spur],
+        value_param_type_syms: &[(Spur, Spur)],
+        expected: Option<Type>,
+        contract: Option<(Spur, Spur)>,
+        require_integer: bool,
+        span: Span,
+    ) -> CompileResult<Option<ConstValue>> {
+        let fact_mode = std::sync::Arc::clone(&self.fact_mode);
+        fact_mode.validate_deferred_value_position(
+            self,
+            value_name,
+            type_params,
+            value_params,
+            value_param_type_syms,
+            expected,
+            contract,
+            require_integer,
+            span,
+        )
+    }
+
+    pub(crate) fn validate_deferred_value_position_with_epoch_facts(
         &mut self,
         value_name: &str,
         type_params: &[Spur],
@@ -2953,20 +3085,13 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         }
 
         if let Some((call_name, args)) = parse_type_call_syntax(value_name) {
-            let mut provider = DeferredSemaTypeSyntaxProvider {
-                inner: SemaTypeSyntaxProvider {
-                    sema: self,
-                    span,
-                    root_authority: SemaTypeRootAuthority::KnownFile(span.file_id),
-                    resolution_context: SemaTypeResolutionContext::Type,
-                    type_substitutions: None,
-                    value_substitutions: None,
-                    observed_type_dependencies: Vec::new(),
-                },
+            let mut provider = DeferredSemaTypeSyntaxProvider::new(
+                self,
+                span,
                 type_params,
                 value_params,
                 value_param_type_syms,
-            };
+            );
             let call = crate::resolve_semantic_comptime_call(
                 &mut provider,
                 &span.file_id,
@@ -2974,7 +3099,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
                 &args,
                 crate::SemanticComptimeCallExpectation::Value,
             );
-            provider.inner.flush_observed_type_dependencies();
+            provider.flush_observed_type_dependencies();
             let call =
                 call.map_err(|failure| self.deferred_value_syntax_compile_error(failure, span))?;
             let function = *self
@@ -3055,17 +3180,18 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             return Ok(concrete);
         }
 
-        let value = match (SemaTypeSyntaxProvider {
-            sema: self,
+        let mut provider = SemaTypeSyntaxProvider::new(
+            self,
             span,
-            root_authority: SemaTypeRootAuthority::KnownFile(span.file_id),
-            resolution_context: SemaTypeResolutionContext::Type,
-            type_substitutions: None,
-            value_substitutions: None,
-            observed_type_dependencies: Vec::new(),
-        })
-        .resolve_value_argument_fact(span.file_id, "compile-time call", value_name)
-        {
+            SemaTypeRootAuthority::KnownFile(span.file_id),
+            SemaTypeResolutionContext::Type,
+            None,
+            None,
+        );
+        let value_result =
+            provider.resolve_value_argument_fact(span.file_id, "compile-time call", value_name);
+        provider.flush_observed_type_dependencies();
+        let value = match value_result {
             Ok(value) => value,
             Err(_) if require_integer => {
                 // This is the outer array-length boundary, not a nested

--- a/crates/rue-air/src/sema/visibility.rs
+++ b/crates/rue-air/src/sema/visibility.rs
@@ -8,12 +8,12 @@ use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_span::FileId;
 
 use super::aggregate_resolution::{
-    AggregateFacts, EpochFacts, is_accessible, resolve_visibility_module_ref, select_qualified_enum,
+    AggregateFacts, is_accessible, resolve_visibility_module_ref, select_qualified_enum,
 };
 use super::{DeclarationPhase, Sema, context::AnalysisContext};
 use crate::types::EnumId;
 
-impl<D: DeclarationPhase> Sema<'_, D> {
+impl<D: DeclarationPhase, Mode: crate::sema::BodyAnalysisFactMode> Sema<'_, D, Mode> {
     /// Check if the accessing file can see a private item from the target file.
     ///
     /// Visibility rules (per ADR-0026):
@@ -31,7 +31,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         target_file_id: FileId,
         is_pub: bool,
     ) -> bool {
-        let facts = EpochFacts::new(self);
+        let facts = self.aggregate_facts();
         is_accessible(&facts, accessing_file_id, target_file_id, is_pub)
     }
 
@@ -66,7 +66,8 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         // `is_accessible` is permissive when either file path is unknown
         // (single-file mode, synthetic items), so the item's path is
         // always known here.
-        let defining_file = EpochFacts::new(self)
+        let defining_file = self
+            .aggregate_facts()
             .file_path(defining_file_id)
             .unwrap_or("<unknown>")
             .to_string();
@@ -111,7 +112,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         // valid qualified type path.
         let enum_id = module_file_id
             .and_then(|module_id| {
-                let facts = EpochFacts::new(self);
+                let facts = self.aggregate_facts();
                 let file = facts.module(module_id).file;
                 select_qualified_enum(&facts, file, type_name)
             })
@@ -142,7 +143,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         module_ref: rue_rir::InstRef,
         ctx: &AnalysisContext,
     ) -> Option<crate::types::ModuleId> {
-        let facts = EpochFacts::new(self);
+        let facts = self.aggregate_facts();
         resolve_visibility_module_ref(&facts, self.rir, module_ref, &ctx.locals)
     }
 }

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -123,9 +123,9 @@ struct SpecializedBody {
 pub const MAX_SPECIALIZATION_ROUNDS: usize = 64;
 
 impl Specializer {
-    fn stable_identity(
+    fn stable_identity<F: crate::sema::BodyAnalysisFactMode>(
         key: &SpecializationKey,
-        sema: &crate::sema::BodySema<'_>,
+        sema: &crate::sema::BodySema<'_, F>,
     ) -> Result<
         crate::SemanticSpecializationIdentity<
             crate::SemanticDefinitionToken,
@@ -168,10 +168,10 @@ impl Specializer {
         })
     }
 
-    fn take_reusable_body(
+    fn take_reusable_body<F: crate::sema::BodyAnalysisFactMode>(
         &self,
         key: &SpecializationKey,
-        sema: &mut crate::sema::BodySema<'_>,
+        sema: &mut crate::sema::BodySema<'_, F>,
     ) -> Option<
         crate::SemanticSpecializedBodyCandidate<
             crate::SemanticDefinitionToken,
@@ -193,11 +193,11 @@ impl Specializer {
     /// `Specializer` itself persists across outer sema waves so an ordinary
     /// helper analyzed later can request a specialization without duplicating
     /// one created by an earlier wave.
-    pub(crate) fn run_to_fixpoint(
+    pub(crate) fn run_to_fixpoint<F: crate::sema::BodyAnalysisFactMode>(
         &mut self,
         functions_with_strings: &mut Vec<(AnalyzedFunction, Vec<String>)>,
         all_warnings: &mut Vec<CompileWarning>,
-        sema: &mut crate::sema::BodySema<'_>,
+        sema: &mut crate::sema::BodySema<'_, F>,
         infer_ctx: &InferenceContext,
         interner: &ThreadedRodeo,
     ) -> CompileResult<DiscoveredReferences> {
@@ -619,8 +619,8 @@ fn rewrite_call_generic(
 /// its existing expansion policy until the compiler query cutover.  Keeping
 /// selection here ensures the transaction does not guess specialization edges
 /// by rescanning RIR syntax.
-pub(crate) fn select_one_body_specializations(
-    sema: &crate::sema::BodySema<'_>,
+pub(crate) fn select_one_body_specializations<F: crate::sema::BodyAnalysisFactMode>(
+    sema: &crate::sema::BodySema<'_, F>,
     mut function: AnalyzedFunction,
 ) -> CompileResult<(
     AnalyzedFunction,
@@ -710,8 +710,8 @@ pub(crate) struct OneSpecializedBody {
 /// Analyze exactly one concrete specialization.  No call-site scan or
 /// specialization fixed point is performed here; the caller supplies the
 /// already-selected local key and receives references for later scheduling.
-pub(crate) fn analyze_one_specialization(
-    sema: &mut crate::sema::BodySema<'_>,
+pub(crate) fn analyze_one_specialization<F: crate::sema::BodyAnalysisFactMode>(
+    sema: &mut crate::sema::BodySema<'_, F>,
     infer_ctx: &InferenceContext,
     key: SpecializationKey,
 ) -> CompileResult<OneSpecializedBody> {
@@ -839,8 +839,8 @@ fn mangle_type(ty: Type) -> String {
 /// their concrete type arguments and a value substitution map from the
 /// comptime value parameters to their concrete values (RUE-166), then
 /// re-analyzes the function body with these substitutions.
-fn create_specialized_function(
-    sema: &mut crate::sema::BodySema<'_>,
+fn create_specialized_function<F: crate::sema::BodyAnalysisFactMode>(
+    sema: &mut crate::sema::BodySema<'_, F>,
     infer_ctx: &InferenceContext,
     key: &SpecializationKey,
     specialized_name: Spur,


### PR DESCRIPTION
## Summary

- introduce a stored `BodyAnalysisFactMode` for one-body semantic analysis
- route endpoint, call, aggregate, inference, and mutable resolution operations through that mode
- propagate the mode through declaration binding, body analysis, and specialization without requiring the mode itself to be cloneable
- add a stateful non-Clone counting mode test covering ordinary functions, methods, specialization, and declaration-base reuse

## Validation

- `scripts/rue fmt`
- `scripts/rue quick`
- focused one-body and non-epoch fact-mode unit tests
- `scripts/rue test` (all heavy suites passed; it exposed two stale source-shape assertions, which were corrected and revalidated by the quick suite)

Refs RUE-1092.