### PR TITLE
Harden frozen type-syntax recovery

### DIFF
--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -123,6 +123,7 @@ mod tests {
     const CALL_RESOLUTION_SOURCE: &str = include_str!("call_resolution.rs");
     const AGGREGATE_RESOLUTION_SOURCE: &str = include_str!("aggregate_resolution.rs");
     const INFERENCE_CONTEXT_SOURCE: &str = include_str!("inference_ctx.rs");
+    const TYPECK_SOURCE: &str = include_str!("typeck.rs");
     const CALL_INTRINSIC_PEER_SOURCE: &str = concat!(
         include_str!("mod.rs"),
         include_str!("aggregates.rs"),
@@ -459,6 +460,75 @@ mod tests {
         assert!(FACT_MODE_SOURCE.contains("= EpochCallFacts<'a, Self>"));
         assert!(FACT_MODE_SOURCE.contains("= EpochAggregateFacts<'a, Self>"));
         assert!(FACT_MODE_SOURCE.contains("= HostInferenceFacts<'a, Self>"));
+    }
+
+    #[test]
+    fn frozen_type_syntax_uses_only_the_declaration_phase_extension() {
+        fn item<'source>(source: &'source str, header: &str) -> &'source str {
+            let start = source.find(header).expect("item header is present");
+            let rest = &source[start..];
+            let open = rest.find('{').expect("item body opens");
+            let mut depth = 0;
+            for (offset, ch) in rest[open..].char_indices() {
+                match ch {
+                    '{' => depth += 1,
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            return &rest[..open + offset + 1];
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            panic!("item body closes");
+        }
+
+        for (extension, count) in [
+            ("D::resolve_indexed_const", 4),
+            ("D::collect_free_function_signature", 2),
+        ] {
+            assert_eq!(
+                TYPECK_SOURCE.matches(extension).count(),
+                count,
+                "type syntax must use {extension} at its exact recovery sites"
+            );
+        }
+        for forbidden in [
+            "binding_impl",
+            "declaration_index",
+            "during_binding",
+            "declaration_binding_active",
+        ] {
+            assert!(
+                !TYPECK_SOURCE.contains(forbidden),
+                "type syntax must not select binding recovery with {forbidden}"
+            );
+        }
+
+        let source_phase = item(
+            SEMA_ROOT_SOURCE,
+            "impl DeclarationPhase for SourceDeclarations",
+        );
+        for method_name in ["resolve_indexed_const", "collect_free_function_signature"] {
+            let method = item(source_phase, &format!("fn {method_name}("));
+            let normalized = method
+                .chars()
+                .filter(|ch| !ch.is_whitespace())
+                .collect::<String>();
+            assert!(
+                normalized.contains("_sema:&mutSema<'_,Self>"),
+                "frozen {method_name} must receive but not use the analyzer"
+            );
+            let open = method.find('{').expect("method body opens");
+            let body = &method[open + 1..method.len() - 1];
+            assert!(
+                body.chars()
+                    .filter(|ch| !ch.is_whitespace())
+                    .eq("Ok(None)".chars()),
+                "frozen {method_name} must make misses authoritative"
+            );
+        }
     }
 
     #[test]

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -262,6 +262,9 @@ impl DeclarationPhase for MutableDeclarations {
         name: Spur,
         file_id: FileId,
     ) -> rue_error::CompileResult<Option<ConstValue>> {
+        if !sema.declaration_binding_active {
+            return Ok(None);
+        }
         sema.resolve_indexed_const_binding_impl(name, file_id)
     }
 
@@ -270,6 +273,9 @@ impl DeclarationPhase for MutableDeclarations {
         target: Spur,
         file_id: Option<FileId>,
     ) -> rue_error::CompileResult<Option<(FileId, bool)>> {
+        if !sema.declaration_binding_active {
+            return Ok(None);
+        }
         sema.collect_free_function_signature_binding_impl(target, file_id)
     }
 }
@@ -1012,14 +1018,6 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
                 feature.adr()
             )))
         }
-    }
-
-    pub(crate) fn try_resolve_indexed_const_during_binding(
-        &mut self,
-        name: Spur,
-        file_id: FileId,
-    ) -> rue_error::CompileResult<Option<ConstValue>> {
-        D::resolve_indexed_const(self, name, file_id)
     }
 
     pub(crate) fn collect_free_function_signature_during_binding(

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -246,11 +246,8 @@ impl<D: DeclarationPhase>
             .sema
             .resolve_const_info_in_file(symbol, root_file)
             .map(|info| info.value);
-        if value.is_none() && self.sema.declaration_binding_active {
-            value = provider_failure(
-                self.sema
-                    .try_resolve_indexed_const_during_binding(symbol, root_file),
-            )?;
+        if value.is_none() {
+            value = provider_failure(D::resolve_indexed_const(self.sema, symbol, root_file))?;
         }
         let Some(ConstValue::Type(value)) = value else {
             return Ok(None);
@@ -316,12 +313,8 @@ impl<D: DeclarationPhase>
         let file = self.sema.module_registry.get_def(*module).file_id;
         let symbol = self.sema.interner.get_or_intern(name);
         self.sema.record_body_module_item_lookup(file, symbol);
-        if self.sema.declaration_binding_active && self.sema.value_const(&(file, symbol)).is_none()
-        {
-            provider_failure(
-                self.sema
-                    .try_resolve_indexed_const_during_binding(symbol, file),
-            )?;
+        if self.sema.value_const(&(file, symbol)).is_none() {
+            provider_failure(D::resolve_indexed_const(self.sema, symbol, file))?;
         }
         let Some(info) = self.sema.value_const(&(file, symbol)) else {
             return Ok(None);
@@ -464,14 +457,14 @@ impl<D: DeclarationPhase>
             TypeRootAuthority::GlobalSpeculative => Some(symbol),
         };
         if key.is_none()
-            && self.sema.declaration_binding_active
             && let TypeRootAuthority::KnownFile(root_file) = self.root_authority
         {
             let observer = self.sema.declaration_type_observer.clone();
-            provider_failure(
-                self.sema
-                    .collect_free_function_signature_during_binding(symbol, Some(root_file)),
-            )?;
+            provider_failure(D::collect_free_function_signature(
+                self.sema,
+                symbol,
+                Some(root_file),
+            ))?;
             self.sema.declaration_type_observer = observer;
             key = self.sema.resolve_function_name_local(symbol, root_file);
         }
@@ -496,14 +489,13 @@ impl<D: DeclarationPhase>
     ) -> SemaProviderResult<Option<crate::SemanticTypeConstructorHead<Spur, Spur, FileId>>> {
         let file = self.sema.module_registry.get_def(*module).file_id;
         let symbol = self.sema.interner.get_or_intern(name);
-        if self.sema.declaration_binding_active {
-            let observer = self.sema.declaration_type_observer.clone();
-            provider_failure(
-                self.sema
-                    .collect_free_function_signature_during_binding(symbol, Some(file)),
-            )?;
-            self.sema.declaration_type_observer = observer;
-        }
+        let observer = self.sema.declaration_type_observer.clone();
+        provider_failure(D::collect_free_function_signature(
+            self.sema,
+            symbol,
+            Some(file),
+        ))?;
+        self.sema.declaration_type_observer = observer;
         let Some(key) = self.sema.resolve_function_name_local(symbol, file) else {
             return Ok(None);
         };
@@ -639,11 +631,7 @@ impl<'s, 'a, 'c, D: DeclarationPhase> SemaTypeSyntaxProvider<'s, 'a, 'c, D> {
                     },
                 );
                 info.value
-            } else if self.sema.declaration_binding_active
-                && let Some(value) = self
-                    .sema
-                    .try_resolve_indexed_const_during_binding(symbol, root_file)?
-            {
+            } else if let Some(value) = D::resolve_indexed_const(self.sema, symbol, root_file)? {
                 self.sema.record_named_const_dependency(
                     super::NamedConstDependencyTargetEvent::ValueConst {
                         file: root_file.index(),
@@ -2492,11 +2480,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         if let Some(binding) = self.module_binding(&(file_id, name)) {
             return Ok(Some(binding.clone()));
         }
-        if !self.declaration_binding_active {
-            return Ok(None);
-        }
-
-        self.try_resolve_indexed_const_during_binding(name, file_id)?;
+        D::resolve_indexed_const(self, name, file_id)?;
         Ok(self.module_binding(&(file_id, name)).cloned())
     }
 


### PR DESCRIPTION
## Summary

- route indexed-constant and free-function-signature recovery through the existing declaration-phase extension points
- make mutable recovery binding-only while frozen source declarations treat misses as authoritative
- add a structural guard that keeps type syntax from reaching into declaration-binding internals

This is a production-used phase-boundary hardening slice. It does not extract or generalize the concrete Sema type-syntax provider, and the owned body evaluator remains follow-up work.

Refs RUE-1092.

## Validation

- scripts/rue fmt
- scripts/rue unit air (634 passed)
- scripts/rue quick
- scripts/rue test (64 lightweight targets; 1670 CLI; 2175 spec; 209 UI; generated oracle 64/64; frontend differential 1443/1443; reproducibility)
- git diff --check