### PR TITLE
Extract an immutable body semantic base

### DIFF
--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -11,7 +11,7 @@ use rue_rir::{InstData, InstRef, RirParamMode};
 use rue_span::{FileId, Span};
 
 use super::RirDeclarationIndexWork;
-use super::{ConstValue, Sema, SemaOutput};
+use super::{BodySemanticBase, ConstValue, Sema, SemaOutput};
 use crate::types::{
     ArrayLen, PtrMutability, Type, TypeKind, parse_array_type_syntax, parse_pointer_type_syntax,
 };
@@ -388,16 +388,21 @@ impl SemanticBindingManifest {
 ///
 pub struct BoundSema<'a> {
     pub(super) sema: super::BodySema<'a>,
+    /// Installed exactly once at the declaration/body boundary. It contains
+    /// immutable data only; a derived body receives a new analyzer assembled
+    /// from it and fresh local overlays.
+    pub(super) body_base: Option<Arc<BodySemanticBase<'a>>>,
     manifest: OnceLock<SemanticBindingManifest>,
     binding_work: DeclarationBindingWork,
 }
 
-impl<'a> Clone for BoundSema<'a> {
-    fn clone(&self) -> Self {
+impl<'a> BoundSema<'a> {
+    pub(super) fn derive_from_body_base(&self, base: Arc<BodySemanticBase<'a>>) -> Self {
         Self {
-            sema: self.sema.clone(),
+            sema: super::BodySema::derive_from_body_semantic_base(&base),
+            body_base: Some(base),
             manifest: self.manifest.clone(),
-            binding_work: self.binding_work.clone(),
+            binding_work: self.binding_work,
         }
     }
 }
@@ -3871,6 +3876,7 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
         BoundSema {
             binding_work,
             sema: self.freeze_declarations(),
+            body_base: None,
             manifest: OnceLock::new(),
         }
     }

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -124,6 +124,7 @@ mod tests {
     const AGGREGATE_RESOLUTION_SOURCE: &str = include_str!("aggregate_resolution.rs");
     const INFERENCE_CONTEXT_SOURCE: &str = include_str!("inference_ctx.rs");
     const TYPECK_SOURCE: &str = include_str!("typeck.rs");
+    const DECLARATION_BASE_SOURCE: &str = include_str!("declaration_base.rs");
     const CALL_INTRINSIC_PEER_SOURCE: &str = concat!(
         include_str!("mod.rs"),
         include_str!("aggregates.rs"),
@@ -246,6 +247,60 @@ mod tests {
             "InstData variant handling mismatch between constraint generation and AIR emission:\n{}",
             errors.join("\n")
         );
+    }
+
+    #[test]
+    fn body_epoch_derivation_has_a_data_only_base_and_fresh_local_overlays() {
+        let base = SEMA_ROOT_SOURCE
+            .split("pub(super) struct BodySemanticBase")
+            .nth(1)
+            .and_then(|source| source.split("/// The declaration-time portion").next())
+            .expect("BodySemanticBase definition is present");
+        for forbidden in ["Sema<", "Sema::", "&Sema", "BodySema", "BoundSema", "Deref"] {
+            assert!(
+                !base.contains(forbidden),
+                "BodySemanticBase must be data-only, not retain {forbidden}"
+            );
+        }
+
+        let local = SEMA_ROOT_SOURCE
+            .split("struct BodyLocalSeed")
+            .nth(1)
+            .and_then(|source| source.split("/// Semantic analyzer").next())
+            .expect("BodyLocalSeed definition is present");
+        for forbidden in ["Sema<", "Sema::", "&Sema", "BodySema", "BoundSema", "Deref"] {
+            assert!(
+                !local.contains(forbidden),
+                "BodyLocalSeed must be data-only, not retain {forbidden}"
+            );
+        }
+
+        let derive = DECLARATION_BASE_SOURCE
+            .split("pub fn derive_body_epoch")
+            .nth(1)
+            .and_then(|source| source.split("/// Type-pool entries").next())
+            .expect("body derivation is present");
+        assert!(derive.contains("body_base"));
+        assert!(derive.contains("derive_from_body_base"));
+        assert!(!derive.contains("self.clone()"));
+        assert!(!SEMA_ROOT_SOURCE.contains("impl<'a, D> Clone for Sema"));
+        assert!(!include_str!("binding_manifest.rs").contains("Clone for BoundSema"));
+
+        let construction = SEMA_ROOT_SOURCE
+            .split("fn derive_from_body_semantic_base")
+            .nth(1)
+            .and_then(|source| {
+                source
+                    .split("impl<D: DeclarationPhase> std::ops::Deref")
+                    .next()
+            })
+            .expect("base construction is present");
+        assert!(construction.contains("type_pool: base.type_pool.derive_overlay()"));
+        assert!(construction.contains("param_arena: base.param_arena.derive_overlay()"));
+        assert!(construction.contains("body_analysis_work: BodyAnalysisWork::default()"));
+        assert!(construction.contains("body_named_dependencies: Vec::new()"));
+        assert!(DECLARATION_BASE_SOURCE.contains("+ local.deferred_ownership_gates.len()"));
+        assert!(DECLARATION_BASE_SOURCE.contains("forced_anonymous_digest_entries"));
     }
 
     #[test]

--- a/crates/rue-air/src/sema/declaration_base.rs
+++ b/crates/rue-air/src/sema/declaration_base.rs
@@ -41,7 +41,9 @@
 //! merely asserted: it reports what a derivation shared and what it copied, read
 //! from the derived containers themselves.
 
-use super::{BoundSema, DeclarationPhase, Sema};
+use std::sync::Arc;
+
+use super::BoundSema;
 
 /// Structural accounting for one epoch derivation (RUE-1135).
 ///
@@ -106,11 +108,11 @@ impl EpochDerivationUnits {
     }
 }
 
-impl<D: DeclarationPhase> Sema<'_, D> {
-    /// Per-family unit counts for one derivation of this epoch, read from the
-    /// live containers rather than from the inputs the epoch was built from.
+impl super::BodySemanticBase<'_> {
+    /// Per-family unit counts for one derivation, read from the immutable base
+    /// and its local seed rather than from a previously analyzed body epoch.
     fn derivation_unit_sizes(&self) -> EpochDerivationUnits {
-        let namespace = &**self;
+        let namespace = &*self.declarations;
         let declaration_namespace_entries_shared = namespace.functions.len()
             + namespace.functions_by_file_name.len()
             + namespace.function_source_names.len()
@@ -120,7 +122,11 @@ impl<D: DeclarationPhase> Sema<'_, D> {
             + namespace.enums_by_file_name.len()
             + namespace.methods.len()
             + namespace.named_method_declarations.len()
-            + namespace.const_resolutions.len();
+            + namespace.const_resolutions.len()
+            // The callable-symbol reversal is built while declarations are
+            // mutable, then frozen in the base alongside the source namespace.
+            // It is an Arc in derived epochs, never a per-body map clone.
+            + self.named_callable_methods_by_symbol.len();
         let endpoint_entries_shared = self.stable_definition_tokens.len()
             + self.stable_definition_endpoints.len()
             + self.const_candidate_tokens.len()
@@ -131,25 +137,31 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         // The per-body owned state a derivation really does copy. Anonymous
         // nominal identity maps and generated-name overlays dominate it; it is
         // sized by the epoch's anonymous universe, not by its declarations.
-        let body_local_entries_copied = self.anonymous_methods.len()
-            + self.named_callable_methods_by_symbol.len()
-            + self.anonymous_callable_methods_by_symbol.len()
-            + self.generated_structs.len()
-            + self.generated_enums.len()
-            + self.anon_struct_identities.len()
-            + self.anon_enum_identities.len()
-            + self.anonymous_digest_owners.len()
-            + self.anonymous_struct_ids.len()
-            + self.anonymous_enum_ids.len()
-            + self.canonical_anonymous_types.len()
-            + self.anon_struct_method_sigs.len()
-            + self.anon_struct_captured_values.len()
-            + self.anon_struct_type_subst.len()
-            + self.destructor_spans.len()
-            + self.infectious_linear.len()
-            + self.ctor_type_displays.len()
-            + self.well_known_option_by_payload.len()
-            + self.well_known_option_identities.len();
+        let local = &self.local_seed;
+        #[cfg(test)]
+        let forced_anonymous_digest_entries = local.forced_anonymous_digests.len();
+        #[cfg(not(test))]
+        let forced_anonymous_digest_entries = 0;
+        let body_local_entries_copied = local.anonymous_methods.len()
+            + local.anonymous_callable_methods_by_symbol.len()
+            + local.generated_structs.len()
+            + local.generated_enums.len()
+            + local.anon_struct_identities.len()
+            + local.anon_enum_identities.len()
+            + local.anonymous_digest_owners.len()
+            + local.anonymous_struct_ids.len()
+            + local.anonymous_enum_ids.len()
+            + local.canonical_anonymous_types.len()
+            + local.anon_struct_method_sigs.len()
+            + local.anon_struct_captured_values.len()
+            + local.anon_struct_type_subst.len()
+            + local.destructor_spans.len()
+            + local.infectious_linear.len()
+            + local.deferred_ownership_gates.len()
+            + local.ctor_type_displays.len()
+            + local.well_known_option_by_payload.len()
+            + local.well_known_option_identities.len()
+            + forced_anonymous_digest_entries;
         EpochDerivationUnits {
             bases_built: 0,
             epochs_derived: 1,
@@ -185,6 +197,7 @@ impl BoundSema<'_> {
     pub fn seal_as_declaration_base(&mut self) {
         self.sema.type_pool = self.sema.type_pool.derive_overlay();
         self.sema.param_arena = self.sema.param_arena.derive_overlay();
+        self.body_base = Some(Arc::new(self.sema.body_semantic_base()));
     }
 
     /// Derive one body-local epoch from this declaration base, charging what the
@@ -196,11 +209,12 @@ impl BoundSema<'_> {
     /// the two layered containers place every local write above the base's
     /// entries rather than into them.
     pub fn derive_body_epoch(&self, units: &mut EpochDerivationUnits) -> Self {
-        units.absorb(self.sema.derivation_unit_sizes());
-        let mut derived = self.clone();
-        derived.sema.type_pool = self.sema.type_pool.derive_overlay();
-        derived.sema.param_arena = self.sema.param_arena.derive_overlay();
-        derived
+        let base = self
+            .body_base
+            .as_ref()
+            .expect("a declaration base must be sealed before deriving a body epoch");
+        units.absorb(base.derivation_unit_sizes());
+        self.derive_from_body_base(base.clone())
     }
 
     /// Type-pool entries this epoch interned itself, excluding everything it

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -311,11 +311,78 @@ pub(crate) struct DeferredOwnershipGate {
     span: Span,
 }
 
+/// Frozen declaration/read state installed once for all body epochs of a
+/// request. It deliberately contains data, never an analyzer facade: body
+/// epochs are constructed from this base plus their own mutable overlay.
+pub(super) struct BodySemanticBase<'a> {
+    declarations: SourceDeclarations,
+    rir: &'a Rir,
+    interner: &'a ThreadedRodeo,
+    declaration_index: Arc<declaration_index::RirDeclarationIndex>,
+    bound_const_candidates: Option<Arc<declaration_index::BoundConstCandidateIndex>>,
+    synthetic_declaration_discovery: bool,
+    named_callable_methods_by_symbol: Arc<HashMap<String, Vec<(StructId, Spur)>>>,
+    stable_definition_tokens: Arc<
+        HashMap<
+            (u32, String, Option<String>, crate::StableDefinitionKind),
+            crate::SemanticDefinitionToken,
+        >,
+    >,
+    stable_definition_endpoints:
+        Arc<HashMap<crate::SemanticDefinitionToken, crate::SemanticDefinitionEndpoint>>,
+    const_candidate_tokens: Arc<HashMap<(u32, String), EpochLocalConstCandidateToken>>,
+    const_candidate_endpoints:
+        Arc<HashMap<EpochLocalConstCandidateToken, EpochLocalConstCandidateEndpoint>>,
+    stable_module_tokens: Arc<HashMap<FileId, crate::SemanticModuleToken>>,
+    stable_module_endpoints:
+        Arc<HashMap<crate::SemanticModuleToken, crate::SemanticModuleEndpoint>>,
+    body_owner_tokens: Arc<HashMap<(u32, String, Option<String>, BodyOwnerKind), BodyOwnerToken>>,
+    preview_features: PreviewFeatures,
+    target: Target,
+    builtin_arch_id: Option<EnumId>,
+    builtin_os_id: Option<EnumId>,
+    builtin_data_model_id: Option<EnumId>,
+    known: KnownSymbols,
+    type_pool: TypeInternPool,
+    module_registry: Arc<crate::module_registry::ModuleRegistry>,
+    canonical_imports: Option<Arc<crate::canonical_imports::CanonicalImportContext>>,
+    file_paths: Arc<HashMap<FileId, String>>,
+    symbol_paths: Arc<HashMap<FileId, String>>,
+    trusted_standard_library_files: Arc<HashSet<FileId>>,
+    root_file_id: Option<FileId>,
+    param_arena: ParamArena,
+    local_seed: BodyLocalSeed,
+}
+
+/// The declaration-time portion of a body-local overlay. Derivation copies
+/// only this anonymous/generated state; all ordinary declaration maps live in
+/// [`BodySemanticBase`].
+struct BodyLocalSeed {
+    anonymous_methods: HashMap<(StructId, Spur), MethodInfo>,
+    anonymous_callable_methods_by_symbol: HashMap<String, Vec<(StructId, Spur)>>,
+    generated_structs: HashMap<Spur, StructId>,
+    generated_enums: HashMap<Spur, EnumId>,
+    anon_struct_identities: HashMap<anon_structs::IssuedAnonymousNominalKey, StructId>,
+    anon_enum_identities: HashMap<anon_structs::IssuedAnonymousNominalKey, EnumId>,
+    anonymous_digest_owners: HashMap<u128, anon_structs::IssuedAnonymousNominalKey>,
+    #[cfg(test)]
+    forced_anonymous_digests: HashMap<anon_structs::IssuedAnonymousNominalKey, u128>,
+    anonymous_struct_ids: HashSet<StructId>,
+    anonymous_enum_ids: HashSet<EnumId>,
+    canonical_anonymous_types: HashMap<Type, anon_structs::IssuedAnonymousNominalKey>,
+    anon_struct_method_sigs: HashMap<StructId, Vec<AnonMethodSig>>,
+    anon_struct_captured_values: HashMap<StructId, HashMap<Spur, ConstValue>>,
+    anon_struct_type_subst: HashMap<StructId, HashMap<Spur, Type>>,
+    destructor_spans: HashMap<StructId, Span>,
+    infectious_linear: HashMap<StructId, (String, String)>,
+    deferred_ownership_gates: Vec<DeferredOwnershipGate>,
+    ctor_type_displays: HashMap<Type, String>,
+    well_known_option_by_payload: HashMap<Type, Type>,
+    well_known_option_identities:
+        std::collections::BTreeSet<anon_structs::IssuedAnonymousNominalKey>,
+}
+
 /// Semantic analyzer that converts RIR to AIR.
-///
-/// Cloning is confined to request-scoped body-epoch derivation. Immutable
-/// declaration data is shared by refcount; body-local mutable state is copied.
-///
 pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
     declarations: D,
     pub(crate) rir: &'a Rir,
@@ -346,7 +413,7 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
     /// named-first resolution precedence explicit even when their rendered
     /// symbols collide. Buckets retain collisions so ambiguity fails closed
     /// instead of depending on hash-map iteration order.
-    pub(crate) named_callable_methods_by_symbol: HashMap<String, Vec<(StructId, Spur)>>,
+    pub(crate) named_callable_methods_by_symbol: Arc<HashMap<String, Vec<(StructId, Spur)>>>,
     pub(crate) anonymous_callable_methods_by_symbol: HashMap<String, Vec<(StructId, Spur)>>,
     /// Body-created synthetic and anonymous type-name overlays.
     pub(crate) generated_structs: HashMap<Spur, StructId>,
@@ -573,103 +640,158 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
         std::collections::BTreeSet<anon_structs::IssuedAnonymousNominalKey>,
 }
 
-impl<'a, D> Clone for Sema<'a, D>
-where
-    D: DeclarationPhase + Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
+impl<'a> BodySema<'a> {
+    /// Freeze the immutable declaration/read universe used by every body
+    /// derived from this request. The base is data-only; construction of a
+    /// body epoch remains the sole responsibility of this production analyzer.
+    pub(super) fn body_semantic_base(&self) -> BodySemanticBase<'a> {
+        BodySemanticBase {
             declarations: self.declarations.clone(),
             rir: self.rir,
             interner: self.interner,
             declaration_index: self.declaration_index.clone(),
             bound_const_candidates: self.bound_const_candidates.clone(),
             synthetic_declaration_discovery: self.synthetic_declaration_discovery,
-            anonymous_methods: self.anonymous_methods.clone(),
             named_callable_methods_by_symbol: self.named_callable_methods_by_symbol.clone(),
-            anonymous_callable_methods_by_symbol: self.anonymous_callable_methods_by_symbol.clone(),
-            generated_structs: self.generated_structs.clone(),
-            generated_enums: self.generated_enums.clone(),
-            anon_struct_identities: self.anon_struct_identities.clone(),
-            anon_enum_identities: self.anon_enum_identities.clone(),
-            anonymous_digest_owners: self.anonymous_digest_owners.clone(),
-            #[cfg(test)]
-            forced_anonymous_digests: self.forced_anonymous_digests.clone(),
-            anonymous_struct_ids: self.anonymous_struct_ids.clone(),
-            anonymous_enum_ids: self.anonymous_enum_ids.clone(),
-            canonical_anonymous_types: self.canonical_anonymous_types.clone(),
-            active_anonymous_producer: self.active_anonymous_producer.clone(),
-            body_analysis_work: self.body_analysis_work.clone(),
-            analyzed_body_owners: self.analyzed_body_owners.clone(),
-            ordinary_body_exports: self.ordinary_body_exports.clone(),
-            specialized_body_exports: self.specialized_body_exports.clone(),
-            reusable_ordinary_bodies: self.reusable_ordinary_bodies.clone(),
-            reusable_specialized_bodies: self.reusable_specialized_bodies.clone(),
             stable_definition_tokens: self.stable_definition_tokens.clone(),
             stable_definition_endpoints: self.stable_definition_endpoints.clone(),
             const_candidate_tokens: self.const_candidate_tokens.clone(),
             const_candidate_endpoints: self.const_candidate_endpoints.clone(),
             stable_module_tokens: self.stable_module_tokens.clone(),
             stable_module_endpoints: self.stable_module_endpoints.clone(),
-            body_dependency_observer: self.body_dependency_observer.clone(),
             body_owner_tokens: self.body_owner_tokens.clone(),
-            body_named_dependencies: self.body_named_dependencies.clone(),
-            body_lookup_collector: self.body_lookup_collector.clone(),
-            one_body_error_recovery: self.one_body_error_recovery,
-            one_body_recovered_errors: self.one_body_recovered_errors.clone(),
-            one_body_inference_failure_incomplete: self.one_body_inference_failure_incomplete,
-            one_body_initial_anonymous_identities: self
-                .one_body_initial_anonymous_identities
-                .clone(),
-            one_body_requested_producer: self.one_body_requested_producer.clone(),
-            body_callable_dependencies: self.body_callable_dependencies.clone(),
-            body_specialization_dependencies: self.body_specialization_dependencies.clone(),
-            ordinary_free_function_dependencies: self.ordinary_free_function_dependencies.clone(),
-            specialized_free_function_origins: self.specialized_free_function_origins.clone(),
-            specialized_free_function_dependencies: self
-                .specialized_free_function_dependencies
-                .clone(),
-            named_method_dependencies: self.named_method_dependencies.clone(),
-            non_generic_named_method_dependencies_complete: self
-                .non_generic_named_method_dependencies_complete,
-            named_destructor_dependencies: self.named_destructor_dependencies.clone(),
-            declaration_type_dependencies: self.declaration_type_dependencies.clone(),
-            declaration_type_call_head_dependencies: self
-                .declaration_type_call_head_dependencies
-                .clone(),
-            declaration_builtin_type_call_head_dependencies: self
-                .declaration_builtin_type_call_head_dependencies
-                .clone(),
-            named_const_dependencies: self.named_const_dependencies.clone(),
-            named_const_dependency_source: self.named_const_dependency_source.clone(),
-            declaration_type_observer: self.declaration_type_observer.clone(),
-            const_resolution_in_progress: self.const_resolution_in_progress.clone(),
-            declaration_binding_active: self.declaration_binding_active,
             preview_features: self.preview_features.clone(),
             target: self.target.clone(),
             builtin_arch_id: self.builtin_arch_id,
             builtin_os_id: self.builtin_os_id,
             builtin_data_model_id: self.builtin_data_model_id,
             known: self.known.clone(),
-            type_pool: self.type_pool.clone(),
+            type_pool: self.type_pool.derive_overlay(),
             module_registry: self.module_registry.clone(),
             canonical_imports: self.canonical_imports.clone(),
             file_paths: self.file_paths.clone(),
             symbol_paths: self.symbol_paths.clone(),
             trusted_standard_library_files: self.trusted_standard_library_files.clone(),
             root_file_id: self.root_file_id,
-            param_arena: self.param_arena.clone(),
-            anon_struct_method_sigs: self.anon_struct_method_sigs.clone(),
-            anon_struct_captured_values: self.anon_struct_captured_values.clone(),
-            anon_struct_type_subst: self.anon_struct_type_subst.clone(),
-            destructor_spans: self.destructor_spans.clone(),
-            infectious_linear: self.infectious_linear.clone(),
-            deferred_ownership_gates: self.deferred_ownership_gates.clone(),
-            comptime_type_call_depth: self.comptime_type_call_depth,
-            fn_signatures_in_flight: self.fn_signatures_in_flight.clone(),
-            ctor_type_displays: self.ctor_type_displays.clone(),
-            well_known_option_by_payload: self.well_known_option_by_payload.clone(),
-            well_known_option_identities: self.well_known_option_identities.clone(),
+            param_arena: self.param_arena.derive_overlay(),
+            local_seed: BodyLocalSeed {
+                anonymous_methods: self.anonymous_methods.clone(),
+                anonymous_callable_methods_by_symbol: self
+                    .anonymous_callable_methods_by_symbol
+                    .clone(),
+                generated_structs: self.generated_structs.clone(),
+                generated_enums: self.generated_enums.clone(),
+                anon_struct_identities: self.anon_struct_identities.clone(),
+                anon_enum_identities: self.anon_enum_identities.clone(),
+                anonymous_digest_owners: self.anonymous_digest_owners.clone(),
+                #[cfg(test)]
+                forced_anonymous_digests: self.forced_anonymous_digests.clone(),
+                anonymous_struct_ids: self.anonymous_struct_ids.clone(),
+                anonymous_enum_ids: self.anonymous_enum_ids.clone(),
+                canonical_anonymous_types: self.canonical_anonymous_types.clone(),
+                anon_struct_method_sigs: self.anon_struct_method_sigs.clone(),
+                anon_struct_captured_values: self.anon_struct_captured_values.clone(),
+                anon_struct_type_subst: self.anon_struct_type_subst.clone(),
+                destructor_spans: self.destructor_spans.clone(),
+                infectious_linear: self.infectious_linear.clone(),
+                deferred_ownership_gates: self.deferred_ownership_gates.clone(),
+                ctor_type_displays: self.ctor_type_displays.clone(),
+                well_known_option_by_payload: self.well_known_option_by_payload.clone(),
+                well_known_option_identities: self.well_known_option_identities.clone(),
+            },
+        }
+    }
+
+    /// Build one independent ordinary body epoch from immutable base data and
+    /// freshly owned body-local state. This intentionally does not clone a
+    /// `Sema` or delegate construction through one.
+    pub(super) fn derive_from_body_semantic_base(base: &BodySemanticBase<'a>) -> Self {
+        let local = &base.local_seed;
+        Self {
+            declarations: base.declarations.clone(),
+            rir: base.rir,
+            interner: base.interner,
+            declaration_index: base.declaration_index.clone(),
+            bound_const_candidates: base.bound_const_candidates.clone(),
+            synthetic_declaration_discovery: base.synthetic_declaration_discovery,
+            anonymous_methods: local.anonymous_methods.clone(),
+            named_callable_methods_by_symbol: base.named_callable_methods_by_symbol.clone(),
+            anonymous_callable_methods_by_symbol: local
+                .anonymous_callable_methods_by_symbol
+                .clone(),
+            generated_structs: local.generated_structs.clone(),
+            generated_enums: local.generated_enums.clone(),
+            anon_struct_identities: local.anon_struct_identities.clone(),
+            anon_enum_identities: local.anon_enum_identities.clone(),
+            anonymous_digest_owners: local.anonymous_digest_owners.clone(),
+            #[cfg(test)]
+            forced_anonymous_digests: local.forced_anonymous_digests.clone(),
+            anonymous_struct_ids: local.anonymous_struct_ids.clone(),
+            anonymous_enum_ids: local.anonymous_enum_ids.clone(),
+            canonical_anonymous_types: local.canonical_anonymous_types.clone(),
+            active_anonymous_producer: None,
+            body_analysis_work: BodyAnalysisWork::default(),
+            analyzed_body_owners: Vec::new(),
+            ordinary_body_exports: Vec::new(),
+            specialized_body_exports: Vec::new(),
+            reusable_ordinary_bodies: HashMap::new(),
+            reusable_specialized_bodies: Vec::new(),
+            stable_definition_tokens: base.stable_definition_tokens.clone(),
+            stable_definition_endpoints: base.stable_definition_endpoints.clone(),
+            const_candidate_tokens: base.const_candidate_tokens.clone(),
+            const_candidate_endpoints: base.const_candidate_endpoints.clone(),
+            stable_module_tokens: base.stable_module_tokens.clone(),
+            stable_module_endpoints: base.stable_module_endpoints.clone(),
+            body_dependency_observer: None,
+            body_owner_tokens: base.body_owner_tokens.clone(),
+            body_named_dependencies: Vec::new(),
+            body_lookup_collector: None,
+            one_body_error_recovery: false,
+            one_body_recovered_errors: Vec::new(),
+            one_body_inference_failure_incomplete: false,
+            one_body_initial_anonymous_identities: std::collections::BTreeSet::new(),
+            one_body_requested_producer: None,
+            body_callable_dependencies: Vec::new(),
+            body_specialization_dependencies: Vec::new(),
+            ordinary_free_function_dependencies: Vec::new(),
+            specialized_free_function_origins: Vec::new(),
+            specialized_free_function_dependencies: Vec::new(),
+            named_method_dependencies: Vec::new(),
+            non_generic_named_method_dependencies_complete: false,
+            named_destructor_dependencies: Vec::new(),
+            declaration_type_dependencies: Vec::new(),
+            declaration_type_call_head_dependencies: Vec::new(),
+            declaration_builtin_type_call_head_dependencies: Vec::new(),
+            named_const_dependencies: Vec::new(),
+            named_const_dependency_source: None,
+            declaration_type_observer: None,
+            const_resolution_in_progress: Vec::new(),
+            declaration_binding_active: false,
+            preview_features: base.preview_features.clone(),
+            target: base.target.clone(),
+            builtin_arch_id: base.builtin_arch_id,
+            builtin_os_id: base.builtin_os_id,
+            builtin_data_model_id: base.builtin_data_model_id,
+            known: base.known.clone(),
+            type_pool: base.type_pool.derive_overlay(),
+            module_registry: base.module_registry.clone(),
+            canonical_imports: base.canonical_imports.clone(),
+            file_paths: base.file_paths.clone(),
+            symbol_paths: base.symbol_paths.clone(),
+            trusted_standard_library_files: base.trusted_standard_library_files.clone(),
+            root_file_id: base.root_file_id,
+            param_arena: base.param_arena.derive_overlay(),
+            anon_struct_method_sigs: local.anon_struct_method_sigs.clone(),
+            anon_struct_captured_values: local.anon_struct_captured_values.clone(),
+            anon_struct_type_subst: local.anon_struct_type_subst.clone(),
+            destructor_spans: local.destructor_spans.clone(),
+            infectious_linear: local.infectious_linear.clone(),
+            deferred_ownership_gates: local.deferred_ownership_gates.clone(),
+            comptime_type_call_depth: 0,
+            fn_signatures_in_flight: HashSet::new(),
+            ctor_type_displays: local.ctor_type_displays.clone(),
+            well_known_option_by_payload: local.well_known_option_by_payload.clone(),
+            well_known_option_identities: local.well_known_option_identities.clone(),
         }
     }
 }
@@ -958,17 +1080,21 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             .iter()
             .map(|(&(struct_id, method_name), info)| (struct_id, method_name, info.has_self))
             .collect::<Vec<_>>();
-        self.named_callable_methods_by_symbol.clear();
-        self.named_callable_methods_by_symbol
-            .reserve(named_methods.len());
-        for (struct_id, method_name, has_self) in named_methods {
-            let symbol =
-                self.method_symbol(struct_id, self.interner.resolve(&method_name), has_self);
-            Self::insert_callable_method_candidate(
-                &mut self.named_callable_methods_by_symbol,
-                symbol,
-                (struct_id, method_name),
-            );
+        let named_symbols = named_methods
+            .iter()
+            .map(|&(struct_id, method_name, has_self)| {
+                (
+                    self.method_symbol(struct_id, self.interner.resolve(&method_name), has_self),
+                    (struct_id, method_name),
+                )
+            })
+            .collect::<Vec<_>>();
+        let named_callable_methods_by_symbol =
+            Arc::make_mut(&mut self.named_callable_methods_by_symbol);
+        named_callable_methods_by_symbol.clear();
+        named_callable_methods_by_symbol.reserve(named_methods.len());
+        for (symbol, key) in named_symbols {
+            Self::insert_callable_method_candidate(named_callable_methods_by_symbol, symbol, key);
         }
         self.anonymous_callable_methods_by_symbol.clear();
         self.anonymous_callable_methods_by_symbol
@@ -1352,7 +1478,7 @@ impl<'a> Sema<'a, MutableDeclarations> {
             bound_const_candidates: None,
             synthetic_declaration_discovery: false,
             anonymous_methods: HashMap::new(),
-            named_callable_methods_by_symbol: HashMap::new(),
+            named_callable_methods_by_symbol: Arc::new(HashMap::new()),
             anonymous_callable_methods_by_symbol: HashMap::new(),
             generated_structs: HashMap::new(),
             generated_enums: HashMap::new(),

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -5,7 +5,7 @@ mod tests {
 
     use crate::ConstValue;
     use crate::inst::{AirArgMode, AirInstData, AirRef};
-    use crate::sema::{Sema, SemaOutput};
+    use crate::sema::{BodySema, Sema, SemaOutput};
     use crate::types::{StructId, Type};
     use lasso::ThreadedRodeo;
     use rue_error::{
@@ -134,23 +134,24 @@ mod tests {
     }
 
     #[test]
-    fn body_epoch_clone_shares_canonical_import_context() {
+    fn body_epoch_base_derivation_shares_canonical_import_context() {
         let sema = gather_two_file_declarations_for_testing(
             "const dep = @import(\"dep.rue\"); fn main() -> i32 { dep.value() }",
             "pub fn value() -> i32 { 1 }",
         )
         .freeze_declarations();
-        let cloned = sema.clone();
+        let base = sema.body_semantic_base();
+        let derived = BodySema::derive_from_body_semantic_base(&base);
         let original = sema
             .canonical_imports
             .as_ref()
             .expect("the two-file fixture installs canonical imports");
-        let cloned = cloned
+        let derived = derived
             .canonical_imports
             .as_ref()
-            .expect("cloning preserves canonical imports");
+            .expect("base derivation preserves canonical imports");
         assert!(
-            Arc::ptr_eq(original, cloned),
+            Arc::ptr_eq(original, derived),
             "body-epoch derivation must share, not copy, the import maps"
         );
         assert!(
@@ -2867,7 +2868,7 @@ mod tests {
         let anonymous = (StructId(u32::MAX - 1), method);
         let symbol = "__anon_struct_5.f".to_string();
         Sema::<crate::sema::MutableDeclarations>::insert_callable_method_candidate(
-            &mut sema.named_callable_methods_by_symbol,
+            Arc::make_mut(&mut sema.named_callable_methods_by_symbol),
             symbol.clone(),
             named,
         );


### PR DESCRIPTION
## Summary

- install a data-only immutable semantic base at the declaration/body boundary
- derive each body epoch with fresh mutable work, results, errors, dependencies, observers, recursion state, and type/parameter overlays
- remove full `Sema` and `BoundSema` cloning from production body derivation
- share the frozen named-callable index and account for every copied local-state family

An independent architectural review found an omitted metric charge for deferred ownership gates and the test-only anonymous digest hook; both are now counted and structurally guarded.

This is a prerequisite slice. Body analysis still reconstructs `BodySema` from the base; a later PR can move the evaluator onto a smaller owned body state without retaining the full analyzer.

## Validation

- `scripts/rue fmt`
- focused body-base growth and order-independence tests
- `scripts/rue unit air` (636 passed)
- `scripts/rue quick`
- `scripts/rue test` (full suite passed)

Refs RUE-1092.