### PR TITLE
Narrow body declaration classification

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -101,6 +101,74 @@ const RUE_868_RAW_FACADE_VOCABULARY: &[&str] = &[
     "StackFrameInfo",
 ];
 
+fn source_between_exact_boundaries<'a>(source: &'a str, start: &str, next: &str) -> &'a str {
+    let start = source.find(start).expect("source boundary starts");
+    let tail = &source[start..];
+    let end = tail.find(next).expect("source boundary ends");
+    &tail[..end]
+}
+
+#[test]
+fn exact_source_boundaries_ignore_braces_in_comments_and_strings() {
+    let fixture = r#"
+    fn selected() {
+        let _ = "}";
+        // }}} must not truncate the selected method
+        observed();
+    }
+
+    fn next() {}
+"#;
+    let selected = source_between_exact_boundaries(fixture, "    fn selected()", "\n    fn next()");
+    assert!(selected.contains("observed();"));
+    assert!(!selected.contains("fn next"));
+}
+
+#[test]
+fn body_transaction_has_no_complete_declaration_candidate_map() {
+    let runtime = include_str!("revisioned_query_database.rs");
+    let method = source_between_exact_boundaries(
+        runtime,
+        "    pub(crate) fn body_transaction(",
+        "\n    pub(crate) fn canonical_body_projection(",
+    );
+    assert!(
+        !method.contains("declaration_candidates"),
+        "body_transaction must not regain the coordinator's complete candidate map"
+    );
+    let compact = method
+        .chars()
+        .filter(|ch| !ch.is_whitespace())
+        .collect::<String>();
+    assert!(
+        !compact.contains(
+            "Arc<BTreeMap<crate::StableDefinitionKey,crate::declaration_candidate::DeclarationCandidateKey>>"
+        ),
+        "body_transaction must derive exact shell candidates from stable keys"
+    );
+    for required in [
+        "&self.stable_declaration_classifications",
+        "StableDeclarationClassificationQueryValue::Selected",
+        "&self.declaration_shells",
+        "DeclarationShellQueryValue::Available",
+    ] {
+        assert!(
+            method.contains(required),
+            "body_transaction lost candidate-set shell classification: {required}"
+        );
+    }
+    for forbidden in [
+        "declaration_occurrence_indexes",
+        "DeclarationOccurrenceIndex",
+        "stable_syntax_candidate_set",
+    ] {
+        assert!(
+            !method.contains(forbidden),
+            "body_transaction bypassed the narrow stable classifier: {forbidden}"
+        );
+    }
+}
+
 const RUE_869_INTERNAL_ROOT_VOCABULARY: &[&str] = &[
     "BoundDefinitionId",
     "BoundDefinitionRecord",

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -471,6 +471,10 @@ pub(crate) struct RevisionedQueryDatabase {
     module_indexes: QueryFamily<ModuleQueryKey, ModuleIndexValue>,
     declaration_occurrence_indexes: QueryFamily<ModuleQueryKey, DeclarationOccurrenceIndexValue>,
     declaration_shells: QueryFamily<DeclarationShellQueryKey, DeclarationShellQueryValue>,
+    stable_declaration_classifications: QueryFamily<
+        StableDeclarationClassificationQueryKey,
+        StableDeclarationClassificationQueryValue,
+    >,
     #[cfg(test)]
     raw_const_syntax: QueryFamily<RawConstSyntaxQueryKey, RawConstSyntaxQueryValue>,
     #[cfg(test)]
@@ -867,6 +871,51 @@ impl QueryKey for DeclarationShellQueryKey {
 enum DeclarationShellQueryValue {
     Available(crate::declaration_candidate::DeclarationShellFact),
     Failure(crate::declaration_candidate::DeclarationShellFailure),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct StableDeclarationClassificationQueryKey(crate::StableDefinitionKey);
+
+impl QueryKey for StableDeclarationClassificationQueryKey {
+    fn stable_identity(&self) -> String {
+        let owner = self.0.owner().map_or_else(
+            || "-".to_owned(),
+            |owner| format!("{:?}:{}:{}", owner.kind(), owner.name().len(), owner.name()),
+        );
+        format!(
+            "{}:{}:{:?}:{:?}:{}:{}:{}",
+            self.0.module().as_str().len(),
+            self.0.module().as_str(),
+            self.0.namespace(),
+            self.0.kind(),
+            self.0.name().len(),
+            self.0.name(),
+            owner,
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StableDeclarationClassificationQueryValue {
+    Selected(crate::declaration_candidate::DeclarationCandidateKey),
+    Absent,
+    Invalid(StableDeclarationClassificationFailure),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StableDeclarationClassificationFailure {
+    MalformedStableKey(crate::StableDefinitionKey),
+    OccurrencesUnavailable(crate::declaration_candidate::DeclarationOccurrenceFailure),
+    Ambiguous(crate::declaration_candidate::DeclarationCandidateKey),
+    DuplicateMultiplicity {
+        key: crate::declaration_candidate::DeclarationCandidateKey,
+        multiplicity: u32,
+    },
+    ParserCapabilityMismatch(crate::declaration_candidate::DeclarationCandidateKey),
+    MultipleAvailable {
+        first: crate::declaration_candidate::DeclarationCandidateKey,
+        second: crate::declaration_candidate::DeclarationCandidateKey,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1976,19 +2025,25 @@ fn body_source_definition_key(
 fn declaration_candidate_for_stable_key(
     key: &StableDefinitionKey,
 ) -> Option<crate::declaration_candidate::DeclarationCandidateKey> {
+    stable_syntax_candidate_set(key)?[0].clone()
+}
+
+fn stable_syntax_candidate_set(
+    key: &StableDefinitionKey,
+) -> Option<[Option<crate::declaration_candidate::DeclarationCandidateKey>; 2]> {
     use crate::StableDefinitionKind as K;
     use crate::declaration_candidate::{
         DeclarationCandidateCategory as C, DeclarationCandidateOwner,
     };
 
-    let category = match key.kind() {
-        K::Function => C::Function,
-        K::Struct => C::Struct,
-        K::Enum => C::Enum,
-        K::ValueConst | K::ModuleBinding => C::ConstCandidate,
-        K::Method => C::Method,
-        K::AssociatedFunction => C::AssociatedFunction,
-        K::Destructor => C::Destructor,
+    let categories = match key.kind() {
+        K::Function => [Some(C::Function), Some(C::ExternFunction)],
+        K::Struct => [Some(C::Struct), None],
+        K::Enum => [Some(C::Enum), None],
+        K::ValueConst | K::ModuleBinding => [Some(C::ConstCandidate), None],
+        K::Method => [Some(C::Method), None],
+        K::AssociatedFunction => [Some(C::AssociatedFunction), None],
+        K::Destructor => [Some(C::Destructor), None],
     };
     let owner = match key.owner() {
         Some(owner) => Some(DeclarationCandidateOwner {
@@ -2004,13 +2059,17 @@ fn declaration_candidate_for_stable_key(
     if key.kind().requires_owner() && owner.is_none() {
         return None;
     }
-    Some(crate::declaration_candidate::DeclarationCandidateKey {
-        module: key.module().clone(),
-        category,
-        name: Arc::from(key.name()),
-        owner,
-        duplicate_discriminator: 0,
-    })
+    Some(categories.map(|category| {
+        category.map(
+            |category| crate::declaration_candidate::DeclarationCandidateKey {
+                module: key.module().clone(),
+                category,
+                name: Arc::from(key.name()),
+                owner: owner.clone(),
+                duplicate_discriminator: 0,
+            },
+        )
+    }))
 }
 
 fn anonymous_nominal_query_key(
@@ -6523,6 +6582,159 @@ impl RevisionedQueryDatabase {
                 },
             )
             .expect("the DeclarationShell family has one canonical name");
+        let occurrences_for_stable_classification = declaration_occurrence_indexes.clone();
+        let shells_for_stable_classification = declaration_shells.clone();
+        let stable_declaration_classifications = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.stable-declaration-classification",
+                declaration_memo_retention,
+                |left: &StableDeclarationClassificationQueryValue,
+                 right: &StableDeclarationClassificationQueryValue| left == right,
+                move |context, _, key: &StableDeclarationClassificationQueryKey| {
+                    use crate::declaration_candidate::{
+                        DeclarationOccurrenceCapability, DeclarationShellFailure,
+                    };
+
+                    let Some(candidates) = stable_syntax_candidate_set(&key.0) else {
+                        return Ok(QueryOutput::success(
+                            StableDeclarationClassificationQueryValue::Invalid(
+                                StableDeclarationClassificationFailure::MalformedStableKey(
+                                    key.0.clone(),
+                                ),
+                            ),
+                        )
+                        .with_terminal_kind(QueryTerminalKind::Failure));
+                    };
+                    let indexed = context.query_registered(
+                        &occurrences_for_stable_classification,
+                        ModuleQueryKey(key.0.module().clone()),
+                    )?;
+                    let rue_query::QueryOutcome::Success(indexed) = indexed.outcome() else {
+                        unreachable!("DeclarationOccurrenceIndex publishes typed values")
+                    };
+                    let value = match indexed {
+                        DeclarationOccurrenceIndexValue::Failure(failure) => {
+                            StableDeclarationClassificationQueryValue::Invalid(
+                                StableDeclarationClassificationFailure::OccurrencesUnavailable(
+                                    failure.clone(),
+                                ),
+                            )
+                        }
+                        DeclarationOccurrenceIndexValue::Available(index) => {
+                            let mut selected = None;
+                            let mut invalid = None;
+                            for candidate in candidates.into_iter().flatten() {
+                                match index.capabilities.get(&candidate) {
+                                    None => {}
+                                    Some(DeclarationOccurrenceCapability::Ambiguous { .. }) => {
+                                        invalid.get_or_insert_with(|| {
+                                            StableDeclarationClassificationFailure::Ambiguous(
+                                                candidate,
+                                            )
+                                        });
+                                    }
+                                    Some(DeclarationOccurrenceCapability::Exact {
+                                        duplicate_multiplicity,
+                                        ..
+                                    }) if *duplicate_multiplicity != 1 => {
+                                        invalid.get_or_insert_with(|| {
+                                            StableDeclarationClassificationFailure::DuplicateMultiplicity {
+                                                key: candidate,
+                                                multiplicity: *duplicate_multiplicity,
+                                            }
+                                        });
+                                    }
+                                    Some(DeclarationOccurrenceCapability::Exact { .. }) => {
+                                        let shell = context.query_registered(
+                                            &shells_for_stable_classification,
+                                            DeclarationShellQueryKey(candidate.clone()),
+                                        )?;
+                                        let rue_query::QueryOutcome::Success(shell) =
+                                            shell.outcome()
+                                        else {
+                                            unreachable!(
+                                                "DeclarationShell publishes typed values"
+                                            )
+                                        };
+                                        match shell {
+                                            DeclarationShellQueryValue::Available(fact)
+                                                if fact.key == candidate =>
+                                            {
+                                                if let Some(first) =
+                                                    selected.replace(candidate.clone())
+                                                {
+                                                    invalid.get_or_insert(
+                                                        StableDeclarationClassificationFailure::MultipleAvailable {
+                                                            first,
+                                                            second: candidate,
+                                                        },
+                                                    );
+                                                }
+                                            }
+                                            DeclarationShellQueryValue::Available(_) => {
+                                                invalid.get_or_insert(
+                                                    StableDeclarationClassificationFailure::ParserCapabilityMismatch(
+                                                        candidate,
+                                                    ),
+                                                );
+                                            }
+                                            DeclarationShellQueryValue::Failure(
+                                                DeclarationShellFailure::OccurrencesUnavailable(
+                                                    failure,
+                                                ),
+                                            ) => {
+                                                invalid.get_or_insert(
+                                                    StableDeclarationClassificationFailure::OccurrencesUnavailable(
+                                                        failure.clone(),
+                                                    ),
+                                                );
+                                            }
+                                            DeclarationShellQueryValue::Failure(
+                                                DeclarationShellFailure::Ambiguous(_),
+                                            ) => {
+                                                invalid.get_or_insert(
+                                                    StableDeclarationClassificationFailure::Ambiguous(
+                                                        candidate,
+                                                    ),
+                                                );
+                                            }
+                                            DeclarationShellQueryValue::Failure(
+                                                DeclarationShellFailure::Absent(_)
+                                                | DeclarationShellFailure::ParserCapabilityMismatch(
+                                                    _,
+                                                ),
+                                            ) => {
+                                                invalid.get_or_insert(
+                                                    StableDeclarationClassificationFailure::ParserCapabilityMismatch(
+                                                        candidate,
+                                                    ),
+                                                );
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            if let Some(failure) = invalid {
+                                StableDeclarationClassificationQueryValue::Invalid(failure)
+                            } else if let Some(candidate) = selected {
+                                StableDeclarationClassificationQueryValue::Selected(candidate)
+                            } else {
+                                StableDeclarationClassificationQueryValue::Absent
+                            }
+                        }
+                    };
+                    let kind = if matches!(
+                        value,
+                        StableDeclarationClassificationQueryValue::Invalid(_)
+                    ) {
+                        QueryTerminalKind::Failure
+                    } else {
+                        QueryTerminalKind::Success
+                    };
+                    Ok(QueryOutput::success(value).with_terminal_kind(kind))
+                },
+            )
+            .expect("the StableDeclarationClassification family has one canonical name");
         let occurrences_for_raw_const = declaration_occurrence_indexes.clone();
         let shells_for_raw_const = declaration_shells.clone();
         let parse_for_raw_const = parse_modules.clone();
@@ -8883,6 +9095,7 @@ impl RevisionedQueryDatabase {
             module_indexes,
             declaration_occurrence_indexes,
             declaration_shells,
+            stable_declaration_classifications,
             #[cfg(test)]
             raw_const_syntax,
             #[cfg(test)]
@@ -9288,12 +9501,6 @@ impl RevisionedQueryDatabase {
         &self,
         revision: Revision,
         key: crate::body_query::BodyQueryKey,
-        declaration_candidates: Arc<
-            BTreeMap<
-                crate::StableDefinitionKey,
-                crate::declaration_candidate::DeclarationCandidateKey,
-            >,
-        >,
         producer_body_terminal_required: bool,
         well_known_demands: Arc<[crate::body_query::WellKnownOptionDemand]>,
         cancellation: CancellationToken,
@@ -9653,33 +9860,40 @@ impl RevisionedQueryDatabase {
                 // negative and qualified lookup inputs.
                 for definition in semantic_dependencies {
                     // Synthetic builtins have stable semantic identities but
-                    // no source declaration candidate. Their semantics are
-                    // fixed by the compiler build and the target/preview
+                    // no available source declaration shell. Their semantics
+                    // are fixed by the compiler build and the target/preview
                     // configuration already carried by the body key.
-                    let candidate = declaration_candidates.get(&definition).or_else(|| {
-                        matches!(
-                            definition.kind(),
-                            crate::StableDefinitionKind::ValueConst
-                                | crate::StableDefinitionKind::ModuleBinding
-                        )
-                        .then(|| {
-                            declaration_candidates.iter().find_map(|(candidate, value)| {
-                                (candidate.module() == definition.module()
-                                    && candidate.name() == definition.name()
-                                    && candidate.owner() == definition.owner()
-                                    && matches!(
-                                        candidate.kind(),
-                                        crate::StableDefinitionKind::ValueConst
-                                            | crate::StableDefinitionKind::ModuleBinding
-                                    ))
-                                .then_some(value)
-                            })
-                        })
-                        .flatten()
-                    });
-                    let Some(candidate) = candidate.cloned() else {
-                        continue;
+                    let classification = context.query_registered(
+                        &self.stable_declaration_classifications,
+                        StableDeclarationClassificationQueryKey(definition),
+                    )?;
+                    let rue_query::QueryOutcome::Success(classification) =
+                        classification.outcome()
+                    else {
+                        unreachable!("StableDeclarationClassification publishes typed values")
                     };
+                    let candidate = match classification {
+                        StableDeclarationClassificationQueryValue::Selected(candidate) => {
+                            candidate.clone()
+                        }
+                        StableDeclarationClassificationQueryValue::Absent => continue,
+                        StableDeclarationClassificationQueryValue::Invalid(_) => {
+                            return Err(QueryAbort::Canceled);
+                        }
+                    };
+                    let shell = context.query_registered(
+                        &self.declaration_shells,
+                        DeclarationShellQueryKey(candidate.clone()),
+                    )?;
+                    let rue_query::QueryOutcome::Success(
+                        DeclarationShellQueryValue::Available(shell),
+                    ) = shell.outcome()
+                    else {
+                        return Err(QueryAbort::Canceled);
+                    };
+                    if shell.key != candidate {
+                        return Err(QueryAbort::Canceled);
+                    }
                     let query = crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
                         declaration: candidate.clone(),
                         configuration: key.configuration.clone(),
@@ -9924,7 +10138,6 @@ impl RevisionedQueryDatabase {
             let terminal = self.body_transaction(
                 revision,
                 key,
-                Arc::new(BTreeMap::new()),
                 false,
                 Arc::from([]),
                 CancellationToken::new(),
@@ -9957,7 +10170,6 @@ impl RevisionedQueryDatabase {
             .body_transaction(
                 revision,
                 key,
-                Arc::new(BTreeMap::new()),
                 false,
                 Arc::from([]),
                 CancellationToken::new(),
@@ -13810,6 +14022,175 @@ mod tests {
     };
     use rue_span::FileId;
     use std::collections::{BTreeSet, HashMap};
+
+    #[test]
+    fn stable_definition_kinds_have_fixed_syntax_candidate_sets() {
+        use crate::StableDefinitionKind as K;
+        use crate::declaration_candidate::DeclarationCandidateCategory as C;
+
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        for (kind, owner, expected) in [
+            (K::Function, None, &[C::Function, C::ExternFunction][..]),
+            (K::Struct, None, &[C::Struct][..]),
+            (K::Enum, None, &[C::Enum][..]),
+            (K::ValueConst, None, &[C::ConstCandidate][..]),
+            (K::ModuleBinding, None, &[C::ConstCandidate][..]),
+            (
+                K::Method,
+                Some((K::Struct, Arc::from("Owner"))),
+                &[C::Method][..],
+            ),
+            (
+                K::AssociatedFunction,
+                Some((K::Struct, Arc::from("Owner"))),
+                &[C::AssociatedFunction][..],
+            ),
+            (
+                K::Destructor,
+                Some((K::Struct, Arc::from("Owner"))),
+                &[C::Destructor][..],
+            ),
+        ] {
+            let key = StableDefinitionKey::from_stable_parts(
+                module.clone(),
+                crate::StableDefinitionNamespace::Value,
+                kind,
+                "item",
+                owner.clone(),
+            );
+            let candidates = stable_syntax_candidate_set(&key)
+                .expect("every well-formed stable definition kind has a syntax candidate set")
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
+            assert_eq!(
+                candidates
+                    .iter()
+                    .map(|candidate| candidate.category)
+                    .collect::<Vec<_>>(),
+                expected,
+                "{kind:?}"
+            );
+            for candidate in candidates {
+                assert_eq!(candidate.module, module);
+                assert_eq!(candidate.name.as_ref(), "item");
+                assert_eq!(candidate.duplicate_discriminator, 0);
+                assert_eq!(
+                    candidate.owner.as_ref().map(|owner| owner.name.as_ref()),
+                    owner.as_ref().map(|(_, name)| name.as_ref())
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn stable_declaration_classification_is_narrow_green_and_multiplicity_sensitive() {
+        let first = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn helper(value: i32) -> i32 { value + 1 }\nfn main() -> i32 { helper(1) }",
+            )],
+            1,
+        );
+        let unrelated = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn helper(value: i32) -> i32 { value + 1 }\nfn extra() -> i32 { 9 }\nfn main() -> i32 { helper(1) }",
+            )],
+            1,
+        );
+        let duplicate = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn helper(value: i32) -> i32 { value + 1 }\nfn helper(value: i32) -> i32 { value + 2 }\nfn main() -> i32 { helper(1) }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let key = StableDeclarationClassificationQueryKey(StableDefinitionKey::from_stable_parts(
+            module,
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::Function,
+            "helper",
+            None,
+        ));
+        let mut database = RevisionedQueryDatabase::default();
+        let first_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&first),
+            &first,
+        );
+        let first = database.runtime.request_registered(
+            &database.stable_declaration_classifications,
+            first_revision,
+            key.clone(),
+            CancellationToken::new(),
+        );
+        let first_terminal = first.terminal().unwrap();
+        let first_stamp = first_terminal.stamp();
+        assert!(matches!(
+            first_terminal.outcome(),
+            rue_query::QueryOutcome::Success(
+                StableDeclarationClassificationQueryValue::Selected(candidate)
+            ) if candidate.category
+                == crate::declaration_candidate::DeclarationCandidateCategory::Function
+        ));
+        assert_eq!(
+            first
+                .dependencies()
+                .iter()
+                .map(|dependency| dependency.node.family())
+                .collect::<Vec<_>>(),
+            vec![
+                "compiler.declaration-occurrence-index",
+                "compiler.declaration-shell"
+            ]
+        );
+
+        let unrelated_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&unrelated),
+            &unrelated,
+        );
+        let unrelated = database.runtime.request_registered(
+            &database.stable_declaration_classifications,
+            unrelated_revision,
+            key.clone(),
+            CancellationToken::new(),
+        );
+        assert_eq!(
+            unrelated.terminal().unwrap().stamp(),
+            first_stamp,
+            "an unrelated declaration may rebuild the module occurrence index but must keep the \
+             narrow classification green"
+        );
+
+        let duplicate_revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&duplicate),
+            &duplicate,
+        );
+        let duplicate = database.runtime.request_registered(
+            &database.stable_declaration_classifications,
+            duplicate_revision,
+            key,
+            CancellationToken::new(),
+        );
+        let duplicate_terminal = duplicate.terminal().unwrap();
+        assert_ne!(duplicate_terminal.stamp(), first_stamp);
+        assert!(matches!(
+            duplicate_terminal.outcome(),
+            rue_query::QueryOutcome::Success(StableDeclarationClassificationQueryValue::Invalid(
+                StableDeclarationClassificationFailure::DuplicateMultiplicity {
+                    multiplicity: 2,
+                    ..
+                }
+            ))
+        ));
+    }
 
     fn source_snapshot(entries: &[(u32, &str, &str, &str)], root: u32) -> SourceSnapshot {
         let physical = entries

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -6627,22 +6627,22 @@ impl RevisionedQueryDatabase {
                                 match index.capabilities.get(&candidate) {
                                     None => {}
                                     Some(DeclarationOccurrenceCapability::Ambiguous { .. }) => {
-                                        invalid.get_or_insert_with(|| {
+                                        invalid.get_or_insert(
                                             StableDeclarationClassificationFailure::Ambiguous(
                                                 candidate,
-                                            )
-                                        });
+                                            ),
+                                        );
                                     }
                                     Some(DeclarationOccurrenceCapability::Exact {
                                         duplicate_multiplicity,
                                         ..
                                     }) if *duplicate_multiplicity != 1 => {
-                                        invalid.get_or_insert_with(|| {
+                                        invalid.get_or_insert(
                                             StableDeclarationClassificationFailure::DuplicateMultiplicity {
                                                 key: candidate,
                                                 multiplicity: *duplicate_multiplicity,
-                                            }
-                                        });
+                                            },
+                                        );
                                     }
                                     Some(DeclarationOccurrenceCapability::Exact { .. }) => {
                                         let shell = context.query_registered(

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -7254,7 +7254,6 @@ impl CompilerSession {
                     let transaction = self.queries.revisioned.body_transaction(
                         runtime_revision,
                         key.clone(),
-                        declaration_candidates.clone(),
                         producer_body_terminal_required,
                         well_known_demands.clone(),
                         cancellation.clone(),
@@ -17928,7 +17927,6 @@ fn main() -> i32 { selected.value() }"#,
             .body_transaction(
                 revision,
                 key.clone(),
-                Arc::new(BTreeMap::new()),
                 false,
                 Arc::from([]),
                 cancellation.clone(),
@@ -17977,7 +17975,6 @@ fn main() -> i32 { selected.value() }"#,
             .body_transaction(
                 revision,
                 key.clone(),
-                Arc::new(BTreeMap::new()),
                 false,
                 Arc::from([]),
                 rue_query::CancellationToken::new(),
@@ -18005,7 +18002,6 @@ fn main() -> i32 { selected.value() }"#,
             .body_transaction(
                 revision,
                 key.clone(),
-                Arc::new(BTreeMap::new()),
                 false,
                 Arc::from([]),
                 rue_query::CancellationToken::new(),
@@ -18719,6 +18715,259 @@ fn main() -> i32 {
     }
 
     #[test]
+    fn body_callable_dependencies_select_exact_shell_candidate_sets() {
+        let source = SourceSnapshot::single(
+            "main.rue",
+            "extern \"C\" { fn foreign() -> i32; }\n\
+             fn helper(value: i32) -> i32 { value + 1 }\n\
+             fn unrelated() -> i32 { 7 }\n\
+             fn main() -> i32 { helper(1) + checked { foreign() } }",
+        )
+        .unwrap();
+        let options = CompileOptions {
+            preview_features: PreviewFeatures::from([PreviewFeature::CFfi]),
+            ..CompileOptions::default()
+        };
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        session.canonical_semantic(&options).unwrap();
+        let main = body_query_key(&mut session, &options, "main");
+        let main_transaction = retained_body_transaction(&session, &main).2;
+        let dependencies = retained_body_dependency_nodes(&session, &main);
+
+        for name in ["helper", "foreign"] {
+            assert!(
+                dependencies.iter().any(|node| {
+                    node.contains("compiler.stable-declaration-classification")
+                        && node.contains(name)
+                }),
+                "body transaction must observe the fixed candidate-set classifier for {name}: \
+                 transaction={main_transaction:?}; dependencies={dependencies:?}"
+            );
+        }
+        for (category, name) in [("Function", "helper"), ("ExternFunction", "foreign")] {
+            assert!(
+                dependencies.iter().any(|node| {
+                    node.contains("compiler.declaration-shell")
+                        && node.contains(&format!(":{category}:"))
+                        && node.contains(name)
+                }),
+                "body transaction must observe the exactly selected shell for {name}: \
+                 transaction={main_transaction:?}; dependencies={dependencies:?}"
+            );
+        }
+        for (category, name) in [("ExternFunction", "helper"), ("Function", "foreign")] {
+            assert!(
+                dependencies.iter().all(|node| {
+                    !(node.contains("compiler.declaration-shell")
+                        && node.contains(&format!(":{category}:"))
+                        && node.contains(name))
+                }),
+                "the unselected opposite-category shell must stay behind the classifier for \
+                 {name}: dependencies={dependencies:?}"
+            );
+        }
+        assert!(
+            dependencies.iter().any(|node| {
+                node.contains("compiler.semantic-nucleus")
+                    && node.contains("signature:")
+                    && node.contains(":Function:")
+                    && node.contains("helper")
+            }),
+            "{dependencies:?}"
+        );
+        assert!(
+            dependencies.iter().any(|node| {
+                node.contains("compiler.semantic-nucleus")
+                    && node.contains("signature:")
+                    && node.contains(":ExternFunction:")
+                    && node.contains("foreign")
+            }),
+            "{dependencies:?}"
+        );
+        assert!(
+            dependencies.iter().all(|node| !node.contains("unrelated")),
+            "an unrelated declaration must not become a body dependency: {dependencies:?}"
+        );
+        assert!(
+            dependencies
+                .iter()
+                .all(|node| !node.contains("compiler.declaration-occurrence-index")),
+            "the module-wide occurrence index must stay behind the stable classifier: \
+             {dependencies:?}"
+        );
+
+        let ambiguous = SourceSnapshot::single(
+            "main.rue",
+            "extern \"C\" { fn foreign() -> i32; fn helper(value: i32) -> i32; }\n\
+             fn helper(value: i32) -> i32 { value + 1 }\n\
+             fn unrelated() -> i32 { 7 }\n\
+             fn main() -> i32 { helper(1) + checked { foreign() } }",
+        )
+        .unwrap();
+        session.update(&ambiguous).into_result().unwrap();
+        assert!(session.canonical_semantic(&options).is_err());
+        let revision = session
+            .queries
+            .revisioned
+            .current_semantic_revision()
+            .expect("failed semantic attempt publishes its revision");
+        let recomputed = std::cell::Cell::new(false);
+        let result = session.queries.revisioned.body_transaction(
+            revision,
+            main.clone(),
+            false,
+            Arc::from([]),
+            rue_query::CancellationToken::new(),
+            |_, _| {
+                recomputed.set(true);
+                Ok(main_transaction.clone())
+            },
+        );
+        assert!(matches!(
+            result,
+            Err(
+                crate::revisioned_query_database::BodyTransactionRequestFailure::Query(
+                    rue_query::QueryAbort::Canceled
+                )
+            )
+        ));
+        assert!(
+            recomputed.get(),
+            "the opposite-category shell edge must invalidate the retained body"
+        );
+
+        let mut fresh = CompilerSession::new();
+        fresh.update(&ambiguous).into_result().unwrap();
+        assert!(fresh.canonical_semantic(&options).is_err());
+        let fresh_revision = fresh
+            .queries
+            .revisioned
+            .current_semantic_revision()
+            .expect("fresh failed semantic attempt publishes its revision");
+        let fresh_computed = std::cell::Cell::new(false);
+        let fresh_result = fresh.queries.revisioned.body_transaction(
+            fresh_revision,
+            main,
+            false,
+            Arc::from([]),
+            rue_query::CancellationToken::new(),
+            |_, _| {
+                fresh_computed.set(true);
+                Ok(main_transaction.clone())
+            },
+        );
+        assert!(matches!(
+            fresh_result,
+            Err(
+                crate::revisioned_query_database::BodyTransactionRequestFailure::Query(
+                    rue_query::QueryAbort::Canceled
+                )
+            )
+        ));
+        assert!(
+            fresh_computed.get(),
+            "a fresh body task must enter computation before the dual-category classifier cancels"
+        );
+    }
+
+    #[test]
+    fn body_candidate_classifier_invalidates_same_category_duplicates_warm_and_fresh() {
+        let valid = SourceSnapshot::single(
+            "main.rue",
+            "fn helper(value: i32) -> i32 { value + 1 }\n\
+             fn main() -> i32 { helper(1) }",
+        )
+        .unwrap();
+        let duplicate = SourceSnapshot::single(
+            "main.rue",
+            "fn helper(value: i32) -> i32 { value + 1 }\n\
+             fn helper(value: i32) -> i32 { value + 2 }\n\
+             fn main() -> i32 { helper(1) }",
+        )
+        .unwrap();
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session.update(&valid).into_result().unwrap();
+        session.canonical_semantic(&options).unwrap();
+        let main = body_query_key(&mut session, &options, "main");
+        let prior = retained_body_transaction(&session, &main).2;
+        let dependencies = retained_body_dependency_nodes(&session, &main);
+        assert!(
+            dependencies.iter().any(|node| {
+                node.contains("compiler.stable-declaration-classification")
+                    && node.contains("helper")
+            }),
+            "{dependencies:?}"
+        );
+
+        session.update(&duplicate).into_result().unwrap();
+        assert!(session.canonical_semantic(&options).is_err());
+        let revision = session
+            .queries
+            .revisioned
+            .current_semantic_revision()
+            .expect("failed semantic attempt publishes its revision");
+        let recomputed = std::cell::Cell::new(false);
+        let result = session.queries.revisioned.body_transaction(
+            revision,
+            main.clone(),
+            false,
+            Arc::from([]),
+            rue_query::CancellationToken::new(),
+            |_, _| {
+                recomputed.set(true);
+                Ok(prior.clone())
+            },
+        );
+        assert!(matches!(
+            result,
+            Err(
+                crate::revisioned_query_database::BodyTransactionRequestFailure::Query(
+                    rue_query::QueryAbort::Canceled
+                )
+            )
+        ));
+        assert!(
+            recomputed.get(),
+            "duplicate multiplicity must invalidate the retained classifier/body edge"
+        );
+
+        let mut fresh = CompilerSession::new();
+        fresh.update(&duplicate).into_result().unwrap();
+        assert!(fresh.canonical_semantic(&options).is_err());
+        let fresh_revision = fresh
+            .queries
+            .revisioned
+            .current_semantic_revision()
+            .expect("fresh failed semantic attempt publishes its revision");
+        let fresh_computed = std::cell::Cell::new(false);
+        let fresh_result = fresh.queries.revisioned.body_transaction(
+            fresh_revision,
+            main,
+            false,
+            Arc::from([]),
+            rue_query::CancellationToken::new(),
+            |_, _| {
+                fresh_computed.set(true);
+                Ok(prior.clone())
+            },
+        );
+        assert!(matches!(
+            fresh_result,
+            Err(
+                crate::revisioned_query_database::BodyTransactionRequestFailure::Query(
+                    rue_query::QueryAbort::Canceled
+                )
+            )
+        ));
+        assert!(
+            fresh_computed.get(),
+            "a fresh body task must enter computation before duplicate multiplicity cancels"
+        );
+    }
+
+    #[test]
     fn unreachable_body_is_not_requested_by_production_reachability() {
         let source =
             SourceSnapshot::single("main.rue", "fn dead() -> i32 { 1 } fn main() -> i32 { 42 }")
@@ -18737,7 +18986,6 @@ fn main() -> i32 {
         let result = session.queries.revisioned.body_transaction(
             revision,
             dead,
-            Arc::new(BTreeMap::new()),
             false,
             Arc::from([]),
             rue_query::CancellationToken::new(),

--- a/crates/rue-compiler/src/session/tests/rfinal_harness.rs
+++ b/crates/rue-compiler/src/session/tests/rfinal_harness.rs
@@ -532,6 +532,19 @@ const EDGE_FAMILY_EXCEPTIONS: &[EdgeFamilyException] = &[
                  keeping this input on the transaction, not on the fact drivers",
     },
     EdgeFamilyException {
+        family: "compiler.declaration-shell",
+        side: EdgeExceptionSide::EpochOnly,
+        reason: "the production transaction roots the exact shell selected by its stable \
+                 declaration classifier; side B starts from already selected declaration facts",
+    },
+    EdgeFamilyException {
+        family: "compiler.stable-declaration-classification",
+        side: EdgeExceptionSide::EpochOnly,
+        reason: "the production transaction classifies each stable semantic dependency through \
+                 its complete fixed syntax-candidate set; side B starts from already selected \
+                 declaration facts",
+    },
+    EdgeFamilyException {
         family: "compiler.semantic-nucleus",
         side: EdgeExceptionSide::ProviderOnly,
         reason: "declaration identity/signature/const facts consulted through the boundary \
@@ -745,7 +758,6 @@ fn capture_terminal(
         .body_transaction(
             revision,
             key.clone(),
-            Arc::new(BTreeMap::new()),
             false,
             Arc::from([]),
             rue_query::CancellationToken::new(),


### PR DESCRIPTION
## Summary

- remove the complete declaration-candidate map from the body transaction boundary
- classify each published stable reference through an independently stamped fixed candidate-set query
- detect same-category duplicates and function/extern ambiguity while exposing only the selected exact shell and semantic-nucleus edges to the body
- keep the coordinator map solely for its separate reachability worklist

This is an incremental ownership and dependency-boundary improvement; it does not claim a recomputation-count reduction while the coordinator still needs the map for reachability.

## Testing

- `scripts/rue quick`
- `scripts/rue test`
- focused compiler-unit, classifier-stamp, warm/fresh ambiguity, API-guard, and rfinal parity tests

Refs RUE-1092.