### PR TITLE
Resolve well-known options per body

### DIFF
--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -6,7 +6,6 @@
 //! sibling `pointers` and `ownership` modules.
 
 use super::*;
-use crate::sema::anon_structs::TrustedTryProducer;
 
 impl<'a> BodySema<'a> {
     // ========================================================================
@@ -1189,12 +1188,11 @@ impl<'a> BodySema<'a> {
     /// bare, annotated, matched, and `?`-operand positions alike. Context (a `let`
     /// annotation, or the `match` arms the result feeds) never *selects* the
     /// nominal — it only *checks* it, and a same-shape user lookalike is a
-    /// mismatch, not a parallel identity. Only when no trusted `Option` module was
-    /// rooted for this body (the registry is empty) does the resolver fall back to
-    /// checking the surrounding context structurally. The ordinary
-    /// comptime-generic `Option` enum is used throughout; no "blessed builtin"
-    /// tier is introduced. The runtime signals success/failure and codegen fills
-    /// in this enum's discriminant + payload.
+    /// mismatch, not a parallel identity. A missing exact registry entry is
+    /// typed internal incompleteness: production resolves the body's complete
+    /// payload set before analysis, so neither context shape nor a lookalike may
+    /// rescue it. The ordinary comptime-generic `Option` enum is used throughout;
+    /// no "blessed builtin" tier is introduced.
     pub(super) fn resolve_option_result_type(
         &mut self,
         ctx: &AnalysisContext,
@@ -1216,7 +1214,16 @@ impl<'a> BodySema<'a> {
         let canonical = self
             .well_known_option_by_payload
             .get(&expected_payload)
-            .copied();
+            .copied()
+            .ok_or_else(|| {
+                CompileError::new(
+                    ErrorKind::InternalError(format!(
+                        "fallible intrinsic @{intrinsic_display} reached body analysis without \
+                         its exact trusted Option({payload_display}) registry entry"
+                    )),
+                    span,
+                )
+            })?;
 
         // Whatever context supplies, if anything. Under `?` no context can supply
         // the `Option` (the enclosing `Option(U)` may carry a different payload),
@@ -1224,7 +1231,7 @@ impl<'a> BodySema<'a> {
         // owns the identity.
         let context_ty = match result_expected {
             Some(ty) => Some(ty),
-            None if canonical.is_some() && ctx.try_operand => None,
+            None if ctx.try_operand => None,
             None => Some(Self::get_resolved_type(
                 ctx,
                 inst_ref,
@@ -1233,70 +1240,25 @@ impl<'a> BodySema<'a> {
             )?),
         };
 
-        if let Some(canonical) = canonical {
-            // The intrinsic result IS `canonical`. If context is present, it must
-            // be that exact identity; a lookalike or a differently-payloaded
-            // trusted `Option` is a mismatch. A context that already poisoned to
-            // `error` produced its own diagnostic — don't cascade, but keep the
-            // canonical identity so downstream composition still resolves.
-            if let Some(ty) = context_ty
-                && !ty.is_error()
-                && ty != canonical
-            {
-                return Err(CompileError::new(
-                    ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
-                        name: intrinsic_display.to_string(),
-                        expected: format!("Option({payload_display})"),
-                        found: ty.safe_name_with_pool(Some(&self.type_pool)),
-                    })),
-                    span,
-                ));
-            }
-            return Ok(canonical);
+        // The intrinsic result IS `canonical`. If context is present, it must
+        // be that exact identity; a lookalike or a differently-payloaded trusted
+        // `Option` is a mismatch. A context that already poisoned to `error`
+        // produced its own diagnostic — don't cascade, but keep the canonical
+        // identity so downstream composition still resolves.
+        if let Some(ty) = context_ty
+            && !ty.is_error()
+            && ty != canonical
+        {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                    name: intrinsic_display.to_string(),
+                    expected: format!("Option({payload_display})"),
+                    found: ty.safe_name_with_pool(Some(&self.type_pool)),
+                })),
+                span,
+            ));
         }
-
-        // No trusted `Option` module was rooted for this body (the registry is
-        // empty). Fall back to checking the surrounding context structurally: it
-        // must itself be the exact trusted-std-shaped `Option(payload)`.
-        let ty = context_ty.expect("registry-absent path always resolves a context type");
-
-        // A bad annotation/pattern already produced its own diagnostic and
-        // poisoned the expected type to `error`; do not cascade a second one.
-        if result_expected.is_some() && ty.is_error() {
-            return Ok(ty);
-        }
-
-        let valid = self.trusted_try_producer(ty) == Some(TrustedTryProducer::Option)
-            && matches!(ty.kind(), TypeKind::Enum(enum_id) if {
-                let def = self.type_pool.enum_def(enum_id);
-                match (def.find_variant("Some"), def.find_variant("None")) {
-                    (Some(si), Some(ni)) if def.variant_count() == 2 => {
-                        let some_payload = def.variant_payload(si);
-                        some_payload.len() == 1
-                            && some_payload[0] == expected_payload
-                            && def.variant_payload(ni).is_empty()
-                    }
-                    _ => false,
-                }
-            });
-
-        if valid {
-            return Ok(ty);
-        }
-
-        let found = if ty.is_error() {
-            "no expected type — annotate the binding or `match` on the result".to_string()
-        } else {
-            ty.safe_name_with_pool(Some(&self.type_pool))
-        };
-        Err(CompileError::new(
-            ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
-                name: intrinsic_display.to_string(),
-                expected: format!("Option({payload_display})"),
-                found,
-            })),
-            span,
-        ))
+        Ok(canonical)
     }
 
     /// Analyze @read_line intrinsic.

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -899,10 +899,10 @@ impl<'a> BodySema<'a> {
         };
 
         // A resolved enum annotation is the expected type for the initializer.
-        // This is how a fallible intrinsic learns its `Option(T)` return from a
-        // `let x: Option(T) = @read_line()` annotation (RUE-6): only sema can
-        // resolve the comptime-generic `Option` alias, so inference cannot
-        // thread it. Narrow to enums so unrelated `let`s are unaffected.
+        // A fallible intrinsic uses this to validate that
+        // `let x: Option(T) = @read_line()` names its exact registry-installed
+        // result (RUE-6); context does not select the intrinsic's nominal.
+        // Narrow to enums so unrelated `let`s are unaffected.
         let prev_expected = ctx.expected_type.take();
         if let Some(annot) = annotation_type {
             // A `str` annotation is the expected type for the initializer so a

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -471,21 +471,18 @@ pub(crate) struct AnalysisContext<'a> {
     /// a surrounding annotation or pattern. Set narrowly around a
     /// let-initializer (to the resolved annotation type) and around a `match`
     /// scrutinee (to the enum named by the arm patterns). The fallible
-    /// intrinsics (`@read_line`, `@parse_*`) read this to learn which in-scope
-    /// `Option(T)` to return (RUE-6, ADR-0038) — inference cannot supply it
-    /// because comptime-generic library enums are resolved only in sema. Left
+    /// intrinsics (`@read_line`, `@parse_*`) read this to validate that an
+    /// annotation or pattern expects their exact registry-installed
+    /// `Option(T)` (RUE-6, ADR-0038). Context never selects that nominal. Left
     /// `None` everywhere else, so no other analysis is affected.
     pub expected_type: Option<Type>,
     /// True only while analyzing the operand of a `?` expression (RUE-318). The
     /// `?` site cannot supply an `expected_type` for a *bare* fallible intrinsic
     /// (`@read_line()?` / `@parse_i64(s)?`): the enclosing function's `Option(U)`
-    /// has the wrong payload (e.g. `@read_line` is `Option(String)`, not the
-    /// function's `Option(i64)`). When this flag is set and no valid expected
-    /// `Option` is available, a fallible intrinsic instantiates its *own* fixed
-    /// `Option(payload)` (it knows its payload) via `find_or_create_anon_enum`,
-    /// the same canonical library enum an in-scope `Option(T)` would produce.
-    /// Left `false` everywhere else, so the plain "context supplies the Option"
-    /// path (a `let` annotation or `match` arms) is unaffected.
+    /// has the wrong payload (e.g. `@read_line` is `Option(StrBuf)`, not the
+    /// function's `Option(i64)`). The fallible intrinsic instead uses its exact
+    /// registry-installed `Option(payload)`. Left `false` everywhere else, where
+    /// a contextual enum may validate — but never select — the result identity.
     pub try_operand: bool,
 }
 

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -778,12 +778,11 @@ impl<'a> BodySema<'a> {
         }
 
         // Derive the expected scrutinee type from the arm patterns, so a
-        // fallible-intrinsic scrutinee learns which in-scope `Option(T)` to
-        // return (`match @read_line() { Option::Some(l) => .., Option::None =>
-        // .. }`, RUE-6). Only sema resolves the comptime-generic `Option`
-        // alias the pattern names, so we resolve the first enum pattern's type
-        // here and expose it while the scrutinee is analyzed. Resolution errors
-        // are ignored — pattern legality is checked on the normal path below.
+        // fallible-intrinsic scrutinee can validate the pattern's `Option(T)`
+        // against its exact registry-installed result (`match @read_line() {
+        // Option::Some(l) => .., Option::None => .. }`, RUE-6). Context does not
+        // select the intrinsic nominal. Resolution errors are ignored — pattern
+        // legality is checked on the normal path below.
         let arms_for_expected = self.rir.match_arms(arms);
         let expected_scrutinee = arms_for_expected.iter().find_map(|(pattern, _)| {
             if let RirPattern::Path { type_name, .. } = &pattern {
@@ -1328,9 +1327,9 @@ impl<'a> BodySema<'a> {
         // A BARE fallible-intrinsic operand — `@read_line()?` / `@parse_i64(s)?`
         // — is special: the intrinsic needs its exact `Option` return type and
         // the `?` site cannot supply it as an `expected_type` (RUE-318), so we
-        // clear `expected_type` and set `try_operand` so the intrinsic
-        // instantiates its OWN fixed payload. A non-intrinsic operand ignores
-        // both flags — its type is resolved independently.
+        // clear `expected_type` and set `try_operand` so the intrinsic uses its
+        // exact registry-installed fixed-payload result. A non-intrinsic operand
+        // ignores both flags — its type is resolved independently.
         let prev_expected = ctx.expected_type.take();
         let prev_try_operand = ctx.try_operand;
         ctx.try_operand = true;

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -624,8 +624,9 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
     /// body's own composition/import universe. Consulted by fallible-intrinsic
     /// resolution (`resolve_option_result_type`) so `@parse_*`/`@read_line`
     /// bind the exact trusted std `Option(payload)` in every context even when
-    /// the body does not `@import` it. A structural fallback stays for programs
-    /// where no trusted module is present.
+    /// the body does not `@import` it. Production installs the complete per-body
+    /// registry before analysis; a missing entry fails closed instead of adopting
+    /// a structurally compatible body-local enum.
     pub(crate) well_known_option_by_payload: HashMap<Type, Type>,
     /// Anonymous enum identities materialized by the well-known `Option`
     /// registry install for this body. They are subtracted from the initial

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -1817,10 +1817,10 @@ mod tests {
     fn fallible_intrinsic_rejects_local_option_context() {
         // RUE-1112: a fallible intrinsic's result IS the exact trusted std
         // `Option`; a local same-shape `Option` lookalike used as its
-        // annotation is not accepted — context only *checks* the identity, and a
-        // lookalike is an ordinary intrinsic type error (E0702), never a way to
-        // select a different nominal. (The trusted-std positive path is covered by
-        // the compiler-crate acceptance tests, which supply the trusted module.)
+        // annotation is not accepted. This direct AIR harness intentionally has
+        // no registry install, so the intrinsic fails closed with an internal
+        // incompleteness diagnostic before context can adopt the lookalike. (The
+        // trusted-std positive path is covered by compiler-crate acceptance tests.)
         let source = r#"
             fn Option(comptime T: type) -> type { enum { Some(T), None } }
 
@@ -1837,8 +1837,21 @@ mod tests {
             compile_to_air(source).expect_err("a local-Option annotation is no longer accepted");
         assert!(
             errors.to_string().contains("parse_i64"),
-            "expected an E0702 intrinsic type mismatch on @parse_i64: {errors}",
+            "expected fail-closed missing-registry diagnostics on @parse_i64: {errors}",
         );
+    }
+
+    #[test]
+    fn fallible_intrinsic_resolver_has_no_registry_miss_shape_fallback() {
+        let source = include_str!("analysis/intrinsics.rs");
+        for forbidden in ["trusted_try_producer", "find_compatible_anon_enum"] {
+            assert!(
+                !source.contains(forbidden),
+                "fallible intrinsic resolution regained a registry-miss fallback: {forbidden}"
+            );
+        }
+        assert!(source.contains("reached body analysis without"));
+        assert!(source.contains("ErrorKind::InternalError"));
     }
 
     #[test]

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -169,6 +169,52 @@ fn body_transaction_has_no_complete_declaration_candidate_map() {
     }
 }
 
+#[test]
+fn well_known_option_resolution_stays_per_body_exact_and_fail_closed() {
+    let runtime = include_str!("revisioned_query_database.rs");
+    let method = source_between_exact_boundaries(
+        runtime,
+        "    pub(crate) fn body_transaction(",
+        "\n    pub(crate) fn canonical_body_projection(",
+    );
+    for required in [
+        "&self.body_toolchain_demands",
+        "exact_option_prerequisites(",
+        "exact_option_query(",
+        "WellKnownOptionResolutionFailure::Incomplete",
+        "WellKnownOptionResolutionFailure::Semantic",
+        "WellKnownOptionResolutionFailure::WrongProjection",
+    ] {
+        assert!(
+            method.contains(required),
+            "body_transaction lost exact atomic Option resolution: {required}"
+        );
+    }
+    for forbidden in [
+        "well_known_demands",
+        "plan_well_known_option_demands",
+        "WellKnownOptionDemand",
+    ] {
+        assert!(
+            !method.contains(forbidden),
+            "body_transaction regained request-global Option planning: {forbidden}"
+        );
+    }
+
+    let exact_keys = include_str!("well_known_option.rs");
+    for forbidden in [
+        "CanonicalRirOutput",
+        "CanonicalMergedProgram",
+        "plan_well_known_option_demands",
+        "WellKnownOptionDemand",
+    ] {
+        assert!(
+            !exact_keys.contains(forbidden),
+            "exact Option-key derivation regained whole-request input: {forbidden}"
+        );
+    }
+}
+
 const RUE_869_INTERNAL_ROOT_VOCABULARY: &[&str] = &[
     "BoundDefinitionId",
     "BoundDefinitionRecord",

--- a/crates/rue-compiler/src/body_query.rs
+++ b/crates/rue-compiler/src/body_query.rs
@@ -42,24 +42,11 @@ pub(crate) enum BodyReference {
     Type(crate::TypeInstanceKey),
 }
 
-/// One trusted-standard-library `Option(payload)` demanded by a body's
-/// fallible-intrinsic use. The `call` is rooted under the requesting body's
-/// lease so the specialization is memoized across bodies that share a payload;
-/// `payload` is the demanded `Some`-variant type. `kind` is the fallible-payload
-/// tag used to select exactly the demands a body's own raw source requires, so a
-/// body roots no specialization it does not use.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct WellKnownOptionDemand {
-    pub(crate) kind: crate::well_known_option::FalliblePayload,
-    pub(crate) payload: crate::durable_semantics::DurableType,
-    pub(crate) call: crate::semantic_query_nucleus::ComptimeCallQueryKey,
-}
-
 /// The per-body resolution of the well-known `Option` demands: the resolved
 /// enum for each demanded payload, plus every anonymous nominal to materialize
-/// narrowly. Empty whenever a body demands nothing (no fallible intrinsics or
-/// no trusted `Option` module present), so freestanding programs keep the
-/// structural `find_compatible_anon_enum` fallback.
+/// narrowly. Empty only when a body contains no fallible intrinsic. A body with
+/// demands reaches analysis only after every exact trusted specialization has
+/// resolved successfully.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct WellKnownOptionResolution {
     pub(crate) option_by_payload: Arc<

--- a/crates/rue-compiler/src/producer_nominal_acceptance_tests.rs
+++ b/crates/rue-compiler/src/producer_nominal_acceptance_tests.rs
@@ -27,19 +27,17 @@ use rue_target::Target;
 // try-operand consumption.
 //
 // Every fallible intrinsic (`@read_line`, `@parse_i32/i64/u32/u64`) returns the
-// exact trusted standard-library `Option(payload)`. When the trusted `Option`
-// module is present, the per-body demand loop roots the matching
-// `Option(payload)` comptime specialization under the requesting body's lease,
-// projects it through a narrow per-body `WellKnownTypes` input, and AIR's
-// `resolve_option_result_type` binds it under `?` — winning over any same-shape
-// local lookalike the legacy structural scan would otherwise pick. When the
-// module is absent, the plan is empty and the legacy `find_compatible_anon_enum`
-// scan stays in force (freestanding programs are unchanged).
+// exact trusted standard-library `Option(payload)`. Each registered body derives
+// its exact payload set from its canonical body-toolchain-demand node and maps
+// every payload directly to one trusted `Option(payload)` comptime query. The
+// complete registry is installed atomically before AIR analysis; a failed or
+// wrong-result specialization fails closed, and no same-shape local lookalike
+// can supply the missing identity.
 // ===========================================================================
 
 /// The trusted standard-library `Option` module source, verbatim from
-/// `std/option.rue`. Provided at the trusted logical path so the demand planner
-/// and projection resolve the real std producer identity.
+/// `std/option.rue`. Provided at the trusted logical path so each exact per-body
+/// query and projection resolves the real std producer identity.
 const TRUSTED_OPTION_SOURCE: &str = r#"
 pub fn Option(comptime T: type) -> type {
     enum {
@@ -60,8 +58,12 @@ const TRUSTED_OPTION_FILE: FileId = FileId::new(2);
 /// Build a snapshot whose root module is `root_source`, with the trusted std
 /// `Option` module provided at `\0rue-std/option.rue`. The root reaches it with
 /// `@import("std/option.rue")` (physical-path suffix match). The trusted flag is
-/// what makes `plan_well_known_option_demands` treat the module as present.
+/// what makes this module the canonical toolchain-owned `Option` declaration.
 fn trusted_option_snapshot(root_source: &str) -> SourceSnapshot {
+    trusted_option_snapshot_with_source(root_source, TRUSTED_OPTION_SOURCE)
+}
+
+fn trusted_option_snapshot_with_source(root_source: &str, option_source: &str) -> SourceSnapshot {
     let metadata = SourceMetadata::new_with_trusted_standard_library(
         ROOT_FILE,
         HashMap::from([
@@ -79,10 +81,7 @@ fn trusted_option_snapshot(root_source: &str) -> SourceSnapshot {
         metadata,
         vec![
             (ROOT_FILE, Arc::new(root_source.to_owned())),
-            (
-                TRUSTED_OPTION_FILE,
-                Arc::new(TRUSTED_OPTION_SOURCE.to_owned()),
-            ),
+            (TRUSTED_OPTION_FILE, Arc::new(option_source.to_owned())),
         ],
     )
     .expect("trusted-option snapshot is valid")
@@ -266,10 +265,10 @@ fn main() -> i32 {
 
 /// t-win (registry wins over a materialized local lookalike). The requesting
 /// body materializes a LOCAL same-shape `Option(i64)` in its own universe — the
-/// exact enum the legacy structural scan would pick — yet `@parse_i64(s)?` still
-/// binds the TRUSTED std `Option(i64)`. The narrow well-known registry is
-/// consulted before the scan, so provenance is the trusted producer even though
-/// a compatible local enum is in scope.
+/// exact enum a shape-based lookup could pick — yet `@parse_i64(s)?` still binds
+/// the TRUSTED std `Option(i64)`. The narrow well-known registry is authoritative,
+/// so provenance is the trusted producer even though a compatible local enum is
+/// in scope.
 #[test]
 fn well_known_registry_wins_over_local_lookalike() {
     let options = CompileOptions::default();
@@ -277,8 +276,8 @@ fn well_known_registry_wins_over_local_lookalike() {
 const opt = @import("std/option.rue");
 fn Local(comptime T: type) -> type { enum { Some(T), None } }
 fn read_num(s: str) -> opt.Option(i64) {
-    // A local Option(i64) lookalike, materialized in THIS body's universe so the
-    // legacy `find_compatible_anon_enum` scan would find and bind it.
+    // A local Option(i64) lookalike, materialized in THIS body's universe. It
+    // remains independently observable but cannot supply the intrinsic result.
     let L = Local(i64);
     let _decoy: L = L.None;
     let O = opt.Option(i64);
@@ -312,6 +311,31 @@ fn main() -> i32 {
         bound_parse_i64_digest(&semantic),
         std_digest,
         "the registry must win: `?` binds the trusted std Option, not the local lookalike",
+    );
+}
+
+#[test]
+fn malformed_trusted_option_surfaces_diagnostics_instead_of_using_a_lookalike() {
+    let source = r#"
+const opt = @import("std/option.rue");
+fn LocalOption(comptime T: type) -> type { enum { Some(T), None } }
+fn main() -> i32 {
+    let L = LocalOption(i32);
+    let _lookalike: L = L.None;
+    let _result = @parse_i32("42");
+    0
+}
+"#;
+    let snapshot = trusted_option_snapshot_with_source(
+        source,
+        "pub fn Option(comptime T: type) -> type { missing }",
+    );
+    let errors = crate::test_frontend_snapshot(&snapshot, &CompileOptions::default())
+        .expect_err("a committed malformed trusted specialization must fail the semantic request");
+    let rendered = errors.to_string();
+    assert!(
+        rendered.contains("missing"),
+        "the trusted Option semantic failure must surface its diagnostics: {rendered}"
     );
 }
 
@@ -387,220 +411,61 @@ fn main() -> i32 {
     );
 }
 
-/// The number of well-known `Option` demands the planner roots for a snapshot.
-/// Built through the same lower path the session uses (`merge_parsed_modules`
-/// then `lower_canonical_rir`), then `plan_well_known_option_demands` directly —
-/// the exact function the session calls once per semantic request.
-fn planned_demand_count(snapshot: &SourceSnapshot, options: &CompileOptions) -> usize {
-    planned_demands(snapshot, options).len()
-}
-
-/// The `FileId` the StrBuf helper assigns to the trusted `\0rue-std/strbuf.rue`
-/// module.
-const TRUSTED_STRBUF_FILE: FileId = FileId::new(3);
-
-/// A minimal trusted `\0rue-std/strbuf.rue` carrying just the `StrBuf` struct in
-/// the canonical `{buf, len, cap}` shape (RUE-1066). The planner only needs the
-/// module present to spell the `StrBuf` nominal `DurableType`; this is enough.
-const TRUSTED_STRBUF_SOURCE: &str = r#"
-pub struct StrBuf {
-    buf: ptr mut u8,
-    len: u64,
-    cap: u64,
-}
-"#;
-
-/// Build a snapshot whose root is `root_source`, with BOTH the trusted std
-/// `Option` and `StrBuf` modules provided at their trusted logical paths.
-fn trusted_option_and_strbuf_snapshot(root_source: &str) -> SourceSnapshot {
-    let metadata = SourceMetadata::new_with_trusted_standard_library(
-        ROOT_FILE,
-        HashMap::from([
-            (ROOT_FILE, "/project/main.rue".to_owned()),
-            (TRUSTED_OPTION_FILE, "/project/std/option.rue".to_owned()),
-            (TRUSTED_STRBUF_FILE, "/project/std/strbuf.rue".to_owned()),
-        ]),
-        HashMap::from([
-            (ROOT_FILE, "main.rue".to_owned()),
-            (TRUSTED_OPTION_FILE, "\0rue-std/option.rue".to_owned()),
-            (TRUSTED_STRBUF_FILE, "\0rue-std/strbuf.rue".to_owned()),
-        ]),
-        HashSet::from([TRUSTED_OPTION_FILE, TRUSTED_STRBUF_FILE]),
-    )
-    .expect("trusted-std metadata is valid");
-    SourceSnapshot::new(
-        metadata,
-        vec![
-            (ROOT_FILE, Arc::new(root_source.to_owned())),
-            (
-                TRUSTED_OPTION_FILE,
-                Arc::new(TRUSTED_OPTION_SOURCE.to_owned()),
-            ),
-            (
-                TRUSTED_STRBUF_FILE,
-                Arc::new(TRUSTED_STRBUF_SOURCE.to_owned()),
-            ),
-        ],
-    )
-    .expect("trusted-option+strbuf snapshot is valid")
-}
-
 /// StrBuf-payload encoding (RUE-1112). `@read_line`'s `Option(StrBuf)` carries a
-/// NOMINAL payload, unlike the scalar `@parse_*` intrinsics. When both trusted
-/// `Option` and `StrBuf` modules are present, the planner roots a demand whose
-/// `ComptimeCallQueryKey` type-argument is the canonical trusted `StrBuf`
-/// `DurableType::Nominal` — the exact spelling `durable_semantics` blesses. Drop
-/// the `StrBuf` module and the read_line demand is skipped (its payload cannot be
-/// spelled), leaving only the scalar demand; the program falls through the scan.
+/// NOMINAL payload, unlike the scalar `@parse_*` intrinsics. The body's lexical
+/// scan names that payload independent of module presence, and the exact-key
+/// helper spells the trusted `StrBuf` stable key directly. Missing modules are
+/// parked before the body transaction rather than filtering this demand.
 #[test]
-fn read_line_plans_a_strbuf_nominal_option_demand() {
-    let options = CompileOptions::default();
-    // The demand planner roots an `Option(payload)` only for a fallible
-    // intrinsic that is the operand of `?` (RUE-1112): that is the sole context
-    // where the registry, not the surrounding annotation/`match`, supplies the
-    // intrinsic's trusted std `Option`. So the probe uses `@read_line()?` /
-    // `@parse_i64(s)?` to exercise the StrBuf and i64 demands.
-    let root = r#"
-fn probe(s: str) {
+fn read_line_has_an_exact_strbuf_nominal_option_key() {
+    let body = r#"{
     let _ = @read_line()?;
     let _ = @parse_i64(s)?;
 }
-fn main() -> i32 { 0 }
 "#;
-
-    // Expected canonical StrBuf nominal DurableType, spelled exactly as the
-    // planner (and durable_semantics) do.
-    let strbuf_module =
-        crate::ModuleId::from_trusted_standard_library_path("\0rue-std/strbuf.rue").unwrap();
+    let kinds = crate::well_known_option::scan_body_payload_kinds(body);
+    assert_eq!(
+        kinds,
+        BTreeSet::from([
+            crate::well_known_option::FalliblePayload::I64,
+            crate::well_known_option::FalliblePayload::StrBuf,
+        ])
+    );
+    let configuration = crate::semantic_query_nucleus::SemanticQueryConfiguration {
+        target: Target::X86_64Linux,
+        preview_features: crate::StablePreviewFeatures::new(&crate::PreviewFeatures::default()),
+    };
+    let (strbuf_payload, strbuf_call) = crate::well_known_option::exact_option_query(
+        crate::well_known_option::FalliblePayload::StrBuf,
+        &configuration,
+    );
     let strbuf_nominal = crate::durable_semantics::DurableType::Nominal(
         crate::StableDefinitionKey::from_stable_parts(
-            strbuf_module,
+            crate::ModuleId::from_trusted_standard_library_path(crate::STRBUF_MODULE_LOGICAL_PATH)
+                .unwrap(),
             crate::StableDefinitionNamespace::Type,
             crate::StableDefinitionKind::Struct,
             "StrBuf",
             None,
         ),
     );
-
-    // Both modules present: read_line's StrBuf demand is rooted.
-    let with_strbuf = trusted_option_and_strbuf_snapshot(root);
-    let demands = planned_demands(&with_strbuf, &options);
-    assert!(
-        demands.iter().any(|d| d.payload == strbuf_nominal),
-        "the read_line demand must carry the trusted StrBuf nominal payload; got {:?}",
-        demands.iter().map(|d| &d.payload).collect::<Vec<_>>(),
-    );
-    assert!(
-        demands
-            .iter()
-            .any(|d| d.payload == crate::durable_semantics::DurableType::I64),
-        "the parse_i64 demand must also be planned",
-    );
-    // And that StrBuf demand's ComptimeCall type-argument is the same nominal.
-    let strbuf_demand = demands
-        .iter()
-        .find(|d| d.payload == strbuf_nominal)
-        .expect("StrBuf demand present");
-    assert!(
-        strbuf_demand
-            .call
-            .type_arguments
-            .iter()
-            .any(|(name, ty)| name.as_ref() == "T" && *ty == strbuf_nominal),
-        "the ComptimeCallQueryKey must bind T = the trusted StrBuf nominal",
-    );
-
-    // Without the StrBuf module the read_line demand is dropped; only i64 remains.
-    let option_only = trusted_option_snapshot(root);
-    let scalar_only = planned_demands(&option_only, &options);
-    assert!(
-        scalar_only.iter().all(|d| d.payload != strbuf_nominal),
-        "without the StrBuf module no StrBuf demand may be planned",
-    );
-    assert!(
-        scalar_only
-            .iter()
-            .any(|d| d.payload == crate::durable_semantics::DurableType::I64),
-        "the scalar i64 demand must still be planned without StrBuf",
+    assert_eq!(strbuf_payload, strbuf_nominal);
+    assert_eq!(
+        strbuf_call.type_arguments.as_ref(),
+        &[(Arc::<str>::from("T"), strbuf_nominal)]
     );
 }
 
-/// The well-known `Option` demands the planner roots for a snapshot — the exact
-/// `WellKnownOptionDemand` list the session builds once per semantic request.
-fn planned_demands(
-    snapshot: &SourceSnapshot,
-    options: &CompileOptions,
-) -> Arc<[crate::body_query::WellKnownOptionDemand]> {
-    let parsed =
-        crate::parsed_modules::parse_source_snapshot_modules(snapshot).expect("snapshot parses");
-    let merged = crate::merge_parsed_modules(&parsed).expect("modules merge");
-    let rir = crate::canonical_lower::lower_canonical_rir(&merged).expect("rir lowers");
-    let configuration = crate::semantic_query_nucleus::SemanticQueryConfiguration {
-        target: options.target,
-        preview_features: crate::StablePreviewFeatures::new(&options.preview_features),
-    };
-    crate::well_known_option::plan_well_known_option_demands(&merged, &rir, &configuration)
-}
-
-/// t1. A body with NO fallible intrinsic plans ZERO `Option` demands even with
-/// the trusted std module present; a body that DOES use one plans a demand;
-/// and a fallible intrinsic with NO trusted module present plans zero (the gate
-/// keeps freestanding programs on the legacy scan). This is the assertable
-/// "zero demands" signal: the count of demands the session roots per request.
+/// t1. The canonical body scan is exact and presence-independent. A quiet body
+/// has no payload; a fallible body always names its payload so the session can
+/// park missing trusted modules before entering the transaction.
 #[test]
-fn no_fallible_intrinsic_plans_zero_option_demands() {
-    let options = CompileOptions::default();
-
-    // Std present, no fallible intrinsic → zero demands.
-    let quiet = trusted_option_snapshot(
-        r#"
-const opt = @import("std/option.rue");
-fn main() -> i32 {
-    let O = opt.Option(i64);
-    match O.Some(41) { O.Some(v) => @intCast(v) + 1, O.None => 0 }
-}
-"#,
-    );
+fn no_fallible_intrinsic_has_zero_exact_body_demands() {
+    assert!(crate::well_known_option::scan_body_payload_kinds("{ let x = 1; x }").is_empty());
     assert_eq!(
-        planned_demand_count(&quiet, &options),
-        0,
-        "a std-present program with no fallible intrinsic must plan zero demands",
-    );
-
-    // Std present, a fallible intrinsic → a demand is planned.
-    let loud = trusted_option_snapshot(
-        r#"
-const opt = @import("std/option.rue");
-fn read_num(s: str) -> opt.Option(i64) {
-    let O = opt.Option(i64);
-    O.Some(@parse_i64(s)?)
-}
-fn main() -> i32 { 0 }
-"#,
-    );
-    assert_eq!(
-        planned_demand_count(&loud, &options),
-        1,
-        "a std-present program using @parse_i64 must plan exactly one (i64) demand",
-    );
-
-    // Fallible intrinsic but NO trusted module → gate keeps the plan empty.
-    let freestanding = SourceSnapshot::single(
-        "<freestanding>",
-        r#"
-fn Option(comptime T: type) -> type { enum { Some(T), None } }
-fn read_num(s: str) -> Option(i64) {
-    let O = Option(i64);
-    O.Some(@parse_i64(s)?)
-}
-fn main() -> i32 { 0 }
-"#,
-    )
-    .expect("snapshot");
-    assert_eq!(
-        planned_demand_count(&freestanding, &options),
-        0,
-        "without a trusted std module the plan must be empty (legacy scan stays in force)",
+        crate::well_known_option::scan_body_payload_kinds("{ let value = @parse_i64(s)?; value }"),
+        BTreeSet::from([crate::well_known_option::FalliblePayload::I64]),
+        "module presence cannot filter a reached body's exact payload demand",
     );
 }
 

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -2098,6 +2098,75 @@ pub(crate) enum BodyTransactionRequestFailure {
     /// (RUE-1089). The dependent body cannot be built and must fail closed; the
     /// failure is never retried and never rescued by RIR recomputation.
     ProducerFailed(Box<crate::semantic_query_nucleus::SemanticNucleusFailure>),
+    /// One exact trusted `Option(payload)` specialization failed before body
+    /// analysis. No partial registry or body terminal is published.
+    WellKnownOptionResolution(WellKnownOptionResolutionFailure),
+}
+
+#[derive(Debug)]
+pub(crate) enum WellKnownOptionResolutionFailure {
+    Incomplete {
+        payload: crate::well_known_option::FalliblePayload,
+        prerequisite: Option<crate::StableDefinitionKey>,
+        detail: Arc<str>,
+    },
+    Semantic {
+        payload: crate::well_known_option::FalliblePayload,
+        failure: Box<crate::semantic_query_nucleus::SemanticNucleusFailure>,
+    },
+    WrongProjection {
+        payload: crate::well_known_option::FalliblePayload,
+        detail: Arc<str>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BodyTransactionFailureClass {
+    RequestCanceled,
+    ProducerFailed,
+    DeferredAnonymousProducers,
+    WellKnownOptionResolution,
+    Query,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WellKnownDependencyAbortClass {
+    Incomplete,
+    Propagate,
+}
+
+fn classify_well_known_dependency_abort(abort: &QueryAbort) -> WellKnownDependencyAbortClass {
+    match abort {
+        QueryAbort::Canceled | QueryAbort::MissingInput(_) => {
+            WellKnownDependencyAbortClass::Incomplete
+        }
+        QueryAbort::Cycle(_) | QueryAbort::ForeignRuntime | QueryAbort::UnpublishedRevision(_) => {
+            WellKnownDependencyAbortClass::Propagate
+        }
+    }
+}
+
+fn classify_body_transaction_failure(
+    abort: &QueryAbort,
+    request_canceled: bool,
+    producer_failed: bool,
+    deferred_anonymous_producers: bool,
+    well_known_option_resolution_failed: bool,
+) -> BodyTransactionFailureClass {
+    if !matches!(abort, QueryAbort::Canceled) {
+        return BodyTransactionFailureClass::Query;
+    }
+    if request_canceled {
+        BodyTransactionFailureClass::RequestCanceled
+    } else if producer_failed {
+        BodyTransactionFailureClass::ProducerFailed
+    } else if deferred_anonymous_producers {
+        BodyTransactionFailureClass::DeferredAnonymousProducers
+    } else if well_known_option_resolution_failed {
+        BodyTransactionFailureClass::WellKnownOptionResolution
+    } else {
+        BodyTransactionFailureClass::Query
+    }
 }
 
 /// Whether a committed semantic-nucleus failure is an internal-error
@@ -9502,7 +9571,6 @@ impl RevisionedQueryDatabase {
         revision: Revision,
         key: crate::body_query::BodyQueryKey,
         producer_body_terminal_required: bool,
-        well_known_demands: Arc<[crate::body_query::WellKnownOptionDemand]>,
         cancellation: CancellationToken,
         compute: impl FnOnce(
             Arc<[crate::durable_semantics::DurableAnonymousNominal]>,
@@ -9519,6 +9587,7 @@ impl RevisionedQueryDatabase {
             .ok_or(BodyTransactionRequestFailure::Query(QueryAbort::Canceled))?;
         let deferred_anonymous_producers = std::cell::RefCell::new(BTreeSet::new());
         let observed_lookups = std::cell::RefCell::new(ObservedLookupRoot::new());
+        let request_cancellation = cancellation.clone();
         // Set when a depended-on anonymous producer committed an anchor-transport
         // internal error (RUE-1089). It is carried out of the query closure — which
         // can only signal a bare `QueryAbort` — and mapped to a fatal
@@ -9526,6 +9595,9 @@ impl RevisionedQueryDatabase {
         // this body instead of being retried or rescued by RIR recomputation.
         let producer_transport_failure: std::cell::RefCell<
             Option<Box<crate::semantic_query_nucleus::SemanticNucleusFailure>>,
+        > = std::cell::RefCell::new(None);
+        let well_known_resolution_failure: std::cell::RefCell<
+            Option<WellKnownOptionResolutionFailure>,
         > = std::cell::RefCell::new(None);
         let result = self.runtime.query(
             &self.body_transactions,
@@ -9633,41 +9705,163 @@ impl RevisionedQueryDatabase {
                         );
                     }
                 }
-                // Root the trusted-std `Option(payload)` demands under THIS
-                // body's lease (RUE-1112). Each `ComptimeCall` resolves the real
-                // materialized `Option` specialization with std provenance; the
-                // nucleus memoizes it so bodies sharing a payload share one
-                // terminal while keeping their own per-body edge. The resolved
-                // enums reach AIR through the narrow per-body `WellKnownTypes`
-                // input, never this body's composition universe. A demand that
-                // fails to project (e.g. an absent payload type) is skipped so
-                // the body simply falls through to the legacy structural scan.
+                // Resolve THIS body's exact trusted-std `Option(payload)` set
+                // atomically (RUE-1112). Every key is derived directly from the
+                // registered body's canonical payload kinds. The session already
+                // parked any missing trusted module before entering this task, so
+                // a committed semantic failure or wrong projection is fatal:
+                // publish neither a partial registry nor a body terminal.
                 let well_known = {
                     let mut option_by_payload = Vec::new();
                     let mut nominals = BTreeMap::new();
-                    for demand in well_known_demands
-                        .iter()
-                        .filter(|demand| body_payload_kinds.contains(&demand.kind))
-                    {
-                        let projected = context.query_registered(
+                    for &payload_kind in body_payload_kinds {
+                        for prerequisite in
+                            crate::well_known_option::exact_option_prerequisites(payload_kind)
+                        {
+                            let classified = match context.query_registered(
+                                &self.stable_declaration_classifications,
+                                StableDeclarationClassificationQueryKey(
+                                    prerequisite.stable.clone(),
+                                ),
+                            ) {
+                                Ok(classified) => classified,
+                                Err(abort) => {
+                                    if matches!(
+                                        classify_well_known_dependency_abort(&abort),
+                                        WellKnownDependencyAbortClass::Propagate
+                                    ) {
+                                        return Err(abort);
+                                    }
+                                    *well_known_resolution_failure.borrow_mut() =
+                                        Some(WellKnownOptionResolutionFailure::Incomplete {
+                                            payload: payload_kind,
+                                            prerequisite: Some(prerequisite.stable),
+                                            detail: Arc::from(format!(
+                                                "exact trusted declaration prerequisite is \
+                                                 unavailable: {abort:?}"
+                                            )),
+                                        });
+                                    return Err(QueryAbort::Canceled);
+                                }
+                            };
+                            match classified.outcome() {
+                                rue_query::QueryOutcome::Success(
+                                    StableDeclarationClassificationQueryValue::Selected(
+                                        candidate,
+                                    ),
+                                ) if candidate == &prerequisite.candidate => {}
+                                rue_query::QueryOutcome::Success(value) => {
+                                    *well_known_resolution_failure.borrow_mut() =
+                                        Some(WellKnownOptionResolutionFailure::Incomplete {
+                                            payload: payload_kind,
+                                            prerequisite: Some(prerequisite.stable),
+                                            detail: Arc::from(format!(
+                                                "exact trusted declaration prerequisite did not \
+                                                 select its required candidate: {value:?}"
+                                            )),
+                                        });
+                                    return Err(QueryAbort::Canceled);
+                                }
+                                rue_query::QueryOutcome::Failure(failure) => {
+                                    *well_known_resolution_failure.borrow_mut() =
+                                        Some(WellKnownOptionResolutionFailure::Incomplete {
+                                            payload: payload_kind,
+                                            prerequisite: Some(prerequisite.stable),
+                                            detail: Arc::from(format!(
+                                                "exact trusted declaration prerequisite query \
+                                                 failed: {failure:?}"
+                                            )),
+                                        });
+                                    return Err(QueryAbort::Canceled);
+                                }
+                            }
+                        }
+                        let (payload, call) = crate::well_known_option::exact_option_query(
+                            payload_kind,
+                            &key.configuration,
+                        );
+                        let projected = match context.query_registered(
                             &self.semantic_nucleus,
                             crate::semantic_query_nucleus::SemanticNucleusKey::ComptimeCall(
-                                demand.call.clone(),
+                                call,
                             ),
-                        )?;
-                        if let rue_query::QueryOutcome::Success(
-                            crate::semantic_query_nucleus::SemanticNucleusValue::ComptimeCall(
-                                projection,
-                            ),
-                        ) = projected.outcome()
-                            && let crate::semantic_query_nucleus::ComptimeCallResultProjection::Type(
-                                option_type,
-                            ) = &projection.result
-                        {
-                            option_by_payload.push((demand.payload.clone(), option_type.clone()));
-                            for nominal in projection.anonymous_nominals.iter() {
-                                nominals.insert(nominal.identity.clone(), nominal.clone());
+                        ) {
+                            Ok(projected) => projected,
+                            Err(abort) => {
+                                if matches!(
+                                    classify_well_known_dependency_abort(&abort),
+                                    WellKnownDependencyAbortClass::Propagate
+                                ) {
+                                    return Err(abort);
+                                }
+                                *well_known_resolution_failure.borrow_mut() =
+                                    Some(WellKnownOptionResolutionFailure::Incomplete {
+                                        payload: payload_kind,
+                                        prerequisite: None,
+                                        detail: Arc::from(format!(
+                                            "exact trusted Option specialization is unavailable: \
+                                             {abort:?}"
+                                        )),
+                                    });
+                                return Err(QueryAbort::Canceled);
                             }
+                        };
+                        let projection = match projected.outcome() {
+                            rue_query::QueryOutcome::Success(
+                                crate::semantic_query_nucleus::SemanticNucleusValue::ComptimeCall(
+                                    projection,
+                                ),
+                            ) => projection,
+                            rue_query::QueryOutcome::Success(
+                                crate::semantic_query_nucleus::SemanticNucleusValue::Failure(
+                                    failure,
+                                ),
+                            ) => {
+                                *well_known_resolution_failure.borrow_mut() =
+                                    Some(WellKnownOptionResolutionFailure::Semantic {
+                                        payload: payload_kind,
+                                        failure: Box::new(failure.clone()),
+                                    });
+                                return Err(QueryAbort::Canceled);
+                            }
+                            rue_query::QueryOutcome::Success(other) => {
+                                *well_known_resolution_failure.borrow_mut() =
+                                    Some(WellKnownOptionResolutionFailure::WrongProjection {
+                                        payload: payload_kind,
+                                        detail: Arc::from(format!(
+                                            "expected ComptimeCall(Type), found {other:?}"
+                                        )),
+                                    });
+                                return Err(QueryAbort::Canceled);
+                            }
+                            rue_query::QueryOutcome::Failure(failure) => {
+                                *well_known_resolution_failure.borrow_mut() =
+                                    Some(WellKnownOptionResolutionFailure::WrongProjection {
+                                        payload: payload_kind,
+                                        detail: Arc::from(format!(
+                                            "expected a semantic nucleus value, found query failure {failure:?}"
+                                        )),
+                                    });
+                                return Err(QueryAbort::Canceled);
+                            }
+                        };
+                        let crate::semantic_query_nucleus::ComptimeCallResultProjection::Type(
+                            option_type,
+                        ) = &projection.result
+                        else {
+                            *well_known_resolution_failure.borrow_mut() =
+                                Some(WellKnownOptionResolutionFailure::WrongProjection {
+                                    payload: payload_kind,
+                                    detail: Arc::from(format!(
+                                        "expected ComptimeCall(Type), found ComptimeCall({:?})",
+                                        projection.result
+                                    )),
+                                });
+                            return Err(QueryAbort::Canceled);
+                        };
+                        option_by_payload.push((payload, option_type.clone()));
+                        for nominal in projection.anonymous_nominals.iter() {
+                            nominals.insert(nominal.identity.clone(), nominal.clone());
                         }
                     }
                     crate::body_query::WellKnownOptionResolution {
@@ -9953,26 +10147,51 @@ impl RevisionedQueryDatabase {
                 }
                 Ok(terminal)
             }
-            // A committed anchor-transport internal error takes precedence over a
-            // deferral: the producer definitively failed, so this body must fail
-            // closed rather than reschedule the producer forever (RUE-1089).
-            Err(QueryAbort::Canceled) if producer_transport_failure.borrow().is_some() => {
-                Err(BodyTransactionRequestFailure::ProducerFailed(
-                    producer_transport_failure
-                        .into_inner()
-                        .expect("guarded by is_some"),
-                ))
+            Err(abort) => {
+                let class = classify_body_transaction_failure(
+                    &abort,
+                    request_cancellation.is_canceled(),
+                    producer_transport_failure.borrow().is_some(),
+                    !deferred_anonymous_producers.borrow().is_empty(),
+                    well_known_resolution_failure.borrow().is_some(),
+                );
+                Err(match class {
+                    // Real request cancellation dominates all out-of-band
+                    // domain failures collected while the closure was running.
+                    BodyTransactionFailureClass::RequestCanceled => {
+                        BodyTransactionRequestFailure::Query(QueryAbort::Canceled)
+                    }
+                    // A committed anchor-transport internal error takes
+                    // precedence over deferral and well-known incompleteness:
+                    // the producer definitively failed (RUE-1089).
+                    BodyTransactionFailureClass::ProducerFailed => {
+                        BodyTransactionRequestFailure::ProducerFailed(
+                            producer_transport_failure
+                                .into_inner()
+                                .expect("failure class requires a producer failure"),
+                        )
+                    }
+                    BodyTransactionFailureClass::DeferredAnonymousProducers => {
+                        BodyTransactionRequestFailure::DeferredAnonymousProducers(
+                            deferred_anonymous_producers
+                                .into_inner()
+                                .into_iter()
+                                .collect::<Vec<_>>()
+                                .into(),
+                        )
+                    }
+                    BodyTransactionFailureClass::WellKnownOptionResolution => {
+                        BodyTransactionRequestFailure::WellKnownOptionResolution(
+                            well_known_resolution_failure
+                                .into_inner()
+                                .expect("failure class requires a well-known failure"),
+                        )
+                    }
+                    BodyTransactionFailureClass::Query => {
+                        BodyTransactionRequestFailure::Query(abort)
+                    }
+                })
             }
-            Err(QueryAbort::Canceled) if !deferred_anonymous_producers.borrow().is_empty() => {
-                Err(BodyTransactionRequestFailure::DeferredAnonymousProducers(
-                    deferred_anonymous_producers
-                        .into_inner()
-                        .into_iter()
-                        .collect::<Vec<_>>()
-                        .into(),
-                ))
-            }
-            Err(abort) => Err(BodyTransactionRequestFailure::Query(abort)),
         }
     }
 
@@ -10063,6 +10282,12 @@ impl RevisionedQueryDatabase {
         self.body_transactions.any_retained_key(|_| true)
     }
 
+    /// Whether the body-reference projection has published any terminal.
+    #[cfg(test)]
+    pub(crate) fn any_body_reference_terminal(&self) -> bool {
+        self.body_references.any_retained_key(|_| true)
+    }
+
     /// Whether the exact body key already has a retained memo node.
     ///
     /// This is deliberately narrower than provenance: a newly reached body has
@@ -10135,17 +10360,11 @@ impl RevisionedQueryDatabase {
                 continue;
             };
             let compute_called = std::cell::Cell::new(false);
-            let terminal = self.body_transaction(
-                revision,
-                key,
-                false,
-                Arc::from([]),
-                CancellationToken::new(),
-                |_, _| {
+            let terminal =
+                self.body_transaction(revision, key, false, CancellationToken::new(), |_, _| {
                     compute_called.set(true);
                     Err(QueryAbort::Canceled)
-                },
-            );
+                });
             if let Ok(terminal) = terminal {
                 assert!(
                     !compute_called.get(),
@@ -10167,14 +10386,9 @@ impl RevisionedQueryDatabase {
         key: crate::body_query::BodyQueryKey,
     ) -> Option<crate::BodyTransaction> {
         let terminal = self
-            .body_transaction(
-                revision,
-                key,
-                false,
-                Arc::from([]),
-                CancellationToken::new(),
-                |_, _| Err(QueryAbort::Canceled),
-            )
+            .body_transaction(revision, key, false, CancellationToken::new(), |_, _| {
+                Err(QueryAbort::Canceled)
+            })
             .ok()?;
         let rue_query::QueryOutcome::Success(transaction) = terminal.outcome() else {
             unreachable!("BodyTransaction publishes typed values")
@@ -14227,6 +14441,307 @@ mod tests {
             Arc::from(name),
             None,
         ))
+    }
+
+    fn trusted_option_body_snapshot(root_source: &str, option_source: &str) -> SourceSnapshot {
+        let option = FileId::new(2);
+        trusted_body_snapshot(root_source, Some((option, option_source)), None)
+    }
+
+    fn trusted_body_snapshot(
+        root_source: &str,
+        option_source: Option<(FileId, &str)>,
+        strbuf_source: Option<(FileId, &str)>,
+    ) -> SourceSnapshot {
+        let root = FileId::new(1);
+        let mut physical = HashMap::from([(root, "/project/main.rue".to_owned())]);
+        let mut logical = HashMap::from([(root, "main.rue".to_owned())]);
+        let mut trusted = std::collections::HashSet::new();
+        let mut sources = vec![(root, Arc::new(root_source.to_owned()))];
+        if let Some((option, source)) = option_source {
+            physical.insert(option, "/sdk/option.rue".to_owned());
+            logical.insert(option, crate::OPTION_MODULE_LOGICAL_PATH.to_owned());
+            trusted.insert(option);
+            sources.push((option, Arc::new(source.to_owned())));
+        }
+        if let Some((strbuf, source)) = strbuf_source {
+            physical.insert(strbuf, "/sdk/strbuf.rue".to_owned());
+            logical.insert(strbuf, crate::STRBUF_MODULE_LOGICAL_PATH.to_owned());
+            trusted.insert(strbuf);
+            sources.push((strbuf, Arc::new(source.to_owned())));
+        }
+        let metadata =
+            SourceMetadata::new_with_trusted_standard_library(root, physical, logical, trusted)
+                .expect("trusted Option metadata is valid");
+        SourceSnapshot::new(metadata, sources).expect("trusted body snapshot is valid")
+    }
+
+    fn main_body_key() -> crate::body_query::BodyQueryKey {
+        crate::body_query::BodyQueryKey {
+            instance: free_function_instance(
+                &ModuleId::from_logical_path("main.rue").unwrap(),
+                "main",
+            ),
+            configuration: semantic_configuration(),
+        }
+    }
+
+    #[test]
+    fn malformed_exact_option_fails_body_request_without_compute_or_publication() {
+        let snapshot = trusted_option_body_snapshot(
+            r#"
+fn LocalOption(comptime T: type) -> type { enum { Some(T), None } }
+fn main() -> i32 {
+    let L = LocalOption(i32);
+    let _lookalike: L = L.None;
+    let _result = @parse_i32("1");
+    0
+}
+"#,
+            "pub fn Option(comptime T: type) -> type { missing }",
+        );
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&snapshot),
+            &snapshot,
+        );
+        let key = main_body_key();
+        let compute_called = std::cell::Cell::new(false);
+        let result = database.body_transaction(
+            revision,
+            key.clone(),
+            false,
+            CancellationToken::new(),
+            |_, _| {
+                compute_called.set(true);
+                Err(QueryAbort::Canceled)
+            },
+        );
+
+        assert!(matches!(
+            result,
+            Err(BodyTransactionRequestFailure::WellKnownOptionResolution(
+                WellKnownOptionResolutionFailure::Semantic {
+                    payload: crate::well_known_option::FalliblePayload::I32,
+                    ..
+                }
+            ))
+        ));
+        assert!(
+            !compute_called.get(),
+            "a local same-shape enum must not rescue the failed trusted specialization"
+        );
+        assert!(!database.has_retained_body_key(&key));
+        assert!(!database.any_body_transaction_terminal());
+        assert!(!database.any_body_reference_terminal());
+        assert_eq!(database.lookup_promotion_entries(), 0);
+    }
+
+    #[test]
+    fn missing_trusted_option_is_typed_incomplete_without_body_publication() {
+        let snapshot = trusted_body_snapshot(
+            r#"fn main() -> i32 { let _result = @parse_i32("1"); 0 }"#,
+            None,
+            None,
+        );
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&snapshot),
+            &snapshot,
+        );
+        let key = main_body_key();
+        let compute_called = std::cell::Cell::new(false);
+        let result = database.body_transaction(
+            revision,
+            key.clone(),
+            false,
+            CancellationToken::new(),
+            |_, _| {
+                compute_called.set(true);
+                Err(QueryAbort::Canceled)
+            },
+        );
+
+        assert!(matches!(
+            result,
+            Err(BodyTransactionRequestFailure::WellKnownOptionResolution(
+                WellKnownOptionResolutionFailure::Incomplete {
+                    payload: crate::well_known_option::FalliblePayload::I32,
+                    prerequisite: Some(ref key),
+                    ..
+                }
+            )) if key.module().as_str() == crate::OPTION_MODULE_LOGICAL_PATH
+        ));
+        assert!(!compute_called.get());
+        assert!(!database.has_retained_body_key(&key));
+        assert!(!database.any_body_transaction_terminal());
+        assert!(!database.any_body_reference_terminal());
+        assert_eq!(database.lookup_promotion_entries(), 0);
+    }
+
+    #[test]
+    fn missing_trusted_strbuf_is_typed_incomplete_without_body_publication() {
+        let snapshot = trusted_body_snapshot(
+            r#"fn main() -> i32 { let _result = @read_line(); 0 }"#,
+            Some((
+                FileId::new(2),
+                "pub fn Option(comptime T: type) -> type { enum { Some(T), None } }",
+            )),
+            None,
+        );
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&snapshot),
+            &snapshot,
+        );
+        let (_, unchecked_call) = crate::well_known_option::exact_option_query(
+            crate::well_known_option::FalliblePayload::StrBuf,
+            &semantic_configuration(),
+        );
+        let unchecked = database.runtime.request_registered(
+            &database.semantic_nucleus,
+            revision,
+            crate::semantic_query_nucleus::SemanticNucleusKey::ComptimeCall(unchecked_call),
+            CancellationToken::new(),
+        );
+        assert!(
+            matches!(
+                unchecked.terminal().map(|terminal| terminal.outcome()),
+                Some(rue_query::QueryOutcome::Success(
+                    crate::semantic_query_nucleus::SemanticNucleusValue::ComptimeCall(_)
+                ))
+            ),
+            "the raw comptime call currently accepts an unverified durable StrBuf key; the exact \
+             stable-classification preflight must remain authoritative: {:?}",
+            unchecked.abort()
+        );
+        let key = main_body_key();
+        let compute_called = std::cell::Cell::new(false);
+        let result = database.body_transaction(
+            revision,
+            key.clone(),
+            false,
+            CancellationToken::new(),
+            |_, _| {
+                compute_called.set(true);
+                Err(QueryAbort::Canceled)
+            },
+        );
+
+        assert!(matches!(
+            result,
+            Err(BodyTransactionRequestFailure::WellKnownOptionResolution(
+                WellKnownOptionResolutionFailure::Incomplete {
+                    payload: crate::well_known_option::FalliblePayload::StrBuf,
+                    prerequisite: Some(ref key),
+                    ..
+                }
+            )) if key.module().as_str() == crate::STRBUF_MODULE_LOGICAL_PATH
+        ));
+        assert!(!compute_called.get());
+        assert!(!database.has_retained_body_key(&key));
+        assert!(!database.any_body_transaction_terminal());
+        assert!(!database.any_body_reference_terminal());
+        assert_eq!(database.lookup_promotion_entries(), 0);
+    }
+
+    #[test]
+    fn wrong_exact_option_projection_fails_body_request_atomically() {
+        let snapshot = trusted_option_body_snapshot(
+            r#"fn main() -> i32 { let _result = @parse_u32("1"); 0 }"#,
+            "pub fn Option(comptime T: type) -> i32 { 0 }",
+        );
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = database.source_revision(
+            &super::super::session::ExactSourceInput::new(&snapshot),
+            &snapshot,
+        );
+        let key = main_body_key();
+        let compute_called = std::cell::Cell::new(false);
+        let result = database.body_transaction(
+            revision,
+            key.clone(),
+            false,
+            CancellationToken::new(),
+            |_, _| {
+                compute_called.set(true);
+                Err(QueryAbort::Canceled)
+            },
+        );
+
+        assert!(matches!(
+            result,
+            Err(BodyTransactionRequestFailure::WellKnownOptionResolution(
+                WellKnownOptionResolutionFailure::WrongProjection {
+                    payload: crate::well_known_option::FalliblePayload::U32,
+                    ..
+                }
+            ))
+        ));
+        assert!(!compute_called.get());
+        assert!(!database.has_retained_body_key(&key));
+        assert!(!database.any_body_transaction_terminal());
+        assert!(!database.any_body_reference_terminal());
+        assert_eq!(database.lookup_promotion_entries(), 0);
+    }
+
+    #[test]
+    fn body_transaction_failure_precedence_is_exhaustive() {
+        assert_eq!(
+            classify_body_transaction_failure(&QueryAbort::Canceled, true, true, true, true,),
+            BodyTransactionFailureClass::RequestCanceled,
+            "a canceled request wins even when every typed domain failure was recorded"
+        );
+        assert_eq!(
+            classify_body_transaction_failure(&QueryAbort::Canceled, false, true, true, true,),
+            BodyTransactionFailureClass::ProducerFailed
+        );
+        assert_eq!(
+            classify_body_transaction_failure(&QueryAbort::Canceled, false, false, true, true,),
+            BodyTransactionFailureClass::DeferredAnonymousProducers
+        );
+        assert_eq!(
+            classify_body_transaction_failure(&QueryAbort::Canceled, false, false, false, true,),
+            BodyTransactionFailureClass::WellKnownOptionResolution
+        );
+        assert_eq!(
+            classify_body_transaction_failure(&QueryAbort::Canceled, false, false, false, false,),
+            BodyTransactionFailureClass::Query
+        );
+        assert_eq!(
+            classify_body_transaction_failure(&QueryAbort::ForeignRuntime, true, true, true, true,),
+            BodyTransactionFailureClass::Query,
+            "domain precedence applies only to the internal cancellation carrier"
+        );
+    }
+
+    #[test]
+    fn well_known_dependency_abort_classification_is_exhaustive() {
+        assert_eq!(
+            classify_well_known_dependency_abort(&QueryAbort::Canceled),
+            WellKnownDependencyAbortClass::Incomplete
+        );
+        assert_eq!(
+            classify_well_known_dependency_abort(&QueryAbort::MissingInput(InputIdentity::new(
+                "well-known-test",
+                "missing",
+            ))),
+            WellKnownDependencyAbortClass::Incomplete
+        );
+        assert_eq!(
+            classify_well_known_dependency_abort(&QueryAbort::ForeignRuntime),
+            WellKnownDependencyAbortClass::Propagate
+        );
+        assert_eq!(
+            classify_well_known_dependency_abort(&QueryAbort::Cycle(Arc::from([]))),
+            WellKnownDependencyAbortClass::Propagate
+        );
+        assert_eq!(
+            classify_well_known_dependency_abort(&QueryAbort::UnpublishedRevision(Revision::new(
+                42, 1,
+            ))),
+            WellKnownDependencyAbortClass::Propagate
+        );
     }
 
     fn declaration_candidate(
@@ -22941,9 +23456,9 @@ mod tests {
         use std::collections::HashSet;
 
         // The freestanding fallible-intrinsic program plus the trusted `Option`
-        // module published at its trusted logical path — exactly the presence
-        // condition `plan_well_known_option_demands` requires. `main` names
-        // `@parse_i64` and `@parse_u32`, so the program demands two payloads.
+        // module published at its trusted logical path. `main` names
+        // `@parse_i64` and `@parse_u32`, so its registered demand node names two
+        // payloads and each maps directly to one exact comptime key.
         let root = FileId::new(1);
         let option = FileId::new(2);
         let physical = HashMap::from([
@@ -22987,14 +23502,12 @@ mod tests {
         let merged = crate::merge_parsed_modules(&parsed).unwrap();
         let rir = crate::lower_canonical_rir(&merged).unwrap();
 
-        // The production demand catalogue: one entry per demanded payload, each
-        // carrying the exact `ComptimeCall` the per-body demand loop roots.
-        let demands = crate::well_known_option::plan_well_known_option_demands(
-            &merged,
-            &rir,
-            &semantic_configuration(),
-        );
-        assert_eq!(demands.len(), 2, "i64 and u32 payloads are demanded");
+        let configuration = semantic_configuration();
+        let demands = [
+            crate::well_known_option::FalliblePayload::I64,
+            crate::well_known_option::FalliblePayload::U32,
+        ]
+        .map(|kind| crate::well_known_option::exact_option_query(kind, &configuration));
 
         // Resolve each demand through the nucleus — the declaration-level
         // durable truth BOTH installs consume — assembling the same
@@ -23009,12 +23522,9 @@ mod tests {
             crate::AnonymousNominalKey,
             crate::durable_semantics::DurableAnonymousNominal,
         > = BTreeMap::new();
-        for demand in demands.iter() {
-            let value = request_semantic_nucleus(
-                &nucleus_db,
-                nucleus_revision,
-                Key::ComptimeCall(demand.call.clone()),
-            );
+        for (payload, call) in demands {
+            let value =
+                request_semantic_nucleus(&nucleus_db, nucleus_revision, Key::ComptimeCall(call));
             let V::ComptimeCall(projection) = value else {
                 panic!("trusted Option comptime call did not resolve: {value:?}");
             };
@@ -23024,7 +23534,7 @@ mod tests {
                     projection.result
                 );
             };
-            option_by_payload.push((demand.payload.clone(), option_type.clone()));
+            option_by_payload.push((payload, option_type.clone()));
             for nominal in projection.anonymous_nominals.iter() {
                 nominals.insert(nominal.identity.clone(), nominal.clone());
             }

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -6783,16 +6783,6 @@ impl CompilerSession {
                 target: options.target,
                 preview_features: StablePreviewFeatures::new(&options.preview_features),
             };
-            // Plan the trusted-std `Option(payload)` demands once for this
-            // semantic request (RUE-1112). The plan is empty — leaving the
-            // legacy AIR structural scan in force — unless the trusted `Option`
-            // module is present AND the program uses a fallible intrinsic. Each
-            // reached body roots these demands under its own lease below.
-            let well_known_demands = crate::well_known_option::plan_well_known_option_demands(
-                &merged,
-                &rir,
-                &configuration,
-            );
             let mut pending = std::collections::BTreeSet::new();
             for record in prepared_definitions.definitions().definitions() {
                 let stable = record.stable_key();
@@ -7255,7 +7245,6 @@ impl CompilerSession {
                         runtime_revision,
                         key.clone(),
                         producer_body_terminal_required,
-                        well_known_demands.clone(),
                         cancellation.clone(),
                         |selected_anonymous, well_known| {
                             queried_body_work.bodies_attempted += 1;
@@ -7413,6 +7402,61 @@ impl CompilerSession {
                                 instance.clone(),
                                 semantic_nucleus_failure_diagnostics(merged.ast(), None, &failure),
                             );
+                            break;
+                        }
+                        Err(crate::revisioned_query_database::BodyTransactionRequestFailure::WellKnownOptionResolution(
+                            failure,
+                        )) => {
+                            use crate::revisioned_query_database::WellKnownOptionResolutionFailure;
+                            let errors = match failure {
+                                WellKnownOptionResolutionFailure::Incomplete {
+                                    payload,
+                                    prerequisite,
+                                    detail,
+                                } => crate::CompileErrors::from(
+                                    crate::CompileError::without_span(
+                                        rue_error::ErrorKind::InternalError(format!(
+                                            "exact trusted Option({payload:?}) prerequisite \
+                                             resolution was incomplete{}: {detail}",
+                                            prerequisite.as_ref().map_or_else(
+                                                String::new,
+                                                |key| format!(" at {key:?}")
+                                            )
+                                        )),
+                                    ),
+                                ),
+                                WellKnownOptionResolutionFailure::Semantic {
+                                    payload,
+                                    failure,
+                                } => {
+                                    let mut errors = semantic_nucleus_failure_diagnostics(
+                                        merged.ast(),
+                                        None,
+                                        &failure,
+                                    );
+                                    if errors.is_empty() {
+                                        errors = crate::CompileErrors::from(
+                                            crate::CompileError::without_span(
+                                                rue_error::ErrorKind::InternalError(format!(
+                                                    "trusted Option({payload:?}) resolution failed without diagnostics: {failure:?}"
+                                                )),
+                                            ),
+                                        );
+                                    }
+                                    errors
+                                }
+                                WellKnownOptionResolutionFailure::WrongProjection {
+                                    payload,
+                                    detail,
+                                } => crate::CompileErrors::from(
+                                    crate::CompileError::without_span(
+                                        rue_error::ErrorKind::InternalError(format!(
+                                            "trusted Option({payload:?}) resolution returned the wrong semantic projection: {detail}"
+                                        )),
+                                    ),
+                                ),
+                            };
+                            body_query_errors.insert(instance.clone(), errors);
                             break;
                         }
                         Err(crate::revisioned_query_database::BodyTransactionRequestFailure::DeferredAnonymousProducers(
@@ -17928,7 +17972,6 @@ fn main() -> i32 { selected.value() }"#,
                 revision,
                 key.clone(),
                 false,
-                Arc::from([]),
                 cancellation.clone(),
                 |_, _| panic!("semantic request must have materialized this body terminal"),
             )
@@ -17976,7 +18019,6 @@ fn main() -> i32 { selected.value() }"#,
                 revision,
                 key.clone(),
                 false,
-                Arc::from([]),
                 rue_query::CancellationToken::new(),
                 |_, _| panic!("semantic request must have materialized this body terminal"),
             )
@@ -18003,7 +18045,6 @@ fn main() -> i32 { selected.value() }"#,
                 revision,
                 key.clone(),
                 false,
-                Arc::from([]),
                 rue_query::CancellationToken::new(),
                 |_, _| panic!("semantic request must have materialized this body terminal"),
             )
@@ -18019,6 +18060,16 @@ fn main() -> i32 { selected.value() }"#,
     /// is provided at `\0rue-std/option.rue`, reached with
     /// `@import("std/option.rue")` (physical-suffix match).
     fn well_known_option_isolation_snapshot(root_source: &str) -> SourceSnapshot {
+        well_known_option_snapshot_with_source(
+            root_source,
+            "pub fn Option(comptime T: type) -> type { enum { Some(T), None } }",
+        )
+    }
+
+    fn well_known_option_snapshot_with_source(
+        root_source: &str,
+        option_source: &str,
+    ) -> SourceSnapshot {
         let root = FileId::new(1);
         let option = FileId::new(2);
         let metadata = SourceMetadata::new_with_trusted_standard_library(
@@ -18038,16 +18089,71 @@ fn main() -> i32 { selected.value() }"#,
             metadata,
             vec![
                 (root, Arc::new(root_source.to_owned())),
-                (
-                    option,
-                    Arc::new(
-                        "pub fn Option(comptime T: type) -> type { enum { Some(T), None } }"
-                            .to_owned(),
-                    ),
-                ),
+                (option, Arc::new(option_source.to_owned())),
             ],
         )
         .unwrap()
+    }
+
+    #[test]
+    fn malformed_well_known_option_repairs_to_fresh_canonical_semantics() {
+        let options = CompileOptions::default();
+        let program = r#"
+const opt = @import("std/option.rue");
+fn main() -> i32 {
+    let O = opt.Option(i32);
+    match @parse_i32("42") {
+        O.Some(value) => value,
+        O.None => 0,
+    }
+}
+"#;
+        let malformed = well_known_option_snapshot_with_source(
+            program,
+            "pub fn Option(comptime T: type) -> type { missing }",
+        );
+        let repaired = well_known_option_isolation_snapshot(program);
+
+        let mut warm = CompilerSession::new();
+        publish_with_test_imports(&mut warm, &malformed);
+        let errors = warm
+            .canonical_semantic(&options)
+            .expect_err("the malformed trusted Option specialization must fail");
+        assert!(
+            errors.to_string().contains("missing"),
+            "the failed attempt must retain the trusted declaration diagnostic: {errors}"
+        );
+        assert!(
+            !warm.queries.revisioned.any_body_transaction_terminal(),
+            "the malformed attempt must not publish a body transaction"
+        );
+        assert!(
+            !warm.queries.revisioned.any_body_reference_terminal(),
+            "the malformed attempt must not publish a body-reference projection"
+        );
+        assert_eq!(
+            warm.queries.revisioned.lookup_promotion_entries(),
+            0,
+            "the malformed attempt must not promote a body lookup root"
+        );
+
+        publish_with_test_imports(&mut warm, &repaired);
+        let warm_repaired = warm
+            .canonical_semantic(&options)
+            .expect("the repaired successor must compile");
+
+        let mut fresh = CompilerSession::new();
+        publish_with_test_imports(&mut fresh, &repaired);
+        let fresh_repaired = fresh
+            .canonical_semantic(&options)
+            .expect("the repaired snapshot must compile fresh");
+
+        assert_eq!(
+            warm_repaired.unstable_parity_snapshot(),
+            fresh_repaired.unstable_parity_snapshot(),
+            "malformed-state warming must not change repaired canonical semantics"
+        );
+        assert!(warm.queries.revisioned.any_body_transaction_terminal());
     }
 
     /// Query-edge isolation. Two reached bodies demand DIFFERENT well-known
@@ -18817,7 +18923,6 @@ fn main() -> i32 {
             revision,
             main.clone(),
             false,
-            Arc::from([]),
             rue_query::CancellationToken::new(),
             |_, _| {
                 recomputed.set(true);
@@ -18850,7 +18955,6 @@ fn main() -> i32 {
             fresh_revision,
             main,
             false,
-            Arc::from([]),
             rue_query::CancellationToken::new(),
             |_, _| {
                 fresh_computed.set(true);
@@ -18913,7 +19017,6 @@ fn main() -> i32 {
             revision,
             main.clone(),
             false,
-            Arc::from([]),
             rue_query::CancellationToken::new(),
             |_, _| {
                 recomputed.set(true);
@@ -18946,7 +19049,6 @@ fn main() -> i32 {
             fresh_revision,
             main,
             false,
-            Arc::from([]),
             rue_query::CancellationToken::new(),
             |_, _| {
                 fresh_computed.set(true);
@@ -18987,7 +19089,6 @@ fn main() -> i32 {
             revision,
             dead,
             false,
-            Arc::from([]),
             rue_query::CancellationToken::new(),
             |_, _| {
                 compute_called.set(true);

--- a/crates/rue-compiler/src/session/tests/rfinal_harness.rs
+++ b/crates/rue-compiler/src/session/tests/rfinal_harness.rs
@@ -759,7 +759,6 @@ fn capture_terminal(
             revision,
             key.clone(),
             false,
-            Arc::from([]),
             rue_query::CancellationToken::new(),
             |_, _| {
                 panic!(

--- a/crates/rue-compiler/src/well_known_option.rs
+++ b/crates/rue-compiler/src/well_known_option.rs
@@ -1,39 +1,28 @@
-//! Per-body well-known `Option(payload)` demand planning.
+//! Exact per-body well-known `Option(payload)` query keys.
 //!
 //! Every fallible intrinsic (`@read_line`, `@parse_i32/i64/u32/u64`) yields the
-//! exact trusted standard-library `Option(payload)`. When a trusted `Option`
-//! module is present in the program, this planner computes the set of payloads
-//! the program demands and roots the matching comptime-`Option` specializations
-//! under each requesting body's lease (see `revisioned_query_database.rs`). The
-//! resolved enums reach AIR through a narrow per-body `WellKnownTypes` input,
-//! never the body's composition/import universe.
-//!
-//! Planning is two-staged. This module builds the whole-program *catalogue* of
-//! demandable `Option(payload)` specializations (one per payload the program
-//! uses anywhere), each tagged with its [`FalliblePayload`] kind. Each reached
-//! body then derives its OWN exact payload set from its canonical raw body
-//! ([`scan_body_payload_kinds`]) and roots only the catalogue entries that set
-//! selects, so a body gains a query edge to a specialization only for a payload
-//! it actually uses and cannot inherit failure or cancellation from an unrelated
-//! body's specialization. The semantic nucleus memoizes each specialization, so
-//! bodies sharing a payload share one terminal. A program with no fallible
-//! intrinsic demands nothing at all.
+//! exact trusted standard-library `Option(payload)`. A registered body derives
+//! its own canonical payload set from [`scan_body_payload_kinds`], then maps each
+//! payload directly to the exact trusted `Option` comptime-call key with
+//! [`exact_option_query`]. No whole-program RIR scan, presence catalogue, or
+//! structural fallback participates in that identity.
 
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
-use crate::body_query::WellKnownOptionDemand;
-use crate::canonical_lower::CanonicalRirOutput;
-use crate::canonical_merge::CanonicalMergedProgram;
 use crate::declaration_candidate::{DeclarationCandidateCategory, DeclarationCandidateKey};
 use crate::durable_semantics::DurableType;
 use crate::semantic_query_nucleus::{
     ComptimeCallQueryKey, DeclarationSemanticQueryKey, SemanticQueryConfiguration,
 };
+use crate::toolchain_module_demand::{OPTION_MODULE_LOGICAL_PATH, STRBUF_MODULE_LOGICAL_PATH};
 use crate::{ModuleId, StableDefinitionKey, StableDefinitionKind, StableDefinitionNamespace};
 
-const TRUSTED_OPTION_MODULE_PATH: &str = "\0rue-std/option.rue";
-const TRUSTED_STRBUF_MODULE_PATH: &str = "\0rue-std/strbuf.rue";
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExactOptionPrerequisite {
+    pub(crate) stable: StableDefinitionKey,
+    pub(crate) candidate: DeclarationCandidateKey,
+}
 
 /// One fallible-intrinsic payload demanded by a body.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -86,122 +75,171 @@ pub(crate) fn scan_body_payload_kinds(body: &str) -> BTreeSet<FalliblePayload> {
     payloads
 }
 
-/// Whether `module` is present among the program's canonical modules.
-fn module_present(merged: &CanonicalMergedProgram, module: &ModuleId) -> bool {
-    merged
-        .ast()
-        .modules()
-        .iter()
-        .any(|candidate| candidate.module_id() == module)
-}
-
-/// Scan the whole-program RIR for every fallible-intrinsic call, returning the
-/// sorted, deduplicated set of demanded payloads.
+/// Map one body's canonical fallible payload kind to its exact trusted
+/// `Option(payload)` comptime query.
 ///
-/// Every fallible intrinsic yields the exact trusted std `Option(payload)` in
-/// every context, so every use — bare, contextually annotated, matched, or the
-/// operand of a `?` — demands the canonical `Option(payload)`. The registry is
-/// the single durable source for that identity; context only checks it. Scanning
-/// all uses (not only `?`-operands) is what lets a plain `let x = @parse_i64(…)`
-/// or `match @parse_i32(…)` resolve to the canonical trusted `Option` rather
-/// than depending on a surrounding annotation to supply the nominal.
-fn scan_fallible_payloads(rir: &CanonicalRirOutput) -> BTreeSet<FalliblePayload> {
-    let interner = rir.semantic_symbols().interner();
-    let mut payloads = BTreeSet::new();
-    for (_, inst) in rir.rir().iter() {
-        if let rue_rir::InstData::Intrinsic { name, .. } = &inst.data
-            && let Some(payload) = FalliblePayload::from_intrinsic_name(interner.resolve(name))
-        {
-            payloads.insert(payload);
-        }
-    }
-    payloads
-}
-
-/// The trusted `StrBuf` nominal `DurableType`, when the trusted `StrBuf` module
-/// is present. `@read_line`'s `Option(StrBuf)` cannot be demanded without it.
-fn trusted_strbuf_type(merged: &CanonicalMergedProgram) -> Option<DurableType> {
-    let module = ModuleId::from_trusted_standard_library_path(TRUSTED_STRBUF_MODULE_PATH).ok()?;
-    module_present(merged, &module).then(|| {
-        DurableType::Nominal(StableDefinitionKey::from_stable_parts(
-            module,
-            StableDefinitionNamespace::Type,
-            StableDefinitionKind::Struct,
-            "StrBuf",
-            None,
-        ))
-    })
-}
-
-/// Plan the well-known `Option` demand catalogue for a semantic request.
-///
-/// Returns an empty catalogue whenever the trusted `Option` module is absent or
-/// the program uses no fallible intrinsic; otherwise it holds one entry per
-/// payload the program uses anywhere, each carrying the exact `ComptimeCall` to
-/// root under a body's lease and the payload it satisfies. Per-body selection
-/// from this catalogue happens in `body_transaction`.
-pub(crate) fn plan_well_known_option_demands(
-    merged: &CanonicalMergedProgram,
-    rir: &CanonicalRirOutput,
+/// This is a pure identity derivation. It performs no module-presence check and
+/// accepts no merged program, RIR, or request-global catalogue. The session
+/// parks missing trusted modules before the body transaction; once the body
+/// enters, this exact key must resolve or the request fails closed.
+pub(crate) fn exact_option_query(
+    kind: FalliblePayload,
     configuration: &SemanticQueryConfiguration,
-) -> Arc<[WellKnownOptionDemand]> {
-    let Ok(option_module) =
-        ModuleId::from_trusted_standard_library_path(TRUSTED_OPTION_MODULE_PATH)
-    else {
-        return Arc::from(Vec::new());
+) -> (DurableType, ComptimeCallQueryKey) {
+    let option_module = ModuleId::from_trusted_standard_library_path(OPTION_MODULE_LOGICAL_PATH)
+        .expect("the canonical trusted Option module path is valid");
+    let option_candidate = exact_option_candidate(option_module);
+    let payload = exact_payload_type(kind);
+    let call = ComptimeCallQueryKey {
+        declaration: DeclarationSemanticQueryKey {
+            declaration: option_candidate,
+            configuration: configuration.clone(),
+        },
+        type_arguments: Arc::from([(Arc::<str>::from("T"), payload.clone())]),
+        value_arguments: Arc::from([]),
     };
-    // The trusted `Option` module must be present to name any specialization.
-    // When it is absent the catalogue is empty and fallible-intrinsic resolution
-    // uses its structural context check instead.
-    if !module_present(merged, &option_module) {
-        return Arc::from(Vec::new());
-    }
-    let payloads = scan_fallible_payloads(rir);
-    if payloads.is_empty() {
-        return Arc::from(Vec::new());
-    }
-    let option_candidate = DeclarationCandidateKey {
+    (payload, call)
+}
+
+fn exact_option_candidate(option_module: ModuleId) -> DeclarationCandidateKey {
+    DeclarationCandidateKey {
         module: option_module,
         category: DeclarationCandidateCategory::Function,
         name: Arc::from("Option"),
         owner: None,
         duplicate_discriminator: 0,
-    };
-    let strbuf = trusted_strbuf_type(merged);
-    let mut demands = Vec::new();
-    for payload in payloads {
-        let payload_type = match payload {
-            FalliblePayload::I32 => DurableType::I32,
-            FalliblePayload::I64 => DurableType::I64,
-            FalliblePayload::U32 => DurableType::U32,
-            FalliblePayload::U64 => DurableType::U64,
-            // Without the trusted StrBuf module the payload cannot be spelled;
-            // the read_line demand is simply not rooted and falls through.
-            FalliblePayload::StrBuf => match &strbuf {
-                Some(strbuf) => strbuf.clone(),
-                None => continue,
+    }
+}
+
+fn exact_payload_type(kind: FalliblePayload) -> DurableType {
+    match kind {
+        FalliblePayload::I32 => DurableType::I32,
+        FalliblePayload::I64 => DurableType::I64,
+        FalliblePayload::U32 => DurableType::U32,
+        FalliblePayload::U64 => DurableType::U64,
+        FalliblePayload::StrBuf => DurableType::Nominal(StableDefinitionKey::from_stable_parts(
+            ModuleId::from_trusted_standard_library_path(STRBUF_MODULE_LOGICAL_PATH)
+                .expect("the canonical trusted StrBuf module path is valid"),
+            StableDefinitionNamespace::Type,
+            StableDefinitionKind::Struct,
+            "StrBuf",
+            None,
+        )),
+    }
+}
+
+/// Exact declarations that must already be present before resolving one
+/// body-owned `Option(payload)` specialization.
+///
+/// The stable classifier observes only these independently keyed declarations:
+/// trusted `Option` for every payload, plus trusted `StrBuf` only for
+/// `@read_line`. Host parking remains the acquisition authority; this is the
+/// query-owned fail-closed check for callers that bypass or race that boundary.
+pub(crate) fn exact_option_prerequisites(kind: FalliblePayload) -> Vec<ExactOptionPrerequisite> {
+    let option_module = ModuleId::from_trusted_standard_library_path(OPTION_MODULE_LOGICAL_PATH)
+        .expect("the canonical trusted Option module path is valid");
+    let mut prerequisites = vec![ExactOptionPrerequisite {
+        stable: StableDefinitionKey::from_stable_parts(
+            option_module.clone(),
+            StableDefinitionNamespace::Value,
+            StableDefinitionKind::Function,
+            "Option",
+            None,
+        ),
+        candidate: exact_option_candidate(option_module),
+    }];
+    if kind == FalliblePayload::StrBuf {
+        let module = ModuleId::from_trusted_standard_library_path(STRBUF_MODULE_LOGICAL_PATH)
+            .expect("the canonical trusted StrBuf module path is valid");
+        prerequisites.push(ExactOptionPrerequisite {
+            stable: StableDefinitionKey::from_stable_parts(
+                module.clone(),
+                StableDefinitionNamespace::Type,
+                StableDefinitionKind::Struct,
+                "StrBuf",
+                None,
+            ),
+            candidate: DeclarationCandidateKey {
+                module,
+                category: DeclarationCandidateCategory::Struct,
+                name: Arc::from("StrBuf"),
+                owner: None,
+                duplicate_discriminator: 0,
             },
-        };
-        let call = ComptimeCallQueryKey {
-            declaration: DeclarationSemanticQueryKey {
-                declaration: option_candidate.clone(),
-                configuration: configuration.clone(),
-            },
-            type_arguments: Arc::from(vec![(Arc::<str>::from("T"), payload_type.clone())]),
-            value_arguments: Arc::from(Vec::new()),
-        };
-        demands.push(WellKnownOptionDemand {
-            kind: payload,
-            payload: payload_type,
-            call,
         });
     }
-    Arc::from(demands)
+    prerequisites
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn every_payload_maps_to_one_exact_trusted_option_key() {
+        let configuration = SemanticQueryConfiguration {
+            target: rue_target::Target::X86_64Linux,
+            preview_features: crate::StablePreviewFeatures::new(&crate::PreviewFeatures::default()),
+        };
+        for (kind, expected) in [
+            (FalliblePayload::I32, DurableType::I32),
+            (FalliblePayload::I64, DurableType::I64),
+            (FalliblePayload::U32, DurableType::U32),
+            (FalliblePayload::U64, DurableType::U64),
+            (
+                FalliblePayload::StrBuf,
+                DurableType::Nominal(StableDefinitionKey::from_stable_parts(
+                    ModuleId::from_trusted_standard_library_path(STRBUF_MODULE_LOGICAL_PATH)
+                        .unwrap(),
+                    StableDefinitionNamespace::Type,
+                    StableDefinitionKind::Struct,
+                    "StrBuf",
+                    None,
+                )),
+            ),
+        ] {
+            let (payload, query) = exact_option_query(kind, &configuration);
+            assert_eq!(payload, expected, "{kind:?}");
+            assert_eq!(
+                query.declaration.declaration.module.as_str(),
+                OPTION_MODULE_LOGICAL_PATH
+            );
+            assert_eq!(
+                query.declaration.declaration.category,
+                DeclarationCandidateCategory::Function
+            );
+            assert_eq!(query.declaration.declaration.name.as_ref(), "Option");
+            assert_eq!(query.declaration.declaration.duplicate_discriminator, 0);
+            assert_eq!(query.declaration.configuration, configuration);
+            assert_eq!(
+                query.type_arguments.as_ref(),
+                &[(Arc::<str>::from("T"), expected)]
+            );
+            assert!(query.value_arguments.is_empty());
+
+            let prerequisites = exact_option_prerequisites(kind);
+            assert_eq!(
+                prerequisites[0].stable.module().as_str(),
+                OPTION_MODULE_LOGICAL_PATH
+            );
+            assert_eq!(prerequisites[0].stable.name(), "Option");
+            assert_eq!(prerequisites[0].candidate, query.declaration.declaration);
+            if kind == FalliblePayload::StrBuf {
+                assert_eq!(prerequisites.len(), 2);
+                assert_eq!(
+                    prerequisites[1].stable.module().as_str(),
+                    STRBUF_MODULE_LOGICAL_PATH
+                );
+                assert_eq!(prerequisites[1].stable.name(), "StrBuf");
+                assert_eq!(
+                    prerequisites[1].candidate.category,
+                    DeclarationCandidateCategory::Struct
+                );
+            } else {
+                assert_eq!(prerequisites.len(), 1);
+            }
+        }
+    }
 
     #[test]
     fn per_body_scan_derives_only_the_body_s_own_payloads() {

--- a/docs/notes/rue-1091-analyzer-rewire-plan.md
+++ b/docs/notes/rue-1091-analyzer-rewire-plan.md
@@ -680,8 +680,8 @@ plus both sides' recorded identity sets agreeing in cardinality and digest ident
 
 **(c) Cross-path differential.** `provider_well_known_option_install_matches_epoch`
 (`revisioned_query_database.rs` test tail) drives BOTH installs from the SAME declaration-level
-durable truth — the nucleus `ComptimeCall` terminals the production demand loop roots
-(`plan_well_known_option_demands` → per-demand `SemanticNucleusKey::ComptimeCall`), for a
+durable truth — the nucleus `ComptimeCall` terminals the production body transaction roots
+(`body-toolchain-demands` → per-payload exact `SemanticNucleusKey::ComptimeCall`), for a
 two-payload program (`@parse_i64` + `@parse_u32`) with the trusted `\0rue-std/option.rue` module
 present. The epoch side binds through the production declaration recipe, projects the registry
 against the SAME `BoundDefinitionSet` that issued the epoch's endpoints


### PR DESCRIPTION
## Summary

- remove the request-global whole-RIR well-known Option catalogue
- derive exact trusted Option and StrBuf prerequisites from each body-owned demand
- fail atomically on incomplete, malformed, or wrong specialization inputs without structural rescue
- preserve cancellation and engine-abort control semantics with warm/fresh repair coverage

## Validation

- `scripts/rue quick`
- `scripts/rue test`
- focused rue-compiler and rue-air tests
- rue-air and rue-compiler Clippy subtargets

Refs RUE-1092.