### PR TITLE
RUE-1092: Move body owner identity into analysis state

### DIFF
--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -316,6 +316,9 @@ pub(super) struct PendingNominalPayload {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DeclarationInstallFailure {
+    /// Body-owner installation was attempted after the declaration base was
+    /// sealed; refreshing only the live epoch would leave derivation data stale.
+    AlreadySealed,
     DuplicatePayload,
     MissingPayload,
     UnexpectedPayload,
@@ -2410,6 +2413,9 @@ impl<'a> BoundSema<'a> {
         mut self,
         endpoints: &[super::BodyOwnerEndpoint],
     ) -> Result<Self, DeclarationInstallFailure> {
+        if self.body_base.is_some() {
+            return Err(DeclarationInstallFailure::AlreadySealed);
+        }
         let issuer = endpoints.first().map(|e| e.token.issuer());
         let mut installed = HashMap::with_capacity(endpoints.len());
         let mut tokens = HashSet::with_capacity(endpoints.len());

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -392,6 +392,7 @@ pub struct BoundSema<'a> {
     /// immutable data only; a derived body receives a new analyzer assembled
     /// from it and fresh local overlays.
     pub(super) body_base: Option<Arc<BodySemanticBase<'a>>>,
+    pub(super) body_state: Option<super::BodyAnalysisState<'a>>,
     manifest: OnceLock<SemanticBindingManifest>,
     binding_work: DeclarationBindingWork,
 }
@@ -400,10 +401,19 @@ impl<'a> BoundSema<'a> {
     pub(super) fn derive_from_body_base(&self, base: Arc<BodySemanticBase<'a>>) -> Self {
         Self {
             sema: super::BodySema::derive_from_body_semantic_base(&base),
-            body_base: Some(base),
+            body_base: Some(base.clone()),
+            body_state: Some(super::BodyAnalysisState::from_body_semantic_base(
+                base.clone(),
+            )),
             manifest: self.manifest.clone(),
             binding_work: self.binding_work,
         }
+    }
+
+    fn take_body_state(&mut self) -> super::BodyAnalysisState<'a> {
+        self.body_state
+            .take()
+            .expect("body analysis requires an installed body-analysis state")
     }
 }
 
@@ -2101,17 +2111,18 @@ impl<'a> BoundSema<'a> {
     /// Analyze exactly one callable body. Ordinary callees are reported as
     /// stable references and are never analyzed by this transaction.
     pub fn analyze_one_body(
-        self,
+        mut self,
         request: super::OneBodyRequest,
         interruption: Option<super::OneBodyInterruption>,
     ) -> super::OneBodyTransactionOutcome {
-        super::one_body::analyze_one_body(self.sema, request, interruption)
+        let state = self.take_body_state();
+        super::one_body::analyze_one_body(self.sema, state, request, interruption)
     }
 
     /// Resolve a stable compiler-owned function instance into this fresh
     /// semantic epoch, then analyze exactly that body.
     pub fn analyze_one_body_instance<K, M>(
-        self,
+        mut self,
         instance: &crate::FunctionInstanceKey<K, M>,
         definition: impl Fn(
             &K,
@@ -2129,8 +2140,10 @@ impl<'a> BoundSema<'a> {
         K: Clone,
         M: Clone,
     {
+        let state = self.take_body_state();
         super::one_body::analyze_one_body_instance(
             self.sema,
+            state,
             instance,
             definition,
             module,
@@ -2165,8 +2178,10 @@ impl<'a> BoundSema<'a> {
         M: Clone,
     {
         self.sema.body_lookup_collector = Some(collector);
+        let state = self.take_body_state();
         super::one_body::analyze_one_body_instance(
             self.sema,
+            state,
             instance,
             definition,
             module,
@@ -2453,6 +2468,9 @@ impl<'a> BoundSema<'a> {
             return Err(DeclarationInstallFailure::IdentityMismatch);
         }
         self.sema.body_owner_tokens = std::sync::Arc::new(installed);
+        self.body_state = Some(super::BodyAnalysisState::from_body_semantic_base(Arc::new(
+            self.sema.body_semantic_base(),
+        )));
         Ok(self)
     }
     pub fn binding_work(&self) -> DeclarationBindingWork {
@@ -3873,10 +3891,15 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
         // the declaration side of the phase boundary. Body analysis receives
         // an immutable namespace with final destructor symbols.
         self.requalify_colliding_destructor_symbols();
+        let sema = self.freeze_declarations();
+        let body_epoch = Arc::new(sema.body_semantic_base());
         BoundSema {
             binding_work,
-            sema: self.freeze_declarations(),
+            sema,
             body_base: None,
+            body_state: Some(super::BodyAnalysisState::from_body_semantic_base(
+                body_epoch,
+            )),
             manifest: OnceLock::new(),
         }
     }

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -260,7 +260,7 @@ mod tests {
         let base = SEMA_ROOT_SOURCE
             .split("pub(super) struct BodySemanticBase")
             .nth(1)
-            .and_then(|source| source.split("/// The declaration-time portion").next())
+            .and_then(|source| source.split("pub(super) struct BodyAnalysisState").next())
             .expect("BodySemanticBase definition is present");
         for forbidden in ["Sema<", "Sema::", "&Sema", "BodySema", "BoundSema", "Deref"] {
             assert!(
@@ -307,6 +307,39 @@ mod tests {
         assert!(construction.contains("body_named_dependencies: Vec::new()"));
         assert!(DECLARATION_BASE_SOURCE.contains("+ local.deferred_ownership_gates.len()"));
         assert!(DECLARATION_BASE_SOURCE.contains("forced_anonymous_digest_entries"));
+    }
+
+    #[test]
+    fn ordinary_owner_identity_uses_the_owned_body_analysis_state() {
+        let state = SEMA_ROOT_SOURCE
+            .split("pub(super) struct BodyAnalysisState")
+            .nth(1)
+            .and_then(|source| source.split("/// The declaration-time portion").next())
+            .expect("BodyAnalysisState definition is present");
+        for forbidden in [
+            "Sema<",
+            "Sema::",
+            "&Sema",
+            "BodySema<",
+            "BodySema::",
+            "BoundSema",
+            "sema:",
+            "Deref",
+        ] {
+            assert!(
+                !state.contains(forbidden),
+                "BodyAnalysisState must not retain {forbidden}"
+            );
+        }
+
+        let ordinary = ONE_BODY_SOURCE
+            .split("fn analyze_definition(")
+            .nth(1)
+            .and_then(|source| source.split("fn analyze_named_method(").next())
+            .expect("ordinary definition analyzer is present");
+        assert!(ordinary.contains("state: &BodyAnalysisState<'_>"));
+        assert!(ordinary.contains("let owner = state.body_owner_token("));
+        assert!(!ordinary.contains("BodyAnalysisState::from_body_semantic_base"));
     }
 
     #[test]

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -340,6 +340,23 @@ mod tests {
         assert!(ordinary.contains("state: &BodyAnalysisState<'_>"));
         assert!(ordinary.contains("let owner = state.body_owner_token("));
         assert!(!ordinary.contains("BodyAnalysisState::from_body_semantic_base"));
+
+        let resolver = SEMA_ROOT_SOURCE
+            .split("fn resolve_body_owner_token(")
+            .nth(1)
+            .and_then(|source| source.split("/// The declaration-time portion").next())
+            .expect("shared owner-token resolver is present");
+        assert!(resolver.contains("allow_fixture_identity"));
+        assert!(
+            resolver.contains(
+                "panic!(\"production body analysis requires installed body-owner tokens\")"
+            )
+        );
+        assert!(SEMA_ROOT_SOURCE.contains("self.epoch.synthetic_declaration_discovery"));
+        assert!(SEMA_ROOT_SOURCE.contains("body analysis requires installed body-owner tokens"));
+        assert!(include_str!("binding_manifest.rs").contains(
+            "if self.body_base.is_some() {\n            return Err(DeclarationInstallFailure::AlreadySealed);"
+        ));
     }
 
     #[test]

--- a/crates/rue-air/src/sema/declaration_base.rs
+++ b/crates/rue-air/src/sema/declaration_base.rs
@@ -198,6 +198,10 @@ impl BoundSema<'_> {
         self.sema.type_pool = self.sema.type_pool.derive_overlay();
         self.sema.param_arena = self.sema.param_arena.derive_overlay();
         self.body_base = Some(Arc::new(self.sema.body_semantic_base()));
+        self.body_state = self
+            .body_base
+            .as_ref()
+            .map(|base| super::BodyAnalysisState::from_body_semantic_base(base.clone()));
     }
 
     /// Derive one body-local epoch from this declaration base, charging what the

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -354,6 +354,55 @@ pub(super) struct BodySemanticBase<'a> {
     local_seed: BodyLocalSeed,
 }
 
+/// Request-local identity state for receiver families that have crossed the
+/// frozen body-epoch boundary. It owns an immutable epoch handle, never an
+/// analyzer; mutable overlays will be added when the next receiver family
+/// crosses the boundary.
+pub(super) struct BodyAnalysisState<'a> {
+    epoch: Arc<BodySemanticBase<'a>>,
+}
+
+impl<'a> BodyAnalysisState<'a> {
+    pub(super) fn from_body_semantic_base(epoch: Arc<BodySemanticBase<'a>>) -> Self {
+        Self { epoch }
+    }
+
+    /// Resolve the exact stable owner identity used by body publication.
+    pub(super) fn body_owner_token(
+        &self,
+        file: FileId,
+        name: &str,
+        owner: Option<&str>,
+        kind: BodyOwnerKind,
+    ) -> BodyOwnerToken {
+        resolve_body_owner_token(&self.epoch.body_owner_tokens, file, name, owner, kind)
+    }
+}
+
+fn resolve_body_owner_token(
+    tokens: &HashMap<(u32, String, Option<String>, BodyOwnerKind), BodyOwnerToken>,
+    file: FileId,
+    name: &str,
+    owner: Option<&str>,
+    kind: BodyOwnerKind,
+) -> BodyOwnerToken {
+    let key = (
+        file.index(),
+        name.to_owned(),
+        owner.map(str::to_owned),
+        kind,
+    );
+    if tokens.is_empty() {
+        return BodyOwnerToken::new(0, file.index());
+    }
+    *tokens.get(&key).unwrap_or_else(|| {
+        panic!(
+            "supported ordinary body must have a validated owner token: {key:?}; installed={:?}",
+            tokens.keys().collect::<Vec<_>>()
+        )
+    })
+}
+
 /// The declaration-time portion of a body-local overlay. Derivation copies
 /// only this anonymous/generated state; all ordinary declaration maps live in
 /// [`BodySemanticBase`].
@@ -1381,22 +1430,11 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         owner: Option<&str>,
         kind: BodyOwnerKind,
     ) -> BodyOwnerToken {
-        let key = (
-            file.index(),
-            name.to_owned(),
-            owner.map(str::to_owned),
-            kind,
-        );
-        if self.body_owner_tokens.is_empty() {
-            // Explicit synthetic fixtures and declaration-failure recovery do
-            // not cross a durable identity boundary. Issuer zero is reserved
-            // for those present API contracts; successful canonical analysis
-            // installs compiler-issued tokens before bodies are analyzed.
-            return BodyOwnerToken::new(0, file.index());
-        }
-        *self.body_owner_tokens.get(&key).unwrap_or_else(|| {
-            panic!("supported ordinary body must have a validated owner token: {key:?}; installed={:?}", self.body_owner_tokens.keys().collect::<Vec<_>>())
-        })
+        // Explicit synthetic fixtures and declaration-failure recovery do not
+        // cross a durable identity boundary. Issuer zero is reserved for
+        // those present API contracts; successful canonical analysis installs
+        // compiler-issued tokens before bodies are analyzed.
+        resolve_body_owner_token(&self.body_owner_tokens, file, name, owner, kind)
     }
 }
 

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -375,7 +375,14 @@ impl<'a> BodyAnalysisState<'a> {
         owner: Option<&str>,
         kind: BodyOwnerKind,
     ) -> BodyOwnerToken {
-        resolve_body_owner_token(&self.epoch.body_owner_tokens, file, name, owner, kind)
+        resolve_body_owner_token(
+            &self.epoch.body_owner_tokens,
+            file,
+            name,
+            owner,
+            kind,
+            self.epoch.synthetic_declaration_discovery,
+        )
     }
 }
 
@@ -385,6 +392,7 @@ fn resolve_body_owner_token(
     name: &str,
     owner: Option<&str>,
     kind: BodyOwnerKind,
+    allow_fixture_identity: bool,
 ) -> BodyOwnerToken {
     let key = (
         file.index(),
@@ -393,7 +401,10 @@ fn resolve_body_owner_token(
         kind,
     );
     if tokens.is_empty() {
-        return BodyOwnerToken::new(0, file.index());
+        if allow_fixture_identity {
+            return BodyOwnerToken::new(0, file.index());
+        }
+        panic!("production body analysis requires installed body-owner tokens");
     }
     *tokens.get(&key).unwrap_or_else(|| {
         panic!(
@@ -1434,7 +1445,14 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         // cross a durable identity boundary. Issuer zero is reserved for
         // those present API contracts; successful canonical analysis installs
         // compiler-issued tokens before bodies are analyzed.
-        resolve_body_owner_token(&self.body_owner_tokens, file, name, owner, kind)
+        resolve_body_owner_token(
+            &self.body_owner_tokens,
+            file,
+            name,
+            owner,
+            kind,
+            self.synthetic_declaration_discovery,
+        )
     }
 }
 

--- a/crates/rue-air/src/sema/one_body.rs
+++ b/crates/rue-air/src/sema/one_body.rs
@@ -17,7 +17,7 @@ use rue_rir::InstData;
 use rue_span::{FileId, Span};
 
 use super::body_endpoint::BodyEndpointProvider;
-use super::{AnalyzedBodyOwnerEvent, AnalyzedFunction, BodyOwnerKind, BodySema};
+use super::{AnalyzedBodyOwnerEvent, AnalyzedFunction, BodyAnalysisState, BodyOwnerKind, BodySema};
 use crate::{
     FunctionInstanceKey, NominalInstanceKey, SemanticBodyExport, SemanticDefinitionToken,
     SemanticModuleToken, SemanticSpecializationIdentity, SemanticSpecializedBodyExport,
@@ -829,6 +829,7 @@ fn finalize_ordinary(
 
 pub(super) fn analyze_one_body(
     mut sema: BodySema<'_>,
+    state: BodyAnalysisState<'_>,
     request: OneBodyRequest,
     interruption: Option<OneBodyInterruption>,
 ) -> OneBodyTransactionOutcome {
@@ -983,13 +984,14 @@ pub(super) fn analyze_one_body(
             }
         }
         OneBodyRequest::Definition(token) => {
-            analyze_definition(&mut sema, &infer_ctx, token, interruption)
+            analyze_definition(&mut sema, &state, &infer_ctx, token, interruption)
         }
     }
 }
 
 pub(super) fn analyze_one_body_instance<K, M>(
     mut sema: BodySema<'_>,
+    state: BodyAnalysisState<'_>,
     instance: &FunctionInstanceKey<K, M>,
     definition: impl Fn(&K) -> Result<SemanticDefinitionToken, crate::SemanticStableResolutionFailure>,
     module: impl Fn(&M) -> Result<SemanticModuleToken, crate::SemanticStableResolutionFailure>,
@@ -1075,7 +1077,7 @@ where
             };
         }
     };
-    analyze_one_body(sema, request, interruption)
+    analyze_one_body(sema, state, request, interruption)
 }
 
 fn function_instance_contains_str<D, M>(instance: &FunctionInstanceKey<D, M>) -> bool {
@@ -1382,6 +1384,7 @@ pub(in crate::sema) fn materialize_instance_type(
 
 fn analyze_definition(
     sema: &mut BodySema<'_>,
+    state: &BodyAnalysisState<'_>,
     infer_ctx: &super::InferenceContext,
     token: SemanticDefinitionToken,
     interruption: Option<OneBodyInterruption>,
@@ -1451,7 +1454,7 @@ fn analyze_definition(
             else {
                 unreachable!()
             };
-            let owner = sema.body_owner_token(
+            let owner = state.body_owner_token(
                 info.file_id,
                 endpoint.name.as_ref(),
                 None,

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -289,6 +289,36 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "production body analysis requires installed body-owner tokens")]
+    fn production_owner_identity_rejects_a_present_state_without_tokens() {
+        let tokens = HashMap::new();
+        super::super::resolve_body_owner_token(
+            &tokens,
+            FileId::DEFAULT,
+            "main",
+            None,
+            crate::BodyOwnerKind::FreeFunction,
+            false,
+        );
+    }
+
+    #[test]
+    fn synthetic_owner_identity_retains_fixture_zero_issuer() {
+        let tokens = HashMap::new();
+        assert_eq!(
+            super::super::resolve_body_owner_token(
+                &tokens,
+                FileId::DEFAULT,
+                "main",
+                None,
+                crate::BodyOwnerKind::FreeFunction,
+                true,
+            ),
+            crate::BodyOwnerToken::new(0, FileId::DEFAULT.index())
+        );
+    }
+
+    #[test]
     fn test_analyze_simple_function() {
         let output = compile_to_air("fn main() -> i32 { 42 }").unwrap();
         let functions = &output.functions;
@@ -3769,6 +3799,28 @@ fn main() -> i32 {
             .install_body_owner_tokens(&owners)
             .unwrap();
         (bound, definitions)
+    }
+
+    #[test]
+    fn owner_token_reinstallation_after_sealing_fails_before_mutation() {
+        let (mut bound, definitions) = one_body_fixture("fn main() {}");
+        let definition = definitions
+            .iter()
+            .find(|definition| definition.kind == crate::StableDefinitionKind::Function)
+            .expect("fixture has a free function");
+        let owners = vec![crate::BodyOwnerEndpoint {
+            token: crate::BodyOwnerToken::new(91, definition.token.slot()),
+            kind: crate::BodyOwnerKind::FreeFunction,
+            file: definition.file,
+            name: definition.name.to_string(),
+            owner_name: None,
+        }];
+
+        bound.seal_as_declaration_base();
+        let Err(failure) = bound.install_body_owner_tokens(&owners) else {
+            panic!("owner-token installation after sealing unexpectedly succeeded")
+        };
+        assert_eq!(failure, crate::DeclarationInstallFailure::AlreadySealed);
     }
 
     fn one_body_two_file_fixture(

--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -714,6 +714,13 @@ pub(crate) fn compare_canonical_durable_declaration_install(
                 "durable semantic installation failed: {failure:?}"
             )))
         })?;
+    let installed = installed
+        .install_body_owner_tokens(&definitions.body_owner_endpoints())
+        .map_err(|failure| {
+            CompileErrors::from(invalid(format!(
+                "comparison body-owner endpoint install failed: {failure:?}"
+            )))
+        })?;
     let binding_work = installed.binding_work();
     let installed_durable = installed
         .with_declaration_semantics(|records, _| {

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -479,8 +479,18 @@ pub(crate) fn bind_query_owned_declarations_for_test<'a>(
     target: crate::Target,
     imports: &CanonicalImportGraph,
 ) -> MultiErrorResult<rue_air::BoundSema<'a>> {
-    query_owned_declaration_shells_for_test(merged, rir, preview_features, target, imports)?
-        .resolve_declarations_for_test()
+    let prepared =
+        prepared_query_declarations_for_test(merged, rir, preview_features, target, imports)?;
+    let CanonicalPreparedDeclarations {
+        shells,
+        definitions,
+        ..
+    } = prepared;
+    let body_owner_endpoints = definitions.body_owner_endpoints();
+    Ok(shells
+        .resolve_declarations_for_test()?
+        .install_body_owner_tokens(&body_owner_endpoints)
+        .expect("query-owned test declarations install their owner endpoints"))
 }
 
 /// The [`bind_query_owned_declarations_for_test`] recipe, additionally handing
@@ -500,8 +510,16 @@ pub(crate) fn bind_query_owned_declarations_with_definitions_for_test<'a>(
 ) -> MultiErrorResult<(rue_air::BoundSema<'a>, BoundDefinitionSet)> {
     let prepared =
         prepared_query_declarations_for_test(merged, rir, preview_features, target, imports)?;
-    let definitions = prepared.definitions;
-    let bound = prepared.shells.resolve_declarations_for_test()?;
+    let CanonicalPreparedDeclarations {
+        shells,
+        definitions,
+        ..
+    } = prepared;
+    let body_owner_endpoints = definitions.body_owner_endpoints();
+    let bound = shells
+        .resolve_declarations_for_test()?
+        .install_body_owner_tokens(&body_owner_endpoints)
+        .expect("query-owned test declarations install their owner endpoints");
     Ok((bound, definitions))
 }
 


### PR DESCRIPTION
## Summary

- introduce the production-used `BodyAnalysisState` receiver for ordinary body-owner identity
- preserve one canonical token resolver while moving the ordinary one-body path off the analyzer receiver
- fail closed when production owner tokens were not installed and reject post-seal reinstallation that could stale the frozen base
- update exact test construction paths to install the already-issued owner endpoints

This is a prerequisite slice for RUE-1092. The provider-backed body evaluator remains follow-up work, so this PR intentionally does not close the issue.

## Validation

- `scripts/rue quick` (final head; 36 targets)
- focused AIR owner/identity and one-body tests
- focused compiler canonical-semantic, bound-definition, projection, and body-transaction tests
- `scripts/rue test` on the receiver-migration commit before the final invariant-only hardening (full suite passed)
- `scripts/rue fmt`
- independent adversarial re-review of the final two-commit diff: no actionable findings
