### PR TITLE
RUE-1092: Move ordinary endpoint selection to body state

### DIFF
--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -2180,8 +2180,9 @@ impl<'a> BoundSema<'a> {
         K: Clone,
         M: Clone,
     {
-        self.sema.body_lookup_collector = Some(collector);
-        let state = self.take_body_state();
+        self.sema.body_lookup_collector = Some(collector.clone());
+        let mut state = self.take_body_state();
+        state.install_body_lookup_collector(collector);
         super::one_body::analyze_one_body_instance(
             self.sema,
             state,
@@ -2295,6 +2296,9 @@ impl<'a> BoundSema<'a> {
             &expected_definitions,
             &expected_modules,
         )?;
+        self.body_state = Some(super::BodyAnalysisState::from_body_semantic_base(Arc::new(
+            self.sema.body_semantic_base(),
+        )));
         Ok(self)
     }
 

--- a/crates/rue-air/src/sema/body_endpoint.rs
+++ b/crates/rue-air/src/sema/body_endpoint.rs
@@ -18,7 +18,7 @@
 //! without retaining a borrow across the surrounding mutations.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::sync::Arc;
 
@@ -34,7 +34,9 @@ use super::body_identity::{
 use super::declaration_index::RirDestructorDeclaration;
 use super::info::{ConstInfo, FunctionInfo, MethodInfo};
 use super::provider::BodyFactProvider;
-use super::{DeclarationPhase, Sema};
+use super::{
+    BodyAnalysisState, BodyLookupCollector, BodyLookupObservation, DeclarationPhase, Sema,
+};
 use crate::intern_pool::TypeInternPool;
 use crate::types::{EnumId, ModuleId, StructId, Type};
 use crate::{
@@ -130,159 +132,337 @@ pub(crate) trait BodyEndpointProvider {
     fn intern_ptr_mut(&self, pointee: Type) -> Option<Type>;
 }
 
-/// Raw immutable endpoint reads supplied by a body-analysis host.
+/// Endpoint reads supplied by a body-analysis host. Most operations are
+/// immutable table reads. Type interning is host-specific and is not part of
+/// the shared read view.
 pub(super) trait BodyEndpointFactSource {
-    fn endpoint_name_symbol(&self, name: &str) -> Option<Spur>;
+    fn endpoint_read_view(&self) -> Option<BodyEndpointReadView<'_>> {
+        None
+    }
+
+    fn endpoint_lookup_collector(&self) -> Option<&BodyLookupCollector> {
+        None
+    }
+
+    fn endpoint_view(&self) -> BodyEndpointReadView<'_> {
+        self.endpoint_read_view()
+            .expect("body endpoint fact source has no shared read view")
+    }
+
+    fn endpoint_name_symbol(&self, name: &str) -> Option<Spur> {
+        self.endpoint_view().name_symbol(name)
+    }
     fn endpoint_definition_endpoint(
         &self,
         token: SemanticDefinitionToken,
-    ) -> Option<SemanticDefinitionEndpoint>;
+    ) -> Option<SemanticDefinitionEndpoint> {
+        self.endpoint_view().definition_endpoint(token)
+    }
     fn endpoint_module_endpoint(
         &self,
         token: SemanticModuleToken,
-    ) -> Option<SemanticModuleEndpoint>;
-    fn endpoint_function_by_file_name(&self, file: FileId, name: Spur) -> Option<Spur>;
-    fn endpoint_struct_by_file_name(&self, file: FileId, name: Spur) -> Option<StructId>;
-    fn endpoint_enum_by_file_name(&self, file: FileId, name: Spur) -> Option<EnumId>;
-    fn endpoint_builtin_or_generated_struct(&self, name: Spur) -> Option<StructId>;
-    fn endpoint_generated_struct(&self, name: Spur) -> Option<StructId>;
-    fn endpoint_builtin_enum(&self, name: Spur) -> Option<EnumId>;
-    fn endpoint_anon_struct(&self, identity: &IssuedAnonymousNominalKey) -> Option<StructId>;
-    fn endpoint_anon_enum(&self, identity: &IssuedAnonymousNominalKey) -> Option<EnumId>;
-    fn endpoint_is_builtin_or_generated_struct(&self, name: Spur) -> bool;
-    fn endpoint_is_builtin_enum(&self, name: Spur) -> bool;
-    fn endpoint_function_info(&self, name: Spur) -> Option<FunctionInfo>;
-    fn endpoint_method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo>;
-    fn endpoint_source_function_name(&self, name: Spur) -> Spur;
-    fn endpoint_first_free_function(&self, source: Spur, file: FileId) -> Option<InstRef>;
+    ) -> Option<SemanticModuleEndpoint> {
+        self.endpoint_view().module_endpoint(token)
+    }
+    fn endpoint_function_by_file_name(&self, file: FileId, name: Spur) -> Option<Spur> {
+        let view = self.endpoint_view();
+        let result = view.function_by_file_name(file, name);
+        view.record_module_item_lookup(self.endpoint_lookup_collector(), file, name);
+        result
+    }
+    fn endpoint_struct_by_file_name(&self, file: FileId, name: Spur) -> Option<StructId> {
+        let view = self.endpoint_view();
+        let result = view.struct_by_file_name(file, name);
+        view.record_module_item_lookup(self.endpoint_lookup_collector(), file, name);
+        result
+    }
+    fn endpoint_enum_by_file_name(&self, file: FileId, name: Spur) -> Option<EnumId> {
+        let view = self.endpoint_view();
+        let result = view.enum_by_file_name(file, name);
+        view.record_module_item_lookup(self.endpoint_lookup_collector(), file, name);
+        result
+    }
+    fn endpoint_builtin_or_generated_struct(&self, name: Spur) -> Option<StructId> {
+        self.endpoint_view().builtin_or_generated_struct(name)
+    }
+    fn endpoint_generated_struct(&self, name: Spur) -> Option<StructId> {
+        self.endpoint_view().generated_struct(name)
+    }
+    fn endpoint_builtin_enum(&self, name: Spur) -> Option<EnumId> {
+        self.endpoint_view().builtin_enum(name)
+    }
+    fn endpoint_anon_struct(&self, identity: &IssuedAnonymousNominalKey) -> Option<StructId> {
+        self.endpoint_view().anon_struct(identity)
+    }
+    fn endpoint_anon_enum(&self, identity: &IssuedAnonymousNominalKey) -> Option<EnumId> {
+        self.endpoint_view().anon_enum(identity)
+    }
+    fn endpoint_is_builtin_or_generated_struct(&self, name: Spur) -> bool {
+        self.endpoint_view().is_builtin_or_generated_struct(name)
+    }
+    fn endpoint_is_builtin_enum(&self, name: Spur) -> bool {
+        self.endpoint_view().is_builtin_enum(name)
+    }
+    fn endpoint_function_info(&self, name: Spur) -> Option<FunctionInfo> {
+        self.endpoint_view().function_info(name)
+    }
+    fn endpoint_method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
+        let view = self.endpoint_view();
+        view.record_member_lookup(self.endpoint_lookup_collector(), struct_id, name);
+        view.method_info(struct_id, name)
+    }
+    fn endpoint_source_function_name(&self, name: Spur) -> Spur {
+        self.endpoint_view().source_function_name(name)
+    }
+    fn endpoint_first_free_function(&self, source: Spur, file: FileId) -> Option<InstRef> {
+        let view = self.endpoint_view();
+        let result = view.first_free_function(source, file);
+        view.record_module_item_lookup(self.endpoint_lookup_collector(), file, source);
+        result
+    }
     fn endpoint_named_method_declaration(
         &self,
         file: FileId,
         ty: Spur,
         method: Spur,
-    ) -> Option<InstRef>;
-    fn endpoint_destructor(&self, file: u32, ty: Spur) -> Option<RirDestructorDeclaration>;
-    fn endpoint_module_id_for_file(&self, file: u32) -> Option<ModuleId>;
-    fn endpoint_intern_array(&self, element: Type, len: u64) -> Option<Type>;
-    fn endpoint_intern_ptr_const(&self, pointee: Type) -> Option<Type>;
-    fn endpoint_intern_ptr_mut(&self, pointee: Type) -> Option<Type>;
+    ) -> Option<InstRef> {
+        self.endpoint_view().named_method_declaration(
+            file,
+            ty,
+            method,
+            self.endpoint_lookup_collector(),
+        )
+    }
+    fn endpoint_destructor(&self, file: u32, ty: Spur) -> Option<RirDestructorDeclaration> {
+        self.endpoint_view()
+            .destructor(file, ty, self.endpoint_lookup_collector())
+    }
+    fn endpoint_module_id_for_file(&self, file: u32) -> Option<ModuleId> {
+        self.endpoint_view().module_id_for_file(file)
+    }
+    fn endpoint_intern_array(&self, _element: Type, _len: u64) -> Option<Type> {
+        None
+    }
+    fn endpoint_intern_ptr_const(&self, _pointee: Type) -> Option<Type> {
+        None
+    }
+    fn endpoint_intern_ptr_mut(&self, _pointee: Type) -> Option<Type> {
+        None
+    }
 }
 
-/// Direct epoch reads for the current host. The generic adapter below owns the
-/// read-only abstraction; this impl is only the production source of facts.
-impl<D: DeclarationPhase> BodyEndpointFactSource for Sema<'_, D> {
-    fn endpoint_name_symbol(&self, name: &str) -> Option<Spur> {
+/// Shared endpoint reads for both the transitional epoch receiver and the
+/// body-analysis state. Lookup observation is supplied separately, so this
+/// view contains no analyzer or mutable analysis state. Its type-pool access
+/// is limited to read-only struct inspection for lookup filtering; type
+/// interning remains a Sema-local overlay operation.
+pub(super) struct BodyEndpointReadView<'a> {
+    interner: &'a ThreadedRodeo,
+    declarations: &'a super::DeclarationNamespace,
+    declaration_index: &'a super::declaration_index::RirDeclarationIndex,
+    stable_definition_endpoints: &'a HashMap<SemanticDefinitionToken, SemanticDefinitionEndpoint>,
+    stable_module_endpoints: &'a HashMap<SemanticModuleToken, SemanticModuleEndpoint>,
+    anonymous_methods: &'a HashMap<(StructId, Spur), MethodInfo>,
+    anonymous_struct_ids: &'a HashSet<StructId>,
+    generated_structs: &'a HashMap<Spur, StructId>,
+    anon_struct_identities: &'a HashMap<IssuedAnonymousNominalKey, StructId>,
+    anon_enum_identities: &'a HashMap<IssuedAnonymousNominalKey, EnumId>,
+    type_pool: &'a TypeInternPool,
+    module_registry: &'a crate::module_registry::ModuleRegistry,
+}
+
+impl BodyEndpointReadView<'_> {
+    fn record_module_item_lookup(
+        &self,
+        collector: Option<&BodyLookupCollector>,
+        file: FileId,
+        name: Spur,
+    ) {
+        let Some(collector) = collector else {
+            return;
+        };
+        collector.record(BodyLookupObservation::ModuleItem {
+            file: file.index(),
+            name: Arc::from(self.interner.resolve(&name)),
+        });
+    }
+
+    fn record_member_lookup(
+        &self,
+        collector: Option<&BodyLookupCollector>,
+        owner: StructId,
+        member: Spur,
+    ) {
+        let Some(collector) = collector else {
+            return;
+        };
+        let Some(definition) = self.type_pool.try_struct_def(owner) else {
+            return;
+        };
+        if self.anonymous_struct_ids.contains(&owner) || definition.is_builtin {
+            return;
+        }
+        collector.record(BodyLookupObservation::Member {
+            owner_file: definition.file_id.index(),
+            owner_name: Arc::from(definition.name.as_str()),
+            member_name: Arc::from(self.interner.resolve(&member)),
+        });
+    }
+
+    fn name_symbol(&self, name: &str) -> Option<Spur> {
         self.interner.get(name)
     }
 
-    fn endpoint_definition_endpoint(
+    fn definition_endpoint(
         &self,
         token: SemanticDefinitionToken,
     ) -> Option<SemanticDefinitionEndpoint> {
         self.stable_definition_endpoints.get(&token).cloned()
     }
 
-    fn endpoint_module_endpoint(
-        &self,
-        token: SemanticModuleToken,
-    ) -> Option<SemanticModuleEndpoint> {
+    fn module_endpoint(&self, token: SemanticModuleToken) -> Option<SemanticModuleEndpoint> {
         self.stable_module_endpoints.get(&token).copied()
     }
 
-    fn endpoint_function_by_file_name(&self, file: FileId, name: Spur) -> Option<Spur> {
-        self.record_body_module_item_lookup(file, name);
-        self.functions_by_file_name.get(&(file, name)).copied()
+    fn function_by_file_name(&self, file: FileId, name: Spur) -> Option<Spur> {
+        self.declarations
+            .functions_by_file_name
+            .get(&(file, name))
+            .copied()
     }
 
-    fn endpoint_struct_by_file_name(&self, file: FileId, name: Spur) -> Option<StructId> {
-        self.record_body_module_item_lookup(file, name);
-        self.structs_by_file_name.get(&(file, name)).copied()
+    fn struct_by_file_name(&self, file: FileId, name: Spur) -> Option<StructId> {
+        self.declarations
+            .structs_by_file_name
+            .get(&(file, name))
+            .copied()
     }
 
-    fn endpoint_enum_by_file_name(&self, file: FileId, name: Spur) -> Option<EnumId> {
-        self.record_body_module_item_lookup(file, name);
-        self.enums_by_file_name.get(&(file, name)).copied()
+    fn enum_by_file_name(&self, file: FileId, name: Spur) -> Option<EnumId> {
+        self.declarations
+            .enums_by_file_name
+            .get(&(file, name))
+            .copied()
     }
 
-    fn endpoint_builtin_or_generated_struct(&self, name: Spur) -> Option<StructId> {
-        self.builtin_structs
+    fn builtin_or_generated_struct(&self, name: Spur) -> Option<StructId> {
+        self.declarations
+            .builtin_structs
             .get(&name)
             .or_else(|| self.generated_structs.get(&name))
             .copied()
     }
 
-    fn endpoint_generated_struct(&self, name: Spur) -> Option<StructId> {
+    fn generated_struct(&self, name: Spur) -> Option<StructId> {
         self.generated_structs.get(&name).copied()
     }
 
-    fn endpoint_builtin_enum(&self, name: Spur) -> Option<EnumId> {
-        self.builtin_enums.get(&name).copied()
+    fn builtin_enum(&self, name: Spur) -> Option<EnumId> {
+        self.declarations.builtin_enums.get(&name).copied()
     }
 
-    fn endpoint_anon_struct(&self, identity: &IssuedAnonymousNominalKey) -> Option<StructId> {
+    fn anon_struct(&self, identity: &IssuedAnonymousNominalKey) -> Option<StructId> {
         self.anon_struct_identities.get(identity).copied()
     }
 
-    fn endpoint_anon_enum(&self, identity: &IssuedAnonymousNominalKey) -> Option<EnumId> {
+    fn anon_enum(&self, identity: &IssuedAnonymousNominalKey) -> Option<EnumId> {
         self.anon_enum_identities.get(identity).copied()
     }
 
-    fn endpoint_is_builtin_or_generated_struct(&self, name: Spur) -> bool {
-        self.builtin_structs.contains_key(&name) || self.generated_structs.contains_key(&name)
+    fn is_builtin_or_generated_struct(&self, name: Spur) -> bool {
+        self.builtin_or_generated_struct(name).is_some()
     }
 
-    fn endpoint_is_builtin_enum(&self, name: Spur) -> bool {
-        self.builtin_enums.contains_key(&name)
+    fn is_builtin_enum(&self, name: Spur) -> bool {
+        self.builtin_enum(name).is_some()
     }
 
-    fn endpoint_function_info(&self, name: Spur) -> Option<FunctionInfo> {
-        self.function_info(name).copied()
+    fn function_info(&self, name: Spur) -> Option<FunctionInfo> {
+        self.declarations.functions.get(&name).copied()
     }
 
-    fn endpoint_method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
-        self.record_body_member_lookup(struct_id, name);
-        self.method_info((struct_id, name)).copied()
+    fn method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
+        self.anonymous_methods
+            .get(&(struct_id, name))
+            .copied()
+            .or_else(|| self.declarations.methods.get(&(struct_id, name)).copied())
     }
 
-    fn endpoint_source_function_name(&self, name: Spur) -> Spur {
-        self.source_function_name(name)
+    fn source_function_name(&self, name: Spur) -> Spur {
+        self.declarations
+            .function_source_names
+            .get(&name)
+            .copied()
+            .unwrap_or(name)
     }
 
-    fn endpoint_first_free_function(&self, source: Spur, file_id: FileId) -> Option<InstRef> {
-        self.record_body_module_item_lookup(file_id, source);
+    fn first_free_function(&self, source: Spur, file_id: FileId) -> Option<InstRef> {
         self.declaration_index
             .first_free_function(source, Some(file_id))
     }
 
-    fn endpoint_named_method_declaration(
+    fn named_method_declaration(
         &self,
-        owner_file: FileId,
-        owner_type_name: Spur,
-        method_name: Spur,
+        file: FileId,
+        ty: Spur,
+        method: Spur,
+        collector: Option<&BodyLookupCollector>,
     ) -> Option<InstRef> {
-        self.record_body_module_item_lookup(owner_file, owner_type_name);
-        let struct_id = self
-            .structs_by_file_name
-            .get(&(owner_file, owner_type_name))?;
-        self.record_body_member_lookup(*struct_id, method_name);
-        self.named_method_declarations
-            .get(&(*struct_id, method_name))
+        self.record_module_item_lookup(collector, file, ty);
+        let struct_id = self.declarations.structs_by_file_name.get(&(file, ty))?;
+        self.record_member_lookup(collector, *struct_id, method);
+        self.declarations
+            .named_method_declarations
+            .get(&(*struct_id, method))
             .copied()
     }
 
-    fn endpoint_destructor(&self, file: u32, type_name: Spur) -> Option<RirDestructorDeclaration> {
-        self.record_body_destructor_lookup(FileId::new(file), type_name);
+    fn destructor(
+        &self,
+        file: u32,
+        ty: Spur,
+        collector: Option<&BodyLookupCollector>,
+    ) -> Option<RirDestructorDeclaration> {
+        if let Some(collector) = collector {
+            collector.record(BodyLookupObservation::Destructor {
+                file,
+                type_name: Arc::from(self.interner.resolve(&ty)),
+            });
+        }
         self.declaration_index
             .destructors()
             .iter()
-            .find(|record| record.span.file_id.index() == file && record.type_name == type_name)
+            .find(|record| record.span.file_id.index() == file && record.type_name == ty)
             .copied()
     }
 
-    fn endpoint_module_id_for_file(&self, file: u32) -> Option<ModuleId> {
+    fn module_id_for_file(&self, file: u32) -> Option<ModuleId> {
         (0..self.module_registry.len())
             .map(|index| ModuleId::new(index as u32))
             .find(|id| self.module_registry.get_def(*id).file_id.index() == file)
+    }
+}
+
+impl<D: DeclarationPhase> BodyEndpointFactSource for Sema<'_, D> {
+    fn endpoint_read_view(&self) -> Option<BodyEndpointReadView<'_>> {
+        Some(BodyEndpointReadView {
+            interner: self.interner,
+            declarations: &self.declarations,
+            declaration_index: &self.declaration_index,
+            stable_definition_endpoints: &self.stable_definition_endpoints,
+            stable_module_endpoints: &self.stable_module_endpoints,
+            anonymous_methods: &self.anonymous_methods,
+            anonymous_struct_ids: &self.anonymous_struct_ids,
+            generated_structs: &self.generated_structs,
+            anon_struct_identities: &self.anon_struct_identities,
+            anon_enum_identities: &self.anon_enum_identities,
+            type_pool: &self.type_pool,
+            module_registry: &self.module_registry,
+        })
+    }
+
+    fn endpoint_lookup_collector(&self) -> Option<&BodyLookupCollector> {
+        self.body_lookup_collector.as_ref()
     }
 
     fn endpoint_intern_array(&self, element: Type, len: u64) -> Option<Type> {
@@ -298,21 +478,45 @@ impl<D: DeclarationPhase> BodyEndpointFactSource for Sema<'_, D> {
     }
 }
 
+impl BodyEndpointFactSource for BodyAnalysisState<'_> {
+    fn endpoint_read_view(&self) -> Option<BodyEndpointReadView<'_>> {
+        let epoch = &self.epoch;
+        Some(BodyEndpointReadView {
+            interner: epoch.interner,
+            declarations: &epoch.declarations.0,
+            declaration_index: &epoch.declaration_index,
+            stable_definition_endpoints: &epoch.stable_definition_endpoints,
+            stable_module_endpoints: &epoch.stable_module_endpoints,
+            anonymous_methods: &epoch.local_seed.anonymous_methods,
+            anonymous_struct_ids: &epoch.local_seed.anonymous_struct_ids,
+            generated_structs: &epoch.local_seed.generated_structs,
+            anon_struct_identities: &epoch.local_seed.anon_struct_identities,
+            anon_enum_identities: &epoch.local_seed.anon_enum_identities,
+            type_pool: &epoch.type_pool,
+            module_registry: &epoch.module_registry,
+        })
+    }
+
+    fn endpoint_lookup_collector(&self) -> Option<&BodyLookupCollector> {
+        self.body_lookup_collector.as_ref()
+    }
+}
+
 /// Read-only endpoint adapter used by the canonical body engine.
 ///
 /// It carries only a host capability; the current epoch-backed host is one
 /// production source, while an owned body state can supply the same reads next.
-pub(crate) struct EpochFacts<'host, H: super::fact_mode::BodyAnalysisReadHost> {
+pub(crate) struct EpochFacts<'host, H: BodyEndpointFactSource> {
     host: &'host H,
 }
 
-impl<'host, H: super::fact_mode::BodyAnalysisReadHost> EpochFacts<'host, H> {
+impl<'host, H: BodyEndpointFactSource> EpochFacts<'host, H> {
     pub(in crate::sema) fn new(host: &'host H) -> Self {
         Self { host }
     }
 }
 
-impl<H: super::fact_mode::BodyAnalysisReadHost> BodyEndpointProvider for EpochFacts<'_, H> {
+impl<H: BodyEndpointFactSource> BodyEndpointProvider for EpochFacts<'_, H> {
     fn name_symbol(&self, name: &str) -> Option<Spur> {
         self.host.endpoint_name_symbol(name)
     }

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -331,6 +331,12 @@ mod tests {
                 "BodyAnalysisState must not retain {forbidden}"
             );
         }
+        for forbidden in ["intern_array", "intern_ptr_const", "intern_ptr_mut"] {
+            assert!(
+                !state.contains(forbidden),
+                "BodyAnalysisState must not expose type interning in this slice: {forbidden}"
+            );
+        }
 
         let ordinary = ONE_BODY_SOURCE
             .split("fn analyze_definition(")
@@ -338,8 +344,42 @@ mod tests {
             .and_then(|source| source.split("fn analyze_named_method(").next())
             .expect("ordinary definition analyzer is present");
         assert!(ordinary.contains("state: &BodyAnalysisState<'_>"));
+        assert!(ordinary.contains("let facts = state.endpoint_facts();"));
+        assert!(ordinary.contains("facts.definition_endpoint(token)"));
+        assert!(ordinary.contains("select_ordinary_definition(&facts, state_endpoint)"));
         assert!(ordinary.contains("let owner = state.body_owner_token("));
         assert!(!ordinary.contains("BodyAnalysisState::from_body_semantic_base"));
+
+        let ordinary_branch = ordinary
+            .split("StableDefinitionKind::Function => {")
+            .nth(1)
+            .and_then(|source| source.split("StableDefinitionKind::Method").next())
+            .expect("ordinary definition branch is present");
+        assert!(ordinary_branch.contains("select_ordinary_definition(&facts, state_endpoint)"));
+        assert!(!ordinary_branch.contains("sema.endpoint_facts()"));
+
+        let unsupported_branches = ordinary
+            .split("StableDefinitionKind::Method")
+            .nth(1)
+            .expect("unsupported callable branches are present");
+        assert!(unsupported_branches.contains("sema.endpoint_facts().definition_endpoint(token)"));
+        assert!(!unsupported_branches.contains("state.endpoint_facts()"));
+
+        let selector = ONE_BODY_SOURCE
+            .split("fn select_ordinary_definition<")
+            .nth(1)
+            .and_then(|source| source.split("fn analyze_named_method(").next())
+            .expect("ordinary endpoint selector is present");
+        assert!(
+            !selector.contains("definition_endpoint("),
+            "ordinary selection must consume the single dispatch endpoint read"
+        );
+        assert!(BODY_ENDPOINT_SOURCE.contains("struct BodyEndpointReadView"));
+        assert!(BODY_ENDPOINT_SOURCE.contains("impl BodyEndpointFactSource for BodyAnalysisState"));
+        assert!(
+            BODY_ENDPOINT_SOURCE
+                .contains("impl<D: DeclarationPhase> BodyEndpointFactSource for Sema")
+        );
 
         let resolver = SEMA_ROOT_SOURCE
             .split("fn resolve_body_owner_token(")
@@ -1133,8 +1173,8 @@ mod tests {
         let adapters = [
             (
                 BODY_ENDPOINT_SOURCE,
-                "pub(crate) struct EpochFacts<'host, H: super::fact_mode::BodyAnalysisReadHost>",
-                "impl<H: super::fact_mode::BodyAnalysisReadHost> BodyEndpointProvider for EpochFacts<'_, H>",
+                "pub(crate) struct EpochFacts<'host, H: BodyEndpointFactSource>",
+                "impl<H: BodyEndpointFactSource> BodyEndpointProvider for EpochFacts<'_, H>",
             ),
             (
                 CALL_RESOLUTION_SOURCE,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -356,15 +356,26 @@ pub(super) struct BodySemanticBase<'a> {
 
 /// Request-local identity state for receiver families that have crossed the
 /// frozen body-epoch boundary. It owns an immutable epoch handle, never an
-/// analyzer; mutable overlays will be added when the next receiver family
-/// crosses the boundary.
+/// analyzer, plus a request-local lookup collector overlay.
 pub(super) struct BodyAnalysisState<'a> {
     epoch: Arc<BodySemanticBase<'a>>,
+    body_lookup_collector: Option<BodyLookupCollector>,
 }
 
 impl<'a> BodyAnalysisState<'a> {
     pub(super) fn from_body_semantic_base(epoch: Arc<BodySemanticBase<'a>>) -> Self {
-        Self { epoch }
+        Self {
+            epoch,
+            body_lookup_collector: None,
+        }
+    }
+
+    pub(super) fn install_body_lookup_collector(&mut self, collector: BodyLookupCollector) {
+        self.body_lookup_collector = Some(collector);
+    }
+
+    pub(super) fn endpoint_facts(&self) -> body_endpoint::EpochFacts<'_, Self> {
+        body_endpoint::EpochFacts::new(self)
     }
 
     /// Resolve the exact stable owner identity used by body publication.
@@ -1254,16 +1265,6 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         collector.record(BodyLookupObservation::ModuleItem {
             file: file.index(),
             name: std::sync::Arc::from(self.interner.resolve(&name)),
-        });
-    }
-
-    pub(crate) fn record_body_destructor_lookup(&self, file: FileId, type_name: Spur) {
-        let Some(collector) = &self.body_lookup_collector else {
-            return;
-        };
-        collector.record(BodyLookupObservation::Destructor {
-            file: file.index(),
-            type_name: std::sync::Arc::from(self.interner.resolve(&type_name)),
         });
     }
 

--- a/crates/rue-air/src/sema/one_body.rs
+++ b/crates/rue-air/src/sema/one_body.rs
@@ -19,9 +19,9 @@ use rue_span::{FileId, Span};
 use super::body_endpoint::BodyEndpointProvider;
 use super::{AnalyzedBodyOwnerEvent, AnalyzedFunction, BodyAnalysisState, BodyOwnerKind, BodySema};
 use crate::{
-    FunctionInstanceKey, NominalInstanceKey, SemanticBodyExport, SemanticDefinitionToken,
-    SemanticModuleToken, SemanticSpecializationIdentity, SemanticSpecializedBodyExport,
-    StableDefinitionKind, Type, TypeInstanceKey,
+    FunctionInstanceKey, NominalInstanceKey, SemanticBodyExport, SemanticDefinitionEndpoint,
+    SemanticDefinitionToken, SemanticModuleToken, SemanticSpecializationIdentity,
+    SemanticSpecializedBodyExport, StableDefinitionKind, Type, TypeInstanceKey,
 };
 
 #[derive(Debug, Clone)]
@@ -1389,7 +1389,8 @@ fn analyze_definition(
     token: SemanticDefinitionToken,
     interruption: Option<OneBodyInterruption>,
 ) -> OneBodyTransactionOutcome {
-    let Some(endpoint) = sema.endpoint_facts().definition_endpoint(token) else {
+    let facts = state.endpoint_facts();
+    let Some(state_endpoint) = facts.definition_endpoint(token) else {
         return fail(
             sema,
             None,
@@ -1398,33 +1399,18 @@ fn analyze_definition(
             )),
         );
     };
-    match endpoint.kind {
+    match state_endpoint.kind {
         StableDefinitionKind::Function => {
-            let Some(source_name) = sema.interner.get(endpoint.name.as_ref()) else {
-                return fail(
-                    sema,
-                    None,
-                    CompileError::without_span(ErrorKind::UndefinedFunction(
-                        endpoint.name.to_string(),
-                    )),
-                );
+            let selection = match select_ordinary_definition(&facts, state_endpoint) {
+                Ok(selection) => selection,
+                Err(error) => return fail(sema, None, error),
             };
-            let Some(name) = sema
-                .endpoint_facts()
-                .function_by_file_name(FileId::new(endpoint.file), source_name)
-            else {
-                return fail(
-                    sema,
-                    None,
-                    CompileError::without_span(ErrorKind::UndefinedFunction(
-                        endpoint.name.to_string(),
-                    )),
-                );
-            };
-            let info = sema
-                .endpoint_facts()
-                .function_info(name)
-                .expect("functions_by_file_name resolved to a registered function");
+            let OrdinaryDefinitionSelection {
+                endpoint,
+                name,
+                info,
+                declaration,
+            } = selection;
             if info.is_generic || info.is_extern {
                 return OneBodyTransactionOutcome::NonTerminal {
                     reason: OneBodyNonTerminalReason::TypedIncomplete(
@@ -1432,19 +1418,6 @@ fn analyze_definition(
                     ),
                 };
             }
-            let source = sema.endpoint_facts().source_function_name(name);
-            let Some(declaration) = sema
-                .endpoint_facts()
-                .first_free_function(source, info.file_id)
-            else {
-                return fail(
-                    sema,
-                    None,
-                    CompileError::without_span(ErrorKind::UndefinedFunction(
-                        endpoint.name.to_string(),
-                    )),
-                );
-            };
             let InstData::FnDecl {
                 params,
                 return_type,
@@ -1505,9 +1478,27 @@ fn analyze_definition(
             }
         }
         StableDefinitionKind::Method | StableDefinitionKind::AssociatedFunction => {
+            let Some(endpoint) = sema.endpoint_facts().definition_endpoint(token) else {
+                return fail(
+                    sema,
+                    None,
+                    CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                        "one-body request has no current stable endpoint".into(),
+                    )),
+                );
+            };
             analyze_named_method(sema, infer_ctx, &endpoint, interruption)
         }
         StableDefinitionKind::Destructor => {
+            let Some(endpoint) = sema.endpoint_facts().definition_endpoint(token) else {
+                return fail(
+                    sema,
+                    None,
+                    CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                        "one-body request has no current stable endpoint".into(),
+                    )),
+                );
+            };
             analyze_named_destructor(sema, infer_ctx, &endpoint, interruption)
         }
         _ => fail(
@@ -1518,6 +1509,44 @@ fn analyze_definition(
             )),
         ),
     }
+}
+
+struct OrdinaryDefinitionSelection {
+    endpoint: SemanticDefinitionEndpoint,
+    name: Spur,
+    info: crate::FunctionInfo,
+    declaration: rue_rir::InstRef,
+}
+
+fn select_ordinary_definition<P: BodyEndpointProvider>(
+    facts: &P,
+    endpoint: SemanticDefinitionEndpoint,
+) -> Result<OrdinaryDefinitionSelection, CompileError> {
+    let Some(source_name) = facts.name_symbol(endpoint.name.as_ref()) else {
+        return Err(CompileError::without_span(ErrorKind::UndefinedFunction(
+            endpoint.name.to_string(),
+        )));
+    };
+    let Some(name) = facts.function_by_file_name(FileId::new(endpoint.file), source_name) else {
+        return Err(CompileError::without_span(ErrorKind::UndefinedFunction(
+            endpoint.name.to_string(),
+        )));
+    };
+    let info = facts
+        .function_info(name)
+        .expect("functions_by_file_name resolved to a registered function");
+    let source = facts.source_function_name(name);
+    let Some(declaration) = facts.first_free_function(source, info.file_id) else {
+        return Err(CompileError::without_span(ErrorKind::UndefinedFunction(
+            endpoint.name.to_string(),
+        )));
+    };
+    Ok(OrdinaryDefinitionSelection {
+        endpoint,
+        name,
+        info,
+        declaration,
+    })
 }
 
 fn analyze_named_method(

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -319,6 +319,53 @@ mod tests {
     }
 
     #[test]
+    fn body_endpoint_state_preserves_anonymous_methods_and_lookup_filtering() {
+        let (mut bound, _) =
+            one_body_fixture("struct Value { fn run(self) -> i32 { 1 } } fn main() {}");
+        let owner_name = bound.sema.interner.get("Value").expect("fixture owner");
+        let method_name = bound.sema.interner.get("run").expect("fixture method");
+        let owner = bound
+            .sema
+            .structs_by_file_name
+            .get(&(FileId::DEFAULT, owner_name))
+            .copied()
+            .expect("fixture struct id");
+        let named = *bound
+            .sema
+            .methods
+            .get(&(owner, method_name))
+            .expect("fixture named method");
+        bound.sema.anonymous_methods.insert(
+            (owner, method_name),
+            crate::sema::MethodInfo {
+                return_type: Type::BOOL,
+                ..named
+            },
+        );
+        bound.sema.anonymous_struct_ids.insert(owner);
+
+        let collector = crate::BodyLookupCollector::new();
+        let mut state = crate::sema::BodyAnalysisState::from_body_semantic_base(Arc::new(
+            bound.sema.body_semantic_base(),
+        ));
+        state.install_body_lookup_collector(collector.clone());
+        use crate::sema::body_endpoint::BodyEndpointProvider;
+        let info = state
+            .endpoint_facts()
+            .method_info(owner, method_name)
+            .expect("anonymous method endpoint");
+
+        assert_eq!(info.return_type, Type::BOOL);
+        assert!(
+            collector.observations().iter().all(|observation| !matches!(
+                observation,
+                crate::BodyLookupObservation::Member { .. }
+            )),
+            "anonymous owners must not publish member lookup observations"
+        );
+    }
+
+    #[test]
     fn test_analyze_simple_function() {
         let output = compile_to_air("fn main() -> i32 { 42 }").unwrap();
         let functions = &output.functions;


### PR DESCRIPTION
## Summary

- route ordinary free-function endpoint and definition selection through BodyAnalysisState
- share one canonical endpoint read view while keeping lookup observations in a request-local overlay
- preserve anonymous-method precedence and lookup filtering, and keep type interning on the Sema-local overlay

This builds on #1988 as the next production-used receiver-family prerequisite for RUE-1092. It does not yet add the registered provider evaluator and does not close the issue.

## Validation

- focused one-body, owner/invariant, and compiler lookup tests
- anonymous endpoint-state regression
- rue-air build
- formatting and diff checks
- independent adversarial review

CI is the authority for the heavier matrix.