### PR TITLE
RUE-1092: Add local provider RIR seam

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -75,8 +75,8 @@ pub use runtime_call::{
 pub use sema::{
     AnalyzedBodyOwnerEvent, AnalyzedCallableKind, AnalyzedFunction, BodyAnalysisFailure,
     BodyAnalysisWork, BodyFactProvider, BodyLookupCollector, BodyLookupObservation,
-    BodyNamedDependencyEvent, BodyOwnerEndpoint, BodyOwnerKind, BodyOwnerToken, BoundSema,
-    BuiltinTypeCallHead, ConstInfo, ConstValue, DeclarationBindingWork,
+    BodyNamedDependencyEvent, BodyOwnerEndpoint, BodyOwnerKind, BodyOwnerToken, BodyRirBundle,
+    BodyRirView, BoundSema, BuiltinTypeCallHead, ConstInfo, ConstValue, DeclarationBindingWork,
     DeclarationBuiltinTypeCallHeadDependencyEvent, DeclarationInstallFailure,
     DeclarationResolutionFailure, DeclarationShells, DeclarationTypeCallHeadDependencyEvent,
     DeclarationTypeDependencyEvent, DeclarationTypeDependencyKind,

--- a/crates/rue-air/src/sema/body_endpoint.rs
+++ b/crates/rue-air/src/sema/body_endpoint.rs
@@ -23,12 +23,12 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use lasso::{Spur, ThreadedRodeo};
-use rue_rir::{InstRef, Rir};
+use rue_rir::InstRef;
 use rue_span::FileId;
 
 use super::anon_structs::IssuedAnonymousNominalKey;
 use super::body_identity::{
-    BodyRirIndex, ConstIdentityHandle, DurableAnonymousSource, DurableConstSource,
+    BodyRirView, ConstIdentityHandle, DurableAnonymousSource, DurableConstSource,
     DurableNominalSource, ProviderIdentityContext,
 };
 use super::declaration_index::RirDestructorDeclaration;
@@ -823,12 +823,7 @@ impl<K> Default for EndpointOverlay<K> {
 pub struct ProviderEndpointFacts<'a, P, S, K, M> {
     provider: &'a P,
     identity: ProviderIdentityContext<K, M, S>,
-    rir: &'a Rir,
-    rir_index: BodyRirIndex,
-    /// The whole-program RIR interner. The RIR-index ops resolve their `&str`
-    /// keys through this interner (the shared `Rir`'s symbol space), distinct
-    /// from the pool's own interner the nominal ops key on.
-    rir_interner: &'a ThreadedRodeo,
+    rir: BodyRirView<'a>,
     overlay: RefCell<EndpointOverlay<K>>,
     /// The issued→durable anonymous seam (RUE-1091 r6b): the anonymous producer
     /// key `resolve_instance_type` carries is in the issued-token domain, so a
@@ -846,33 +841,22 @@ where
     K: Clone + Eq + Hash,
     M: Clone + Eq + Hash,
 {
-    /// Construct the driver over a provider, a durable nominal source, and the
-    /// shared whole-program `Rir` + interner. The pool and RIR index are built
-    /// here; nominals are minted lazily on first consult and the overlay token
-    /// space starts empty (a caller mints a token per nominal with
-    /// [`Self::register_named_nominal`]).
-    pub fn new(provider: &'a P, source: S, rir: &'a Rir, rir_interner: &'a ThreadedRodeo) -> Self {
-        Self::with_identity(
-            provider,
-            ProviderIdentityContext::new(source),
-            rir,
-            rir_interner,
-        )
+    /// Construct the driver over one request-local RIR view and identity
+    /// context. The view's declaration index is shared rather than rebuilt.
+    pub fn new(provider: &'a P, source: S, rir: BodyRirView<'a>) -> Self {
+        Self::with_identity(provider, ProviderIdentityContext::new(source), rir)
     }
 
     /// Construct the driver inside an existing per-body identity universe.
     pub fn with_identity(
         provider: &'a P,
         identity: ProviderIdentityContext<K, M, S>,
-        rir: &'a Rir,
-        rir_interner: &'a ThreadedRodeo,
+        rir: BodyRirView<'a>,
     ) -> Self {
         Self {
             provider,
             identity,
             rir,
-            rir_index: BodyRirIndex::new(rir),
-            rir_interner,
             overlay: RefCell::new(EndpointOverlay::default()),
             anon_by_issued: RefCell::new(HashMap::new()),
         }
@@ -891,6 +875,25 @@ where
         durable: crate::AnonymousNominalKey<K, M>,
     ) {
         self.anon_by_issued.borrow_mut().insert(issued, durable);
+    }
+
+    /// Register one anonymous method atomically under both lookup preimages in
+    /// the identity context shared with the call facade.
+    pub fn register_anonymous_method(
+        &self,
+        file: FileId,
+        owner: &str,
+        method: &str,
+        info: MethodInfo,
+    ) -> bool {
+        self.identity
+            .register_anonymous_method(file, owner, method, info)
+    }
+
+    /// Return the registered method for a compact receiver/name pair,
+    /// preserving the canonical anonymous-before-named order.
+    pub fn method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
+        self.identity.method((struct_id, name))
     }
 
     /// Mint (or dedup) the anonymous nominal for a durable identity key directly,
@@ -1092,12 +1095,12 @@ where
     }
 
     /// (R) The first free-function RIR declaration for `(source_name, file)`,
-    /// answered by [`BodyRirIndex`] over the shared `Rir` — the exact `InstRef`
+    /// answered by [`BodyRirIndex`] over the request-local `Rir` — the exact `InstRef`
     /// [`EpochFacts::first_free_function`] returns, keyed provider-naturally by
     /// the source name string.
     pub fn first_free_function(&self, source_name: &str, file: FileId) -> Option<InstRef> {
-        let symbol = self.rir_interner.get(source_name)?;
-        self.rir_index.first_free_function(symbol, file)
+        let symbol = self.rir.rir_interner().get(source_name)?;
+        self.rir.rir_index().first_free_function(symbol, file)
     }
 
     /// (R) The named-method RIR declaration for `(owner_file, owner_type_name,
@@ -1110,9 +1113,10 @@ where
         owner_type_name: &str,
         method: &str,
     ) -> Option<InstRef> {
-        let owner = self.rir_interner.get(owner_type_name)?;
-        let method_sym = self.rir_interner.get(method)?;
-        self.rir_index
+        let owner = self.rir.rir_interner().get(owner_type_name)?;
+        let method_sym = self.rir.rir_interner().get(method)?;
+        self.rir
+            .rir_index()
             .named_method_declaration(owner_file, owner, method_sym)
     }
 
@@ -1122,8 +1126,9 @@ where
     /// destructor record's public handle); the epoch keys the same record by the
     /// same `(file, type_name)` scan.
     pub fn destructor(&self, file: FileId, type_name: &str) -> Option<InstRef> {
-        let symbol = self.rir_interner.get(type_name)?;
-        self.rir_index
+        let symbol = self.rir.rir_interner().get(type_name)?;
+        self.rir
+            .rir_index()
             .destructor(file.index(), symbol)
             .map(|record| record.declaration)
     }
@@ -1211,14 +1216,17 @@ where
         declaring_file: FileId,
         source_name: &str,
     ) -> Option<ConstInfo> {
-        let name = self.rir_interner.get(source_name)?;
-        let declaration = self.rir_index.const_declaration(declaring_file, name)?;
+        let name = self.rir.rir_interner().get(source_name)?;
+        let declaration = self
+            .rir
+            .rir_index()
+            .const_declaration(declaring_file, name)?;
         self.identity
             .pool_mut()?
             .resolve_const(
                 key,
                 ConstIdentityHandle {
-                    span: self.rir.get(declaration).span,
+                    span: self.rir.rir().get(declaration).span,
                 },
             )
             .ok()
@@ -1233,15 +1241,18 @@ where
         target: &M,
         is_public: bool,
     ) -> Option<ConstInfo> {
-        let name = self.rir_interner.get(source_name)?;
-        let declaration = self.rir_index.const_declaration(declaring_file, name)?;
+        let name = self.rir.rir_interner().get(source_name)?;
+        let declaration = self
+            .rir
+            .rir_index()
+            .const_declaration(declaring_file, name)?;
         let module = self.identity.modules().id_for_durable(target)?;
         let ty = Type::new_module(module);
         Some(ConstInfo {
             is_pub: is_public,
             ty,
             value: super::ConstValue::Type(ty),
-            span: self.rir.get(declaration).span,
+            span: self.rir.rir().get(declaration).span,
         })
     }
 
@@ -1387,9 +1398,11 @@ where
         None
     }
 
-    fn method_info(&self, _struct_id: StructId, _name: Spur) -> Option<MethodInfo> {
-        // r4b-3: the receiver→pool identity the endpoint seam owns.
-        None
+    fn method_info(&self, struct_id: StructId, name: Spur) -> Option<MethodInfo> {
+        // The shared registry preserves Sema's anonymous-before-named order.
+        // Named entries are installed from the exact call fact before analysis
+        // consumes the endpoint view; both facades then observe one authority.
+        self.method_info(struct_id, name)
     }
 
     fn source_function_name(&self, name: Spur) -> Spur {
@@ -1410,7 +1423,8 @@ where
         owner_type_name: Spur,
         method_name: Spur,
     ) -> Option<InstRef> {
-        self.rir_index
+        self.rir
+            .rir_index()
             .named_method_declaration(owner_file, owner_type_name, method_name)
     }
 

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -56,15 +56,14 @@
 //!   underlying `resolve` refuses them. A comptime-*value* parameter (concrete
 //!   type, `is_comptime = true`) resolves fully and marks `is_generic`; only a
 //!   comptime-*type* parameter referencing a generic parameter refuses;
-//! - **anonymous method dispatch / bodies** —
+//! - **anonymous method bodies** —
 //!   [`BodyIdentityPool::find_or_create_anon`] (r6b) mints the producer-nominal
 //!   anonymous struct / enum from its durable identity + shape, and
-//!   [`BodyIdentityPool::install_well_known_option_types`] (r6c) ports the
-//!   trusted well-known `Option` registry onto that machinery, but method
-//!   BODIES and dispatch registration still need the request-local
-//!   whole-program `Rir` and belong to the flip's overlay method installation;
-//!   an issued anonymous key with no registered durable identity still
-//!   resolves by lookup only ([`BodyIdentityPool::register_issued_anonymous`]);
+//!   [`ProviderIdentityContext::register_anonymous_method`] supplies the
+//!   request-local dispatch entry shared by endpoint and call facades. The
+//!   method body itself remains a local RIR concern; an issued anonymous key
+//!   with no registered durable identity still resolves by lookup only
+//!   ([`BodyIdentityPool::register_issued_anonymous`]);
 //! - **module identity** and generic-parameter substitution (endpoint /
 //!   inference families) — these arms are *refused*, never approximated;
 //! - **drop metadata** — durable named and anonymous nominals carry destructor
@@ -81,7 +80,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use lasso::{Spur, ThreadedRodeo};
-use rue_rir::{InstData, InstRef, Rir, RirParamMode};
+use rue_rir::{InstData, InstRef, Rir, RirParamMode, ValidatedRir};
 use rue_span::{FileId, Span};
 
 use super::ConstValue;
@@ -375,9 +374,77 @@ pub(in crate::sema) struct BodyIdentityPool<K, M, S> {
 /// call, endpoint, and aggregate drivers therefore clone this lightweight
 /// handle rather than constructing peer pools. This is the provider-side
 /// equivalent of every epoch adapter borrowing the same `BodySema`.
+#[derive(Default)]
+struct ProviderMethodRegistry {
+    anonymous: HashMap<(StructId, Spur), MethodInfo>,
+    anonymous_by_owner: HashMap<(FileId, Arc<str>, Arc<str>), (StructId, Spur)>,
+    named: HashMap<(StructId, Spur), MethodInfo>,
+    named_by_owner: HashMap<(FileId, Arc<str>, Arc<str>), (StructId, Spur)>,
+}
+
+impl ProviderMethodRegistry {
+    fn register_anonymous(
+        &mut self,
+        compact: (StructId, Spur),
+        owner: (FileId, Arc<str>, Arc<str>),
+        info: MethodInfo,
+    ) -> bool {
+        if self.anonymous.contains_key(&compact) || self.anonymous_by_owner.contains_key(&owner) {
+            return false;
+        }
+        self.anonymous.insert(compact, info);
+        self.anonymous_by_owner.insert(owner, compact);
+        true
+    }
+
+    fn register_named(
+        &mut self,
+        compact: (StructId, Spur),
+        owner: (FileId, Arc<str>, Arc<str>),
+        info: MethodInfo,
+    ) -> bool {
+        if self.named.contains_key(&compact) || self.named_by_owner.contains_key(&owner) {
+            return false;
+        }
+        self.named.insert(compact, info);
+        self.named_by_owner.insert(owner, compact);
+        true
+    }
+
+    fn method(&self, compact: (StructId, Spur)) -> Option<MethodInfo> {
+        self.anonymous
+            .get(&compact)
+            .or_else(|| self.named.get(&compact))
+            .copied()
+    }
+
+    fn method_by_owner(&self, owner: &(FileId, Arc<str>, Arc<str>)) -> Option<MethodInfo> {
+        self.anonymous_by_owner
+            .get(owner)
+            .and_then(|compact| self.anonymous.get(compact))
+            .or_else(|| {
+                self.named_by_owner
+                    .get(owner)
+                    .and_then(|compact| self.named.get(compact))
+            })
+            .copied()
+    }
+
+    fn named_by_owner(&self, owner: &(FileId, Arc<str>, Arc<str>)) -> Option<MethodInfo> {
+        self.named_by_owner
+            .get(owner)
+            .and_then(|compact| self.named.get(compact))
+            .copied()
+    }
+}
+
 pub struct ProviderIdentityContext<K, M, S> {
     pool: Rc<RefCell<BodyIdentityPool<K, M, S>>>,
     modules: Rc<RefCell<ProviderModuleRegistry<M>>>,
+    /// One request-local method authority shared by every provider facade.
+    /// Each entry is registered atomically under its compact and durable-owner
+    /// preimages; the owner maps point back into the canonical compact maps.
+    methods: Rc<RefCell<ProviderMethodRegistry>>,
     frozen: Rc<Cell<bool>>,
 }
 
@@ -386,6 +453,7 @@ impl<K, M, S> Clone for ProviderIdentityContext<K, M, S> {
         Self {
             pool: Rc::clone(&self.pool),
             modules: Rc::clone(&self.modules),
+            methods: Rc::clone(&self.methods),
             frozen: Rc::clone(&self.frozen),
         }
     }
@@ -402,6 +470,7 @@ where
         Self {
             pool: Rc::new(RefCell::new(BodyIdentityPool::new(source))),
             modules: Rc::new(RefCell::new(ProviderModuleRegistry::default())),
+            methods: Rc::new(RefCell::new(ProviderMethodRegistry::default())),
             frozen: Rc::new(Cell::new(false)),
         }
     }
@@ -436,6 +505,73 @@ where
 
     pub(in crate::sema) fn modules_mut(&self) -> RefMut<'_, ProviderModuleRegistry<M>> {
         self.modules.borrow_mut()
+    }
+
+    /// Install one anonymous method under both lookup preimages in one atomic
+    /// operation. Conflicting or duplicate registrations fail closed.
+    pub fn register_anonymous_method(
+        &self,
+        file: FileId,
+        owner: &str,
+        method: &str,
+        info: MethodInfo,
+    ) -> bool {
+        let Some(owner_id) = info.struct_type.as_struct() else {
+            return false;
+        };
+        let method_symbol = self.pool().intern_name(method);
+        self.methods.borrow_mut().register_anonymous(
+            (owner_id, method_symbol),
+            (file, Arc::from(owner), Arc::from(method)),
+            info,
+        )
+    }
+
+    /// Install one named method under both lookup preimages. The registry keeps
+    /// it separate from anonymous entries so lookups preserve anonymous-first
+    /// precedence while `named_method_info` remains named-only.
+    pub(in crate::sema) fn register_named_method(
+        &self,
+        file: FileId,
+        owner: &str,
+        method: &str,
+        info: MethodInfo,
+    ) -> bool {
+        let Some(owner_id) = info.struct_type.as_struct() else {
+            return false;
+        };
+        let method_symbol = self.pool().intern_name(method);
+        self.methods.borrow_mut().register_named(
+            (owner_id, method_symbol),
+            (file, Arc::from(owner), Arc::from(method)),
+            info,
+        )
+    }
+
+    pub(in crate::sema) fn method(&self, key: (StructId, Spur)) -> Option<MethodInfo> {
+        self.methods.borrow().method(key)
+    }
+
+    pub(in crate::sema) fn method_for_owner(
+        &self,
+        file: FileId,
+        owner: &str,
+        method: &str,
+    ) -> Option<MethodInfo> {
+        self.methods
+            .borrow()
+            .method_by_owner(&(file, Arc::from(owner), Arc::from(method)))
+    }
+
+    pub(in crate::sema) fn named_method_for_owner(
+        &self,
+        file: FileId,
+        owner: &str,
+        method: &str,
+    ) -> Option<MethodInfo> {
+        self.methods
+            .borrow()
+            .named_by_owner(&(file, Arc::from(owner), Arc::from(method)))
     }
 }
 
@@ -1814,9 +1950,9 @@ where
 /// inert: it contributes only a span and cannot assemble a [`ConstInfo`] without
 /// the independent durable-record join succeeding.
 ///
-/// Inert per the pool arc: `#![cfg_attr(not(test), allow(dead_code))]` on this
-/// module. There are zero production callers; the flip slice (r4b) wires it
-/// under body analysis.
+/// The index is request-local and is built once by [`BodyRirBundle`]. It is
+/// intentionally not a query value or a durable artifact.
+#[derive(Debug)]
 pub(in crate::sema) struct BodyRirIndex {
     /// Production's body-independent declaration index, re-used verbatim for
     /// `first_free_function` and `destructor`.
@@ -1830,8 +1966,91 @@ pub(in crate::sema) struct BodyRirIndex {
     const_declarations: HashMap<(FileId, Spur), InstRef>,
 }
 
+/// One request-local RIR universe shared by every provider fact facade for a
+/// body. The validated RIR, its matching semantic interner, and the derived
+/// declaration index have one owner so endpoint, call, aggregate, type, and
+/// inference facts cannot accidentally construct independent compact-identity
+/// authorities.
+#[derive(Debug)]
+pub struct BodyRirBundle {
+    rir: ValidatedRir,
+    rir_interner: ThreadedRodeo,
+    rir_index: Arc<BodyRirIndex>,
+}
+
+impl BodyRirBundle {
+    pub fn new(rir: ValidatedRir, rir_interner: ThreadedRodeo) -> Self {
+        let rir_index = Arc::new(BodyRirIndex::new(&rir));
+        Self {
+            rir,
+            rir_interner,
+            rir_index,
+        }
+    }
+
+    pub fn instruction_count(&self) -> usize {
+        self.rir.len()
+    }
+
+    pub fn anonymous_type_anchors(&self) -> Vec<rue_rir::RirStructuralAnchor> {
+        self.rir
+            .iter()
+            .filter_map(|(_, instruction)| match &instruction.data {
+                rue_rir::InstData::AnonStructType { anchor, .. }
+                | rue_rir::InstData::AnonEnumType { anchor, .. } => Some(anchor.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Borrow the one local RIR/index/interner authority for provider fact
+    /// facades. The view is cheap and carries no independent identity state.
+    pub fn view(&self) -> BodyRirView<'_> {
+        BodyRirView {
+            rir: &self.rir,
+            rir_interner: &self.rir_interner,
+            index: self.rir_index.clone(),
+        }
+    }
+}
+
+/// A shared read view over one body-local RIR authority. Production callers
+/// obtain it from [`BodyRirBundle::view`]; compatibility/test callers may build
+/// the same view around an already validated RIR and its matching interner.
+#[derive(Debug, Clone)]
+pub struct BodyRirView<'a> {
+    rir: &'a Rir,
+    rir_interner: &'a ThreadedRodeo,
+    index: Arc<BodyRirIndex>,
+}
+
+impl<'a> BodyRirView<'a> {
+    /// Construct the same shared view for an existing RIR/interner pair. The
+    /// index is built by the view once, never independently by endpoint/call
+    /// facades.
+    pub fn from_parts(rir: &'a Rir, rir_interner: &'a ThreadedRodeo) -> Self {
+        Self {
+            rir,
+            rir_interner,
+            index: Arc::new(BodyRirIndex::new(rir)),
+        }
+    }
+
+    pub(in crate::sema) fn rir(&self) -> &Rir {
+        self.rir
+    }
+
+    pub(in crate::sema) fn rir_interner(&self) -> &ThreadedRodeo {
+        self.rir_interner
+    }
+
+    pub(in crate::sema) fn rir_index(&self) -> &BodyRirIndex {
+        &self.index
+    }
+}
+
 impl BodyRirIndex {
-    /// Build the index from the shared whole-program `Rir`. Constructs one
+    /// Build the index from the request-local body `Rir`. Constructs one
     /// [`RirDeclarationIndex`] and derives the named-method point map from the
     /// owner edges it already classified — no second arena walk of the method
     /// universe, no durable metadata, no pool.
@@ -1937,6 +2156,80 @@ mod tests {
     type DType = SemanticImportType<Key, Module>;
 
     type AnonKey = AnonymousNominalKey<Key, Module>;
+
+    #[test]
+    fn provider_method_registry_is_atomic_and_anonymous_first() {
+        let symbols = ThreadedRodeo::new();
+        let method = symbols.get_or_intern("shift");
+        let compact = (StructId(7), method);
+        let owner = (
+            FileId::new(3),
+            Arc::<str>::from("Widget"),
+            Arc::<str>::from("shift"),
+        );
+        let info = |body| MethodInfo {
+            struct_type: Type::new_struct(compact.0),
+            has_self: true,
+            self_mode: RirParamMode::Borrow,
+            self_is_mut: false,
+            params: ParamRange::EMPTY,
+            return_type: Type::I32,
+            body: InstRef::from_raw(body),
+            span: Span::with_file(owner.0, 1, 2),
+        };
+        let named = info(10);
+        let anonymous = info(11);
+        let conflicting = info(12);
+        let mut registry = ProviderMethodRegistry::default();
+
+        assert!(registry.register_named(compact, owner.clone(), named));
+        assert!(registry.register_anonymous(compact, owner.clone(), anonymous));
+        assert_eq!(registry.method(compact).unwrap().body, anonymous.body);
+        assert_eq!(
+            registry.method_by_owner(&owner).unwrap().body,
+            anonymous.body
+        );
+        assert_eq!(registry.named_by_owner(&owner).unwrap().body, named.body);
+
+        assert!(
+            !registry.register_anonymous(compact, owner.clone(), conflicting),
+            "a second compact/owner registration cannot split the two indexes"
+        );
+        assert_eq!(registry.method(compact).unwrap().body, anonymous.body);
+        assert_eq!(
+            registry.method_by_owner(&owner).unwrap().body,
+            anonymous.body
+        );
+    }
+
+    #[test]
+    fn provider_fact_facades_use_the_shared_body_rir_view() {
+        let endpoint = include_str!("body_endpoint.rs");
+        let endpoint_start = endpoint.find("pub struct ProviderEndpointFacts").unwrap();
+        let endpoint_fields = &endpoint[endpoint_start
+            ..endpoint[endpoint_start..]
+                .find("\n}\n\nimpl<'a, P, S, K, M>")
+                .map(|offset| endpoint_start + offset + 2)
+                .unwrap()];
+        assert!(endpoint_fields.contains("BodyRirView"));
+        assert!(!endpoint_fields.contains("&'a Rir"));
+        assert!(!endpoint_fields.contains("ThreadedRodeo"));
+        assert!(!endpoint_fields.contains("BodyRirIndex"));
+        assert!(!endpoint.contains("BodyRirIndex::new"));
+
+        let calls = include_str!("call_resolution.rs");
+        let calls_start = calls.find("pub struct ProviderCallFacts").unwrap();
+        let calls_fields = &calls[calls_start
+            ..calls[calls_start..]
+                .find("\n}\n\nimpl<'a, P, S, K, M>")
+                .map(|offset| calls_start + offset + 2)
+                .unwrap()];
+        assert!(calls_fields.contains("BodyRirView"));
+        assert!(!calls_fields.contains("&'a Rir"));
+        assert!(!calls_fields.contains("ThreadedRodeo"));
+        assert!(!calls_fields.contains("BodyRirIndex"));
+        assert!(!calls.contains("BodyRirIndex::new"));
+    }
 
     /// A durable nominal + callable source backed by fixed maps, standing in for
     /// r4b's stable-keyed provider.

--- a/crates/rue-air/src/sema/call_resolution.rs
+++ b/crates/rue-air/src/sema/call_resolution.rs
@@ -36,12 +36,12 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::hash::Hash;
 
-use lasso::{Spur, ThreadedRodeo};
-use rue_rir::{InstData, InstRef, Rir};
+use lasso::Spur;
+use rue_rir::{InstData, InstRef};
 use rue_span::FileId;
 
 use super::body_identity::{
-    BodyRirIndex, DurableCallableSource, DurableNominalSource, FunctionIdentityHandle,
+    BodyRirView, DurableCallableSource, DurableNominalSource, FunctionIdentityHandle,
     MethodIdentityHandle, ProviderIdentityContext,
 };
 use super::info::{ConstInfo, FunctionInfo, MethodInfo};
@@ -381,12 +381,7 @@ pub(in crate::sema) fn resolve_static_call_reference<P: CallResolutionFacts>(
 pub struct ProviderCallFacts<'a, P, S, K, M> {
     provider: &'a P,
     identity: ProviderIdentityContext<K, M, S>,
-    rir_index: BodyRirIndex,
-    rir: &'a Rir,
-    /// The whole-program RIR interner. Input names arrive already interned here
-    /// (the provider path resolves them to `&str` and re-interns into the pool's
-    /// own interner); the RIR index is keyed on this interner's [`Spur`]s.
-    rir_interner: &'a ThreadedRodeo,
+    rir: BodyRirView<'a>,
     value_consts: RefCell<HashMap<(u32, Spur), ConstInfo>>,
     module_bindings: RefCell<HashMap<(u32, Spur), ConstInfo>>,
 }
@@ -398,31 +393,22 @@ where
     K: Clone + Eq + Hash,
     M: Eq + Hash,
 {
-    /// Construct the driver over a provider, a durable source, and the shared
-    /// whole-program `Rir` + interner. The pool and RIR index are built here;
-    /// nominals and callables are minted lazily on first consult.
-    pub fn new(provider: &'a P, source: S, rir: &'a Rir, rir_interner: &'a ThreadedRodeo) -> Self {
-        Self::with_identity(
-            provider,
-            ProviderIdentityContext::new(source),
-            rir,
-            rir_interner,
-        )
+    /// Construct the driver over one request-local RIR bundle and identity
+    /// context. The bundle's declaration index is shared rather than rebuilt.
+    pub fn new(provider: &'a P, source: S, rir: BodyRirView<'a>) -> Self {
+        Self::with_identity(provider, ProviderIdentityContext::new(source), rir)
     }
 
     /// Construct the driver inside an existing per-body identity universe.
     pub fn with_identity(
         provider: &'a P,
         identity: ProviderIdentityContext<K, M, S>,
-        rir: &'a Rir,
-        rir_interner: &'a ThreadedRodeo,
+        rir: BodyRirView<'a>,
     ) -> Self {
         Self {
             provider,
             identity,
-            rir_index: BodyRirIndex::new(rir),
             rir,
-            rir_interner,
             value_consts: RefCell::new(HashMap::new()),
             module_bindings: RefCell::new(HashMap::new()),
         }
@@ -448,6 +434,11 @@ where
     /// parity is asserted through resolved strings.
     pub fn resolve_symbol(&self, symbol: Spur) -> String {
         self.identity.pool().resolve_symbol(symbol).to_owned()
+    }
+
+    /// Intern a body-local name in the shared provider identity universe.
+    pub fn name_symbol(&self, name: &str) -> Spur {
+        self.identity.pool().intern_name(name)
     }
 
     /// Install an already materialized value constant into the call family's
@@ -513,8 +504,8 @@ where
     /// `span`/`file_id` from the located `FnDecl` inst, the same inst production
     /// sources them from — a differential asserts, never assumes, the equality.
     pub fn function_info(&self, key: &K, source_name: &str, file: FileId) -> Option<FunctionInfo> {
-        let source_sym = self.rir_interner.get(source_name)?;
-        let declaration = self.rir_index.first_free_function(source_sym, file)?;
+        let source_sym = self.rir.rir_interner().get(source_name)?;
+        let declaration = self.rir.rir_index().first_free_function(source_sym, file)?;
         let handle = self.function_handle(declaration)?;
         self.identity.pool_mut()?.resolve_function(key, handle).ok()
     }
@@ -529,9 +520,13 @@ where
         owner_type_name: &str,
         method: &str,
     ) -> Option<MethodInfo> {
-        let declaration = self.named_method_declaration(owner_file, owner_type_name, method)?;
-        let handle = self.method_handle(declaration)?;
-        self.identity.pool_mut()?.resolve_method(key, handle).ok()
+        if let Some(info) = self
+            .identity
+            .method_for_owner(owner_file, owner_type_name, method)
+        {
+            return Some(info);
+        }
+        self.resolve_and_register_named_method(key, owner_file, owner_type_name, method)
     }
 
     /// (P) The *named* method info for `(owner, method)`. Anonymous-owner methods
@@ -545,7 +540,42 @@ where
         owner_type_name: &str,
         method: &str,
     ) -> Option<MethodInfo> {
-        self.method_info(key, owner_file, owner_type_name, method)
+        if let Some(info) =
+            self.identity
+                .named_method_for_owner(owner_file, owner_type_name, method)
+        {
+            return Some(info);
+        }
+        self.resolve_and_register_named_method(key, owner_file, owner_type_name, method)
+    }
+
+    fn resolve_and_register_named_method(
+        &self,
+        key: &K,
+        owner_file: FileId,
+        owner_type_name: &str,
+        method: &str,
+    ) -> Option<MethodInfo> {
+        let declaration = self.named_method_declaration(owner_file, owner_type_name, method)?;
+        let handle = self.method_handle(declaration)?;
+        let info = self.identity.pool_mut()?.resolve_method(key, handle).ok()?;
+        self.identity
+            .register_named_method(owner_file, owner_type_name, method, info)
+            .then_some(info)
+    }
+
+    /// Install one anonymous method atomically under its compact and
+    /// durable-owner lookup preimages. Endpoint and call facades cloned from
+    /// this context therefore observe the same anonymous-first result.
+    pub fn register_anonymous_method(
+        &self,
+        file: FileId,
+        owner: &str,
+        method: &str,
+        info: MethodInfo,
+    ) -> bool {
+        self.identity
+            .register_anonymous_method(file, owner, method, info)
     }
 
     /// (P) The named-method RIR declaration for `(owner_file, owner_type_name,
@@ -563,9 +593,10 @@ where
         owner_type_name: &str,
         method: &str,
     ) -> Option<InstRef> {
-        let owner_sym = self.rir_interner.get(owner_type_name)?;
-        let method_sym = self.rir_interner.get(method)?;
-        self.rir_index
+        let owner_sym = self.rir.rir_interner().get(owner_type_name)?;
+        let method_sym = self.rir.rir_interner().get(method)?;
+        self.rir
+            .rir_index()
             .named_method_declaration(owner_file, owner_sym, method_sym)
     }
 
@@ -604,7 +635,7 @@ where
     /// `body`, the pre-resolution return symbol, the RIR-only
     /// `is_extern`/`is_c_export`, and the `@allow` directive flags.
     fn function_handle(&self, declaration: InstRef) -> Option<FunctionIdentityHandle> {
-        let inst = self.rir.get(declaration);
+        let inst = self.rir.rir().get(declaration);
         let InstData::FnDecl {
             body,
             return_type,
@@ -616,7 +647,7 @@ where
         else {
             return None;
         };
-        let dirs = self.rir.directives(directives);
+        let dirs = self.rir.rir().directives(directives);
         Some(FunctionIdentityHandle {
             body: *body,
             declaration,
@@ -633,7 +664,7 @@ where
 
     /// Fill a [`MethodIdentityHandle`] from the located method `FnDecl` inst.
     fn method_handle(&self, declaration: InstRef) -> Option<MethodIdentityHandle> {
-        let inst = self.rir.get(declaration);
+        let inst = self.rir.rir().get(declaration);
         let InstData::FnDecl {
             body,
             self_mode,
@@ -659,8 +690,8 @@ where
         mut directives: impl Iterator<Item = rue_rir::RirDirectiveView<'r>>,
         warning_name: &str,
     ) -> bool {
-        let allow_sym = self.rir_interner.get("allow");
-        let warning_sym = self.rir_interner.get(warning_name);
+        let allow_sym = self.rir.rir_interner().get("allow");
+        let warning_sym = self.rir.rir_interner().get(warning_name);
         directives.any(|directive| {
             Some(directive.name) == allow_sym
                 && directive.args.iter().any(|arg| Some(*arg) == warning_sym)

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -114,9 +114,10 @@ pub use aggregate_resolution::{
 };
 pub use body_endpoint::ProviderEndpointFacts;
 pub use body_identity::{
-    DurableAnonymousShape, DurableAnonymousSource, DurableCallableSource, DurableConst,
-    DurableConstSource, DurableFunction, DurableMethod, DurableNominal, DurableNominalBody,
-    DurableNominalSource, DurableSignatureParameter, ProviderIdentityContext,
+    BodyRirBundle, BodyRirView, DurableAnonymousShape, DurableAnonymousSource,
+    DurableCallableSource, DurableConst, DurableConstSource, DurableFunction, DurableMethod,
+    DurableNominal, DurableNominalBody, DurableNominalSource, DurableSignatureParameter,
+    ProviderIdentityContext,
 };
 pub use call_resolution::ProviderCallFacts;
 

--- a/crates/rue-compiler/src/body_overlay.rs
+++ b/crates/rue-compiler/src/body_overlay.rs
@@ -101,9 +101,8 @@ pub(crate) struct BodySemanticOverlay {
     /// type-world analog of the definition/module token space: it lets the
     /// overlay own the nominal metadata a body later renders, materialized on
     /// demand through the exact body-fact provider instead of read from the
-    /// whole-epoch `type_pool`. Only the test-only `ProviderTypeFacts` path
-    /// fills it; production never does.
-    #[cfg(test)]
+    /// whole-epoch `type_pool`. The provider-backed body path fills it from
+    /// exact durable facts; it is request-local and never published.
     materialized_nominals: HashMap<StableDefinitionKey, crate::DurableDeclarationPayload>,
     counters: Arc<OverlayMaterializationCounters>,
 }
@@ -130,7 +129,6 @@ impl BodySemanticOverlay {
             module_ids: Vec::new(),
             module_slots: HashMap::new(),
             recipe_tokens: HashMap::new(),
-            #[cfg(test)]
             materialized_nominals: HashMap::new(),
             counters,
         }
@@ -146,7 +144,6 @@ impl BodySemanticOverlay {
     /// recorded by the body-fact provider op that supplied `payload`, not here:
     /// materialization is where metadata lands, the provider call is where the
     /// edge lands, and the two happen together (never at render).
-    #[cfg(test)]
     pub(crate) fn materialize_nominal(
         &mut self,
         key: &StableDefinitionKey,

--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -63,20 +63,8 @@ impl ModuleRirOutput {
         self.work
     }
 
-    pub(crate) fn instruction_count(&self) -> usize {
-        self.rir.len()
-    }
-
-    #[cfg(test)]
-    pub(crate) fn anonymous_type_anchors(&self) -> Vec<rue_rir::RirStructuralAnchor> {
-        self.rir
-            .iter()
-            .filter_map(|(_, instruction)| match &instruction.data {
-                rue_rir::InstData::AnonStructType { anchor, .. }
-                | rue_rir::InstData::AnonEnumType { anchor, .. } => Some(anchor.clone()),
-                _ => None,
-            })
-            .collect()
+    pub(crate) fn into_body_rir_bundle(self) -> rue_air::BodyRirBundle {
+        rue_air::BodyRirBundle::new(self.rir, self.symbols.into_interner())
     }
 }
 

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -222,10 +222,11 @@ pub(crate) use durable_body::{
 pub(crate) use durable_semantics::{
     DURABLE_SEMANTIC_SCHEMA_VERSION, DurableDeclarationSemantic, DurableSemanticSchemaVersion,
 };
+pub(crate) use durable_semantics::{DurableConstValue, DurableDeclarationPayload, DurableType};
 #[cfg(test)]
 pub(crate) use durable_semantics::{
-    DurableConstValue, DurableDeclarationPayload, DurableParameterMode, DurableSemanticParameter,
-    DurableSemanticProjectionFailure, DurableSemanticProjectionWork, DurableType,
+    DurableParameterMode, DurableSemanticParameter, DurableSemanticProjectionFailure,
+    DurableSemanticProjectionWork,
 };
 
 // Small foundational types callers need to configure or inspect the facade.

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -515,8 +515,9 @@ pub(crate) struct RevisionedQueryDatabase {
     /// Per-`(module, import-path)` binding-resolution family. Registered query
     /// machinery for the exact provider boundary. Production body import
     /// dependencies are mediated by module-binding name and semantic-nucleus
-    /// terminals; the direct provider remains a differential test adapter.
-    #[cfg(test)]
+    /// terminals; the provider captures these exact family handles for a
+    /// request-local body task.
+    #[allow(dead_code)]
     lookup_imports: QueryFamily<LookupImportKey, LookupImportValue>,
     /// Test-only log of every module whose immutable name index was built,
     /// proving in-module fan-out (ADR-0066 §4).
@@ -572,11 +573,11 @@ pub(crate) struct RevisionedQueryDatabase {
     /// each exact issued batch and the trusted publish append here at
     /// publication — instead of re-deriving it by scanning complete views.
     lineage_additions: Vec<ModuleRevision>,
-    /// Provider-op observation counters (RUE-1091, ADR-0066 §4). The exact
-    /// [`CompilerBodyFactProvider`] is a test-only differential adapter in this
-    /// slice; no production path constructs it, so every counter here reads zero
-    /// on a production compile. Exposed through the unstable surface, mirroring
-    /// the recipe-cache meter.
+    /// Provider-op observation counters (RUE-1091, ADR-0066 §4), shared by the
+    /// production-compiled exact provider and its differential probes. The
+    /// registered body evaluator becomes the first non-test constructor; until
+    /// that routing slice lands, ordinary production compiles leave them zero.
+    /// Exposed through the unstable surface, mirroring the recipe-cache meter.
     provider_observation_meter: Arc<ProviderObservationCounters>,
     /// Session-held retention lease over the lookup families (RUE-1091,
     /// ADR-0066 §4). A rooted semantic publication promotes its exact observed
@@ -1225,14 +1226,12 @@ impl CanonicalNameResolution {
 /// Key for the per-`(module, import-path)` binding-resolution family. One
 /// logical terminal per distinct consulted import path in a consulting module,
 /// matching ADR-0066 §4 "one logical terminal per … import-path key".
-#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct LookupImportKey {
     module: ModuleId,
     specifier: Arc<str>,
 }
 
-#[cfg(test)]
 impl QueryKey for LookupImportKey {
     fn stable_identity(&self) -> String {
         format!("{}::@import::{}", self.module, self.specifier)
@@ -1242,7 +1241,6 @@ impl QueryKey for LookupImportKey {
 /// A resolved import binding. Position-free by construction: it carries only the
 /// normalized specifier, never the `@import` call's source offset, so a
 /// trivia-only edit that shifts the call preserves the binding's stamp.
-#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ResolvedImportBinding {
     normalized_specifier: Arc<str>,
@@ -1253,7 +1251,6 @@ struct ResolvedImportBinding {
 /// absent module binding is a first-class terminal result and dependency
 /// edge"): a later edit that makes the path resolve changes this stamp and
 /// invalidates exactly the consumers of the failed lookup.
-#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ImportBindingFailure {
     /// No `@import` directive in the consulting module names this specifier.
@@ -1265,11 +1262,9 @@ enum ImportBindingFailure {
     Ambiguous,
 }
 
-#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct LookupImportValue(Result<ResolvedImportBinding, ImportBindingFailure>);
 
-#[cfg(test)]
 impl LookupImportValue {
     /// Classify a consulted import path against the consulting module's declared
     /// `@import` specifiers. Pure and `O(module imports)`; it reads only the
@@ -2031,12 +2026,12 @@ fn body_source_definition_key(
 #[derive(Debug)]
 struct OwnedBodyLowering {
     module: Arc<crate::parsed_modules::ParsedModule>,
-    rir: crate::canonical_lower::ModuleRirOutput,
+    bundle: rue_air::BodyRirBundle,
 }
 
 impl OwnedBodyLowering {
     fn instruction_count(&self) -> usize {
-        self.rir.instruction_count()
+        self.bundle.instruction_count()
     }
 
     fn function_count(&self) -> usize {
@@ -2054,7 +2049,7 @@ impl OwnedBodyLowering {
 
     #[cfg(test)]
     fn anonymous_type_anchors(&self) -> Vec<rue_rir::RirStructuralAnchor> {
-        self.rir.anonymous_type_anchors()
+        self.bundle.anonymous_type_anchors()
     }
 }
 
@@ -2128,7 +2123,10 @@ fn lower_owned_body_input(
         &anchors,
     )
     .map_err(|(error, _)| Arc::from(error.to_string()))?;
-    Ok(OwnedBodyLowering { module, rir })
+    Ok(OwnedBodyLowering {
+        module,
+        bundle: rir.into_body_rir_bundle(),
+    })
 }
 
 fn declaration_candidate_for_stable_key(
@@ -7381,17 +7379,16 @@ impl RevisionedQueryDatabase {
                 },
             )
             .expect("the LookupName family has one canonical name");
-        #[cfg(test)]
         let index_for_import_lookup = module_indexes.clone();
         #[cfg(test)]
         let lookup_import_eval_probe = lookup_import_eval_log.clone();
-        #[cfg(test)]
         let lookup_imports = runtime
             .family_with_equality_and_evaluator(
                 "compiler.lookup-import",
                 declaration_memo_retention,
                 |left: &LookupImportValue, right: &LookupImportValue| left == right,
                 move |context, _, key: &LookupImportKey| {
+                    #[cfg(test)]
                     lookup_import_eval_probe
                         .lock()
                         .expect("lookup-import probe is not poisoned")
@@ -9462,7 +9459,6 @@ impl RevisionedQueryDatabase {
             declaration_imports,
             semantic_nucleus,
             lookup_names,
-            #[cfg(test)]
             lookup_imports,
             #[cfg(test)]
             module_index_build_log,
@@ -9500,8 +9496,8 @@ impl RevisionedQueryDatabase {
 
 impl RevisionedQueryDatabase {
     /// An owned snapshot of the provider-op observation counters. Reads all
-    /// zeros on the production path — the exact provider is a test-only
-    /// differential adapter until the RUE-1091 step-4 flip.
+    /// zeros until the registered body evaluator starts constructing the exact
+    /// provider; differential probes exercise the same production-compiled ops.
     pub(crate) fn provider_observation_metrics(
         &self,
     ) -> crate::unstable::ProviderObservationMetrics {
@@ -12190,7 +12186,7 @@ pub(crate) fn execution(attempt: &QueryRequestAttempt<impl Sized>) -> RequestExe
 }
 
 // ---------------------------------------------------------------------------
-// RUE-1091 slice 3b — the exact body-fact provider (test-only differential).
+// RUE-1091 slice 3b — the exact body-fact provider.
 //
 // `CompilerBodyFactProvider` implements the rue-air `BodyFactProvider` boundary
 // inside a `BodyTransaction`-style query context: every op requests its exact
@@ -12198,26 +12194,24 @@ pub(crate) fn execution(attempt: &QueryRequestAttempt<impl Sized>) -> RequestExe
 // call *is* the dependency observation (ADR-0066 §4). It converts the private
 // query-terminal values into rue-air's owned candidate-set / durable facts.
 //
-// The whole provider path is `#[cfg(test)]`: it is a differential adapter that
-// cross-checks each returned fact against the production epoch's equivalent
-// terminal, never a selectable production path. The step-4 flip promotes it.
-// It consumes the `#[cfg(test)]` `lookup-import` family, so gating the whole
-// provider on test keeps the family and its one consumer on the same cfg.
+// The provider is production-compiled and is request-scoped; the observation
+// probe below remains test-only. It consumes only the promoted exact lookup
+// and import families and never retains the database or coordinator.
 // ---------------------------------------------------------------------------
 
 /// Owned receiver-type identity the provider keys method/operator candidates
 /// and drop/`@copy` metadata on. It is exactly the `(receiver-type identity,
 /// member name)` key the 3a review binds these ops to — never a per-body
 /// universe walk and never a new module-index column.
-#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
 pub(crate) struct ReceiverTypeIdentity {
     module: ModuleId,
     type_name: Arc<str>,
     type_category: crate::declaration_candidate::DeclarationCandidateCategory,
 }
 
-#[cfg(test)]
+#[allow(dead_code)]
 impl ReceiverTypeIdentity {
     pub(crate) fn new(
         module: ModuleId,
@@ -12240,7 +12234,7 @@ impl ReceiverTypeIdentity {
 /// sole language item is `StrBuf` (`\0rue-std/strbuf.rue`). A bare name that is
 /// not a known language item (an anonymous owner) yields `None` and stays
 /// refused — the residual owned by r6b / the flip.
-#[cfg(test)]
+#[allow(dead_code)]
 fn bare_language_item_owner(type_name: &str) -> Option<(ModuleId, rue_air::LangItem)> {
     match type_name {
         "StrBuf" => Some((
@@ -12274,7 +12268,7 @@ struct ProviderProbeValue;
 /// Convert a rue-air provider namespace to the compiler's presemantic
 /// namespace, and back, so a body names a namespace without depending on the
 /// compiler's candidate model.
-#[cfg(test)]
+#[allow(dead_code)]
 fn provider_namespace_to_definition(namespace: rue_air::ProviderNamespace) -> DefinitionNamespace {
     match namespace {
         rue_air::ProviderNamespace::ModuleItem => DefinitionNamespace::ModuleItem,
@@ -12282,7 +12276,7 @@ fn provider_namespace_to_definition(namespace: rue_air::ProviderNamespace) -> De
     }
 }
 
-#[cfg(test)]
+#[allow(dead_code)]
 fn definition_namespace_to_provider(namespace: DefinitionNamespace) -> rue_air::ProviderNamespace {
     match namespace {
         DefinitionNamespace::ModuleItem => rue_air::ProviderNamespace::ModuleItem,
@@ -12290,7 +12284,7 @@ fn definition_namespace_to_provider(namespace: DefinitionNamespace) -> rue_air::
     }
 }
 
-#[cfg(test)]
+#[allow(dead_code)]
 fn definition_kind_to_provider(kind: DefinitionKind) -> rue_air::ProviderDefinitionKind {
     match kind {
         DefinitionKind::Function => rue_air::ProviderDefinitionKind::Function,
@@ -12302,7 +12296,7 @@ fn definition_kind_to_provider(kind: DefinitionKind) -> rue_air::ProviderDefinit
 }
 
 /// Project one retained `LookupNameFact` into an owned rue-air candidate.
-#[cfg(test)]
+#[allow(dead_code)]
 fn name_candidate_from_fact(fact: &LookupNameFact) -> rue_air::NameCandidate {
     rue_air::NameCandidate {
         namespace: definition_namespace_to_provider(fact.namespace),
@@ -12314,7 +12308,7 @@ fn name_candidate_from_fact(fact: &LookupNameFact) -> rue_air::NameCandidate {
 }
 
 /// Classify a retained `LookupName` value into the owned rue-air candidate set.
-#[cfg(test)]
+#[allow(dead_code)]
 fn name_resolution_from_value(value: &LookupNameValue) -> rue_air::NameResolution {
     match &value.0 {
         Err(LookupNameFailure::ModuleIndexUnavailable(_)) => {
@@ -12327,7 +12321,7 @@ fn name_resolution_from_value(value: &LookupNameValue) -> rue_air::NameResolutio
 }
 
 /// Classify a retained `LookupImport` value into the owned rue-air result.
-#[cfg(test)]
+#[allow(dead_code)]
 fn import_resolution_from_value(value: &LookupImportValue) -> rue_air::ImportResolution {
     match &value.0 {
         Ok(binding) => rue_air::ImportResolution::Resolved {
@@ -12341,74 +12335,100 @@ fn import_resolution_from_value(value: &LookupImportValue) -> rue_air::ImportRes
 
 /// The compiler-side implementation of the rue-air exact provider boundary.
 ///
-/// Bound entirely inside one query task: `context` records each edge, `database`
-/// supplies the backing family handles, and `configuration` keys the
-/// semantic-nucleus terminals. A `QueryAbort` from any nested request is
-/// captured and surfaced to the task after the batch so the trait methods stay
-/// abort-free (rue-air never sees a query-runtime type).
-#[cfg(test)]
-pub(crate) struct CompilerBodyFactProvider<'a> {
-    context: &'a rue_query::QueryContext,
-    database: &'a RevisionedQueryDatabase,
-    configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
-    aborted: std::cell::RefCell<Option<QueryAbort>>,
-    /// The lookup terminals this provider observes for the rooted request,
-    /// pinned while the request lease is still live (RUE-1091, ADR-0066 §4). A
-    /// name lookup pins its `compiler.lookup-name` terminal; an import resolution
-    /// pins its `compiler.lookup-import` terminal. A speculative lookup no
-    /// published root observes is never promoted, so a terminal touched purely to
-    /// probe is left in this set only if the driving request actually publishes a
-    /// root and promotes it. [`Self::take_observed_root`] hands the set to the
-    /// session lease at promotion.
-    observed: std::cell::RefCell<ObservedLookupRoot>,
+/// Bound entirely inside one query task: the cloneable query bundle records
+/// each edge and owns the exact family handles/configuration/status needed by
+/// the provider. No database or coordinator handle is retained by the provider.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CompilerBodyProviderIncomplete {
+    Canceled,
+    MissingInput(rue_query::InputIdentity),
 }
 
-#[cfg(test)]
-impl<'a> CompilerBodyFactProvider<'a> {
-    fn new(
-        context: &'a rue_query::QueryContext,
-        database: &'a RevisionedQueryDatabase,
-        configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
-    ) -> Self {
-        Self {
-            context,
-            database,
-            configuration,
-            aborted: std::cell::RefCell::new(None),
-            observed: std::cell::RefCell::new(ObservedLookupRoot::new()),
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CompilerBodyProviderStatus {
+    Ready,
+    Incomplete(CompilerBodyProviderIncomplete),
+    Fatal(QueryAbort),
+}
+
+fn provider_status_should_replace(
+    current: &CompilerBodyProviderStatus,
+    next: &CompilerBodyProviderStatus,
+) -> bool {
+    match (current, next) {
+        (CompilerBodyProviderStatus::Fatal(_), _) => false,
+        (_, CompilerBodyProviderStatus::Fatal(_)) => true,
+        (CompilerBodyProviderStatus::Ready, _) => true,
+        (CompilerBodyProviderStatus::Incomplete(_), _) => false,
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct CompilerBodyProviderQueries<'a> {
+    context: &'a rue_query::QueryContext,
+    lookup_names: QueryFamily<LookupNameKey, LookupNameValue>,
+    lookup_imports: QueryFamily<LookupImportKey, LookupImportValue>,
+    semantic_nucleus: QueryFamily<
+        crate::semantic_query_nucleus::SemanticNucleusKey,
+        crate::semantic_query_nucleus::SemanticNucleusValue,
+    >,
+    body_produced_anonymous:
+        QueryFamily<crate::body_query::BodyQueryKey, crate::body_query::ProducedAnonymous>,
+    body_toolchain_demands:
+        QueryFamily<crate::body_query::BodyQueryKey, crate::BodyToolchainDemand>,
+    configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
+    status: std::rc::Rc<std::cell::RefCell<CompilerBodyProviderStatus>>,
+    observed: std::rc::Rc<std::cell::RefCell<ObservedLookupRoot>>,
+    meter: Arc<ProviderObservationCounters>,
+}
+
+#[allow(dead_code)]
+impl<'a> CompilerBodyProviderQueries<'a> {
+    fn finish_status(&self) -> Result<(), CompilerBodyProviderStatus> {
+        match self.status.borrow().clone() {
+            CompilerBodyProviderStatus::Ready => Ok(()),
+            status => Err(status),
         }
+    }
+}
+
+pub(crate) struct CompilerBodyFactProvider<'a> {
+    queries: CompilerBodyProviderQueries<'a>,
+}
+
+#[allow(dead_code)]
+impl<'a> CompilerBodyFactProvider<'a> {
+    pub(crate) fn new(queries: CompilerBodyProviderQueries<'a>) -> Self {
+        Self { queries }
     }
 
     /// Take the observed lookup-pin set for promotion into the session lease.
     fn take_observed_root(&self) -> ObservedLookupRoot {
-        self.observed.replace(ObservedLookupRoot::new())
+        self.queries.observed.replace(ObservedLookupRoot::new())
     }
 
-    /// Record a nested request's abort with one uniform rule across every op:
-    /// `QueryAbort::Canceled` is the runtime's universal "not available at this
-    /// revision / deferred" signal, so the provider maps it to an observed
-    /// absence (the op's empty/`None` sentinel) and does not poison the task —
-    /// the request is still recorded as an observed edge either way. Any other
-    /// abort (a true cycle, a foreign runtime, a missing input) is genuinely
-    /// fatal and is captured so the task surfaces it at its boundary. This keeps
-    /// the abort handling identical for name, nucleus, import, member, producer,
-    /// and toolchain observations.
     fn observe_abort(&self, abort: QueryAbort) {
-        if matches!(abort, QueryAbort::Canceled) {
-            return;
-        }
-        let mut slot = self.aborted.borrow_mut();
-        if slot.is_none() {
-            *slot = Some(abort);
+        let status = match abort {
+            QueryAbort::Canceled => {
+                CompilerBodyProviderStatus::Incomplete(CompilerBodyProviderIncomplete::Canceled)
+            }
+            QueryAbort::MissingInput(input) => CompilerBodyProviderStatus::Incomplete(
+                CompilerBodyProviderIncomplete::MissingInput(input),
+            ),
+            fatal => CompilerBodyProviderStatus::Fatal(fatal),
+        };
+        let mut current = self.queries.status.borrow_mut();
+        if provider_status_should_replace(&current, &status) {
+            *current = status;
         }
     }
 
-    fn taken_abort(&self) -> Option<QueryAbort> {
-        self.aborted.borrow_mut().take()
+    pub(crate) fn finish_status(&self) -> Result<(), CompilerBodyProviderStatus> {
+        self.queries.finish_status()
     }
 
     fn meter(&self) -> &ProviderObservationCounters {
-        &self.database.provider_observation_meter
+        &self.queries.meter
     }
 
     fn body_query_key(
@@ -12417,7 +12437,7 @@ impl<'a> CompilerBodyFactProvider<'a> {
     ) -> crate::body_query::BodyQueryKey {
         crate::body_query::BodyQueryKey {
             instance: instance.clone(),
-            configuration: self.configuration.clone(),
+            configuration: self.queries.configuration.clone(),
         }
     }
 
@@ -12435,16 +12455,18 @@ impl<'a> CompilerBodyFactProvider<'a> {
             name: Arc::from(name),
         };
         match self
+            .queries
             .context
-            .query_registered(&self.database.lookup_names, key)
+            .query_registered(&self.queries.lookup_names, key)
         {
             Ok(terminal) => {
                 // Pin the observed lookup-name terminal while the request lease
                 // still protects it, so the promoted set transfers it with no
                 // birth-eviction window.
-                self.observed
+                self.queries
+                    .observed
                     .borrow_mut()
-                    .record(&self.database.lookup_names, &terminal);
+                    .record(&self.queries.lookup_names, &terminal);
                 match terminal.outcome() {
                     rue_query::QueryOutcome::Success(value) => name_resolution_from_value(value),
                     _ => rue_air::NameResolution::IndexUnavailable,
@@ -12458,15 +12480,17 @@ impl<'a> CompilerBodyFactProvider<'a> {
     }
 
     /// Observe one semantic-nucleus terminal, recording its edge. Deterministic
-    /// failures publish as `Success(Failure)`; a `QueryAbort` returns `None`
-    /// (Canceled as observed absence, other aborts captured for the boundary).
+    /// failures publish as `Success(Failure)`; a `QueryAbort` returns the
+    /// trait's absence-shaped value only provisionally and records a typed
+    /// provider status that the request boundary must check before publication.
     fn nucleus(
         &self,
         key: crate::semantic_query_nucleus::SemanticNucleusKey,
     ) -> Option<crate::semantic_query_nucleus::SemanticNucleusValue> {
         match self
+            .queries
             .context
-            .query_registered(&self.database.semantic_nucleus, key)
+            .query_registered(&self.queries.semantic_nucleus, key)
         {
             Ok(terminal) => match terminal.outcome() {
                 rue_query::QueryOutcome::Success(value) => Some(value.clone()),
@@ -12485,7 +12509,7 @@ impl<'a> CompilerBodyFactProvider<'a> {
     ) -> crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
         crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
             declaration: decl.clone(),
-            configuration: self.configuration.clone(),
+            configuration: self.queries.configuration.clone(),
         }
     }
 
@@ -12536,7 +12560,7 @@ impl<'a> CompilerBodyFactProvider<'a> {
                 self.nucleus(crate::semantic_query_nucleus::SemanticNucleusKey::Identity(
                     crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
                         declaration: key.clone(),
-                        configuration: self.configuration.clone(),
+                        configuration: self.queries.configuration.clone(),
                     },
                 ))
             else {
@@ -12547,7 +12571,7 @@ impl<'a> CompilerBodyFactProvider<'a> {
                 crate::semantic_query_nucleus::SemanticNucleusKey::Signature(
                     crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
                         declaration: key.clone(),
-                        configuration: self.configuration.clone(),
+                        configuration: self.queries.configuration.clone(),
                     },
                 ),
             ) {
@@ -12575,7 +12599,7 @@ impl<'a> CompilerBodyFactProvider<'a> {
 
 /// One observed receiver member: its declaration handle, syntactic kind,
 /// `self`-receiver classification (from the signature), and visibility.
-#[cfg(test)]
+#[allow(dead_code)]
 struct MemberObservation {
     declaration: crate::declaration_candidate::DeclarationCandidateKey,
     kind: rue_air::MemberKind,
@@ -12583,7 +12607,6 @@ struct MemberObservation {
     is_public: bool,
 }
 
-#[cfg(test)]
 impl rue_air::BodyFactProvider for CompilerBodyFactProvider<'_> {
     type ModuleRef = ModuleId;
     type DeclarationRef = crate::declaration_candidate::DeclarationCandidateKey;
@@ -12858,15 +12881,17 @@ impl rue_air::BodyFactProvider for CompilerBodyFactProvider<'_> {
             specifier: Arc::from(specifier),
         };
         match self
+            .queries
             .context
-            .query_registered(&self.database.lookup_imports, key)
+            .query_registered(&self.queries.lookup_imports, key)
         {
             Ok(terminal) => {
                 // Pin the observed lookup-import terminal under the live request
                 // lease, exactly as the name-lookup op does.
-                self.observed
+                self.queries
+                    .observed
                     .borrow_mut()
-                    .record(&self.database.lookup_imports, &terminal);
+                    .record(&self.queries.lookup_imports, &terminal);
                 match terminal.outcome() {
                     rue_query::QueryOutcome::Success(value) => import_resolution_from_value(value),
                     _ => rue_air::ImportResolution::Absent,
@@ -13002,19 +13027,18 @@ impl rue_air::BodyFactProvider for CompilerBodyFactProvider<'_> {
         self.meter()
             .producer_facts
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        match self.context.query_registered(
-            &self.database.body_produced_anonymous,
+        match self.queries.context.query_registered(
+            &self.queries.body_produced_anonymous,
             self.body_query_key(instance),
         ) {
             Ok(terminal) => match terminal.outcome() {
                 rue_query::QueryOutcome::Success(value) => Some(value.clone()),
                 _ => None,
             },
-            // A body with no producer-owned anonymous projection cancels this
-            // terminal. The uniform `observe_abort` rule maps that Canceled to an
-            // observed absence (`None`) exactly as every other op treats a
-            // deferred terminal — the request is still recorded as an observed
-            // edge — while a genuinely fatal abort is captured for the boundary.
+            // A body with no producer-owned anonymous projection may leave this
+            // terminal incomplete. The trait remains abort-free, so the
+            // request-local status records the typed incomplete state and the
+            // terminal boundary rejects publication before any result is used.
             Err(abort) => {
                 self.observe_abort(abort);
                 None
@@ -13030,8 +13054,8 @@ impl rue_air::BodyFactProvider for CompilerBodyFactProvider<'_> {
             .toolchain_facts
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let empty = crate::BodyToolchainDemand::from_payload_kinds([], None);
-        match self.context.query_registered(
-            &self.database.body_toolchain_demands,
+        match self.queries.context.query_registered(
+            &self.queries.body_toolchain_demands,
             self.body_query_key(instance),
         ) {
             Ok(terminal) => match terminal.outcome() {
@@ -13075,15 +13099,14 @@ impl rue_air::BodyFactProvider for CompilerBodyFactProvider<'_> {
 // r5); builtin `str` and slice generated-struct names are ANSWERED as of r6a
 // (pure durable name facts); `Str(N)` (a generated fixed-capacity struct) →
 // r6b with the generated-struct/anonymous family; anonymous producer nominals
-// (r4) and well-known `Option` (r6b). Every operation is `#[cfg(test)]`: this is a
-// differential adapter behind the same gate as `CompilerBodyFactProvider`, never
-// a selectable production path.
+// (r4) and well-known `Option` (r6b). These operations are production-compiled
+// provider facades; the eventual body evaluator is the only production caller.
 // ---------------------------------------------------------------------------
 
 /// A recoverable failure surfaced by [`ProviderTypeFacts`]. Aborts never reach
-/// the trait surface — `CompilerBodyFactProvider` captures them and returns the
-/// op's absence sentinel — so the abort associated type is [`Infallible`].
-#[cfg(test)]
+/// the trait surface — `CompilerBodyFactProvider` captures them in its typed
+/// request status and returns only a provisional absence-shaped value — so the
+/// abort associated type is [`Infallible`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ProviderTypeFactsFailure {
     /// A shape whose facts the body-fact boundary does not yet expose in r2. The
@@ -13094,13 +13117,12 @@ pub(crate) enum ProviderTypeFactsFailure {
 
 /// The type-syntax/nominal ProviderFacts: resolves type syntax from the exact
 /// body-fact provider and materializes consulted nominals into the overlay.
-#[cfg(test)]
 pub(crate) struct ProviderTypeFacts<'p, 'o, 'db> {
     provider: &'p CompilerBodyFactProvider<'db>,
     overlay: &'o mut crate::body_overlay::BodySemanticOverlay,
 }
 
-#[cfg(test)]
+#[allow(dead_code)]
 fn provider_definition_category(
     kind: rue_air::ProviderDefinitionKind,
 ) -> crate::declaration_candidate::DeclarationCandidateCategory {
@@ -13116,7 +13138,7 @@ fn provider_definition_category(
 
 /// The durable type for a primitive type-syntax name, mirroring
 /// `rue_air::Type::from_primitive_name` in the durable algebra.
-#[cfg(test)]
+#[allow(dead_code)]
 fn primitive_durable_type(name: &str) -> Option<crate::DurableType> {
     use crate::DurableType as T;
     Some(match name {
@@ -13138,7 +13160,7 @@ fn primitive_durable_type(name: &str) -> Option<crate::DurableType> {
     })
 }
 
-#[cfg(test)]
+#[allow(dead_code)]
 impl<'p, 'o, 'db> ProviderTypeFacts<'p, 'o, 'db> {
     pub(crate) fn new(
         provider: &'p CompilerBodyFactProvider<'db>,
@@ -13279,7 +13301,6 @@ impl<'p, 'o, 'db> ProviderTypeFacts<'p, 'o, 'db> {
     }
 }
 
-#[cfg(test)]
 impl<'p, 'o, 'db> rue_air::SemanticModulePathProvider<ModuleId, ModuleId, ModuleId>
     for ProviderTypeFacts<'p, 'o, 'db>
 {
@@ -13319,7 +13340,6 @@ impl<'p, 'o, 'db> rue_air::SemanticModulePathProvider<ModuleId, ModuleId, Module
     }
 }
 
-#[cfg(test)]
 impl<'p, 'o, 'db>
     rue_air::SemanticTypeSyntaxProvider<
         ModuleId,
@@ -13735,14 +13755,11 @@ impl<'p, 'o, 'db>
 // SignatureFacts consults only read-only provider terminals and never mints an
 // overlay identity, so it borrows `&CompilerBodyFactProvider` alone — a comptime
 // call that reduces to an anonymous nominal is deferred to the overlay-owning
-// slices (r4/r6), reported as `SignatureReduceOutcome::DeferredAnonymous`. Every
-// item is `#[cfg(test)]`: a differential adapter behind the same gate as
-// `CompilerBodyFactProvider`, never a selectable production path.
+// slices (r4/r6), reported as `SignatureReduceOutcome::DeferredAnonymous`.
 // ---------------------------------------------------------------------------
 
 /// The comptime type-constructor / value-argument ProviderFacts. Resolves
 /// signature-level comptime facts from the exact body-fact provider.
-#[cfg(test)]
 pub(crate) struct SignatureFacts<'p, 'db> {
     provider: &'p CompilerBodyFactProvider<'db>,
 }
@@ -13752,7 +13769,7 @@ pub(crate) struct SignatureFacts<'p, 'db> {
 /// (the anonymous reduction result is a body-level durable value production's
 /// declaration binder rejects exporting); the endpoint pool mints the identity
 /// itself (RUE-1091 r6b).
-#[cfg(test)]
+#[allow(dead_code)]
 fn durable_type_uses_anonymous_nominal(ty: &crate::DurableType) -> bool {
     use crate::DurableType as T;
     match ty {
@@ -13768,14 +13785,13 @@ fn durable_type_uses_anonymous_nominal(ty: &crate::DurableType) -> bool {
 /// The outcome of a boundary comptime-call reduction: a reduced non-anonymous
 /// type or value, an anonymous-nominal result deferred in the type-syntax path,
 /// or a head that did not reduce.
-#[cfg(test)]
 enum SignatureReduceOutcome {
     Reduced(rue_air::SemanticComptimeCallResult<crate::DurableType, crate::DurableConstValue>),
     DeferredAnonymous,
     DidNotReduce,
 }
 
-#[cfg(test)]
+#[allow(dead_code)]
 impl<'p, 'db> SignatureFacts<'p, 'db> {
     pub(crate) fn new(provider: &'p CompilerBodyFactProvider<'db>) -> Self {
         Self { provider }
@@ -13969,6 +13985,28 @@ impl<'p, 'db> SignatureFacts<'p, 'db> {
     }
 }
 
+#[allow(dead_code)]
+impl RevisionedQueryDatabase {
+    fn compiler_body_provider_queries<'a>(
+        &self,
+        context: &'a rue_query::QueryContext,
+        configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
+    ) -> CompilerBodyProviderQueries<'a> {
+        CompilerBodyProviderQueries {
+            context,
+            lookup_names: self.lookup_names.clone(),
+            lookup_imports: self.lookup_imports.clone(),
+            semantic_nucleus: self.semantic_nucleus.clone(),
+            body_produced_anonymous: self.body_produced_anonymous.clone(),
+            body_toolchain_demands: self.body_toolchain_demands.clone(),
+            configuration,
+            status: std::rc::Rc::new(std::cell::RefCell::new(CompilerBodyProviderStatus::Ready)),
+            observed: std::rc::Rc::new(std::cell::RefCell::new(ObservedLookupRoot::new())),
+            meter: self.provider_observation_meter.clone(),
+        }
+    }
+}
+
 /// The recorded edges and captured result of one provider-observation probe.
 #[cfg(test)]
 pub(crate) struct ProviderProbeOutcome<R> {
@@ -13990,50 +14028,83 @@ impl RevisionedQueryDatabase {
     }
 
     /// Run `run` against a fresh [`CompilerBodyFactProvider`] inside one query
-    /// task at `revision`. The returned outcome carries the closure's result and
-    /// the exact set of query edges the provider recorded, so a test proves both
-    /// the returned facts (differential vs the production epoch) and that each op
-    /// recorded exactly its backing terminal.
+    /// task at `revision`. A non-ready provider returns its typed status and
+    /// publishes no probe terminal or provisional result.
     pub(crate) fn probe_body_facts<R>(
         &self,
         revision: Revision,
         configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
         label: &str,
         run: impl FnOnce(&CompilerBodyFactProvider<'_>) -> R,
-    ) -> ProviderProbeOutcome<R> {
+    ) -> Result<ProviderProbeOutcome<R>, CompilerBodyProviderStatus> {
         let captured: std::cell::RefCell<Option<R>> = std::cell::RefCell::new(None);
+        let non_ready: std::cell::RefCell<Option<CompilerBodyProviderStatus>> =
+            std::cell::RefCell::new(None);
         let run_cell = std::cell::RefCell::new(Some(run));
-        let terminal = self
-            .runtime
-            .query(
-                &self.provider_probe,
-                revision,
-                ProviderProbeKey {
-                    label: Arc::from(label),
-                },
-                CancellationToken::new(),
-                |context| {
-                    let provider =
-                        CompilerBodyFactProvider::new(context, self, configuration.clone());
-                    let run = run_cell.borrow_mut().take().expect("probe runs once");
-                    let result = run(&provider);
-                    if let Some(abort) = provider.taken_abort() {
-                        return Err(abort);
+        let terminal = match self.runtime.query(
+            &self.provider_probe,
+            revision,
+            ProviderProbeKey {
+                label: Arc::from(label),
+            },
+            CancellationToken::new(),
+            |context| {
+                let provider = CompilerBodyFactProvider::new(
+                    self.compiler_body_provider_queries(context, configuration.clone()),
+                );
+                let run = run_cell.borrow_mut().take().expect("probe runs once");
+                let result = run(&provider);
+                match provider.finish_status() {
+                    Ok(()) => {
+                        *captured.borrow_mut() = Some(result);
+                        Ok(QueryOutput::success(ProviderProbeValue))
                     }
-                    *captured.borrow_mut() = Some(result);
-                    Ok(QueryOutput::success(ProviderProbeValue))
-                },
-            )
-            .expect("provider probe published a terminal");
+                    Err(status) => {
+                        *non_ready.borrow_mut() = Some(status.clone());
+                        Err(match status {
+                            CompilerBodyProviderStatus::Fatal(abort) => abort,
+                            CompilerBodyProviderStatus::Incomplete(_) => {
+                                // The query runtime has no typed incomplete
+                                // channel. Keep the terminal absent here and
+                                // return the captured provider status below.
+                                QueryAbort::Canceled
+                            }
+                            CompilerBodyProviderStatus::Ready => unreachable!(),
+                        })
+                    }
+                }
+            },
+        ) {
+            Ok(terminal) => terminal,
+            Err(abort) => {
+                return Err(non_ready
+                    .into_inner()
+                    .unwrap_or(CompilerBodyProviderStatus::Fatal(abort)));
+            }
+        };
         let dependencies = terminal
             .dependencies()
             .iter()
             .map(|observation| observation.node.clone())
             .collect();
-        ProviderProbeOutcome {
+        Ok(ProviderProbeOutcome {
             result: captured.into_inner().expect("probe captured a result"),
             dependencies,
-        }
+        })
+    }
+
+    /// Success-only convenience for differential tests whose fixture installs
+    /// every exact provider prerequisite. Tests exercising incompleteness use
+    /// [`Self::probe_body_facts`] and assert its typed status instead.
+    pub(crate) fn probe_ready_body_facts<R>(
+        &self,
+        revision: Revision,
+        configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
+        label: &str,
+        run: impl FnOnce(&CompilerBodyFactProvider<'_>) -> R,
+    ) -> ProviderProbeOutcome<R> {
+        self.probe_body_facts(revision, configuration, label, run)
+            .expect("ready provider fixture published its probe terminal")
     }
 
     /// Drive `run` (a set of provider lookups) as one rooted request under the
@@ -14068,13 +14139,22 @@ impl RevisionedQueryDatabase {
             },
             CancellationToken::new(),
             |context| {
-                let provider = CompilerBodyFactProvider::new(context, self, configuration.clone());
+                let provider = CompilerBodyFactProvider::new(
+                    self.compiler_body_provider_queries(context, configuration.clone()),
+                );
                 let run = run_cell.borrow_mut().take().expect("probe runs once");
                 run(&provider);
                 if cancel {
                     // Abort before publishing a root: the observed pins drop with
                     // the provider and are never promoted (the never-promote rule).
                     return Err(QueryAbort::Canceled);
+                }
+                if let Err(status) = provider.finish_status() {
+                    return Err(match status {
+                        CompilerBodyProviderStatus::Fatal(abort) => abort,
+                        CompilerBodyProviderStatus::Incomplete(_) => QueryAbort::Canceled,
+                        CompilerBodyProviderStatus::Ready => unreachable!(),
+                    });
                 }
                 *captured.borrow_mut() = Some(provider.take_observed_root());
                 Ok(QueryOutput::success(ProviderProbeValue))
@@ -14519,6 +14599,87 @@ mod tests {
     };
     use rue_span::FileId;
     use std::collections::{BTreeSet, HashMap};
+
+    #[test]
+    fn compiler_provider_fatal_status_dominates_incomplete_status() {
+        let incomplete =
+            CompilerBodyProviderStatus::Incomplete(CompilerBodyProviderIncomplete::Canceled);
+        let missing = CompilerBodyProviderStatus::Incomplete(
+            CompilerBodyProviderIncomplete::MissingInput(InputIdentity::new("body", "signature")),
+        );
+        let fatal = CompilerBodyProviderStatus::Fatal(QueryAbort::ForeignRuntime);
+
+        assert!(provider_status_should_replace(&incomplete, &fatal));
+        assert!(!provider_status_should_replace(&fatal, &missing));
+        assert!(!provider_status_should_replace(&incomplete, &missing));
+    }
+
+    #[test]
+    fn production_provider_boundary_uses_owned_handles_and_shared_rir_view() {
+        let compiler = include_str!("revisioned_query_database.rs");
+        let query_start = compiler
+            .find("pub(crate) struct CompilerBodyProviderQueries")
+            .unwrap();
+        let query_end = compiler[query_start..]
+            .find("\n}\n\n#[allow(dead_code)]\nimpl<'a> CompilerBodyProviderQueries")
+            .map(|offset| query_start + offset + 2)
+            .unwrap();
+        let query_fields = &compiler[query_start..query_end];
+        assert!(query_fields.contains("QueryFamily"));
+        for banned in [
+            "RevisionedQueryDatabase",
+            "CanonicalMergedProgram",
+            "CanonicalRirOutput",
+            "declaration_manifest",
+            "reachability",
+            "InstRef",
+            "Spur",
+            "Span",
+            "FileId",
+            "ProviderIdentityContext::new",
+        ] {
+            assert!(
+                !query_fields.contains(banned),
+                "provider query bundle retains banned boundary artifact `{banned}`"
+            );
+        }
+
+        let provider_start = compiler
+            .find("pub(crate) struct CompilerBodyFactProvider")
+            .unwrap();
+        let provider_end = compiler[provider_start..]
+            .find("\n}\n\n#[allow(dead_code)]\nimpl<'a> CompilerBodyFactProvider")
+            .map(|offset| provider_start + offset + 2)
+            .unwrap();
+        assert!(!compiler[provider_start..provider_end].contains("RevisionedQueryDatabase"));
+
+        let type_start = compiler
+            .find("pub(crate) struct ProviderTypeFacts")
+            .unwrap();
+        let type_end = compiler[type_start..]
+            .find("impl<'p, 'o, 'db> rue_air::SemanticModulePathProvider")
+            .map(|offset| type_start + offset)
+            .unwrap();
+        let type_slice = &compiler[type_start..type_end];
+        assert!(type_slice.contains("materialize_nominal"));
+        assert!(!type_slice.contains("intern_definition"));
+        assert!(!type_slice.contains("intern_module"));
+        assert!(!type_slice.contains("ProviderIdentityContext::new"));
+
+        let test_module = compiler
+            .find("\n#[cfg(test)]\nmod tests")
+            .expect("revisioned-query tests have a cfg boundary");
+        assert!(
+            !compiler[..test_module].contains("BodyRirView::from_parts"),
+            "production provider construction must obtain its view from BodyRirBundle::view"
+        );
+        let lower = include_str!("canonical_lower.rs");
+        assert!(lower.contains("BodyRirBundle::new"));
+        assert!(
+            lower.contains("into_body_rir_bundle"),
+            "the production lowerer owns the request-local bundle"
+        );
+    }
 
     #[test]
     fn stable_definition_kinds_have_fixed_syntax_candidate_sets() {
@@ -21228,13 +21389,18 @@ fn main() -> i32 {
         let revision = revision_for(&mut database, &snapshot);
         let config = semantic_configuration();
 
-        let outcome = database.probe_body_facts(revision, config, "name-lookup", |provider| {
-            (
-                provider.lookup_unqualified(&m, rue_air::ProviderNamespace::ModuleItem, "Uniq"),
-                provider.lookup_unqualified(&m, rue_air::ProviderNamespace::ModuleItem, "dup"),
-                provider.lookup_unqualified(&m, rue_air::ProviderNamespace::ModuleItem, "absent"),
-            )
-        });
+        let outcome =
+            database.probe_ready_body_facts(revision, config, "name-lookup", |provider| {
+                (
+                    provider.lookup_unqualified(&m, rue_air::ProviderNamespace::ModuleItem, "Uniq"),
+                    provider.lookup_unqualified(&m, rue_air::ProviderNamespace::ModuleItem, "dup"),
+                    provider.lookup_unqualified(
+                        &m,
+                        rue_air::ProviderNamespace::ModuleItem,
+                        "absent",
+                    ),
+                )
+            });
         let (uniq, dup, absent) = &outcome.result;
 
         // Positive / negative / ambiguous are distinct candidate-set outcomes.
@@ -21269,10 +21435,14 @@ fn main() -> i32 {
 
         // Visibility- and kind-filtered views are candidate SETS the caller
         // narrows locally: `Uniq` is public, `Hidden` is not.
-        let hidden =
-            database.probe_body_facts(revision, semantic_configuration(), "vis", |provider| {
+        let hidden = database.probe_ready_body_facts(
+            revision,
+            semantic_configuration(),
+            "vis",
+            |provider| {
                 provider.lookup_unqualified(&m, rue_air::ProviderNamespace::ModuleItem, "Hidden")
-            });
+            },
+        );
         assert!(matches!(hidden.result, rue_air::NameResolution::Unique(_)));
         assert_eq!(hidden.result.visible(true), rue_air::NameResolution::Absent);
         assert_eq!(uniq.visible(true), *uniq);
@@ -21321,8 +21491,11 @@ fn main() -> i32 {
         let mut database = RevisionedQueryDatabase::default();
         let revision = revision_for(&mut database, &snapshot);
 
-        let outcome =
-            database.probe_body_facts(revision, semantic_configuration(), "import", |provider| {
+        let outcome = database.probe_ready_body_facts(
+            revision,
+            semantic_configuration(),
+            "import",
+            |provider| {
                 (
                     provider.resolve_import(&m, "dep.rue"),
                     // The requested `mixed.rue` normalizes to the same target as both
@@ -21334,7 +21507,8 @@ fn main() -> i32 {
                     provider.resolve_import(&m, "./dep.rue"),
                     provider.resolve_import(&m, "missing.rue"),
                 )
-            });
+            },
+        );
         let (dep, mixed, dot_dep, missing) = &outcome.result;
         assert_eq!(
             *dep,
@@ -21401,8 +21575,11 @@ fn main() -> i32 {
         // distinct label or a repeat would reuse the first probe's terminal and
         // never run its closure.
         let label = format!("type-syntax:{syntax}");
-        let outcome =
-            database.probe_body_facts(revision, semantic_configuration(), &label, |provider| {
+        let outcome = database.probe_ready_body_facts(
+            revision,
+            semantic_configuration(),
+            &label,
+            |provider| {
                 let mut overlay = crate::body_overlay::BodySemanticOverlay::new();
                 let mut facts = ProviderTypeFacts::new(provider, &mut overlay);
                 let resolved =
@@ -21427,7 +21604,8 @@ fn main() -> i32 {
                     .as_ref()
                     .and_then(|key| overlay.materialized_nominal(key).cloned());
                 (resolved, materialized)
-            });
+            },
+        );
         let (resolved, materialized) = outcome.result;
         (resolved, materialized, outcome.dependencies)
     }
@@ -21904,7 +22082,7 @@ fn main() -> i32 {
         let mut database = RevisionedQueryDatabase::default();
         let revision = revision_for(&mut database, &snapshot);
 
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             semantic_configuration(),
             "signature-facts:Wrap",
@@ -21937,7 +22115,7 @@ fn main() -> i32 {
             "head carries durable parameter names and the type/value split"
         );
         // Absent / non-callable heads do not resolve.
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             semantic_configuration(),
             "signature-facts:absent",
@@ -21988,8 +22166,11 @@ fn main() -> i32 {
         let box_probe = box_struct.clone();
         let copy_probe = copy_receiver.clone();
         let res_probe = res_receiver.clone();
-        let outcome =
-            database.probe_body_facts(revision, config.clone(), "decl-facts", move |provider| {
+        let outcome = database.probe_ready_body_facts(
+            revision,
+            config.clone(),
+            "decl-facts",
+            move |provider| {
                 (
                     provider.declaration_identity(&helper_probe),
                     provider.signature(&helper_probe),
@@ -22001,7 +22182,8 @@ fn main() -> i32 {
                     provider.drop_copy_metadata(&res_probe),
                     provider.trusted_toolchain_facts(&helper_instance),
                 )
-            });
+            },
+        );
         let (
             identity,
             signature,
@@ -22170,7 +22352,7 @@ fn main() -> i32 {
             }
         };
         let outcome =
-            database.probe_body_facts(revision, semantic_configuration(), "callable", probes);
+            database.probe_ready_body_facts(revision, semantic_configuration(), "callable", probes);
         let (get, make, absent_method, absent_type, get_as_assoc, make_as_method, bare) =
             outcome.result;
 
@@ -22263,7 +22445,7 @@ fn main() -> i32 {
             }
         };
         let outcome =
-            database.probe_body_facts(revision, semantic_configuration(), "siblings", probes);
+            database.probe_ready_body_facts(revision, semantic_configuration(), "siblings", probes);
         let (left_result, right_result, dup_result) = outcome.result;
 
         assert_eq!(
@@ -22370,13 +22552,16 @@ fn main() -> i32 {
         let revision = revision_for(&mut database, &snapshot);
         let source_adapter = DurableDeclSource::from_declarations(&decls);
 
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             semantic_configuration(),
             "call-fn-info",
             move |provider| {
-                let facts =
-                    rue_air::ProviderCallFacts::new(provider, source_adapter, rir_ref, interner);
+                let facts = rue_air::ProviderCallFacts::new(
+                    provider,
+                    source_adapter,
+                    rue_air::BodyRirView::from_parts(rir_ref, interner),
+                );
                 let info = facts
                     .function_info(&make_key, "make", file)
                     .expect("make resolves through the provider path");
@@ -22467,13 +22652,16 @@ fn main() -> i32 {
         let revision = revision_for(&mut database, &snapshot);
         let source_adapter = DurableDeclSource::from_declarations(&decls);
 
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             semantic_configuration(),
             "call-fn-contains",
             move |provider| {
-                let facts =
-                    rue_air::ProviderCallFacts::new(provider, source_adapter, rir, interner);
+                let facts = rue_air::ProviderCallFacts::new(
+                    provider,
+                    source_adapter,
+                    rue_air::BodyRirView::from_parts(rir, interner),
+                );
                 (
                     // A declared free function is present.
                     facts.function_contains_in_module(&m, "helper"),
@@ -22603,16 +22791,23 @@ fn main() -> i32 {
         // edges (the receiver name lookup + the member semantic-nucleus facts) —
         // the richer provider-era footprint that is the post-flip truth (r4a-1
         // carry-forward: the finer dependencies are the more-correct behavior).
-        let bare_outcome =
-            database.probe_body_facts(revision, semantic_configuration(), "call-bare-lift", {
+        let bare_outcome = database.probe_ready_body_facts(
+            revision,
+            semantic_configuration(),
+            "call-bare-lift",
+            {
                 let bare = bare_key.clone();
                 let adapter = DurableDeclSource::from_declarations(&decls);
                 move |provider| {
-                    let facts =
-                        rue_air::ProviderCallFacts::new(provider, adapter, rir_ref, interner);
+                    let facts = rue_air::ProviderCallFacts::new(
+                        provider,
+                        adapter,
+                        rue_air::BodyRirView::from_parts(rir_ref, interner),
+                    );
                     facts.callable_symbol_receiver(&bare).is_some()
                 }
-            });
+            },
+        );
         assert!(
             bare_outcome.result,
             "r6a lifts the bare language-item owner symbol the epoch answers: {bare_key}"
@@ -22638,15 +22833,22 @@ fn main() -> i32 {
         // owner) stays refused: `bare_language_item_owner` returns None, so the
         // reversal fails closed before any lookup — the residual r6b / the flip
         // owns.
-        let residual_outcome =
-            database.probe_body_facts(revision, semantic_configuration(), "call-bare-residual", {
+        let residual_outcome = database.probe_ready_body_facts(
+            revision,
+            semantic_configuration(),
+            "call-bare-residual",
+            {
                 let adapter = DurableDeclSource::from_declarations(&decls);
                 move |provider| {
-                    let facts =
-                        rue_air::ProviderCallFacts::new(provider, adapter, rir_ref, interner);
+                    let facts = rue_air::ProviderCallFacts::new(
+                        provider,
+                        adapter,
+                        rue_air::BodyRirView::from_parts(rir_ref, interner),
+                    );
                     facts.callable_symbol_receiver("Mystery.foo").is_some()
                 }
-            });
+            },
+        );
         assert!(
             !residual_outcome.result,
             "a bare non-language-item owner stays refused (the anonymous-owner residual)"
@@ -22660,16 +22862,23 @@ fn main() -> i32 {
         // Probe B — the QUALIFIED symbol: provider=Some, and the success records
         // exactly the r4a-1 footprint (the receiver name lookup + the member
         // semantic-nucleus facts), nothing else.
-        let ok_outcome =
-            database.probe_body_facts(revision, semantic_configuration(), "call-qual-success", {
+        let ok_outcome = database.probe_ready_body_facts(
+            revision,
+            semantic_configuration(),
+            "call-qual-success",
+            {
                 let qualified = qualified_key.clone();
                 let adapter = DurableDeclSource::from_declarations(&decls);
                 move |provider| {
-                    let facts =
-                        rue_air::ProviderCallFacts::new(provider, adapter, rir_ref, interner);
+                    let facts = rue_air::ProviderCallFacts::new(
+                        provider,
+                        adapter,
+                        rue_air::BodyRirView::from_parts(rir_ref, interner),
+                    );
                     facts.callable_symbol_receiver(&qualified).is_some()
                 }
-            });
+            },
+        );
         assert!(
             ok_outcome.result,
             "the provider reverses the file-qualified user method symbol"
@@ -22740,22 +22949,56 @@ fn main() -> i32 {
         let revision = revision_for(&mut database, &snapshot);
         let source_adapter = DurableDeclSource::from_declarations(&decls);
 
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             semantic_configuration(),
             "call-method-info",
             move |provider| {
-                let facts =
-                    rue_air::ProviderCallFacts::new(provider, source_adapter, rir_ref, interner);
-                let info = facts
-                    .method_info(&shift_key, file, "Widget", "shift")
-                    .expect("Widget.shift resolves through the provider path");
+                let identity = rue_air::ProviderIdentityContext::new(source_adapter);
+                let view = rue_air::BodyRirView::from_parts(rir_ref, interner);
+                let facts = rue_air::ProviderCallFacts::with_identity(
+                    provider,
+                    identity.clone(),
+                    view.clone(),
+                );
+                let endpoints =
+                    rue_air::ProviderEndpointFacts::with_identity(provider, identity, view);
                 // `named_method_info` coincides over the named differential scope
                 // (no anonymous fallback), mirroring the epoch's `methods.get`.
                 let named = facts
                     .named_method_info(&shift_key, file, "Widget", "shift")
                     .expect("named_method_info resolves");
-                assert_eq!(named.body, info.body, "named_method_info agrees on body");
+                let compact_owner = named.struct_type.as_struct().expect("Widget is a struct");
+                let compact_name = facts.name_symbol("shift");
+                assert_eq!(
+                    endpoints
+                        .method_info(compact_owner, compact_name)
+                        .expect("the endpoint facade observes the named registration")
+                        .body,
+                    named.body,
+                    "endpoint method lookup falls back to the shared named entry"
+                );
+                let anonymous = rue_air::MethodInfo {
+                    body: rue_rir::InstRef::from_raw(named.body.as_u32() + 1),
+                    ..named
+                };
+                assert!(
+                    facts.register_anonymous_method(file, "Widget", "shift", anonymous),
+                    "the anonymous method registers atomically under both lookup keys"
+                );
+                let info = facts
+                    .method_info(&shift_key, file, "Widget", "shift")
+                    .expect("anonymous method wins over the named collision");
+                assert_eq!(info.body, anonymous.body, "anonymous method has precedence");
+                assert_ne!(named.body, info.body, "the collision is observable");
+                assert_eq!(
+                    endpoints
+                        .method_info(compact_owner, compact_name)
+                        .expect("the endpoint facade observes the anonymous registration")
+                        .body,
+                    anonymous.body,
+                    "endpoint and call facades agree on anonymous-first precedence"
+                );
                 // Double consult: idempotent, the pool re-mints nothing.
                 let second = facts
                     .method_info(&shift_key, file, "Widget", "shift")
@@ -22789,10 +23032,10 @@ fn main() -> i32 {
                 });
                 assert_eq!(modes[0], rue_rir::RirParamMode::Normal);
 
-                (info, receiver, ret)
+                (info, named, receiver, ret)
             },
         );
-        let (info, receiver, ret) = outcome.result;
+        let (info, named, receiver, ret) = outcome.result;
 
         // Cross-path against the LIVE epoch `MethodInfo` (not literals):
         // pool-independent fields directly, pool-relative types by render.
@@ -22805,8 +23048,12 @@ fn main() -> i32 {
         assert_eq!(info.self_mode, rue_rir::RirParamMode::Borrow);
         assert_eq!(info.self_is_mut, prod.self_is_mut, "self_is_mut matches");
         assert_eq!(
-            info.body, prod.body,
-            "method body InstRef matches the epoch"
+            named.body, prod.body,
+            "named method body InstRef matches the epoch"
+        );
+        assert_ne!(
+            info.body, named.body,
+            "anonymous collision remains selected"
         );
         assert_eq!(info.span, prod.span, "method span matches the epoch");
 
@@ -22861,7 +23108,7 @@ fn main() -> i32 {
         let rir_ref = rir.rir();
         let mut database = RevisionedQueryDatabase::default();
         let revision = revision_for(&mut database, &snapshot);
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             semantic_configuration(),
             "call-associated-info",
@@ -22869,8 +23116,7 @@ fn main() -> i32 {
                 let facts = rue_air::ProviderCallFacts::new(
                     provider,
                     DurableDeclSource::from_declarations(&decls),
-                    rir_ref,
-                    interner,
+                    rue_air::BodyRirView::from_parts(rir_ref, interner),
                 );
                 let info = facts
                     .method_info(&make_key, file, "Counter", "make")
@@ -22940,7 +23186,7 @@ fn main() -> i32 {
         let rir_ref = rir.rir();
         let mut database = RevisionedQueryDatabase::default();
         let revision = revision_for(&mut database, &snapshot);
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             semantic_configuration(),
             "endpoint-destructor-metadata",
@@ -22948,8 +23194,7 @@ fn main() -> i32 {
                 let facts = rue_air::ProviderEndpointFacts::new(
                     provider,
                     DurableDeclSource::from_declarations(&decls),
-                    rir_ref,
-                    interner,
+                    rue_air::BodyRirView::from_parts(rir_ref, interner),
                 );
                 let token =
                     facts.register_named_nominal(box_key, file.index(), "Box", Kind::Struct);
@@ -23094,13 +23339,16 @@ fn main() -> i32 {
         let call_adapter = DurableDeclSource::from_declarations(&decls);
         let aggregate_adapter = DurableDeclSource::from_declarations(&decls);
 
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             semantic_configuration(),
             "endpoint-resolve",
             move |provider| {
-                let facts =
-                    rue_air::ProviderEndpointFacts::new(provider, adapter, rir_ref, interner);
+                let facts = rue_air::ProviderEndpointFacts::new(
+                    provider,
+                    adapter,
+                    rue_air::BodyRirView::from_parts(rir_ref, interner),
+                );
                 let named = |token: DTok| -> T<DTok, MTok> { T::Nominal(N::Named(token)) };
                 let point_token =
                     facts.register_named_nominal(point_key.clone(), 1, "Point", Kind::Struct);
@@ -23217,8 +23465,11 @@ fn main() -> i32 {
                     )
                 });
 
-                let call_facts =
-                    rue_air::ProviderCallFacts::new(provider, call_adapter, rir_ref, interner);
+                let call_facts = rue_air::ProviderCallFacts::new(
+                    provider,
+                    call_adapter,
+                    rue_air::BodyRirView::from_parts(rir_ref, interner),
+                );
                 let call_module = call_facts
                     .register_module(
                         durable_module.clone(),
@@ -23361,12 +23612,16 @@ fn main() -> i32 {
         let revision = revision_for(&mut database, &snapshot);
         let adapter = DurableDeclSource::from_declarations(&decls);
 
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             semantic_configuration(),
             "endpoint-deferred",
             move |provider| {
-                let facts = rue_air::ProviderEndpointFacts::new(provider, adapter, rir, interner);
+                let facts = rue_air::ProviderEndpointFacts::new(
+                    provider,
+                    adapter,
+                    rue_air::BodyRirView::from_parts(rir, interner),
+                );
                 let point_token = facts.register_named_nominal(
                     point_key.clone(),
                     file.index(),
@@ -23524,13 +23779,16 @@ fn main() -> i32 {
             .with_anonymous_nominals(&projection.anonymous_nominals);
         let identity_for_probe = durable_identity.clone();
 
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             semantic_configuration(),
             "endpoint-anon-mint",
             move |provider| {
-                let facts =
-                    rue_air::ProviderEndpointFacts::new(provider, adapter, rir_ref, interner);
+                let facts = rue_air::ProviderEndpointFacts::new(
+                    provider,
+                    adapter,
+                    rue_air::BodyRirView::from_parts(rir_ref, interner),
+                );
                 // Direct pool mint (the keystone): mint the anonymous nominal from
                 // its durable identity + shape.
                 let minted = facts
@@ -23665,13 +23923,16 @@ fn main() -> i32 {
             .with_anonymous_nominals(&projection.anonymous_nominals);
         let identity_for_probe = durable_identity.clone();
 
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             semantic_configuration(),
             "endpoint-anon-enum-mint",
             move |provider| {
-                let facts =
-                    rue_air::ProviderEndpointFacts::new(provider, adapter, rir_ref, interner);
+                let facts = rue_air::ProviderEndpointFacts::new(
+                    provider,
+                    adapter,
+                    rue_air::BodyRirView::from_parts(rir_ref, interner),
+                );
                 // Direct pool mint from the RAW durable identity + shape.
                 let minted = facts
                     .mint_anonymous(&identity_for_probe)
@@ -23937,13 +24198,16 @@ fn main() -> i32 {
         let interner = rir.semantic_symbols().interner();
         let mut database = RevisionedQueryDatabase::default();
         let revision = revision_for(&mut database, &snapshot);
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             semantic_configuration(),
             "well-known-option-install",
             move |provider| {
-                let facts =
-                    rue_air::ProviderEndpointFacts::new(provider, adapter, rir_ref, interner);
+                let facts = rue_air::ProviderEndpointFacts::new(
+                    provider,
+                    adapter,
+                    rue_air::BodyRirView::from_parts(rir_ref, interner),
+                );
                 facts
                     .install_well_known_option_types(&identities, &pairs)
                     .expect("the pool installs the well-known registry");
@@ -24050,13 +24314,16 @@ fn main() -> i32 {
         // so an empty durable source suffices.
         let adapter = DurableDeclSource::from_declarations(&[]);
 
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             semantic_configuration(),
             "endpoint-slice",
             move |provider| {
-                let facts =
-                    rue_air::ProviderEndpointFacts::new(provider, adapter, rir_ref, interner);
+                let facts = rue_air::ProviderEndpointFacts::new(
+                    provider,
+                    adapter,
+                    rue_air::BodyRirView::from_parts(rir_ref, interner),
+                );
                 // Seed the generated slice, then resolve the `Slice` arm.
                 facts
                     .register_generated_slice(&D::I64, "[i64]")
@@ -24119,12 +24386,16 @@ fn main() -> i32 {
         let revision = revision_for(&mut database, &snapshot);
         let adapter = DurableDeclSource::from_declarations(&decls);
 
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             semantic_configuration(),
             "endpoint-rir-ops",
             move |provider| {
-                let facts = rue_air::ProviderEndpointFacts::new(provider, adapter, rir, interner);
+                let facts = rue_air::ProviderEndpointFacts::new(
+                    provider,
+                    adapter,
+                    rue_air::BodyRirView::from_parts(rir, interner),
+                );
 
                 // (R) first_free_function: a free function resolves; a method
                 // name and an absent name do not.
@@ -24335,24 +24606,20 @@ fn main() -> i32 {
         let adapter = DurableDeclSource::from_declarations(&decls);
         let mut database = RevisionedQueryDatabase::default();
         let revision = revision_for(&mut database, &snapshot);
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             semantic_configuration(),
             "endpoint-const-info",
             move |provider| {
                 let identity = rue_air::ProviderIdentityContext::new(adapter);
+                let rir_view = rue_air::BodyRirView::from_parts(rir_ref, interner);
                 let facts = rue_air::ProviderEndpointFacts::with_identity(
                     provider,
                     identity.clone(),
-                    rir_ref,
-                    interner,
+                    rir_view.clone(),
                 );
-                let calls = rue_air::ProviderCallFacts::with_identity(
-                    provider,
-                    identity.clone(),
-                    rir_ref,
-                    interner,
-                );
+                let calls =
+                    rue_air::ProviderCallFacts::with_identity(provider, identity.clone(), rir_view);
                 let aggregate = rue_air::ProviderAggregateFacts::with_identity(identity);
                 let mut rendered = Vec::new();
                 for (name, key) in value_keys {
@@ -24623,7 +24890,7 @@ fn main() -> i32 {
         let rir_ref = rir.rir();
         let mut database = RevisionedQueryDatabase::default();
         let revision = revision_for(&mut database, &snapshot);
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             semantic_configuration(),
             "aggregate-selection-order",
@@ -24634,8 +24901,7 @@ fn main() -> i32 {
                 let endpoint = rue_air::ProviderEndpointFacts::with_identity(
                     provider,
                     identity.clone(),
-                    rir_ref,
-                    interner,
+                    rue_air::BodyRirView::from_parts(rir_ref, interner),
                 );
                 let mut facts = rue_air::ProviderAggregateFacts::with_identity(identity);
                 facts.register_named_nominal(point_key, file, "Point");
@@ -24889,7 +25155,7 @@ fn main() -> i32 {
 
         let receiver_probe = receiver.clone();
         let outcome =
-            database.probe_body_facts(revision, config.clone(), "members", move |provider| {
+            database.probe_ready_body_facts(revision, config.clone(), "members", move |provider| {
                 (
                     provider.method_candidates(&receiver_probe, "get"),
                     provider.method_candidates(&receiver_probe, "make"),
@@ -24926,10 +25192,12 @@ fn main() -> i32 {
         // reachable and equals the production epoch's — including receiver mode,
         // parameter modes, and return type.
         let sig_probe = get_candidate.declaration.clone();
-        let sig_outcome =
-            database.probe_body_facts(revision, config.clone(), "member-sig", move |provider| {
-                provider.signature(&sig_probe)
-            });
+        let sig_outcome = database.probe_ready_body_facts(
+            revision,
+            config.clone(),
+            "member-sig",
+            move |provider| provider.signature(&sig_probe),
+        );
         let provider_sig = sig_outcome.result.expect("get has a signature");
         let epoch_sig = request_semantic_nucleus(
             &database,
@@ -25017,12 +25285,11 @@ fn main() -> i32 {
         let bad = declaration_candidate(&database, revision, &m, Cat::Struct, "Bad");
         let good = declaration_candidate(&database, revision, &m, Cat::Struct, "Good");
         let plain = declaration_candidate(&database, revision, &m, Cat::Function, "plain");
-        let plain_instance = free_function_instance(&m, "plain");
 
         let bad_probe = bad.clone();
         let good_probe = good.clone();
         let plain_probe = plain.clone();
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             config.clone(),
             "representative",
@@ -25030,12 +25297,11 @@ fn main() -> i32 {
                 (
                     provider.nominal_well_formedness(&bad_probe),
                     provider.nominal_well_formedness(&good_probe),
-                    provider.producer_body_facts(&plain_instance),
                     provider.signature(&plain_probe),
                 )
             },
         );
-        let (bad_wf, good_wf, produced, plain_sig) = outcome.result;
+        let (bad_wf, good_wf, plain_sig) = outcome.result;
 
         // The diagnostics body's nominal is ill-formed; the good one is not. Both
         // match the semantic-nucleus well-formedness terminal.
@@ -25059,42 +25325,41 @@ fn main() -> i32 {
             "the production epoch also fails Bad's well-formedness"
         );
 
-        // A plain function produces no owned anonymous nominal. The op maps the
-        // producer terminal's deferral to an observed absence (uniform Canceled
-        // rule) rather than swallowing it specially.
-        assert!(produced.is_none());
         assert!(plain_sig.is_some());
 
-        // MINOR-1 differential: the provider's producer result matches the
-        // production epoch's terminal fact-for-fact. A non-producer body's
-        // `body-produced-anonymous` terminal defers (publishes nothing), so both
-        // the provider and the epoch observe the same absence — and, because no
-        // terminal is published, neither records a producer dependency edge (a
-        // deferred producer yields no fact and therefore no observation, which
-        // is exactly what the ADR's "the typed call IS the observation" implies).
-        let epoch_produced = database.runtime.request_registered(
-            &database.body_produced_anonymous,
+        let plain_instance = free_function_instance(&m, "plain");
+        let canceled = database.probe_body_facts(
             revision,
-            crate::body_query::BodyQueryKey {
-                instance: free_function_instance(&m, "plain"),
-                configuration: config.clone(),
+            config.clone(),
+            "representative-canceled",
+            move |provider| provider.producer_body_facts(&plain_instance),
+        );
+        assert!(matches!(
+            canceled,
+            Err(CompilerBodyProviderStatus::Incomplete(
+                CompilerBodyProviderIncomplete::Canceled
+            ))
+        ));
+
+        let missing_module = ModuleId::from_logical_path("missing.rue").unwrap();
+        let missing = database.probe_body_facts(
+            revision,
+            config,
+            "representative-missing",
+            move |provider| {
+                provider.lookup_unqualified(
+                    &missing_module,
+                    rue_air::ProviderNamespace::ModuleItem,
+                    "never",
+                )
             },
-            CancellationToken::new(),
         );
-        assert!(
-            epoch_produced.terminal().is_none(),
-            "the production epoch's producer terminal is equally unavailable for a \
-             non-producer body"
-        );
-        assert!(
-            !outcome
-                .dependencies
-                .iter()
-                .any(|node| node.family() == "compiler.body-produced-anonymous"),
-            "a deferred producer publishes no terminal, so no producer edge is \
-             recorded: {:?}",
-            outcome.dependencies
-        );
+        assert!(matches!(
+            missing,
+            Err(CompilerBodyProviderStatus::Incomplete(
+                CompilerBodyProviderIncomplete::MissingInput(_)
+            ))
+        ));
     }
 
     #[test]
@@ -25124,7 +25389,7 @@ fn main() -> i32 {
         };
 
         let provider_instance = pair_instance.clone();
-        let outcome = database.probe_body_facts(
+        let outcome = database.probe_ready_body_facts(
             revision,
             configuration,
             "producer-specialization-instance",
@@ -25446,8 +25711,9 @@ fn main() -> i32 {
                     },
                     CancellationToken::new(),
                     |context| {
-                        let provider =
-                            CompilerBodyFactProvider::new(context, &database, config.clone());
+                        let provider = CompilerBodyFactProvider::new(
+                            database.compiler_body_provider_queries(context, config.clone()),
+                        );
                         for name in ["A", "B", "C", "main"] {
                             provider.lookup_unqualified(&module, NS, name);
                         }
@@ -25526,6 +25792,28 @@ fn main() -> i32 {
         assert_eq!(
             metrics.leased_terminals, 0,
             "a canceled attempt leases no terminal into the session lease"
+        );
+
+        // A missing exact input is also provisional: it must not be converted
+        // into an absent lookup and promoted as if the provider were ready.
+        let missing_module = ModuleId::from_logical_path("missing.rue").unwrap();
+        assert!(
+            !database.publish_lookup_root(
+                revision,
+                config.clone(),
+                "probe-missing-input",
+                "root-missing-input",
+                false,
+                |p| {
+                    p.lookup_unqualified(&missing_module, NS, "never");
+                },
+            ),
+            "a MissingInput provider status publishes no root"
+        );
+        assert_eq!(
+            database.lookup_pressure_metrics().published_roots,
+            0,
+            "the MissingInput attempt does not promote a root"
         );
 
         // The keys the canceled attempt merely validated are speculative: no

--- a/crates/rue-compiler/src/session/tests/rfinal_harness.rs
+++ b/crates/rue-compiler/src/session/tests/rfinal_harness.rs
@@ -1972,14 +1972,10 @@ fn run_body_replay(
     let identity = rue_air::ProviderIdentityContext::new(
         DurableDeclSource::from_declarations(decls).with_anonymous_nominals(produced_union),
     );
-    let endpoint = rue_air::ProviderEndpointFacts::with_identity(
-        provider,
-        identity.clone(),
-        rir,
-        rir_interner,
-    );
-    let calls =
-        rue_air::ProviderCallFacts::with_identity(provider, identity.clone(), rir, rir_interner);
+    let rir_view = rue_air::BodyRirView::from_parts(rir, rir_interner);
+    let endpoint =
+        rue_air::ProviderEndpointFacts::with_identity(provider, identity.clone(), rir_view.clone());
+    let calls = rue_air::ProviderCallFacts::with_identity(provider, identity.clone(), rir_view);
     let aggregate = rue_air::ProviderAggregateFacts::with_identity(identity);
     for (module, file) in module_files {
         let path = module.logical_path();
@@ -2151,8 +2147,11 @@ impl ProviderFactsOverlayAnalyzer {
         let rir = inputs.rir.rir();
         let interner = inputs.rir.semantic_symbols().interner();
         let label = format!("side-b:{run_tag}:{case_name}:{body}");
-        let outcome =
-            database.probe_body_facts(revision, side_b_configuration(), &label, move |provider| {
+        let outcome = database.probe_ready_body_facts(
+            revision,
+            side_b_configuration(),
+            &label,
+            move |provider| {
                 run_body_replay(
                     provider,
                     &decls,
@@ -2164,7 +2163,8 @@ impl ProviderFactsOverlayAnalyzer {
                     rir,
                     interner,
                 )
-            });
+            },
+        );
         let (mut facts, exceptions, agg_seed) = outcome.result;
         if oracle.failed {
             facts.push(
@@ -2542,7 +2542,7 @@ fn side_b_absent_lookup_records_only_its_keyed_terminals() {
     let decls = inputs.decls.clone();
     let rir = inputs.rir.rir();
     let interner = inputs.rir.semantic_symbols().interner();
-    let outcome = database.probe_body_facts(
+    let outcome = database.probe_ready_body_facts(
         revision,
         side_b_configuration(),
         "side-b:e0481:absent",
@@ -2550,8 +2550,7 @@ fn side_b_absent_lookup_records_only_its_keyed_terminals() {
             let calls = rue_air::ProviderCallFacts::new(
                 provider,
                 DurableDeclSource::from_declarations(&decls),
-                rir,
-                interner,
+                rue_air::BodyRirView::from_parts(rir, interner),
             );
             assert!(!calls.function_contains_in_module(&module, "missing"));
         },
@@ -2615,8 +2614,7 @@ fn side_b_forced_eviction_and_cancellation_leave_no_partial_state() {
             let calls = rue_air::ProviderCallFacts::new(
                 provider,
                 DurableDeclSource::from_declarations(&decls),
-                rir,
-                interner,
+                rue_air::BodyRirView::from_parts(rir, interner),
             );
             let _ = calls.function_contains_in_module(&module, "helper");
             let _ = calls.function_contains_in_module(&module, "main");
@@ -2655,16 +2653,19 @@ fn side_b_forced_eviction_and_cancellation_leave_no_partial_state() {
         let decls = decls.clone();
         let module = module.clone();
         let label = format!("side-b:evict:{index}");
-        let outcome =
-            database.probe_body_facts(revision, side_b_configuration(), &label, move |provider| {
+        let outcome = database.probe_ready_body_facts(
+            revision,
+            side_b_configuration(),
+            &label,
+            move |provider| {
                 let calls = rue_air::ProviderCallFacts::new(
                     provider,
                     DurableDeclSource::from_declarations(&decls),
-                    rir,
-                    interner,
+                    rue_air::BodyRirView::from_parts(rir, interner),
                 );
                 calls.function_contains_in_module(&module, &name)
-            });
+            },
+        );
         assert!(!outcome.result, "filler names are absent");
     }
     let after_eviction = analyzer.replay_case(
@@ -2721,7 +2722,7 @@ fn side_b_cross_module_private_lookup_is_driver_supplied() {
     let revision = inputs.revision(&mut database);
     let leaf_module = ModuleId::from_logical_path("sub/leaf.rue").unwrap();
 
-    let outcome = database.probe_body_facts(
+    let outcome = database.probe_ready_body_facts(
         revision,
         side_b_configuration(),
         "side-b:cross-module-private",
@@ -2798,7 +2799,7 @@ fn side_b_finalize_containment_metadata_freeze_hook() {
     let file = inputs.module_files[counter.module()];
     let rir = inputs.rir.rir();
     let interner = inputs.rir.semantic_symbols().interner();
-    let outcome = database.probe_body_facts(
+    let outcome = database.probe_ready_body_facts(
         revision,
         side_b_configuration(),
         "side-b:freeze-hook",
@@ -2808,8 +2809,7 @@ fn side_b_finalize_containment_metadata_freeze_hook() {
             let endpoint = rue_air::ProviderEndpointFacts::with_identity(
                 provider,
                 identity.clone(),
-                rir,
-                interner,
+                rue_air::BodyRirView::from_parts(rir, interner),
             );
             let mut aggregate = rue_air::ProviderAggregateFacts::with_identity(identity);
             let token = endpoint.register_named_nominal(


### PR DESCRIPTION
## Summary

- own one validated body-local RIR bundle, matching interner, and shared declaration index
- promote the exact provider query handles and typed incomplete/fatal status boundary without retaining a database backpointer
- share one identity and method registry across endpoint, call, aggregate, type, and inference facts, preserving anonymous-before-named lookup
- make provider probes return typed incomplete outcomes without publishing provisional results

## Validation

- `scripts/rue unit compiler provider_` (36 passed)
- `scripts/rue unit compiler body_input` (4 passed)
- `scripts/rue unit air provider_fact_facades`
- focused atomic method-registry and typed incomplete tests
- `scripts/rue fmt`
- `git diff --check`

Part of RUE-1092