### PR TITLE
RUE-1138: reject endpoint installation after sealing

### DIFF
--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -316,9 +316,12 @@ pub(super) struct PendingNominalPayload {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DeclarationInstallFailure {
-    /// Body-owner installation was attempted after the declaration base was
-    /// sealed; refreshing only the live epoch would leave derivation data stale.
+    /// An identity endpoint installation was attempted after the declaration
+    /// base was sealed; refreshing only the live epoch would leave derivation
+    /// data stale.
     AlreadySealed,
+    /// Stable endpoint validation failed before installation.
+    EndpointResolution(crate::SemanticStableResolutionFailure),
     DuplicatePayload,
     MissingPayload,
     UnexpectedPayload,
@@ -336,6 +339,12 @@ pub enum DeclarationInstallFailure {
     /// types; the carried message names both stable keys and the digest. Surfaces
     /// as a fail-closed E9000 internal error.
     AnonymousDigestCollision(Box<str>),
+}
+
+impl From<crate::SemanticStableResolutionFailure> for DeclarationInstallFailure {
+    fn from(failure: crate::SemanticStableResolutionFailure) -> Self {
+        Self::EndpointResolution(failure)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2274,7 +2283,10 @@ impl<'a> BoundSema<'a> {
         mut self,
         definitions: &[crate::SemanticDefinitionEndpoint],
         modules: &[crate::SemanticModuleEndpoint],
-    ) -> Result<Self, crate::SemanticStableResolutionFailure> {
+    ) -> Result<Self, DeclarationInstallFailure> {
+        if self.body_base.is_some() {
+            return Err(DeclarationInstallFailure::AlreadySealed);
+        }
         let expected_definitions = self
             .binding_manifest()
             .bindings()
@@ -3974,7 +3986,7 @@ mod tests {
     fn install_stable_endpoints(
         definitions: &[crate::SemanticDefinitionEndpoint],
         modules: &[crate::SemanticModuleEndpoint],
-    ) -> Result<(), crate::SemanticStableResolutionFailure> {
+    ) -> Result<(), crate::DeclarationInstallFailure> {
         let (tokens, interner) = Lexer::new("fn main() {}").tokenize().unwrap();
         let (ast, interner) = Parser::new(tokens, interner).parse().unwrap();
         let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
@@ -4002,13 +4014,16 @@ mod tests {
             file: 0,
         };
         assert_eq!(install_stable_endpoints(&[endpoint.clone()], &[]), Ok(()));
-        assert_eq!(install_stable_endpoints(&[], &[]), Err(F::Missing));
+        assert_eq!(
+            install_stable_endpoints(&[], &[]),
+            Err(crate::DeclarationInstallFailure::from(F::Missing))
+        );
 
         let mut duplicate = endpoint.clone();
         duplicate.token = crate::SemanticDefinitionToken::new(7, 1);
         assert_eq!(
             install_stable_endpoints(&[endpoint.clone(), duplicate], &[]),
-            Err(F::Ambiguous)
+            Err(crate::DeclarationInstallFailure::from(F::Ambiguous))
         );
 
         let mut wrong_kind = endpoint.clone();
@@ -4017,23 +4032,26 @@ mod tests {
         wrong_kind.kind = StableDefinitionKind::ValueConst;
         assert_eq!(
             install_stable_endpoints(&[wrong_kind], &[]),
-            Err(F::WrongKind)
+            Err(crate::DeclarationInstallFailure::from(F::WrongKind))
         );
 
         let mut nonexistent = endpoint.clone();
         nonexistent.name = Arc::from("other");
         assert_eq!(
             install_stable_endpoints(&[nonexistent], &[]),
-            Err(F::Missing)
+            Err(crate::DeclarationInstallFailure::from(F::Missing))
         );
-        assert_eq!(install_stable_endpoints(&[], &[]), Err(F::Missing));
+        assert_eq!(
+            install_stable_endpoints(&[], &[]),
+            Err(crate::DeclarationInstallFailure::from(F::Missing))
+        );
         let extra_module = crate::SemanticModuleEndpoint {
             token: crate::SemanticModuleToken::new(7, 1),
             file: 99,
         };
         assert_eq!(
             install_stable_endpoints(&[endpoint.clone()], &[module, extra_module]),
-            Err(F::Missing)
+            Err(crate::DeclarationInstallFailure::from(F::Missing))
         );
 
         let foreign_module = crate::SemanticModuleEndpoint {
@@ -4042,7 +4060,7 @@ mod tests {
         };
         assert_eq!(
             install_stable_endpoints(&[endpoint], &[foreign_module]),
-            Err(F::ForeignIssuer)
+            Err(crate::DeclarationInstallFailure::from(F::ForeignIssuer))
         );
     }
 

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -3810,6 +3810,16 @@ fn main() -> i32 {
         crate::sema::BoundSema<'static>,
         Vec<crate::SemanticDefinitionEndpoint>,
     ) {
+        one_body_fixture_with_install_order(source, false)
+    }
+
+    fn one_body_fixture_with_install_order(
+        source: &str,
+        owner_before_stable: bool,
+    ) -> (
+        crate::sema::BoundSema<'static>,
+        Vec<crate::SemanticDefinitionEndpoint>,
+    ) {
         let (rir, interner) = lower_files(&[(source, FileId::DEFAULT)]);
         let rir = Box::leak(Box::new(rir));
         let interner = Box::leak(Box::new(interner));
@@ -3840,12 +3850,83 @@ fn main() -> i32 {
                 owner: binding.owner.clone(),
             })
             .collect::<Vec<_>>();
-        let bound = resolved
-            .install_stable_identity_endpoints(&definitions, &[])
-            .unwrap()
-            .install_body_owner_tokens(&owners)
-            .unwrap();
+        let bound = if owner_before_stable {
+            resolved
+                .install_body_owner_tokens(&owners)
+                .unwrap()
+                .install_stable_identity_endpoints(&definitions, &[])
+                .unwrap()
+        } else {
+            resolved
+                .install_stable_identity_endpoints(&definitions, &[])
+                .unwrap()
+                .install_body_owner_tokens(&owners)
+                .unwrap()
+        };
         (bound, definitions)
+    }
+
+    #[test]
+    fn stable_endpoint_install_refreshes_body_state_in_both_install_orders() {
+        for owner_before_stable in [false, true] {
+            let (bound, _) =
+                one_body_fixture_with_install_order("fn main() {}", owner_before_stable);
+            bound
+                .analyze_all_bodies_for_test()
+                .expect("pre-seal endpoint installation must refresh body state");
+        }
+    }
+
+    #[test]
+    fn stable_endpoint_reinstallation_after_sealing_fails_before_mutation() {
+        let (mut bound, definitions) = one_body_fixture("fn main() {}");
+        bound.seal_as_declaration_base();
+
+        let sealed_base = bound
+            .body_base
+            .as_ref()
+            .expect("sealing installs a declaration base")
+            .clone();
+        let base_definition_tokens = sealed_base.stable_definition_tokens.clone();
+        let base_definition_endpoints = sealed_base.stable_definition_endpoints.clone();
+        let base_module_tokens = sealed_base.stable_module_tokens.clone();
+        let base_module_endpoints = sealed_base.stable_module_endpoints.clone();
+
+        let mut units = crate::EpochDerivationUnits::default();
+        let derived = bound.derive_body_epoch(&mut units);
+        let derived_definition_tokens = derived.sema.stable_definition_tokens.clone();
+        let derived_definition_endpoints = derived.sema.stable_definition_endpoints.clone();
+        let derived_module_tokens = derived.sema.stable_module_tokens.clone();
+        let derived_module_endpoints = derived.sema.stable_module_endpoints.clone();
+
+        let Err(failure) = bound.install_stable_identity_endpoints(&definitions, &[]) else {
+            panic!("stable endpoint installation after sealing unexpectedly succeeded")
+        };
+        assert_eq!(failure, crate::DeclarationInstallFailure::AlreadySealed);
+
+        assert_eq!(sealed_base.stable_definition_tokens, base_definition_tokens);
+        assert_eq!(
+            sealed_base.stable_definition_endpoints,
+            base_definition_endpoints
+        );
+        assert_eq!(sealed_base.stable_module_tokens, base_module_tokens);
+        assert_eq!(sealed_base.stable_module_endpoints, base_module_endpoints);
+        assert_eq!(
+            derived.sema.stable_definition_tokens,
+            derived_definition_tokens
+        );
+        assert_eq!(
+            derived.sema.stable_definition_endpoints,
+            derived_definition_endpoints
+        );
+        assert_eq!(derived.sema.stable_module_tokens, derived_module_tokens);
+        assert_eq!(
+            derived.sema.stable_module_endpoints,
+            derived_module_endpoints
+        );
+        derived
+            .analyze_all_bodies_for_test()
+            .expect("already-derived epoch remains usable after rejection");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reject stable identity endpoint installation once a declaration base is sealed
- preserve endpoint-resolution failures as a distinct typed install error
- cover both valid pre-seal installation orders and prove sealed/derived state remains unchanged after rejection

## Testing

- `scripts/rue unit air stable_endpoint_`
- `scripts/rue unit air`
- `scripts/rue quick`
- `scripts/rue fmt`

Fixes RUE-1138