### PR TITLE
Fix --emit backend path parity

### DIFF
--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -226,6 +226,77 @@ args = ["--emit", "asm", "-j1", "main.rue"]
 compile_only = true
 compile_stdout_contains = ["=== Assembly", "main"]
 
+# RUE-1141: backend diagnostics are projections of the production backend
+# product. In particular, helper definitions and calls must use the same
+# canonical machine symbols that a normal object build uses.
+[[case]]
+name = "backend_emits_use_production_symbols_x86_64"
+description = "Every x86-64 backend emit stage projects the production lowering/allocation/emission path and its canonical symbols."
+files = [{ path = "main.rue", source = """
+fn helper() -> i32 { 42 }
+fn main() -> i32 { helper() }
+""" }]
+args = [
+    "--target", "x86-64-linux",
+    "--emit", "lowering",
+    "--emit", "mir",
+    "--emit", "liveness",
+    "--emit", "regalloc",
+    "--emit", "asm",
+    "main.rue",
+]
+compile_only = true
+compile_stdout_contains = [
+    "=== Instruction Selection",
+    "=== MIR",
+    "=== Liveness",
+    "=== Register Allocation",
+    "=== Assembly",
+    "function __rue_sem_v1_",
+    ".globl __rue_sem_v1_",
+    "call __rue_sem_v1_",
+]
+compile_stdout_not_contains = [
+    "function helper:",
+    ".globl helper",
+    "helper:",
+    "call helper",
+]
+
+[[case]]
+name = "backend_emits_use_production_symbols_aarch64"
+description = "Every AArch64 backend emit stage projects the production lowering/allocation/emission path and its canonical symbols."
+files = [{ path = "main.rue", source = """
+fn helper() -> i32 { 42 }
+fn main() -> i32 { helper() }
+""" }]
+args = [
+    "--target", "aarch64-linux",
+    "--emit", "lowering",
+    "--emit", "mir",
+    "--emit", "liveness",
+    "--emit", "regalloc",
+    "--emit", "asm",
+    "main.rue",
+]
+compile_only = true
+compile_stdout_contains = [
+    "=== Instruction Selection",
+    "=== MIR",
+    "=== Liveness",
+    "=== Register Allocation",
+    "=== Assembly",
+    "function __rue_sem_v1_",
+    ".globl __rue_sem_v1_",
+    "bl __rue_sem_v1_",
+]
+compile_stdout_not_contains = [
+    "function helper:",
+    ".globl helper",
+    "helper:",
+    "bl helper",
+]
+
 [[case]]
 name = "emit_lowering_reports_semantic_byref_errors"
 description = "--emit lowering reports by-ref non-place operands rejected during semantic/AIR construction (RUE-760)."

--- a/crates/rue-cli-tests/cases/std_strbuf.toml
+++ b/crates/rue-cli-tests/cases/std_strbuf.toml
@@ -225,7 +225,15 @@ fn main() -> i32 {
 """ }]
 args = ["--emit", "mir", "main.rue"]
 compile_only = true
-compile_stdout_contains = ["duplicate", "byte_range", "concat_borrowed", "copy_packed_bytes"]
+# Backend views expose production machine symbols. These are the stable-symbol
+# hex payloads for duplicate, byte_range, concat_borrowed, and
+# copy_packed_bytes respectively.
+compile_stdout_contains = [
+    "6475706c6963617465",
+    "627974655f72616e6765",
+    "636f6e6361745f626f72726f776564",
+    "636f70795f7061636b65645f6279746573",
+]
 
 [[case]]
 name = "raw_pointer_helpers_are_not_associated_surface"

--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -69,6 +69,11 @@ pub fn analyze_debug(mir: &Aarch64Mir) -> LivenessDebugInfo {
     crate::liveness::analyze_debug_adapter(&Aarch64LivenessAdapter { mir })
 }
 
+/// Compute allocator liveness and its diagnostic projection together.
+pub(crate) fn analyze_with_debug(mir: &Aarch64Mir) -> (LivenessInfo, LivenessDebugInfo) {
+    crate::liveness::analyze_with_debug_adapter(&Aarch64LivenessAdapter { mir })
+}
+
 /// Compute loop information for Aarch64Mir.
 pub fn analyze_loops(mir: &Aarch64Mir) -> LoopInfo {
     crate::liveness::analyze_loops_adapter(&Aarch64LivenessAdapter { mir })

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -33,8 +33,6 @@ use rue_error::CompileResult;
 use rue_target::Target;
 
 use crate::MachineCode;
-use crate::regalloc::RegAllocDebugInfo;
-
 // Re-export from parent
 pub use super::{EmittedCode, EmittedRelocation};
 
@@ -45,14 +43,65 @@ pub(crate) fn prepare_backend(
     target: Target,
     symbols: crate::MachineSymbolResolver<'_>,
 ) -> CompileResult<crate::codegen_pipeline::PreparedMir<Aarch64Mir, Reg>> {
-    crate::codegen_pipeline::prepare_mir(
+    prepare_backend_with_artifacts(
+        cfg,
+        type_pool,
+        interner,
+        target,
+        symbols,
+        crate::BackendArtifactRequest::default(),
+    )
+    .map(|(prepared, _artifacts)| prepared)
+}
+
+fn prepare_backend_with_artifacts(
+    cfg: &ValidatedCfg,
+    type_pool: &FrozenTypeInternPool,
+    interner: &ThreadedRodeo,
+    target: Target,
+    symbols: crate::MachineSymbolResolver<'_>,
+    request: crate::BackendArtifactRequest,
+) -> CompileResult<(
+    crate::codegen_pipeline::PreparedMir<Aarch64Mir, Reg>,
+    crate::BackendArtifacts,
+)> {
+    crate::codegen_pipeline::prepare_mir_with_artifacts(
         cfg,
         type_pool,
         cfg_lower::ARG_REGS.len() as u32,
         cfg_lower::RET_REGS.len() as u32,
         crate::frame_layout::SavedRegScheme::Aarch64,
-        || CfgLower::new_with_symbols(cfg, type_pool, interner, target, symbols).lower(),
-        |mir, existing_slots| RegAlloc::new(mir, existing_slots).allocate_with_spills(),
+        || {
+            let (mir, lowering) = if request.lowering {
+                let (mir, debug) =
+                    CfgLower::new_with_symbols(cfg, type_pool, interner, target, symbols)
+                        .lower_with_debug()?;
+                (mir, Some(debug))
+            } else {
+                (
+                    CfgLower::new_with_symbols(cfg, type_pool, interner, target, symbols)
+                        .lower()?,
+                    None,
+                )
+            };
+            let mir_text = request.mir.then(|| mir.to_string());
+            Ok((
+                mir,
+                crate::BackendArtifacts {
+                    lowering,
+                    mir: mir_text,
+                    ..Default::default()
+                },
+            ))
+        },
+        |mir, existing_slots, artifacts| {
+            let (mir, spills, used_callee_saved, liveness, regalloc) =
+                RegAlloc::new_with_artifacts(mir, existing_slots, request.liveness)
+                    .allocate_with_artifacts(request.regalloc)?;
+            artifacts.liveness = liveness.map(|debug| debug.to_string());
+            artifacts.regalloc = regalloc.map(|debug| debug.to_string());
+            Ok((mir, spills, used_callee_saved))
+        },
         |mir| {
             peephole::optimize(mir.instructions_vec_mut());
         },
@@ -61,7 +110,7 @@ pub(crate) fn prepare_backend(
     )
 }
 
-fn generate_inner<T, Emit>(
+fn generate_inner(
     cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     strings: &[String],
@@ -70,12 +119,10 @@ fn generate_inner<T, Emit>(
     symbols: crate::MachineSymbolResolver<'_>,
     atoms: &[crate::LocalAtomProjection<'_>],
     require_complete_atoms: bool,
-    emit: Emit,
-) -> CompileResult<(T, Vec<String>)>
-where
-    Emit: for<'a> FnOnce(Emitter<'a>) -> CompileResult<T>,
-{
-    let mut prepared = prepare_backend(cfg, type_pool, interner, target, symbols)?;
+    request: crate::BackendArtifactRequest,
+) -> CompileResult<crate::BackendProduct> {
+    let (mut prepared, mut artifacts) =
+        prepare_backend_with_artifacts(cfg, type_pool, interner, target, symbols, request)?;
     let referenced_strings = prepared
         .mir
         .instructions()
@@ -108,8 +155,26 @@ where
     .with_sret(prepared.has_sret)
     .with_frame_layout(prepared.frame_layout)
     .with_param_homing(prepared.param_homing.clone());
-    let emitted = emit(emitter)?;
-    Ok((emitted, local_strings))
+    let machine_code = if request.asm {
+        let emitted = emitter.emit_all()?;
+        artifacts.asm = Some(emitted.to_asm());
+        MachineCode {
+            code: emitted.to_bytes(),
+            relocations: emitted.relocations,
+            strings: local_strings,
+        }
+    } else {
+        let (code, relocations) = emitter.emit()?;
+        MachineCode {
+            code,
+            relocations,
+            strings: local_strings,
+        }
+    };
+    Ok(crate::BackendProduct {
+        machine_code,
+        artifacts,
+    })
 }
 
 /// Generate machine code from CFG.
@@ -122,7 +187,7 @@ pub fn generate(
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<MachineCode> {
-    let ((code, relocations), strings) = generate_inner(
+    Ok(generate_inner(
         cfg,
         type_pool,
         strings,
@@ -131,16 +196,9 @@ pub fn generate(
         crate::MachineSymbolResolver::default(),
         &[],
         false,
-        |emitter| {
-            // Keep the normal path allocation-free with respect to assembly text.
-            emitter.emit()
-        },
-    )?;
-    Ok(MachineCode {
-        code,
-        relocations,
-        strings,
-    })
+        crate::BackendArtifactRequest::default(),
+    )?
+    .machine_code)
 }
 
 pub fn generate_with_symbols(
@@ -151,7 +209,7 @@ pub fn generate_with_symbols(
     target: Target,
     symbols: crate::MachineSymbolResolver<'_>,
 ) -> CompileResult<MachineCode> {
-    let ((code, relocations), strings) = generate_inner(
+    Ok(generate_inner(
         cfg,
         type_pool,
         strings,
@@ -160,13 +218,9 @@ pub fn generate_with_symbols(
         symbols,
         &[],
         false,
-        |emitter| emitter.emit(),
-    )?;
-    Ok(MachineCode {
-        code,
-        relocations,
-        strings,
-    })
+        crate::BackendArtifactRequest::default(),
+    )?
+    .machine_code)
 }
 
 pub fn generate_with_symbols_and_atoms(
@@ -178,7 +232,7 @@ pub fn generate_with_symbols_and_atoms(
     symbols: crate::MachineSymbolResolver<'_>,
     atoms: &[crate::LocalAtomProjection<'_>],
 ) -> CompileResult<MachineCode> {
-    let ((code, relocations), strings) = generate_inner(
+    Ok(generate_inner(
         cfg,
         type_pool,
         strings,
@@ -187,85 +241,23 @@ pub fn generate_with_symbols_and_atoms(
         symbols,
         atoms,
         true,
-        |emitter| emitter.emit(),
-    )?;
-    Ok(MachineCode {
-        code,
-        relocations,
-        strings,
-    })
+        crate::BackendArtifactRequest::default(),
+    )?
+    .machine_code)
 }
 
-/// Generate machine code with assembly text from CFG.
-///
-/// This returns both machine code bytes and human-readable assembly text
-/// showing the actual emitted instructions (including prologue/epilogue).
-pub fn generate_with_asm(
+/// Run the production backend and retain requested diagnostic projections.
+pub fn generate_product_with_symbols_and_atoms(
     cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
     target: Target,
-) -> CompileResult<(MachineCode, String)> {
-    let (emitted, strings) = generate_inner(
-        cfg,
-        type_pool,
-        strings,
-        interner,
-        target,
-        crate::MachineSymbolResolver::default(),
-        &[],
-        false,
-        |emitter| emitter.emit_all(),
-    )?;
-    let asm = emitted.to_asm();
-    let machine_code = MachineCode {
-        code: emitted.to_bytes(),
-        relocations: emitted.relocations,
-        strings,
-    };
-    Ok((machine_code, asm))
-}
-
-/// Generate register allocation debug info from CFG.
-///
-/// This returns information about the register allocation process,
-/// including live ranges, interference, and allocation decisions.
-pub fn generate_regalloc_info(
-    cfg: &ValidatedCfg,
-    type_pool: &FrozenTypeInternPool,
-    interner: &ThreadedRodeo,
-    target: Target,
-) -> CompileResult<RegAllocDebugInfo<Reg>> {
-    let has_sret = crate::codegen_pipeline::validate_pre_lowering_budget(
-        cfg,
-        type_pool,
-        cfg_lower::ARG_REGS.len() as u32,
-        cfg_lower::RET_REGS.len() as u32,
-        crate::frame_layout::SavedRegScheme::Aarch64,
-    )?;
-
-    // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, interner, target).lower()?;
-
-    // Allocate physical registers with debug info
-    let existing_slots = crate::codegen_pipeline::checked_slot_sum([
-        cfg.num_locals(),
-        cfg.num_params(),
-        u32::from(has_sret),
-    ])
-    .ok_or_else(|| crate::codegen_pipeline::frame_budget_error(cfg, None))?;
-    let (_mir, num_spills, used_callee_saved, debug_info) =
-        RegAlloc::new(mir, existing_slots).allocate_with_debug()?;
-    let total_slots = existing_slots
-        .checked_add(num_spills)
-        .ok_or_else(|| crate::codegen_pipeline::frame_budget_error(cfg, None))?;
-    crate::frame_layout::FrameLayout::try_new(
-        crate::frame_layout::SavedRegScheme::Aarch64,
-        used_callee_saved.len(),
-        total_slots,
+    symbols: crate::MachineSymbolResolver<'_>,
+    atoms: &[crate::LocalAtomProjection<'_>],
+    request: crate::BackendArtifactRequest,
+) -> CompileResult<crate::BackendProduct> {
+    generate_inner(
+        cfg, type_pool, strings, interner, target, symbols, atoms, true, request,
     )
-    .map_err(|_| crate::codegen_pipeline::frame_budget_error(cfg, None))?;
-
-    Ok(debug_info)
 }

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -65,6 +65,16 @@ impl RegAlloc {
         }
     }
 
+    pub(crate) fn new_with_artifacts(
+        mir: Aarch64Mir,
+        existing_locals: u32,
+        capture_liveness: bool,
+    ) -> Self {
+        Self {
+            driver: RegAllocDriver::new_with_artifacts(mir, existing_locals, capture_liveness),
+        }
+    }
+
     pub fn num_spills(&self) -> u32 {
         self.driver.num_spills()
     }
@@ -81,6 +91,19 @@ impl RegAlloc {
         self,
     ) -> CompileResult<(Aarch64Mir, u32, Vec<Reg>, RegAllocDebugInfo<Reg>)> {
         self.driver.allocate_with_debug()
+    }
+
+    pub(crate) fn allocate_with_artifacts(
+        self,
+        capture_regalloc: bool,
+    ) -> CompileResult<(
+        Aarch64Mir,
+        u32,
+        Vec<Reg>,
+        Option<crate::LivenessDebugInfo>,
+        Option<RegAllocDebugInfo<Reg>>,
+    )> {
+        self.driver.allocate_with_artifacts(capture_regalloc)
     }
 
     fn rewrite_inst(
@@ -1210,6 +1233,12 @@ impl RegAllocBackend for Aarch64Backend {
 
     fn analyze(mir: &Self::Mir) -> LivenessInfo<Self::Reg> {
         liveness::analyze(mir)
+    }
+
+    fn analyze_with_debug(
+        mir: &Self::Mir,
+    ) -> (LivenessInfo<Self::Reg>, crate::regalloc::LivenessDebugInfo) {
+        liveness::analyze_with_debug(mir)
     }
 
     fn analyze_loops(mir: &Self::Mir) -> LoopInfo {

--- a/crates/rue-codegen/src/api_inventory.rs
+++ b/crates/rue-codegen/src/api_inventory.rs
@@ -6,7 +6,7 @@ fn production_generate_entry_points_require_validated_cfg() {
         include_str!("x86_64/mod.rs"),
         include_str!("aarch64/mod.rs"),
     ] {
-        for entry_point in ["generate", "generate_with_asm", "generate_regalloc_info"] {
+        for entry_point in ["generate", "generate_product_with_symbols_and_atoms"] {
             let signature = backend
                 .split(&format!("pub fn {entry_point}("))
                 .nth(1)
@@ -17,6 +17,15 @@ fn production_generate_entry_points_require_validated_cfg() {
                 "{entry_point} accepts an unvalidated CFG"
             );
             assert!(!signature.contains("cfg: &Cfg,"));
+        }
+        for removed in [
+            "pub fn generate_with_asm(",
+            "pub fn generate_regalloc_info(",
+        ] {
+            assert!(
+                !backend.contains(removed),
+                "presentation-only backend entry point returned: {removed}"
+            );
         }
     }
 

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -152,7 +152,11 @@ pub(crate) fn validate_pre_lowering_budget(
 ///   sret pointer so register-allocation spills cannot overlap any of them.
 /// - `total_locals` includes only original locals and new spill slots because
 ///   emitters account for parameters and sret separately.
-pub(crate) fn prepare_mir<M, R, Lower, Allocate, Peephole, Schedule, Verify>(
+///
+/// Run the canonical backend pipeline while carrying optional diagnostic
+/// observations alongside the same lowering and allocation execution.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn prepare_mir_with_artifacts<M, R, D, Lower, Allocate, Peephole, Schedule, Verify>(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,
     arg_reg_count: u32,
@@ -163,10 +167,10 @@ pub(crate) fn prepare_mir<M, R, Lower, Allocate, Peephole, Schedule, Verify>(
     peephole: Peephole,
     schedule: Schedule,
     verify: Verify,
-) -> CompileResult<PreparedMir<M, R>>
+) -> CompileResult<(PreparedMir<M, R>, D)>
 where
-    Lower: FnOnce() -> CompileResult<M>,
-    Allocate: FnOnce(M, u32) -> CompileResult<(M, u32, Vec<R>)>,
+    Lower: FnOnce() -> CompileResult<(M, D)>,
+    Allocate: FnOnce(M, u32, &mut D) -> CompileResult<(M, u32, Vec<R>)>,
     Peephole: FnOnce(&mut M),
     Schedule: FnOnce(&mut M),
     Verify: FnOnce(&M) -> CompileResult<()>,
@@ -177,10 +181,10 @@ where
         validate_pre_lowering_budget(cfg, type_pool, arg_reg_count, return_reg_count, scheme)?;
     let param_homing = param_homing_plan(cfg);
 
-    let mir = lower()?;
+    let (mir, mut artifacts) = lower()?;
     let existing_slots = checked_slot_sum([num_locals_original, num_params, u32::from(has_sret)])
         .ok_or_else(|| frame_budget_error(cfg, None))?;
-    let (mut mir, num_spills, used_callee_saved) = allocate(mir, existing_slots)?;
+    let (mut mir, num_spills, used_callee_saved) = allocate(mir, existing_slots, &mut artifacts)?;
 
     peephole(&mut mir);
     schedule(&mut mir);
@@ -194,16 +198,19 @@ where
     let frame_layout = FrameLayout::try_new(scheme, used_callee_saved.len(), total_slots)
         .map_err(|_| frame_budget_error(cfg, None))?;
 
-    Ok(PreparedMir {
-        mir,
-        total_locals,
-        num_locals_original,
-        num_params,
-        has_sret,
-        used_callee_saved,
-        param_homing,
-        frame_layout,
-    })
+    Ok((
+        PreparedMir {
+            mir,
+            total_locals,
+            num_locals_original,
+            num_params,
+            has_sret,
+            used_callee_saved,
+            param_homing,
+            frame_layout,
+        },
+        artifacts,
+    ))
 }
 
 #[cfg(test)]
@@ -215,7 +222,7 @@ mod tests {
     use rue_cfg::{Cfg, CfgArgMode, CfgCallArg, CfgInst, CfgInstData};
     use rue_span::Span;
 
-    use super::{SavedRegScheme, prepare_mir, validate_pre_lowering_budget};
+    use super::{SavedRegScheme, prepare_mir_with_artifacts, validate_pre_lowering_budget};
 
     #[test]
     fn pass_order_and_frame_slot_formulas_are_single_source() {
@@ -234,7 +241,7 @@ mod tests {
         // A seven-slot return exceeds the six-register budget, so spill
         // placement sees 3 locals + 2 params + 1 sret-pointer slot. Four
         // spills then produce 3 + 4 emitted locals (not 3 + 2 + 1 + 4).
-        let prepared = prepare_mir(
+        let (prepared, ()) = prepare_mir_with_artifacts(
             &cfg,
             &type_pool,
             6,
@@ -242,9 +249,9 @@ mod tests {
             SavedRegScheme::X86_64,
             || {
                 events.borrow_mut().push("lower");
-                Ok(10_u32)
+                Ok((10_u32, ()))
             },
-            |mir, existing_slots| {
+            |mir, existing_slots, _artifacts| {
                 events.borrow_mut().push("allocate");
                 assert_eq!(existing_slots, 6);
                 Ok((mir + 1, 4, vec![5_u8]))

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -248,6 +248,37 @@ pub struct MachineCode {
     pub strings: Vec<String>,
 }
 
+/// Optional observations captured while the production backend pipeline runs.
+///
+/// These flags never select a different lowering, allocation, scheduling, or
+/// emission implementation. They only retain diagnostic projections from the
+/// exact execution which produces [`MachineCode`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BackendArtifactRequest {
+    pub lowering: bool,
+    pub mir: bool,
+    pub liveness: bool,
+    pub regalloc: bool,
+    pub asm: bool,
+}
+
+/// Diagnostic projections retained by one production backend execution.
+#[derive(Debug, Default)]
+pub struct BackendArtifacts {
+    pub lowering: Option<LoweringDebugInfo>,
+    pub mir: Option<String>,
+    pub liveness: Option<String>,
+    pub regalloc: Option<String>,
+    pub asm: Option<String>,
+}
+
+/// Canonical per-function backend product before object-file projection.
+#[derive(Debug)]
+pub struct BackendProduct {
+    pub machine_code: MachineCode,
+    pub artifacts: BackendArtifacts,
+}
+
 /// Stable local-data identity projected onto the current program string table.
 ///
 /// Multiple occurrence identities may intentionally share one dense ID when
@@ -753,33 +784,40 @@ mod tests {
         let (cfg, type_pool, interner) = aggregate_cfg(40);
         assert!(cfg_lower::fn_uses_sret_return(&cfg, &type_pool, 6));
         assert!(cfg_lower::fn_uses_sret_return(&cfg, &type_pool, 8));
-        assert!(
-            !x86_64::generate_regalloc_info(&cfg, &type_pool, &interner)
-                .expect("x86 register allocation should succeed")
-                .spills
-                .is_empty(),
-            "fixture must exercise x86 spills"
-        );
-        assert!(
-            !aarch64::generate_regalloc_info(
-                &cfg,
-                &type_pool,
-                &interner,
-                rue_target::Target::Aarch64Linux,
-            )
-            .expect("AArch64 register allocation should succeed")
-            .spills
-            .is_empty(),
-            "fixture must exercise AArch64 spills"
-        );
         let strings = vec!["pipeline parity sentinel".to_owned()];
+        let request = BackendArtifactRequest {
+            lowering: true,
+            mir: true,
+            liveness: true,
+            regalloc: true,
+            asm: true,
+        };
 
         let x86 = x86_64::generate(&cfg, &type_pool, &strings, &interner)
             .expect("x86 normal generation should succeed");
-        let (x86_asm_code, x86_asm) =
-            x86_64::generate_with_asm(&cfg, &type_pool, &strings, &interner)
-                .expect("x86 assembly generation should succeed");
-        assert_same_machine_code(&x86, &x86_asm_code);
+        let x86_product = x86_64::generate_product_with_symbols_and_atoms(
+            &cfg,
+            &type_pool,
+            &strings,
+            &interner,
+            MachineSymbolResolver::default(),
+            &[],
+            request,
+        )
+        .expect("x86 diagnostic product should succeed");
+        assert_same_machine_code(&x86, &x86_product.machine_code);
+        assert!(x86_product.artifacts.lowering.is_some());
+        assert!(x86_product.artifacts.mir.is_some());
+        assert!(x86_product.artifacts.liveness.is_some());
+        let x86_regalloc = x86_product
+            .artifacts
+            .regalloc
+            .expect("x86 register allocation projection");
+        assert!(
+            !x86_regalloc.contains("Spills:\n  none"),
+            "fixture must exercise x86 spills"
+        );
+        let x86_asm = x86_product.artifacts.asm.expect("x86 assembly projection");
         assert!(!x86_asm.is_empty());
         assert!(x86_asm.contains("jno "), "fixture must retain rel32 fixups");
 
@@ -789,10 +827,33 @@ mod tests {
         ] {
             let arm = aarch64::generate(&cfg, &type_pool, &strings, &interner, target)
                 .expect("AArch64 normal generation should succeed");
-            let (arm_asm_code, arm_asm) =
-                aarch64::generate_with_asm(&cfg, &type_pool, &strings, &interner, target)
-                    .expect("AArch64 assembly generation should succeed");
-            assert_same_machine_code(&arm, &arm_asm_code);
+            let arm_product = aarch64::generate_product_with_symbols_and_atoms(
+                &cfg,
+                &type_pool,
+                &strings,
+                &interner,
+                target,
+                MachineSymbolResolver::default(),
+                &[],
+                request,
+            )
+            .expect("AArch64 diagnostic product should succeed");
+            assert_same_machine_code(&arm, &arm_product.machine_code);
+            assert!(arm_product.artifacts.lowering.is_some());
+            assert!(arm_product.artifacts.mir.is_some());
+            assert!(arm_product.artifacts.liveness.is_some());
+            let arm_regalloc = arm_product
+                .artifacts
+                .regalloc
+                .expect("AArch64 register allocation projection");
+            assert!(
+                !arm_regalloc.contains("Spills:\n  none"),
+                "fixture must exercise AArch64 spills"
+            );
+            let arm_asm = arm_product
+                .artifacts
+                .asm
+                .expect("AArch64 assembly projection");
             assert!(!arm_asm.is_empty());
             assert!(
                 arm_asm.contains("b.vc "),
@@ -812,15 +873,25 @@ mod tests {
             rue_target::Target::Aarch64Linux,
         )
         .expect("AArch64 Linux normal generation should succeed");
-        let (linux_asm_code, linux_asm) = aarch64::generate_with_asm(
+        let linux_product = aarch64::generate_product_with_symbols_and_atoms(
             &cfg,
             &type_pool,
             &[],
             &interner,
             rue_target::Target::Aarch64Linux,
+            MachineSymbolResolver::default(),
+            &[],
+            BackendArtifactRequest {
+                asm: true,
+                ..Default::default()
+            },
         )
         .expect("AArch64 Linux assembly generation should succeed");
-        assert_same_machine_code(&linux, &linux_asm_code);
+        assert_same_machine_code(&linux, &linux_product.machine_code);
+        let linux_asm = linux_product
+            .artifacts
+            .asm
+            .expect("Linux assembly projection");
         assert!(linux_asm.contains("svc #0x0"));
         assert!(!linux_asm.contains("b.lo "));
         assert!(!linux_asm.contains("neg x0, x0"));
@@ -833,15 +904,25 @@ mod tests {
             rue_target::Target::Aarch64Macos,
         )
         .expect("AArch64 macOS normal generation should succeed");
-        let (macos_asm_code, macos_asm) = aarch64::generate_with_asm(
+        let macos_product = aarch64::generate_product_with_symbols_and_atoms(
             &cfg,
             &type_pool,
             &[],
             &interner,
             rue_target::Target::Aarch64Macos,
+            MachineSymbolResolver::default(),
+            &[],
+            BackendArtifactRequest {
+                asm: true,
+                ..Default::default()
+            },
         )
         .expect("AArch64 macOS assembly generation should succeed");
-        assert_same_machine_code(&macos, &macos_asm_code);
+        assert_same_machine_code(&macos, &macos_product.machine_code);
+        let macos_asm = macos_product
+            .artifacts
+            .asm
+            .expect("macOS assembly projection");
         assert!(macos_asm.contains("svc #0x80"));
         let svc = macos_asm
             .find("svc #0x80")

--- a/crates/rue-codegen/src/liveness.rs
+++ b/crates/rue-codegen/src/liveness.rs
@@ -97,6 +97,23 @@ where
     )
 }
 
+/// Compute allocator liveness and its diagnostic projection in one dataflow
+/// execution for a target adapter.
+pub fn analyze_with_debug_adapter<A>(adapter: &A) -> (LivenessInfo<A::Reg>, LivenessDebugInfo)
+where
+    A: LivenessAdapter,
+{
+    analyze_with_debug(
+        adapter.instructions(),
+        adapter.vreg_count(),
+        |inst| adapter.label(inst),
+        |idx, inst, label_to_idx| adapter.successors(idx, inst, label_to_idx),
+        |inst| adapter.uses(inst),
+        |inst| adapter.defs(inst),
+        |inst| adapter.clobbers(inst),
+    )
+}
+
 /// Compute loop information for any backend implementing [`LivenessAdapter`].
 pub fn analyze_loops_adapter<A>(adapter: &A) -> LoopInfo
 where
@@ -177,14 +194,78 @@ pub fn analyze<I, R>(
 where
     R: Copy + Eq + std::hash::Hash,
 {
+    analyze_inner(
+        instructions,
+        vreg_count,
+        get_label,
+        get_successors,
+        get_uses,
+        get_defs,
+        get_clobbers,
+        false,
+    )
+    .0
+}
+
+/// Compute production liveness and its diagnostic projection in one dataflow
+/// execution.
+pub fn analyze_with_debug<I, R>(
+    instructions: &[I],
+    vreg_count: u32,
+    get_label: impl Fn(&I) -> Option<LabelId>,
+    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> Vec<usize>,
+    get_uses: impl Fn(&I) -> Vec<VReg>,
+    get_defs: impl Fn(&I) -> Vec<VReg>,
+    get_clobbers: impl Fn(&I) -> Vec<R>,
+) -> (LivenessInfo<R>, LivenessDebugInfo)
+where
+    R: Copy + Eq + std::hash::Hash,
+{
+    let (liveness, debug) = analyze_inner(
+        instructions,
+        vreg_count,
+        get_label,
+        get_successors,
+        get_uses,
+        get_defs,
+        get_clobbers,
+        true,
+    );
+    (
+        liveness,
+        debug.expect("debug liveness requested from the canonical analysis"),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn analyze_inner<I, R>(
+    instructions: &[I],
+    vreg_count: u32,
+    get_label: impl Fn(&I) -> Option<LabelId>,
+    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> Vec<usize>,
+    get_uses: impl Fn(&I) -> Vec<VReg>,
+    get_defs: impl Fn(&I) -> Vec<VReg>,
+    get_clobbers: impl Fn(&I) -> Vec<R>,
+    collect_debug: bool,
+) -> (LivenessInfo<R>, Option<LivenessDebugInfo>)
+where
+    R: Copy + Eq + std::hash::Hash,
+{
     let num_insts = instructions.len();
 
     if num_insts == 0 {
-        return LivenessInfo {
-            ranges: IndexMap::new(),
-            live_at: Vec::new(),
-            clobbers_at: Vec::new(),
-        };
+        return (
+            LivenessInfo {
+                ranges: IndexMap::new(),
+                live_at: Vec::new(),
+                clobbers_at: Vec::new(),
+            },
+            collect_debug.then(|| LivenessDebugInfo {
+                instructions: Vec::new(),
+                live_ranges: IndexMap::new(),
+                vreg_count,
+            }),
+        );
     }
 
     // Step 1: Build label -> instruction index map
@@ -219,11 +300,34 @@ where
     // Step 7: Collect clobbers
     let clobbers_at: Vec<Vec<R>> = instructions.iter().map(|i| get_clobbers(i)).collect();
 
-    LivenessInfo {
-        ranges,
-        live_at,
-        clobbers_at,
-    }
+    let debug = collect_debug.then(|| {
+        let bitset_to_hashset = |bs: &FixedBitSet| -> std::collections::HashSet<VReg> {
+            bs.ones().map(|idx| VReg::new(idx as u32)).collect()
+        };
+        let instruction_liveness = (0..num_insts)
+            .map(|idx| InstructionLiveness {
+                index: idx,
+                live_in: bitset_to_hashset(&live_in[idx]),
+                live_out: bitset_to_hashset(&live_out[idx]),
+                defs: inst_defs[idx].clone(),
+                uses: inst_uses[idx].clone(),
+            })
+            .collect();
+        LivenessDebugInfo {
+            instructions: instruction_liveness,
+            live_ranges: ranges.clone(),
+            vreg_count,
+        }
+    });
+
+    (
+        LivenessInfo {
+            ranges,
+            live_at,
+            clobbers_at,
+        },
+        debug,
+    )
 }
 
 /// Compute detailed liveness debug information.
@@ -241,62 +345,16 @@ pub fn analyze_debug<I, R>(
 where
     R: Copy + Eq + std::hash::Hash,
 {
-    let num_insts = instructions.len();
-
-    if num_insts == 0 {
-        return LivenessDebugInfo {
-            instructions: Vec::new(),
-            live_ranges: IndexMap::new(),
-            vreg_count,
-        };
-    }
-
-    // Step 1: Build label -> instruction index map
-    let label_to_idx = build_label_map(instructions, &get_label);
-
-    // Step 2: Build successor lists for each instruction
-    let successors = build_successor_lists(instructions, &label_to_idx, &get_successors);
-
-    // Step 3: Pre-compute uses and defs for each instruction
-    let inst_uses: Vec<Vec<VReg>> = instructions.iter().map(&get_uses).collect();
-    let inst_defs: Vec<Vec<VReg>> = instructions.iter().map(&get_defs).collect();
-
-    // Step 4: Backward dataflow analysis to compute live sets
-    let (live_in, live_out) =
-        compute_dataflow(num_insts, vreg_count, &successors, &inst_uses, &inst_defs);
-
-    // Step 5: Build live ranges from dataflow results
-    let has_back_edge = has_back_edge(&successors);
-    let live_ranges = build_live_ranges(
-        num_insts,
+    analyze_with_debug(
+        instructions,
         vreg_count,
-        &inst_uses,
-        &inst_defs,
-        &live_in,
-        &live_out,
-        has_back_edge,
-    );
-
-    // Step 6: Build per-instruction liveness info
-    let bitset_to_hashset = |bs: &FixedBitSet| -> std::collections::HashSet<VReg> {
-        bs.ones().map(|idx| VReg::new(idx as u32)).collect()
-    };
-
-    let instruction_liveness: Vec<InstructionLiveness> = (0..num_insts)
-        .map(|idx| InstructionLiveness {
-            index: idx,
-            live_in: bitset_to_hashset(&live_in[idx]),
-            live_out: bitset_to_hashset(&live_out[idx]),
-            defs: inst_defs[idx].clone(),
-            uses: inst_uses[idx].clone(),
-        })
-        .collect();
-
-    LivenessDebugInfo {
-        instructions: instruction_liveness,
-        live_ranges,
-        vreg_count,
-    }
+        get_label,
+        get_successors,
+        get_uses,
+        get_defs,
+        |_| Vec::<R>::new(),
+    )
+    .1
 }
 
 // ============================================================================

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -944,6 +944,7 @@ pub trait RegAllocBackend {
     fn vreg_count(mir: &Self::Mir) -> u32;
     fn instructions(mir: &Self::Mir) -> &[Self::Inst];
     fn analyze(mir: &Self::Mir) -> LivenessInfo<Self::Reg>;
+    fn analyze_with_debug(mir: &Self::Mir) -> (LivenessInfo<Self::Reg>, LivenessDebugInfo);
     fn analyze_loops(mir: &Self::Mir) -> LoopInfo;
     fn coalesce_candidates(instructions: &[Self::Inst]) -> Vec<CoalesceCandidate>;
     fn allocatable_regs() -> &'static [Self::Reg];
@@ -1036,6 +1037,7 @@ pub struct RegAllocDriver<B: RegAllocBackend> {
     mir: B::Mir,
     allocation: IndexMap<VReg, Option<Allocation<B::Reg>>>,
     liveness: LivenessInfo<B::Reg>,
+    liveness_debug: Option<LivenessDebugInfo>,
     loop_info: LoopInfo,
     coalesce_result: CoalesceResult,
     num_spills: u32,
@@ -1046,8 +1048,19 @@ pub struct RegAllocDriver<B: RegAllocBackend> {
 impl<B: RegAllocBackend> RegAllocDriver<B> {
     /// Create the shared allocator state and perform target-provided analyses.
     pub fn new(mir: B::Mir, existing_locals: u32) -> Self {
+        Self::new_with_artifacts(mir, existing_locals, false)
+    }
+
+    /// Create allocator state while optionally retaining the diagnostic
+    /// projection of the same liveness dataflow used for allocation.
+    pub fn new_with_artifacts(mir: B::Mir, existing_locals: u32, capture_liveness: bool) -> Self {
         let vreg_count = B::vreg_count(&mir) as usize;
-        let mut liveness = B::analyze(&mir);
+        let (mut liveness, liveness_debug) = if capture_liveness {
+            let (liveness, debug) = B::analyze_with_debug(&mir);
+            (liveness, Some(debug))
+        } else {
+            (B::analyze(&mir), None)
+        };
         let loop_info = B::analyze_loops(&mir);
         let candidates = B::coalesce_candidates(B::instructions(&mir));
         let coalesce_result = coalesce(&candidates, &mut liveness);
@@ -1059,6 +1072,7 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
             mir,
             allocation,
             liveness,
+            liveness_debug,
             loop_info,
             coalesce_result,
             num_spills: 0,
@@ -1086,6 +1100,35 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
         self.validate_spill_budget()?;
         self.rewrite_instructions()?;
         Ok((self.mir, self.num_spills, self.used_callee_saved))
+    }
+
+    /// Run the canonical allocation/rewrite execution while optionally
+    /// retaining the diagnostic allocation projection.
+    pub fn allocate_with_artifacts(
+        mut self,
+        capture_regalloc: bool,
+    ) -> CompileResult<(
+        B::Mir,
+        u32,
+        Vec<B::Reg>,
+        Option<LivenessDebugInfo>,
+        Option<RegAllocDebugInfo<B::Reg>>,
+    )> {
+        let regalloc_debug = if capture_regalloc {
+            Some(self.assign_registers_with_debug())
+        } else {
+            self.assign_registers();
+            None
+        };
+        self.validate_spill_budget()?;
+        self.rewrite_instructions()?;
+        Ok((
+            self.mir,
+            self.num_spills,
+            self.used_callee_saved,
+            self.liveness_debug,
+            regalloc_debug,
+        ))
     }
 
     /// Run the debug assignment path, followed by the same rewrite path.

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -730,8 +730,21 @@ fn main() -> i32 {
         let target = Target::Aarch64Linux;
 
         let info = generate_stack_frame_info(&cfg, "gcd", &type_pool, &interner, target).unwrap();
-        let (_machine_code, asm) =
-            crate::aarch64::generate_with_asm(&cfg, &type_pool, &[], &interner, target).unwrap();
+        let product = crate::aarch64::generate_product_with_symbols_and_atoms(
+            &cfg,
+            &type_pool,
+            &[],
+            &interner,
+            target,
+            crate::MachineSymbolResolver::default(),
+            &[],
+            crate::BackendArtifactRequest {
+                asm: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let asm = product.artifacts.asm.expect("assembly projection");
 
         // Parameters are homed into the frame by explicit `str x*, [x29, #N]`
         // prologue stores; every reported parameter slot must appear at that

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -69,6 +69,11 @@ pub fn analyze_debug(mir: &X86Mir) -> LivenessDebugInfo {
     crate::liveness::analyze_debug_adapter(&X86LivenessAdapter { mir })
 }
 
+/// Compute allocator liveness and its diagnostic projection together.
+pub(crate) fn analyze_with_debug(mir: &X86Mir) -> (LivenessInfo, LivenessDebugInfo) {
+    crate::liveness::analyze_with_debug_adapter(&X86LivenessAdapter { mir })
+}
+
 /// Compute loop information for X86Mir.
 pub fn analyze_loops(mir: &X86Mir) -> LoopInfo {
     crate::liveness::analyze_loops_adapter(&X86LivenessAdapter { mir })

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -26,8 +26,6 @@ pub use emit::Emitter;
 pub use mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
 pub use regalloc::RegAlloc;
 
-use crate::regalloc::RegAllocDebugInfo;
-
 use lasso::ThreadedRodeo;
 use rue_air::FrozenTypeInternPool;
 use rue_cfg::ValidatedCfg;
@@ -42,14 +40,61 @@ pub(crate) fn prepare_backend(
     interner: &ThreadedRodeo,
     symbols: crate::MachineSymbolResolver<'_>,
 ) -> CompileResult<crate::codegen_pipeline::PreparedMir<X86Mir, Reg>> {
-    crate::codegen_pipeline::prepare_mir(
+    prepare_backend_with_artifacts(
+        cfg,
+        type_pool,
+        interner,
+        symbols,
+        crate::BackendArtifactRequest::default(),
+    )
+    .map(|(prepared, _artifacts)| prepared)
+}
+
+fn prepare_backend_with_artifacts(
+    cfg: &ValidatedCfg,
+    type_pool: &FrozenTypeInternPool,
+    interner: &ThreadedRodeo,
+    symbols: crate::MachineSymbolResolver<'_>,
+    request: crate::BackendArtifactRequest,
+) -> CompileResult<(
+    crate::codegen_pipeline::PreparedMir<X86Mir, Reg>,
+    crate::BackendArtifacts,
+)> {
+    crate::codegen_pipeline::prepare_mir_with_artifacts(
         cfg,
         type_pool,
         cfg_lower::ARG_REGS.len() as u32,
         cfg_lower::RET_REGS.len() as u32,
         crate::frame_layout::SavedRegScheme::X86_64,
-        || CfgLower::new_with_symbols(cfg, type_pool, interner, symbols).lower(),
-        |mir, existing_slots| RegAlloc::new(mir, existing_slots).allocate_with_spills(),
+        || {
+            let (mir, lowering) = if request.lowering {
+                let (mir, debug) = CfgLower::new_with_symbols(cfg, type_pool, interner, symbols)
+                    .lower_with_debug()?;
+                (mir, Some(debug))
+            } else {
+                (
+                    CfgLower::new_with_symbols(cfg, type_pool, interner, symbols).lower()?,
+                    None,
+                )
+            };
+            let mir_text = request.mir.then(|| mir.to_string());
+            Ok((
+                mir,
+                crate::BackendArtifacts {
+                    lowering,
+                    mir: mir_text,
+                    ..Default::default()
+                },
+            ))
+        },
+        |mir, existing_slots, artifacts| {
+            let (mir, spills, used_callee_saved, liveness, regalloc) =
+                RegAlloc::new_with_artifacts(mir, existing_slots, request.liveness)
+                    .allocate_with_artifacts(request.regalloc)?;
+            artifacts.liveness = liveness.map(|debug| debug.to_string());
+            artifacts.regalloc = regalloc.map(|debug| debug.to_string());
+            Ok((mir, spills, used_callee_saved))
+        },
         |mir| {
             peephole::optimize(mir.instructions_vec_mut());
         },
@@ -58,7 +103,7 @@ pub(crate) fn prepare_backend(
     )
 }
 
-fn generate_inner<T, Emit>(
+fn generate_inner(
     cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     strings: &[String],
@@ -66,12 +111,10 @@ fn generate_inner<T, Emit>(
     symbols: crate::MachineSymbolResolver<'_>,
     atoms: &[crate::LocalAtomProjection<'_>],
     require_complete_atoms: bool,
-    emit: Emit,
-) -> CompileResult<(T, Vec<String>)>
-where
-    Emit: for<'a> FnOnce(Emitter<'a>) -> CompileResult<T>,
-{
-    let mut prepared = prepare_backend(cfg, type_pool, interner, symbols)?;
+    request: crate::BackendArtifactRequest,
+) -> CompileResult<crate::BackendProduct> {
+    let (mut prepared, mut artifacts) =
+        prepare_backend_with_artifacts(cfg, type_pool, interner, symbols, request)?;
     let referenced_strings = prepared
         .mir
         .instructions()
@@ -104,8 +147,26 @@ where
     .with_sret(prepared.has_sret)
     .with_frame_layout(prepared.frame_layout)
     .with_param_homing(prepared.param_homing.clone());
-    let emitted = emit(emitter)?;
-    Ok((emitted, local_strings))
+    let machine_code = if request.asm {
+        let emitted = emitter.emit_all()?;
+        artifacts.asm = Some(emitted.to_asm());
+        MachineCode {
+            code: emitted.to_bytes(),
+            relocations: emitted.relocations,
+            strings: local_strings,
+        }
+    } else {
+        let (code, relocations) = emitter.emit()?;
+        MachineCode {
+            code,
+            relocations,
+            strings: local_strings,
+        }
+    };
+    Ok(crate::BackendProduct {
+        machine_code,
+        artifacts,
+    })
 }
 
 /// Generate machine code from CFG.
@@ -118,7 +179,7 @@ pub fn generate(
     strings: &[String],
     interner: &ThreadedRodeo,
 ) -> CompileResult<MachineCode> {
-    let ((code, relocations), strings) = generate_inner(
+    Ok(generate_inner(
         cfg,
         type_pool,
         strings,
@@ -126,16 +187,9 @@ pub fn generate(
         crate::MachineSymbolResolver::default(),
         &[],
         false,
-        |emitter| {
-            // Keep the normal path allocation-free with respect to assembly text.
-            emitter.emit()
-        },
-    )?;
-    Ok(MachineCode {
-        code,
-        relocations,
-        strings,
-    })
+        crate::BackendArtifactRequest::default(),
+    )?
+    .machine_code)
 }
 
 pub fn generate_with_symbols(
@@ -145,7 +199,7 @@ pub fn generate_with_symbols(
     interner: &ThreadedRodeo,
     symbols: crate::MachineSymbolResolver<'_>,
 ) -> CompileResult<MachineCode> {
-    let ((code, relocations), strings) = generate_inner(
+    Ok(generate_inner(
         cfg,
         type_pool,
         strings,
@@ -153,13 +207,9 @@ pub fn generate_with_symbols(
         symbols,
         &[],
         false,
-        |emitter| emitter.emit(),
-    )?;
-    Ok(MachineCode {
-        code,
-        relocations,
-        strings,
-    })
+        crate::BackendArtifactRequest::default(),
+    )?
+    .machine_code)
 }
 
 pub fn generate_with_symbols_and_atoms(
@@ -170,7 +220,7 @@ pub fn generate_with_symbols_and_atoms(
     symbols: crate::MachineSymbolResolver<'_>,
     atoms: &[crate::LocalAtomProjection<'_>],
 ) -> CompileResult<MachineCode> {
-    let ((code, relocations), strings) = generate_inner(
+    Ok(generate_inner(
         cfg,
         type_pool,
         strings,
@@ -178,82 +228,22 @@ pub fn generate_with_symbols_and_atoms(
         symbols,
         atoms,
         true,
-        |emitter| emitter.emit(),
-    )?;
-    Ok(MachineCode {
-        code,
-        relocations,
-        strings,
-    })
+        crate::BackendArtifactRequest::default(),
+    )?
+    .machine_code)
 }
 
-/// Generate machine code with assembly text from CFG.
-///
-/// This returns both machine code bytes and human-readable assembly text
-/// showing the actual emitted instructions (including prologue/epilogue).
-pub fn generate_with_asm(
+/// Run the production backend and retain requested diagnostic projections.
+pub fn generate_product_with_symbols_and_atoms(
     cfg: &ValidatedCfg,
     type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
-) -> CompileResult<(MachineCode, String)> {
-    let (emitted, strings) = generate_inner(
-        cfg,
-        type_pool,
-        strings,
-        interner,
-        crate::MachineSymbolResolver::default(),
-        &[],
-        false,
-        |emitter| emitter.emit_all(),
-    )?;
-    let asm = emitted.to_asm();
-    let machine_code = MachineCode {
-        code: emitted.to_bytes(),
-        relocations: emitted.relocations,
-        strings,
-    };
-    Ok((machine_code, asm))
-}
-
-/// Generate register allocation debug info from CFG.
-///
-/// This returns information about the register allocation process,
-/// including live ranges, interference, and allocation decisions.
-pub fn generate_regalloc_info(
-    cfg: &ValidatedCfg,
-    type_pool: &FrozenTypeInternPool,
-    interner: &ThreadedRodeo,
-) -> CompileResult<RegAllocDebugInfo<Reg>> {
-    let has_sret = crate::codegen_pipeline::validate_pre_lowering_budget(
-        cfg,
-        type_pool,
-        cfg_lower::ARG_REGS.len() as u32,
-        cfg_lower::RET_REGS.len() as u32,
-        crate::frame_layout::SavedRegScheme::X86_64,
-    )?;
-
-    // Lower CFG to X86Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, interner).lower()?;
-
-    // Allocate physical registers with debug info
-    let existing_slots = crate::codegen_pipeline::checked_slot_sum([
-        cfg.num_locals(),
-        cfg.num_params(),
-        u32::from(has_sret),
-    ])
-    .ok_or_else(|| crate::codegen_pipeline::frame_budget_error(cfg, None))?;
-    let (_mir, num_spills, used_callee_saved, debug_info) =
-        RegAlloc::new(mir, existing_slots).allocate_with_debug()?;
-    let total_slots = existing_slots
-        .checked_add(num_spills)
-        .ok_or_else(|| crate::codegen_pipeline::frame_budget_error(cfg, None))?;
-    crate::frame_layout::FrameLayout::try_new(
-        crate::frame_layout::SavedRegScheme::X86_64,
-        used_callee_saved.len(),
-        total_slots,
+    symbols: crate::MachineSymbolResolver<'_>,
+    atoms: &[crate::LocalAtomProjection<'_>],
+    request: crate::BackendArtifactRequest,
+) -> CompileResult<crate::BackendProduct> {
+    generate_inner(
+        cfg, type_pool, strings, interner, symbols, atoms, true, request,
     )
-    .map_err(|_| crate::codegen_pipeline::frame_budget_error(cfg, None))?;
-
-    Ok(debug_info)
 }

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -59,6 +59,16 @@ impl RegAlloc {
         }
     }
 
+    pub(crate) fn new_with_artifacts(
+        mir: X86Mir,
+        existing_locals: u32,
+        capture_liveness: bool,
+    ) -> Self {
+        Self {
+            driver: RegAllocDriver::new_with_artifacts(mir, existing_locals, capture_liveness),
+        }
+    }
+
     pub fn num_spills(&self) -> u32 {
         self.driver.num_spills()
     }
@@ -75,6 +85,19 @@ impl RegAlloc {
         self,
     ) -> CompileResult<(X86Mir, u32, Vec<Reg>, RegAllocDebugInfo<Reg>)> {
         self.driver.allocate_with_debug()
+    }
+
+    pub(crate) fn allocate_with_artifacts(
+        self,
+        capture_regalloc: bool,
+    ) -> CompileResult<(
+        X86Mir,
+        u32,
+        Vec<Reg>,
+        Option<crate::LivenessDebugInfo>,
+        Option<RegAllocDebugInfo<Reg>>,
+    )> {
+        self.driver.allocate_with_artifacts(capture_regalloc)
     }
 
     fn rewrite_inst(
@@ -1243,6 +1266,12 @@ impl RegAllocBackend for X86Backend {
 
     fn analyze(mir: &Self::Mir) -> LivenessInfo<Self::Reg> {
         liveness::analyze(mir)
+    }
+
+    fn analyze_with_debug(
+        mir: &Self::Mir,
+    ) -> (LivenessInfo<Self::Reg>, crate::regalloc::LivenessDebugInfo) {
+        liveness::analyze_with_debug(mir)
     }
 
     fn analyze_loops(mir: &Self::Mir) -> LoopInfo {

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1474,7 +1474,15 @@ fn removed_parallel_entry_points_cannot_return() {
 fn orphaned_backend_inspection_exports_cannot_return() {
     let facade = include_str!("lib.rs");
     let backend = include_str!("backend.rs");
-    let removed = ["generate_allocated_mir"];
+    let unstable = include_str!("unstable.rs");
+    let removed = [
+        "generate_allocated_mir",
+        "generate_emitted_asm",
+        "generate_liveness_info",
+        "generate_lowering_info",
+        "generate_mir",
+        "generate_regalloc_info",
+    ];
 
     for name in removed {
         assert!(
@@ -1485,7 +1493,15 @@ fn orphaned_backend_inspection_exports_cannot_return() {
             !code_identifiers(backend).contains(&name),
             "orphaned backend inspection path returned: {name}"
         );
+        assert!(
+            !code_identifiers(unstable).contains(&name),
+            "unstable presentation regained a parallel backend path: {name}"
+        );
     }
+    assert!(
+        code_identifiers(unstable).contains(&"generate_backend_products"),
+        "unstable presentation must project the canonical production backend product"
+    );
 }
 
 #[test]

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -59,6 +59,13 @@ fn foreign_call_symbol_mappings(
     symbol_mappings
 }
 
+/// Canonical per-function result of the production backend pipeline.
+pub(crate) struct FunctionBackendProduct {
+    pub(crate) machine_name: String,
+    pub(crate) machine_code: rue_codegen::MachineCode,
+    pub(crate) artifacts: rue_codegen::BackendArtifacts,
+}
+
 /// Compile analyzed functions to a binary.
 ///
 /// This backend handles both architectures. It:
@@ -150,25 +157,25 @@ pub(crate) fn generate_pre_link_objects(
         }
     }
 
-    // Generate object files based on target architecture
-    let mut object_files = match options.target.arch() {
-        Arch::X86_64 => generate_x86_64_objects(
-            functions,
-            type_pool,
-            strings,
-            interner,
-            options,
-            foreign_symbols,
-        )?,
-        Arch::Aarch64 => generate_aarch64_objects(
-            functions,
-            type_pool,
-            strings,
-            interner,
-            options,
-            foreign_symbols,
-        )?,
-    };
+    let products = generate_backend_products(
+        functions,
+        type_pool,
+        strings,
+        interner,
+        options,
+        foreign_symbols,
+        rue_codegen::BackendArtifactRequest::default(),
+    )?;
+    let mut object_files = products
+        .into_iter()
+        .map(|product| project_backend_object(product, options.target))
+        .collect::<CompileResult<Vec<_>>>()
+        .map_err(CompileErrors::from)?;
+    info!(
+        function_count = functions.len(),
+        object_bytes = object_files.iter().map(Vec::len).sum::<usize>(),
+        "codegen complete"
+    );
 
     // Emit a C-ABI entry thunk object for every `pub extern "C" fn` export
     // (ADR-0064 P4). The native body was already generated above under its
@@ -182,23 +189,25 @@ pub(crate) fn generate_pre_link_objects(
     Ok(object_files)
 }
 
-/// Generate x86-64 object files for all functions.
+/// Run the production per-function backend pipeline, optionally retaining
+/// diagnostic projections from that exact execution.
 #[allow(clippy::too_many_arguments)]
-fn generate_x86_64_objects(
+pub(crate) fn generate_backend_products(
     functions: &[FunctionWithCfg],
     type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
     options: &CompileOptions,
     foreign_symbols: &[String],
-) -> MultiErrorResult<Vec<Vec<u8>>> {
-    let _span = info_span!("codegen", arch = "x86_64").entered();
+    request: rue_codegen::BackendArtifactRequest,
+) -> MultiErrorResult<Vec<FunctionBackendProduct>> {
+    let _span = info_span!("codegen", arch = ?options.target.arch()).entered();
     let symbol_mappings = foreign_call_symbol_mappings(functions, foreign_symbols);
     let foreign_set: std::collections::BTreeSet<String> = foreign_symbols.iter().cloned().collect();
     let symbols =
         rue_codegen::MachineSymbolResolver::new_with_foreign(&symbol_mappings, &foreign_set);
 
-    let results: Vec<CompileResult<Vec<u8>>> = functions
+    let results: Vec<CompileResult<FunctionBackendProduct>> = functions
         .par_iter()
         .map(|func| {
             let stable_atom_ids = func
@@ -220,122 +229,77 @@ fn generate_x86_64_objects(
                     content: &atom.content,
                 })
                 .collect::<Vec<_>>();
-            let machine_code = rue_codegen::x86_64::generate_with_symbols_and_atoms(
-                &func.cfg,
-                type_pool,
-                strings,
-                interner,
-                symbols,
-                &atom_projection,
-            )?;
-            validate_production_call_relocations(&machine_code.relocations, &symbol_mappings)?;
-
-            let mut obj_builder = ObjectBuilder::new(options.target, &func.machine_name)
-                .code(machine_code.code)
-                .strings(machine_code.strings);
-
-            for reloc in machine_code.relocations {
-                let rel_type = match reloc.kind {
-                    RelocationKind::X86Pc32 => RelocationType::Pc32,
-                    RelocationKind::X86Plt32 => RelocationType::Plt32,
-                    RelocationKind::Aarch64AdrpPage21
-                    | RelocationKind::Aarch64AddLo12
-                    | RelocationKind::Aarch64Call26 => {
-                        unreachable!("x86-64 codegen emitted AArch64 relocation {:?}", reloc.kind)
-                    }
-                };
-
-                obj_builder = obj_builder.relocation(CodeRelocation {
-                    offset: reloc.offset,
-                    symbol: reloc.symbol,
-                    rel_type,
-                    addend: reloc.addend,
-                });
+            let mut product = match options.target.arch() {
+                Arch::X86_64 => rue_codegen::x86_64::generate_product_with_symbols_and_atoms(
+                    &func.cfg,
+                    type_pool,
+                    strings,
+                    interner,
+                    symbols,
+                    &atom_projection,
+                    request,
+                )?,
+                Arch::Aarch64 => rue_codegen::aarch64::generate_product_with_symbols_and_atoms(
+                    &func.cfg,
+                    type_pool,
+                    strings,
+                    interner,
+                    options.target,
+                    symbols,
+                    &atom_projection,
+                    request,
+                )?,
+            };
+            if let Some(lowering) = &mut product.artifacts.lowering {
+                lowering.fn_name.clone_from(&func.machine_name);
             }
-
-            Ok(obj_builder.build())
+            validate_production_call_relocations(
+                &product.machine_code.relocations,
+                &symbol_mappings,
+            )?;
+            Ok(FunctionBackendProduct {
+                machine_name: func.machine_name.clone(),
+                machine_code: product.machine_code,
+                artifacts: product.artifacts,
+            })
         })
         .collect();
 
-    collect_codegen_results(results, functions.len())
+    results
+        .into_iter()
+        .collect::<CompileResult<Vec<_>>>()
+        .map_err(CompileErrors::from)
 }
 
-/// Generate AArch64 object files for all functions.
-#[allow(clippy::too_many_arguments)]
-fn generate_aarch64_objects(
-    functions: &[FunctionWithCfg],
-    type_pool: &FrozenTypeInternPool,
-    strings: &[String],
-    interner: &ThreadedRodeo,
-    options: &CompileOptions,
-    foreign_symbols: &[String],
-) -> MultiErrorResult<Vec<Vec<u8>>> {
-    let _span = info_span!("codegen", arch = "aarch64").entered();
-    let symbol_mappings = foreign_call_symbol_mappings(functions, foreign_symbols);
-    let foreign_set: std::collections::BTreeSet<String> = foreign_symbols.iter().cloned().collect();
-    let symbols =
-        rue_codegen::MachineSymbolResolver::new_with_foreign(&symbol_mappings, &foreign_set);
+fn project_backend_object(
+    product: FunctionBackendProduct,
+    target: Target,
+) -> CompileResult<Vec<u8>> {
+    let mut obj_builder = ObjectBuilder::new(target, &product.machine_name)
+        .code(product.machine_code.code)
+        .strings(product.machine_code.strings);
 
-    let results: Vec<CompileResult<Vec<u8>>> = functions
-        .par_iter()
-        .map(|func| {
-            let stable_atom_ids = func
-                .local_atoms
-                .iter()
-                .map(|atom| {
-                    crate::StableSymbolEncoder::encode(&crate::StableSymbolId::LocalAtom(
-                        atom.identity.clone(),
-                    ))
-                })
-                .collect::<Vec<_>>();
-            let atom_projection = func
-                .local_atoms
-                .iter()
-                .zip(&stable_atom_ids)
-                .map(|(atom, stable_id)| rue_codegen::LocalAtomProjection {
-                    stable_id,
-                    dense_id: atom.dense_id,
-                    content: &atom.content,
-                })
-                .collect::<Vec<_>>();
-            let machine_code = rue_codegen::aarch64::generate_with_symbols_and_atoms(
-                &func.cfg,
-                type_pool,
-                strings,
-                interner,
-                options.target,
-                symbols,
-                &atom_projection,
-            )?;
-            validate_production_call_relocations(&machine_code.relocations, &symbol_mappings)?;
-
-            let mut obj_builder = ObjectBuilder::new(options.target, &func.machine_name)
-                .code(machine_code.code)
-                .strings(machine_code.strings);
-
-            for reloc in machine_code.relocations {
-                let rel_type = match reloc.kind {
-                    RelocationKind::Aarch64AdrpPage21 => RelocationType::AdrpPage21,
-                    RelocationKind::Aarch64AddLo12 => RelocationType::AddLo12,
-                    RelocationKind::Aarch64Call26 => RelocationType::Call26,
-                    RelocationKind::X86Pc32 | RelocationKind::X86Plt32 => {
-                        unreachable!("AArch64 codegen emitted x86-64 relocation {:?}", reloc.kind)
-                    }
-                };
-
-                obj_builder = obj_builder.relocation(CodeRelocation {
-                    offset: reloc.offset,
-                    symbol: reloc.symbol,
-                    rel_type,
-                    addend: reloc.addend,
-                });
+    for reloc in product.machine_code.relocations {
+        let rel_type = match (target.arch(), reloc.kind) {
+            (Arch::X86_64, RelocationKind::X86Pc32) => RelocationType::Pc32,
+            (Arch::X86_64, RelocationKind::X86Plt32) => RelocationType::Plt32,
+            (Arch::Aarch64, RelocationKind::Aarch64AdrpPage21) => RelocationType::AdrpPage21,
+            (Arch::Aarch64, RelocationKind::Aarch64AddLo12) => RelocationType::AddLo12,
+            (Arch::Aarch64, RelocationKind::Aarch64Call26) => RelocationType::Call26,
+            (arch, kind) => {
+                return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+                    format!("{arch:?} codegen emitted incompatible relocation {kind:?}"),
+                )));
             }
-
-            Ok(obj_builder.build())
-        })
-        .collect();
-
-    collect_codegen_results(results, functions.len())
+        };
+        obj_builder = obj_builder.relocation(CodeRelocation {
+            offset: reloc.offset,
+            symbol: reloc.symbol,
+            rel_type,
+            addend: reloc.addend,
+        });
+    }
+    Ok(obj_builder.build())
 }
 
 /// Emit the C-ABI entry thunk objects for every `pub extern "C" fn` export
@@ -412,28 +376,6 @@ fn generate_export_thunk_objects(
     objects
 }
 
-/// Collect codegen results, propagating errors and logging stats.
-fn collect_codegen_results(
-    results: Vec<CompileResult<Vec<u8>>>,
-    function_count: usize,
-) -> MultiErrorResult<Vec<Vec<u8>>> {
-    let mut object_files = Vec::with_capacity(results.len());
-    let mut total_object_bytes = 0usize;
-
-    for result in results {
-        let obj = result.map_err(CompileErrors::from)?;
-        total_object_bytes += obj.len();
-        object_files.push(obj);
-    }
-
-    info!(
-        function_count,
-        object_bytes = total_object_bytes,
-        "codegen complete"
-    );
-    Ok(object_files)
-}
-
 /// Standalone codegen APIs retain their historical passthrough behavior, but
 /// the compiler's production path must never let an unresolved source or glue
 /// name reach the linker. Runtime exports and already-projected canonical
@@ -463,201 +405,6 @@ fn validate_production_call_relocations(
         )));
     }
     Ok(())
-}
-
-/// Machine IR that can hold either x86-64 or AArch64 MIR.
-///
-/// This enum allows the `--emit mir` and `--emit asm` commands to work
-/// with any target architecture.
-pub enum Mir {
-    /// x86-64 machine IR.
-    X86_64(X86Mir),
-    /// AArch64 machine IR.
-    Aarch64(Aarch64Mir),
-}
-
-impl std::fmt::Display for Mir {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Mir::X86_64(mir) => write!(f, "{}", mir),
-            Mir::Aarch64(mir) => write!(f, "{}", mir),
-        }
-    }
-}
-
-impl Mir {
-    /// Format MIR as assembly text.
-    ///
-    /// This prints the MIR instructions in assembly-like format.
-    /// When called with allocated MIR (post-regalloc), physical registers
-    /// are shown (rax, rbx, r12 for x86-64; x0, x1, x19 for aarch64).
-    #[cfg(test)]
-    #[allow(dead_code)]
-    pub fn format_assembly(&self) -> String {
-        let mut output = String::new();
-        match self {
-            Mir::X86_64(mir) => {
-                use rue_codegen::x86_64::X86Inst;
-                for inst in mir.instructions() {
-                    match inst {
-                        X86Inst::Label { id } => {
-                            output.push_str(&format!("{}:\n", id));
-                        }
-                        X86Inst::CallRel { symbol_id } => {
-                            output.push_str(&format!("    call {}\n", mir.get_symbol(*symbol_id)));
-                        }
-                        _ => {
-                            output.push_str(&format!("    {}\n", inst));
-                        }
-                    }
-                }
-            }
-            Mir::Aarch64(mir) => {
-                use rue_codegen::aarch64::Aarch64Inst;
-                for inst in mir.instructions() {
-                    match inst {
-                        Aarch64Inst::Label { id } => {
-                            output.push_str(&format!("{}:\n", id));
-                        }
-                        Aarch64Inst::Bl { symbol_id } => {
-                            output.push_str(&format!("    bl {}\n", mir.get_symbol(*symbol_id)));
-                        }
-                        _ => {
-                            output.push_str(&format!("    {}\n", inst));
-                        }
-                    }
-                }
-            }
-        }
-        output
-    }
-}
-
-/// Generate MIR from CFG for the given target (for debugging/inspection).
-///
-/// This returns the MIR before register allocation, with virtual registers.
-pub fn generate_mir(
-    cfg: &Cfg,
-    type_pool: &FrozenTypeInternPool,
-    interner: &ThreadedRodeo,
-    target: Target,
-) -> CompileResult<Mir> {
-    match target.arch() {
-        Arch::X86_64 => {
-            let mir = rue_codegen::x86_64::CfgLower::new(cfg, type_pool, interner).lower()?;
-            Ok(Mir::X86_64(mir))
-        }
-        Arch::Aarch64 => {
-            let mir =
-                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, interner, target).lower()?;
-            Ok(Mir::Aarch64(mir))
-        }
-    }
-}
-
-/// Generate liveness debug information for a CFG.
-///
-/// This performs liveness analysis on the MIR (before register allocation)
-/// and returns detailed per-instruction liveness information.
-///
-/// Used by `--emit liveness` to visualize which values are live at each program point.
-pub fn generate_liveness_info(
-    cfg: &Cfg,
-    type_pool: &FrozenTypeInternPool,
-    interner: &ThreadedRodeo,
-    target: Target,
-) -> CompileResult<rue_codegen::LivenessDebugInfo> {
-    match target.arch() {
-        Arch::X86_64 => {
-            let mir = rue_codegen::x86_64::CfgLower::new(cfg, type_pool, interner).lower()?;
-            Ok(rue_codegen::x86_64::liveness::analyze_debug(&mir))
-        }
-        Arch::Aarch64 => {
-            let mir =
-                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, interner, target).lower()?;
-            Ok(rue_codegen::aarch64::liveness::analyze_debug(&mir))
-        }
-    }
-}
-
-/// Generate lowering debug information for a CFG.
-///
-/// This performs CFG-to-MIR lowering (instruction selection) and returns
-/// detailed information about how each CFG instruction maps to MIR instructions.
-///
-/// Used by `--emit lowering` to visualize the instruction selection process.
-pub fn generate_lowering_info(
-    cfg: &Cfg,
-    type_pool: &FrozenTypeInternPool,
-    interner: &ThreadedRodeo,
-    target: Target,
-) -> CompileResult<rue_codegen::LoweringDebugInfo> {
-    match target.arch() {
-        Arch::X86_64 => {
-            let (_mir, debug_info) =
-                rue_codegen::x86_64::CfgLower::new(cfg, type_pool, interner).lower_with_debug()?;
-            Ok(debug_info)
-        }
-        Arch::Aarch64 => {
-            let (_mir, debug_info) =
-                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, interner, target)
-                    .lower_with_debug()?;
-            Ok(debug_info)
-        }
-    }
-}
-
-/// Generate the actual emitted assembly text for a CFG.
-///
-/// Unlike `format_assembly()` on Mir which shows MIR instructions,
-/// this returns the actual assembly that will be emitted, including
-/// prologue/epilogue code that the emitter adds.
-///
-/// This is useful for debugging and for --emit asm output that accurately
-/// reflects what's in the binary.
-pub fn generate_emitted_asm(
-    cfg: &Cfg,
-    type_pool: &FrozenTypeInternPool,
-    strings: &[String],
-    interner: &ThreadedRodeo,
-    target: Target,
-) -> CompileResult<String> {
-    match target.arch() {
-        Arch::X86_64 => {
-            let (_machine_code, asm) =
-                rue_codegen::x86_64::generate_with_asm(cfg, type_pool, strings, interner)?;
-            Ok(asm)
-        }
-        Arch::Aarch64 => {
-            let (_machine_code, asm) =
-                rue_codegen::aarch64::generate_with_asm(cfg, type_pool, strings, interner, target)?;
-            Ok(asm)
-        }
-    }
-}
-
-/// Generate register allocation debug information for a CFG.
-///
-/// This returns information about the register allocation process,
-/// including live ranges, interference edges, and allocation decisions.
-/// The output is formatted as a human-readable string.
-pub fn generate_regalloc_info(
-    cfg: &Cfg,
-    type_pool: &FrozenTypeInternPool,
-    interner: &ThreadedRodeo,
-    target: Target,
-) -> CompileResult<String> {
-    match target.arch() {
-        Arch::X86_64 => {
-            let debug_info = rue_codegen::x86_64::generate_regalloc_info(cfg, type_pool, interner)?;
-            Ok(debug_info.to_string())
-        }
-        Arch::Aarch64 => {
-            let debug_info =
-                rue_codegen::aarch64::generate_regalloc_info(cfg, type_pool, interner, target)?;
-            Ok(debug_info.to_string())
-        }
-    }
 }
 
 // ============================================================================
@@ -816,19 +563,30 @@ drop fn StrBuf(self) { }
 
     fn assert_three_result_slots_cross_cleanup(target: Target) {
         let (rir, semantic) = strbuf_concat_frontend();
-        let main = semantic
-            .functions()
-            .iter()
-            .find(|function| function.analyzed.name == "main")
-            .unwrap();
-        let assembly = generate_emitted_asm(
-            &main.cfg,
+        let options = CompileOptions {
+            target,
+            ..Default::default()
+        };
+        let interner = rir.semantic_symbols().interner();
+        let foreign_symbols = collect_foreign_symbols(rir.rir(), interner);
+        let products = generate_backend_products(
+            semantic.functions(),
             semantic.type_pool(),
             semantic.strings(),
-            rir.semantic_symbols().interner(),
-            target,
+            interner,
+            &options,
+            &foreign_symbols,
+            rue_codegen::BackendArtifactRequest {
+                asm: true,
+                ..Default::default()
+            },
         )
         .unwrap();
+        let assembly = products
+            .into_iter()
+            .find(|product| product.machine_name == "main")
+            .and_then(|product| product.artifacts.asm)
+            .expect("main assembly projection");
         let instructions = assembly
             .lines()
             .map(|line| line.split_once(":   ").map_or(line, |(_, inst)| inst))
@@ -878,9 +636,24 @@ drop fn StrBuf(self) { }
         let stores = frame_accesses(true);
         let loads = frame_accesses(false);
 
+        let concat_symbols = semantic
+            .functions()
+            .iter()
+            .filter(|function| function.analyzed.name.contains("concat_borrowed"))
+            .map(|function| function.machine_name.as_str())
+            .collect::<HashSet<_>>();
+        let cleanup_symbols = semantic
+            .functions()
+            .iter()
+            .filter(|function| {
+                function.analyzed.name.contains(".__drop")
+                    || function.analyzed.name.starts_with("__rue_drop_")
+            })
+            .map(|function| function.machine_name.as_str())
+            .collect::<HashSet<_>>();
         let concats: Vec<_> = calls
             .iter()
-            .filter(|(_, symbol)| symbol.contains("concat_borrowed"))
+            .filter(|(_, symbol)| concat_symbols.contains(symbol.as_str()))
             .collect();
         assert_eq!(concats.len(), 2, "{target}: expected both concatenations");
 
@@ -897,7 +670,7 @@ drop fn StrBuf(self) { }
                 .filter(|(index, symbol)| {
                     index > concat_index
                         && *index < println_index
-                        && (symbol.contains(".__drop") || symbol.starts_with("__rue_drop_"))
+                        && cleanup_symbols.contains(symbol.as_str())
                 })
                 .map(|(index, _)| *index)
                 .collect();
@@ -936,24 +709,15 @@ drop fn StrBuf(self) { }
                 target,
                 ..CompileOptions::default()
             };
-            let objects = match target.arch() {
-                Arch::X86_64 => generate_x86_64_objects(
-                    semantic.functions(),
-                    semantic.type_pool(),
-                    semantic.strings(),
-                    interner,
-                    &options,
-                    &[],
-                ),
-                Arch::Aarch64 => generate_aarch64_objects(
-                    semantic.functions(),
-                    semantic.type_pool(),
-                    semantic.strings(),
-                    interner,
-                    &options,
-                    &[],
-                ),
-            }
+            let objects = generate_pre_link_objects(
+                semantic.functions(),
+                semantic.type_pool(),
+                semantic.strings(),
+                interner,
+                &options,
+                &[],
+                &[],
+            )
             .unwrap();
 
             let all_object_bytes: Vec<_> = objects.into_iter().flatten().collect();
@@ -978,24 +742,15 @@ drop fn StrBuf(self) { }
                 target,
                 ..CompileOptions::default()
             };
-            let objects = match target.arch() {
-                Arch::X86_64 => generate_x86_64_objects(
-                    semantic.functions(),
-                    semantic.type_pool(),
-                    semantic.strings(),
-                    interner,
-                    &options,
-                    &[],
-                ),
-                Arch::Aarch64 => generate_aarch64_objects(
-                    semantic.functions(),
-                    semantic.type_pool(),
-                    semantic.strings(),
-                    interner,
-                    &options,
-                    &[],
-                ),
-            }
+            let objects = generate_pre_link_objects(
+                semantic.functions(),
+                semantic.type_pool(),
+                semantic.strings(),
+                interner,
+                &options,
+                &[],
+                &[],
+            )
             .unwrap();
 
             let mut undefined = HashSet::new();

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -1145,7 +1145,7 @@ drop fn StrBuf(self) { }
                 );
 
                 for &target in Target::all() {
-                    generate_mir(cfg, &state.type_pool, &state.interner, target)
+                    test_codegen_state(&state, target)
                         .unwrap_or_else(|error| panic!("{name} must lower for {target}: {error}"));
                 }
                 test_compile_source(&source).unwrap_or_else(|error| {
@@ -1220,7 +1220,7 @@ drop fn StrBuf(self) { }
                 );
 
                 for &target in Target::all() {
-                    generate_mir(cfg, &state.type_pool, &state.interner, target)
+                    test_codegen_state(&state, target)
                         .unwrap_or_else(|error| panic!("{name} must lower for {target}: {error}"));
                 }
                 test_compile_source(&source).unwrap_or_else(|error| {
@@ -1259,12 +1259,8 @@ drop fn StrBuf(self) { }
                 let state = test_cfg(&source)
                     .unwrap_or_else(|error| panic!("never must coerce to {name}: {error}"));
                 for &target in Target::all() {
-                    for function in &state.functions {
-                        generate_mir(&function.cfg, &state.type_pool, &state.interner, target)
-                            .unwrap_or_else(|error| {
-                                panic!("{name} must lower for {target}: {error}")
-                            });
-                    }
+                    test_codegen_state(&state, target)
+                        .unwrap_or_else(|error| panic!("{name} must lower for {target}: {error}"));
                 }
                 test_compile_source(&source)
                     .unwrap_or_else(|error| panic!("{name} must compile and link: {error}"));

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -196,8 +196,6 @@ pub(crate) use source_identity::{
 
 // Immutable query artifacts and stable identities returned by CompilerSession.
 #[cfg(test)]
-pub(crate) use backend::generate_mir;
-#[cfg(test)]
 pub(crate) use body_query::{BodyTransaction, transaction_equal};
 pub(crate) use bound_definitions::{
     BoundDefinitionRecord, BoundDefinitionSet, StableDefinitionKey, StableDefinitionKind,
@@ -264,7 +262,7 @@ pub(crate) use syntax::SyntaxWork;
 pub(crate) use lasso::ThreadedRodeo;
 pub(crate) use rue_air::{AnalyzedFunction, SemaOutput, Type};
 pub(crate) use rue_cfg::{CfgBuilder, ValidatedCfg as Cfg};
-pub(crate) use rue_codegen::{RelocationKind, X86Mir, aarch64::Aarch64Mir};
+pub(crate) use rue_codegen::RelocationKind;
 pub(crate) use rue_linker::{
     Archive, CodeRelocation, Linker, ObjectBuilder, ObjectFile, RelocationType,
 };

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -585,20 +585,24 @@ mod tests {
         assert_eq!(parameter_type("aliased"), Type::new_struct(canonical_id));
 
         for &target in Target::all() {
-            for function in semantic.functions() {
-                generate_mir(
-                    &function.cfg,
-                    pool,
-                    rir.semantic_symbols().interner(),
-                    target,
-                )
-                .unwrap_or_else(|error| {
-                    panic!(
-                        "canonical source StrBuf function {} should lower for {target}: {error}",
-                        function.analyzed.name
-                    )
-                });
-            }
+            let options = CompileOptions {
+                target,
+                ..Default::default()
+            };
+            let interner = rir.semantic_symbols().interner();
+            let foreign_symbols = crate::backend::collect_foreign_symbols(rir.rir(), interner);
+            crate::backend::generate_backend_products(
+                semantic.functions(),
+                pool,
+                semantic.strings(),
+                interner,
+                &options,
+                &foreign_symbols,
+                rue_codegen::BackendArtifactRequest::default(),
+            )
+            .unwrap_or_else(|error| {
+                panic!("canonical source StrBuf functions should lower for {target}: {error}")
+            });
         }
     }
 
@@ -1933,15 +1937,8 @@ mod tests {
         }
 
         for &target in Target::all() {
-            for function in &state.functions {
-                generate_mir(&function.cfg, &state.type_pool, &state.interner, target)
-                    .unwrap_or_else(|error| {
-                        panic!(
-                            "{} should lower for {target}: {error}",
-                            function.analyzed.name
-                        )
-                    });
-            }
+            test_codegen_state(&state, target)
+                .unwrap_or_else(|error| panic!("drop glue should lower for {target}: {error}"));
         }
     }
 

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -127,6 +127,8 @@ pub(crate) struct CompileState {
     pub functions: Vec<FunctionWithCfg>,
     /// Type intern pool containing all struct and enum definitions.
     pub type_pool: FrozenTypeInternPool,
+    /// String literals referenced by test CFGs.
+    pub strings: Vec<String>,
     /// Warnings collected during compilation.
     pub warnings: Vec<CompileWarning>,
 }

--- a/crates/rue-compiler/src/test_support.rs
+++ b/crates/rue-compiler/src/test_support.rs
@@ -35,13 +35,31 @@ pub(crate) fn test_cfg(source: &str) -> MultiErrorResult<CompileState> {
     let semantic = std::sync::Arc::try_unwrap(semantic)
         .expect("test session uniquely owns its semantic output after return");
     let (_, symbols) = rir.into_parts();
-    let (functions, type_pool, _, warnings) = semantic.into_parts();
+    let (functions, type_pool, strings, warnings) = semantic.into_parts();
     Ok(CompileState {
         interner: symbols.into_interner(),
         functions,
         type_pool,
+        strings,
         warnings,
     })
+}
+
+pub(crate) fn test_codegen_state(state: &CompileState, target: Target) -> MultiErrorResult<()> {
+    let options = CompileOptions {
+        target,
+        ..Default::default()
+    };
+    crate::backend::generate_backend_products(
+        &state.functions,
+        &state.type_pool,
+        &state.strings,
+        &state.interner,
+        &options,
+        &[],
+        rue_codegen::BackendArtifactRequest::default(),
+    )
+    .map(drop)
 }
 
 pub(crate) fn test_frontend_snapshot(

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -741,119 +741,152 @@ impl crate::CompilerSession {
                     .selected_semantic_rir_owner()
                     .expect("successful semantic query retains canonical RIR");
                 let interner = rir.semantic_symbols().interner();
-                for function in semantic.functions() {
-                    match stage {
-                        PresentationStage::Air => {
-                            writeln!(&mut text, "function {}:", function.analyzed.name)
+                let backend_request = match stage {
+                    PresentationStage::Lowering => Some(rue_codegen::BackendArtifactRequest {
+                        lowering: true,
+                        ..Default::default()
+                    }),
+                    PresentationStage::Mir => Some(rue_codegen::BackendArtifactRequest {
+                        mir: true,
+                        ..Default::default()
+                    }),
+                    PresentationStage::Liveness => Some(rue_codegen::BackendArtifactRequest {
+                        liveness: true,
+                        ..Default::default()
+                    }),
+                    PresentationStage::RegAlloc => Some(rue_codegen::BackendArtifactRequest {
+                        regalloc: true,
+                        ..Default::default()
+                    }),
+                    PresentationStage::Asm => Some(rue_codegen::BackendArtifactRequest {
+                        asm: true,
+                        ..Default::default()
+                    }),
+                    _ => None,
+                };
+                if let Some(backend_request) = backend_request {
+                    let foreign_symbols =
+                        crate::backend::collect_foreign_symbols(rir.rir(), interner);
+                    let products = crate::backend::generate_backend_products(
+                        semantic.functions(),
+                        semantic.type_pool(),
+                        semantic.strings(),
+                        interner,
+                        request.options,
+                        &foreign_symbols,
+                        backend_request,
+                    )?;
+                    for product in products {
+                        match stage {
+                            PresentationStage::Lowering => {
+                                write!(
+                                    &mut text,
+                                    "{}",
+                                    product
+                                        .artifacts
+                                        .lowering
+                                        .expect("lowering projection was requested")
+                                )
                                 .expect("write to String");
-                            writeln!(
-                                &mut text,
-                                "{}",
-                                function.analyzed.air.display_with_interner(interner)
-                            )
-                            .expect("write to String");
-                        }
-                        PresentationStage::Cfg => {
-                            writeln!(
-                                &mut text,
-                                "{}",
-                                function.cfg.display_with_interner(interner)
-                            )
-                            .expect("write to String");
-                        }
-                        PresentationStage::Lowering => {
-                            write!(
-                                &mut text,
-                                "{}",
-                                crate::backend::generate_lowering_info(
-                                    &function.cfg,
-                                    semantic.type_pool(),
-                                    interner,
-                                    request.options.target,
-                                )?
-                            )
-                            .expect("write to String");
-                        }
-                        PresentationStage::Mir => {
-                            writeln!(&mut text, "function {}:", function.analyzed.name)
+                            }
+                            PresentationStage::Mir => {
+                                writeln!(&mut text, "function {}:", product.machine_name)
+                                    .expect("write to String");
+                                writeln!(
+                                    &mut text,
+                                    "{}",
+                                    product.artifacts.mir.expect("MIR projection was requested")
+                                )
                                 .expect("write to String");
-                            writeln!(
-                                &mut text,
-                                "{}",
-                                crate::backend::generate_mir(
-                                    &function.cfg,
-                                    semantic.type_pool(),
-                                    interner,
-                                    request.options.target,
-                                )?
-                            )
-                            .expect("write to String");
-                        }
-                        PresentationStage::Liveness => {
-                            writeln!(&mut text, "function {}:", function.analyzed.name)
+                            }
+                            PresentationStage::Liveness => {
+                                writeln!(&mut text, "function {}:", product.machine_name)
+                                    .expect("write to String");
+                                writeln!(
+                                    &mut text,
+                                    "{}",
+                                    product
+                                        .artifacts
+                                        .liveness
+                                        .expect("liveness projection was requested")
+                                )
                                 .expect("write to String");
-                            writeln!(
-                                &mut text,
-                                "{}",
-                                crate::backend::generate_liveness_info(
-                                    &function.cfg,
-                                    semantic.type_pool(),
-                                    interner,
-                                    request.options.target,
-                                )?
-                            )
-                            .expect("write to String");
-                        }
-                        PresentationStage::RegAlloc => {
-                            writeln!(&mut text, "function {}:", function.analyzed.name)
+                            }
+                            PresentationStage::RegAlloc => {
+                                writeln!(&mut text, "function {}:", product.machine_name)
+                                    .expect("write to String");
+                                write!(
+                                    &mut text,
+                                    "{}",
+                                    product
+                                        .artifacts
+                                        .regalloc
+                                        .expect("regalloc projection was requested")
+                                )
                                 .expect("write to String");
-                            write!(
-                                &mut text,
-                                "{}",
-                                crate::backend::generate_regalloc_info(
-                                    &function.cfg,
-                                    semantic.type_pool(),
-                                    interner,
-                                    request.options.target,
-                                )?
-                            )
-                            .expect("write to String");
-                        }
-                        PresentationStage::Asm => {
-                            writeln!(&mut text, ".globl {}", function.analyzed.name)
+                            }
+                            PresentationStage::Asm => {
+                                writeln!(&mut text, ".globl {}", product.machine_name)
+                                    .expect("write to String");
+                                writeln!(&mut text, "{}:", product.machine_name)
+                                    .expect("write to String");
+                                write!(
+                                    &mut text,
+                                    "{}",
+                                    product
+                                        .artifacts
+                                        .asm
+                                        .expect("assembly projection was requested")
+                                )
                                 .expect("write to String");
-                            writeln!(&mut text, "{}:", function.analyzed.name)
+                            }
+                            _ => unreachable!("backend request has a backend presentation stage"),
+                        }
+                    }
+                } else {
+                    for function in semantic.functions() {
+                        match stage {
+                            PresentationStage::Air => {
+                                writeln!(&mut text, "function {}:", function.analyzed.name)
+                                    .expect("write to String");
+                                writeln!(
+                                    &mut text,
+                                    "{}",
+                                    function.analyzed.air.display_with_interner(interner)
+                                )
                                 .expect("write to String");
-                            write!(
-                                &mut text,
-                                "{}",
-                                crate::backend::generate_emitted_asm(
-                                    &function.cfg,
-                                    semantic.type_pool(),
-                                    semantic.strings(),
-                                    interner,
-                                    request.options.target,
-                                )?
-                            )
-                            .expect("write to String");
+                            }
+                            PresentationStage::Cfg => {
+                                writeln!(
+                                    &mut text,
+                                    "{}",
+                                    function.cfg.display_with_interner(interner)
+                                )
+                                .expect("write to String");
+                            }
+                            PresentationStage::StackFrame => {
+                                writeln!(
+                                    &mut text,
+                                    "{}",
+                                    rue_codegen::generate_stack_frame_info(
+                                        &function.cfg,
+                                        &function.machine_name,
+                                        semantic.type_pool(),
+                                        interner,
+                                        request.options.target,
+                                    )?
+                                )
+                                .expect("write to String");
+                            }
+                            PresentationStage::Tokens
+                            | PresentationStage::Ast
+                            | PresentationStage::Rir
+                            | PresentationStage::Lowering
+                            | PresentationStage::Mir
+                            | PresentationStage::Liveness
+                            | PresentationStage::RegAlloc
+                            | PresentationStage::Asm => unreachable!(),
                         }
-                        PresentationStage::StackFrame => {
-                            writeln!(
-                                &mut text,
-                                "{}",
-                                rue_codegen::generate_stack_frame_info(
-                                    &function.cfg,
-                                    &function.analyzed.name,
-                                    semantic.type_pool(),
-                                    interner,
-                                    request.options.target,
-                                )?
-                            )
-                            .expect("write to String");
-                        }
-                        PresentationStage::Tokens
-                        | PresentationStage::Ast
-                        | PresentationStage::Rir => unreachable!(),
                     }
                 }
             }

--- a/crates/rue-spec/cases/golden/ir-dumps.toml
+++ b/crates/rue-spec/cases/golden/ir-dumps.toml
@@ -169,7 +169,7 @@ fn main() -> i32 {
 """
 target = "x86-64-linux"
 expected_mir = """
-function set:
+function __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s3_736574t0_:
     mov v0, [rbp-8]
     mov v1, 42
     mov [v0], v1
@@ -186,7 +186,7 @@ function main:
     mov rax, v4
     push rax
     pop rdi
-    call set
+    call __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s3_736574t0_
     mov v3, 0
     mov v5, [rbp-8]
     mov rdi, v5
@@ -209,7 +209,7 @@ fn main() -> i32 {
 """
 target = "aarch64-macos"
 expected_mir = """
-function set:
+function __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s3_736574t0_:
     ldr v0, [fp, #-8]
     mov v1, #42
     str v1, [v0]
@@ -224,7 +224,7 @@ function main:
     ldr v2, [fp, #-8]
     add v4, fp, #-8
     mov x0, v4
-    bl set
+    bl __rue_sem_v1_t0_t0_s8_746573742e727565t0_t0_s3_736574t0_
     mov v3, #0
     ldr v5, [fp, #-8]
     mov x0, v5

--- a/scripts/test-reproducible-output.sh
+++ b/scripts/test-reproducible-output.sh
@@ -290,7 +290,7 @@ assert_semantic_stage_markers() {
             return 1
         fi
     done
-    if ! grep -Fq '.globl Payload$left_2ftypes_2erue.__drop' "$output"; then
+    if ! grep -Fq '.globl __rue_sem_v1_' "$output"; then
         printf 'FAIL: semantic-order assembly stage emitted no pinned function body\n' >&2
         return 1
     fi
@@ -299,7 +299,7 @@ assert_semantic_stage_markers() {
 assert_cross_target_assembly() {
     local target="$1" output="$2"
     if ! grep -Fq "=== Assembly ($target) ===" "$output" ||
-        ! grep -Fq '.globl Payload$left_2ftypes_2erue.__drop' "$output"; then
+        ! grep -Fq '.globl __rue_sem_v1_' "$output"; then
         printf 'FAIL: %s assembly output is empty or incomplete\n' "$target" >&2
         return 1
     fi


### PR DESCRIPTION
## Summary

- make production codegen optionally retain diagnostic projections from the same backend execution
- route lowering, MIR, liveness, regalloc, and assembly output through that canonical product
- delete the peer diagnostic implementations and label backend views with production machine symbols
- add x86-64 and AArch64 parity coverage, including spills and relocation/string equivalence

## Validation

- `scripts/rue test`
- `scripts/rue cli backend_emits_use_production_symbols`
- `./buck2 test //:reproducible-programs`

Fixes RUE-1141.
Refs RUE-1031.