### PR TITLE
RUE-1137: carry observation-regime identity in the revision compatibility token

### DIFF
--- a/benchmarks/manifest.toml
+++ b/benchmarks/manifest.toml
@@ -41,11 +41,16 @@ scenarios = [
   # Bound tokens (RUE-850) removed the textual conversion discard, so the two
   # semantically unchanged CFGs stay reusable on ordinary source edits; these
   # rows mirror assert_structure in rue-compiler-session-bench.
-  { name = "leaf_edit", modules = [1, 6], semantic_bodies = [6, 0], cfgs = [4, 2], semantic_queries = [1, 0] },
-  { name = "widely_depended_definition_edit", modules = [1, 6], semantic_bodies = [6, 0], cfgs = [4, 2], semantic_queries = [1, 0] },
-  { name = "import_change", modules = [2, 5], semantic_bodies = [6, 0], cfgs = [4, 2], semantic_queries = [1, 0] },
-  { name = "diagnostic_error_edit", modules = [1, 6], semantic_bodies = [5, 0], cfgs = [0, 0], semantic_queries = [1, 0] },
-  { name = "diagnostic_recovery", modules = [1, 6], semantic_bodies = [6, 0], cfgs = [4, 2], semantic_queries = [1, 0] },
+  #
+  # RUE-1137 made the revision compatibility slot carry observation-regime
+  # identity rather than a per-request counter, so retained terminals survive an
+  # edit under unchanged read rules. The semantic_bodies columns are therefore
+  # the edit's reverse closure instead of the whole program.
+  { name = "leaf_edit", modules = [1, 6], semantic_bodies = [1, 5], cfgs = [4, 2], semantic_queries = [1, 0] },
+  { name = "widely_depended_definition_edit", modules = [1, 6], semantic_bodies = [1, 5], cfgs = [4, 2], semantic_queries = [1, 0] },
+  { name = "import_change", modules = [2, 5], semantic_bodies = [2, 4], cfgs = [4, 2], semantic_queries = [1, 0] },
+  { name = "diagnostic_error_edit", modules = [1, 6], semantic_bodies = [1, 4], cfgs = [0, 0], semantic_queries = [1, 0] },
+  { name = "diagnostic_recovery", modules = [1, 6], semantic_bodies = [1, 5], cfgs = [4, 2], semantic_queries = [1, 0] },
 ]
 
 [[benchmark]]

--- a/crates/rue-compiler-session-bench/src/representative.rs
+++ b/crates/rue-compiler-session-bench/src/representative.rs
@@ -385,14 +385,24 @@ fn assert_structure(scenarios: &[Value]) {
         ("no_change_query", [0, 0, 0, 0, 0, 0, 0, 1]),
         // Opaque bound tokens remove the old textual conversion discard, so
         // the two semantically unchanged CFGs remain reusable.
-        ("leaf_edit", [1, 6, 6, 0, 4, 2, 1, 0]),
-        ("widely_depended_definition_edit", [1, 6, 6, 0, 4, 2, 1, 0]),
-        ("import_change", [2, 5, 6, 0, 4, 2, 1, 0]),
-        ("diagnostic_error_edit", [1, 6, 5, 0, 0, 0, 1, 0]),
+        //
+        // Body reuse under rooted demand arrived with RUE-1137: the revision
+        // compatibility slot now carries observation-regime identity instead of
+        // a per-request counter, so an edit no longer invalidates every
+        // retained terminal for lack of a matching token. These rows are the
+        // reverse-closure of each edit, not the whole program.
+        ("leaf_edit", [1, 6, 1, 5, 4, 2, 1, 0]),
+        ("widely_depended_definition_edit", [1, 6, 1, 5, 4, 2, 1, 0]),
+        // The import edit drops one leaf and adds its replacement, so two
+        // modules are required and the removed module's dependents recompute.
+        ("import_change", [2, 5, 2, 4, 4, 2, 1, 0]),
+        // The failing body is required; the four unaffected bodies reuse. No
+        // CFG is built because the request fails before CFG construction.
+        ("diagnostic_error_edit", [1, 6, 1, 4, 0, 0, 1, 0]),
         // The failed ParseModule terminal is retained. Recovery changes only
         // that module's source leaf, so the other six module terminals remain
         // exact hits rather than being re-adopted after the diagnostic epoch.
-        ("diagnostic_recovery", [1, 6, 6, 0, 4, 2, 1, 0]),
+        ("diagnostic_recovery", [1, 6, 1, 5, 4, 2, 1, 0]),
     ];
     for (name, counts) in expected {
         let work = &get(name)["required_vs_reused_work"];

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -49,6 +49,48 @@ impl ImportDiscoveryContext {
     pub fn epoch(&self) -> u64 {
         self.epoch
     }
+
+    /// Stable identity of the filesystem *observation regime* (RUE-1137).
+    ///
+    /// This is the revision compatibility token for import-input publication.
+    /// It changes when the rules governing reads change — discovery epoch,
+    /// project root, std root, or read policy — and NOT when an individual
+    /// file changes. File changes are per-leaf stamp changes, so a retained
+    /// terminal stays validatable across an ordinary edit; a regime change
+    /// invalidates wholesale because the compiler can no longer relate its
+    /// retained observations to the new rules.
+    ///
+    /// Deriving this from content rather than from a per-request counter is
+    /// what allows warm reuse under rooted demand. The counter that used to
+    /// occupy this slot minted a fresh epoch per request, so no predecessor
+    /// terminal was ever eligible for red/green validation.
+    ///
+    /// A stable digest is used rather than `DefaultHasher` so the token does
+    /// not vary across processes or toolchain versions; the reproducibility
+    /// harness compares publication identity across runs.
+    pub fn regime_token(&self) -> u64 {
+        use sha2::{Digest, Sha256};
+
+        let mut digest = Sha256::new();
+        // Length-prefix every field so distinct field boundaries cannot be
+        // forged by concatenation (e.g. roots "/a" + "/bc" vs "/ab" + "/c").
+        let mut field = |bytes: &[u8]| {
+            digest.update((bytes.len() as u64).to_le_bytes());
+            digest.update(bytes);
+        };
+        field(&self.epoch.to_le_bytes());
+        field(self.project_root.as_bytes());
+        match self.std_root.as_deref() {
+            Some(root) => {
+                field(b"std");
+                field(root.as_bytes());
+            }
+            None => field(b"no-std"),
+        }
+        field(self.read_policy_revision.as_bytes());
+        let bytes = digest.finalize();
+        u64::from_le_bytes(bytes[..8].try_into().expect("sha256 yields 32 bytes"))
+    }
     pub fn project_root(&self) -> &str {
         &self.project_root
     }
@@ -610,7 +652,16 @@ pub enum ImportDemandMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ImportInputRevision {
     pub(crate) revision_id: u64,
+    /// Per-request identity. Distinguishes one rooted import-input request
+    /// from the next, and is what a trusted-toolchain successor delta must
+    /// match. This is deliberately NOT the revision compatibility token
+    /// (RUE-1137): keeping the two separate is what lets a successor request
+    /// reuse retained terminals while still being recognizable as a distinct
+    /// request.
     pub(crate) request_generation: u64,
+    /// Observation-regime identity, from [`ImportDiscoveryContext::regime_token`].
+    /// This occupies the runtime revision's compatibility slot.
+    pub(crate) compatibility_token: u64,
     pub(crate) frontier_round: u64,
 }
 

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -9644,7 +9644,7 @@ impl RevisionedQueryDatabase {
     /// queries must run on that successor revision when one exists.
     pub(crate) fn current_semantic_revision(&self) -> Option<Revision> {
         self.current_import_revision
-            .map(|revision| Revision::new(revision.revision_id, revision.request_generation))
+            .map(|revision| Revision::new(revision.revision_id, revision.compatibility_token))
             .or({
                 #[cfg(test)]
                 {
@@ -10925,7 +10925,7 @@ impl RevisionedQueryDatabase {
                 "import demand requested from a non-current immutable revision",
             ));
         }
-        let runtime_revision = Revision::new(revision.revision_id, revision.request_generation);
+        let runtime_revision = Revision::new(revision.revision_id, revision.compatibility_token);
         let view = {
             let store = lock_import_store(&self.import_store);
             store
@@ -11088,7 +11088,7 @@ impl RevisionedQueryDatabase {
         self.exact_import_groups_dispatched = self
             .exact_import_groups_dispatched
             .saturating_add(roots.occurrences().len() as u64);
-        let runtime_revision = Revision::new(revision.revision_id, revision.request_generation);
+        let runtime_revision = Revision::new(revision.revision_id, revision.compatibility_token);
         let mut groups = Vec::new();
         for occurrence in roots.occurrences() {
             let attempt = self.runtime.request_registered(
@@ -11242,7 +11242,7 @@ impl RevisionedQueryDatabase {
         ImportObservationLedger,
     )> {
         let current = self.current_import_revision?;
-        let runtime = Revision::new(current.revision_id, current.request_generation);
+        let runtime = Revision::new(current.revision_id, current.compatibility_token);
         let view = {
             let store = lock_import_store(&self.import_store);
             store
@@ -11315,7 +11315,13 @@ impl RevisionedQueryDatabase {
         for source in ledger.iter().filter_map(ImportObservation::accepted_source) {
             crate::import_discovery::accepted_import_module(source, &accepted_reads)?;
         }
-        let revision = Revision::new(self.next_revision, generation);
+        // RUE-1137: the runtime revision's compatibility slot carries
+        // observation-regime identity, not the per-request counter. A request
+        // reading under unchanged rules therefore publishes a revision its
+        // predecessor's terminals can still be validated against; only a
+        // regime change (roots, read policy, discovery epoch) resets the epoch.
+        let compatibility_token = context.regime_token();
+        let revision = Revision::new(self.next_revision, compatibility_token);
         self.next_revision += 1;
         let mut leaves = Vec::new();
         let mut accepted_topology = ledger
@@ -11435,6 +11441,7 @@ impl RevisionedQueryDatabase {
         let published = ImportInputRevision {
             revision_id: revision.id(),
             request_generation: generation,
+            compatibility_token,
             frontier_round,
         };
         self.current_import_revision = Some(published);
@@ -11467,7 +11474,7 @@ impl RevisionedQueryDatabase {
                 "a successor overlay must extend the current published revision",
             ));
         }
-        let parent_runtime = Revision::new(parent.revision_id, parent.request_generation);
+        let parent_runtime = Revision::new(parent.revision_id, parent.compatibility_token);
         let parent_view = {
             let store = lock_import_store(&self.import_store);
             store
@@ -11621,7 +11628,9 @@ impl RevisionedQueryDatabase {
             }
         }
 
-        let revision = Revision::new(self.next_revision, parent.request_generation);
+        // An overlay successor stays inside its parent's observation regime, so
+        // it inherits the parent's compatibility token verbatim (RUE-1137).
+        let revision = Revision::new(self.next_revision, parent.compatibility_token);
         self.next_revision += 1;
         let mut leaves = Vec::new();
         {
@@ -11696,6 +11705,7 @@ impl RevisionedQueryDatabase {
         let published = ImportInputRevision {
             revision_id: revision.id(),
             request_generation: parent.request_generation,
+            compatibility_token: parent.compatibility_token,
             frontier_round,
         };
         self.current_import_revision = Some(published);
@@ -18985,7 +18995,7 @@ fn main() -> i32 {
         let revision = database
             .begin_import_inputs(&snapshot, context.clone(), reads.clone())
             .unwrap();
-        let runtime_revision = Revision::new(revision.revision_id, revision.request_generation);
+        let runtime_revision = Revision::new(revision.revision_id, revision.compatibility_token);
         let root = ModuleId::from_logical_path("main.rue").unwrap();
         let modules = snapshot
             .source_revision()
@@ -19131,7 +19141,7 @@ fn main() -> i32 {
             begin_database_plan(&mut database, &mut assembler, context);
         let revision =
             publish_manifest_observations(&mut database, &snapshot, reads, &plan, revision);
-        let runtime_revision = Revision::new(revision.revision_id, revision.request_generation);
+        let runtime_revision = Revision::new(revision.revision_id, revision.compatibility_token);
         let module = ModuleId::from_logical_path("main.rue").unwrap();
         let parsed = database.runtime.request_registered(
             &database.parse_modules,
@@ -19301,7 +19311,7 @@ fn main() -> i32 {
             &database.declaration_imports,
             Revision::new(
                 first_revision.revision_id,
-                first_revision.request_generation,
+                first_revision.compatibility_token,
             ),
             key.clone(),
             CancellationToken::new(),
@@ -19322,7 +19332,7 @@ fn main() -> i32 {
         );
         let shifted_runtime = Revision::new(
             shifted_revision.revision_id,
-            shifted_revision.request_generation,
+            shifted_revision.compatibility_token,
         );
         let relocated = database.runtime.request_registered(
             &database.declaration_imports,
@@ -19374,7 +19384,7 @@ fn main() -> i32 {
         );
         let pending = database.runtime.request_registered(
             &database.declaration_imports,
-            Revision::new(revision.revision_id, revision.request_generation),
+            Revision::new(revision.revision_id, revision.compatibility_token),
             key.clone(),
             CancellationToken::new(),
         );
@@ -19389,7 +19399,7 @@ fn main() -> i32 {
             publish_manifest_observations(&mut database, &snapshot, reads, &plan, revision);
         let recovered = database.runtime.request_registered(
             &database.declaration_imports,
-            Revision::new(completed.revision_id, completed.request_generation),
+            Revision::new(completed.revision_id, completed.compatibility_token),
             key,
             CancellationToken::new(),
         );
@@ -19415,7 +19425,7 @@ fn main() -> i32 {
         let mut database = RevisionedQueryDatabase::default();
         let (snapshot, reads, revision, plan) =
             begin_database_plan(&mut database, &mut assembler, context);
-        let runtime_revision = Revision::new(revision.revision_id, revision.request_generation);
+        let runtime_revision = Revision::new(revision.revision_id, revision.compatibility_token);
         let module = ModuleId::from_logical_path("main.rue").unwrap();
         let query =
             Key::ConstResolution(crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
@@ -19443,7 +19453,7 @@ fn main() -> i32 {
             publish_manifest_observations(&mut database, &snapshot, reads, &plan, revision);
         let recovered = database.runtime.request_registered(
             &database.semantic_nucleus,
-            Revision::new(completed.revision_id, completed.request_generation),
+            Revision::new(completed.revision_id, completed.compatibility_token),
             query,
             CancellationToken::new(),
         );
@@ -19484,7 +19494,7 @@ fn main() -> i32 {
             begin_database_plan(&mut database, &mut assembler, context);
         let revision =
             publish_manifest_observations(&mut database, &snapshot, reads, &plan, revision);
-        let runtime_revision = Revision::new(revision.revision_id, revision.request_generation);
+        let runtime_revision = Revision::new(revision.revision_id, revision.compatibility_token);
         let module = ModuleId::from_logical_path("main.rue").unwrap();
         let selected = database.runtime.request_registered(
             &database.declaration_imports,
@@ -19601,7 +19611,7 @@ fn main() -> i32 {
             &database.declaration_imports,
             Revision::new(
                 first_revision.revision_id,
-                first_revision.request_generation,
+                first_revision.compatibility_token,
             ),
             key.clone(),
             CancellationToken::new(),
@@ -19638,7 +19648,7 @@ fn main() -> i32 {
             &database.declaration_imports,
             Revision::new(
                 remapped_revision.revision_id,
-                remapped_revision.request_generation,
+                remapped_revision.compatibility_token,
             ),
             key.clone(),
             CancellationToken::new(),
@@ -19679,7 +19689,7 @@ fn main() -> i32 {
             &database.declaration_imports,
             Revision::new(
                 green_revision.revision_id,
-                green_revision.request_generation,
+                green_revision.compatibility_token,
             ),
             key,
             CancellationToken::new(),
@@ -19740,7 +19750,7 @@ fn main() -> i32 {
             &database.declaration_imports,
             Revision::new(
                 first_revision.revision_id,
-                first_revision.request_generation,
+                first_revision.compatibility_token,
             ),
             key.clone(),
             CancellationToken::new(),
@@ -19800,7 +19810,7 @@ fn main() -> i32 {
             &database.declaration_imports,
             Revision::new(
                 remapped_revision.revision_id,
-                remapped_revision.request_generation,
+                remapped_revision.compatibility_token,
             ),
             key.clone(),
             CancellationToken::new(),
@@ -19845,7 +19855,7 @@ fn main() -> i32 {
             &database.declaration_imports,
             Revision::new(
                 green_revision.revision_id,
-                green_revision.request_generation,
+                green_revision.compatibility_token,
             ),
             key,
             CancellationToken::new(),
@@ -19993,7 +20003,7 @@ fn main() -> i32 {
         let revision = database
             .begin_import_inputs(&snapshot, context, reads)
             .unwrap();
-        let runtime_revision = Revision::new(revision.revision_id, revision.request_generation);
+        let runtime_revision = Revision::new(revision.revision_id, revision.compatibility_token);
         let module = ModuleId::from_logical_path("main.rue").unwrap();
         let key = |index| {
             declaration_import_key(

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -10899,10 +10899,32 @@ impl RevisionedQueryDatabase {
         let generation = self.next_import_request;
         self.current_import_revision = None;
         self.lineage_additions.clear();
-        // A new request generation is a fresh filesystem observation epoch.
-        // Reuse requires a future explicit watch/read-policy proof token. The
-        // API deliberately has no carried-ledger input that could be mistaken
-        // for freshness authority.
+        // A new request is a fresh filesystem observation epoch only when the
+        // observation *regime* changed. Under an unchanged regime the published
+        // revision carries the same compatibility token as its predecessor, so
+        // retained terminals stay eligible for red/green validation (RUE-1137,
+        // ADR-0063 §2.1). The API still has no carried-ledger input that could
+        // be mistaken for freshness authority.
+        //
+        // MISSING SOUNDNESS GUARD — implement RUE-1148 before any host reads
+        // sources from disk across requests.
+        //
+        // Carrying the token forward asserts that inputs this request did not
+        // re-observe are unchanged. Nothing here verifies that. ADR-0063 §2.1
+        // requires a Tier B re-observation sweep over the previous rooted
+        // closure's accepted-read set — stat, re-read and re-hash on metadata
+        // mismatch, republish only on content-digest change, and never trust an
+        // mtime inside the filesystem's indistinguishable window of now.
+        //
+        // That sweep does not exist yet. It is unobservable today because no
+        // host re-reads the filesystem between requests: the CLI opens exactly
+        // one request per invocation (`crates/rue/src/source_loader.rs`, before
+        // its frontier loop), in-process hosts supply their own snapshots, and
+        // nothing is retained across processes. A watch mode, LSP, or daemon
+        // breaks every one of those assumptions and must not ship first.
+        //
+        // The session-bench fixtures cannot catch this: they edit through the
+        // session API and never write out of band, so they pass either way.
         self.publish_import_view(
             snapshot,
             context,

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -5281,7 +5281,11 @@ impl CompilerSession {
             predecessor: predecessor_revision,
         };
         let runtime_revision =
-            rue_query::Revision::new(revision.revision_id, revision.request_generation);
+            // The runtime revision's compatibility slot is the observation
+            // regime, not the per-request counter (RUE-1137). This must match
+            // how import publication built the revision, or the module-input
+            // and parse projections cannot find their published views.
+            rue_query::Revision::new(revision.revision_id, revision.compatibility_token);
         self.parse_modules_dispatched = self
             .parse_modules_dispatched
             .saturating_add(appended.len() as u64);

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -1709,6 +1709,28 @@ where
             active.remove(&self.incarnation);
             return match result {
                 TaskQueryResult::Terminal { terminal, .. } => Ok(Some(terminal.stamp)),
+                // A dependency that cannot be produced under this revision
+                // because one of its inputs is gone does not abort the
+                // dependent: it makes the dependent's retained terminal
+                // invalid, so the dependent recomputes against the current
+                // graph (RUE-1137 item 8).
+                //
+                // The distinction is which side of the edge the demand is on.
+                // Demanding an input a *computation* has not yet discovered is
+                // the external-input protocol asking the host to supply it.
+                // Re-demanding an input a *retained terminal already observed*,
+                // and finding it absent, is an ordinary red edge — the removal
+                // is the change. Without this, editing an import so a module
+                // leaves the graph aborts every dependent instead of
+                // recomputing it.
+                //
+                // Only missing inputs are absorbed. Cancellation, dependency
+                // cycles, and engine invariant violations still propagate: they
+                // say nothing about whether the retained terminal is stale.
+                TaskQueryResult::Aborted {
+                    abort: QueryAbort::MissingInput(_),
+                    ..
+                } => Ok(None),
                 TaskQueryResult::Aborted { abort, .. } => Err(abort),
             };
         }

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -605,6 +605,20 @@ fn drive_import_discovery_to_close(
     continuation: Option<ImportInputRevision>,
     reclose: Option<ReClose<'_>>,
 ) -> Result<ClosedDiscovery, SourceLoadError> {
+    // Exactly one import-input request is opened per invocation, here, before
+    // the frontier loop below. Rounds inside that loop publish overlay
+    // successors which inherit this request's compatibility token, so the whole
+    // discovery of one program observes one filesystem regime.
+    //
+    // That single-request shape is load-bearing for soundness, not just tidy.
+    // Since RUE-1137 a successor request under an unchanged regime reuses its
+    // predecessor's retained terminals, which asserts that inputs it did not
+    // re-observe are unchanged. Nothing verifies that assertion yet — the Tier B
+    // re-observation sweep required by ADR-0063 §2.1 is unimplemented.
+    //
+    // So: do not add a second request per process, and do not make this driver
+    // long-lived or filesystem-watching, until RUE-1148 lands. A `--watch` mode
+    // or LSP host belongs behind that issue, not in front of it.
     let mut input_revision = match continuation {
         Some(revision) => revision,
         None => {

--- a/docs/designs/0063-parallel-demand-driven-incremental-compilation.md
+++ b/docs/designs/0063-parallel-demand-driven-incremental-compilation.md
@@ -12,7 +12,7 @@ superseded-by:
 supersedes: [0045, 0053]
 amends: [0051]
 amended-by: [0066]
-relates: ["ADR-0050", "ADR-0052", "ADR-0055", "ADR-0058", "ADR-0061", "RUE-328", "RUE-648", "RUE-812", "RUE-1021", "RUE-1022", "RUE-1023", "RUE-1024", "RUE-1025", "RUE-1026", "RUE-1027", "RUE-1028", "RUE-1029", "RUE-1030", "RUE-1031", "RUE-1032", "RUE-1033"]
+relates: ["ADR-0050", "ADR-0052", "ADR-0055", "ADR-0058", "ADR-0061", "RUE-328", "RUE-648", "RUE-812", "RUE-1021", "RUE-1022", "RUE-1023", "RUE-1024", "RUE-1025", "RUE-1026", "RUE-1027", "RUE-1028", "RUE-1029", "RUE-1030", "RUE-1031", "RUE-1032", "RUE-1033", "RUE-1137"]
 ---
 
 # ADR-0063: Parallel demand-driven incremental compilation
@@ -193,6 +193,75 @@ unrelated source therefore does not invalidate an already-parsed module.
 Current-versus-last-good selection belongs to a request/session publication
 layer over immutable revisions. It is not mutable state inside every query
 algorithm.
+
+#### 2.1 Filesystem observation authority
+
+Ruled by Steve on 2026-07-26 (RUE-1137). This subsection defines when a new
+rooted import-input request may validate retained terminals against its
+predecessor. It is the input contract RUE-1023 refers to.
+
+**The compatibility token is observation-regime identity, not request
+identity.** A revision's compatibility slot carries a stable digest of the rules
+governing reads — discovery epoch, project root, std root, read policy revision.
+It changes when those rules change and *not* when a file changes. File changes
+are per-leaf stamp changes, so a retained terminal remains validatable across an
+ordinary edit; a regime change resets the epoch wholesale because the compiler
+can no longer relate its retained observations to the new rules.
+
+Per-request identity remains separate and is what a trusted-toolchain successor
+delta must match. Conflating the two is what previously made warm reuse
+unreachable: a per-request counter in the compatibility slot meant no
+predecessor terminal was ever eligible for red/green validation, so every rooted
+compilation recomputed every body irrespective of its dependencies.
+
+**Two authority tiers may assert filesystem stability. Bare assertions may
+not.**
+
+- *Tier A (watched).* The host supplies a proof attesting an active watcher
+  covering the accepted-read set. Content changes arrive as ordinary leaf
+  updates.
+- *Tier B (unwatched, default).* The compiler is its own authority via a
+  re-observation sweep over the previous rooted closure's accepted-read set at
+  request start.
+
+Tier B is the correctness baseline and Tier A is a latency optimization over it.
+Warm reuse is therefore available to unwatched hosts, including a plain CLI and
+a future watch mode, rather than only to a watcher-equipped editor.
+
+**The sweep compares content, not metadata.** For each entry: stat it; on any
+size/mtime/identity mismatch re-read and re-hash; republish the leaf only when
+the *content digest* differs. A metadata mismatch alone is not a change, because
+editors and build tools routinely rewrite files without changing bytes.
+
+**Unreliable timestamps fall back to hashing.** A stat whose mtime lies within
+the filesystem's indistinguishable window of now must not be trusted: such a
+timestamp cannot separate "written before we hashed it" from "written after."
+Those leaves are content-hashed. This rule is not optional hardening — it is why
+the preceding rule is sound.
+
+**Absent leaves invalidate; they do not demand.** A retained terminal whose
+already-observed input leaf is absent from the successor's published view is
+invalid and recomputes. Missing-input demand is for leaves a computation has not
+yet discovered, not for leaves a retained terminal already observed. Without
+this distinction an import edit that removes a module aborts every dependent
+instead of recomputing it. Cancellation, dependency cycles, and engine invariant
+violations continue to propagate, since none of them indicate staleness.
+
+**Remaining rulings.** Missing, denied, unreadable, ambiguous, and malformed
+reads stay distinguishable typed observations, so any transition between them
+invalidates the dependent closure; a read-policy change is a regime change and
+still fails closed. Speculative work inherits no authority and drives no
+re-observation. A canceled or abandoned request establishes no freshness, and
+its successor re-sweeps any leaf an incomplete sweep did not cover. A regime
+change makes prior terminals ineligible for validation but forces no eviction;
+they age out under existing bounded retention, so a watcher restart does not
+produce a retention cliff.
+
+**Implementation status.** The compatibility token and absent-leaf invalidation
+are implemented. **The Tier B sweep is not.** Nothing currently retains
+terminals across a filesystem re-read the compiler did not itself perform, so no
+present host is affected; a long-lived filesystem-reading host must not ship
+before the sweep exists.
 
 ### 3. Query identity, computation, and publication
 


### PR DESCRIPTION
## Problem

`begin_import_inputs` minted a fresh compatibility token per request: it incremented `request_generation`, and that counter occupied the runtime revision's compatibility slot. Since `Revision::is_compatible_with` compares that slot alone, no terminal retained under a predecessor was ever eligible for red/green validation. Every rooted compilation recomputed every body regardless of whether its dependencies changed, so warm body reuse was unreachable for any program that reaches its sources through import discovery — which is every program with an import.

`docs/notes/module-axis-locality-findings.md` measured this and localized it to that one call. This PR implements the ruling recorded on RUE-1137.

## Change

**Split the two concerns the counter conflated.** `request_generation` stays per-request identity, used for view lookup and for matching a trusted-toolchain successor delta. A new `compatibility_token` carries observation-regime identity, derived from `ImportDiscoveryContext` (discovery epoch, project root, std root, read policy revision) by a stable length-prefixed SHA-256 digest, and occupies the compatibility slot. A request reading under unchanged rules can validate its predecessor's terminals; a regime change still resets the epoch wholesale. The digest is stable rather than `DefaultHasher` because the reproducibility harness compares publication identity across runs.

**Absent leaves invalidate rather than demand.** Validating a retained terminal re-demands its dependencies, and `compiler.parse-module` reads its module source as a required input, so a module leaving the import graph made every dependent abort with `MissingInput` instead of recomputing. A missing input encountered while validating an *already-observed* dependency is now an ordinary red edge. Missing-input demand remains for leaves a computation has not yet discovered. Cancellation, dependency cycles, and engine invariant violations still propagate — none of them indicate staleness.

## Results

Representative fixture, semantic bodies required/reused:

| scenario | before | after | warm latency |
|---|---|---|---|
| `leaf_edit` | 6/0 | **1/5** | 6.38 → 5.00 ms |
| `widely_depended_definition_edit` | 6/0 | **1/5** | 6.83 → 4.67 ms |
| `import_change` | 6/0 | **2/4** | 6.65 → 5.69 ms |
| `diagnostic_error_edit` | 5/0 | **1/4** | 5.31 → 3.99 ms |
| `diagnostic_recovery` | 6/0 | **1/5** | 7.17 → 7.03 ms |

Module-axis rooted-demand rows reach staged locality — 1 computed / 15 reused on a leaf edit, 0/16 on an unrelated edit — identically at 1, 2, 4, and 8 modules. Cold/reused artifact, diagnostic, and output parity assertions hold throughout, so reuse produces identical output rather than merely faster output.

The checked-in structural-work expectations move to the new reverse-closure values in both `assert_structure` and `benchmarks/manifest.toml`; those rows encoded the old whole-program behavior.

## Validation

`rue-compiler-test` 876 pass, `rue-query-test` 55 pass, differential-oracle, public-API and scaling-matrix targets green, `scripts/rue quick` 36/36 with the oracle agreeing on every modeled eligible case.

Not run locally: the full `scripts/rue test` suite and non-x86-64 targets. CI is the full-platform authority.

## Scope: what this does and does not change about filesystem trust

No current host is affected by the absence of the Tier B sweep (RUE-1148), and the reasoning is worth stating explicitly for review:

- **Within a request**, behavior is unchanged. `begin_import_input_request` is called once, at `crates/rue/src/source_loader.rs:614`, *before* the frontier loop. Rounds inside that loop always shared one token — the overlay path used `parent.request_generation` before and `parent.compatibility_token` now, with identical semantics.
- **Across requests in one process**, only the session bench and test harnesses open multiple requests, and they supply their own snapshots. The compiler never re-reads the filesystem between them.
- **Across processes**, nothing is retained; there is no persistence, so every CLI build is cold regardless.

There is therefore no path today in which a retained terminal is validated against filesystem state the compiler did not itself observe.

The sweep becomes load-bearing when a **long-lived host re-reads sources from disk across requests** — watch mode, an LSP, a daemon. ADR-0063 §2.1 states that such a host must not ship before RUE-1148 lands, and RUE-1148 is `blockedBy` this issue.

One limitation reviewers should know: the existing session-bench fixtures edit through the session API and never write out of band, so they cannot detect a missing sweep — they pass either way. RUE-1148 accordingly requires a test that writes to disk directly.

## ADR

`docs/designs/0063-parallel-demand-driven-incremental-compilation.md` gains §2.1, the input contract RUE-1023 refers to: the compatibility-token rule, the two authority tiers with Tier B as baseline and Tier A as optimization, content-digest rather than metadata comparison, the unreliable-timestamp fallback, absent-leaf invalidation, and the speculation/cancellation/retention rulings. Prior art is Zig, which operates the same stat-then-hash contract in production and added filesystem watching years later as a supplement rather than a replacement.

Fixes RUE-1137
