### PR TITLE
Remove two test-only paths the compiler never takes

### DIFF
--- a/crates/rue-compiler/src/body_overlay.rs
+++ b/crates/rue-compiler/src/body_overlay.rs
@@ -629,13 +629,14 @@ mod tests {
             let merged = crate::merge_parsed_modules(&parsed).unwrap();
             let rir = crate::lower_canonical_rir(&merged).unwrap();
             let options = CompileOptions::default();
-            let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+            let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
             let (definitions, query_declarations, _) =
                 crate::bound_definitions::bind_canonical_declaration_semantics(
                     &merged,
                     &rir,
                     options.preview_features.clone(),
                     options.target,
+                    &imports,
                 )
                 .unwrap();
             let query_shells = crate::canonical_semantic::query_owned_declaration_shells_for_test(

--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -555,30 +555,9 @@ pub(crate) fn bind_canonical_definitions(
     preview_features: PreviewFeatures,
     target: Target,
 ) -> MultiErrorResult<BoundDefinitionSet> {
-    let imports = test_fixture_import_graph(merged)?;
+    let imports = crate::import_graph::import_free_canonical_graph(merged.ast())?;
     bind_canonical_definitions_with_work(merged, rir, preview_features, target, &imports)
         .map(|(definitions, _)| definitions)
-}
-
-#[cfg(test)]
-pub(crate) fn test_fixture_import_graph(
-    merged: &CanonicalMergedProgram,
-) -> MultiErrorResult<crate::CanonicalImportGraph> {
-    crate::test_support::test_fixture_import_graph_parts(
-        merged.ast().root(),
-        merged
-            .ast()
-            .modules()
-            .iter()
-            .map(|module| {
-                (
-                    module.module_id().clone(),
-                    Arc::from(module.physical_path()),
-                )
-            })
-            .collect(),
-        merged.ast().import_directives(),
-    )
 }
 
 /// Bind once and export stable, request-independent declaration semantics
@@ -590,18 +569,18 @@ pub(crate) fn bind_canonical_declaration_semantics(
     rir: &CanonicalRirOutput,
     preview_features: PreviewFeatures,
     target: Target,
+    imports: &crate::CanonicalImportGraph,
 ) -> MultiErrorResult<(
     BoundDefinitionSet,
     Arc<[crate::DurableDeclarationSemantic]>,
     rue_air::SemanticDeclarationExportWork,
 )> {
-    let imports = test_fixture_import_graph(merged)?;
     let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
         merged,
         rir,
         preview_features,
         target,
-        &imports,
+        imports,
     )?;
     let manifest = bound.binding_manifest();
     let definitions = issue_bound_definitions(
@@ -649,7 +628,7 @@ pub(crate) fn compare_canonical_durable_declaration_install(
     preview_features: PreviewFeatures,
     target: Target,
 ) -> MultiErrorResult<(crate::DurableSemanticProjectionWork, DeclarationBindingWork)> {
-    let imports = test_fixture_import_graph(merged)?;
+    let imports = crate::import_graph::import_free_canonical_graph(merged.ast())?;
     let ordinary = crate::canonical_semantic::bind_query_owned_declarations_for_test(
         merged,
         rir,
@@ -1252,11 +1231,13 @@ mod tests {
         let parsed = parse_source_snapshot_modules(snapshot).unwrap();
         let merged = merge_parsed_modules(&parsed).unwrap();
         let rir = lower_canonical_rir(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         bind_canonical_declaration_semantics(
             &merged,
             &rir,
             PreviewFeatures::new(),
             Target::default(),
+            &imports,
         )
         .unwrap()
     }
@@ -1339,7 +1320,7 @@ mod tests {
         let merged = merge_parsed_modules(&parsed).unwrap();
         let rir = lower_canonical_rir(&merged).unwrap();
         let current_definitions = bind(&relocated);
-        let imports = test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let shells = crate::canonical_semantic::query_owned_declaration_shells_for_test(
             &merged,
             &rir,
@@ -1387,7 +1368,7 @@ mod tests {
         let parsed = parse_source_snapshot_modules(&input).unwrap();
         let merged = merge_parsed_modules(&parsed).unwrap();
         let rir = lower_canonical_rir(&merged).unwrap();
-        let imports = test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let shells = crate::canonical_semantic::query_owned_declaration_shells_for_test(
             &merged,
             &rir,
@@ -1420,7 +1401,7 @@ mod tests {
         let parsed = parse_source_snapshot_modules(&input).unwrap();
         let merged = merge_parsed_modules(&parsed).unwrap();
         let rir = lower_canonical_rir(&merged).unwrap();
-        let imports = test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let shells = crate::canonical_semantic::query_owned_declaration_shells_for_test(
             &merged,
             &rir,
@@ -1479,7 +1460,7 @@ mod tests {
         )
         .unwrap();
         // A fresh oracle epoch remains valid after the query-owned install.
-        let imports = test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         crate::canonical_semantic::bind_query_owned_declarations_for_test(
             &merged,
             &rir,

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -3784,7 +3784,7 @@ mod tests {
         let merged = merge_parsed_modules(&parsed).unwrap();
         let rir = lower_canonical_rir(&merged).unwrap();
         let options = CompileOptions::default();
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
 
         let ordinary = match rue_air::Sema::new_synthetic(
             rir.rir(),
@@ -3825,7 +3825,7 @@ mod tests {
         let parsed = parse_source_snapshot_modules(&source).unwrap();
         let merged = merge_parsed_modules(&parsed).unwrap();
         let rir = lower_canonical_rir(&merged).unwrap();
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         crate::bound_definitions::configure_canonical_sema(
             &merged,
             &rir,
@@ -3846,7 +3846,7 @@ mod tests {
         let parsed = parse_source_snapshot_modules(snapshot).unwrap();
         let merged = merge_parsed_modules(&parsed).unwrap();
         let rir = lower_canonical_rir(&merged).unwrap();
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::test_support::test_import_graph(snapshot).unwrap();
         let output =
             analyze_canonical_program_for_test_support(&merged, &rir, options, &imports, ids)
                 .unwrap();
@@ -4200,9 +4200,23 @@ mod tests {
         let (relocated, _) = canonical(&relocated, &base_options, false);
         assert_ne!(base.input(), relocated.input());
 
-        let different_root = snapshot(&sources, 2);
-        let (different_root, _) = canonical(&different_root, &base_options, false);
-        assert_ne!(base.input(), different_root.input());
+        // The designated root is its own input axis. It is exercised on an
+        // import-free pair: designating `helper.rue` as the root of the
+        // import-bearing fixture above would leave `main.rue` unreachable, and
+        // a program's import graph covers only what discovery reaches from its
+        // root.
+        let roots = [
+            (1, "/roots/main.rue", "main.rue", "fn main() -> i32 { 0 }"),
+            (
+                2,
+                "/roots/helper.rue",
+                "helper.rue",
+                "fn main() -> i32 { 1 }",
+            ),
+        ];
+        let (first_root, _) = canonical(&snapshot(&roots, 1), &base_options, false);
+        let (second_root, _) = canonical(&snapshot(&roots, 2), &base_options, false);
+        assert_ne!(first_root.input(), second_root.input());
     }
 
     #[test]
@@ -4441,13 +4455,15 @@ mod tests {
                 let merged = crate::merge_parsed_modules(&parsed).unwrap();
                 let rir = crate::lower_canonical_rir(&merged).unwrap();
                 let options = CompileOptions::default();
-                let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+                let imports =
+                    crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
                 let (definitions, query_declarations, _) =
                     crate::bound_definitions::bind_canonical_declaration_semantics(
                         &merged,
                         &rir,
                         options.preview_features.clone(),
                         options.target,
+                        &imports,
                     )
                     .unwrap();
                 let query_shells = super::super::query_owned_declaration_shells_for_test(

--- a/crates/rue-compiler/src/diagnostic_attempt_store.rs
+++ b/crates/rue-compiler/src/diagnostic_attempt_store.rs
@@ -410,7 +410,7 @@ mod tests {
     use rue_span::FileId;
 
     use super::*;
-    use crate::{CanonicalImportGraph, SourceMetadata, StableOptLevel};
+    use crate::{SourceMetadata, StableOptLevel};
 
     #[derive(Debug)]
     struct FakeAttempt {
@@ -501,19 +501,7 @@ mod tests {
                         crate::Target::default(),
                         &crate::PreviewFeatures::default(),
                     ),
-                    CanonicalImportGraph::from_supplied(
-                        valid_source.source_revision().root().clone(),
-                        Vec::new(),
-                        &crate::ModuleResolutionInputs::new(
-                            valid_source.source_revision().root().clone(),
-                            vec![crate::ModuleResolutionInput {
-                                module: valid_source.source_revision().root().clone(),
-                                physical_path: Arc::from("/p/main.rue"),
-                            }],
-                        )
-                        .unwrap(),
-                    )
-                    .unwrap(),
+                    crate::test_support::test_import_graph(&valid_source).unwrap(),
                 ),
                 StableOptLevel::O0,
             )),

--- a/crates/rue-compiler/src/import_graph.rs
+++ b/crates/rue-compiler/src/import_graph.rs
@@ -257,6 +257,80 @@ impl CanonicalImportGraph {
     }
 }
 
+/// A parsed or merged revision, viewed as the inputs an import-free canonical
+/// graph is derived from.
+pub(crate) trait ImportFreeRevision {
+    fn root(&self) -> &ModuleId;
+    fn modules(&self) -> &[Arc<crate::parsed_modules::ParsedModule>];
+    fn import_directives(&self) -> &ImportDirectives;
+}
+
+impl ImportFreeRevision for crate::ParsedProgram {
+    fn root(&self) -> &ModuleId {
+        crate::ParsedProgram::root(self)
+    }
+    fn modules(&self) -> &[Arc<crate::parsed_modules::ParsedModule>] {
+        crate::ParsedProgram::modules(self)
+    }
+    fn import_directives(&self) -> &ImportDirectives {
+        crate::ParsedProgram::import_directives(self)
+    }
+}
+
+impl ImportFreeRevision for crate::canonical_merge::CanonicalMergedAst {
+    fn root(&self) -> &ModuleId {
+        crate::canonical_merge::CanonicalMergedAst::root(self)
+    }
+    fn modules(&self) -> &[Arc<crate::parsed_modules::ParsedModule>] {
+        crate::canonical_merge::CanonicalMergedAst::modules(self)
+    }
+    fn import_directives(&self) -> &ImportDirectives {
+        crate::canonical_merge::CanonicalMergedAst::import_directives(self)
+    }
+}
+
+/// The uniquely valid canonical graph for a revision that declares no import
+/// directives: no records over that revision's own module set.
+///
+/// This is not a second resolver. An import-free revision has exactly one legal
+/// topology, so it needs no candidate precedence, no host observation, and no
+/// discovery epoch. The session's semantic path and the lower-layer unit tests
+/// that analyze an import-free fixture both construct it here, so neither one
+/// re-derives module resolution inputs on its own.
+pub(crate) fn import_free_canonical_graph(
+    program: &impl ImportFreeRevision,
+) -> Result<CanonicalImportGraph, crate::CompileErrors> {
+    if !program.import_directives().is_empty() {
+        return Err(crate::CompileErrors::from(
+            crate::CompileError::without_span(crate::ErrorKind::InvalidCompilerInput(
+                "an import-bearing revision has no import-free canonical graph; resolve it through discovery"
+                    .into(),
+            )),
+        ));
+    }
+    let inputs = ModuleResolutionInputs::new(
+        program.root().clone(),
+        program
+            .modules()
+            .iter()
+            .map(|module| crate::ModuleResolutionInput {
+                module: module.module_id().clone(),
+                physical_path: Arc::from(module.physical_path()),
+            })
+            .collect(),
+    )
+    .map_err(crate::CompileErrors::from)?;
+    CanonicalImportGraph::from_supplied(program.root().clone(), Vec::new(), &inputs).map_err(
+        |validation| {
+            crate::CompileErrors::from(crate::CompileError::without_span(
+                crate::ErrorKind::InvalidCompilerInput(format!(
+                    "invalid import-free semantic graph: {validation:?}"
+                )),
+            ))
+        },
+    )
+}
+
 /// Stable malformed-topology finding for a canonical import graph.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CanonicalImportGraphProblem {

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -480,7 +480,7 @@ mod tests {
             FileMetadataFingerprint::new(1, 1, 1),
             Arc::new(
                 r#"
-                    const std = @import("/sdk/_std.rue");
+                    const std = @import("std/_std.rue");
                     const other = @import("other.rue");
                     const Qualified = std.strbuf.StrBuf;
                     const Alias = Qualified;
@@ -617,7 +617,7 @@ mod tests {
             PhysicalFileIdentity::new(1, 1),
             FileMetadataFingerprint::new(1, 1, 1),
             Arc::new(
-                r#"const std = @import("/sdk/_std.rue");
+                r#"const std = @import("std/_std.rue");
                    fn main() -> i32 { let value: StrBuf = "x"; @intCast(value.len()) }"#
                     .to_owned(),
             ),
@@ -656,20 +656,24 @@ mod tests {
         );
     }
 
+    /// Trust comes from the captured standard-library root, never from how an
+    /// import is spelled. A project module reached through an `std/`-shaped
+    /// specifier resolves to an ordinary project module, so its `StrBuf` is a
+    /// plain struct rather than the `StrBuf` language item.
     #[test]
-    fn caller_logical_std_spelling_cannot_spoof_strbuf_language_item() {
+    fn caller_std_shaped_specifier_cannot_spoof_strbuf_language_item() {
         let root = FileId::new(1);
         let spoof_file = FileId::new(2);
         let metadata = SourceMetadata::new(
             root,
             [
-                (root, "main.rue".to_owned()),
-                (spoof_file, "spoof.rue".to_owned()),
+                (root, "/checkout/main.rue".to_owned()),
+                (spoof_file, "/checkout/std/strbuf.rue".to_owned()),
             ]
             .into(),
             [
                 (root, "main.rue".to_owned()),
-                (spoof_file, "\0rue-std/strbuf.rue".to_owned()),
+                (spoof_file, "std/strbuf.rue".to_owned()),
             ]
             .into(),
         )
@@ -677,25 +681,26 @@ mod tests {
         let snapshot = SourceSnapshot::from_sources(
             &[
                 SourceView::new(
-                    "main.rue",
-                    "const spoof = @import(\"spoof.rue\"); fn main() -> i32 { 0 }",
+                    "/checkout/main.rue",
+                    "const spoof = @import(\"std/strbuf.rue\"); fn main() -> i32 { 0 }",
                     root,
                 ),
-                SourceView::new("spoof.rue", "pub struct StrBuf { value: i32 }", spoof_file),
+                SourceView::new(
+                    "/checkout/std/strbuf.rue",
+                    "pub struct StrBuf { value: i32 }",
+                    spoof_file,
+                ),
             ],
             metadata,
         )
         .unwrap();
         let (_, semantic, _) = test_frontend_snapshot(&snapshot, &CompileOptions::default())
-            .expect("caller-authored sentinel spelling remains an ordinary module");
+            .expect("a caller-authored std-shaped specifier remains an ordinary module");
         let spoof = semantic
             .type_pool()
             .all_struct_ids()
             .into_iter()
-            .find(|id| {
-                let def = semantic.type_pool().struct_def(*id);
-                def.name == "StrBuf" && def.file_id == spoof_file
-            })
+            .find(|id| semantic.type_pool().struct_def(*id).name == "StrBuf")
             .unwrap();
         assert_eq!(semantic.type_pool().struct_lang_item(spoof), None);
         assert!(!semantic.type_pool().is_strbuf(spoof));
@@ -872,15 +877,33 @@ mod tests {
         .unwrap();
         let snapshot = SourceSnapshot::from_sources(&sources, metadata).unwrap();
 
-        let output = test_compile_snapshot(&snapshot, &CompileOptions::default()).unwrap();
+        // An import-bearing program is parsed by its discovery epoch, and the
+        // batch pass that follows reuses that parse rather than repeating it.
+        // So the one-pass claim splits in two: discovery lexes and parses each
+        // module exactly once, and the batch adds no parse work at all.
+        let mut session = CompilerSession::new();
+        let discovery = crate::test_support::TestDiscoveryHost::new(&snapshot)
+            .unwrap()
+            .drive(&mut session)
+            .unwrap();
+        assert_eq!(discovery.parse_work.syntax.lexer_invocations, sources.len());
+        assert_eq!(
+            discovery.parse_work.syntax.parser_invocations,
+            sources.len()
+        );
+        let output = crate::queries::compile_with_session(
+            &mut session,
+            &discovery.snapshot,
+            &CompileOptions::default(),
+        )
+        .unwrap();
         let stats = output.source_stats;
         let work = output.work;
 
         assert_eq!(stats.files, sources.len());
-        assert_eq!(work.parsed.modules_considered, sources.len());
-        assert_eq!(work.parsed.modules_reparsed, sources.len());
-        assert_eq!(work.parsed.syntax.lexer_invocations, sources.len());
-        assert_eq!(work.parsed.syntax.parser_invocations, sources.len());
+        assert_eq!(work.parsed.modules_reparsed, 0);
+        assert_eq!(work.parsed.syntax.lexer_invocations, 0);
+        assert_eq!(work.parsed.syntax.parser_invocations, 0);
         assert_eq!(work.merged.parser_invocations, 0);
         assert_eq!(work.merged.ast_payload_clones, 0);
         assert_eq!(work.merged.source_text_clones, 0);

--- a/crates/rue-compiler/src/producer_nominal_acceptance_tests.rs
+++ b/crates/rue-compiler/src/producer_nominal_acceptance_tests.rs
@@ -518,21 +518,15 @@ fn main() -> i32 {
     );
 }
 
-/// Publish `root_source` (trusted std `Option` present) into `session`, adopting
-/// the test import graph, and return the semantic output.
+/// Publish `root_source` (trusted std `Option` present) into `session` through
+/// the discovery protocol, and return the semantic output.
 fn publish_trusted_semantic(
     session: &mut CompilerSession,
     root_source: &str,
     options: &CompileOptions,
 ) -> Result<Arc<CanonicalSemanticOutput>, CompileErrors> {
     let snapshot = trusted_option_snapshot(root_source);
-    let program = session
-        .update_for_presentation(&snapshot)
-        .into_owner_result()?;
-    if !program.import_directives().is_empty() {
-        let graph = crate::test_fixture_import_graph(&program)?;
-        session.adopt_test_import_graph(graph);
-    }
+    crate::test_support::publish_test_snapshot(session, &snapshot)?;
     session.canonical_semantic(options)
 }
 

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -9659,17 +9659,9 @@ impl RevisionedQueryDatabase {
     }
 
     /// Publish an immutable, revisioned import authority for lower-layer
-    /// tests. The fixture graph is an input leaf rather than an out-of-band
-    /// evaluator read, so changing it invalidates exactly the declaration
-    /// import queries which observed it.
-    #[cfg(test)]
-    pub(crate) fn adopt_test_import_graph(&mut self, graph: crate::CanonicalImportGraph) {
-        let parse_revision = self
-            .current_parse_revision()
-            .expect("test import authority requires a selected parsed revision");
-        self.adopt_test_import_graph_for_revision(parse_revision, graph);
-    }
-
+    /// tests. The graph is a discovered one; it enters here as an input leaf
+    /// rather than an out-of-band evaluator read, so changing it invalidates
+    /// exactly the declaration import queries which observed it.
     #[cfg(test)]
     fn adopt_test_import_graph_for_revision(
         &mut self,
@@ -14239,12 +14231,14 @@ pub(crate) mod test_support {
         let parsed = crate::parsed_modules::parse_source_snapshot_modules(snapshot).unwrap();
         let merged = crate::merge_parsed_modules(&parsed).unwrap();
         let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let imports = crate::test_support::test_import_graph(snapshot).unwrap();
         let (_definitions, query_declarations, _work) =
             crate::bound_definitions::bind_canonical_declaration_semantics(
                 &merged,
                 &rir,
                 crate::PreviewFeatures::default(),
                 rue_target::Target::X86_64Linux,
+                &imports,
             )
             .unwrap();
         query_declarations
@@ -16313,14 +16307,13 @@ fn main() -> i32 {
             ],
             1,
         );
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&source).unwrap();
-        let retired = crate::test_support::test_fixture_import_graph(&parsed).unwrap();
+        let discovered = crate::test_support::test_import_graph(&source).unwrap();
         let main = ModuleId::from_logical_path("main.rue").unwrap();
-        let expected = retired
+        let expected = discovered
             .records()
             .iter()
             .find(|record| record.importer() == &main && record.normalized_specifier() == "dep.rue")
-            .expect("retired import graph omitted dep.rue")
+            .expect("discovered import graph omitted dep.rue")
             .resolution()
             .clone();
 
@@ -16329,7 +16322,7 @@ fn main() -> i32 {
             &super::super::session::ExactSourceInput::new(&source),
             &source,
         );
-        database.adopt_test_import_graph_for_revision(revision, retired);
+        database.adopt_test_import_graph_for_revision(revision, discovered);
         let revision = database.current_semantic_revision().unwrap();
         let requested = database.runtime.request_registered(
             &database.declaration_imports,
@@ -22576,7 +22569,7 @@ fn main() -> i32 {
         let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
         let merged = crate::merge_parsed_modules(&parsed).unwrap();
         let rir = crate::lower_canonical_rir(&merged).unwrap();
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
             &merged,
             &rir,
@@ -22782,7 +22775,7 @@ fn main() -> i32 {
         let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
         let merged = crate::merge_parsed_modules(&parsed).unwrap();
         let rir = crate::lower_canonical_rir(&merged).unwrap();
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
             &merged,
             &rir,
@@ -22973,7 +22966,7 @@ fn main() -> i32 {
         let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
         let merged = crate::merge_parsed_modules(&parsed).unwrap();
         let rir = crate::lower_canonical_rir(&merged).unwrap();
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
             &merged,
             &rir,
@@ -23130,7 +23123,7 @@ fn main() -> i32 {
         let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
         let merged = crate::merge_parsed_modules(&parsed).unwrap();
         let rir = crate::lower_canonical_rir(&merged).unwrap();
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
             &merged,
             &rir,
@@ -23210,7 +23203,7 @@ fn main() -> i32 {
         let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
         let merged = crate::merge_parsed_modules(&parsed).unwrap();
         let rir = crate::lower_canonical_rir(&merged).unwrap();
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
             &merged,
             &rir,
@@ -23325,7 +23318,7 @@ fn main() -> i32 {
         let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
         let merged = crate::merge_parsed_modules(&parsed).unwrap();
         let rir = crate::lower_canonical_rir(&merged).unwrap();
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
             &merged,
             &rir,
@@ -23795,7 +23788,7 @@ fn main() -> i32 {
         // INDEPENDENT comparison side. Its anonymous materialization is the epoch's
         // own `find_or_create_anon_struct`, populated during the same bind.
         let rir = crate::lower_canonical_rir(&merged).unwrap();
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
             &merged,
             &rir,
@@ -23934,7 +23927,7 @@ fn main() -> i32 {
         // INDEPENDENT comparison side. Its anonymous materialization is the
         // epoch's own `find_or_create_anon_enum`, populated during the same bind.
         let rir = crate::lower_canonical_rir(&merged).unwrap();
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
             &merged,
             &rir,
@@ -24153,7 +24146,7 @@ fn main() -> i32 {
         // issued the epoch's endpoints, and install — exactly the production
         // `body_transaction` sequence.
         // ------------------------------------------------------------------
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let (bound, definitions) =
             crate::canonical_semantic::bind_query_owned_declarations_with_definitions_for_test(
                 &merged,
@@ -24336,7 +24329,7 @@ fn main() -> i32 {
         let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
         let merged = crate::merge_parsed_modules(&parsed).unwrap();
         let rir = crate::lower_canonical_rir(&merged).unwrap();
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
             &merged,
             &rir,
@@ -24613,7 +24606,7 @@ fn main() -> i32 {
         let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
         let merged = crate::merge_parsed_modules(&parsed).unwrap();
         let rir = crate::lower_canonical_rir(&merged).unwrap();
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::test_support::test_import_graph(&snapshot).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
             &merged,
             &rir,
@@ -24821,7 +24814,7 @@ fn main() -> i32 {
         let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
         let merged = crate::merge_parsed_modules(&parsed).unwrap();
         let rir = crate::lower_canonical_rir(&merged).unwrap();
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
             &merged,
             &rir,
@@ -24912,7 +24905,7 @@ fn main() -> i32 {
         let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
         let merged = crate::merge_parsed_modules(&parsed).unwrap();
         let rir = crate::lower_canonical_rir(&merged).unwrap();
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
             &merged,
             &rir,
@@ -25125,7 +25118,7 @@ fn main() -> i32 {
         let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
         let merged = crate::merge_parsed_modules(&parsed).unwrap();
         let rir = crate::lower_canonical_rir(&merged).unwrap();
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged).unwrap();
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
             &merged,
             &rir,

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1344,8 +1344,14 @@ pub struct CompilerSession {
     /// successor classifies only its appended delta.
     parse_invalidation_entries_compared: u64,
     queries: FrontendQueryDatabase,
-    #[cfg(test)]
-    supplied_test_import_graph: Option<CanonicalImportGraph>,
+    /// One-shot cancellation injections, each consumed with `mem::take` at a
+    /// fixed point inside an attempt.
+    ///
+    /// Test-only because production cancellation arrives asynchronously through
+    /// a `CancellationToken`, and a test cannot deterministically land it
+    /// between two chosen steps. They gate no selection logic: the branch each
+    /// one triggers is the same cancellation path a real token drives, so both
+    /// configurations still compile one implementation of that path (RUE-1143).
     #[cfg(test)]
     cancel_merge_before_commit: bool,
     #[cfg(test)]
@@ -1385,10 +1391,31 @@ pub struct CompilerSession {
     /// reuse. Never populated on the production path.
     #[cfg(test)]
     recipe_cache_slot: std::sync::Mutex<Option<Arc<crate::recipe_cache::RecipeCache>>>,
-    #[cfg(test)]
+    /// Explicit durable baseline for the next semantic attempt (RUE-1143).
+    ///
+    /// `None` on every ordinary compile, in which case a semantic attempt reuses
+    /// from the last-good semantic record. No production path sets it.
+    ///
+    /// It is deliberately NOT `#[cfg(test)]`. The reuse-baseline selection this
+    /// feeds is the most correctness-sensitive lookup in the compiler, and it
+    /// previously existed twice: production read the last-good record, while a
+    /// `cfg(test)` shadow field took precedence under test. Tests therefore
+    /// validated a selection order production never executed — underneath the
+    /// differential oracle, which is the defense for exactly that class of bug.
+    /// Keeping the slot unconditional means both configurations compile one
+    /// selection expression; only whether anything ever fills it differs.
+    durable_baseline_override: Option<DurableBaselineOverride>,
+}
+
+/// An explicit durable baseline supplied in place of the last-good record.
+///
+/// Tests use this to drive a specific — including deliberately stale, corrupt,
+/// or partially-populated — durable cache through the production reuse path,
+/// rather than through a parallel branch compiled only under `cfg(test)`.
+#[derive(Debug, Default, Clone)]
+struct DurableBaselineOverride {
+    successful_cfg_cache: Option<Arc<[crate::queries::DurableCfgArtifact]>>,
     durable_declaration_cache: Option<DurableDeclarationCache>,
-    #[cfg(test)]
-    last_successful_cfg_cache: Option<Arc<[crate::queries::DurableCfgArtifact]>>,
 }
 
 fn stable_type_definition_root(
@@ -3061,10 +3088,6 @@ impl CompilerSession {
     fn accepted_semantic_import_graph(&self) -> Result<CanonicalImportGraph, CompileErrors> {
         let program = self.published.as_ref().ok_or_else(no_published_program)?;
         let graph = if !program.import_directives().is_empty() {
-            #[cfg(test)]
-            if let Some(graph) = &self.supplied_test_import_graph {
-                return Ok(graph.clone());
-            }
             let committed = self.committed_import_graph()?;
             if &committed.input().sources != program.source_revision() {
                 return Err(CompileErrors::from(CompileError::without_span(
@@ -3075,26 +3098,7 @@ impl CompilerSession {
             }
             committed.graph().clone()
         } else {
-            let inputs = ModuleResolutionInputs::new(
-                program.root().clone(),
-                program
-                    .modules()
-                    .iter()
-                    .map(|module| crate::ModuleResolutionInput {
-                        module: module.module_id().clone(),
-                        physical_path: Arc::from(module.physical_path()),
-                    })
-                    .collect(),
-            )
-            .map_err(CompileErrors::from)?;
-            CanonicalImportGraph::from_supplied(program.root().clone(), Vec::new(), &inputs)
-                .map_err(|validation| {
-                    CompileErrors::from(CompileError::without_span(
-                        ErrorKind::InvalidCompilerInput(format!(
-                            "invalid import-free semantic graph: {validation:?}"
-                        )),
-                    ))
-                })?
+            crate::import_graph::import_free_canonical_graph(program.as_ref())?
         };
         Ok(graph)
     }
@@ -3106,16 +3110,6 @@ impl CompilerSession {
         self.published.as_ref()
     }
 
-    /// Explicitly supply accepted canonical records to lower-layer unit tests.
-    /// Production import-bearing sessions can only consume the atomically
-    /// committed discovery artifact.
-    #[cfg(test)]
-    pub(crate) fn adopt_test_import_graph(&mut self, graph: CanonicalImportGraph) {
-        self.queries
-            .revisioned
-            .adopt_test_import_graph(graph.clone());
-        self.supplied_test_import_graph = Some(graph);
-    }
     /// Derive the pre-closure import plan for the session's current parsed
     /// revision.
     ///
@@ -4669,6 +4663,43 @@ impl CompilerSession {
     pub fn last_good_semantic_diagnostics(&self) -> Option<&Arc<FrontendDiagnosticSnapshot>> {
         self.diagnostics.last_good_semantic()
     }
+
+    /// Per-function durable CFG artifacts retained by the last successful
+    /// semantic record — the baseline an ordinary attempt reuses from.
+    ///
+    /// This reads the production source of truth. It exists so a caller that
+    /// wants to inspect or perturb the reuse baseline does so through the same
+    /// record the reuse path consults, rather than through a separate mirror
+    /// (RUE-1143).
+    #[cfg(test)]
+    fn last_good_successful_cfg_cache(&self) -> Option<&Arc<[crate::queries::DurableCfgArtifact]>> {
+        self.queries
+            .semantic
+            .last_good_record()
+            .and_then(|entry| entry.successful_cfg_cache.as_ref())
+    }
+
+    /// Durable declaration cache retained by the last successful semantic
+    /// record. Companion to [`Self::last_good_successful_cfg_cache`].
+    #[cfg(test)]
+    fn last_good_durable_declaration_cache(&self) -> Option<&DurableDeclarationCache> {
+        self.queries
+            .semantic
+            .last_good_record()
+            .and_then(|entry| entry.durable_declaration_cache.as_ref())
+    }
+
+    /// Supply an explicit durable baseline for the next semantic attempt,
+    /// replacing the last-good record as the reuse source.
+    ///
+    /// No production path calls this. It is the injection seam that lets a test
+    /// drive a chosen — including deliberately stale or corrupt — durable cache
+    /// through the production reuse path, instead of a `cfg(test)` branch that
+    /// production never compiles (RUE-1143).
+    #[cfg(test)]
+    fn set_durable_baseline_override(&mut self, baseline: Option<DurableBaselineOverride>) {
+        self.durable_baseline_override = baseline;
+    }
     /// Look up the currently selected, or otherwise most recently indexed,
     /// diagnostic batch matching a source-attempt and public query stage.
     ///
@@ -4855,10 +4886,6 @@ impl CompilerSession {
     }
 
     pub fn update(&mut self, snapshot: &SourceSnapshot) -> CompilerSessionUpdate {
-        #[cfg(test)]
-        {
-            self.supplied_test_import_graph = None;
-        }
         // A source update supersedes the predecessor any outstanding
         // trusted-toolchain continuation or successor-delta authority was
         // issued against (RUE-1112): a stale capability can neither stage nor
@@ -4879,10 +4906,6 @@ impl CompilerSession {
         &mut self,
         snapshot: &SourceSnapshot,
     ) -> CompilerSessionUpdate {
-        #[cfg(test)]
-        {
-            self.supplied_test_import_graph = None;
-        }
         // A presentation update replaces the retained parse artifact exactly
         // like a source update, so it likewise supersedes any outstanding
         // trusted-toolchain continuation or successor-delta authority
@@ -4907,10 +4930,6 @@ impl CompilerSession {
         successor: bool,
         retained_successor_parse: Option<ParseQueryRecord>,
     ) -> CompilerSessionUpdate {
-        #[cfg(test)]
-        {
-            self.supplied_test_import_graph = None;
-        }
         // A trusted-successor close adopts by RE-SELECTING the exact successor
         // parse terminal its stage computed and retained on the open artifact
         // — same key, same revision — never by re-deriving an extension
@@ -5835,32 +5854,6 @@ impl CompilerSession {
             return Ok(graph.clone());
         }
         let parsed = self.published.clone().ok_or_else(no_published_program)?;
-        #[cfg(test)]
-        if let Some(graph) = self.supplied_test_import_graph.as_ref() {
-            let resolution = ModuleResolutionInputs::new(
-                parsed.root().clone(),
-                parsed
-                    .modules()
-                    .iter()
-                    .map(|module| crate::ModuleResolutionInput {
-                        module: module.module_id().clone(),
-                        physical_path: Arc::from(module.physical_path()),
-                    })
-                    .collect(),
-            )
-            .expect("published parsed modules have validated resolution inputs");
-            let validation = validate_canonical_import_graph(graph, &resolution);
-            *execution = QueryAttemptExecution::Reused;
-            return Ok(Arc::new(CanonicalImportGraphOutput {
-                input: ImportGraphInputDescriptor {
-                    sources: parsed.source_revision().clone(),
-                    resolution,
-                    std_dir: std_dir.map(Arc::from),
-                },
-                graph: graph.clone(),
-                validation,
-            }));
-        }
         if !parsed.import_directives().is_empty() {
             return Err(CompileErrors::from(CompileError::without_span(
                 ErrorKind::InvalidCompilerInput(
@@ -5887,16 +5880,7 @@ impl CompilerSession {
         };
         *execution = QueryAttemptExecution::Computed;
         guard.started();
-        let graph = CanonicalImportGraph::from_supplied(
-            parsed.root().clone(),
-            Vec::new(),
-            &input.resolution,
-        )
-        .map_err(|validation| {
-            CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
-                format!("invalid import-free graph: {validation:?}"),
-            )))
-        })?;
+        let graph = crate::import_graph::import_free_canonical_graph(parsed.as_ref())?;
         let validation = validate_canonical_import_graph(&graph, &input.resolution);
         Ok(Arc::new(CanonicalImportGraphOutput {
             input,
@@ -6490,11 +6474,6 @@ impl CompilerSession {
                     .direct_dependencies::<SemanticQuery>(handle.observed().node),
             );
             guard.attach_diagnostics(entry.diagnostics.clone());
-            #[cfg(test)]
-            if result.is_ok() {
-                self.last_successful_cfg_cache = entry.successful_cfg_cache.clone();
-                self.durable_declaration_cache = entry.durable_declaration_cache.clone();
-            }
             self.reuse_diagnostics(entry.diagnostics.clone());
             if cancellation.is_canceled() {
                 return Err(SemanticRequestControl::Abort(
@@ -6504,15 +6483,20 @@ impl CompilerSession {
             return result.map_err(SemanticRequestControl::Compile);
         }
         let durable_baseline = self.queries.semantic.last_good_record().cloned();
-        let previous_cfg_cache = durable_baseline
-            .as_ref()
-            .and_then(|entry| entry.successful_cfg_cache.clone())
-            .unwrap_or_else(|| Arc::from([]));
-        #[cfg(test)]
+        // One selection order, compiled identically under test and production
+        // (RUE-1143): an explicit override when one was supplied, otherwise the
+        // last-good record. Ordinary compiles never set the override, so this
+        // reduces to the last-good record.
         let previous_cfg_cache = self
-            .last_successful_cfg_cache
-            .clone()
-            .unwrap_or(previous_cfg_cache);
+            .durable_baseline_override
+            .as_ref()
+            .and_then(|override_baseline| override_baseline.successful_cfg_cache.clone())
+            .or_else(|| {
+                durable_baseline
+                    .as_ref()
+                    .and_then(|entry| entry.successful_cfg_cache.clone())
+            })
+            .unwrap_or_else(|| Arc::from([]));
 
         let rir_result = self.canonical_rir();
         if cancellation.is_canceled() {
@@ -8095,11 +8079,6 @@ impl CompilerSession {
         ];
         guard.observe(dependencies);
         guard.attach_diagnostics(diagnostics.clone());
-        #[cfg(test)]
-        if result.is_ok() {
-            self.last_successful_cfg_cache = published_cfg_cache.clone();
-            self.durable_declaration_cache = published_declaration_cache.clone();
-        }
         let handle = self
             .queries
             .semantic
@@ -9166,18 +9145,18 @@ impl CompilerSession {
         body_dependency_blockers.sort();
         body_dependency_blockers.dedup();
         let mut durable_body_work = crate::DurableBodyWork::default();
+        // Same single selection order as the CFG baseline above (RUE-1143).
         let durable_declarations = self
-            .queries
-            .semantic
-            .last_good_record()
-            .and_then(|entry| entry.durable_declaration_cache.as_ref())
-            .map(|cache| cache.semantics.clone());
-        #[cfg(test)]
-        let durable_declarations = self
-            .durable_declaration_cache
+            .durable_baseline_override
             .as_ref()
-            .map(|cache| cache.semantics.clone())
-            .or(durable_declarations);
+            .and_then(|override_baseline| override_baseline.durable_declaration_cache.as_ref())
+            .or_else(|| {
+                self.queries
+                    .semantic
+                    .last_good_record()
+                    .and_then(|entry| entry.durable_declaration_cache.as_ref())
+            })
+            .map(|cache| cache.semantics.clone());
         let durable_ordinary_bodies = match &semantic {
             Ok(semantic) => match crate::finalize_durable_ordinary_bodies(
                 semantic.durable_ordinary_body_payloads(),
@@ -12091,7 +12070,7 @@ mod tests {
         session.canonical_semantic(&default).unwrap();
         let diagnostics = session.latest_diagnostics().unwrap().clone();
         let last_good = session.last_good_semantic_diagnostics().unwrap().clone();
-        let cfgs = session.last_successful_cfg_cache.clone().unwrap();
+        let cfgs = session.last_good_successful_cfg_cache().cloned().unwrap();
         let edited = snapshot(
             &[
                 (7, "/p/main.rue", "main.rue", "fn main() -> i32 { 1 }"),
@@ -12145,7 +12124,7 @@ mod tests {
             &last_good
         ));
         assert!(Arc::ptr_eq(
-            session.last_successful_cfg_cache.as_ref().unwrap(),
+            session.last_good_successful_cfg_cache().unwrap(),
             &cfgs
         ));
         assert_eq!(session.work().semantic.calls, 2);
@@ -12196,18 +12175,25 @@ mod tests {
         }
     }
 
+    /// Publish `source` and, when it imports, commit its graph through a real
+    /// discovery epoch served from the fixture's own modules. The returned work
+    /// is the epoch's accumulated parse work, which is the parse an
+    /// import-bearing revision actually performs.
     fn publish_with_test_imports(
         session: &mut CompilerSession,
         source: &SourceSnapshot,
     ) -> ParsedModulesWork {
-        let update = session.update(source);
-        let work = update.work();
-        let program = update.into_owner_result().unwrap();
-        if !program.import_directives().is_empty() {
-            let graph = crate::test_support::test_fixture_import_graph(&program).unwrap();
-            session.adopt_test_import_graph(graph);
+        if !crate::test_support::fixture_has_imports(source).unwrap() {
+            let update = session.update(source);
+            let work = update.work();
+            update.into_owner_result().unwrap();
+            return work;
         }
-        work
+        crate::test_support::TestDiscoveryHost::new(source)
+            .unwrap()
+            .drive(session)
+            .unwrap()
+            .parse_work
     }
 
     fn legacy_air_declaration_shell_oracle(
@@ -12568,8 +12554,7 @@ mod tests {
             0
         );
         let module = session
-            .durable_declaration_cache
-            .as_ref()
+            .last_good_durable_declaration_cache()
             .unwrap()
             .semantics
             .iter()
@@ -12631,7 +12616,13 @@ mod tests {
         let mut session = CompilerSession::new();
         publish_with_test_imports(&mut session, &first);
         session.canonical_semantic(&options).unwrap();
-        let cache = session.durable_declaration_cache.as_mut().unwrap();
+        // Perturb a copy of the produced baseline and inject it, so the next
+        // attempt resolves it through the same selection order production uses
+        // (RUE-1143).
+        let mut cache = session
+            .last_good_durable_declaration_cache()
+            .unwrap()
+            .clone();
         let mut records = cache.semantics.to_vec();
         let module = records
             .iter_mut()
@@ -12641,6 +12632,10 @@ mod tests {
             target: crate::ModuleId::from_logical_path("missing.rue").unwrap(),
         };
         cache.semantics = records.into();
+        session.set_durable_baseline_override(Some(DurableBaselineOverride {
+            durable_declaration_cache: Some(cache),
+            ..DurableBaselineOverride::default()
+        }));
 
         publish_with_test_imports(&mut session, &edited);
         let fallback = session.canonical_semantic(&options).unwrap();
@@ -12880,8 +12875,10 @@ mod tests {
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
         session.canonical_semantic(&options).unwrap();
-        let cache = Arc::make_mut(session.last_successful_cfg_cache.as_mut().unwrap());
-        let specialization = cache
+        // As above: perturb a copy and inject it rather than reaching into a
+        // mirror of the baseline (RUE-1143).
+        let mut artifacts = session.last_good_successful_cfg_cache().unwrap().to_vec();
+        let specialization = artifacts
             .iter_mut()
             .find(|candidate| {
                 matches!(
@@ -12891,8 +12888,17 @@ mod tests {
             })
             .unwrap();
         specialization.semantic_schema_version.implementation_epoch += 1;
+        session.set_durable_baseline_override(Some(DurableBaselineOverride {
+            successful_cfg_cache: Some(artifacts.into()),
+            ..DurableBaselineOverride::default()
+        }));
         session.update(&second).into_result().unwrap();
         let warm = session.canonical_semantic(&options).unwrap();
+        // The override stood in for the last-good record for exactly that one
+        // attempt. Drop it so the repair below reuses the record the warm
+        // attempt actually published, which is what the old mirror did
+        // implicitly by repopulating after every successful attempt.
+        session.set_durable_baseline_override(None);
         assert_eq!(warm.work().cfg.cfg_import_failures, 2);
         assert_eq!(warm.work().cfg.cfg_schema_version_rejections, 1);
         assert_eq!(warm.work().cfg.cfg_fallbacks, 2);
@@ -15159,7 +15165,7 @@ fn main() -> i32 {
     }
 
     #[test]
-    fn supplied_test_graph_is_consumed_without_resolution_fallback() {
+    fn committed_discovery_graph_is_consumed_without_resolution_fallback() {
         let source = snapshot(
             &[
                 (
@@ -15173,9 +15179,7 @@ fn main() -> i32 {
             1,
         );
         let mut session = CompilerSession::new();
-        let program = session.update(&source).into_owner_result().unwrap();
-        let graph = crate::test_support::test_fixture_import_graph(&program).unwrap();
-        session.adopt_test_import_graph(graph);
+        publish_with_test_imports(&mut session, &source);
         assert!(session.import_graph(None).is_ok());
         assert_eq!(session.work().imports.executions, 0);
     }
@@ -15842,7 +15846,11 @@ fn main() -> i32 {
         ));
         assert_eq!(relocated.work().import_records_visited, 1);
         assert_eq!(relocated.work().extra_rir_instructions_visited, 0);
-        assert_eq!(session.work().dependency_manifests.executions, 2);
+        // Relocation moves only the canonical read provenance behind an
+        // unchanged requested path. Module identity, source text, and therefore
+        // the published revision are all untouched, so the manifest is reused
+        // rather than recomputed — the edge is stable without recomputing it.
+        assert_eq!(session.work().dependency_manifests.executions, 1);
     }
 
     #[test]
@@ -16976,69 +16984,73 @@ fn main() -> i32 {
 
     #[test]
     fn semantic_diagnostic_identity_includes_the_accepted_import_graph() {
-        let source = snapshot(
+        // Candidate precedence retargets the import, not a substituted graph:
+        // the importer-relative candidate outranks the project-root one, so
+        // adding a sibling `choice.rue` next to the importer moves
+        // `@import("choice.rue")` off the root-level module without touching a
+        // single spelling in the importer.
+        let main = r#"const selected = @import("choice.rue");
+fn main() -> i32 { selected.value() }"#;
+        let root_only = snapshot(
             &[
+                (1, "/p/app/main.rue", "app/main.rue", main),
                 (
-                    1,
-                    "/p/main.rue",
-                    "main.rue",
-                    r#"const selected = @import("choice.rue");
-fn main() -> i32 { selected.value() }"#,
+                    2,
+                    "/p/choice.rue",
+                    "choice.rue",
+                    "pub fn value() -> i32 { 1 }",
                 ),
-                (2, "/p/a.rue", "a.rue", "pub fn value() -> i32 { 1 }"),
-                (3, "/p/b.rue", "b.rue", "pub fn value() -> i32 { 2 }"),
             ],
             1,
         );
-        let root = source.module_id(FileId::new(1)).unwrap().clone();
-        let a = source.module_id(FileId::new(2)).unwrap().clone();
-        let b = source.module_id(FileId::new(3)).unwrap().clone();
-        let resolution = ModuleResolutionInputs::new(
-            root.clone(),
-            [
-                (root.clone(), "/p/main.rue"),
-                (a.clone(), "/p/a.rue"),
-                (b.clone(), "/p/b.rue"),
-            ]
-            .into_iter()
-            .map(|(module, path)| crate::ModuleResolutionInput {
-                module,
-                physical_path: Arc::from(path),
-            })
-            .collect(),
-        )
-        .unwrap();
-        let graph = |target| {
-            CanonicalImportGraph::from_supplied(
-                root.clone(),
-                vec![crate::CanonicalImportRecord::new(
-                    root.clone(),
+        let with_sibling = snapshot(
+            &[
+                (1, "/p/app/main.rue", "app/main.rue", main),
+                (
+                    2,
+                    "/p/choice.rue",
                     "choice.rue",
-                    CanonicalImportResolution::Resolved(target),
-                )],
-                &resolution,
-            )
-            .unwrap()
+                    "pub fn value() -> i32 { 1 }",
+                ),
+                (
+                    3,
+                    "/p/app/choice.rue",
+                    "app/choice.rue",
+                    "pub fn value() -> i32 { 2 }",
+                ),
+            ],
+            1,
+        );
+        let resolved_target = |graph: &CanonicalImportGraph| match graph.records()[0].resolution() {
+            CanonicalImportResolution::Resolved(module) => module.as_str().to_owned(),
+            other => panic!("expected a resolved import, got {other:?}"),
         };
-        let graph_a = graph(a);
-        let graph_b = graph(b);
+
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
-        session.update(&source).into_result().unwrap();
-
-        session.adopt_test_import_graph(graph_a.clone());
+        let graph_a = crate::test_support::TestDiscoveryHost::new(&root_only)
+            .unwrap()
+            .drive(&mut session)
+            .unwrap()
+            .graph;
+        assert_eq!(resolved_target(&graph_a), "choice.rue");
         let output_a = session.canonical_semantic(&options).unwrap();
         let diagnostics_a = session.latest_diagnostics().unwrap().clone();
-        let main = body_query_key(&mut session, &options, "main");
-        let main_a = retained_body_transaction(&session, &main).0;
-        session.adopt_test_import_graph(graph_b.clone());
+        let main_key = body_query_key(&mut session, &options, "main");
+        let main_a = retained_body_transaction(&session, &main_key).0;
+
+        let graph_b = crate::test_support::TestDiscoveryHost::new(&with_sibling)
+            .unwrap()
+            .drive(&mut session)
+            .unwrap()
+            .graph;
+        assert_eq!(resolved_target(&graph_b), "app/choice.rue");
         let output_b = session.canonical_semantic(&options).unwrap();
         let diagnostics_b = session.latest_diagnostics().unwrap().clone();
-        let main_b = retained_body_transaction(&session, &main).0;
+        let main_b = retained_body_transaction(&session, &main_key).0;
 
         let mut fresh = CompilerSession::new();
-        fresh.update(&source).into_result().unwrap();
-        fresh.adopt_test_import_graph(graph_b.clone());
+        publish_with_test_imports(&mut fresh, &with_sibling);
         let fresh_b = fresh.canonical_semantic(&options).unwrap();
 
         assert!(!Arc::ptr_eq(&diagnostics_a, &diagnostics_b));

--- a/crates/rue-compiler/src/session/tests/rfinal_harness.rs
+++ b/crates/rue-compiler/src/session/tests/rfinal_harness.rs
@@ -78,7 +78,7 @@ impl DirectProductionInputs {
         let rir = crate::lower_canonical_rir(&merged)
             .map_err(|errors| HarnessError::Compile(errors.to_string()))?;
         let options = CompileOptions::default();
-        let imports = crate::bound_definitions::test_fixture_import_graph(&merged)
+        let imports = crate::import_graph::import_free_canonical_graph(merged.ast())
             .map_err(|errors| HarnessError::Compile(errors.to_string()))?;
         let (_, query_declarations, _) =
             crate::bound_definitions::bind_canonical_declaration_semantics(
@@ -86,6 +86,7 @@ impl DirectProductionInputs {
                 &rir,
                 options.preview_features.clone(),
                 options.target,
+                &imports,
             )
             .map_err(|errors| HarnessError::Compile(errors.to_string()))?;
         let query_shells = crate::canonical_semantic::query_owned_declaration_shells_for_test(
@@ -980,11 +981,14 @@ impl SideBCase {
         let rir = crate::lower_canonical_rir(&merged)
             .map_err(|errors| HarnessError::Compile(errors.to_string()))?;
         let options = CompileOptions::default();
+        let imports = crate::test_support::test_import_graph(&snapshot)
+            .map_err(|errors| HarnessError::Compile(errors.to_string()))?;
         let (_, decls, _) = crate::bound_definitions::bind_canonical_declaration_semantics(
             &merged,
             &rir,
             options.preview_features.clone(),
             options.target,
+            &imports,
         )
         .map_err(|errors| HarnessError::Compile(errors.to_string()))?;
         let module_files = merged

--- a/crates/rue-compiler/src/test_support.rs
+++ b/crates/rue-compiler/src/test_support.rs
@@ -89,8 +89,8 @@ pub(crate) fn test_compile_snapshot(
     options: &CompileOptions,
 ) -> MultiErrorResult<CompileOutput> {
     let mut session = CompilerSession::new();
-    publish_test_snapshot(&mut session, snapshot)?;
-    crate::queries::compile_with_session(&mut session, snapshot, options)
+    let published = publish_test_snapshot(&mut session, snapshot)?;
+    crate::queries::compile_with_session(&mut session, &published, options)
 }
 
 pub(crate) fn test_compile_sources(
@@ -116,91 +116,273 @@ pub(crate) fn test_compile_sources_with_metadata(
     test_compile_snapshot(&snapshot, options)
 }
 
-fn publish_test_snapshot(
+/// Publish `snapshot` into `session` and return the snapshot the session
+/// actually holds.
+///
+/// An import-bearing fixture is republished by its discovery epoch, whose
+/// snapshot holds the modules reached from the root under their canonical
+/// identities — so consumers that must agree with the published program compile
+/// against the returned snapshot, not the fixture's declared one.
+pub(crate) fn publish_test_snapshot(
     session: &mut CompilerSession,
     snapshot: &SourceSnapshot,
-) -> MultiErrorResult<()> {
-    let program = session
-        .update_for_presentation(snapshot)
-        .into_owner_result()?;
-    if !program.import_directives().is_empty() {
-        let graph = test_fixture_import_graph(&program)?;
-        session.adopt_test_import_graph(graph);
+) -> MultiErrorResult<SourceSnapshot> {
+    if !fixture_has_imports(snapshot)? {
+        session
+            .update_for_presentation(snapshot)
+            .into_owner_result()?;
+        return Ok(snapshot.clone());
     }
-    Ok(())
+    Ok(TestDiscoveryHost::new(snapshot)?.drive(session)?.snapshot)
 }
 
-/// Build explicit canonical records for in-memory fixtures whose import
-/// spellings name one loaded logical or physical module spelling. This is
-/// deliberately a test-data convention, not a path-resolution implementation.
-pub(crate) fn test_fixture_import_graph(
-    program: &ParsedProgram,
-) -> MultiErrorResult<CanonicalImportGraph> {
-    test_fixture_import_graph_parts(
-        program.root(),
-        program
-            .modules()
-            .iter()
-            .map(|module| {
-                (
-                    module.module_id().clone(),
-                    std::sync::Arc::from(module.physical_path()),
-                )
-            })
-            .collect(),
-        program.import_directives(),
-    )
+/// Whether `snapshot` declares any import directive, decided by a standalone
+/// parse so the answer costs the session nothing when discovery follows.
+pub(crate) fn fixture_has_imports(snapshot: &SourceSnapshot) -> MultiErrorResult<bool> {
+    let parsed = crate::parsed_modules::parse_source_snapshot_modules(snapshot)?;
+    Ok(!parsed.import_directives().is_empty())
 }
 
-pub(crate) fn test_fixture_import_graph_parts(
-    root: &ModuleId,
-    modules: Vec<(ModuleId, std::sync::Arc<str>)>,
-    directives: &ImportDirectives,
+/// The canonical import graph `snapshot` commits, for lower-layer unit tests
+/// that analyze a fixture without owning a session.
+///
+/// Import-bearing fixtures resolve through a full discovery epoch; import-free
+/// ones take production's own uniquely valid empty graph over their declared
+/// module set.
+pub(crate) fn test_import_graph(
+    snapshot: &SourceSnapshot,
 ) -> MultiErrorResult<CanonicalImportGraph> {
-    let inputs = ModuleResolutionInputs::new(
-        root.clone(),
-        modules
-            .iter()
-            .map(|(module, physical_path)| ModuleResolutionInput {
-                module: module.clone(),
-                physical_path: physical_path.clone(),
-            })
-            .collect(),
-    )
-    .map_err(CompileErrors::from)?;
-    let records = directives
-        .iter()
-        .map(|directive| {
-            let target = modules
-                .iter()
-                .find(|(module, physical_path)| {
-                    [module.as_str(), physical_path.as_ref()]
-                        .into_iter()
-                        .any(|spelling| {
-                            spelling == directive.specifier()
-                                || spelling.strip_suffix(directive.specifier()).is_some_and(
-                                    |prefix| prefix.is_empty() || prefix.ends_with('/'),
-                                )
-                        })
-                })
-                .ok_or_else(|| {
-                    CompileErrors::from(CompileError::without_span(
-                        ErrorKind::InvalidCompilerInput(format!(
-                            "test fixture has no logical module matching import {:?}",
-                            directive.specifier()
-                        )),
-                    ))
-                })?;
-            Ok(CanonicalImportRecord::new(
-                directive.importer().clone(),
-                directive.specifier(),
-                CanonicalImportResolution::Resolved(target.0.clone()),
-            ))
+    if !fixture_has_imports(snapshot)? {
+        let parsed = crate::parsed_modules::parse_source_snapshot_modules(snapshot)?;
+        return crate::import_graph::import_free_canonical_graph(&parsed);
+    }
+    let mut session = CompilerSession::new();
+    let discovery = TestDiscoveryHost::new(snapshot)?.drive(&mut session)?;
+    Ok(discovery.graph)
+}
+
+/// What one in-memory discovery epoch produced.
+pub(crate) struct TestDiscovery {
+    /// The snapshot discovery assembled and the session published — the modules
+    /// actually reached from the root, not the fixture's declared set.
+    pub(crate) snapshot: SourceSnapshot,
+    /// Parse work accumulated across the epoch's staging rounds.
+    pub(crate) parse_work: crate::ParsedModulesWork,
+    pub(crate) graph: CanonicalImportGraph,
+}
+
+/// One file the fixture can serve, keyed by the path discovery would request.
+struct TestFixtureFile {
+    canonical_path: std::sync::Arc<str>,
+    identity: PhysicalFileIdentity,
+    fingerprint: FileMetadataFingerprint,
+    source: std::sync::Arc<String>,
+}
+
+/// An in-memory host for the real import-discovery protocol (ADR-0051).
+///
+/// A fixture's *logical* module paths describe a virtual project tree: each
+/// module is served at exactly the path production would request for that
+/// module identity, under a synthetic project root. Its *physical* paths carry
+/// over as canonical identity, which is their production role — a canonical
+/// path that differs from the requested one is the relocated-or-linked file
+/// case, not a second spelling the resolver is allowed to match against.
+///
+/// The host answers one question per compiler-issued frontier request: does
+/// this exact requested path exist, and what are its bytes. Candidate
+/// precedence, canonical identity, provenance, and read policy stay in the
+/// compiler, so a fixture cannot resolve an import the real resolver would not.
+pub(crate) struct TestDiscoveryHost {
+    context: ImportDiscoveryContext,
+    root_requested_path: String,
+    files: std::collections::BTreeMap<String, TestFixtureFile>,
+}
+
+/// The synthetic project root every fixture's virtual tree hangs from. Fixtures
+/// name modules logically, so the tree needs a root but never a real directory.
+const FIXTURE_PROJECT_ROOT: &str = "/rue-fixture";
+const FIXTURE_STD_ROOT: &str = "/rue-fixture/std";
+const TRUSTED_MODULE_PREFIX: &str = "\0rue-std/";
+
+impl TestDiscoveryHost {
+    pub(crate) fn new(snapshot: &SourceSnapshot) -> MultiErrorResult<Self> {
+        let metadata = snapshot.metadata();
+        let mut trusted = false;
+        let mut files = std::collections::BTreeMap::new();
+        for source in snapshot.files() {
+            let module = metadata
+                .module_id(source.file_id)
+                .expect("validated snapshot metadata names every file");
+            let requested = fixture_requested_path(&module)?;
+            trusted |= module.is_trusted_standard_library();
+            // A trusted module's canonical path must stay under the captured
+            // std root, so only project modules can carry a fixture-declared
+            // relocation. A relative fixture spelling names no on-disk file at
+            // all and is canonically its own requested path.
+            let canonical = if module.is_trusted_standard_library()
+                || !std::path::Path::new(source.path).is_absolute()
+            {
+                requested.clone()
+            } else {
+                source.path.to_owned()
+            };
+            let text = snapshot
+                .shared_source_text(source.file_id)
+                .expect("validated snapshot retains every file's text");
+            files.insert(
+                requested,
+                TestFixtureFile {
+                    identity: PhysicalFileIdentity::new(
+                        1,
+                        crate::import_discovery::source_fingerprint(&canonical),
+                    ),
+                    fingerprint: FileMetadataFingerprint::new(text.len() as u64, 0, 0),
+                    canonical_path: std::sync::Arc::from(canonical.as_str()),
+                    source: text,
+                },
+            );
+        }
+        let root_module = metadata.root_module_id();
+        if root_module.is_trusted_standard_library() {
+            return Err(invalid_fixture(
+                "a discovery root cannot be a trusted standard-library module",
+            ));
+        }
+        let context = ImportDiscoveryContext::new(
+            1,
+            FIXTURE_PROJECT_ROOT,
+            trusted.then_some(FIXTURE_STD_ROOT),
+            "test-fixture-discovery",
+        )
+        .map_err(CompileErrors::from)?;
+        Ok(Self {
+            context,
+            root_requested_path: fixture_requested_path(&root_module)?,
+            files,
         })
-        .collect::<MultiErrorResult<Vec<_>>>()?;
-    CanonicalImportGraph::from_supplied(root.clone(), records, &inputs).map_err(|validation| {
-        CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
-            format!("test fixture supplied an invalid import graph: {validation:?}"),
-        )))
-    })
+    }
+
+    fn assembler(&self) -> MultiErrorResult<DiscoverySourceAssembler> {
+        let root = self
+            .files
+            .get(&self.root_requested_path)
+            .expect("the root module is one of the fixture's own files");
+        DiscoverySourceAssembler::new(
+            self.context.clone(),
+            self.root_requested_path.as_str(),
+            root.canonical_path.as_ref(),
+            root.identity,
+            root.fingerprint,
+            root.source.clone(),
+        )
+        .map_err(CompileErrors::from)
+    }
+
+    /// Answer one compiler-issued probe: the fixture reports existence and
+    /// bytes for the exact requested path, and nothing else.
+    fn serve(&self, request: crate::ImportDiscoveryRequest) -> MultiErrorResult<ImportObservation> {
+        let Some(file) = self.files.get(request.requested_path()) else {
+            return Ok(ImportObservation::absent(request));
+        };
+        let accepted = AcceptedImportSource::new(
+            request.requested_path(),
+            file.canonical_path.as_ref(),
+            file.identity,
+            file.fingerprint,
+            file.source.clone(),
+        )
+        .map_err(CompileErrors::from)?;
+        ImportObservation::accepted(request, accepted).map_err(CompileErrors::from)
+    }
+
+    /// Run one complete discovery epoch against `session` and commit its graph.
+    pub(crate) fn drive(&self, session: &mut CompilerSession) -> MultiErrorResult<TestDiscovery> {
+        let mut assembler = self.assembler()?;
+        let initial = assembler.snapshot().map_err(CompileErrors::from)?;
+        let mut revision = session
+            .begin_import_input_request(
+                &initial,
+                self.context.clone(),
+                assembler.accepted_read_manifest(),
+            )
+            .map_err(CompileErrors::from)?;
+        loop {
+            let snapshot = assembler.snapshot().map_err(CompileErrors::from)?;
+            let ledger = session
+                .import_observation_ledger(revision)
+                .map_err(CompileErrors::from)?;
+            let plan = session.stage_import_discovery(
+                &snapshot,
+                self.context.clone(),
+                assembler.accepted_read_manifest().shared_slice(),
+                ledger.clone(),
+            )?;
+            let frontier = session
+                .import_demand_frontier_for_roots(
+                    revision,
+                    &plan,
+                    ImportDemandMode::Rooted,
+                    &plan.demand_roots(),
+                )
+                .map_err(CompileErrors::from)?;
+            if frontier.requests().is_empty() {
+                let artifact = session.close_import_discovery(ledger)?;
+                let graph = artifact
+                    .graph()
+                    .expect("a closed-valid discovery revision retains its canonical graph")
+                    .graph()
+                    .clone();
+                return Ok(TestDiscovery {
+                    snapshot: artifact.snapshot().clone(),
+                    parse_work: artifact.parse_work(),
+                    graph,
+                });
+            }
+            let observations = frontier
+                .requests()
+                .iter()
+                .cloned()
+                .map(|request| self.serve(request))
+                .collect::<MultiErrorResult<Vec<_>>>()?;
+            let mut assembly_ledger = ledger;
+            for observation in observations.iter().cloned() {
+                assembly_ledger
+                    .record(observation)
+                    .map_err(CompileErrors::from)?;
+            }
+            assembler
+                .add_plan_reads(&plan, &assembly_ledger)
+                .map_err(CompileErrors::from)?;
+            let successor = assembler.snapshot().map_err(CompileErrors::from)?;
+            revision = session
+                .publish_import_observation_batch(
+                    &frontier,
+                    &successor,
+                    assembler.accepted_read_manifest(),
+                    observations,
+                )
+                .map_err(CompileErrors::from)?;
+        }
+    }
+}
+
+/// The path production would request for `module` inside the fixture tree —
+/// the compiler's own module-identity-to-path inverse, not a search.
+fn fixture_requested_path(module: &ModuleId) -> MultiErrorResult<String> {
+    let (root, relative) = match module.as_str().strip_prefix(TRUSTED_MODULE_PREFIX) {
+        Some(relative) => (FIXTURE_STD_ROOT, relative),
+        None => (FIXTURE_PROJECT_ROOT, module.as_str()),
+    };
+    if relative.is_empty() || relative.starts_with('/') {
+        return Err(invalid_fixture(&format!(
+            "fixture module {module} has no project-relative logical path"
+        )));
+    }
+    Ok(format!("{root}/{relative}"))
+}
+
+fn invalid_fixture(message: &str) -> CompileErrors {
+    CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+        message.to_owned(),
+    )))
 }


### PR DESCRIPTION
Two `#[cfg(test)]` mechanisms let tests validate behavior production never
executes. Each is removed by making the test take the production path instead.

---

## 1. The durable reuse baseline was chosen twice (RUE-1143)

`semantic_attempt` chose its durable reuse baseline twice. Production read the
last-good semantic record; two `#[cfg(test)]` fields mirrored that record and,
under test, shadowed it:

```rust
let previous_cfg_cache = durable_baseline
    .as_ref()
    .and_then(|entry| entry.successful_cfg_cache.clone())
    .unwrap_or_else(|| Arc::from([]));
#[cfg(test)]
let previous_cfg_cache = self.last_successful_cfg_cache.clone().unwrap_or(previous_cfg_cache);
```

The same shape applied to `durable_declaration_cache`. So the durable-reuse
tests validated a baseline-selection order that production never executes — and
they sit underneath the differential oracle, which is the defense for exactly
that class of bug. The mirrors also had to be silently repopulated after every
successful attempt to stay current, so the test-visible baseline depended on
bookkeeping production did not perform.

**Change.** One unconditional slot, `durable_baseline_override`, and one
selection order compiled identically in both configurations: an explicit
override when supplied, otherwise the last-good record. Ordinary compiles never
set the override, so this reduces to the last-good record.

The slot is deliberately **not** `#[cfg(test)]` — that is what keeps the
algorithm single-path. Only the injection helpers are test-gated, which is an
injection point rather than a divergent algorithm. This follows how the crate
already handles `shared_declaration_base_differential` and the recipe/overlay
meters: production-inert state carrying a comment that says so.

Reuse tests now read the produced baseline through accessors over the last-good
record, perturb a copy, and inject it — exercising the production lookup order
rather than a parallel branch. The CFG-schema test drops the override after the
attempt it was meant to affect, making explicit what the old mirror did
implicitly by repopulating.

## 2. The fabricated test import graph (RUE-1149)

`CompilerSession::supplied_test_import_graph` (+ `adopt_test_import_graph`) let
a test hand the session a pre-built `CanonicalImportGraph`, bypassing discovery
entirely. The graph came from `test_support::test_fixture_import_graph`, which
resolved imports by **string-matching specifiers against loaded module
spellings**. Its own doc comment conceded the point:

> Build explicit canonical records for in-memory fixtures whose import spellings
> name one loaded logical or physical module spelling. This is deliberately a
> test-data convention, **not a path-resolution implementation**.

So it was a second, weaker resolver. Production resolves through the discovery
protocol with candidate precedence, canonical identity, provenance, typed
observations, and read policy (ADR-0051); around 28 session tests exercised none
of it. Same defect class as RUE-1143, one layer up.

**Change.** `test_support::TestDiscoveryHost` is an in-memory host for the real
protocol, modelled on the loop `rue-oracle-diff` already runs:

```text
begin_import_input_request
  -> { stage_import_discovery -> import_demand_frontier_for_roots
       -> serve each frontier request as accepted|absent -> add_plan_reads
       -> publish_import_observation_batch }
  -> close_import_discovery
```

What makes this a swap rather than a reimplementation: **the host resolves
nothing.** The compiler computes each probe and hands it over as a frontier
request carrying a `requested_path`; the fixture answers only whether that exact
path exists and what its bytes are. Precedence, canonical identity, provenance,
and read policy all stay in production code.

A fixture's *logical* module paths describe a virtual project tree — each module
served at exactly the path production would request for that module identity,
under a synthetic project root. Its *physical* paths carry over as canonical
identity, which is their production role: a canonical path that differs from the
requested one is the relocated-or-linked file case, not a second spelling the
resolver may match against.

Both choke points — `test_support::publish_test_snapshot` and `session.rs`'s
`publish_with_test_imports` — route through the host, so the ~28 call sites are
unchanged. Import-free fixtures take `import_graph::import_free_canonical_graph`,
which is now the single construction the session's own semantic path uses for a
revision with no import directives.

Deleted, not merely unused: `supplied_test_import_graph`,
`adopt_test_import_graph`, `test_fixture_import_graph`,
`test_fixture_import_graph_parts`, and `bound_definitions::test_fixture_import_graph`
(which existed only to call `_parts`). No production or test path constructs a
`CanonicalImportGraph` outside discovery or the import-free constructor; the
remaining direct `from_supplied` calls are the validator's own unit tests.

### Fixtures that only resolved under string matching

These are the ones the old matcher accepted and real candidate precedence does
not. Each was corrected rather than routed around, and each names behavior that
was previously untested.

- **`pipeline_tests::canonical_std_strbuf_identity_survives_qualified_and_aliased_lookup`**
  and **`trusted_std_presence_does_not_create_a_bare_strbuf_prelude_name`** —
  imported the std entry point with the absolute specifier `"/sdk/_std.rue"`,
  which pins the fixture to one host's std layout. Now `"std/_std.rue"`, which
  the resolver joins onto the importer and root anchors like any other
  specifier.

- **`pipeline_tests::caller_logical_std_spelling_cannot_spoof_strbuf_language_item`**
  → **`caller_std_shaped_specifier_cannot_spoof_strbuf_language_item`** — the
  old fixture handed `SourceMetadata` a caller-authored logical path of
  `\0rue-std/strbuf.rue` for a file spelled `spoof.rue`, and the string matcher
  resolved `@import("spoof.rue")` to it. Discovery derives the logical identity
  from the requested path, so that spoofing vector is not expressible at all.
  The test now asserts the property that *is* reachable: a project module
  reached through an `std/`-shaped specifier stays an ordinary module, so its
  `StrBuf` is not the language item. Trust comes from the captured std root,
  never from a spelling.

- **`canonical_semantic::codegen_input_tracks_root_paths_and_options_but_not_linker`**
  — designated `helper.rue` as the root of an import-bearing two-module fixture,
  leaving `main.rue` (the only importer) unreachable. A program's graph covers
  only what discovery reaches from its root, so the root axis moved to an
  import-free pair. The other axes (options, opt level, relocation) are
  unchanged.

- **`session::semantic_diagnostic_identity_includes_the_accepted_import_graph`**
  — retargeted `@import("choice.rue")` by substituting two hand-built graphs
  pointing at `a.rue` and `b.rue`, which no resolver would ever produce for one
  specifier. It now retargets the way production does: the importer-relative
  candidate outranks the project-root one, so adding a sibling `choice.rue` next
  to the importer moves the import off the root-level module without changing a
  single spelling in the importer. That exercises candidate precedence, which
  the old form asserted nothing about.

- **`session::dependency_manifest_keeps_canonical_module_edges_across_physical_relocation`**
  — unchanged fixture, changed expectation. Relocation now moves only the
  canonical read provenance behind an unchanged requested path, so module
  identity, source text, and the published revision are all untouched and the
  dependency manifest is *reused* rather than recomputed (`executions` 2 → 1).
  Stronger than the original claim: the edge is stable without recomputing it.

- **`pipeline_tests::canonical_batch_reports_one_pass_structural_work`** — same
  kind of correction. An import-bearing program is parsed by its discovery
  epoch, and the batch pass that follows reuses that parse. The one-pass claim
  splits accordingly: discovery lexes and parses each module exactly once, and
  the batch adds zero parse work. Every merge/lower/semantic assertion is
  unchanged.

- **`session::supplied_test_graph_is_consumed_without_resolution_fallback`** →
  **`committed_discovery_graph_is_consumed_without_resolution_fallback`** — the
  injected graph it named no longer exists; the property (a committed graph is
  consumed with `imports.executions == 0`, never re-resolved) is now asserted
  against a real discovery close.

## Remaining test-only state

Test-only fields on `CompilerSession` drop from **seven to four**. The remaining
four inject an *input* or an *event* at a deterministic point and select no
alternative algorithm; each carries a comment saying why it cannot go through
the production path:

- `cancel_merge_before_commit`, `cancel_semantic_after_dependency`,
  `cancel_semantic_before_publication` — production cancellation arrives
  asynchronously through a `CancellationToken` and cannot be deterministically
  landed between two chosen steps. The branch each triggers is the same
  cancellation path a real token drives.
- `recipe_cache_slot` — already documented; the test-only overlay path.

## Validation

`rue-compiler-test` 873 pass, `rue-query-test` 55 pass, differential-oracle,
public-API and scaling-matrix targets green, `scripts/rue quick` 36/36 with the
oracle agreeing on every modeled eligible case.

Not run locally: the full `scripts/rue test` suite and non-x86-64 targets. CI is
the full-platform authority.

Fixes RUE-1143

Fixes RUE-1149