### PR TITLE
RUE-786: attribute whole-pipeline and backend subphase timing

### DIFF
--- a/crates/rue-codegen/BUCK
+++ b/crates/rue-codegen/BUCK
@@ -30,6 +30,7 @@ rue_crate(
         "//crates/rue-target:rue-target",
         "//third-party:fixedbitset",
         "//third-party:lasso",
+        "//third-party:tracing",
     ],
     test_deps = [
         "//crates/rue-lexer:rue-lexer",

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -31,6 +31,7 @@ use rue_air::FrozenTypeInternPool;
 use rue_cfg::ValidatedCfg;
 use rue_error::CompileResult;
 use rue_target::Target;
+use tracing::info_span;
 
 use crate::MachineCode;
 // Re-export from parent
@@ -133,17 +134,26 @@ fn generate_inner(
             | Aarch64Inst::StringConstCap { string_id, .. } => Some(*string_id),
             _ => None,
         });
-    let (local_strings, string_id_remap) =
-        crate::compact_string_table(strings, atoms, referenced_strings, require_complete_atoms)?;
-    for inst in prepared.mir.instructions_vec_mut() {
-        let string_id = match inst {
-            Aarch64Inst::StringConstPtr { string_id, .. }
-            | Aarch64Inst::StringConstLen { string_id, .. }
-            | Aarch64Inst::StringConstCap { string_id, .. } => string_id,
-            _ => continue,
-        };
-        *string_id = string_id_remap[string_id];
-    }
+    let local_strings = {
+        let _span = info_span!("string_table_compaction").entered();
+        let (local_strings, string_id_remap) = crate::compact_string_table(
+            strings,
+            atoms,
+            referenced_strings,
+            require_complete_atoms,
+        )?;
+        for inst in prepared.mir.instructions_vec_mut() {
+            let string_id = match inst {
+                Aarch64Inst::StringConstPtr { string_id, .. }
+                | Aarch64Inst::StringConstLen { string_id, .. }
+                | Aarch64Inst::StringConstCap { string_id, .. } => string_id,
+                _ => continue,
+            };
+            *string_id = string_id_remap[string_id];
+        }
+        local_strings
+    };
+    let _emission_span = info_span!("machine_emission").entered();
     let emitter = Emitter::new(
         &prepared.mir,
         prepared.total_locals,

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -8,6 +8,7 @@
 use rue_air::{ArgClass, ArgConvention, FrozenTypeInternPool, NativeCallAbi, ReturnClass};
 use rue_cfg::{Cfg, CfgArgMode, CfgInstData, CfgValue};
 use rue_error::{CompileError, CompileResult, ErrorKind};
+use tracing::info_span;
 
 use crate::frame_layout::{FrameLayout, SavedRegScheme};
 
@@ -181,14 +182,29 @@ where
         validate_pre_lowering_budget(cfg, type_pool, arg_reg_count, return_reg_count, scheme)?;
     let param_homing = param_homing_plan(cfg);
 
-    let (mir, mut artifacts) = lower()?;
+    let (mir, mut artifacts) = {
+        let _span = info_span!("mir_lowering").entered();
+        lower()?
+    };
     let existing_slots = checked_slot_sum([num_locals_original, num_params, u32::from(has_sret)])
         .ok_or_else(|| frame_budget_error(cfg, None))?;
-    let (mut mir, num_spills, used_callee_saved) = allocate(mir, existing_slots, &mut artifacts)?;
+    let (mut mir, num_spills, used_callee_saved) = {
+        let _span = info_span!("register_allocation").entered();
+        allocate(mir, existing_slots, &mut artifacts)?
+    };
 
-    peephole(&mut mir);
-    schedule(&mut mir);
-    verify(&mir)?;
+    {
+        let _span = info_span!("mir_peephole").entered();
+        peephole(&mut mir);
+    }
+    {
+        let _span = info_span!("mir_scheduling").entered();
+        schedule(&mut mir);
+    }
+    {
+        let _span = info_span!("mir_verification").entered();
+        verify(&mir)?;
+    }
 
     let total_locals = num_locals_original
         .checked_add(num_spills)

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -30,6 +30,7 @@ use lasso::ThreadedRodeo;
 use rue_air::FrozenTypeInternPool;
 use rue_cfg::ValidatedCfg;
 use rue_error::CompileResult;
+use tracing::info_span;
 
 // Re-export from parent
 pub use super::{EmittedCode, EmittedRelocation, MachineCode};
@@ -125,17 +126,26 @@ fn generate_inner(
             | X86Inst::StringConstCap { string_id, .. } => Some(*string_id),
             _ => None,
         });
-    let (local_strings, string_id_remap) =
-        crate::compact_string_table(strings, atoms, referenced_strings, require_complete_atoms)?;
-    for inst in prepared.mir.instructions_vec_mut() {
-        let string_id = match inst {
-            X86Inst::StringConstPtr { string_id, .. }
-            | X86Inst::StringConstLen { string_id, .. }
-            | X86Inst::StringConstCap { string_id, .. } => string_id,
-            _ => continue,
-        };
-        *string_id = string_id_remap[string_id];
-    }
+    let local_strings = {
+        let _span = info_span!("string_table_compaction").entered();
+        let (local_strings, string_id_remap) = crate::compact_string_table(
+            strings,
+            atoms,
+            referenced_strings,
+            require_complete_atoms,
+        )?;
+        for inst in prepared.mir.instructions_vec_mut() {
+            let string_id = match inst {
+                X86Inst::StringConstPtr { string_id, .. }
+                | X86Inst::StringConstLen { string_id, .. }
+                | X86Inst::StringConstCap { string_id, .. } => string_id,
+                _ => continue,
+            };
+            *string_id = string_id_remap[string_id];
+        }
+        local_strings
+    };
+    let _emission_span = info_span!("machine_emission").entered();
     let emitter = Emitter::new(
         &prepared.mir,
         prepared.total_locals,

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -201,7 +201,13 @@ pub(crate) fn generate_backend_products(
     foreign_symbols: &[String],
     request: rue_codegen::BackendArtifactRequest,
 ) -> MultiErrorResult<Vec<FunctionBackendProduct>> {
-    let _span = info_span!("codegen", arch = ?options.target.arch()).entered();
+    // Rayon workers do not inherit the calling thread's current span, so the
+    // per-function subphase spans inside rue-codegen would otherwise be
+    // reported as extra timing roots. Hold the span by value and re-enter it
+    // inside the closure so every worker's subphases nest under this one
+    // `codegen` aggregate (RUE-786).
+    let codegen_span = info_span!("codegen", arch = ?options.target.arch());
+    let _entered = codegen_span.clone().entered();
     let symbol_mappings = foreign_call_symbol_mappings(functions, foreign_symbols);
     let foreign_set: std::collections::BTreeSet<String> = foreign_symbols.iter().cloned().collect();
     let symbols =
@@ -210,6 +216,7 @@ pub(crate) fn generate_backend_products(
     let results: Vec<CompileResult<FunctionBackendProduct>> = functions
         .par_iter()
         .map(|func| {
+            let _worker = codegen_span.enter();
             let stable_atom_ids = func
                 .local_atoms
                 .iter()
@@ -275,6 +282,9 @@ fn project_backend_object(
     product: FunctionBackendProduct,
     target: Target,
 ) -> CompileResult<Vec<u8>> {
+    // Object serialization runs after the parallel codegen fan-out, so it is a
+    // sibling leaf of `codegen` rather than one of its subphases (RUE-786).
+    let _span = info_span!("object_serialization").entered();
     let mut obj_builder = ObjectBuilder::new(target, &product.machine_name)
         .code(product.machine_code.code)
         .strings(product.machine_code.strings);

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -1155,6 +1155,11 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
     durable_cfg_candidates: Arc<[crate::queries::DurableCfgArtifact]>,
     body_work: crate::DurableBodyWork,
 ) -> Result<CanonicalSemanticOutput, CanonicalSemanticFailure> {
+    // Rebinding the durable declaration records and rebuilding the query
+    // dependency edges runs before whole-program analysis opens `sema`. It is
+    // real per-declaration work, so it gets its own leaf instead of widening
+    // the pipeline's unattributed residual (RUE-786).
+    let declaration_reuse_span = info_span!("declaration_reuse").entered();
     let input = CodegenInputDescriptor {
         semantic: SemanticInputDescriptor::new(
             merged.definitions().source_snapshot(),
@@ -1444,6 +1449,7 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
     );
     reuse.durable_records_reused = durable.len();
     reuse.ordinary_declaration_resolutions_skipped = 1;
+    drop(declaration_reuse_span);
     let sema_span = info_span!("sema").entered();
     finish_canonical_analysis(
         input,
@@ -2532,7 +2538,11 @@ pub(crate) fn analyze_body_query<'a>(
     } else {
         None
     };
-    let epoch = match shared_base.get_or_derive(
+    // Deriving this body's epoch from the shared declaration base runs for
+    // every reached body, unlike the one-shot prepare/project/install stages
+    // above, so it is timed separately (RUE-786).
+    let derive_span = info_span!("body_derive_epoch").entered();
+    let derived = shared_base.get_or_derive(
         merged,
         rir,
         options,
@@ -2544,7 +2554,9 @@ pub(crate) fn analyze_body_query<'a>(
         key,
         shared_projection,
         work,
-    ) {
+    );
+    drop(derive_span);
+    let epoch = match derived {
         Ok(epoch) => epoch,
         Err(failure) => return Ok(failure),
     };
@@ -3611,6 +3623,11 @@ fn finish_canonical_analysis_with(
             work,
         )
     })?;
+    // Everything after CFG construction — drop-dependency attachment, warning
+    // ordering, and semantic-output assembly — is the finalization tail. It
+    // runs outside both `sema` and `cfg_construction`, so it needs its own leaf
+    // for the pipeline residual to stay honest (RUE-786).
+    let _finalization_span = info_span!("semantic_finalization").entered();
     let durable_specialized_body_payloads =
         crate::durable_body::attach_specialized_implicit_drop_dependencies(
             durable_specialized_body_payloads,

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -490,14 +490,17 @@ pub(crate) fn link_internal_with_warnings(
     let mut linker = Linker::new(options.target);
 
     // Add all object files to the linker
-    for obj_bytes in object_files {
-        let obj = ObjectFile::parse(obj_bytes)
-            .map_err(link_error)
-            .map_err(CompileErrors::from)?;
-        linker
-            .add_object(obj)
-            .map_err(link_error)
-            .map_err(CompileErrors::from)?;
+    {
+        let _span = info_span!("link_parse_objects", object_count = object_files.len()).entered();
+        for obj_bytes in object_files {
+            let obj = ObjectFile::parse(obj_bytes)
+                .map_err(link_error)
+                .map_err(CompileErrors::from)?;
+            linker
+                .add_object(obj)
+                .map_err(link_error)
+                .map_err(CompileErrors::from)?;
+        }
     }
 
     // Determine the entry point symbol based on target.
@@ -518,24 +521,27 @@ pub(crate) fn link_internal_with_warnings(
     // before the runtime so a foreign member that itself depends on a runtime
     // symbol can still be satisfied. Each archive resolves the undefined
     // `extern "C"` symbols referenced by the compiled objects.
-    for archive_path in &options.link_archives {
-        let archive = read_user_archive(archive_path)
-            .map_err(CompileError::without_span)
+    {
+        let _span = info_span!("link_archive_resolve").entered();
+        for archive_path in &options.link_archives {
+            let archive = read_user_archive(archive_path)
+                .map_err(CompileError::without_span)
+                .map_err(CompileErrors::from)?;
+            linker
+                .add_archive(archive)
+                .map_err(link_error)
+                .map_err(CompileErrors::from)?;
+        }
+
+        // Add the runtime library
+        let runtime = validate_runtime_archive(runtime_bytes, options.target)
+            .map_err(link_error)
             .map_err(CompileErrors::from)?;
         linker
-            .add_archive(archive)
+            .add_archive(runtime)
             .map_err(link_error)
             .map_err(CompileErrors::from)?;
     }
-
-    // Add the runtime library
-    let runtime = validate_runtime_archive(runtime_bytes, options.target)
-        .map_err(link_error)
-        .map_err(CompileErrors::from)?;
-    linker
-        .add_archive(runtime)
-        .map_err(link_error)
-        .map_err(CompileErrors::from)?;
 
     // Link to executable. An undefined symbol at this point is an unresolved
     // `extern "C"` import (or a runtime gap); name the symbol and the archives

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -9868,6 +9868,13 @@ impl RevisionedQueryDatabase {
             key.clone(),
             cancellation,
             |context| {
+                // The transaction's prerequisite fan-out (raw body, toolchain
+                // demands, transitive anonymous nominals, well-known `Option`
+                // resolution) and its trailing lookup-edge recording both run
+                // per reached body around the analysis itself. They are timed
+                // as their own leaves so the residual between `body_transaction`
+                // and `body_analysis` is not telemetry-dark (RUE-786).
+                let prerequisites_span = tracing::info_span!("body_query_prerequisites").entered();
                 let raw = context.query_registered(
                     &self.raw_declaration_bodies,
                     RawDeclarationBodyQueryKey(candidate),
@@ -10134,6 +10141,7 @@ impl RevisionedQueryDatabase {
                         ),
                     }
                 };
+                drop(prerequisites_span);
                 let transaction = compute(
                     selected_anonymous
                         .into_values()
@@ -10141,6 +10149,7 @@ impl RevisionedQueryDatabase {
                         .into(),
                     well_known,
                 )?;
+                let _lookups_span = tracing::info_span!("body_query_lookups").entered();
                 for lookup in transaction.lookup_observations() {
                     match lookup {
                         crate::body_query::BodyLookupKey::Name {
@@ -10703,6 +10712,10 @@ impl RevisionedQueryDatabase {
             if cancellation.is_canceled() {
                 return Err(SemanticNucleusBatchFailure::Query(QueryAbort::Canceled));
             }
+            // Declaration-semantics projection splits into a per-module
+            // occurrence index and a per-declaration nucleus request; both were
+            // previously inside the pipeline's unattributed residual (RUE-786).
+            let index_span = tracing::info_span!("declaration_occurrence_index").entered();
             let indexed = self.runtime.request_registered(
                 &self.declaration_occurrence_indexes,
                 revision,
@@ -10712,6 +10725,7 @@ impl RevisionedQueryDatabase {
             let terminal = indexed
                 .into_result()
                 .map_err(SemanticNucleusBatchFailure::Query)?;
+            drop(index_span);
             let rue_query::QueryOutcome::Success(indexed) = terminal.outcome() else {
                 unreachable!("DeclarationOccurrenceIndex publishes typed values")
             };
@@ -10748,6 +10762,7 @@ impl RevisionedQueryDatabase {
                     configuration: configuration.clone(),
                 };
                 let request = |key: Key| {
+                    let _span = tracing::info_span!("declaration_nucleus").entered();
                     let attempt = self.runtime.request_registered(
                         &self.semantic_nucleus,
                         revision,

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -3765,12 +3765,17 @@ impl CompilerSession {
             );
             return Err(errors);
         }
+        // Staging splits into the canonical parse of everything read so far and
+        // the import-plan construction over the resulting program. Both were
+        // previously folded into the driver's unattributed region (RUE-786).
+        let parse_staging_span = tracing::info_span!("import_parse_staging").entered();
         let (parse_result, staged_work, staged_successor_parse) = self.parse_staging_snapshot(
             snapshot,
             successor
                 .as_ref()
                 .map(|(revision, delta)| (*revision, delta)),
         );
+        drop(parse_staging_span);
         parse_work.accumulate(staged_work);
         let program = match parse_result {
             Ok(program) => program,
@@ -3822,6 +3827,7 @@ impl CompilerSession {
             self.last_good_discovery_artifact()
                 .and_then(|artifact| artifact.plan.clone())
         });
+        let plan_build_span = tracing::info_span!("import_plan_build").entered();
         let plan_build = match (new_modules, predecessor_plan) {
             (Some(new_modules), Some(predecessor)) => {
                 crate::ImportDiscoveryPlan::extend_trusted_successor(
@@ -3885,6 +3891,8 @@ impl CompilerSession {
                 return Err(errors);
             }
         };
+        drop(plan_build_span);
+        let _plan_publish_span = tracing::info_span!("import_plan_publish").entered();
         let plan_diagnostics = if publish_plan {
             let shape_diagnostics = crate::ImportDiscoveryPlan::shape_diagnostics(&program);
             self.publish_import_diagnostics(
@@ -4987,6 +4995,11 @@ impl CompilerSession {
         ParsedModulesWork,
         ParseInvalidationSummary,
     ) {
+        // Keying, module parsing, and terminal publication are separate costs
+        // inside the parse query. Timing them apart keeps the staging residual
+        // from hiding whole-snapshot content hashing behind `parse_file`
+        // (RUE-786).
+        let key_span = tracing::info_span!("parse_query_key").entered();
         let source = ExactSourceInput::new(snapshot);
         // An ordinary key carries every file's exact content identity, so the
         // typed store hashes and compares each of them.
@@ -5018,11 +5031,16 @@ impl CompilerSession {
         self.parse_modules_dispatched = self
             .parse_modules_dispatched
             .saturating_add(demanded_modules.len() as u64);
-        let (modular_result, modular_work) = self.queries.revisioned.parse_program(
-            revision,
-            snapshot.source_revision().root(),
-            demanded_modules,
-        );
+        drop(key_span);
+        let (modular_result, modular_work) = {
+            let _span = tracing::info_span!("parse_program").entered();
+            self.queries.revisioned.parse_program(
+                revision,
+                snapshot.source_revision().root(),
+                demanded_modules,
+            )
+        };
+        let _commit_span = tracing::info_span!("parse_query_commit").entered();
         self.parse_invalidation_entries_compared = self
             .parse_invalidation_entries_compared
             .saturating_add(snapshot.len() as u64);
@@ -6017,10 +6035,12 @@ impl CompilerSession {
             .last_good_record()
             .expect("merge has a successful parse terminal")
             .runtime_revision;
-        let projected_indexes = self
-            .queries
-            .revisioned
-            .projected_module_indexes(runtime_revision, &parsed);
+        let projected_indexes = {
+            let _span = tracing::info_span!("module_index_projection").entered();
+            self.queries
+                .revisioned
+                .projected_module_indexes(runtime_revision, &parsed)
+        };
         // Freeze the traversal work before the fallible duplicate/definition
         // checks so deterministic merge failures retain the work already done.
         *attempt_work = Some(CanonicalMergeWork {
@@ -6042,16 +6062,19 @@ impl CompilerSession {
             .batch_diagnostic_order
             .as_ref()
             .map(crate::shared_segments::SharedList::as_arc);
-        let merged = projected_indexes
-            .and_then(|indexes| {
-                merge_parsed_modules_reusing_indexes(
-                    &parsed,
-                    &indexes,
-                    self.definition_shard_baseline.as_ref(),
-                    batch_order.as_deref(),
-                )
-            })
-            .map(Arc::new);
+        let merged = {
+            let _span = tracing::info_span!("canonical_merge").entered();
+            projected_indexes
+                .and_then(|indexes| {
+                    merge_parsed_modules_reusing_indexes(
+                        &parsed,
+                        &indexes,
+                        self.definition_shard_baseline.as_ref(),
+                        batch_order.as_deref(),
+                    )
+                })
+                .map(Arc::new)
+        };
         if self.cancel_merge_at_commit_boundary() {
             guard.request_cancel();
             return Err(CompileErrors::from(CompileError::without_span(
@@ -6192,11 +6215,17 @@ impl CompilerSession {
                     .iter()
                     .map(|module| module.module_id().clone())
                     .collect::<Vec<_>>();
-                let (module_rirs, query_work) =
-                    self.queries.revisioned.module_rirs(revision, module_ids);
+                let (module_rirs, query_work) = {
+                    let _span = tracing::info_span!("module_rir_lowering").entered();
+                    self.queries.revisioned.module_rirs(revision, module_ids)
+                };
                 match module_rirs {
                     Ok(modules) => {
-                        match project_module_rirs_with_work(merged, &modules, query_work) {
+                        let projected = {
+                            let _span = tracing::info_span!("rir_projection").entered();
+                            project_module_rirs_with_work(merged, &modules, query_work)
+                        };
+                        match projected {
                             Ok(rir) => {
                                 let rir = Arc::new(rir);
                                 *attempt_work = Some(rir.work());
@@ -6566,15 +6595,20 @@ impl CompilerSession {
             .revisioned
             .current_semantic_revision()
             .expect("semantic preparation observes a published source/import revision");
-        let query_shells = self.queries.revisioned.projected_declaration_shells(
-            runtime_revision,
-            merged.ast(),
-            cancellation.clone(),
-        );
+        let declaration_shells_span = tracing::info_span!("declaration_shells").entered();
+        let query_shells = {
+            let _span = tracing::info_span!("declaration_shell_projection").entered();
+            self.queries.revisioned.projected_declaration_shells(
+                runtime_revision,
+                merged.ast(),
+                cancellation.clone(),
+            )
+        };
         let mut body_query_shells = None;
         let mut prepared = match query_shells {
             Ok(query_shells) => {
                 body_query_shells = Some(query_shells.clone());
+                let _span = tracing::info_span!("declaration_shell_prepare").entered();
                 prepare_query_declaration_shells(&merged, &rir, options, &imports, &query_shells)
             }
             Err(crate::revisioned_query_database::DeclarationShellBatchFailure::Query(abort)) => {
@@ -6587,18 +6621,23 @@ impl CompilerSession {
                 CanonicalSemanticWork::default(),
             )),
         };
+        drop(declaration_shells_span);
+        let declaration_semantics = {
+            let _span = tracing::info_span!("declaration_semantics_projection").entered();
+            self.queries.revisioned.projected_declaration_semantics(
+                runtime_revision,
+                merged.ast(),
+                options.target,
+                &options.preview_features,
+                cancellation.clone(),
+            )
+        };
         let (
             query_declarations,
             query_anonymous_nominals,
             query_declaration_dependencies,
             query_c_export_roots,
-        ) = match self.queries.revisioned.projected_declaration_semantics(
-            runtime_revision,
-            merged.ast(),
-            options.target,
-            &options.preview_features,
-            cancellation.clone(),
-        ) {
+        ) = match declaration_semantics {
             Ok(projection) => (
                 Some(projection.declarations),
                 projection.anonymous_nominals,
@@ -7013,6 +7052,12 @@ impl CompilerSession {
                     Arc::clone(&declaration_base_meter),
                 );
                 while let Some(instance) = priority_pending.pop().or_else(|| pending.pop_first()) {
+                    // Worklist scheduling — depth bookkeeping, producer-deferral
+                    // detection, and visit marking — runs for every popped
+                    // instance, including the ones that defer without ever
+                    // reaching a query. It is timed here so the coordinator's own
+                    // cost is separable from the per-body queries (RUE-786).
+                    let schedule_span = tracing::info_span!("body_schedule").entered();
                     let popped_depth = instance_depth.get(&instance).copied().unwrap_or(0);
                     // Producer-nominal identity is exact: a reached anonymous
                     // member is already its own canonical producer identity, so
@@ -7108,6 +7153,7 @@ impl CompilerSession {
                         instance: instance.clone(),
                         configuration: configuration.clone(),
                     };
+                    drop(schedule_span);
                     // RUE-1112: query THIS reached body's trusted-toolchain
                     // demand projection (the registered `body-toolchain-demands`
                     // node over its exact raw body) FIRST, and check the demanded
@@ -7118,11 +7164,15 @@ impl CompilerSession {
                     // The projection is pure and I/O-free, so this never itself
                     // reads the filesystem; the host driver acquires the absent
                     // modules and retries on a successor.
-                    match self.queries.revisioned.body_toolchain_demands(
-                        runtime_revision,
-                        key.clone(),
-                        cancellation.clone(),
-                    ) {
+                    let toolchain_demands = {
+                        let _span = tracing::info_span!("body_toolchain_demands").entered();
+                        self.queries.revisioned.body_toolchain_demands(
+                            runtime_revision,
+                            key.clone(),
+                            cancellation.clone(),
+                        )
+                    };
+                    match toolchain_demands {
                         Ok(terminal) => {
                             let rue_query::QueryOutcome::Success(demand) = terminal.outcome()
                             else {
@@ -7245,6 +7295,12 @@ impl CompilerSession {
                     };
                     let attempted_before = queried_body_work.bodies_attempted;
                     let had_retained_body = self.queries.revisioned.has_retained_body_key(&key);
+                    // The body transaction is the per-body query node the
+                    // traversal spends most of its time in; the `body_*`
+                    // pipeline stages nest inside its analysis closure, so
+                    // without this span the reuse-and-dispatch cost around them
+                    // fell into `body_queries`' residual (RUE-786).
+                    let transaction_span = tracing::info_span!("body_transaction").entered();
                     let transaction = self.queries.revisioned.body_transaction(
                         runtime_revision,
                         key.clone(),
@@ -7278,6 +7334,12 @@ impl CompilerSession {
                             if specialized {
                                 queried_body_work.specialized_bodies_attempted += 1;
                             }
+                            // Merging this body's selected anonymous nominals
+                            // over the whole-program set is per-body work
+                            // proportional to that set, so it is timed apart
+                            // from the analysis it feeds (RUE-786).
+                            let anonymous_span =
+                                tracing::info_span!("body_anonymous_scope").entered();
                             let mut body_anonymous = query_anonymous_nominals
                                 .iter()
                                 .cloned()
@@ -7290,9 +7352,11 @@ impl CompilerSession {
                                     .map(|nominal| (nominal.identity.clone(), nominal)),
                             );
                             let body_anonymous = body_anonymous.into_values().collect::<Vec<_>>();
+                            drop(anonymous_span);
                             let query_declarations = query_declarations.as_deref().expect(
                                 "body traversal follows a successful declaration projection",
                             );
+                            let analysis_span = tracing::info_span!("body_analysis").entered();
                             let transaction = crate::canonical_semantic::analyze_body_query(
                                 &merged,
                                 &rir,
@@ -7308,6 +7372,7 @@ impl CompilerSession {
                                 &shared_base,
                                 &mut stage_context,
                             );
+                            drop(analysis_span);
                             // Fold the stage-sourced per-body declaration-context
                             // work (whatever actually ran) into the running total.
                             let context = &mut queried_body_work.per_body_declaration_context;
@@ -7391,6 +7456,7 @@ impl CompilerSession {
                             transaction
                         },
                     );
+                    drop(transaction_span);
                     let transaction = match transaction {
                         Ok(terminal) => terminal,
                         Err(crate::revisioned_query_database::BodyTransactionRequestFailure::ProducerFailed(
@@ -7523,8 +7589,16 @@ impl CompilerSession {
                     else {
                         unreachable!("BodyTransaction publishes typed values")
                     };
-                    body_query_reference_cache
-                        .insert(instance.clone(), transaction.references().clone());
+                    // Recording this body's outcome — its reference set, its
+                    // diagnostics, and the anonymous producers it published —
+                    // is the coordinator's other per-body cost. The anonymous
+                    // projection nests inside as its own leaf (RUE-786).
+                    let _record_span = tracing::info_span!("body_record").entered();
+                    {
+                        let _span = tracing::info_span!("body_cache_references").entered();
+                        body_query_reference_cache
+                            .insert(instance.clone(), transaction.references().clone());
+                    }
                     if let crate::body_query::BodyTransaction::DeterministicFailure {
                         errors, ..
                     } = &transaction
@@ -7535,14 +7609,15 @@ impl CompilerSession {
                         transaction,
                         crate::body_query::BodyTransaction::Success { .. }
                     ) {
-                        let produced = match self
-                            .queries
-                            .revisioned
-                            .body_produced_anonymous_projection(
+                        let projection = {
+                            let _span = tracing::info_span!("body_anonymous_projection").entered();
+                            self.queries.revisioned.body_produced_anonymous_projection(
                                 runtime_revision,
                                 key.clone(),
                                 cancellation.clone(),
-                            ) {
+                            )
+                        };
+                        let produced = match projection {
                             Ok(produced) => produced,
                             Err(rue_query::QueryAbort::Canceled) if !cancellation.is_canceled() => {
                                 body_query_errors.insert(
@@ -7616,6 +7691,7 @@ impl CompilerSession {
                             }
                         }
                     }
+                    let enqueue_span = tracing::info_span!("body_enqueue_references").entered();
                     let references = transaction.references();
                     for reference in references.0.iter() {
                         if let crate::body_query::BodyReference::Callable(callable) = reference
@@ -7652,11 +7728,14 @@ impl CompilerSession {
                             );
                         }
                     }
+                    drop(enqueue_span);
                     if matches!(
                         transaction,
                         crate::body_query::BodyTransaction::Success { .. }
                     ) && callable_has_query_body(&instance)
                     {
+                        let _projection_span =
+                            tracing::info_span!("body_canonical_projection").entered();
                         let body = match self.queries.revisioned.canonical_body_projection(
                             runtime_revision,
                             key.clone(),

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 
 use rue_target::Target;
+use tracing::info_span;
 
 use crate::archive::Archive;
 use crate::constants::{
@@ -1100,6 +1101,9 @@ impl Linker {
         use crate::constants::{VM_PROT_EXECUTE, VM_PROT_READ};
         use crate::macho::{MachOBuilder, Section64, Segment64, VM_BASE};
 
+        // The Mach-O path splits into the same three phases as `link_elf`.
+        let layout_span = info_span!("link_layout").entered();
+
         // Merge sections and collect relocations
         // For Mach-O, we put code AND rodata in the __TEXT segment (same as clang/ld64).
         // Only writable data goes in __DATA.
@@ -1337,6 +1341,9 @@ impl Linker {
             .ok_or_else(|| LinkError::UndefinedSymbol(entry_point.to_string()))?;
         let entry_offset = entry_vaddr - text_vaddr;
 
+        drop(layout_span);
+        let relocate_span = info_span!("link_relocate").entered();
+
         // Apply relocations
         for PendingRelocation {
             offset: patch_offset,
@@ -1433,6 +1440,9 @@ impl Linker {
             )?;
         }
 
+        drop(relocate_span);
+        let _emit_span = info_span!("link_emit").entered();
+
         // Now build the binary with the relocated code.
         // Note: rodata is already included in merged_text (code + rodata in __TEXT);
         // only writable data goes to the __DATA segment.
@@ -1487,6 +1497,12 @@ impl Linker {
         // (vaddr % page_size) must equal (file_offset % page_size).
         // With code at file offset HEADER_SIZE, we set vaddr accordingly.
         let code_start = self.base_addr + HEADER_SIZE;
+
+        // Section merge, segment addresses, and symbol resolution are one
+        // layout phase; relocation and image serialization follow it. The
+        // guards are dropped at those boundaries so the three phases are
+        // sibling leaves rather than one opaque `linker` row (RUE-786).
+        let layout_span = info_span!("link_layout").entered();
 
         // First, collect and merge all code sections
         let mut merged_text = Vec::new();
@@ -1723,6 +1739,9 @@ impl Linker {
             .get(entry_point)
             .ok_or_else(|| LinkError::UndefinedSymbol(entry_point.to_string()))?;
 
+        drop(layout_span);
+        let relocate_span = info_span!("link_relocate").entered();
+
         // Apply relocations
         for PendingRelocation {
             offset,
@@ -1801,6 +1820,9 @@ impl Linker {
             // Mach-O path via `apply_relocation` (RUE-335).
             apply_relocation(buf, offset, pc, target_addr, addend, rel_type, &sym_name)?;
         }
+
+        drop(relocate_span);
+        let _emit_span = info_span!("link_emit").entered();
 
         // Build the ELF with proper W^X segment separation
         //

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1194,7 +1194,13 @@ fn main() {
     }
     match compile_result {
         Ok(output) => {
-            let publication = output.publish();
+            // Publication runs after the compiler's timing root closes, so it
+            // is measured as a driver phase: it breaks down process-minus-root
+            // overhead without becoming a second timing root (RUE-786).
+            let publication = {
+                let _span = tracing::info_span!("output_write", driver_phase = true).entered();
+                output.publish()
+            };
             // Warnings live outside the publication result so failures cannot
             // discard them; present them before inspecting and reporting the
             // publication outcome.
@@ -1339,10 +1345,23 @@ mod tests {
         });
 
         let edges = data.parent_edges();
-        assert!(
-            edges.contains(&("compile".to_owned(), "parse_file".to_owned())),
-            "discovery parse escaped the compile root: {edges:?}"
-        );
+        // Discovery parsing now sits under the driver's own source-loading
+        // phases (RUE-786) rather than directly under the root, so assert the
+        // whole chain: the parse must still reach `compile`, and each link
+        // names the phase that owns that share of discovery time.
+        for expected in [
+            ("compile", "import_discovery_round"),
+            ("import_discovery_round", "import_plan"),
+            ("import_plan", "import_stage"),
+            ("import_stage", "import_parse_staging"),
+            ("import_parse_staging", "parse_program"),
+            ("parse_program", "parse_file"),
+        ] {
+            assert!(
+                edges.contains(&(expected.0.to_owned(), expected.1.to_owned())),
+                "discovery parse escaped the compile root at {expected:?}: {edges:?}"
+            );
+        }
         assert!(
             edges.contains(&("compile".to_owned(), "compile_pipeline".to_owned())),
             "post-discovery pipeline escaped the compile root: {edges:?}"

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -496,13 +496,22 @@ pub(crate) enum SourceLoadError {
 pub(crate) fn load(
     request: SourceLoadRequest<'_>,
 ) -> Result<ImportDiscoveryResult, SourceLoadError> {
-    let manifest = request
-        .source_manifest_path
-        .map(SourceManifest::load)
-        .transpose()
-        .map_err(SourceLoadError::Message)?;
-    validate_manifest_allows_source(manifest.as_ref(), request.root_source, "root")
-        .map_err(SourceLoadError::Message)?;
+    // Source loading is the first half of the `compile` root: manifest policy,
+    // then the demand-driven import-discovery frontier. It was previously
+    // timed only through the `parse_file` spans it happens to contain, which
+    // left the rest of discovery in the root's unattributed residual (RUE-786).
+    let _span = tracing::info_span!("source_loading").entered();
+    let manifest = {
+        let _span = tracing::info_span!("source_manifest").entered();
+        let manifest = request
+            .source_manifest_path
+            .map(SourceManifest::load)
+            .transpose()
+            .map_err(SourceLoadError::Message)?;
+        validate_manifest_allows_source(manifest.as_ref(), request.root_source, "root")
+            .map_err(SourceLoadError::Message)?;
+        manifest
+    };
     discover_and_load_imports(request.root_source, manifest, request.std_root)
 }
 
@@ -637,23 +646,36 @@ fn drive_import_discovery_to_close(
     let final_plan;
     let witness;
     loop {
-        let snapshot = assembler
-            .snapshot()
-            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-        let ledger = import_observation_ledger(staging, input_revision)
-            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        // One frontier round: plan and frontier construction (which owns the
+        // canonical parse of everything read so far), then the host reads that
+        // answer the frontier's requests. Both halves are timed so a discovery
+        // regression is localized to compiler planning or to filesystem I/O.
+        let _round_span = tracing::info_span!("import_discovery_round").entered();
+        let plan_span = tracing::info_span!("import_plan").entered();
+        let (snapshot, ledger) = {
+            let _span = tracing::info_span!("import_revision_inputs").entered();
+            let snapshot = assembler
+                .snapshot()
+                .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+            let ledger = import_observation_ledger(staging, input_revision)
+                .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+            (snapshot, ledger)
+        };
         // A trusted-toolchain successor stages from the compiler-published view
         // itself; the host supplies only the opaque capability. The assembler's
         // snapshot/manifest reach the compiler solely through the verified
         // observation-batch publication.
-        let staged = match &reclose {
-            Some(reclose) => stage_import_discovery_successor(staging, reclose.delta),
-            None => staging.stage_import_discovery(
-                &snapshot,
-                context.clone(),
-                assembler.accepted_read_manifest().shared_slice(),
-                ledger.clone(),
-            ),
+        let staged = {
+            let _span = tracing::info_span!("import_stage").entered();
+            match &reclose {
+                Some(reclose) => stage_import_discovery_successor(staging, reclose.delta),
+                None => staging.stage_import_discovery(
+                    &snapshot,
+                    context.clone(),
+                    assembler.accepted_read_manifest().shared_slice(),
+                    ledger.clone(),
+                ),
+            }
         };
         let plan = match staged {
             Ok(plan) => plan,
@@ -676,19 +698,24 @@ fn drive_import_discovery_to_close(
             Some(_) => plan_delta_roots(&plan),
             None => plan.demand_roots(),
         };
-        let frontier = import_demand_frontier_for_roots(
-            staging,
-            input_revision,
-            &plan,
-            ImportDemandMode::Rooted,
-            &roots,
-        )
-        .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
+        let frontier = {
+            let _span = tracing::info_span!("import_frontier").entered();
+            import_demand_frontier_for_roots(
+                staging,
+                input_revision,
+                &plan,
+                ImportDemandMode::Rooted,
+                &roots,
+            )
+            .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?
+        };
+        drop(plan_span);
         if frontier.requests().is_empty() {
             final_plan = plan;
             witness = frontier;
             break;
         }
+        let _read_span = tracing::info_span!("import_read").entered();
         let observations = frontier
             .requests()
             .iter()
@@ -733,6 +760,7 @@ fn drive_import_discovery_to_close(
         .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
     }
 
+    let _close_span = tracing::info_span!("import_discovery_close").entered();
     let snapshot = assembler
         .snapshot()
         .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
@@ -910,6 +938,7 @@ pub(crate) fn acquire_reached_toolchain_modules(
     if result.revision.status() != ImportDiscoveryStatus::ClosedValid {
         return Ok(());
     }
+    let _span = tracing::info_span!("toolchain_acquisition").entered();
     for _ in 0..MAX_TOOLCHAIN_ACQUISITION_ROUNDS {
         match semantic_or_toolchain_park(&mut result.session, options) {
             // Analysis satisfied every reached-body demand (or there were none).

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -69,6 +69,18 @@ struct TimingDataInner {
     /// Order in which passes were first seen, for deterministic output.
     pass_order: Vec<String>,
 
+    /// Accumulated measurements per driver-phase name.
+    ///
+    /// Driver phases are host work outside the compiler's timing root, such as
+    /// writing the linked executable. They are measured with the same span
+    /// machinery but kept out of `passes` and out of `root_duration`, so
+    /// `total_ms` keeps meaning "compiler work" and `compile` stays the sole
+    /// timing root (RUE-786).
+    driver_phases: HashMap<String, DriverPhaseAggregate>,
+
+    /// Order in which driver phases were first seen, for deterministic output.
+    driver_phase_order: Vec<String>,
+
     /// Union of intervals in which at least one root span was active.
     ///
     /// Child spans overlap their parents, so summing every pass duration
@@ -104,6 +116,13 @@ struct PassAggregate {
     leaf_invocations: u64,
 }
 
+/// Measurements aggregated across every driver-phase span with the same name.
+#[derive(Debug, Clone, Copy, Default)]
+struct DriverPhaseAggregate {
+    duration: Duration,
+    invocations: u64,
+}
+
 /// JSON output structure for benchmark timing data.
 ///
 /// This structure is designed for machine-readable output that can be
@@ -119,6 +138,13 @@ pub struct BenchmarkTiming {
     pub metadata: BenchmarkMetadata,
     /// Individual pass timings in milliseconds.
     pub passes: Vec<PassTiming>,
+    /// Driver-side phases measured outside the compiler's timing root.
+    ///
+    /// These break down `process - total_ms`, never `total_ms` itself, so they
+    /// must not be added to the pass table. The field is omitted entirely when
+    /// the run measured no driver phase.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub driver_phases: Vec<DriverPhaseTiming>,
     /// Total compilation time in milliseconds.
     pub total_ms: f64,
     /// Source code metrics (lines, bytes, tokens).
@@ -170,6 +196,17 @@ pub struct PassTiming {
     pub leaf_invocations: u64,
 }
 
+/// Timing for one driver-side phase outside the compiler's timing root.
+#[derive(Debug, Clone, Serialize)]
+pub struct DriverPhaseTiming {
+    /// Name of the driver phase (e.g., "output_write").
+    pub name: String,
+    /// Time spent in this phase in milliseconds.
+    pub duration_ms: f64,
+    /// Number of spans aggregated into this row.
+    pub invocations: u64,
+}
+
 impl TimingData {
     /// Create a new empty timing data collector.
     pub fn new() -> Self {
@@ -177,6 +214,8 @@ impl TimingData {
             inner: Arc::new(Mutex::new(TimingDataInner {
                 passes: HashMap::new(),
                 pass_order: Vec::new(),
+                driver_phases: HashMap::new(),
+                driver_phase_order: Vec::new(),
                 root_duration: Duration::ZERO,
                 active_roots: 0,
                 root_active_since: None,
@@ -208,6 +247,18 @@ impl TimingData {
         // Track order of first occurrence
         if !inner.pass_order.contains(&pass.to_string()) {
             inner.pass_order.push(pass.to_string());
+        }
+    }
+
+    /// Record one driver-phase span outside the compiler's timing root.
+    fn record_driver_phase(&self, phase: &str, duration: Duration) {
+        let mut inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        let entry = inner.driver_phases.entry(phase.to_string()).or_default();
+        entry.duration += duration;
+        entry.invocations += 1;
+
+        if !inner.driver_phase_order.contains(&phase.to_string()) {
+            inner.driver_phase_order.push(phase.to_string());
         }
     }
 
@@ -355,6 +406,20 @@ impl TimingData {
         ));
         output.push_str("\n  Pass rows are inclusive; nested rows overlap their parents.\n");
 
+        if !inner.driver_phase_order.is_empty() {
+            output.push_str("\n  Driver phases (outside the compiler total):\n");
+            for phase in &inner.driver_phase_order {
+                if let Some(measurement) = inner.driver_phases.get(phase) {
+                    output.push_str(&format!(
+                        "  {:<width$} {:>8.1}ms\n",
+                        format!("{}:", capitalize(phase)),
+                        measurement.duration.as_secs_f64() * 1000.0,
+                        width = max_name_len + 1
+                    ));
+                }
+            }
+        }
+
         output
     }
 
@@ -399,6 +464,21 @@ impl TimingData {
             })
             .collect();
 
+        let driver_phases = inner
+            .driver_phase_order
+            .iter()
+            .filter_map(|phase| {
+                inner
+                    .driver_phases
+                    .get(phase)
+                    .map(|measurement| DriverPhaseTiming {
+                        name: phase.clone(),
+                        duration_ms: measurement.duration.as_secs_f64() * 1000.0,
+                        invocations: measurement.invocations,
+                    })
+            })
+            .collect();
+
         let metadata = BenchmarkMetadata {
             timestamp: iso8601_now(),
             version: version.to_string(),
@@ -410,6 +490,7 @@ impl TimingData {
             timing_model: "inclusive_spans",
             metadata,
             passes,
+            driver_phases,
             total_ms,
             source_metrics,
             peak_memory_bytes,
@@ -579,6 +660,27 @@ struct SpanTiming {
     /// Store this at creation because a child may outlive its parent; looking
     /// the parent up again during a later enter/close can then be ambiguous.
     is_root: bool,
+    /// Whether this span measures driver work outside the compiler root.
+    ///
+    /// Set by a `driver_phase = true` span field, and inherited by children so
+    /// nested driver work cannot be mistaken for a compiler pass.
+    is_driver_phase: bool,
+}
+
+/// Reads the `driver_phase` marker off a span's creation-time fields.
+#[derive(Default)]
+struct DriverPhaseVisitor {
+    is_driver_phase: bool,
+}
+
+impl tracing::field::Visit for DriverPhaseVisitor {
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        if field.name() == "driver_phase" {
+            self.is_driver_phase = value;
+        }
+    }
+
+    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
 }
 
 impl SpanTiming {
@@ -613,7 +715,7 @@ impl<S> Layer<S> for TimingLayer
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
-    fn on_new_span(&self, _attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         // Initialize timing state for this span
         if let Some(span) = ctx.span(id) {
             let parent_id = span.parent().map(|parent| parent.id().clone());
@@ -622,6 +724,17 @@ where
                 .parent()
                 .map(|parent| (parent.name().to_owned(), span.name().to_owned()));
             let is_root = parent_id.is_none();
+            let mut visitor = DriverPhaseVisitor::default();
+            attrs.record(&mut visitor);
+            let parent_is_driver_phase = parent_id
+                .as_ref()
+                .and_then(|parent_id| ctx.span(parent_id))
+                .is_some_and(|parent| {
+                    parent
+                        .extensions()
+                        .get::<SpanTiming>()
+                        .is_some_and(|timing| timing.is_driver_phase)
+                });
             let mut extensions = span.extensions_mut();
             extensions.insert(SpanTiming {
                 active_enters: 0,
@@ -629,6 +742,7 @@ where
                 accumulated: Duration::ZERO,
                 has_children: false,
                 is_root,
+                is_driver_phase: visitor.is_driver_phase || parent_is_driver_phase,
             });
             drop(extensions);
 
@@ -652,7 +766,7 @@ where
         if let Some(span) = ctx.span(id) {
             let mut extensions = span.extensions_mut();
             if let Some(timing) = extensions.get_mut::<SpanTiming>() {
-                if timing.is_root {
+                if timing.is_root && !timing.is_driver_phase {
                     self.data.enter_root_span(timing);
                 } else {
                     // Sample after acquiring the per-span extension lock so
@@ -667,7 +781,7 @@ where
         if let Some(span) = ctx.span(id) {
             let mut extensions = span.extensions_mut();
             if let Some(timing) = extensions.get_mut::<SpanTiming>() {
-                if timing.is_root {
+                if timing.is_root && !timing.is_driver_phase {
                     self.data.exit_root_span(timing);
                 } else {
                     // Sample after acquiring the per-span extension lock so
@@ -689,6 +803,7 @@ where
                         timing.duration(),
                         timing.is_root,
                         !timing.has_children,
+                        timing.is_driver_phase,
                     )
                 })
             };
@@ -696,8 +811,12 @@ where
             // Do not hold the span's extension lock while acquiring the
             // aggregate-data lock. Root enter/exit callbacks deliberately use
             // the opposite pair together (extension, then aggregate data).
-            if let Some((name, duration, is_root, is_leaf)) = measurement {
-                self.data.record_span(&name, duration, is_root, is_leaf);
+            if let Some((name, duration, is_root, is_leaf, is_driver_phase)) = measurement {
+                if is_driver_phase {
+                    self.data.record_driver_phase(&name, duration);
+                } else {
+                    self.data.record_span(&name, duration, is_root, is_leaf);
+                }
             }
         }
     }
@@ -770,7 +889,14 @@ mod tests {
             .find(|pass| pass.name == "parse_file")
             .unwrap();
         assert_eq!(direct_parse.invocations, 1);
-        assert_eq!(direct_parse.root_invocations, 1);
+        // The parse query's own phases wrap it (RUE-786), so `parse_query_key`
+        // and its siblings own the root here and `parse_file` nests beneath
+        // `parse_program`.
+        assert_eq!(direct_parse.root_invocations, 0);
+        assert!(
+            direct_edges.contains(&("parse_program".to_owned(), "parse_file".to_owned())),
+            "direct parse edges: {direct_edges:?}"
+        );
 
         let session_data = TimingData::new();
         let session_subscriber =
@@ -789,7 +915,10 @@ mod tests {
         for expected in [
             ("parse_file", "lexer"),
             ("parse_file", "parser"),
-            ("semantic_astgen", "definition_snapshot_modules"),
+            // The definition snapshot is built by the canonical merge, which
+            // RUE-786 gave its own span beneath the astgen aggregate.
+            ("semantic_astgen", "canonical_merge"),
+            ("canonical_merge", "definition_snapshot_modules"),
         ] {
             assert!(
                 session_edges.contains(&(expected.0.to_owned(), expected.1.to_owned())),
@@ -816,16 +945,36 @@ mod tests {
             .unwrap();
         // The session parses the source module once, then lazily reparses the
         // demanded body-free declaration terminal inside the semantic query.
+        // Neither is a root any more: RUE-786 timed the parse query's own
+        // phases around the first, and the shell projection that demands the
+        // second, so both nest beneath the request that asked for them.
         assert_eq!(session_parse_file.invocations, 2);
-        assert_eq!(session_parse_file.root_invocations, 2);
+        assert_eq!(session_parse_file.root_invocations, 0);
+        for expected in [
+            ("parse_program", "parse_file"),
+            ("declaration_nucleus", "parse_file"),
+        ] {
+            assert!(
+                session_edges.contains(&(expected.0.to_owned(), expected.1.to_owned())),
+                "the demanded reparse is timed beneath its request: {session_edges:?}"
+            );
+        }
         // RUE-1027 constructs one declaration-shell epoch plus one isolated
-        // exact-body epoch for the reached `main` terminal. The shell epoch's
-        // index remains a top-level leaf; the exact-body epoch's index is a
-        // leaf timed beneath its body_prepare_declarations pipeline stage.
-        // Neither is nested beneath whole-program sema.
+        // exact-body epoch for the reached `main` terminal. Both indexes stay
+        // leaves; RUE-786 gave each epoch's surrounding stage a span, so the
+        // shell epoch's index is timed beneath `declaration_shells` and the
+        // exact-body epoch's beneath `body_prepare_declarations`. Neither is
+        // nested beneath whole-program sema.
         assert_eq!(rir_declaration_index.invocations, 2);
-        assert_eq!(rir_declaration_index.root_invocations, 1);
+        assert_eq!(rir_declaration_index.root_invocations, 0);
         assert_eq!(rir_declaration_index.leaf_invocations, 2);
+        assert!(
+            session_edges.contains(&(
+                "declaration_shell_prepare".to_owned(),
+                "rir_declaration_index".to_owned()
+            )),
+            "the shell epoch's index is timed beneath its stage: {session_edges:?}"
+        );
         assert!(
             session_edges.contains(&(
                 "body_prepare_declarations".to_owned(),
@@ -853,10 +1002,31 @@ mod tests {
             compile_edges.contains(&("compile".to_owned(), "compile_pipeline".to_owned())),
             "missing compile -> compile_pipeline in batch edges: {compile_edges:?}"
         );
-        for child in ["rir_declaration_index", "sema"] {
+        for edge in [
+            ("compile_pipeline", "declaration_shells"),
+            ("declaration_shells", "declaration_shell_prepare"),
+            ("declaration_shell_prepare", "rir_declaration_index"),
+            ("compile_pipeline", "sema"),
+            // The backend and linker subphases RUE-786 added must reach the
+            // pipeline aggregate rather than escaping to their own roots —
+            // codegen in particular runs its subphases on Rayon workers.
+            ("compile_pipeline", "codegen"),
+            ("codegen", "mir_lowering"),
+            ("codegen", "register_allocation"),
+            ("codegen", "machine_emission"),
+            // Object serialization runs after the parallel fan-out returns, so
+            // it is a sibling of `codegen`, not one of its subphases.
+            ("compile_pipeline", "object_serialization"),
+            ("compile_pipeline", "linker"),
+            ("linker", "link_parse_objects"),
+            ("linker", "link_layout"),
+            ("linker", "link_emit"),
+        ] {
             assert!(
-                compile_edges.contains(&("compile_pipeline".to_owned(), child.to_owned())),
-                "missing compile_pipeline -> {child} in batch edges: {compile_edges:?}"
+                compile_edges.contains(&(edge.0.to_owned(), edge.1.to_owned())),
+                "missing {} -> {} in batch edges: {compile_edges:?}",
+                edge.0,
+                edge.1
             );
         }
         assert!(
@@ -930,15 +1100,30 @@ mod tests {
 
         // Every reached body runs the per-body pipeline stages beneath the one
         // coordinator span, so the timing table can split the semantic query
-        // path that RUE-1083 found unattributed.
+        // path that RUE-1083 found unattributed. RUE-786 interposed the
+        // per-body query, analysis, and epoch-derivation spans between them;
+        // the stages must still descend from the same coordinator.
         let edges = data.parent_edges();
-        for stage in [
-            "body_prepare_declarations",
-            "body_project_declarations",
-            "body_install_declarations",
-            "body_analyze",
-            "body_export",
+        for edge in [
+            ("body_queries", "body_transaction"),
+            ("body_transaction", "body_analysis"),
+            ("body_analysis", "body_derive_epoch"),
+            ("body_derive_epoch", "body_prepare_declarations"),
+            ("body_derive_epoch", "body_project_declarations"),
+            ("body_derive_epoch", "body_install_declarations"),
+            ("body_analysis", "body_analyze"),
+            ("body_analysis", "body_export"),
         ] {
+            assert!(
+                edges.contains(&(edge.0.to_owned(), edge.1.to_owned())),
+                "missing {} -> {} edge: {edges:?}",
+                edge.0,
+                edge.1
+            );
+        }
+        // The coordinator's own per-body work is timed apart from the queries
+        // it drives, so neither can absorb the other's cost.
+        for stage in ["body_schedule", "body_record", "body_toolchain_demands"] {
             assert!(
                 edges.contains(&("body_queries".to_owned(), stage.to_owned())),
                 "missing body_queries -> {stage} edge: {edges:?}"
@@ -1002,6 +1187,73 @@ mod tests {
             validation_edges
                 .contains(&("parser".to_owned(), "parser_grammar_execution".to_owned()))
         );
+    }
+
+    #[test]
+    fn driver_phase_spans_stay_out_of_the_compiler_total() {
+        let data = TimingData::new();
+        let subscriber = tracing_subscriber::registry().with(TimingLayer::new(data.clone()));
+        tracing::subscriber::with_default(subscriber, || {
+            {
+                let _compile = tracing::info_span!("compile").entered();
+                let _leaf = tracing::info_span!("sema").entered();
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            let _write = tracing::info_span!("output_write", driver_phase = true).entered();
+            // A driver phase's own children are driver work too, so they must
+            // not reappear as compiler passes either.
+            let _nested = tracing::info_span!("output_fsync").entered();
+            std::thread::sleep(Duration::from_millis(5));
+        });
+
+        let timing = data.to_benchmark_timing_with_metrics("test", "test", None, None);
+        let pass_names: Vec<_> = timing
+            .passes
+            .iter()
+            .map(|pass| pass.name.as_str())
+            .collect();
+        assert_eq!(pass_names, ["sema", "compile"], "{pass_names:?}");
+        let phase_names: Vec<_> = timing
+            .driver_phases
+            .iter()
+            .map(|phase| phase.name.as_str())
+            .collect();
+        assert_eq!(phase_names, ["output_fsync", "output_write"]);
+        assert!(
+            timing
+                .driver_phases
+                .iter()
+                .all(|phase| phase.invocations == 1)
+        );
+
+        // `compile` remains the sole root and still owns the whole total, so a
+        // driver phase can never inflate or dilute the compiler's percentages.
+        let compile = timing
+            .passes
+            .iter()
+            .find(|pass| pass.name == "compile")
+            .unwrap();
+        assert_eq!(compile.root_invocations, 1);
+        assert!((compile.duration_ms - timing.total_ms).abs() < f64::EPSILON);
+        let write = timing
+            .driver_phases
+            .iter()
+            .find(|phase| phase.name == "output_write")
+            .unwrap();
+        assert!(write.duration_ms > 0.0);
+
+        let json = data.to_json_with_metrics("test", "test", None, None);
+        assert!(json.contains("\"driver_phases\""), "{json}");
+        assert!(data.report().contains("Driver phases"));
+    }
+
+    #[test]
+    fn a_run_without_driver_phases_omits_the_field_entirely() {
+        let data = TimingData::new();
+        data.record("lexer", Duration::from_millis(1));
+        let json = data.to_json_with_metrics("test", "test", None, None);
+        assert!(!json.contains("driver_phases"), "{json}");
+        assert!(!data.report().contains("Driver phases"));
     }
 
     #[test]
@@ -1151,6 +1403,7 @@ mod tests {
             accumulated: Duration::ZERO,
             has_children: false,
             is_root: true,
+            is_driver_phase: false,
         };
         let mut delayed = SpanTiming {
             active_enters: 0,
@@ -1158,6 +1411,7 @@ mod tests {
             accumulated: Duration::ZERO,
             has_children: false,
             is_root: true,
+            is_driver_phase: false,
         };
 
         // Model a callback that captured t=10ms, stalled, and was applied
@@ -1192,6 +1446,7 @@ mod tests {
             accumulated: Duration::ZERO,
             has_children: false,
             is_root: false,
+            is_driver_phase: false,
         };
         timing.enter_at(start);
         timing.enter_at(start + Duration::from_millis(10));

--- a/docs/process/logging.md
+++ b/docs/process/logging.md
@@ -41,6 +41,22 @@ handwritten parser reports nesting scan, parser-state setup, grammar execution,
 and directive validation as direct leaves. Parsing runs on the caller thread;
 there is no parser graph construction, token adaptation, or worker lifecycle.
 
+A span may declare `driver_phase = true` to mark host work that runs outside the
+compiler's timing root, such as writing the linked executable. Those spans (and
+their children) are reported in `driver_phases` instead of `passes`; they break
+down process-minus-root overhead and never contribute to the compiler total, so
+`compile` stays the sole timing root. Reserve this for driver work that is
+genuinely outside `compile` — instrument compiler work with an ordinary span.
+
+Work that runs on Rayon workers needs its parent passed explicitly: workers do
+not inherit the caller's current span, so a nested span created there would be
+reported as its own timing root. Hold the parent span by value and re-enter it
+as the first statement inside the closure, as `codegen` does in
+`crates/rue-compiler/src/backend.rs`.
+
+The full current span tree, and the harness bound on unattributed time, are in
+[perf-baseline.md](perf-baseline.md).
+
 ### Adding Instrumentation
 
 Each compilation pass should have a tracing span wrapping the work:

--- a/docs/process/perf-baseline.md
+++ b/docs/process/perf-baseline.md
@@ -56,23 +56,144 @@ The compiler wraps each pass in a tracing span, and some spans are **nested**,
 so the raw timing JSON contains both leaf passes and their aggregate parents:
 
 ```
-compile                 <- canonical discovery parsing + compiler work
-├─ parse_file           <- aggregate, repeated for each canonical module
-│  ├─ lexer             <- leaf
-│  └─ parser            <- aggregate
-│     ├─ parser_nesting_scan       <- leaf
-│     ├─ parser_state_setup        <- leaf
-│     ├─ parser_grammar_execution   <- leaf
-│     └─ parser_directive_validation <- leaf after grammar success
-└─ compile_pipeline     <- post-discovery query/backend aggregate
-   ├─ semantic_astgen   <- aggregate: canonical semantic AST -> RIR
-   │  └─ definition_snapshot_modules <- durable module/name-candidate index
-   ├─ rir_declaration_index <- leaf: snapshot-local RIR declaration candidates
-   ├─ sema              <- leaf: type checking / AIR
-   ├─ cfg_construction  <- leaf
-   ├─ codegen           <- leaf: MIR lower + regalloc + emit
-   └─ linker            <- leaf: built-in ELF link in these baseline runs
+compile                        <- canonical discovery + compiler work
+├─ source_loading              <- driver: manifest policy + import discovery
+│  ├─ source_manifest          <- leaf
+│  ├─ import_discovery_round   <- aggregate, one per frontier round
+│  │  ├─ import_plan           <- aggregate: plan + frontier construction
+│  │  │  ├─ import_revision_inputs <- leaf: snapshot + observation ledger
+│  │  │  ├─ import_stage       <- aggregate: staging this round's plan
+│  │  │  │  ├─ import_parse_staging <- aggregate: the canonical parse
+│  │  │  │  │  ├─ parse_query_key    <- leaf: whole-snapshot content keying
+│  │  │  │  │  ├─ parse_program      <- aggregate: per-module parse requests
+│  │  │  │  │  │  └─ parse_file      <- aggregate, per canonical module
+│  │  │  │  │  │     ├─ lexer        <- leaf
+│  │  │  │  │  │     └─ parser       <- aggregate
+│  │  │  │  │  │        ├─ parser_nesting_scan          <- leaf
+│  │  │  │  │  │        ├─ parser_state_setup           <- leaf
+│  │  │  │  │  │        ├─ parser_grammar_execution     <- leaf
+│  │  │  │  │  │        └─ parser_directive_validation  <- leaf after grammar
+│  │  │  │  │  └─ parse_query_commit <- leaf: terminal publication
+│  │  │  │  ├─ import_plan_build   <- leaf
+│  │  │  │  └─ import_plan_publish <- leaf
+│  │  │  └─ import_frontier    <- leaf: demanded reads for this round
+│  │  └─ import_read           <- leaf: host filesystem reads
+│  └─ import_discovery_close   <- leaf
+├─ toolchain_acquisition       <- driver: park-aware reached-body semantics
+│  └─ (the semantic phases below; see "Where semantic analysis runs")
+└─ compile_pipeline            <- post-discovery query/backend aggregate
+   ├─ semantic_astgen          <- aggregate: canonical semantic AST -> RIR
+   │  ├─ module_index_projection <- leaf
+   │  ├─ canonical_merge       <- aggregate: merge parsed modules
+   │  │  └─ definition_snapshot_modules <- durable module/name-candidate index
+   │  ├─ module_rir_lowering   <- leaf: per-module RIR
+   │  └─ rir_projection        <- leaf: project/remap module RIR
+   ├─ declaration_shells       <- aggregate: shell epoch
+   │  ├─ declaration_shell_projection <- aggregate: per-module index requests
+   │  └─ declaration_shell_prepare    <- aggregate
+   │     └─ rir_declaration_index <- leaf: snapshot-local declaration candidates
+   ├─ declaration_semantics_projection <- aggregate
+   │  ├─ declaration_occurrence_index  <- leaf, per module
+   │  └─ declaration_nucleus   <- aggregate, per declaration query
+   ├─ body_queries             <- aggregate: reached-body traversal
+   │  ├─ body_schedule         <- leaf: worklist scheduling
+   │  ├─ body_toolchain_demands <- leaf
+   │  ├─ body_transaction      <- aggregate: the per-body query node
+   │  │  ├─ body_query_prerequisites <- leaf
+   │  │  ├─ body_anonymous_scope     <- leaf
+   │  │  ├─ body_analysis      <- aggregate
+   │  │  │  ├─ body_derive_epoch <- aggregate
+   │  │  │  │  ├─ body_prepare_declarations <- aggregate
+   │  │  │  │  ├─ body_project_declarations <- leaf
+   │  │  │  │  └─ body_install_declarations <- leaf
+   │  │  │  ├─ body_analyze    <- leaf
+   │  │  │  └─ body_export     <- leaf
+   │  │  └─ body_query_lookups <- leaf: lookup dependency edges
+   │  └─ body_record           <- aggregate: publish this body's outcome
+   │     ├─ body_cache_references     <- leaf
+   │     ├─ body_anonymous_projection <- leaf
+   │     ├─ body_enqueue_references   <- leaf
+   │     └─ body_canonical_projection <- leaf
+   ├─ declaration_reuse        <- leaf: durable declaration rebinding
+   ├─ sema                     <- leaf: whole-program type checking / AIR
+   ├─ cfg_construction         <- leaf
+   ├─ semantic_finalization    <- leaf: post-CFG assembly and warning order
+   ├─ codegen                  <- aggregate, per function on Rayon workers
+   │  ├─ mir_lowering          <- leaf
+   │  ├─ register_allocation   <- leaf
+   │  ├─ mir_peephole          <- leaf
+   │  ├─ mir_scheduling        <- leaf
+   │  ├─ mir_verification      <- leaf
+   │  ├─ string_table_compaction <- leaf
+   │  └─ machine_emission      <- leaf
+   ├─ object_serialization     <- leaf, after the parallel fan-out returns
+   └─ linker                   <- aggregate: built-in link in baseline runs
+      ├─ link_parse_objects    <- leaf
+      ├─ link_archive_resolve  <- leaf
+      ├─ link_layout           <- leaf
+      ├─ link_relocate         <- leaf
+      └─ link_emit             <- leaf
 ```
+
+RUE-786 added the driver, pipeline, backend, and linker rows above. Note the
+consequences for comparisons across that boundary: `codegen` and `linker` used
+to be **leaves** whose internals were fully counted as attributed work, and are
+now aggregates whose leaf children are counted instead. A pre-RUE-786 leaf sum
+is therefore not comparable to a post-RUE-786 one.
+
+### Where semantic analysis runs
+
+For the filesystem CLI, the whole-program semantic query is evaluated inside
+`toolchain_acquisition`, not inside `compile_pipeline`. The driver runs a rooted,
+park-aware semantic attempt there so it can satisfy a reached body's
+trusted-toolchain demands before compiling; the query is memoized, so the later
+`compile_pipeline` call reads the cached result. Phase rows aggregate by span
+name regardless of position, so `sema` and its neighbours still appear as single
+rows — but their parent in a CLI run is the driver phase, and that is why
+`compile` minus `compile_pipeline` is large.
+
+### Driver phases
+
+Some driver work happens outside the compiler's timing root entirely. Writing
+the linked executable is the current example: it deliberately runs after
+`compile` closes so the compiler total measures compiler work. Such spans
+declare `driver_phase = true` and are reported in a separate `driver_phases`
+array rather than in `passes`. They are a breakdown of `process - total_ms`;
+they never contribute to `total_ms`, and `compile` remains the sole timing root.
+The field is omitted when a run measured no driver phase.
+
+### The unattributed bound
+
+`scripts/perf-baseline.py` fails when a workload's median unattributed share —
+`max(root - leaf work, 0) / root`, paired per sample — exceeds
+`--max-unattributed-percent` (default 50). The point is that a phase shipped
+without a span fails the harness instead of quietly widening the telemetry-dark
+region. Measured shares on a release compiler currently run from about 12% on
+the small examples to about 39% on `large_structs`.
+
+Parallel leaf spans can overlap and inflate leaf work, which only makes the
+check more permissive, so it never fails spuriously under `--jobs > 1`.
+
+### Where the remaining residual is
+
+The residual is no longer spread across the compiler; it is concentrated in the
+**rue-query request machinery**. Every remaining large gap has the same shape —
+an aggregate whose children are the compute work and whose residual is the
+runtime's own per-request cost (key hashing, memo lookup, dependency recording,
+terminal publication):
+
+| aggregate | what its residual measures |
+| --- | --- |
+| `body_transaction` | one `body_transaction` request per reached body |
+| `declaration_shell_projection` | one `declaration_occurrence_indexes` request per module |
+| `declaration_nucleus` | one `semantic_nucleus` request per declaration |
+| `parse_program` | one `parse_modules` request per module |
+
+That is a real and useful finding rather than a gap in this work: it says the
+cost is in `rue_query::Runtime::request_impl`, not in any pass. Attributing it
+requires spans inside the query runtime's request path, which is the accounting
+boundary RUE-817 owns, so it is deliberately out of scope here. The bound above
+should ratchet down when that lands.
 
 Since RUE-642, timing JSON schema v2 labels the model as `inclusive_spans`.
 `total_ms` is the inclusive duration of root compiler spans, and pass
@@ -206,9 +327,10 @@ compiler bottleneck; an arena conversion is not justified by current data.
    interner merging and AST symbol remapping.
 
 2. **`codegen` is second (~17%)**, concentrated where there is a lot of code to
-   emit (`many_functions`, `large_structs`). This covers MIR lowering, register
-   allocation, and instruction emission together — worth splitting into finer
-   spans before optimizing, so the hot sub-phase is visible.
+   emit (`many_functions`, `large_structs`). At the time of this table it was a
+   single leaf covering MIR lowering, register allocation, and instruction
+   emission together; RUE-786 split it into the per-sub-phase leaves listed in
+   "Reading the numbers", so the hot sub-phase is now visible directly.
 
 3. **`sema` is third (~11%)** and scales with type/expression volume
    (`arithmetic_heavy`, `large_structs`, `register_pressure`).
@@ -227,8 +349,10 @@ compiler bottleneck; an arena conversion is not justified by current data.
 - **parser (historical):** the baseline confirmed lexing was cheap relative to
   the former parser. RUE-905 replaced that implementation; profile the current
   parser before choosing further parser work.
-- **codegen:** add per-sub-phase spans (lower / regalloc / emit) to see which
-  dominates before touching it; regalloc is the usual suspect under pressure.
+- **codegen:** the per-sub-phase spans now exist (RUE-786). Read
+  `register_allocation` against `mir_lowering`, `mir_scheduling`, and
+  `machine_emission` before touching it; regalloc is the usual suspect under
+  pressure and does measure largest on the stress corpus.
 - **sema:** watch for quadratic scans over symbols/types as programs grow.
 
 ## Resolved historical pathology: exponential parse time on nested blocks

--- a/scripts/perf-baseline.py
+++ b/scripts/perf-baseline.py
@@ -38,6 +38,14 @@ samples are never combined into a fictional timing breakdown. It also measures
 the fresh process around `subprocess.run`: that includes startup, source
 discovery, and driver work outside the `compile` span.
 
+Two v2 surfaces exist for work outside the pass table. `driver_phases` breaks
+down driver overhead (`process - root`) with spans the compiler deliberately
+keeps out of its timing root, such as writing the linked executable; they are
+never added to `total_ms`. And the harness enforces a ceiling on unattributed
+time — the share of the root span no leaf pass claims — so a phase that ships
+without instrumentation fails this run instead of quietly widening the gap.
+See `--max-unattributed-percent`.
+
 In JSON phase rows, `median_percent` is the median of the per-sample
 phase/root ratios. It is intentionally not the ratio between the independently
 aggregated `median_ms` phase duration and compile median.
@@ -80,6 +88,17 @@ DEEP_NESTING_TIMEOUT_SECONDS = 10.0
 # leaf the compiler emits that is not listed here is appended afterwards in
 # first-seen order, so a newly instrumented pass still shows up.
 CANONICAL_LEAF_ORDER = [
+    # Driver-side source loading and import discovery.
+    "source_manifest",
+    "import_revision_inputs",
+    "parse_query_key",
+    "parse_query_commit",
+    "import_plan_build",
+    "import_plan_publish",
+    "import_frontier",
+    "import_read",
+    "import_discovery_close",
+    # Frontend.
     "parse_file",  # schema-v1 combined lexer/parser leaf
     "lexer",
     "parser",  # pre-RUE-892 parser leaf
@@ -88,15 +107,72 @@ CANONICAL_LEAF_ORDER = [
     "parser_grammar_execution",
     "parser_directive_validation",
     "definition_snapshot",
+    "definition_snapshot_modules",
     "merge_" + "symbols",  # historical schema-v1 name
+    "module_index_projection",
+    "canonical_merge",
     "astgen",
     "semantic_astgen",
+    "module_rir_lowering",
+    "rir_projection",
     "rir_declaration_index",
+    # Semantic analysis.
+    "declaration_shells",
+    "declaration_shell_projection",
+    "declaration_shell_prepare",
+    "declaration_occurrence_index",
+    "declaration_nucleus",
+    "declaration_reuse",
+    "body_schedule",
+    "body_toolchain_demands",
+    "body_query_prerequisites",
+    "body_anonymous_scope",
+    "body_prepare_declarations",
+    "body_project_declarations",
+    "body_install_declarations",
+    "body_analyze",
+    "body_export",
+    "body_query_lookups",
+    "body_cache_references",
+    "body_anonymous_projection",
+    "body_enqueue_references",
+    "body_canonical_projection",
     "sema",
     "cfg_construction",
+    "semantic_finalization",
+    # Backend.
     "codegen",
+    "mir_lowering",
+    "register_allocation",
+    "mir_peephole",
+    "mir_scheduling",
+    "mir_verification",
+    "string_table_compaction",
+    "machine_emission",
+    "object_serialization",
+    # Linking.
     "linker",
+    "link_parse_objects",
+    "link_archive_resolve",
+    "link_layout",
+    "link_relocate",
+    "link_emit",
 ]
+
+# Default ceiling on the share of the compiler's root span that no leaf pass
+# claims (RUE-786). The harness fails when a workload exceeds it, so newly
+# uninstrumented work has to be either given a span or explicitly accepted by
+# raising the bound, rather than silently widening the telemetry-dark region.
+#
+# The measured range across the current corpus on a release compiler is roughly
+# 12% (small examples) to 39% (large_structs). What remains is concentrated in
+# the rue-query request machinery rather than in any compiler pass: the gap
+# between `body_transaction` and its children, and the same shape inside
+# `declaration_shell_projection`, `declaration_nucleus`, and `parse_program`,
+# which are all per-module/per-body `request_registered` loops. Attributing that
+# means instrumenting the query runtime itself (RUE-817), so this bound leaves
+# headroom over the worst workload today and is meant to ratchet DOWN once it is.
+DEFAULT_MAX_UNATTRIBUTED_PERCENT = 50.0
 
 
 def repo_root() -> Path:
@@ -315,8 +391,11 @@ def aggregate(samples):
             "leaf_to_root_ratio_mad_percent": 0.0,
             "unattributed_ms": 0.0,
             "unattributed_mad_ms": 0.0,
+            "unattributed_percent": 0.0,
+            "unattributed_mad_percent": 0.0,
             "overlapping_leaf_work_ms": 0.0,
             "overlapping_leaf_work_mad_ms": 0.0,
+            "driver_phases": [],
             "source_metrics": None,
             "target": None,
             "compiler_version": None,
@@ -332,7 +411,11 @@ def aggregate(samples):
     overhead_samples = []
     leaf_to_root_ratio_samples = []
     unattributed_samples = []
+    unattributed_percent_samples = []
     overlapping_leaf_work_samples = []
+    per_driver_phase = {}
+    driver_phase_order = []
+    expected_driver_phase_names = None
     memory_samples = []
     memory_available = None
     source_metrics = None
@@ -479,8 +562,58 @@ def aggregate(samples):
         leaf_to_root_ratio_samples.append(
             leaf_work_ms / compile_ms * 100.0 if compile_ms > 0 else 0.0
         )
-        unattributed_samples.append(max(compile_ms - leaf_work_ms, 0.0))
+        unattributed_ms_sample = max(compile_ms - leaf_work_ms, 0.0)
+        unattributed_samples.append(unattributed_ms_sample)
+        unattributed_percent_samples.append(
+            unattributed_ms_sample / compile_ms * 100.0 if compile_ms > 0 else 0.0
+        )
         overlapping_leaf_work_samples.append(max(leaf_work_ms - compile_ms, 0.0))
+
+        # Driver phases measure host work outside the compiler root, so they
+        # never appear in `passes` and never enter the accounting above. They
+        # are aggregated separately as a breakdown of driver overhead.
+        sample_driver_phases = sample.get("driver_phases", [])
+        if not isinstance(sample_driver_phases, list):
+            raise ValueError(f"sample {sample_number} driver_phases must be a list")
+        driver_phase_ms = {}
+        for phase_index, phase in enumerate(sample_driver_phases):
+            if not isinstance(phase, dict):
+                raise ValueError(
+                    f"sample {sample_number} driver phase {phase_index + 1} "
+                    "must be an object"
+                )
+            phase_name = phase.get("name")
+            if not isinstance(phase_name, str) or not phase_name:
+                raise ValueError(
+                    f"sample {sample_number} driver phase {phase_index + 1} has no name"
+                )
+            if phase_name in driver_phase_ms:
+                raise ValueError(
+                    f"sample {sample_number} has duplicate driver phase {phase_name!r}"
+                )
+            driver_phase_ms[phase_name] = finite_nonnegative(
+                phase.get("duration_ms"),
+                f"sample {sample_number} driver phase {phase_name!r}",
+            )
+            nonnegative_int(
+                phase.get("invocations"),
+                f"sample {sample_number} driver phase {phase_name!r} invocations",
+                positive=True,
+            )
+        driver_phase_names = set(driver_phase_ms)
+        if expected_driver_phase_names is None:
+            expected_driver_phase_names = driver_phase_names
+            driver_phase_order.extend(driver_phase_ms)
+            per_driver_phase = {name: [] for name in driver_phase_ms}
+        elif driver_phase_names != expected_driver_phase_names:
+            missing = sorted(expected_driver_phase_names - driver_phase_names)
+            extra = sorted(driver_phase_names - expected_driver_phase_names)
+            raise ValueError(
+                f"sample {sample_number} driver phase set drifted; "
+                f"missing={missing}, extra={extra}"
+            )
+        for name in per_driver_phase:
+            per_driver_phase[name].append(driver_phase_ms[name])
 
         process_ms = finite_nonnegative(
             sample.get("_process_ms", compile_ms),
@@ -547,6 +680,9 @@ def aggregate(samples):
         leaf_to_root_ratio_samples
     )
     unattributed_ms, unattributed_mad_ms = median_and_mad(unattributed_samples)
+    unattributed_percent, unattributed_mad_percent = median_and_mad(
+        unattributed_percent_samples
+    )
     overlapping_leaf_work_ms, overlapping_leaf_work_mad_ms = median_and_mad(
         overlapping_leaf_work_samples
     )
@@ -589,8 +725,14 @@ def aggregate(samples):
         "leaf_to_root_ratio_mad_percent": leaf_to_root_ratio_mad_percent,
         "unattributed_ms": unattributed_ms,
         "unattributed_mad_ms": unattributed_mad_ms,
+        "unattributed_percent": unattributed_percent,
+        "unattributed_mad_percent": unattributed_mad_percent,
         "overlapping_leaf_work_ms": overlapping_leaf_work_ms,
         "overlapping_leaf_work_mad_ms": overlapping_leaf_work_mad_ms,
+        "driver_phases": [
+            (name, statistics.median(per_driver_phase[name]))
+            for name in driver_phase_order
+        ],
         "source_metrics": source_metrics,
         "target": compiler_identity[0] if compiler_identity else None,
         "compiler_version": compiler_identity[1] if compiler_identity else None,
@@ -670,6 +812,14 @@ def run_corpus(rue_bin, corpus, iterations, warmup, workdir, timeout, jobs):
                     "median": aggregated["unattributed_ms"],
                     "mad": aggregated["unattributed_mad_ms"],
                 },
+                "unattributed_percent": {
+                    "median": aggregated["unattributed_percent"],
+                    "mad": aggregated["unattributed_mad_percent"],
+                },
+                "driver_phases": [
+                    {"name": name, "median_ms": ms}
+                    for name, ms in aggregated["driver_phases"]
+                ],
                 "overlapping_leaf_work_ms": {
                     "median": aggregated["overlapping_leaf_work_ms"],
                     "mad": aggregated["overlapping_leaf_work_mad_ms"],
@@ -709,6 +859,22 @@ def hot_passes(results, top=3):
     grand = sum(result["compile_ms"]["median"] for result in results) or 1.0
     ranked = sorted(totals.items(), key=lambda kv: kv[1], reverse=True)
     return [(name, ms, ms / grand * 100.0) for name, ms in ranked]
+
+
+def unattributed_violations(results, bound_percent):
+    """Workloads whose median unattributed share exceeds `bound_percent`.
+
+    The bound is a ceiling on `max(root - leaf work, 0) / root`, computed per
+    sample and then medianed, so a phase that runs with no span of its own has
+    to fail the harness rather than quietly widen the residual (RUE-786).
+    Parallel leaf spans can overlap and inflate leaf work, which only makes
+    this check more permissive — never falsely failing.
+    """
+    return [
+        (result["name"], result["unattributed_percent"]["median"])
+        for result in results
+        if result["unattributed_percent"]["median"] > bound_percent
+    ]
 
 
 def print_text(results, iterations):
@@ -755,10 +921,17 @@ def print_text(results, iterations):
             f"(MAD {leaf_ratio['mad']:.1f}, paired samples)"
         )
         unattributed = r["unattributed_ms"]
+        unattributed_pct = r["unattributed_percent"]
         print(
             f"  {'UNATTRIBUTED':<{namew}}  {unattributed['median']:>8.2f} ms  "
-            f"(MAD {unattributed['mad']:.2f}, paired samples)"
+            f"(MAD {unattributed['mad']:.2f}, {unattributed_pct['median']:.1f}% of root, "
+            "paired samples)"
         )
+        for phase in r["driver_phases"]:
+            print(
+                f"  {phase['name']:<{namew}}  {phase['median_ms']:>8.2f} ms  "
+                "(driver phase, outside the compiler total)"
+            )
         overlap = r["overlapping_leaf_work_ms"]
         if overlap["median"] > 0 or overlap["mad"] > 0:
             print(
@@ -859,6 +1032,16 @@ def main():
         default=1,
         help="compiler jobs per fresh process (default 1; use 0 for auto)",
     )
+    ap.add_argument(
+        "--max-unattributed-percent",
+        type=float,
+        default=DEFAULT_MAX_UNATTRIBUTED_PERCENT,
+        help=(
+            "fail when a workload's median unattributed share of the compiler "
+            f"root exceeds this (default {DEFAULT_MAX_UNATTRIBUTED_PERCENT:g}; "
+            "pass 100 to only report it)"
+        ),
+    )
     ap.add_argument("--rue-bin", help="path to an already-built rue binary")
     ap.add_argument("--release", action="store_true", help="locate the compiler via //platforms:release")
     ap.add_argument("--format", choices=["text", "markdown", "json"], default="text")
@@ -869,6 +1052,8 @@ def main():
         ap.error("--warmup must be non-negative")
     if args.jobs < 0:
         ap.error("--jobs must be non-negative")
+    if not 0.0 <= args.max_unattributed_percent <= 100.0:
+        ap.error("--max-unattributed-percent must be between 0 and 100")
     if args.release and (args.rue_bin or os.environ.get("RUE")):
         ap.error("--release cannot be combined with --rue-bin or RUE")
 
@@ -929,6 +1114,16 @@ def main():
         print_markdown(results)
     else:
         print_text(results, args.iterations)
+
+    violations = unattributed_violations(results, args.max_unattributed_percent)
+    if violations:
+        detail = ", ".join(f"{name} {percent:.1f}%" for name, percent in violations)
+        sys.exit(
+            "perf-baseline: unattributed compiler time exceeds "
+            f"{args.max_unattributed_percent:g}% of the root span: {detail}\n"
+            "Give the new work a tracing span, or raise "
+            "--max-unattributed-percent deliberately."
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/test-benchmark-tools.py
+++ b/scripts/test-benchmark-tools.py
@@ -129,6 +129,9 @@ class PerfBaselineAggregationTests(unittest.TestCase):
         )
         self.assertEqual(result["unattributed_ms"], 2.0)
         self.assertEqual(result["unattributed_mad_ms"], 1.0)
+        # The share is paired per sample before the median, exactly like the
+        # absolute residual: median(2/11, 1/10, 3/12) as percentages.
+        self.assertAlmostEqual(result["unattributed_percent"], 2.0 / 11.0 * 100.0)
         self.assertEqual(result["inclusive_rows"], [("parse", 5.5, 50.0)])
         self.assertEqual(result["overlapping_leaf_work_ms"], 0.0)
         self.assertEqual(result["overlapping_leaf_work_mad_ms"], 0.0)
@@ -137,6 +140,81 @@ class PerfBaselineAggregationTests(unittest.TestCase):
         self.assertEqual(
             [name for name, _ms, _percent in result["rows"]],
             ["lexer", "parser", "codegen"],
+        )
+
+    def test_driver_phases_aggregate_outside_the_compiler_total(self):
+        samples = []
+        for compile_ms, write_ms in ((10.0, 1.0), (12.0, 3.0), (11.0, 2.0)):
+            sample = self.sample(compile_ms, compile_ms + 5.0)
+            sample["driver_phases"] = [
+                {"name": "output_write", "duration_ms": write_ms, "invocations": 1}
+            ]
+            samples.append(sample)
+        result = perf_baseline.aggregate(samples)
+        self.assertEqual(result["driver_phases"], [("output_write", 2.0)])
+        # Driver phases describe process-minus-root overhead only; they must
+        # not enter the leaf table or shrink the unattributed residual.
+        self.assertNotIn("output_write", [name for name, _ms, _pct in result["rows"]])
+        self.assertEqual(result["unattributed_ms"], 2.0)
+
+    def test_driver_phase_shape_and_membership_are_validated(self):
+        def with_phases(phases):
+            sample = self.sample(10.0, 15.0)
+            sample["driver_phases"] = phases
+            return sample
+
+        cases = [
+            ([{"duration_ms": 1.0, "invocations": 1}], "has no name"),
+            (
+                [{"name": "output_write", "duration_ms": -1.0, "invocations": 1}],
+                "must be a finite non-negative number",
+            ),
+            (
+                [{"name": "output_write", "duration_ms": 1.0, "invocations": 0}],
+                "must be greater than zero",
+            ),
+            (
+                [
+                    {"name": "output_write", "duration_ms": 1.0, "invocations": 1},
+                    {"name": "output_write", "duration_ms": 2.0, "invocations": 1},
+                ],
+                "duplicate driver phase",
+            ),
+        ]
+        for phases, message in cases:
+            with self.subTest(phases=phases):
+                with self.assertRaisesRegex(ValueError, message):
+                    perf_baseline.aggregate([with_phases(phases)])
+
+        with self.assertRaisesRegex(ValueError, "driver phase set drifted"):
+            perf_baseline.aggregate(
+                [
+                    with_phases(
+                        [
+                            {
+                                "name": "output_write",
+                                "duration_ms": 1.0,
+                                "invocations": 1,
+                            }
+                        ]
+                    ),
+                    with_phases([]),
+                ]
+            )
+
+    def test_unattributed_bound_fails_only_above_the_configured_tolerance(self):
+        def result(name, percent):
+            return {"name": name, "unattributed_percent": {"median": percent}}
+
+        results = [result("tight", 9.0), result("loose", 30.0), result("edge", 25.0)]
+        self.assertEqual(
+            perf_baseline.unattributed_violations(results, 25.0),
+            [("loose", 30.0)],
+        )
+        self.assertEqual(perf_baseline.unattributed_violations(results, 100.0), [])
+        self.assertEqual(
+            [name for name, _percent in perf_baseline.unattributed_violations(results, 5.0)],
+            ["tight", "loose", "edge"],
         )
 
     def test_inclusive_ratio_handles_zero_root_and_is_paired_before_median(self):
@@ -480,6 +558,8 @@ class PerfBaselineAggregationTests(unittest.TestCase):
             "driver_overhead_ms": {"median": 5.0, "mad": 0.0},
             "leaf_to_root_ratio_percent": {"median": 40.0, "mad": 0.0},
             "unattributed_ms": {"median": 12.0, "mad": 0.0},
+            "unattributed_percent": {"median": 60.0, "mad": 0.0},
+            "driver_phases": [{"name": "output_write", "median_ms": 1.5}],
             "overlapping_leaf_work_ms": {"median": 0.0, "mad": 0.0},
             "peak_memory_bytes": None,
         }


### PR DESCRIPTION
Closes RUE-786.

## Problem

The timing surface folded the driver's source loading, most of the semantic query path, and all of code generation and linking into a handful of coarse spans. Measured on trunk, 25–45% of the compiler's root span was claimed by no leaf pass at all, so latency work could not be aimed at a phase and a warm-rebuild regression could hide entirely inside the residual.

## What changed

Spans were added across the four dark regions:

- **Driver** — `source_loading`, the per-round discovery frontier (`import_revision_inputs`, `import_stage`, `import_parse_staging`, `parse_query_key` / `parse_program` / `parse_query_commit`, `import_plan_build`, `import_plan_publish`, `import_frontier`, `import_read`), `import_discovery_close`, and `toolchain_acquisition`.
- **Pipeline** — `module_index_projection`, `canonical_merge`, `module_rir_lowering`, `rir_projection`, the declaration shell and nucleus projections, the per-body query and coordinator phases, `declaration_reuse`, and `semantic_finalization`.
- **Backend** — `mir_lowering`, `register_allocation`, `mir_peephole`, `mir_scheduling`, `mir_verification`, `string_table_compaction`, `machine_emission`, and `object_serialization`.
- **Linker** — `link_parse_objects`, `link_archive_resolve`, and `link_layout` / `link_relocate` / `link_emit` on both the ELF and Mach-O paths.

The full resulting tree is documented in `docs/process/perf-baseline.md`.

### Rayon span parentage

Backend subphases execute inside a `par_iter`, and Rayon workers do not inherit the calling thread's current span. Left alone, every subphase would have been reported as an independent timing root with nondeterministic parentage (work stealing means the calling thread gets correct nesting and the workers do not). The `codegen` span is now held by value and re-entered as the first statement inside the closure. A regression test asserts `codegen -> mir_lowering` and friends in the batch edge set, and a `--jobs 0` run confirms `compile` is still the sole root with zero overlapping leaf work.

### Driver phases

Executable publication deliberately runs after the compiler's timing root closes, so it can be neither nested under `compile` (mis-attribution) nor made a second root (`total_ms` is consumed as "compiler time" by the dashboard, scaling bench, and scenario tooling). A span may now declare `driver_phase = true`; the timing layer routes it — and its children — into a separate `driver_phases` array instead of `passes`, and excludes it from the root-duration union. It is a breakdown of `process - total_ms`, never of `total_ms`. `compile` remains the sole timing root and schema v2 is unchanged apart from the new optional field, which is omitted entirely when a run measures no driver phase.

### Harness bound on unattributed time

`scripts/perf-baseline.py` now computes the unattributed share per sample (`max(root - leaf work, 0) / root`, paired before the median, consistent with the existing accounting), reports it in text and JSON, and fails when a workload's median exceeds `--max-unattributed-percent`. Parallel leaf spans can overlap and inflate leaf work, which only makes the check more permissive, so it cannot fail spuriously under `--jobs > 1`.

## Measured effect

Release compiler, `-O0`, `--jobs 1`, via `scripts/perf-baseline.py`:

| workload | unattributed share |
|---|---|
| hello | 13.0% |
| fibonacci | 13.2% |
| quicksort | 14.3% |
| multi_file | 16.0% |
| structs | 18.6% |
| deep_nesting | 23.9% |
| array_heavy | 25.0% |
| register_pressure | 25.4% |
| arithmetic_heavy | 28.1% |
| many_functions | 29.2% |
| large_structs | 39.9% |

The default bound is 50, leaving headroom over the worst workload. Verified in both directions: the corpus passes at the default, and a tighter bound exits 1 naming the offending workloads and their measured shares.

## Where the remaining residual is

It is **not** spread across the compiler any more. Every remaining large gap has the same shape — an aggregate whose children are the compute work, and whose residual is rue-query's own per-request cost (key hashing, memo lookup, dependency recording, terminal publication in `request_impl`):

| aggregate | what its residual measures |
| --- | --- |
| `body_transaction` | one `body_transaction` request per reached body |
| `declaration_shell_projection` | one `declaration_occurrence_indexes` request per module |
| `declaration_nucleus` | one `semantic_nucleus` request per declaration |
| `parse_program` | one `parse_modules` request per module |

Attributing that needs spans inside the query runtime's request path, which is the accounting boundary RUE-817 owns. I deliberately left it out of this PR rather than reaching into `rue-query`'s core — happy to fold it in here instead if reviewers would rather see it done in one go.

Two things worth noting about the numbers. Merging trunk moved the profile on its own: the recent query-attempt work raised exactly the request-machinery share this instrumentation now makes visible. And `codegen` and `linker` used to be **leaves**, so their internals counted as fully attributed work; they are aggregates now and only their leaf children count, which makes a pre-change leaf sum non-comparable to a post-change one. Both are called out in `docs/process/perf-baseline.md`.

Refs RUE-817.

## Testing

- `scripts/rue quick`; full spec suite (2178 passed).
- Unit tests for `rue`, `rue-compiler`, `rue-codegen`, `rue-linker`, `rue-query`, `rue-air`, `rue-cfg`, `rue-rir`, `rue-parser`.
- `scripts/test-benchmark-tools.py` (117 passed), including new coverage for driver-phase aggregation, driver-phase shape/membership validation, the paired unattributed share, and the bound itself.
- Existing nesting tests asserted the old shallower tree and were updated to assert the new chains explicitly rather than loosened.
- Manual: `--time-passes` text output, `--benchmark-json`, `--jobs 0`, and every `--emit` stage.
- `scripts/perf-baseline.py` end to end against a release compiler.