### PR TITLE
Run the heavy corpora as cacheable build actions

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -1,8 +1,8 @@
 # Repo-root test-suite targets (RUE-144 / RUE-132).
 #
-# Each sh_test ties a test-harness binary to the rue compiler and the on-disk
-# inputs the suite actually reads (cases/, std/, docs/), so Buck owns the binary
-# handoff and caches each suite against its real inputs:
+# Each suite ties a test-harness binary to the rue compiler and the on-disk
+# inputs it actually reads (cases/, std/, docs/), so Buck owns the binary
+# handoff and keys each suite on its real inputs:
 #
 #   buck2 test //...        # runs unit tests + spec/UI/CLI suites + repo gates
 #
@@ -10,17 +10,41 @@
 # under std/ re-runs the CLI and spec suites (std/ MUST be a declared input here
 # or either suite could get false cache hits on standard-library changes).
 #
+# RUE-1118: the heavy corpora run through `cached_corpus_suite` rather than a
+# bare sh_test. buck2 re-executes every test invocation — test executions are
+# not actions and never reach the action cache — so a plain sh_test re-ran the
+# whole corpus on each merge even when the merge commit's tree was byte-identical
+# to the tree the PR run had just validated. The macro moves the harness into a
+# cacheable build action and leaves a thin sh_test asserting its stamp, so the
+# suite keeps its name, labels, and result line. See corpus.bzl for the input
+# contract this makes load-bearing.
+#
 # Mechanics: the harness binaries already locate everything via env vars
-# (rue-test-runner's find_rue_binary / find_dir), `$(exe_target ...)` /
-# `$(location ...)` expand to absolute paths, and sh_test runs from the
-# project root — so the harness binary itself can be the `test` command and
-# no wrapper script is needed. A filegroup's output directory is named after
-# the rule and contains its srcs at package-relative paths, hence the
-# `$(location ...)/cases` shape.
+# (rue-test-runner's find_rue_binary / find_dir), and a filegroup's output
+# directory is named after the rule and contains its srcs at package-relative
+# paths, hence the `$(location ...)/cases` shape. In an sh_test those macros
+# expand to absolute paths and the test runs from the project root; in a
+# genrule they are relative to the action's working directory, which is why
+# cached_corpus_suite routes them through scripts/corpus-action.
 #
 # These suites live at the repo root rather than in the harness crates' BUCK
 # files so that `buck2 test //crates/...` (quick-test.sh, test.sh's filtered
 # path) still means "unit tests only".
+
+load(":corpus.bzl", "cached_corpus_suite")
+
+# The two halves of a cached corpus suite: the action wrapper that runs a
+# harness and writes its stamp, and the thin check that asserts the stamp.
+sh_binary(
+    name = "corpus-action",
+    main = "scripts/corpus-action",
+)
+
+sh_binary(
+    name = "corpus-stamp-check",
+    main = "scripts/corpus-stamp-check",
+    visibility = ["PUBLIC"],
+)
 
 # The formatting gate lives in fmt.sh, not here. A `fmt-check` sh_test used to
 # sit at this spot, taking its file list from `glob(["crates/**/*.rs"])`. A
@@ -164,16 +188,21 @@ filegroup(
     ]),
 )
 
-sh_test(
+cached_corpus_suite(
     name = "spec-tests",
     labels = ["rue_heavy_suite"],
-    test = "//crates/rue-spec:rue-spec",
+    harness = "//crates/rue-spec:rue-spec",
     args = ["--quiet"],
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
         "RUE_REAL_STD_PATH": "$(location :std)/std",
         "RUE_SPEC_CASES": "$(location //crates/rue-spec:cases)/cases",
     },
+    absolutize = [
+        "RUE_BINARY",
+        "RUE_REAL_STD_PATH",
+        "RUE_SPEC_CASES",
+    ],
 )
 
 sh_test(
@@ -186,15 +215,19 @@ sh_test(
     },
 )
 
-sh_test(
+cached_corpus_suite(
     name = "ui-tests",
     labels = ["rue_heavy_suite"],
-    test = "//crates/rue-ui-tests:rue-ui-tests",
+    harness = "//crates/rue-ui-tests:rue-ui-tests",
     args = ["--quiet"],
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
         "RUE_UI_CASES": "$(location //crates/rue-ui-tests:cases)/cases",
     },
+    absolutize = [
+        "RUE_BINARY",
+        "RUE_UI_CASES",
+    ],
 )
 
 # Shared verbatim by //:cli-tests and its shards so a slice runs exactly the
@@ -223,15 +256,37 @@ _CLI_TEST_ENV = {
     "RUE_STD_DIR": "$(location :std)/std",
 }
 
+# Every _CLI_TEST_ENV entry is a path the harness hands to a compiler spawned
+# with a case's temp directory as cwd, so all of them must be absolute (see
+# corpus.bzl). The harness's find_dir fallbacks would otherwise resolve against
+# the action's working directory and silently miss the real corpus.
+_CLI_TEST_ABSOLUTIZE = [
+    "RUE_BINARY",
+    "RUE_CLI_CASES",
+    "RUE_EXAMPLES_DIR",
+    "RUE_REPO_DIR",
+    "RUE_STD_DIR",
+]
+
+# RUE-1083 recalibrated several per-case heavyweight compile budgets upward, so
+# the serialized aggregate can exceed a short outer bound. These replace the
+# test executor's timeout, which scripts/ci-heavy-suite used to pass and a build
+# action does not get; the per-case contracts in execution_contracts.toml remain
+# the honest gates. Re-tighten when the per-case budgets come back down.
+_CLI_TESTS_TIMEOUT_SECONDS = 1800
+_CLI_SHARD_TIMEOUT_SECONDS = 1200
+
 # The full CLI corpus in one invocation: the canonical target that a local
 # `./test.sh` full run executes and that the RUE-924 corpus-omission audit
 # tracks (REQUIRED_CORPUS_HARNESSES in test.sh).
-sh_test(
+cached_corpus_suite(
     name = "cli-tests",
     labels = ["rue_heavy_suite"],
-    test = "//crates/rue-cli-tests:rue-cli-tests",
+    harness = "//crates/rue-cli-tests:rue-cli-tests",
     args = _CLI_TEST_ARGS,
     env = _CLI_TEST_ENV,
+    absolutize = _CLI_TEST_ABSOLUTIZE,
+    timeout_seconds = _CLI_TESTS_TIMEOUT_SECONDS,
 )
 
 # Required release coverage is deliberately bounded: compile the real driver
@@ -239,11 +294,12 @@ sh_test(
 # differential-opt corpus through that release-built compiler. The scheduled
 # full-release workflow owns exhaustive //... coverage off the PR critical
 # path (RUE-1129).
-sh_test(
+cached_corpus_suite(
     name = "release-smoke",
-    test = "//crates/rue-cli-tests:rue-cli-tests",
+    harness = "//crates/rue-cli-tests:rue-cli-tests",
     args = ["--quiet", "differential_opt"],
     env = _CLI_TEST_ENV,
+    absolutize = _CLI_TEST_ABSOLUTIZE,
 )
 
 # RUE-1116: parallel CI shards of the CLI corpus. Same harness and declared
@@ -261,14 +317,16 @@ sh_test(
 CLI_TEST_SHARD_COUNT = 4
 
 [
-    sh_test(
+    cached_corpus_suite(
         name = "cli-tests-shard-{}".format(_shard),
         labels = ["rue_heavy_suite", "rue_cli_shard"],
-        test = "//crates/rue-cli-tests:rue-cli-tests",
+        harness = "//crates/rue-cli-tests:rue-cli-tests",
         args = _CLI_TEST_ARGS,
         env = dict(_CLI_TEST_ENV.items() + [
             ("RUE_CLI_TEST_SHARD", "{}/{}".format(_shard, CLI_TEST_SHARD_COUNT)),
         ]),
+        absolutize = _CLI_TEST_ABSOLUTIZE,
+        timeout_seconds = _CLI_SHARD_TIMEOUT_SECONDS,
     )
     for _shard in range(CLI_TEST_SHARD_COUNT)
 ]
@@ -284,20 +342,27 @@ CLI_TEST_SHARD_COUNT = 4
 # UTC). This exact target stays a transparent success stub until the
 # remaining per-body incremental work brings the stress compile back into a
 # reasonable budget. Every other example family runs real cases above.
-sh_test(
+cached_corpus_suite(
     name = "cli-tests-caldera",
     labels = ["rue_heavy_suite"],
-    test = "//crates/rue-cli-tests:rue-cli-tests",
+    harness = "//crates/rue-cli-tests:rue-cli-tests",
     args = ["--quiet", "caldera"],
     env = dict(_CLI_TEST_ENV.items() + [
         ("RUE_CALDERA_SUCCESS_STUB", "RUE-1083"),
     ]),
+    absolutize = _CLI_TEST_ABSOLUTIZE,
 )
 
 # RUE-1083: `examples/` is a declared input because this suite now also checks a
 # real maintained program (rill) for byte-stable output, not just the
 # purpose-built fixture. An edit under examples/ must therefore re-run it.
 sh_test(
+    # RUE-1118: still a plain sh_test, so it re-runs on every invocation. Its
+    # harness is a shell script rather than a target, and unlike the corpus
+    # harnesses it reads repository paths directly rather than through declared
+    # env inputs — the input contract cached_corpus_suite depends on has to be
+    # established before caching this one would be sound rather than a false
+    # pass. It is also off the merge queue's critical path.
     name = "reproducible-programs",
     labels = ["rue_heavy_suite"],
     test = "scripts/test-reproducible-output.sh",
@@ -315,6 +380,8 @@ sh_test(
 # reference oracle and native codegen. It lives at the root so full/no-argument
 # `test.sh` and CI include it while `quick-test.sh` remains unit-only.
 sh_test(
+    # RUE-1118: still a plain sh_test, for the same reason as
+    # //:reproducible-programs above.
     name = "oracle-diff-generated-smoke",
     labels = ["rue_heavy_suite"],
     test = "scripts/oracle-diff-generated-smoke.sh",
@@ -601,6 +668,25 @@ sh_test(
     test = "scripts/test-wrapper-scripts.sh",
     env = {
         "RUE_WRAPPER_ROOT": "$(location :wrapper-script-inputs)",
+    },
+)
+
+# RUE-1118: corpus-action decides whether a corpus suite's result is written to
+# the action cache, so its stamp-only-on-success and absolutization contracts
+# are pinned independently of any corpus actually running.
+filegroup(
+    name = "corpus-script-inputs",
+    srcs = [
+        "scripts/corpus-action",
+        "scripts/corpus-stamp-check",
+    ],
+)
+
+sh_test(
+    name = "corpus-action-tests",
+    test = "scripts/test-corpus-action.sh",
+    env = {
+        "RUE_CORPUS_SCRIPTS_ROOT": "$(location :corpus-script-inputs)",
     },
 )
 

--- a/BUCK
+++ b/BUCK
@@ -215,6 +215,13 @@ sh_test(
     },
 )
 
+# RUE-1118: RUE_REAL_STD_PATH was missing here. Cases marked `real_std` compile
+# against the standard library, and rue-test-runner resolves it through that
+# variable with a cwd-relative fallback ("std", "../std", ...). Under the old
+# sh_test, which ran from the project root, the fallback silently found the real
+# std/ and the suite passed against an input Buck did not know about — the exact
+# false-hit hazard this file's header warns about. Declaring it makes std/ a
+# tracked input of the UI corpus.
 cached_corpus_suite(
     name = "ui-tests",
     labels = ["rue_heavy_suite"],
@@ -222,10 +229,12 @@ cached_corpus_suite(
     args = ["--quiet"],
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_REAL_STD_PATH": "$(location :std)/std",
         "RUE_UI_CASES": "$(location //crates/rue-ui-tests:cases)/cases",
     },
     absolutize = [
         "RUE_BINARY",
+        "RUE_REAL_STD_PATH",
         "RUE_UI_CASES",
     ],
 )

--- a/corpus.bzl
+++ b/corpus.bzl
@@ -1,0 +1,84 @@
+"""Corpus suites that run as cacheable build actions (RUE-1118).
+
+buck2 re-executes every `buck2 test` invocation. Test executions are not
+actions: they are handed to the test executor, they never appear in buck2's
+`Commands: N (cached: ...)` accounting, and OSS buck2 ships no test-result
+cache. Measured on three CI runs of one byte-identical tree (two `pull_request`,
+one `merge_group`), build actions converged to 465/465 cache hits while the
+corpora re-ran in full every time, at 91-97% of the merge queue's critical path.
+
+`cached_corpus_suite` splits each corpus in two:
+
+  * a `genrule` that runs the harness and writes a stamp on success. This is an
+    ordinary action, keyed on its declared inputs, so a PR run uploads it and
+    the merge_group run reads it back.
+  * a thin `sh_test` that asserts the stamp exists. It keeps the target's name,
+    labels, and `Pass: root//:NAME (time)` result line, so `scripts/ci-heavy-suite`
+    and test.sh's RUE-924 corpus-omission audit keep working unchanged.
+
+THE INPUT CONTRACT IS NOW LOAD-BEARING. Under a plain `sh_test` an undeclared
+input was merely untracked — the suite re-ran regardless. Here an undeclared
+input is a false pass: change a file the action does not name, and the corpus
+reports success against the previous tree's result. Every path a harness reads
+at runtime MUST reach it through `env` (or `args`), and therefore through
+`$(location ...)`. When adding a corpus input, add it here, not just to the
+harness.
+"""
+
+def cached_corpus_suite(
+        name,
+        harness,
+        args = [],
+        env = {},
+        absolutize = [],
+        labels = [],
+        timeout_seconds = None):
+    """Define a corpus suite whose expensive run is a cacheable build action.
+
+    Args:
+        name: the test target's name. The action becomes `NAME-action`.
+        harness: the corpus harness binary target.
+        args: arguments passed to the harness.
+        env: environment for the harness, as on the equivalent `sh_test`.
+        absolutize: the `env` keys holding paths. Buck expands `$(location ...)`
+            inside a genrule relative to the action's working directory, which is
+            not the project root, and the harnesses spawn the compiler with each
+            case's temp directory as cwd. `scripts/corpus-action` resolves these
+            to absolute paths immediately before the harness runs.
+        labels: labels for the test target. The action carries none: it is not a
+            test, and `rue_heavy_suite` drives test discovery.
+        timeout_seconds: outer bound replacing the test executor's timeout, which
+            a build action does not get. The per-case budgets in
+            execution_contracts.toml remain the honest gates.
+    """
+    for key in absolutize:
+        if key not in env:
+            fail("cached_corpus_suite({}): absolutize names '{}', which is not in env".format(name, key))
+
+    action_env = dict(env.items())
+    action_env["RUE_CORPUS_ABSOLUTIZE"] = " ".join(absolutize)
+    if timeout_seconds != None:
+        action_env["RUE_CORPUS_TIMEOUT_SECONDS"] = str(timeout_seconds)
+
+    # A genrule cmd cannot use shell command substitution: `$(...)` is Buck's
+    # own macro syntax. Everything variable lives in `env` instead, and
+    # scripts/corpus-action does the resolving.
+    cmd = " ".join([
+        "$(exe_target //:corpus-action)",
+        "$OUT",
+        "$(exe_target {})".format(harness),
+    ] + ["'{}'".format(arg) for arg in args])
+
+    native.genrule(
+        name = name + "-action",
+        out = "stamp.txt",
+        cmd = cmd,
+        env = action_env,
+    )
+
+    native.sh_test(
+        name = name,
+        labels = labels,
+        test = "//:corpus-stamp-check",
+        args = ["$(location :{}-action)".format(name)],
+    )

--- a/corpus.bzl
+++ b/corpus.bzl
@@ -55,25 +55,13 @@ def cached_corpus_suite(
         if key not in env:
             fail("cached_corpus_suite({}): absolutize names '{}', which is not in env".format(name, key))
 
-    action_env = dict(env.items())
-    action_env["RUE_CORPUS_ABSOLUTIZE"] = " ".join(absolutize)
-    if timeout_seconds != None:
-        action_env["RUE_CORPUS_TIMEOUT_SECONDS"] = str(timeout_seconds)
-
-    # A genrule cmd cannot use shell command substitution: `$(...)` is Buck's
-    # own macro syntax. Everything variable lives in `env` instead, and
-    # scripts/corpus-action does the resolving.
-    cmd = " ".join([
-        "$(exe_target //:corpus-action)",
-        "$OUT",
-        "$(exe_target {})".format(harness),
-    ] + ["'{}'".format(arg) for arg in args])
-
-    native.genrule(
+    _corpus_action(
         name = name + "-action",
-        out = "stamp.txt",
-        cmd = cmd,
-        env = action_env,
+        harness = harness,
+        harness_args = args,
+        corpus_env = env,
+        absolutize = absolutize,
+        timeout_seconds = timeout_seconds,
     )
 
     native.sh_test(
@@ -82,3 +70,56 @@ def cached_corpus_suite(
         test = "//:corpus-stamp-check",
         args = ["$(location :{}-action)".format(name)],
     )
+
+def _corpus_action_impl(ctx: AnalysisContext) -> list[Provider]:
+    stamp = ctx.actions.declare_output("stamp.txt")
+
+    action_env = dict(ctx.attrs.corpus_env.items())
+    action_env["RUE_CORPUS_ABSOLUTIZE"] = " ".join(ctx.attrs.absolutize)
+    if ctx.attrs.timeout_seconds != None:
+        action_env["RUE_CORPUS_TIMEOUT_SECONDS"] = str(ctx.attrs.timeout_seconds)
+
+    ctx.actions.run(
+        cmd_args(
+            ctx.attrs.wrapper[RunInfo],
+            stamp.as_output(),
+            ctx.attrs.harness[RunInfo],
+            ctx.attrs.harness_args,
+        ),
+        env = action_env,
+        category = "rue_corpus",
+        identifier = ctx.label.name,
+        # The corpus spawns the real compiler and links native binaries, so it
+        # belongs on the lane's own platform; this matches the repository's
+        # ordinary --prefer-local policy. It does not affect cache *reads* —
+        # lookup still happens before a miss executes.
+        local_only = True,
+        # THE POINT OF THIS RULE. `genrule` computes
+        #     cacheable = attrs.cacheable and (local_only or prefer_local)
+        # and passes it as allow_cache_upload, where local_only/prefer_local are
+        # driven purely by a Meta-internal label allowlist (uses_sudo, qt_moc,
+        # yarn_install, ...). A plain genrule therefore never uploads its result
+        # in this repository: the first merge_group run of RUE-1118 re-executed
+        # every corpus on a tree byte-identical to the one the PR run had just
+        # built, because nothing had ever been written to the cache. Stating the
+        # intent here is both honest and immune to a prelude bump reorganizing
+        # that label list.
+        allow_cache_upload = True,
+    )
+
+    return [DefaultInfo(default_output = stamp)]
+
+_corpus_action = rule(
+    impl = _corpus_action_impl,
+    attrs = {
+        # `attrs.arg` expands $(location ...) / $(exe_target ...) in the values
+        # and registers what they name as inputs of the action — which is what
+        # keys the cache entry, and what the input contract above is about.
+        "absolutize": attrs.list(attrs.string(), default = []),
+        "corpus_env": attrs.dict(attrs.string(), attrs.arg(), default = {}),
+        "harness": attrs.dep(providers = [RunInfo]),
+        "harness_args": attrs.list(attrs.string(), default = []),
+        "timeout_seconds": attrs.option(attrs.int(), default = None),
+        "wrapper": attrs.dep(providers = [RunInfo], default = "//:corpus-action"),
+    },
+)

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -156,6 +156,56 @@ question of how expensive a real change's remaining local actions were. Both
 signals matter: a central Rust or ThinLTO change can have a high numerical hit
 rate while a few invalidated actions remain on the critical path.
 
+**Those counters cannot see test time, and reading them as if they can is the
+trap this section exists to prevent.** Buck's `Commands: N (cached: C, remote: R,
+local: L)` line counts *actions*. A `buck2 test` invocation also performs a test
+execution, which is not an action: it is handed to the test executor, it never
+appears in that line, and OSS buck2 ships no test-result cache. Measured in one
+`merge_group` run, a corpus whose test took `0.0s` and a corpus whose test took
+`11:18` both reported `Commands: 465`. A job can therefore print
+`Cache hits: 100%` while re-running an eleven-minute suite, which reads as
+"everything was cached" and is not.
+
+## Corpus suites are build actions (RUE-1118)
+
+Because test executions cannot be cached, a plain `sh_test` corpus re-ran on
+every merge even when the merge commit's tree was byte-identical to the tree the
+PR run had just validated. Three CI runs of one such tree — two `pull_request`,
+one `merge_group` — converged to 465/465 cached build actions while every corpus
+re-executed in full, at 91–97% of the merge queue's critical path.
+
+`cached_corpus_suite` (`corpus.bzl`) therefore splits each heavy corpus in two:
+
+- a **genrule** that runs the harness through `scripts/corpus-action` and writes
+  a stamp on success. This is an ordinary action, so the PR run uploads it and
+  the `merge_group` run reads it back like any compile;
+- a thin **`sh_test`** that asserts the stamp. It keeps the suite's name, labels,
+  and `Pass: root//:NAME (time)` result line, so `scripts/ci-heavy-suite` and
+  test.sh's RUE-924 corpus-omission audit keep working unchanged.
+
+Two consequences are worth knowing before changing a corpus target:
+
+1. **The declared input contract is now load-bearing.** Under a plain `sh_test`
+   an undeclared input was merely untracked — the suite re-ran regardless. Here
+   an undeclared input is a false pass: change a file the action does not name
+   and the corpus reports success against the previous tree's result. Every path
+   a harness reads at runtime must reach it through `env`, and hence through
+   `$(location ...)`.
+2. **Paths must be absolute.** `$(location ...)` expands to an absolute path in
+   an `sh_test`, which runs from the project root, but to a path relative to the
+   action's working directory in a genrule. The harnesses spawn the compiler with
+   each case's temp directory as cwd, and `find_dir` falls back to relative
+   defaults, so a relative value can resolve to a real but wrong directory and
+   quietly test nothing. `corpus-action` resolves everything named in the suite's
+   `absolutize` list immediately before the harness runs; it cannot be done in
+   BUCK because a genrule cmd has no shell command substitution — `$(...)` is
+   Buck's own macro syntax.
+
+`//:reproducible-programs` and `//:oracle-diff-generated-smoke` remain plain
+`sh_test`s: their harnesses are shell scripts that read repository paths
+directly rather than through declared env inputs, so establishing that contract
+has to come first. Both are off the merge queue's critical path.
+
 RUE-320 also adds a merge-group-only remote-execution canary. It disables action
 cache reads, selects the no-fallback `//platforms:remote_execution` executor, and
 requires Buck to report remotely executed actions. This is deliberately

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -192,14 +192,35 @@ Two consequences are worth knowing before changing a corpus target:
    a harness reads at runtime must reach it through `env`, and hence through
    `$(location ...)`.
 2. **Paths must be absolute.** `$(location ...)` expands to an absolute path in
-   an `sh_test`, which runs from the project root, but to a path relative to the
-   action's working directory in a genrule. The harnesses spawn the compiler with
-   each case's temp directory as cwd, and `find_dir` falls back to relative
-   defaults, so a relative value can resolve to a real but wrong directory and
-   quietly test nothing. `corpus-action` resolves everything named in the suite's
-   `absolutize` list immediately before the harness runs; it cannot be done in
-   BUCK because a genrule cmd has no shell command substitution — `$(...)` is
-   Buck's own macro syntax.
+   an `sh_test`, which runs from the project root, but to a project-relative path
+   in a build action. The harnesses spawn the compiler with each case's temp
+   directory as cwd, and `find_dir` falls back to relative defaults, so a
+   relative value can resolve to a real but wrong directory and quietly test
+   nothing. `corpus-action` resolves everything named in the suite's
+   `absolutize` list immediately before the harness runs.
+3. **The suite must be a rule that permits cache uploads.** `cached_corpus_suite`
+   defines its own rule rather than using `genrule` for one reason: the prelude
+   computes `cacheable = attrs.cacheable and (local_only or prefer_local)` and
+   passes that as `allow_cache_upload`, where those two flags come from a
+   Meta-internal label allowlist (`uses_sudo`, `qt_moc`, `yarn_install`, ...). A
+   plain genrule therefore never uploads here, and the first merge_group run of
+   RUE-1118 re-executed every corpus on a tree byte-identical to the one the PR
+   run had just built. The rule sets `allow_cache_upload = True` explicitly.
+
+### Reading whether a corpus was cache-served
+
+The thin `sh_test` reports `Pass: root//:NAME (0.0s)` whether the corpus ran for
+eleven minutes or was served from cache — it only checks the stamp. **Do not read
+that line as evidence of anything.** Two signals actually answer the question:
+
+- `Commands: N (cached: C, remote: R, local: L)` — the corpus is one action, so a
+  cache-served suite adds to `cached` and a re-executed one adds to `local`. The
+  pre-RUE-1118 baseline for a CLI shard was 465 commands; it is 466 now.
+- the job's wall time, which is unambiguous.
+
+This matters because the two failure modes look identical in the test output. A
+merge_group run that reports `Pass (0.0s)` on all eighteen corpus jobs while each
+one takes ten minutes is doing no caching at all.
 
 `//:reproducible-programs` and `//:oracle-diff-generated-smoke` remain plain
 `sh_test`s: their harnesses are shell scripts that read repository paths

--- a/scripts/ci-heavy-suite
+++ b/scripts/ci-heavy-suite
@@ -23,24 +23,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# RUE-1083 recalibrated several per-case heavyweight compile budgets upward
-# while per-body incremental work continues, so the CLI corpus's serialized
-# heavyweight aggregate can exceed the test executor's 600-second default
-# (linux-arm64 shard 1 hit the outer timeout at 10:00 with zero case
-# failures). The outer margin is plumbing; the per-case contract budgets in
-# execution_contracts.toml remain the honest gates. Re-tighten when the
-# per-case budgets come back down.
-test_args=("$target")
-case "$target" in
-    //:cli-tests)
-        test_args+=(-- --timeout 1800)
-        ;;
-    //:cli-tests-shard-*)
-        test_args+=(-- --timeout 1200)
-        ;;
-esac
-
-./buck2 test "${test_args[@]}" 2>&1 | tee "$log"
+# RUE-1118: the corpus itself now runs as a cacheable build action, and the
+# test executor only asserts that action's stamp — a sub-second test whatever
+# the corpus costs. The outer bound that used to be passed here as
+# `--timeout` moved to each suite's timeout_seconds in BUCK, where it applies
+# to the action that actually does the work. The per-case contract budgets in
+# execution_contracts.toml remain the honest gates.
+./buck2 test "$target" 2>&1 | tee "$log"
 status=${PIPESTATUS[0]}
 if [[ "$status" -ne 0 ]]; then
     exit "$status"

--- a/scripts/corpus-action
+++ b/scripts/corpus-action
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Run one corpus harness as a cacheable Buck build action (RUE-1118).
+#
+# buck2 re-executes every `buck2 test` invocation. Test executions are not
+# actions: they are handed to the test executor, they never appear in buck2's
+# `Commands: N (cached: ...)` accounting, and OSS buck2 has no test-result
+# cache. A corpus that runs as a *build* action instead is keyed on its declared
+# inputs like any other action, so the merge_group run reuses the result the PR
+# run uploaded rather than re-running the suite.
+#
+# usage: scripts/corpus-action STAMP HARNESS [ARG ...]
+#
+# Buck expands $(location) and $(exe_target) inside a genrule to paths relative
+# to the action's working directory, which is not the project root. The corpus
+# harnesses spawn the compiler with each case's temp directory as cwd, so every
+# path handed to them must be absolute. The environment variables named in
+# RUE_CORPUS_ABSOLUTIZE are resolved here, immediately before the harness runs,
+# rather than in BUCK: a genrule cmd cannot use shell command substitution
+# because `$(...)` is Buck's own macro syntax.
+set -uo pipefail
+
+if [[ $# -lt 2 ]]; then
+    echo "usage: scripts/corpus-action STAMP HARNESS [ARG ...]" >&2
+    exit 2
+fi
+
+stamp="$1"
+harness="$2"
+shift 2
+
+# Resolve a path without requiring GNU realpath (macOS runners ship BSD tools
+# and no coreutils). A directory resolves directly; anything else resolves
+# through its parent so that missing-but-declared outputs still absolutize.
+absolutize() {
+    local path="$1"
+    if [[ -d "$path" ]]; then
+        (cd "$path" && pwd)
+        return
+    fi
+    local dir base
+    dir="$(dirname "$path")"
+    base="$(basename "$path")"
+    if [[ ! -d "$dir" ]]; then
+        echo "error: cannot resolve '$path': no such directory '$dir'" >&2
+        return 1
+    fi
+    printf '%s/%s\n' "$(cd "$dir" && pwd)" "$base"
+}
+
+for name in ${RUE_CORPUS_ABSOLUTIZE:-}; do
+    value="${!name:-}"
+    if [[ -z "$value" ]]; then
+        echo "error: $name is listed in RUE_CORPUS_ABSOLUTIZE but is unset or empty" >&2
+        exit 2
+    fi
+    if ! resolved="$(absolutize "$value")"; then
+        echo "error: cannot absolutize $name='$value'" >&2
+        exit 2
+    fi
+    export "$name=$resolved"
+done
+# The harness must not observe this action's own plumbing.
+unset RUE_CORPUS_ABSOLUTIZE
+
+harness="$(absolutize "$harness")" || exit 2
+
+# The per-case budgets in execution_contracts.toml are the honest gates. This
+# outer bound only replaces the test executor's timeout, which a build action
+# does not get: without it a wedged harness runs until the GitHub job timeout
+# and reports nothing useful.
+timeout_seconds="${RUE_CORPUS_TIMEOUT_SECONDS:-}"
+unset RUE_CORPUS_TIMEOUT_SECONDS
+if [[ -n "$timeout_seconds" ]] && command -v timeout >/dev/null 2>&1; then
+    timeout "$timeout_seconds" "$harness" "$@"
+    status=$?
+    if [[ "$status" -eq 124 ]]; then
+        echo "error: corpus harness exceeded ${timeout_seconds}s: $harness $*" >&2
+    fi
+else
+    "$harness" "$@"
+    status=$?
+fi
+
+if [[ "$status" -ne 0 ]]; then
+    # Buck surfaces a failed action's stderr, and no stamp is written, so the
+    # failure cannot be cached and the next run re-executes the corpus.
+    echo "error: corpus harness failed (exit $status): $harness $*" >&2
+    exit "$status"
+fi
+
+# The stamp is the action's only output. Its content is deliberately not the
+# harness's stdout: an identical tree must produce an identical stamp, or the
+# artifact would differ between the PR run and the merge_group run for no
+# semantic reason.
+printf 'corpus harness passed\n' >"$stamp"

--- a/scripts/corpus-stamp-check
+++ b/scripts/corpus-stamp-check
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Assert that a corpus action produced its stamp (RUE-1118).
+#
+# The expensive corpus run is a cacheable build action; this is the thin test
+# that carries the suite's name, labels, and Pass/Fail result line. Buck builds
+# the action first, so reaching this script at all means the harness passed —
+# either in this run or in an earlier one whose result the action cache served.
+# A failing harness writes no stamp, so the suite fails as a build failure and
+# nothing is cached.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: scripts/corpus-stamp-check STAMP" >&2
+    exit 2
+fi
+
+stamp="$1"
+
+if [[ ! -f "$stamp" ]]; then
+    echo "error: corpus stamp does not exist: $stamp" >&2
+    exit 1
+fi
+
+if [[ ! -s "$stamp" ]]; then
+    echo "error: corpus stamp is empty: $stamp" >&2
+    exit 1
+fi

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -289,10 +289,15 @@ EOF
         "$(grep -Fxq 'test //... --exclude rue_heavy_suite --always-exclude' "$sb/calls" && echo 0 || echo 1)"
     check "suite: heavy targets are discovered from the live graph" \
         "$(grep -Fxq 'uquery attrfilter(labels, rue_heavy_suite, //...)' "$sb/calls" && echo 0 || echo 1)"
-    check "suite: monolithic CLI corpus receives the extended executor timeout" \
-        "$(grep -Fxq 'test //:cli-tests -- --timeout 1800' "$sb/calls" && echo 0 || echo 1)"
-    check "suite: every other heavy target uses the default executor timeout" \
-        "$([ "$(grep -Ec '^test //:(cli-tests-caldera|spec-tests|ui-tests|oracle-diff-generated-smoke|reproducible-programs)$' "$sb/calls")" -eq 5 ] && echo 0 || echo 1)"
+    # RUE-1118: every heavy target is now invoked bare. The corpus runs as a
+    # cacheable build action and the test executor only asserts its stamp, so an
+    # executor timeout here would bound a sub-second check while reading as if
+    # the corpus were still bounded; the real outer bound is each suite's
+    # timeout_seconds in BUCK.
+    check "suite: heavy targets are invoked without an executor timeout" \
+        "$(! grep -Fq -- '-- --timeout' "$sb/calls" && echo 0 || echo 1)"
+    check "suite: every heavy target is invoked exactly once" \
+        "$([ "$(grep -Ec '^test //:(cli-tests|cli-tests-caldera|spec-tests|ui-tests|oracle-diff-generated-smoke|reproducible-programs)$' "$sb/calls")" -eq 6 ] && echo 0 || echo 1)"
     check "suite: no concurrent heavy label sweep occurs" \
         "$(! grep -Fq -- '--include rue_heavy_suite' "$sb/calls" && echo 0 || echo 1)"
     check "suite: host lock is released" "$([[ ! -e "$sb/lock" ]] && echo 0 || echo 1)"

--- a/scripts/test-corpus-action.sh
+++ b/scripts/test-corpus-action.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# test-corpus-action.sh — regression tests for scripts/corpus-action (RUE-1118).
+#
+# corpus-action is what makes a corpus suite's result cacheable, so its failure
+# modes are asymmetric: a spurious failure is loud and self-correcting, but
+# writing a stamp when the harness did not pass would cache a false green and
+# every later run of that tree would report success without executing anything.
+# These tests pin the stamp-only-on-success contract, and the absolutization
+# contract that keeps a harness from silently resolving a relative path against
+# the action's working directory instead of the real corpus.
+#
+# Each test runs the real script in a throwaway sandbox against a fake harness.
+set -uo pipefail
+
+if [ -n "${RUE_CORPUS_SCRIPTS_ROOT:-}" ]; then
+    SCRIPTS_DIR="$RUE_CORPUS_SCRIPTS_ROOT/scripts"
+else
+    SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
+CORPUS_ACTION="$SCRIPTS_DIR/corpus-action"
+
+failures=0
+tests=0
+
+check() {
+    local label="$1" expected="$2" actual="$3"
+    tests=$((tests + 1))
+    if [ "$expected" != "$actual" ]; then
+        echo "FAIL: $label: expected '$expected', got '$actual'" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+sandbox() {
+    mktemp -d "${TMPDIR:-/tmp}/rue-corpus-action-test.XXXXXX"
+}
+
+# A harness that passes writes a stamp.
+t_success() {
+    local dir stamp status
+    dir="$(sandbox)"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$dir/harness"
+    chmod +x "$dir/harness"
+    stamp="$dir/stamp.txt"
+    (cd "$dir" && "$CORPUS_ACTION" "$stamp" ./harness >/dev/null 2>&1)
+    status=$?
+    check "passing harness exits 0" "0" "$status"
+    check "passing harness writes a stamp" "yes" "$([ -s "$stamp" ] && echo yes || echo no)"
+    rm -rf "$dir"
+}
+
+# A harness that fails writes NO stamp: the action fails, nothing is cached,
+# and the next run re-executes the corpus.
+t_failure_writes_no_stamp() {
+    local dir stamp status
+    dir="$(sandbox)"
+    printf '#!/usr/bin/env bash\nexit 3\n' >"$dir/harness"
+    chmod +x "$dir/harness"
+    stamp="$dir/stamp.txt"
+    (cd "$dir" && "$CORPUS_ACTION" "$stamp" ./harness >/dev/null 2>&1)
+    status=$?
+    check "failing harness propagates its status" "3" "$status"
+    check "failing harness writes no stamp" "no" "$([ -e "$stamp" ] && echo yes || echo no)"
+    rm -rf "$dir"
+}
+
+# Declared path variables reach the harness as absolute paths. The corpus
+# harnesses spawn the compiler with a case temp dir as cwd, so a relative value
+# would resolve somewhere else entirely — or, worse, resolve to a real but wrong
+# directory and quietly test nothing.
+t_absolutize() {
+    local dir status observed
+    dir="$(sandbox)"
+    mkdir -p "$dir/cases"
+    printf '#!/usr/bin/env bash\nprintf "%%s" "$RUE_TEST_CASES" > "$OBSERVED"\nexit 0\n' >"$dir/harness"
+    chmod +x "$dir/harness"
+    (
+        cd "$dir" &&
+            OBSERVED="$dir/observed" \
+                RUE_TEST_CASES="cases" \
+                RUE_CORPUS_ABSOLUTIZE="RUE_TEST_CASES" \
+                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness >/dev/null 2>&1
+    )
+    status=$?
+    observed="$(cat "$dir/observed" 2>/dev/null)"
+    check "absolutized run succeeds" "0" "$status"
+    check "declared path reaches the harness absolute" "$(cd "$dir/cases" && pwd)" "$observed"
+    rm -rf "$dir"
+}
+
+# An unset variable named in RUE_CORPUS_ABSOLUTIZE is a BUCK wiring bug. Failing
+# closed matters more than usual here: continuing would let the harness fall back
+# to its own relative default and pass against the wrong corpus.
+t_missing_absolutize_target_fails() {
+    local dir status
+    dir="$(sandbox)"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$dir/harness"
+    chmod +x "$dir/harness"
+    (
+        cd "$dir" &&
+            RUE_CORPUS_ABSOLUTIZE="RUE_NOT_SET_ANYWHERE" \
+                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness >/dev/null 2>&1
+    )
+    status=$?
+    check "unset absolutize target fails" "2" "$status"
+    check "unset absolutize target writes no stamp" "no" "$([ -e "$dir/stamp.txt" ] && echo yes || echo no)"
+    rm -rf "$dir"
+}
+
+# The harness must not see this action's own plumbing variables.
+t_plumbing_is_hidden() {
+    local dir observed
+    dir="$(sandbox)"
+    printf '#!/usr/bin/env bash\nprintf "%%s|%%s" "${RUE_CORPUS_ABSOLUTIZE:-unset}" "${RUE_CORPUS_TIMEOUT_SECONDS:-unset}" > "$OBSERVED"\nexit 0\n' >"$dir/harness"
+    chmod +x "$dir/harness"
+    (
+        cd "$dir" &&
+            OBSERVED="$dir/observed" \
+                RUE_CORPUS_ABSOLUTIZE="" \
+                RUE_CORPUS_TIMEOUT_SECONDS="60" \
+                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness >/dev/null 2>&1
+    )
+    observed="$(cat "$dir/observed" 2>/dev/null)"
+    check "plumbing variables are unset for the harness" "unset|unset" "$observed"
+    rm -rf "$dir"
+}
+
+# A wedged harness is bounded, and a timeout is a failure, so no stamp is
+# written and the timed-out result is never cached.
+t_timeout() {
+    local dir status
+    dir="$(sandbox)"
+    if ! command -v timeout >/dev/null 2>&1; then
+        echo "skip: no timeout(1) on this host"
+        return
+    fi
+    printf '#!/usr/bin/env bash\nsleep 30\n' >"$dir/harness"
+    chmod +x "$dir/harness"
+    (
+        cd "$dir" &&
+            RUE_CORPUS_TIMEOUT_SECONDS=1 \
+                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness >/dev/null 2>&1
+    )
+    status=$?
+    check "timed-out harness fails" "124" "$status"
+    check "timed-out harness writes no stamp" "no" "$([ -e "$dir/stamp.txt" ] && echo yes || echo no)"
+    rm -rf "$dir"
+}
+
+t_usage() {
+    local status
+    "$CORPUS_ACTION" >/dev/null 2>&1
+    status=$?
+    check "no arguments is a usage error" "2" "$status"
+}
+
+t_success
+t_failure_writes_no_stamp
+t_absolutize
+t_missing_absolutize_target_fails
+t_plumbing_is_hidden
+t_timeout
+t_usage
+
+if [ "$failures" -ne 0 ]; then
+    echo "corpus-action: $failures/$tests checks failed" >&2
+    exit 1
+fi
+echo "corpus-action: $tests checks passed"

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -767,20 +767,16 @@ EOF
   check "ci-heavy-suite: labeled target with a result succeeds" \
     "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
 
-  : >"$sb/calls.log"
-  rc=0
-  (cd "$sb" && FAKE_CALL_LOG="$sb/calls.log" ./ci-heavy-suite //:cli-tests) >/dev/null 2>&1 || rc=$?
-  check "ci-heavy-suite: monolithic CLI corpus receives the extended executor timeout" \
-    "$([ "$rc" -eq 0 ] && grep -Fxq 'test //:cli-tests -- --timeout 1800' "$sb/calls.log" && echo 0 || echo 1)"
-
-  : >"$sb/calls.log"
-  rc=0
-  (cd "$sb" && FAKE_LABELED_TARGET=//:cli-tests-shard-1 FAKE_CALL_LOG="$sb/calls.log" ./ci-heavy-suite //:cli-tests-shard-1) >/dev/null 2>&1 || rc=$?
-  check "ci-heavy-suite: CLI shard receives the extended executor timeout" \
-    "$([ "$rc" -eq 0 ] && grep -Fxq 'test //:cli-tests-shard-1 -- --timeout 1200' "$sb/calls.log" && echo 0 || echo 1)"
-
-  local other_target
-  for other_target in \
+  # RUE-1118: ci-heavy-suite no longer carries per-target executor timeouts. The
+  # corpus runs as a cacheable build action and the test executor only asserts
+  # its stamp, so the outer bound belongs on the action — it is each suite's
+  # timeout_seconds in BUCK. A stray `--timeout` here would bound the wrong
+  # thing (a sub-second stamp check) and read as if the corpus were still
+  # bounded, so pin that every target is invoked identically and bare.
+  local heavy_target
+  for heavy_target in \
+    //:cli-tests \
+    //:cli-tests-shard-1 \
     //:cli-tests-caldera \
     //:spec-tests \
     //:ui-tests \
@@ -789,9 +785,9 @@ EOF
     //:tutorial-snippet-tests; do
     : >"$sb/calls.log"
     rc=0
-    (cd "$sb" && FAKE_LABELED_TARGET="$other_target" FAKE_CALL_LOG="$sb/calls.log" ./ci-heavy-suite "$other_target") >/dev/null 2>&1 || rc=$?
-    check "ci-heavy-suite: $other_target retains the default executor timeout" \
-      "$([ "$rc" -eq 0 ] && grep -Fxq "test $other_target" "$sb/calls.log" && echo 0 || echo 1)"
+    (cd "$sb" && FAKE_LABELED_TARGET="$heavy_target" FAKE_CALL_LOG="$sb/calls.log" ./ci-heavy-suite "$heavy_target") >/dev/null 2>&1 || rc=$?
+    check "ci-heavy-suite: $heavy_target is invoked without an executor timeout" \
+      "$([ "$rc" -eq 0 ] && grep -Fxq "test $heavy_target" "$sb/calls.log" && echo 0 || echo 1)"
   done
 
   rc=0


### PR DESCRIPTION
## Problem

buck2 re-executes every `buck2 test` invocation. Test executions are not actions: they are handed to the test executor, they never appear in buck2's `Commands: N (cached: ...)` accounting, and OSS buck2 ships no test-result cache. The merge queue therefore re-ran every corpus in full on each merge, even when the merge commit's tree was byte-identical to the tree the PR run had just validated.

Measured on three CI runs of one such tree (`1c9fe424`) — PR runs [30232087197](https://github.com/rue-language/rue/actions/runs/30232087197) and [30232994034](https://github.com/rue-language/rue/actions/runs/30232994034), merge_group run [30233477187](https://github.com/rue-language/rue/actions/runs/30233477187):

| lane | PR run 1 | PR run 2 | merge_group |
| --- | ---: | ---: | ---: |
| linux-x64 cli-shard-1 | 10:27.1 | 11:28.9 | 11:18.2 |
| linux-arm64 cli-shard-1 | 11:35.7 | 11:36.3 | 11:21.6 |
| linux-x64 spec | 1:30.1 | 1:40.5 | 1:41.2 |
| build actions (corpus jobs) | 463–465 / 465 | **465 / 465** | **465 / 465** |

The build converges to a perfect hit rate; the corpora re-execute every time. The slowest merge_group job was 744s — 7s setup, 59s of analysis and CAS materialization for a fully cached build, and **678s (91%) of test execution**.

## What changed

`cached_corpus_suite` (`corpus.bzl`) splits each heavy corpus in two:

- a **genrule** that runs the harness via `scripts/corpus-action` and writes a stamp on success — an ordinary action keyed on its declared inputs, so the PR run uploads it and the merge_group run reads it back;
- a thin **`sh_test`** asserting the stamp, which keeps the suite's name, labels, and `Pass: root//:NAME (time)` line. `scripts/ci-heavy-suite`'s result assertion and `test.sh`'s RUE-924 corpus-omission audit therefore work unchanged.

Converted: the CLI corpus and its four shards, Caldera, spec, UI, release smoke.

Not converted: `//:reproducible-programs` and `//:oracle-diff-generated-smoke`. Their harnesses are shell scripts that read repository paths directly rather than through declared env inputs, so that contract has to be established first or caching them would be a false pass rather than a win. Both are off the merge queue's critical path. Marked inline.

Per-target executor timeouts move from `ci-heavy-suite` to each suite's `timeout_seconds` — the test executor now only asserts a sub-second stamp, so a `--timeout` there would bound the wrong thing while reading as if the corpus were still bounded. Per-case budgets in `execution_contracts.toml` remain the honest gates.

## Two contracts this makes load-bearing

Documented in `corpus.bzl` and `docs/process/build-cache.md`:

1. **Declared inputs now decide correctness.** Under a plain `sh_test` an undeclared input was merely untracked — the suite re-ran regardless. Here it is a false pass: change a file the action does not name and the corpus reports success against the previous tree's result.
2. **Paths must be absolute.** `$(location ...)` expands absolute in an `sh_test` (which runs from the project root) but relative to the action's working directory in a genrule. The harnesses spawn the compiler with a case temp dir as cwd, and `find_dir` falls back to relative defaults, so a relative value can resolve to a real but wrong directory and quietly test nothing. `corpus-action` resolves everything named in a suite's `absolutize` list immediately before the harness runs; it cannot be done in BUCK because a genrule cmd has no shell command substitution — `$(...)` is Buck's own macro syntax.

## Testing

Mechanism, against the pinned buck2 with byte-identical inputs in one daemon:

| | unchanged inputs |
| --- | --- |
| `sh_test` | re-runs (5.0s → 5.0s) |
| `genrule` | **not re-run** (4.1s → 0.098s) |

`//:spec-tests` end to end:

- ran the real corpus as a build action — 2177 passed, 1 failed against a deliberately broken case;
- unchanged inputs: **0.4s**, down from ~70s cold;
- edited spec case: re-ran in 64s, so invalidation tracks inputs;
- failing case: build error naming the case, **no stamp written**, nothing cached;
- `buck2 test //:spec-tests` → `✓ Pass: root//:spec-tests (0.0s)`.

`//:cli-tests-shard-0` ran as a build action in ~3.5 min, matching its 3:39 CI time, so it executed the real slice rather than no-opping.

Also passing: `//:corpus-action-tests` (new, 12 checks over the stamp-only-on-success, absolutization, fail-closed, plumbing-isolation and timeout contracts), `//:wrapper-script-tests`, `//:cli-shard-coverage-validation`. Heavy-suite label discovery still returns all ten targets, and a `--exclude rue_heavy_suite --always-exclude` pass does not build the corpus actions (0.2s against an invalidated suite), so the broad pass stays fast.

**Not verifiable locally:** actual cross-run reuse needs the shared cache, which this checkout has no key for — OSS buck2 has no persistent local action cache, so a locally reverted edit re-runs rather than hitting the earlier result. Cross-run and cross-platform behavior is what CI on this PR will show. The per-platform digest separation rests on each action depending on the host-built `rue` and harness binaries; worth confirming against the first merge_group run that macOS and Linux lanes do not share entries.

Refs RUE-1118.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Apefw5j746c6nptMFptfBT)_