### PR TITLE
Make the clippy and fmt gates fail instead of silently skipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,12 @@ jobs:
         uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
 
       - name: Check formatting
-        # Buck declares all Rust sources as inputs and applies the hermetic
-        # rustfmt target's platform-specific runtime environment.
-        run: ./buck2 test //:fmt-check
+        # Runs the hermetic rustfmt over every Rust source. This used to be
+        # `buck2 test //:fmt-check`, whose file list came from a root-package
+        # `glob(["crates/**/*.rs"])` -- and Buck globs do not descend into
+        # subpackages, so the 30 crates owning a BUCK file were all invisible.
+        # That gate checked 1 file of 281 and passed regardless (RUE-1152).
+        run: ./fmt.sh check
 
       - name: Check production debug assertions
         run: scripts/validate-debug-assert-policy.py

--- a/BUCK
+++ b/BUCK
@@ -22,23 +22,17 @@
 # files so that `buck2 test //crates/...` (quick-test.sh, test.sh's filtered
 # path) still means "unit tests only".
 
-# Formatting is a first-class repository check. The source files are both
-# passed to rustfmt and declared as resources, so Buck invalidates the cached
-# result when any Rust source changes. The rustfmt target's RunInfo owns host
-# selection and dynamic-library setup; write-mode formatting remains in
-# fmt.sh because build/test actions must not mutate the source tree.
-_RUST_SOURCES = glob(["crates/**/*.rs"])
-
-sh_test(
-    name = "fmt-check",
-    test = "toolchains//rust:rustfmt",
-    args = [
-        "--edition",
-        "2024",
-        "--check",
-    ] + _RUST_SOURCES,
-    resources = _RUST_SOURCES,
-)
+# The formatting gate lives in fmt.sh, not here. A `fmt-check` sh_test used to
+# sit at this spot, taking its file list from `glob(["crates/**/*.rs"])`. A
+# Buck glob does not descend into subpackages, and all 30 crates that own a
+# BUCK file are subpackages -- so the list resolved to the single source under
+# crates/rue-runtime-asan/ (the one crate without a BUCK file). The gate ran
+# rustfmt over 1 file of 281 and reported a pass for the other 280 (RUE-1152).
+#
+# Restoring cache-aware checking here means enumerating sources per crate,
+# which is a real change rather than a glob tweak; until then CI calls
+# `./fmt.sh check`, whose `find`-based discovery covers every source and now
+# fails rather than exits 0 when it finds none.
 
 # The std library sources are runtime inputs to CLI integration tests and spec
 # cases that opt into the real std (compiled programs `@import` them via

--- a/clippy.sh
+++ b/clippy.sh
@@ -41,7 +41,11 @@ echo "Running clippy on ${#CLIPPY_TARGETS[@]} targets..."
 clippy_err="$(mktemp)"
 trap 'rm -f "$clippy_err"' EXIT
 clippy_status=0
-SHOW_OUTPUT="$(./buck2 build "${CLIPPY_TARGETS[@]}" --show-output 2>"$clippy_err")" \
+# `--materializations=all` is load-bearing, not a tuning knob. A remote cache
+# hit satisfies the build without ever writing the diagnostics file to local
+# disk, and the loop below can only read files that exist -- so without this the
+# gate scores cached targets as clean (RUE-1152).
+SHOW_OUTPUT="$(./buck2 build "${CLIPPY_TARGETS[@]}" --materializations=all --show-output 2>"$clippy_err")" \
     || clippy_status=$?
 if [ "$clippy_status" -ne 0 ]; then
     echo "clippy.sh: 'buck2 build' failed (exit $clippy_status) -- a real compile" >&2
@@ -56,8 +60,20 @@ FAILED=0
 # clippy finding into an `error:` line, whereas benign non-lint codegen output
 # (e.g. `-Ctarget-feature` `warning:` notes that rustc emits unconditionally
 # and that ordinary builds also print) must NOT gate. So grep for `^error`.
+CHECKED=0
+MISSING=0
 while read -r TARGET ARTIFACT; do
     [ -z "${ARTIFACT:-}" ] && continue
+    # A file that does not exist is not the same claim as a file that is empty.
+    # The old `[ -s ... ] || continue` collapsed the two, so an unmaterialized
+    # artifact was silently scored as "no findings" and the gate went green on
+    # code it had never actually read (RUE-1152).
+    if [ ! -e "$ARTIFACT" ]; then
+        echo "clippy.sh: diagnostics artifact missing for $TARGET: $ARTIFACT" >&2
+        MISSING=$((MISSING + 1))
+        continue
+    fi
+    CHECKED=$((CHECKED + 1))
     [ -s "$ARTIFACT" ] || continue
     # Strip ANSI colour codes so CI logs stay readable and grep is reliable.
     CLEANED="$(sed -E 's/\x1b\[[0-9;]*m//g' "$ARTIFACT")"
@@ -68,6 +84,17 @@ while read -r TARGET ARTIFACT; do
         echo "::endgroup::"
     fi
 done <<< "$SHOW_OUTPUT"
+
+# Coverage is part of the verdict. A gate that cannot say how many targets it
+# read cannot distinguish "clean" from "never looked", which is precisely how
+# 98 findings reached trunk under a green check.
+if [ "$MISSING" -ne 0 ] || [ "$CHECKED" -ne "${#CLIPPY_TARGETS[@]}" ]; then
+    echo "" >&2
+    echo "clippy gate FAILED: read $CHECKED diagnostics files for ${#CLIPPY_TARGETS[@]}" >&2
+    echo "enumerated targets ($MISSING missing). Refusing to report a pass for" >&2
+    echo "targets whose diagnostics the gate never read." >&2
+    exit 1
+fi
 
 if [ "$FAILED" -ne 0 ]; then
     echo ""

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -171,7 +171,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Err(CompileError::new(
             ErrorKind::TypeMismatch {
                 expected: "integer, bool, string, unit, struct, array, or enum".to_string(),
-                found: ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                found: ty.safe_name_with_pool(Some(self.body_type_pool())),
             },
             span,
         ))
@@ -338,7 +338,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         expected: "a type".to_string(),
                         found: head_result
                             .ty
-                            .safe_name_with_pool(Some(&self.body_type_pool())),
+                            .safe_name_with_pool(Some(self.body_type_pool())),
                     },
                     span,
                 ));
@@ -349,7 +349,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
                             expected: "struct type".to_string(),
-                            found: reduced_ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                            found: reduced_ty.safe_name_with_pool(Some(self.body_type_pool())),
                         },
                         span,
                     ));
@@ -363,7 +363,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         expected: "module".to_string(),
                         found: module_result
                             .ty
-                            .safe_name_with_pool(Some(&self.body_type_pool())),
+                            .safe_name_with_pool(Some(self.body_type_pool())),
                     },
                     span,
                 ));
@@ -404,7 +404,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
                                 expected: "struct type".to_string(),
-                                found: ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                                found: ty.safe_name_with_pool(Some(self.body_type_pool())),
                             },
                             span,
                         ));
@@ -509,7 +509,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         ErrorKind::LiteralOutOfRange {
                             value: *value,
                             ty: expected_field_type
-                                .safe_name_with_pool(Some(&self.body_type_pool())),
+                                .safe_name_with_pool(Some(self.body_type_pool())),
                         },
                         field_inst.span,
                     ));
@@ -555,10 +555,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: expected_field_type
-                            .safe_name_with_pool(Some(&self.body_type_pool())),
+                            .safe_name_with_pool(Some(self.body_type_pool())),
                         found: field_result
                             .ty
-                            .safe_name_with_pool(Some(&self.body_type_pool())),
+                            .safe_name_with_pool(Some(self.body_type_pool())),
                     },
                     span,
                 )
@@ -566,7 +566,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     format!(
                         "field '{}' expects type {}",
                         init_name,
-                        expected_field_type.safe_name_with_pool(Some(&self.body_type_pool()))
+                        expected_field_type.safe_name_with_pool(Some(self.body_type_pool()))
                     ),
                     span,
                 ));
@@ -871,7 +871,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
                     expected: "a runtime value".to_string(),
-                    found: elem_ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                    found: elem_ty.safe_name_with_pool(Some(self.body_type_pool())),
                 },
                 span,
             ));
@@ -1150,7 +1150,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // the comptime-only `type`, would reach the intern pool and panic
         // (RUE-253).
         for elem_ref in &elem_refs {
-            if let Some(elem_ty) = ctx.resolved_types.get(&elem_ref).copied() {
+            if let Some(elem_ty) = ctx.resolved_types.get(elem_ref).copied() {
                 self.reject_non_runtime_array_element(elem_ty, span)?;
             }
         }
@@ -1190,7 +1190,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return Err(CompileError::new(
                     ErrorKind::InternalError(format!(
                         "Array literal inferred as non-array type: {}",
-                        array_type.safe_name_with_pool(Some(&self.body_type_pool()))
+                        array_type.safe_name_with_pool(Some(self.body_type_pool()))
                     )),
                     span,
                 ));
@@ -1266,7 +1266,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return Err(CompileError::new(
                     ErrorKind::InternalError(format!(
                         "Array-repeat literal inferred as non-array type: {}",
-                        array_type.safe_name_with_pool(Some(&self.body_type_pool()))
+                        array_type.safe_name_with_pool(Some(self.body_type_pool()))
                     )),
                     span,
                 ));
@@ -1285,7 +1285,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if !self.is_type_copy(elem_type) {
             return Err(CompileError::new(
                 ErrorKind::ArrayRepeatNonCopy {
-                    element_type: elem_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                    element_type: elem_type.safe_name_with_pool(Some(self.body_type_pool())),
                 },
                 span,
             ));

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -3460,8 +3460,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ) -> CompileError {
         CompileError::new(
             ErrorKind::TypeMismatch {
-                expected: expected.safe_name_with_pool(Some(&self.body_type_pool())),
-                found: found.safe_name_with_pool(Some(&self.body_type_pool())),
+                expected: expected.safe_name_with_pool(Some(self.body_type_pool())),
+                found: found.safe_name_with_pool(Some(self.body_type_pool())),
             },
             span,
         )

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -85,7 +85,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: "StrBuf".to_string(),
-                        found: operand.ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                        found: operand.ty.safe_name_with_pool(Some(self.body_type_pool())),
                     },
                     span,
                 ));
@@ -181,7 +181,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             .with_help(format!("`{fn_name}` takes exactly one text argument")));
         }
         self.validate_explicit_call_modes(&args, std::iter::once(RirParamMode::Normal))?;
-        let arg_value = args.get(0).unwrap().value;
+        let arg_value = args.first().unwrap().value;
 
         // Borrow the argument (like a `+` operand): analyze in projection mode
         // and cancel any move marker so a variable operand is not consumed and
@@ -198,7 +198,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     expected: "text".to_string(),
                     found: arg_result
                         .ty
-                        .safe_name_with_pool(Some(&self.body_type_pool())),
+                        .safe_name_with_pool(Some(self.body_type_pool())),
                 },
                 self.body_rir_ref().get(arg_value).span,
             )
@@ -298,7 +298,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     expected: "integer type".to_string(),
                     found: lhs_result
                         .ty
-                        .safe_name_with_pool(Some(&self.body_type_pool())),
+                        .safe_name_with_pool(Some(self.body_type_pool())),
                 },
                 span,
             ));
@@ -378,7 +378,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
                     expected: "integer".to_string(),
-                    found: lhs_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                    found: lhs_type.safe_name_with_pool(Some(self.body_type_pool())),
                 },
                 self.body_rir_ref().get(lhs).span,
             ));

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -630,8 +630,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 if !self.types_compatible(found, expected) && !expected.is_error() {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
-                            expected: expected.safe_name_with_pool(Some(&self.body_type_pool())),
-                            found: found.safe_name_with_pool(Some(&self.body_type_pool())),
+                            expected: expected.safe_name_with_pool(Some(self.body_type_pool())),
+                            found: found.safe_name_with_pool(Some(self.body_type_pool())),
                         },
                         self.body_rir_ref().get(args.get(i).unwrap().value).span,
                     ));
@@ -888,7 +888,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     }
                     return Err(CompileError::new(
                         ErrorKind::UndefinedAssocFn {
-                            type_name: reduced_ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                            type_name: reduced_ty.safe_name_with_pool(Some(self.body_type_pool())),
                             function_name: variant_name,
                         },
                         span,
@@ -915,7 +915,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             _ => {
                 return Err(CompileError::new(
                     ErrorKind::MethodCallOnNonStruct {
-                        found: receiver_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                        found: receiver_type.safe_name_with_pool(Some(self.body_type_pool())),
                         method_name: method_name_str,
                     },
                     span,
@@ -1313,7 +1313,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
                             expected: "struct type".to_string(),
-                            found: ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                            found: ty.safe_name_with_pool(Some(self.body_type_pool())),
                         },
                         span,
                     ));
@@ -1335,7 +1335,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
                             expected: "struct type".to_string(),
-                            found: ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                            found: ty.safe_name_with_pool(Some(self.body_type_pool())),
                         },
                         span,
                     ));

--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -241,7 +241,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                                 Err(CompileError::new(
                                     ErrorKind::LiteralOutOfRange {
                                         value: value as u64,
-                                        ty: ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                                        ty: ty.safe_name_with_pool(Some(self.body_type_pool())),
                                     },
                                     inst.span,
                                 ))
@@ -251,7 +251,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                                         reason: format!(
                                             "value {} is out of range for type {}",
                                             value,
-                                            ty.safe_name_with_pool(Some(&self.body_type_pool()))
+                                            ty.safe_name_with_pool(Some(self.body_type_pool()))
                                         ),
                                     },
                                     inst.span,

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -602,7 +602,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Err(CompileError::new(
             ErrorKind::TypeMismatch {
                 expected: "an array or a StrBuf".to_string(),
-                found: coll_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                found: coll_type.safe_name_with_pool(Some(self.body_type_pool())),
             },
             span,
         )
@@ -637,7 +637,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     expected: "StrBuf".to_string(),
                     found: coll_result
                         .ty
-                        .safe_name_with_pool(Some(&self.body_type_pool())),
+                        .safe_name_with_pool(Some(self.body_type_pool())),
                 },
                 span,
             )
@@ -764,7 +764,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "dbg".to_string(),
                     expected: "integer, bool, or String".to_string(),
-                    found: arg_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                    found: arg_type.safe_name_with_pool(Some(self.body_type_pool())),
                 })),
                 span,
             ));
@@ -994,7 +994,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     expected: "bool condition".to_string(),
                     found: cond_result
                         .ty
-                        .safe_name_with_pool(Some(&self.body_type_pool())),
+                        .safe_name_with_pool(Some(self.body_type_pool())),
                 })),
                 cond_span,
             ));
@@ -1068,7 +1068,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: intrinsic_name.to_string(),
                     expected: "text message".to_string(),
-                    found: message_ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                    found: message_ty.safe_name_with_pool(Some(self.body_type_pool())),
                 })),
                 message_span,
             ));
@@ -1110,7 +1110,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: intrinsic_name.to_string(),
                     expected: "integer".to_string(),
-                    found: from_ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                    found: from_ty.safe_name_with_pool(Some(self.body_type_pool())),
                 })),
                 span,
             ));
@@ -1135,7 +1135,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                         name: intrinsic_name.to_string(),
                         expected: "integer".to_string(),
-                        found: ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                        found: ty.safe_name_with_pool(Some(self.body_type_pool())),
                     })),
                     span,
                 ));
@@ -1266,7 +1266,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: intrinsic_display.to_string(),
                     expected: format!("Option({payload_display})"),
-                    found: ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                    found: ty.safe_name_with_pool(Some(self.body_type_pool())),
                 })),
                 span,
             ));
@@ -1366,7 +1366,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "@to_string".to_string(),
                     expected: "integer".to_string(),
-                    found: arg_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                    found: arg_type.safe_name_with_pool(Some(self.body_type_pool())),
                 })),
                 span,
             ));
@@ -1457,7 +1457,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: format!("@{}", intrinsic_name_str),
                     expected: "text".to_string(),
-                    found: arg_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                    found: arg_type.safe_name_with_pool(Some(self.body_type_pool())),
                 })),
                 span,
             ));
@@ -1693,7 +1693,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                 name: format!("@{display}"),
                 expected: "u64".to_string(),
-                found: found.safe_name_with_pool(Some(&self.body_type_pool())),
+                found: found.safe_name_with_pool(Some(self.body_type_pool())),
             })),
             span,
         ))
@@ -1744,7 +1744,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                         name: format!("@{display}"),
                         expected: "integer".to_string(),
-                        found: ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                        found: ty.safe_name_with_pool(Some(self.body_type_pool())),
                     })),
                     self.body_rir_ref().get(arg.value).span,
                 ));

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -1517,7 +1517,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 "consider making parameter `{}` inout: `inout {}: {}`",
                 name_str,
                 name_str,
-                ty.safe_name_with_pool(Some(&self.body_type_pool()))
+                ty.safe_name_with_pool(Some(self.body_type_pool()))
             ))
         }
     }
@@ -1632,10 +1632,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
-                            expected: param_ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                            expected: param_ty.safe_name_with_pool(Some(self.body_type_pool())),
                             found: value_result
                                 .ty
-                                .safe_name_with_pool(Some(&self.body_type_pool())),
+                                .safe_name_with_pool(Some(self.body_type_pool())),
                         },
                         self.body_rir_ref().get(value).span,
                     ));
@@ -2051,7 +2051,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     return Err(CompileError::new(
                         ErrorKind::MoveOutOfIndex {
                             element_type: field_type
-                                .safe_name_with_pool(Some(&self.body_type_pool())),
+                                .safe_name_with_pool(Some(self.body_type_pool())),
                         },
                         span,
                     )
@@ -2182,7 +2182,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             None => {
                 return Err(CompileError::new(
                     ErrorKind::FieldAccessOnNonStruct {
-                        found: base_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                        found: base_type.safe_name_with_pool(Some(self.body_type_pool())),
                     },
                     span,
                 ));
@@ -2332,7 +2332,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     // This shouldn't happen if try_trace_place worked correctly
                     return Err(CompileError::new(
                         ErrorKind::IndexOnNonArray {
-                            found: parent_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                            found: parent_type.safe_name_with_pool(Some(self.body_type_pool())),
                         },
                         span,
                     ));
@@ -2392,7 +2392,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     return Err(CompileError::new(
                         ErrorKind::MoveOutOfIndex {
                             element_type: elem_type
-                                .safe_name_with_pool(Some(&self.body_type_pool())),
+                                .safe_name_with_pool(Some(self.body_type_pool())),
                         },
                         span,
                     )
@@ -2514,7 +2514,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             None => {
                 return Err(CompileError::new(
                     ErrorKind::IndexOnNonArray {
-                        found: base_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                        found: base_type.safe_name_with_pool(Some(self.body_type_pool())),
                     },
                     span,
                 ));
@@ -2540,7 +2540,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if !self.is_type_copy(elem_type) {
             return Err(CompileError::new(
                 ErrorKind::MoveOutOfIndex {
-                    element_type: elem_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                    element_type: elem_type.safe_name_with_pool(Some(self.body_type_pool())),
                 },
                 span,
             )
@@ -2635,7 +2635,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     expected: "an integer".to_string(),
                     found: index_result
                         .ty
-                        .safe_name_with_pool(Some(&self.body_type_pool())),
+                        .safe_name_with_pool(Some(self.body_type_pool())),
                 },
                 self.body_rir_ref().get(index).span,
             ));
@@ -2738,7 +2738,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     expected: "an integer".to_string(),
                     found: index_result
                         .ty
-                        .safe_name_with_pool(Some(&self.body_type_pool())),
+                        .safe_name_with_pool(Some(self.body_type_pool())),
                 },
                 self.body_rir_ref().get(index).span,
             ));
@@ -2823,7 +2823,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     expected: "an integer".to_string(),
                     found: index_result
                         .ty
-                        .safe_name_with_pool(Some(&self.body_type_pool())),
+                        .safe_name_with_pool(Some(self.body_type_pool())),
                 },
                 self.body_rir_ref().get(index).span,
             ));
@@ -3052,7 +3052,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 None => {
                     return Err(CompileError::new(
                         ErrorKind::FieldAccessOnNonStruct {
-                            found: base_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                            found: base_type.safe_name_with_pool(Some(self.body_type_pool())),
                         },
                         span,
                     ));
@@ -3215,7 +3215,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 None => {
                     return Err(CompileError::new(
                         ErrorKind::IndexOnNonArray {
-                            found: base_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                            found: base_type.safe_name_with_pool(Some(self.body_type_pool())),
                         },
                         span,
                     ));
@@ -3232,7 +3232,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         expected: "integer type".to_string(),
                         found: index_result
                             .ty
-                            .safe_name_with_pool(Some(&self.body_type_pool())),
+                            .safe_name_with_pool(Some(self.body_type_pool())),
                     },
                     self.body_rir_ref().get(index).span,
                 ));
@@ -3565,7 +3565,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if !self.type_requires_consumption(dest_ty) || discharged {
             return Ok(());
         }
-        let type_name = dest_ty.safe_name_with_pool(Some(&self.body_type_pool()));
+        let type_name = dest_ty.safe_name_with_pool(Some(self.body_type_pool()));
         let err = if through_inout {
             CompileError::new(
                 ErrorKind::LinearValueOverwrittenThroughInout { type_name },
@@ -3639,7 +3639,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
         let err = CompileError::new(
             ErrorKind::LinearValueDiscarded {
-                type_name: ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                type_name: ty.safe_name_with_pool(Some(self.body_type_pool())),
             },
             self.body_rir_ref().get(inst_ref).span,
         )
@@ -4050,7 +4050,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         ctx: &AnalysisContext,
     ) -> CompileResult<()> {
         if self.is_strbuf(found) || self.is_str_fixed_struct(found) {
-            let found_name = found.safe_name_with_pool(Some(&self.body_type_pool()));
+            let found_name = found.safe_name_with_pool(Some(self.body_type_pool()));
             let mut err = CompileError::new(
                 ErrorKind::BufferNotFirstClassStr {
                     found: found_name,

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -341,7 +341,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let mut cgen = ConstraintGenerator::with_lazy_facts(
                 self.body_rir_ref(),
                 self.body_interner(),
-                &self.body_type_pool(),
+                self.body_type_pool(),
                 type_subst,
                 &facts,
             );
@@ -501,34 +501,34 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let error_kind = match &err.kind {
                 UnifyResult::Ok => unreachable!("UnificationError should never contain Ok"),
                 UnifyResult::TypeMismatch { expected, found } => ErrorKind::TypeMismatch {
-                    expected: expected.name_with_pool(&self.body_type_pool()),
-                    found: found.name_with_pool(&self.body_type_pool()),
+                    expected: expected.name_with_pool(self.body_type_pool()),
+                    found: found.name_with_pool(self.body_type_pool()),
                 },
                 UnifyResult::IntLiteralNonInteger { found } => ErrorKind::TypeMismatch {
                     expected: "integer type".to_string(),
-                    found: found.safe_name_with_pool(Some(&self.body_type_pool())),
+                    found: found.safe_name_with_pool(Some(self.body_type_pool())),
                 },
                 UnifyResult::StringLiteralNonString { found } => ErrorKind::TypeMismatch {
                     expected: "string type".to_string(),
-                    found: found.name_with_pool(&self.body_type_pool()),
+                    found: found.name_with_pool(self.body_type_pool()),
                 },
                 UnifyResult::OccursCheck { var, ty } => ErrorKind::TypeMismatch {
                     expected: "non-recursive type".to_string(),
                     found: format!(
                         "{var} = {} (infinite type)",
-                        ty.name_with_pool(&self.body_type_pool())
+                        ty.name_with_pool(self.body_type_pool())
                     ),
                 },
                 UnifyResult::NotSigned { ty } => {
-                    ErrorKind::CannotNegate(ty.safe_name_with_pool(Some(&self.body_type_pool())))
+                    ErrorKind::CannotNegate(ty.safe_name_with_pool(Some(self.body_type_pool())))
                 }
                 UnifyResult::NotInteger { ty } => ErrorKind::TypeMismatch {
                     expected: "integer type".to_string(),
-                    found: ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                    found: ty.safe_name_with_pool(Some(self.body_type_pool())),
                 },
                 UnifyResult::NotUnsigned { ty } => ErrorKind::TypeMismatch {
                     expected: "unsigned integer type".to_string(),
-                    found: ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                    found: ty.safe_name_with_pool(Some(self.body_type_pool())),
                 },
                 UnifyResult::ArrayLengthMismatch { expected, found } => {
                     ErrorKind::ArrayLengthMismatch {
@@ -743,7 +743,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 _ => {
                     return Err(CompileError::new(
                         ErrorKind::FieldAccessOnNonStruct {
-                            found: base_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                            found: base_type.safe_name_with_pool(Some(self.body_type_pool())),
                         },
                         field_span,
                     ));
@@ -839,7 +839,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 _ => {
                     return Err(CompileError::new(
                         ErrorKind::IndexOnNonArray {
-                            found: base_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                            found: base_type.safe_name_with_pool(Some(self.body_type_pool())),
                         },
                         inst.span,
                     ));
@@ -858,7 +858,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         expected: "integer type".to_string(),
                         found: index_result
                             .ty
-                            .safe_name_with_pool(Some(&self.body_type_pool())),
+                            .safe_name_with_pool(Some(self.body_type_pool())),
                     },
                     self.body_rir_ref().get(*index).span,
                 ));

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -61,7 +61,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     return Err(CompileError::new(
                         ErrorKind::LiteralOutOfRange {
                             value: *value,
-                            ty: ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                            ty: ty.safe_name_with_pool(Some(self.body_type_pool())),
                         },
                         inst.span,
                     ));
@@ -193,7 +193,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     };
                     return Err(CompileError::new(
                         ErrorKind::CannotNegate(
-                            ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                            ty.safe_name_with_pool(Some(self.body_type_pool())),
                         ),
                         inst.span,
                     )
@@ -252,7 +252,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
                             expected: "integer type".to_string(),
-                            found: ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                            found: ty.safe_name_with_pool(Some(self.body_type_pool())),
                         },
                         inst.span,
                     ));

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -937,7 +937,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 };
                 let arms = self.body_rir_ref().match_arms(arms).to_vec();
                 for (pattern, body) in arms.iter() {
-                    match const_pattern_matches(&pattern, scrut) {
+                    match const_pattern_matches(pattern, scrut) {
                         Some(true) => return self.eval_const_expr(*body, env),
                         Some(false) => continue,
                         // Undecidable pattern (e.g. an enum-variant `Path`

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -156,7 +156,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                                     expected: "()".to_string(),
                                     found: result
                                         .ty
-                                        .safe_name_with_pool(Some(&self.body_type_pool())),
+                                        .safe_name_with_pool(Some(self.body_type_pool())),
                                 },
                                 self.body_rir_ref().get(block).span,
                             )
@@ -233,15 +233,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
                                 expected: then_type
-                                    .safe_name_with_pool(Some(&self.body_type_pool())),
-                                found: else_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                                    .safe_name_with_pool(Some(self.body_type_pool())),
+                                found: else_type.safe_name_with_pool(Some(self.body_type_pool())),
                             },
                             else_span,
                         )
                         .with_label(
                             format!(
                                 "this is of type `{}`",
-                                then_type.safe_name_with_pool(Some(&self.body_type_pool()))
+                                then_type.safe_name_with_pool(Some(self.body_type_pool()))
                             ),
                             then_span,
                         )
@@ -278,7 +278,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: "()".to_string(),
-                        found: then_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                        found: then_type.safe_name_with_pool(Some(self.body_type_pool())),
                     },
                     self.body_rir_ref().get(then_block).span,
                 )
@@ -486,7 +486,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         scrutinee_type: Type,
         span: Span,
     ) -> CompileResult<i64> {
-        let ty_name = scrutinee_type.safe_name_with_pool(Some(&self.body_type_pool()));
+        let ty_name = scrutinee_type.safe_name_with_pool(Some(self.body_type_pool()));
         if negative {
             if scrutinee_type.is_unsigned() {
                 return Err(
@@ -824,7 +824,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         {
             return Err(CompileError::new(
                 ErrorKind::InvalidMatchType(
-                    scrutinee_type.safe_name_with_pool(Some(&self.body_type_pool())),
+                    scrutinee_type.safe_name_with_pool(Some(self.body_type_pool())),
                 ),
                 span,
             ));
@@ -950,7 +950,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
                                 expected: scrutinee_type
-                                    .safe_name_with_pool(Some(&self.body_type_pool())),
+                                    .safe_name_with_pool(Some(self.body_type_pool())),
                                 found: "integer".to_string(),
                             },
                             pattern_span,
@@ -991,7 +991,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
                                 expected: scrutinee_type
-                                    .safe_name_with_pool(Some(&self.body_type_pool())),
+                                    .safe_name_with_pool(Some(self.body_type_pool())),
                                 found: "bool".to_string(),
                             },
                             pattern_span,
@@ -1061,7 +1061,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
                                 expected: scrutinee_type
-                                    .safe_name_with_pool(Some(&self.body_type_pool())),
+                                    .safe_name_with_pool(Some(self.body_type_pool())),
                                 found: enum_def.name.clone(),
                             },
                             pattern_span,
@@ -1116,7 +1116,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // The enclosing match dispatched on the discriminant, so in this
             // arm the payload is read (move mode) via `EnumPayloadGet`.
             let mut binding_stmts =
-                self.materialize_match_bindings(air, &pattern, scrutinee_result.air_ref, ctx)?;
+                self.materialize_match_bindings(air, pattern, scrutinee_result.air_ref, ctx)?;
 
             // RUE-238: a non-binding arm (a wildcard `_`, or a variant matched
             // without binding its payload) still *consumes* the scrutinee — the
@@ -1410,7 +1410,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         return Err(CompileError::new(
                             ErrorKind::QuestionOutsideOptionFn {
                                 return_type: return_type
-                                    .safe_name_with_pool(Some(&self.body_type_pool())),
+                                    .safe_name_with_pool(Some(self.body_type_pool())),
                             },
                             span,
                         ));
@@ -1456,7 +1456,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         return Err(CompileError::new(
                             ErrorKind::QuestionOutsideResultFn {
                                 return_type: return_type
-                                    .safe_name_with_pool(Some(&self.body_type_pool())),
+                                    .safe_name_with_pool(Some(self.body_type_pool())),
                             },
                             span,
                         ));
@@ -1465,8 +1465,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 if !self.types_equivalent(err_ty, ret_err_ty) {
                     return Err(CompileError::new(
                         ErrorKind::QuestionErrTypeMismatch {
-                            operand_err: err_ty.safe_name_with_pool(Some(&self.body_type_pool())),
-                            fn_err: ret_err_ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                            operand_err: err_ty.safe_name_with_pool(Some(self.body_type_pool())),
+                            fn_err: ret_err_ty.safe_name_with_pool(Some(self.body_type_pool())),
                         },
                         span,
                     ));
@@ -1704,13 +1704,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // rather than losing a field (RUE-269). The `_` discard (RUE-601) is
         // exempt: it binds nothing, so any number may repeat (`Rect(_, _)`).
         for (i, name) in bindings.iter().enumerate() {
-            if self.body_interner().resolve(&name) == "_" {
+            if self.body_interner().resolve(name) == "_" {
                 continue;
             }
             if bindings.iter().take(i).any(|existing| existing == name) {
                 return Err(CompileError::new(
                     ErrorKind::DuplicatePatternBinding {
-                        name: self.body_interner().resolve(&name).to_string(),
+                        name: self.body_interner().resolve(name).to_string(),
                     },
                     pattern_span,
                 ));
@@ -1725,7 +1725,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // discriminant-only match on a payload-carrying variant. The
             // enumerate index `i` still tracks the real field position for the
             // other bindings.
-            if self.body_interner().resolve(&binding_name) == "_" {
+            if self.body_interner().resolve(binding_name) == "_" {
                 continue;
             }
             let field_ty = payload[i];
@@ -1812,8 +1812,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     ErrorKind::TypeMismatch {
                         expected: ctx
                             .return_type
-                            .safe_name_with_pool(Some(&self.body_type_pool())),
-                        found: inner_ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                            .safe_name_with_pool(Some(self.body_type_pool())),
+                        found: inner_ty.safe_name_with_pool(Some(self.body_type_pool())),
                     },
                     span,
                 ));
@@ -1826,7 +1826,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     ErrorKind::TypeMismatch {
                         expected: ctx
                             .return_type
-                            .safe_name_with_pool(Some(&self.body_type_pool())),
+                            .safe_name_with_pool(Some(self.body_type_pool())),
                         found: "()".to_string(),
                     },
                     span,

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -3405,7 +3405,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         if let Some(value) = value {
             let (function_name, param_name) = contract.expect("value contracts name a parameter");
             return super::comptime_eval::validate_comptime_value_for_type_impl(
-                &self.interner,
+                self.interner,
                 &self.type_pool,
                 function_name,
                 param_name,
@@ -3451,7 +3451,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             Some(slots) => Ok(slots as u32),
             None => Err(CompileError::new(
                 ErrorKind::TypeTooLarge {
-                    type_name: ty.safe_name_with_pool(Some(&self.body_type_pool())),
+                    type_name: ty.safe_name_with_pool(Some(self.body_type_pool())),
                     max_bytes: MAX_TYPE_SIZE_BYTES,
                 },
                 span,

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -145,7 +145,13 @@ mod shard_selector_tests {
         assert_eq!(selector.index(), 2);
         assert_eq!(selector.count(), 4);
         // Surrounding whitespace is tolerated.
-        assert_eq!(ShardSelector::parse(Some(" 0 / 3 ")).unwrap().unwrap().count(), 3);
+        assert_eq!(
+            ShardSelector::parse(Some(" 0 / 3 "))
+                .unwrap()
+                .unwrap()
+                .count(),
+            3
+        );
     }
 
     #[test]
@@ -158,7 +164,10 @@ mod shard_selector_tests {
             ShardSelector::parse(Some("a/4")),
             Err(ShardSpecError::Malformed(_))
         ));
-        assert_eq!(ShardSelector::parse(Some("0/0")), Err(ShardSpecError::ZeroCount));
+        assert_eq!(
+            ShardSelector::parse(Some("0/0")),
+            Err(ShardSpecError::ZeroCount)
+        );
         assert_eq!(
             ShardSelector::parse(Some("4/4")),
             Err(ShardSpecError::IndexOutOfRange { index: 4, count: 4 })
@@ -174,7 +183,10 @@ mod shard_selector_tests {
         for i in 0..5000 {
             let name = format!("cli.section{}::case_{}", i % 37, i);
             let hits = shards.iter().filter(|shard| shard.includes(&name)).count();
-            assert_eq!(hits, 1, "name {name:?} matched {hits} shards, expected exactly 1");
+            assert_eq!(
+                hits, 1,
+                "name {name:?} matched {hits} shards, expected exactly 1"
+            );
         }
     }
 

--- a/fmt.sh
+++ b/fmt.sh
@@ -23,16 +23,19 @@ while IFS= read -r -d '' rust_file; do
     RUST_FILES+=("$rust_file")
 done < <(find "$(pwd)/crates" -name "*.rs" -type f -print0)
 
+# Finding no sources is a broken checkout or a bad discovery change, never a
+# clean tree. Exiting 0 here would report a pass for work never done, which is
+# how //:fmt-check silently covered 1 file of 281 (RUE-1152).
 if [ "${#RUST_FILES[@]}" -eq 0 ]; then
-    echo "No Rust files found"
-    exit 0
+    echo "fmt.sh: no Rust files found under crates/ -- discovery is broken." >&2
+    exit 1
 fi
 
 if [ "$MODE" = "check" ]; then
-    echo "Checking Rust formatting..."
+    echo "Checking Rust formatting (${#RUST_FILES[@]} files)..."
     ./buck2 run toolchains//rust:rustfmt -- \
         --edition 2024 --check "${RUST_FILES[@]}"
-    echo "All files formatted correctly!"
+    echo "All ${#RUST_FILES[@]} files formatted correctly!"
 else
     echo "Formatting Rust files..."
     ./buck2 run toolchains//rust:rustfmt -- \


### PR DESCRIPTION
Both lint gates could report a pass for code they never examined. Each failed open. This fixes the gates, then fixes the 98 findings that reached trunk underneath them.

## The fmt gate checked 1 file of 281

The CI `fmt` job ran `buck2 test //:fmt-check`, whose file list came from a root-package glob:

```python
_RUST_SOURCES = glob(["crates/**/*.rs"])
```

A Buck glob does not descend into subpackages, and all 30 crates that own a `BUCK` file are subpackages. So the list resolved to exactly one entry:

```console
$ ./buck2 cquery 'root//:fmt-check' --output-attribute args
"args": ["--edition", "2024", "--check", "crates/rue-runtime-asan/src/main.rs"]
```

`crates/rue-runtime-asan/` is the only crate without a `BUCK` file. Every other Rust source was invisible to the gate, which reported success for all 280 of them.

CI now calls `./fmt.sh check`, whose `find`-based discovery covers every source:

```console
$ ./fmt.sh check
All 281 files formatted correctly!
```

The `//:fmt-check` target is removed rather than left certifying one file. Restoring cache-aware checking inside Buck means enumerating sources per crate instead of one root glob — a real change, not a glob tweak, so it is follow-up work and the BUCK comment says so.

`fmt.sh` carried a matching hazard: empty discovery printed "No Rust files found" and exited **0**, so a broken checkout or a bad discovery change read as a clean tree. It now fails, and reports the file count in both modes so coverage is visible in the log.

## The clippy gate scored unread artifacts as clean

`clippy.sh` builds a `[clippy.txt]` subtarget per crate and greps each for `^error`. The loop skipped anything it could not read:

```bash
[ -s "$ARTIFACT" ] || continue
```

`-s` is false both for a file that is empty (genuinely clean) and for one that does not exist. Those are different claims, and collapsing them means a target whose diagnostics were never materialized counts as passing. A remote cache hit can satisfy the build without writing that file to local disk.

Three changes:

- `--materializations=all`, so a cache hit still lands the diagnostics on disk. This is load-bearing, not a tuning knob.
- A missing artifact is an error, not a skip.
- Files-read must equal targets-enumerated, so partial coverage can no longer pass as full coverage.

```console
$ ./clippy.sh
Running clippy on 66 targets...
clippy gate passed: no lint violations.
```

## The 98 findings this was hiding

97 `needless_borrow` and 1 `get_first`, across 12 files in `crates/rue-air/src/sema/`:

| count | file |
|---|---|
| 21 | `sema/control_flow.rs` |
| 18 | `sema/analysis/ownership.rs` |
| 14 | `sema/aggregates.rs` |
| 12 | `sema/analysis/intrinsics.rs` |
| 12 | `sema/analysis/type_inference.rs` |
| 6 | `sema/analysis/calls.rs` |
| 5 | `sema/analysis/builtin_ops.rs` |
| 3 | `sema/analyze_ops.rs` |
| 2 | `sema/analysis.rs`, `sema/analysis/instructions.rs`, `sema/typeck.rs` |
| 1 | `sema/comptime_eval.rs` |

That total matches the `aborting due to 98 previous errors` seen when a run did evaluate them. They entered with RUE-1092 (`14edd527`) and surfaced only when a PR run happened to read the artifacts — which presents as "this PR broke clippy" on a branch that never touched `rue-air`, which is what prompted this.

Every edit is the lint's own machine-applicable suggestion: drop a borrow the compiler immediately dereferences, and `args.get(0)` → `args.first()`. No control-flow or signature changes. Applied programmatically from the diagnostics with each target character verified before editing (98 applied, 0 skipped).

## Validation

`rue-air` 76 pass, `rue-compiler-test` 873, `rue-query-test` 654, differential-oracle 4. `./clippy.sh` green over 66 targets with `rue-air`'s `clippy.txt` at 0 bytes. `./fmt.sh check` green over 281 files.

Not run locally: the full `scripts/rue test` suite and non-x86-64 targets. CI is the full-platform authority — and for this PR in particular, CI is now checking something.

Fixes RUE-1152

---
_Generated by [Claude Code](https://claude.ai/code/session_01XbGPNzfcXMgL4p44rVXuSu)_