### PR TITLE
RUE-1092: generalize canonical body publication

### DIFF
--- a/crates/rue-air/src/sema/anon_structs.rs
+++ b/crates/rue-air/src/sema/anon_structs.rs
@@ -76,7 +76,7 @@ impl EpochLocalConstCandidateProducer {
 ///
 /// This is the single place the AIR domain walks a `StableProducerId` to its
 /// definition. It backs both the deterministic export ordering
-/// ([`Sema::anonymous_key_cmp`]) and trusted-producer recognition under `?`
+/// ([`anonymous_key_cmp`]) and trusted-producer recognition under `?`
 /// (RUE-1112): a `Type` whose anonymous key roots at the trusted
 /// `std/option.rue::Option` (or `std/result.rue::Result`) function definition is
 /// an exact std producer, everything else a lookalike.
@@ -108,25 +108,25 @@ pub(crate) fn anonymous_producer_root(
     }
 }
 
-impl<D: DeclarationPhase> Sema<'_, D> {
-    /// Deterministic export/presentation ordering of two producer-nominal keys.
-    ///
-    /// This is a *presentation* order only — it decides how anonymous exports are
-    /// listed and sorted (see the `one_body.rs` sort), never type identity.
-    /// Identity is the producer-nominal `AnonymousNominalKey` itself (ADR-0066);
-    /// two keys that order equal here are still distinct types unless they are
-    /// the same key. Since RUE-1112 deleted the last min-selection consumer
-    /// (`find_compatible_anon_enum`), no code treats this ordering as identity
-    /// authority.
-    pub(crate) fn anonymous_key_cmp(
-        left: &IssuedAnonymousNominalKey,
-        right: &IssuedAnonymousNominalKey,
-    ) -> Ordering {
-        anonymous_producer_root(&left.producer)
-            .cmp(&anonymous_producer_root(&right.producer))
-            .then_with(|| left.cmp(right))
-    }
+/// Deterministic export/presentation ordering of two producer-nominal keys.
+///
+/// This is a *presentation* order only — it decides how anonymous exports are
+/// listed and sorted (see the `one_body.rs` sort), never type identity.
+/// Identity is the producer-nominal `AnonymousNominalKey` itself (ADR-0066);
+/// two keys that order equal here are still distinct types unless they are the
+/// same key. Since RUE-1112 deleted the last min-selection consumer
+/// (`find_compatible_anon_enum`), no code treats this ordering as identity
+/// authority.
+pub(crate) fn anonymous_key_cmp(
+    left: &IssuedAnonymousNominalKey,
+    right: &IssuedAnonymousNominalKey,
+) -> Ordering {
+    anonymous_producer_root(&left.producer)
+        .cmp(&anonymous_producer_root(&right.producer))
+        .then_with(|| left.cmp(right))
+}
 
+impl<D: DeclarationPhase> Sema<'_, D> {
     /// The trusted standard-library producer family `ty` is an exact
     /// specialization of, or `None` for a non-enum or a lookalike (RUE-1112).
     ///

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -128,9 +128,20 @@ mod tests {
     const TYPECK_SOURCE: &str = include_str!("typeck.rs");
     const DECLARATION_BASE_SOURCE: &str = include_str!("declaration_base.rs");
     const SEMANTIC_BODY_EXPORT_SOURCE: &str = include_str!("semantic_body_export.rs");
+    const ANON_STRUCTS_SOURCE: &str = include_str!("anon_structs.rs");
     const VISIBILITY_SOURCE: &str = include_str!("visibility.rs");
     const ONE_BODY_SOURCE: &str = include_str!("one_body.rs");
     const BINDING_MANIFEST_SOURCE: &str = include_str!("binding_manifest.rs");
+    const BODY_PUBLICATION_AUTHORITY_SOURCES: &[(&str, &str)] = &[
+        ("analysis.rs", ANALYSIS_ROOT_SOURCE),
+        ("anon_structs.rs", ANON_STRUCTS_SOURCE),
+        ("context.rs", include_str!("context.rs")),
+        ("mod.rs", SEMA_ROOT_SOURCE),
+        ("one_body.rs", ONE_BODY_SOURCE),
+        ("ordinary_engine.rs", ORDINARY_ENGINE_SOURCE),
+        ("provider.rs", include_str!("provider.rs")),
+        ("semantic_body_export.rs", SEMANTIC_BODY_EXPORT_SOURCE),
+    ];
     const CALL_INTRINSIC_PEER_SOURCE: &str = concat!(
         include_str!("mod.rs"),
         include_str!("aggregates.rs"),
@@ -496,6 +507,26 @@ mod tests {
 
     #[test]
     fn body_publication_and_shared_identity_have_exact_receivers() {
+        fn braced_item<'a>(source: &'a str, marker: &str) -> &'a str {
+            let start = source.find(marker).expect("item marker exists");
+            let item = &source[start..];
+            let open = item.find('{').expect("item body opens");
+            let mut depth = 0;
+            for (offset, ch) in item[open..].char_indices() {
+                match ch {
+                    '{' => depth += 1,
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            return &item[..open + offset + 1];
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            panic!("item body closes");
+        }
+
         fn impl_items(source: &str) -> Vec<&str> {
             let mut items = Vec::new();
             let mut remaining = source;
@@ -537,17 +568,20 @@ mod tests {
         }
 
         let impls = impl_items(SEMANTIC_BODY_EXPORT_SOURCE);
-        assert_eq!(
-            impls.len(),
-            5,
-            "receiver partition has five cohesive blocks"
-        );
+        assert_eq!(impls.len(), 6, "receiver partition has six cohesive blocks");
         assert_eq!(
             impls
                 .iter()
                 .filter(|item| item.starts_with("impl BodySema<'_>"))
                 .count(),
             3
+        );
+        assert_eq!(
+            impls
+                .iter()
+                .filter(|item| item.starts_with("impl SemanticBodyExportHost for BodySema<'_>"))
+                .count(),
+            1
         );
         assert_eq!(
             impls
@@ -560,9 +594,9 @@ mod tests {
         let body_methods = [
             "export_specialized_body",
             "export_ordinary_body",
-            "export_one_body_with_specializations",
             "export_anonymous_body_with_specializations",
-            "export_body",
+        ];
+        let body_identity_methods = [
             "export_body_type",
             "body_function_identity",
             "body_struct_identity",
@@ -580,6 +614,98 @@ mod tests {
                 "{method} must be body-only"
             );
         }
+        for method in body_identity_methods {
+            let needle = format!("fn {method}(");
+            let owners = impls
+                .iter()
+                .filter(|item| item.contains(&needle))
+                .collect::<Vec<_>>();
+            assert_eq!(
+                owners.len(),
+                2,
+                "{method} has one algorithm and one adapter"
+            );
+            assert!(
+                owners
+                    .iter()
+                    .any(|owner| owner.starts_with("impl BodySema<'_>"))
+            );
+            assert!(owners.iter().any(|owner| {
+                owner.starts_with("impl SemanticBodyExportHost for BodySema<'_>")
+            }));
+        }
+
+        assert_eq!(
+            BODY_PUBLICATION_AUTHORITY_SOURCES
+                .iter()
+                .map(|(_, source)| source.matches("fn export_body<").count())
+                .sum::<usize>(),
+            1,
+            "the publication-relevant sema inventory has one generic exporter authority"
+        );
+        assert_eq!(
+            SEMANTIC_BODY_EXPORT_SOURCE
+                .matches("pub(super) fn export_body<H: SemanticBodyExportHost>(")
+                .count(),
+            1,
+            "stable body serialization is one non-overridable free algorithm"
+        );
+        assert!(SEMANTIC_BODY_EXPORT_SOURCE.contains("pub(super) trait SemanticBodyExportHost"));
+        let host_start = SEMANTIC_BODY_EXPORT_SOURCE
+            .find("pub(super) trait SemanticBodyExportHost")
+            .unwrap();
+        let exporter_start = SEMANTIC_BODY_EXPORT_SOURCE
+            .find("pub(super) fn export_body<H: SemanticBodyExportHost>")
+            .unwrap();
+        let host_contract = &SEMANTIC_BODY_EXPORT_SOURCE[host_start..exporter_start];
+        assert!(
+            !host_contract.contains("fn export_body("),
+            "the host contract cannot override the canonical exporter"
+        );
+        let exporter = &SEMANTIC_BODY_EXPORT_SOURCE[exporter_start..];
+        for forbidden in ["BodySema<'_>", "ProviderBodyAnalysisState", "Sema<"] {
+            let adapter_start = exporter
+                .find("impl SemanticBodyExportHost for BodySema<'_>")
+                .unwrap();
+            assert!(
+                !exporter[..adapter_start].contains(forbidden),
+                "canonical exporter must remain representation-neutral: {forbidden}"
+            );
+        }
+        assert_eq!(
+            BODY_PUBLICATION_AUTHORITY_SOURCES
+                .iter()
+                .map(|(_, source)| source.matches(".export_body(").count())
+                .sum::<usize>(),
+            0,
+            "publication-relevant sema code must not restore exporter method dispatch"
+        );
+
+        let specialized_wrapper =
+            braced_item(SEMANTIC_BODY_EXPORT_SOURCE, "fn export_specialized_body(");
+        assert_eq!(specialized_wrapper.matches("export_body(").count(), 1);
+        assert!(specialized_wrapper.contains(
+            "let body = export_body(
+            self,
+            owner,
+            base_info.span,"
+        ));
+        let ordinary_wrapper = braced_item(SEMANTIC_BODY_EXPORT_SOURCE, "fn export_ordinary_body(");
+        assert_eq!(ordinary_wrapper.matches("export_body(").count(), 1);
+        assert!(
+            ordinary_wrapper
+                .contains("export_body(self, owner, body_span, analyzed, strings, warnings, None)")
+        );
+        let anonymous_wrapper = braced_item(
+            SEMANTIC_BODY_EXPORT_SOURCE,
+            "fn export_anonymous_body_with_specializations(",
+        );
+        assert_eq!(anonymous_wrapper.matches("export_body(").count(), 1);
+        assert!(anonymous_wrapper.contains(
+            "let exported = export_body(
+            self,
+            crate::BodyOwnerToken::new(0, 0),"
+        ));
 
         let shared_methods = [
             "function_identity",
@@ -606,7 +732,10 @@ mod tests {
             .flat_map(|item| method_names(item))
             .collect::<Vec<_>>();
         actual_body_methods.sort_unstable();
-        let mut expected_body_methods = body_methods.to_vec();
+        let mut expected_body_methods = body_methods
+            .into_iter()
+            .chain(body_identity_methods)
+            .collect::<Vec<_>>();
         expected_body_methods.sort_unstable();
         assert_eq!(actual_body_methods, expected_body_methods);
 
@@ -620,20 +749,72 @@ mod tests {
         expected_shared_methods.sort_unstable();
         assert_eq!(actual_shared_methods, expected_shared_methods);
 
-        for forbidden in ["Deref", "\ntrait "] {
-            assert!(
-                !SEMANTIC_BODY_EXPORT_SOURCE.contains(forbidden),
-                "publication must not gain a wrapper authority through {forbidden}"
-            );
-        }
+        assert!(!SEMANTIC_BODY_EXPORT_SOURCE.contains("Deref"));
 
         for method in [
-            "export_one_body_with_specializations",
             "export_specialized_body",
             "export_anonymous_body_with_specializations",
         ] {
             assert!(ONE_BODY_SOURCE.contains(&format!("sema.{method}(")));
         }
+        assert!(ONE_BODY_SOURCE.contains("pub(super) trait OneBodyPublicationHost"));
+        assert!(ONE_BODY_SOURCE.contains("fn publish_ordinary<H: OneBodyPublicationHost>"));
+        assert!(ONE_BODY_SOURCE.contains("fn body_references<H: OneBodyPublicationHost>"));
+        assert!(ONE_BODY_SOURCE.contains("fn fail<H: OneBodyPublicationHost>"));
+        assert!(
+            ONE_BODY_SOURCE.contains("fn produced_anonymous_nominals<H: OneBodyPublicationHost>")
+        );
+        assert_eq!(ONE_BODY_SOURCE.matches("fn publish_ordinary<").count(), 1);
+        assert_eq!(ONE_BODY_SOURCE.matches("fn body_references<").count(), 1);
+        assert_eq!(
+            ONE_BODY_SOURCE
+                .matches("fn produced_anonymous_nominals<")
+                .count(),
+            1
+        );
+        for marker in [
+            "fn produced_anonymous_nominals<H: OneBodyPublicationHost>",
+            "fn body_references<H: OneBodyPublicationHost>",
+            "fn fail<H: OneBodyPublicationHost>",
+            "fn publish_ordinary<H: OneBodyPublicationHost>",
+        ] {
+            assert!(
+                !braced_item(ONE_BODY_SOURCE, marker).contains("BodySema"),
+                "{marker} must remain representation-neutral"
+            );
+        }
+        let ordinary_publication = braced_item(
+            ONE_BODY_SOURCE,
+            "fn publish_ordinary<H: OneBodyPublicationHost>",
+        );
+        assert_eq!(
+            ordinary_publication
+                .matches("super::semantic_body_export::export_body(")
+                .count(),
+            1,
+            "ordinary publication must call the non-overridable exporter"
+        );
+        assert_eq!(
+            BODY_PUBLICATION_AUTHORITY_SOURCES
+                .iter()
+                .map(|(_, source)| source.matches("fn anonymous_key_cmp(").count())
+                .sum::<usize>(),
+            1,
+            "publication-relevant sema code has one anonymous ordering authority"
+        );
+        let comparator = braced_item(ANON_STRUCTS_SOURCE, "pub(crate) fn anonymous_key_cmp(");
+        assert!(comparator.contains(
+            "anonymous_producer_root(&left.producer)
+        .cmp(&anonymous_producer_root(&right.producer))
+        .then_with(|| left.cmp(right))"
+        ));
+        let produced = braced_item(ONE_BODY_SOURCE, "fn produced_anonymous_nominals<H");
+        assert_eq!(
+            produced
+                .matches("super::anon_structs::anonymous_key_cmp(left, right)")
+                .count(),
+            1
+        );
         assert!(ANALYSIS_ROOT_SOURCE.contains("sema.export_ordinary_body("));
         assert!(BINDING_MANIFEST_SOURCE.contains("self.stable_definition_token("));
     }

--- a/crates/rue-air/src/sema/one_body.rs
+++ b/crates/rue-air/src/sema/one_body.rs
@@ -218,36 +218,35 @@ fn interruption_outcome(interruption: OneBodyInterruption) -> OneBodyTransaction
     }
 }
 
-fn stable_token(
-    sema: &BodySema<'_>,
+fn stable_token<H: OneBodyPublicationHost>(
+    host: &H,
     file: u32,
     name: &str,
     owner: Option<&str>,
     kind: StableDefinitionKind,
 ) -> Result<SemanticDefinitionToken, crate::SemanticBodyExportFailure> {
-    sema.stable_definition_token(file, name, owner, kind)
+    host.publication_stable_token(file, name, owner, kind)
 }
 
-fn target_dependency(
-    sema: &BodySema<'_>,
+fn target_dependency<H: OneBodyPublicationHost>(
+    host: &H,
     target: &super::NamedConstDependencyTargetEvent,
 ) -> Result<OneBodyDependency, crate::SemanticBodyExportFailure> {
     use super::{DeclarationTypeDependencyTargetKind as TK, NamedConstDependencyTargetEvent as T};
     match target {
         T::ValueConst { file, name } => {
-            stable_token(sema, *file, name, None, StableDefinitionKind::ValueConst)
+            stable_token(host, *file, name, None, StableDefinitionKind::ValueConst)
                 .map(OneBodyDependency::Definition)
         }
         T::FreeFunction { file, name } => {
-            stable_token(sema, *file, name, None, StableDefinitionKind::Function)
+            stable_token(host, *file, name, None, StableDefinitionKind::Function)
                 .map(|token| OneBodyDependency::Callable(FunctionInstanceKey::Definition(token)))
         }
         T::NamedType { file, name, kind } => {
-            if let Some(symbol) = sema.interner.get(name.as_str()) {
-                let facts = sema.endpoint_facts();
-                let builtin_kind = if facts.is_builtin_enum(symbol) {
+            if let Some(symbol) = host.publication_name_symbol(name.as_str()) {
+                let builtin_kind = if host.publication_is_builtin_enum(symbol) {
                     Some(crate::AnonymousNominalKind::Enum)
-                } else if facts.is_builtin_or_generated_struct(symbol) {
+                } else if host.publication_is_builtin_or_generated_struct(symbol) {
                     Some(crate::AnonymousNominalKind::Struct)
                 } else {
                     None
@@ -264,7 +263,7 @@ fn target_dependency(
                 TK::Enum => StableDefinitionKind::Enum,
                 TK::ValueConst => StableDefinitionKind::ValueConst,
             };
-            let token = stable_token(sema, *file, name, None, kind)?;
+            let token = stable_token(host, *file, name, None, kind)?;
             if matches!(
                 kind,
                 StableDefinitionKind::Struct | StableDefinitionKind::Enum
@@ -277,14 +276,14 @@ fn target_dependency(
             }
         }
         T::ModuleBinding { file, name } => {
-            stable_token(sema, *file, name, None, StableDefinitionKind::ModuleBinding)
+            stable_token(host, *file, name, None, StableDefinitionKind::ModuleBinding)
                 .map(OneBodyDependency::Definition)
         }
     }
 }
 
 #[derive(Debug)]
-enum ReferenceProjectionFailure {
+pub(super) enum ReferenceProjectionFailure {
     TypedIncomplete(crate::SemanticBodyExportFailure),
     EngineAbort,
 }
@@ -292,6 +291,262 @@ enum ReferenceProjectionFailure {
 impl From<crate::SemanticBodyExportFailure> for ReferenceProjectionFailure {
     fn from(reason: crate::SemanticBodyExportFailure) -> Self {
         Self::TypedIncomplete(reason)
+    }
+}
+
+/// Representation-neutral facts and ledgers consumed by the canonical
+/// one-body publication funnel.
+///
+/// Semantic analysis and specialization finish before this boundary. The
+/// funnel owns stable positive-reference projection, deterministic failure
+/// classification, produced-anonymous export, and success serialization. A
+/// host exposes point operations and immutable request-local ledgers; it does
+/// not lend an analyzer or a declaration epoch to the algorithm.
+pub(super) trait OneBodyPublicationHost:
+    super::semantic_body_export::SemanticBodyExportHost
+{
+    fn publication_stable_token(
+        &self,
+        file: u32,
+        name: &str,
+        owner: Option<&str>,
+        kind: StableDefinitionKind,
+    ) -> Result<SemanticDefinitionToken, crate::SemanticBodyExportFailure>;
+    fn publication_name_symbol(&self, name: &str) -> Option<Spur>;
+    fn publication_resolve_symbol(&self, symbol: &Spur) -> &str;
+    fn publication_is_builtin_or_generated_struct(&self, symbol: Spur) -> bool;
+    fn publication_is_builtin_enum(&self, symbol: Spur) -> bool;
+    fn publication_body_function_identity(
+        &self,
+        symbol: Spur,
+    ) -> Result<
+        FunctionInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
+        crate::SemanticBodyExportFailure,
+    >;
+    fn publication_method_identity(
+        &self,
+        structure: crate::StructId,
+        method: Spur,
+    ) -> Result<
+        FunctionInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
+        ReferenceProjectionFailure,
+    >;
+    fn publication_canonical_type_instance(
+        &self,
+        ty: Type,
+    ) -> Result<
+        TypeInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
+        crate::SemanticBodyExportFailure,
+    >;
+    fn publication_canonical_argument_value(
+        &self,
+        value: super::ConstValue,
+    ) -> Result<
+        crate::CanonicalArgumentValue<SemanticDefinitionToken, SemanticModuleToken>,
+        crate::SemanticBodyExportFailure,
+    >;
+
+    fn publication_specialization_dependencies(
+        &self,
+    ) -> &[(
+        AnalyzedBodyOwnerEvent,
+        FunctionInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
+    )];
+    fn publication_callable_dependencies(&self) -> &[(AnalyzedBodyOwnerEvent, Spur)];
+    fn publication_named_dependencies(&self) -> &[super::BodyNamedDependencyEvent];
+    fn publication_type_dependencies(&self) -> &[super::DeclarationTypeDependencyEvent];
+    fn publication_type_call_head_dependencies(
+        &self,
+    ) -> &[super::DeclarationTypeCallHeadDependencyEvent];
+
+    fn publication_anonymous_identities(
+        &self,
+    ) -> Vec<(
+        Type,
+        crate::AnonymousNominalKey<SemanticDefinitionToken, SemanticModuleToken>,
+    )>;
+    fn publication_initial_anonymous_contains(
+        &self,
+        identity: &crate::AnonymousNominalKey<SemanticDefinitionToken, SemanticModuleToken>,
+    ) -> bool;
+    fn publication_type_pool(&self) -> &crate::TypeInternPool;
+    fn publication_anonymous_method_signatures(
+        &self,
+        structure: crate::StructId,
+    ) -> &[super::AnonMethodSig];
+    fn publication_anonymous_type_captures(&self, structure: crate::StructId) -> Vec<(Spur, Type)>;
+    fn publication_anonymous_value_captures(
+        &self,
+        structure: crate::StructId,
+    ) -> Vec<(Spur, super::ConstValue)>;
+
+    fn publication_inference_failure_incomplete(&self) -> bool;
+    fn publication_recovered_errors(&self) -> &[CompileError];
+}
+
+impl OneBodyPublicationHost for BodySema<'_> {
+    fn publication_stable_token(
+        &self,
+        file: u32,
+        name: &str,
+        owner: Option<&str>,
+        kind: StableDefinitionKind,
+    ) -> Result<SemanticDefinitionToken, crate::SemanticBodyExportFailure> {
+        self.stable_definition_token(file, name, owner, kind)
+    }
+
+    fn publication_name_symbol(&self, name: &str) -> Option<Spur> {
+        self.interner.get(name)
+    }
+
+    fn publication_resolve_symbol(&self, symbol: &Spur) -> &str {
+        self.interner.resolve(symbol)
+    }
+
+    fn publication_is_builtin_or_generated_struct(&self, symbol: Spur) -> bool {
+        self.endpoint_facts().is_builtin_or_generated_struct(symbol)
+    }
+
+    fn publication_is_builtin_enum(&self, symbol: Spur) -> bool {
+        self.endpoint_facts().is_builtin_enum(symbol)
+    }
+
+    fn publication_body_function_identity(
+        &self,
+        symbol: Spur,
+    ) -> Result<
+        FunctionInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
+        crate::SemanticBodyExportFailure,
+    > {
+        self.body_function_identity(symbol)
+    }
+
+    fn publication_method_identity(
+        &self,
+        structure: crate::StructId,
+        method: Spur,
+    ) -> Result<
+        FunctionInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
+        ReferenceProjectionFailure,
+    > {
+        let Some(info) = self.endpoint_facts().method_info(structure, method) else {
+            return Err(ReferenceProjectionFailure::EngineAbort);
+        };
+        let symbol = self.method_symbol(structure, self.interner.resolve(&method), info.has_self);
+        let Some(symbol) = self.interner.get(&symbol) else {
+            return Err(ReferenceProjectionFailure::EngineAbort);
+        };
+        self.body_function_identity(symbol).map_err(Into::into)
+    }
+
+    fn publication_canonical_type_instance(
+        &self,
+        ty: Type,
+    ) -> Result<
+        TypeInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
+        crate::SemanticBodyExportFailure,
+    > {
+        self.canonical_type_instance(ty)
+    }
+
+    fn publication_canonical_argument_value(
+        &self,
+        value: super::ConstValue,
+    ) -> Result<
+        crate::CanonicalArgumentValue<SemanticDefinitionToken, SemanticModuleToken>,
+        crate::SemanticBodyExportFailure,
+    > {
+        self.canonical_argument_value(value)
+    }
+
+    fn publication_specialization_dependencies(
+        &self,
+    ) -> &[(
+        AnalyzedBodyOwnerEvent,
+        FunctionInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
+    )] {
+        &self.body_specialization_dependencies
+    }
+
+    fn publication_callable_dependencies(&self) -> &[(AnalyzedBodyOwnerEvent, Spur)] {
+        &self.body_callable_dependencies
+    }
+
+    fn publication_named_dependencies(&self) -> &[super::BodyNamedDependencyEvent] {
+        &self.body_named_dependencies
+    }
+
+    fn publication_type_dependencies(&self) -> &[super::DeclarationTypeDependencyEvent] {
+        &self.declaration_type_dependencies
+    }
+
+    fn publication_type_call_head_dependencies(
+        &self,
+    ) -> &[super::DeclarationTypeCallHeadDependencyEvent] {
+        &self.declaration_type_call_head_dependencies
+    }
+
+    fn publication_anonymous_identities(
+        &self,
+    ) -> Vec<(
+        Type,
+        crate::AnonymousNominalKey<SemanticDefinitionToken, SemanticModuleToken>,
+    )> {
+        self.canonical_anonymous_types
+            .iter()
+            .map(|(ty, identity)| (*ty, identity.clone()))
+            .collect()
+    }
+
+    fn publication_initial_anonymous_contains(
+        &self,
+        identity: &crate::AnonymousNominalKey<SemanticDefinitionToken, SemanticModuleToken>,
+    ) -> bool {
+        self.one_body_initial_anonymous_identities
+            .contains(identity)
+    }
+
+    fn publication_type_pool(&self) -> &crate::TypeInternPool {
+        &self.type_pool
+    }
+
+    fn publication_anonymous_method_signatures(
+        &self,
+        structure: crate::StructId,
+    ) -> &[super::AnonMethodSig] {
+        self.anon_struct_method_sigs
+            .get(&structure)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    fn publication_anonymous_type_captures(&self, structure: crate::StructId) -> Vec<(Spur, Type)> {
+        self.anon_struct_type_subst
+            .get(&structure)
+            .into_iter()
+            .flat_map(|captures| captures.iter())
+            .map(|(name, ty)| (*name, *ty))
+            .collect()
+    }
+
+    fn publication_anonymous_value_captures(
+        &self,
+        structure: crate::StructId,
+    ) -> Vec<(Spur, super::ConstValue)> {
+        self.anon_struct_captured_values
+            .get(&structure)
+            .into_iter()
+            .flat_map(|captures| captures.iter())
+            .map(|(name, value)| (*name, *value))
+            .collect()
+    }
+
+    fn publication_inference_failure_incomplete(&self) -> bool {
+        self.one_body_inference_failure_incomplete
+    }
+
+    fn publication_recovered_errors(&self) -> &[CompileError] {
+        &self.one_body_recovered_errors
     }
 }
 
@@ -314,13 +569,13 @@ fn semantic_parameter_mode(mode: rue_rir::RirParamMode) -> crate::SemanticParame
     }
 }
 
-fn produced_method_type(
-    sema: &BodySema<'_>,
+fn produced_method_type<H: OneBodyPublicationHost>(
+    host: &H,
     ty: &super::AnonMethodType,
     owner: &crate::AnonymousNominalKey<SemanticDefinitionToken, SemanticModuleToken>,
 ) -> Result<SemanticProducedAnonymousMethodType, crate::SemanticBodyExportFailure> {
-    fn concrete(
-        sema: &BodySema<'_>,
+    fn concrete<H: OneBodyPublicationHost>(
+        host: &H,
         ty: &super::AnonMethodType,
         owner: &crate::AnonymousNominalKey<SemanticDefinitionToken, SemanticModuleToken>,
     ) -> Result<
@@ -331,16 +586,16 @@ fn produced_method_type(
             super::AnonMethodType::SelfType => {
                 TypeInstanceKey::Nominal(NominalInstanceKey::Anonymous(owner.clone()))
             }
-            super::AnonMethodType::Concrete(ty) => sema.canonical_type_instance(*ty)?,
+            super::AnonMethodType::Concrete(ty) => host.publication_canonical_type_instance(*ty)?,
             super::AnonMethodType::Array { element, len } => TypeInstanceKey::Array {
-                element: Box::new(concrete(sema, element, owner)?),
+                element: Box::new(concrete(host, element, owner)?),
                 len: *len,
             },
             super::AnonMethodType::PtrConst(pointee) => {
-                TypeInstanceKey::PtrConst(Box::new(concrete(sema, pointee, owner)?))
+                TypeInstanceKey::PtrConst(Box::new(concrete(host, pointee, owner)?))
             }
             super::AnonMethodType::PtrMut(pointee) => {
-                TypeInstanceKey::PtrMut(Box::new(concrete(sema, pointee, owner)?))
+                TypeInstanceKey::PtrMut(Box::new(concrete(host, pointee, owner)?))
             }
             super::AnonMethodType::Syntax(_) => {
                 return Err(crate::SemanticBodyExportFailure::UnsupportedType);
@@ -350,48 +605,40 @@ fn produced_method_type(
 
     Ok(match ty {
         super::AnonMethodType::SelfType => SemanticProducedAnonymousMethodType::SelfType,
-        _ => SemanticProducedAnonymousMethodType::Concrete(concrete(sema, ty, owner)?),
+        _ => SemanticProducedAnonymousMethodType::Concrete(concrete(host, ty, owner)?),
     })
 }
 
-fn produced_anonymous_nominals(
-    sema: &BodySema<'_>,
+fn produced_anonymous_nominals<H: OneBodyPublicationHost>(
+    host: &H,
 ) -> Result<Arc<[SemanticProducedAnonymousNominal]>, crate::SemanticBodyExportFailure> {
-    let mut identities = sema
-        .canonical_anonymous_types
-        .iter()
-        .filter(|(_, identity)| {
-            !sema
-                .one_body_initial_anonymous_identities
-                .contains(*identity)
-        })
-        .map(|(ty, identity)| (*ty, identity.clone()))
+    let mut identities = host
+        .publication_anonymous_identities()
+        .into_iter()
+        .filter(|(_, identity)| !host.publication_initial_anonymous_contains(identity))
         .collect::<Vec<_>>();
     // Deterministic total order over the direct producer keys so the exported
     // nominal stream never depends on `HashMap` iteration order.
-    identities.sort_by(|(_, left), (_, right)| BodySema::anonymous_key_cmp(left, right));
+    identities.sort_by(|(_, left), (_, right)| super::anon_structs::anonymous_key_cmp(left, right));
 
     identities
         .into_iter()
         .map(|(ty, identity)| {
             let (shape, type_captures, value_captures) = match (ty.kind(), identity.kind) {
                 (crate::TypeKind::Struct(struct_id), crate::AnonymousNominalKind::Struct) => {
-                    let definition = sema.type_pool.struct_def(struct_id);
+                    let definition = host.publication_type_pool().struct_def(struct_id);
                     let fields = definition
                         .fields
                         .iter()
                         .map(|field| {
                             Ok((
                                 Arc::from(field.name.as_str()),
-                                sema.canonical_type_instance(field.ty)?,
+                                host.publication_canonical_type_instance(field.ty)?,
                             ))
                         })
                         .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
-                    let methods = sema
-                        .anon_struct_method_sigs
-                        .get(&struct_id)
-                        .map(Vec::as_slice)
-                        .unwrap_or_default()
+                    let methods = host
+                        .publication_anonymous_method_signatures(struct_id)
                         .iter()
                         .map(|method| {
                             let parameters = method
@@ -401,33 +648,31 @@ fn produced_anonymous_nominals(
                                 .zip(&method.param_comptime)
                                 .map(|((ty, mode), is_comptime)| {
                                     Ok((
-                                        produced_method_type(sema, ty, &identity)?,
+                                        produced_method_type(host, ty, &identity)?,
                                         semantic_parameter_mode(*mode),
                                         *is_comptime,
                                     ))
                                 })
                                 .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
                             Ok(SemanticProducedAnonymousMethodSignature {
-                                name: Arc::from(sema.interner.resolve(&method.name)),
+                                name: Arc::from(host.publication_resolve_symbol(&method.name)),
                                 has_self: method.has_self,
                                 self_mode: semantic_parameter_mode(method.self_mode),
                                 parameters: parameters.into(),
-                                result: produced_method_type(sema, &method.return_type, &identity)?,
+                                result: produced_method_type(host, &method.return_type, &identity)?,
                             })
                         })
                         .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
                     let mut type_captures: Vec<(
                         Arc<str>,
                         TypeInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
-                    )> = sema
-                        .anon_struct_type_subst
-                        .get(&struct_id)
+                    )> = host
+                        .publication_anonymous_type_captures(struct_id)
                         .into_iter()
-                        .flat_map(|captures| captures.iter())
                         .map(|(name, ty)| {
                             Ok((
-                                Arc::<str>::from(sema.interner.resolve(name)),
-                                sema.canonical_type_instance(*ty)?,
+                                Arc::<str>::from(host.publication_resolve_symbol(&name)),
+                                host.publication_canonical_type_instance(ty)?,
                             ))
                         })
                         .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
@@ -435,15 +680,13 @@ fn produced_anonymous_nominals(
                     let mut value_captures: Vec<(
                         Arc<str>,
                         crate::CanonicalArgumentValue<SemanticDefinitionToken, SemanticModuleToken>,
-                    )> = sema
-                        .anon_struct_captured_values
-                        .get(&struct_id)
+                    )> = host
+                        .publication_anonymous_value_captures(struct_id)
                         .into_iter()
-                        .flat_map(|captures| captures.iter())
                         .map(|(name, value)| {
                             Ok((
-                                Arc::<str>::from(sema.interner.resolve(name)),
-                                sema.canonical_argument_value(*value)?,
+                                Arc::<str>::from(host.publication_resolve_symbol(&name)),
+                                host.publication_canonical_argument_value(value)?,
                             ))
                         })
                         .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
@@ -458,7 +701,7 @@ fn produced_anonymous_nominals(
                     )
                 }
                 (crate::TypeKind::Enum(enum_id), crate::AnonymousNominalKind::Enum) => {
-                    let definition = sema.type_pool.enum_def(enum_id);
+                    let definition = host.publication_type_pool().enum_def(enum_id);
                     let variants = definition
                         .variants
                         .iter()
@@ -467,7 +710,7 @@ fn produced_anonymous_nominals(
                             let payload = definition
                                 .variant_payload(index)
                                 .iter()
-                                .map(|ty| sema.canonical_type_instance(*ty))
+                                .map(|ty| host.publication_canonical_type_instance(*ty))
                                 .collect::<Result<Vec<_>, _>>()?;
                             Ok((Arc::from(name.as_str()), Arc::from(payload)))
                         })
@@ -577,8 +820,8 @@ fn dependency_has_issuer(dependency: &OneBodyDependency, issuer: u64) -> bool {
     }
 }
 
-fn body_references(
-    sema: &BodySema<'_>,
+fn body_references<H: OneBodyPublicationHost>(
+    host: &H,
     owner: Option<super::BodyOwnerToken>,
     referenced_functions: &HashSet<Spur>,
     referenced_methods: &HashSet<(crate::StructId, Spur)>,
@@ -593,40 +836,33 @@ fn body_references(
 ) -> Result<Arc<[OneBodyDependency]>, ReferenceProjectionFailure> {
     let mut references = BTreeSet::new();
     for function in referenced_functions {
-        let identity = sema.body_function_identity(*function)?;
+        let identity = host.publication_body_function_identity(*function)?;
         references.insert(OneBodyDependency::Callable(identity));
     }
     for (structure, method) in referenced_methods {
-        let Some(info) = sema.endpoint_facts().method_info(*structure, *method) else {
-            return Err(ReferenceProjectionFailure::EngineAbort);
-        };
-        let symbol = sema.method_symbol(*structure, sema.interner.resolve(method), info.has_self);
-        let Some(symbol) = sema.interner.get(&symbol) else {
-            return Err(ReferenceProjectionFailure::EngineAbort);
-        };
-        let identity = sema.body_function_identity(symbol)?;
+        let identity = host.publication_method_identity(*structure, *method)?;
         references.insert(OneBodyDependency::Callable(identity));
     }
-    for (source, identity) in &sema.body_specialization_dependencies {
+    for (source, identity) in host.publication_specialization_dependencies() {
         if owner.is_some_and(|owner| source.token() != Some(owner)) {
             continue;
         }
         references.insert(OneBodyDependency::Callable(identity.clone()));
     }
-    for (source, symbol) in &sema.body_callable_dependencies {
+    for (source, symbol) in host.publication_callable_dependencies() {
         if owner.is_some_and(|owner| source.token() != Some(owner)) {
             continue;
         }
-        let identity = sema.body_function_identity(*symbol)?;
+        let identity = host.publication_body_function_identity(*symbol)?;
         references.insert(OneBodyDependency::Callable(identity));
     }
-    for event in &sema.body_named_dependencies {
+    for event in host.publication_named_dependencies() {
         if owner.is_some_and(|owner| event.source.token() != Some(owner)) {
             continue;
         }
-        references.insert(target_dependency(sema, &event.target)?);
+        references.insert(target_dependency(host, &event.target)?);
     }
-    for event in &sema.declaration_type_dependencies {
+    for event in host.publication_type_dependencies() {
         if event.dependency_kind != super::DeclarationTypeDependencyKind::Body
             || owner.is_some_and(|owner| event.source_token != Some(owner))
         {
@@ -642,10 +878,13 @@ fn body_references(
         {
             continue;
         }
-        if sema.interner.get(&event.target_name).is_some_and(|symbol| {
-            let facts = sema.endpoint_facts();
-            facts.is_builtin_or_generated_struct(symbol) || facts.is_builtin_enum(symbol)
-        }) {
+        if host
+            .publication_name_symbol(&event.target_name)
+            .is_some_and(|symbol| {
+                host.publication_is_builtin_or_generated_struct(symbol)
+                    || host.publication_is_builtin_enum(symbol)
+            })
+        {
             continue;
         }
         let kind = match event.target_kind {
@@ -655,7 +894,7 @@ fn body_references(
                 StableDefinitionKind::ValueConst
             }
         };
-        let token = stable_token(sema, event.target_file, &event.target_name, None, kind)?;
+        let token = stable_token(host, event.target_file, &event.target_name, None, kind)?;
         if matches!(
             kind,
             StableDefinitionKind::Struct | StableDefinitionKind::Enum
@@ -667,14 +906,14 @@ fn body_references(
             references.insert(OneBodyDependency::Definition(token));
         }
     }
-    for event in &sema.declaration_type_call_head_dependencies {
+    for event in host.publication_type_call_head_dependencies() {
         if event.dependency_kind != super::DeclarationTypeDependencyKind::Body
             || owner.is_some_and(|owner| event.source_token != Some(owner))
         {
             continue;
         }
         let token = stable_token(
-            sema,
+            host,
             event.callable_file,
             &event.callable_name,
             None,
@@ -699,15 +938,15 @@ fn body_references(
                     instance,
                     FunctionInstanceKey::Specialization { arguments, .. }
                         if !arguments.values.is_empty()
-                ) && !sema
-                    .body_specialization_dependencies
+                ) && !host
+                    .publication_specialization_dependencies()
                     .iter()
                     .any(|(_, recorded)| recorded == *instance)
             })
             .cloned()
             .map(OneBodyDependency::Callable),
     );
-    for (source, identity) in &sema.body_specialization_dependencies {
+    for (source, identity) in host.publication_specialization_dependencies() {
         if owner.is_some_and(|owner| source.token() != Some(owner)) {
             continue;
         }
@@ -728,12 +967,12 @@ fn body_references(
     Ok(references)
 }
 
-fn fail(
-    sema: &BodySema<'_>,
+fn fail<H: OneBodyPublicationHost>(
+    host: &H,
     owner: Option<super::BodyOwnerToken>,
     error: CompileError,
 ) -> OneBodyTransactionOutcome {
-    if sema.one_body_inference_failure_incomplete {
+    if host.publication_inference_failure_incomplete() {
         return OneBodyTransactionOutcome::NonTerminal {
             reason: OneBodyNonTerminalReason::TypedIncomplete(
                 crate::SemanticBodyExportFailure::MissingStableIdentity,
@@ -754,16 +993,16 @@ fn fail(
             reason: OneBodyNonTerminalReason::EngineAbort,
         };
     }
-    let errors = if sema.one_body_recovered_errors.is_empty() {
+    let errors = if host.publication_recovered_errors().is_empty() {
         CompileErrors::from(error)
     } else {
         let mut errors = CompileErrors::new();
-        for error in &sema.one_body_recovered_errors {
+        for error in host.publication_recovered_errors() {
             errors.push(error.clone());
         }
         errors
     };
-    match body_references(sema, owner, &HashSet::new(), &HashSet::new(), &[], &[]) {
+    match body_references(host, owner, &HashSet::new(), &HashSet::new(), &[], &[]) {
         Ok(references) => OneBodyTransactionOutcome::DeterministicFailure { errors, references },
         Err(failure) => projection_failure_outcome(failure),
     }
@@ -785,8 +1024,42 @@ fn finalize_ordinary(
             Ok(selected) => selected,
             Err(error) => return fail(sema, Some(owner), error),
         };
-    let references = match body_references(
+    publish_ordinary(
         sema,
+        owner,
+        body_span,
+        function,
+        warnings,
+        strings,
+        referenced_functions,
+        referenced_methods,
+        specializations,
+        specialization_instances,
+        interruption,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn publish_ordinary<H: OneBodyPublicationHost>(
+    host: &H,
+    owner: super::BodyOwnerToken,
+    body_span: Span,
+    function: AnalyzedFunction,
+    warnings: Vec<rue_error::CompileWarning>,
+    strings: Vec<String>,
+    referenced_functions: HashSet<Spur>,
+    referenced_methods: HashSet<(crate::StructId, Spur)>,
+    specializations: Vec<(
+        Spur,
+        SemanticSpecializationIdentity<SemanticDefinitionToken, SemanticModuleToken>,
+    )>,
+    specialization_instances: Vec<
+        FunctionInstanceKey<SemanticDefinitionToken, SemanticModuleToken>,
+    >,
+    interruption: Option<OneBodyInterruption>,
+) -> OneBodyTransactionOutcome {
+    let references = match body_references(
+        host,
         Some(owner),
         &referenced_functions,
         &referenced_methods,
@@ -800,7 +1073,7 @@ fn finalize_ordinary(
         return interruption_outcome(interruption);
     }
     let specialized_calls = specializations.iter().cloned().collect::<HashMap<_, _>>();
-    let produced_anonymous_nominals = match produced_anonymous_nominals(sema) {
+    let produced_anonymous_nominals = match produced_anonymous_nominals(host) {
         Ok(produced) => produced,
         Err(reason) => {
             return OneBodyTransactionOutcome::NonTerminal {
@@ -808,13 +1081,14 @@ fn finalize_ordinary(
             };
         }
     };
-    match sema.export_one_body_with_specializations(
+    match super::semantic_body_export::export_body(
+        host,
         owner,
         body_span,
         &function,
         &strings,
         &warnings,
-        &specialized_calls,
+        Some(&specialized_calls),
     ) {
         Ok(artifact) => OneBodyTransactionOutcome::Success {
             artifact: OneBodyCanonicalArtifact::Ordinary(Box::new(artifact)),

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -39,16 +39,16 @@ impl BodySema<'_> {
             None,
             super::BodyOwnerKind::FreeFunction,
         );
-        let body = self
-            .export_body(
-                owner,
-                base_info.span,
-                analyzed,
-                strings,
-                warnings,
-                Some(specialized_calls),
-            )?
-            .body;
+        let body = export_body(
+            self,
+            owner,
+            base_info.span,
+            analyzed,
+            strings,
+            warnings,
+            Some(specialized_calls),
+        )?
+        .body;
         let type_arguments = type_arguments
             .iter()
             .map(|value| self.export_body_type(*value))
@@ -95,32 +95,7 @@ impl BodySema<'_> {
         strings: &[String],
         warnings: &[CompileWarning],
     ) -> Result<SemanticBodyExport, F> {
-        self.export_body(owner, body_span, analyzed, strings, warnings, None)
-    }
-
-    /// Test-only exact-body export after generic-call selection has rewritten
-    /// the caller.  Production keeps its established pre-specialization export
-    /// ordering until the compiler body-query cutover.
-    pub(in crate::sema) fn export_one_body_with_specializations(
-        &self,
-        owner: BodyOwnerToken,
-        body_span: Span,
-        analyzed: &AnalyzedFunction,
-        strings: &[String],
-        warnings: &[CompileWarning],
-        specialized_calls: &HashMap<
-            Spur,
-            SemanticSpecializationIdentity<SemanticDefinitionToken, SemanticModuleToken>,
-        >,
-    ) -> Result<SemanticBodyExport, F> {
-        self.export_body(
-            owner,
-            body_span,
-            analyzed,
-            strings,
-            warnings,
-            Some(specialized_calls),
-        )
+        export_body(self, owner, body_span, analyzed, strings, warnings, None)
     }
 
     pub(in crate::sema) fn export_anonymous_body_with_specializations(
@@ -141,7 +116,8 @@ impl BodySema<'_> {
         // Anonymous bodies have no compiler-issued named owner token. The
         // shared value exporter does not inspect this placeholder; only its
         // ordinary wrapper publishes the owner field.
-        let exported = self.export_body(
+        let exported = export_body(
+            self,
             crate::BodyOwnerToken::new(0, 0),
             body_span,
             analyzed,
@@ -154,490 +130,546 @@ impl BodySema<'_> {
             body: exported.body,
         })
     }
+}
 
-    fn export_body(
+/// Representation-neutral capabilities consumed by the one canonical AIR to
+/// stable semantic-body exporter.
+///
+/// The exporter owns validation, anchor conversion, instruction/reference
+/// rewriting, and warning publication. A host supplies only identity/type
+/// projection and symbol spelling from its request-local authority.
+pub(super) trait SemanticBodyExportHost {
+    fn export_body_type(
         &self,
-        owner: BodyOwnerToken,
-        body_span: Span,
-        analyzed: &AnalyzedFunction,
-        strings: &[String],
-        warnings: &[CompileWarning],
-        specialized_calls: Option<
-            &HashMap<
-                Spur,
-                SemanticSpecializationIdentity<SemanticDefinitionToken, SemanticModuleToken>,
-            >,
+        ty: Type,
+    ) -> Result<SemanticImportType<SemanticDefinitionToken, SemanticModuleToken>, F>;
+    fn body_struct_identity(
+        &self,
+        id: crate::StructId,
+    ) -> Result<crate::NominalInstanceKey<SemanticDefinitionToken, SemanticModuleToken>, F>;
+    fn body_enum_identity(
+        &self,
+        id: crate::EnumId,
+    ) -> Result<crate::NominalInstanceKey<SemanticDefinitionToken, SemanticModuleToken>, F>;
+    fn body_function_identity(
+        &self,
+        symbol: Spur,
+    ) -> Result<crate::FunctionInstanceKey<SemanticDefinitionToken, SemanticModuleToken>, F>;
+    fn resolve_publication_symbol(&self, symbol: &Spur) -> &str;
+}
+
+pub(super) fn export_body<H: SemanticBodyExportHost>(
+    host: &H,
+    owner: BodyOwnerToken,
+    body_span: Span,
+    analyzed: &AnalyzedFunction,
+    strings: &[String],
+    warnings: &[CompileWarning],
+    specialized_calls: Option<
+        &HashMap<
+            Spur,
+            SemanticSpecializationIdentity<SemanticDefinitionToken, SemanticModuleToken>,
         >,
-    ) -> Result<SemanticBodyExport, F> {
-        let warning_anchor = |span: Span| {
-            if span.file_id != body_span.file_id
-                || span.start < body_span.start
-                || span.end > body_span.end
-            {
-                return Err(F::ForeignSpan);
-            }
-            Ok(SemanticBodyAnchor {
-                start: span.start - body_span.start,
-                end: span.end - body_span.start,
-            })
-        };
-        let warnings = warnings
-            .iter()
-            .map(|warning| {
-                let anchor = warning
-                    .span()
-                    .ok_or(F::ForeignSpan)
-                    .and_then(warning_anchor)?;
-                let diagnostic = warning.diagnostic();
-                Ok(crate::SemanticBodyWarning {
-                    kind: warning.kind.clone(),
-                    anchor,
-                    labels: diagnostic
-                        .labels
-                        .iter()
-                        .map(|label| {
-                            Ok(crate::SemanticBodyWarningLabel {
-                                message: Arc::from(label.message.as_str()),
-                                anchor: warning_anchor(label.span)?,
-                            })
-                        })
-                        .collect::<Result<Vec<_>, F>>()?
-                        .into(),
-                    notes: diagnostic
-                        .notes
-                        .iter()
-                        .map(|note| Arc::from(note.0.as_str()))
-                        .collect(),
-                    helps: diagnostic
-                        .helps
-                        .iter()
-                        .map(|help| Arc::from(help.0.as_str()))
-                        .collect(),
-                    suggestions: diagnostic
-                        .suggestions
-                        .iter()
-                        .map(|suggestion| {
-                            Ok(crate::SemanticBodyWarningSuggestion {
-                                message: Arc::from(suggestion.message.as_str()),
-                                anchor: warning_anchor(suggestion.span)?,
-                                replacement: Arc::from(suggestion.replacement.as_str()),
-                                applicability: suggestion.applicability,
-                            })
-                        })
-                        .collect::<Result<Vec<_>, F>>()?
-                        .into(),
-                })
-            })
-            .collect::<Result<Vec<_>, F>>()?;
-        let body = &analyzed.air;
-        let instruction_count = body.len();
-        let place_count = body.places().len();
-        let r = |value: crate::AirRef, current: usize| -> Result<u32, F> {
-            let index = value.as_u32() as usize;
-            if index >= instruction_count || index >= current {
-                return Err(F::InvalidInstructionReference);
-            }
-            Ok(value.as_u32())
-        };
-        let place = |value: crate::AirPlaceRef| -> Result<u32, F> {
-            if value.as_u32() as usize >= place_count {
-                return Err(F::InvalidPlaceReference);
-            }
-            Ok(value.as_u32())
-        };
-
-        let mut places = Vec::with_capacity(place_count);
-        for source in body.places() {
-            let mut projections = Vec::with_capacity(source.projection_count());
-            for projection in body.get_place_projections(source) {
-                projections.push(match projection {
-                    AirProjection::Field {
-                        struct_id,
-                        field_index,
-                    } => SemanticBodyProjection::Field {
-                        struct_key: self.body_struct_identity(*struct_id)?,
-                        field_index: *field_index,
-                    },
-                    AirProjection::Index { array_type, index } => {
-                        if index.as_u32() as usize >= instruction_count {
-                            return Err(F::InvalidInstructionReference);
-                        }
-                        SemanticBodyProjection::Index {
-                            array_type: self.export_body_type(*array_type)?,
-                            index: index.as_u32(),
-                        }
-                    }
-                });
-            }
-            places.push(SemanticBodyPlace {
-                base: source.base,
-                base_type: self.export_body_type(source.base_type)?,
-                projections: Arc::from(projections),
-            });
+    >,
+) -> Result<SemanticBodyExport, F> {
+    let warning_anchor = |span: Span| {
+        if span.file_id != body_span.file_id
+            || span.start < body_span.start
+            || span.end > body_span.end
+        {
+            return Err(F::ForeignSpan);
         }
+        Ok(SemanticBodyAnchor {
+            start: span.start - body_span.start,
+            end: span.end - body_span.start,
+        })
+    };
+    let warnings = warnings
+        .iter()
+        .map(|warning| {
+            let anchor = warning
+                .span()
+                .ok_or(F::ForeignSpan)
+                .and_then(warning_anchor)?;
+            let diagnostic = warning.diagnostic();
+            Ok(crate::SemanticBodyWarning {
+                kind: warning.kind.clone(),
+                anchor,
+                labels: diagnostic
+                    .labels
+                    .iter()
+                    .map(|label| {
+                        Ok(crate::SemanticBodyWarningLabel {
+                            message: Arc::from(label.message.as_str()),
+                            anchor: warning_anchor(label.span)?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, F>>()?
+                    .into(),
+                notes: diagnostic
+                    .notes
+                    .iter()
+                    .map(|note| Arc::from(note.0.as_str()))
+                    .collect(),
+                helps: diagnostic
+                    .helps
+                    .iter()
+                    .map(|help| Arc::from(help.0.as_str()))
+                    .collect(),
+                suggestions: diagnostic
+                    .suggestions
+                    .iter()
+                    .map(|suggestion| {
+                        Ok(crate::SemanticBodyWarningSuggestion {
+                            message: Arc::from(suggestion.message.as_str()),
+                            anchor: warning_anchor(suggestion.span)?,
+                            replacement: Arc::from(suggestion.replacement.as_str()),
+                            applicability: suggestion.applicability,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, F>>()?
+                    .into(),
+            })
+        })
+        .collect::<Result<Vec<_>, F>>()?;
+    let body = &analyzed.air;
+    let instruction_count = body.len();
+    let place_count = body.places().len();
+    let r = |value: crate::AirRef, current: usize| -> Result<u32, F> {
+        let index = value.as_u32() as usize;
+        if index >= instruction_count || index >= current {
+            return Err(F::InvalidInstructionReference);
+        }
+        Ok(value.as_u32())
+    };
+    let place = |value: crate::AirPlaceRef| -> Result<u32, F> {
+        if value.as_u32() as usize >= place_count {
+            return Err(F::InvalidPlaceReference);
+        }
+        Ok(value.as_u32())
+    };
 
-        let mut instructions = Vec::with_capacity(instruction_count);
-        for (current, (_, inst)) in body.iter().enumerate() {
-            if inst.span.file_id != body_span.file_id
-                || inst.span.start < body_span.start
-                || inst.span.end < inst.span.start
-                || inst.span.end > body_span.end
-            {
-                return Err(F::ForeignSpan);
-            }
-            let unary = |v| r(v, current);
-            let binary = |a, b| Ok::<_, F>((r(a, current)?, r(b, current)?));
-            let call_args = |range| -> Result<Arc<[SemanticBodyCallArg]>, F> {
-                body.get_call_args(range)
-                    .map(|arg| {
-                        Ok(SemanticBodyCallArg {
-                            value: r(arg.value, current)?,
-                            mode: arg.mode,
-                        })
-                    })
-                    .collect::<Result<Vec<_>, _>>()
-                    .map(Arc::from)
-            };
-            let intrinsic_args = |range| -> Result<Arc<[SemanticBodyCallArg]>, F> {
-                body.get_intrinsic_args(range)
-                    .map(|value| {
-                        Ok(SemanticBodyCallArg {
-                            value: r(value, current)?,
-                            mode: crate::AirArgMode::Normal,
-                        })
-                    })
-                    .collect::<Result<Vec<_>, _>>()
-                    .map(Arc::from)
-            };
-            let data = match &inst.data {
-                AirInstData::Const(v) => SemanticBodyInstData::Const(*v),
-                AirInstData::BoolConst(v) => SemanticBodyInstData::BoolConst(*v),
-                AirInstData::StringConst(v) => {
-                    if *v as usize >= strings.len() {
-                        return Err(F::InvalidStringReference);
-                    }
-                    SemanticBodyInstData::StringConst(*v)
-                }
-                AirInstData::UnitConst => SemanticBodyInstData::UnitConst,
-                AirInstData::TypeConst(v) => {
-                    SemanticBodyInstData::TypeConst(self.export_body_type(*v)?)
-                }
-                AirInstData::Add(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::Add(a, b)
-                }
-                AirInstData::Sub(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::Sub(a, b)
-                }
-                AirInstData::Mul(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::Mul(a, b)
-                }
-                AirInstData::WrappingAdd(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::WrappingAdd(a, b)
-                }
-                AirInstData::WrappingSub(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::WrappingSub(a, b)
-                }
-                AirInstData::WrappingMul(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::WrappingMul(a, b)
-                }
-                AirInstData::Div(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::Div(a, b)
-                }
-                AirInstData::Mod(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::Mod(a, b)
-                }
-                AirInstData::Eq(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::Eq(a, b)
-                }
-                AirInstData::Ne(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::Ne(a, b)
-                }
-                AirInstData::Lt(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::Lt(a, b)
-                }
-                AirInstData::Gt(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::Gt(a, b)
-                }
-                AirInstData::Le(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::Le(a, b)
-                }
-                AirInstData::Ge(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::Ge(a, b)
-                }
-                AirInstData::And(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::And(a, b)
-                }
-                AirInstData::Or(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::Or(a, b)
-                }
-                AirInstData::BitAnd(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::BitAnd(a, b)
-                }
-                AirInstData::BitOr(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::BitOr(a, b)
-                }
-                AirInstData::BitXor(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::BitXor(a, b)
-                }
-                AirInstData::Shl(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::Shl(a, b)
-                }
-                AirInstData::Shr(a, b) => {
-                    let (a, b) = binary(*a, *b)?;
-                    SemanticBodyInstData::Shr(a, b)
-                }
-                AirInstData::Neg(v) => SemanticBodyInstData::Neg(unary(*v)?),
-                AirInstData::Not(v) => SemanticBodyInstData::Not(unary(*v)?),
-                AirInstData::BitNot(v) => SemanticBodyInstData::BitNot(unary(*v)?),
-                AirInstData::Branch {
-                    cond,
-                    then_value,
-                    else_value,
-                } => SemanticBodyInstData::Branch {
-                    cond: r(*cond, current)?,
-                    then_value: r(*then_value, current)?,
-                    else_value: else_value.map(|v| r(v, current)).transpose()?,
-                },
-                AirInstData::Loop { cond, body: value } => SemanticBodyInstData::Loop {
-                    cond: r(*cond, current)?,
-                    body: r(*value, current)?,
-                },
-                AirInstData::InfiniteLoop { body: value } => SemanticBodyInstData::InfiniteLoop {
-                    body: r(*value, current)?,
-                },
-                AirInstData::Match { scrutinee, arms } => {
-                    let arms = body
-                        .get_match_arms(arms)
-                        .map(|(pattern, value)| {
-                            let pattern = match pattern {
-                                AirPattern::Wildcard => SemanticBodyPattern::Wildcard,
-                                AirPattern::Int(v) => SemanticBodyPattern::Int(v),
-                                AirPattern::Bool(v) => SemanticBodyPattern::Bool(v),
-                                AirPattern::EnumVariant {
-                                    enum_id,
-                                    variant_index,
-                                } => SemanticBodyPattern::EnumVariant {
-                                    enum_key: self.body_enum_identity(enum_id)?,
-                                    variant_index,
-                                },
-                            };
-                            Ok(SemanticBodyMatchArm {
-                                pattern,
-                                body: r(value, current)?,
-                            })
-                        })
-                        .collect::<Result<Vec<_>, F>>()?;
-                    SemanticBodyInstData::Match {
-                        scrutinee: r(*scrutinee, current)?,
-                        arms: Arc::from(arms),
-                    }
-                }
-                AirInstData::Break => SemanticBodyInstData::Break,
-                AirInstData::Continue => SemanticBodyInstData::Continue,
-                AirInstData::Alloc { slot, init } => SemanticBodyInstData::Alloc {
-                    slot: *slot,
-                    init: r(*init, current)?,
-                },
-                AirInstData::Load { slot } => SemanticBodyInstData::Load { slot: *slot },
-                AirInstData::Store { slot, value } => SemanticBodyInstData::Store {
-                    slot: *slot,
-                    value: r(*value, current)?,
-                },
-                AirInstData::ParamStore { param_slot, value } => SemanticBodyInstData::ParamStore {
-                    param_slot: *param_slot,
-                    value: r(*value, current)?,
-                },
-                AirInstData::Ret(value) => {
-                    SemanticBodyInstData::Ret(value.map(|value| r(value, current)).transpose()?)
-                }
-                AirInstData::Call {
-                    runtime,
-                    name,
-                    args,
-                } => {
-                    if let Some(runtime) = runtime {
-                        SemanticBodyInstData::RuntimeCall {
-                            runtime: *runtime,
-                            args: call_args(args)?,
-                        }
-                    } else {
-                        match specialized_calls.and_then(|calls| calls.get(name)) {
-                            Some(identity) => SemanticBodyInstData::CallSpecialized {
-                                identity: identity.clone(),
-                                args: call_args(args)?,
-                            },
-                            None => SemanticBodyInstData::Call {
-                                function: self.body_function_identity(*name)?,
-                                args: call_args(args)?,
-                            },
-                        }
-                    }
-                }
-                AirInstData::CallGeneric { .. } => return Err(F::UnsupportedGenericCall),
-                AirInstData::Intrinsic {
-                    runtime,
-                    name,
-                    args,
-                } => SemanticBodyInstData::Intrinsic {
-                    runtime: *runtime,
-                    name: Arc::from(self.interner.resolve(name)),
-                    args: intrinsic_args(args)?,
-                },
-                AirInstData::Param { index } => SemanticBodyInstData::Param { index: *index },
-                AirInstData::Block { statements, value } => SemanticBodyInstData::Block {
-                    statements: body
-                        .get_block_statements(statements)
-                        .map(|v| r(v, current))
-                        .collect::<Result<Vec<_>, _>>()?
-                        .into(),
-                    value: r(*value, current)?,
-                },
-                AirInstData::StructInit {
+    let mut places = Vec::with_capacity(place_count);
+    for source in body.places() {
+        let mut projections = Vec::with_capacity(source.projection_count());
+        for projection in body.get_place_projections(source) {
+            projections.push(match projection {
+                AirProjection::Field {
                     struct_id,
-                    fields,
-                    source_order,
-                } => SemanticBodyInstData::StructInit {
-                    struct_key: self.body_struct_identity(*struct_id)?,
-                    fields: body
-                        .get_struct_fields(fields)
-                        .map(|value| r(value, current))
-                        .collect::<Result<Vec<_>, _>>()?
-                        .into(),
-                    source_order: body
-                        .get_source_order(source_order)
-                        .map(|value| u32::try_from(value).map_err(|_| F::SizeOverflow))
-                        .collect::<Result<Vec<_>, _>>()?
-                        .into(),
-                },
-                AirInstData::ArrayInit { elements } => SemanticBodyInstData::ArrayInit {
-                    elements: body
-                        .get_array_elements(elements)
-                        .map(|v| r(v, current))
-                        .collect::<Result<Vec<_>, _>>()?
-                        .into(),
-                },
-                AirInstData::PlaceRead { place: value } => SemanticBodyInstData::PlaceRead {
-                    place: place(*value)?,
-                },
-                AirInstData::PlaceWrite { place: p, value } => SemanticBodyInstData::PlaceWrite {
-                    place: place(*p)?,
-                    value: r(*value, current)?,
-                },
-                AirInstData::EnumVariant {
-                    enum_id,
-                    variant_index,
-                    payload,
-                } => SemanticBodyInstData::EnumVariant {
-                    enum_key: self.body_enum_identity(*enum_id)?,
-                    variant_index: *variant_index,
-                    payload: body
-                        .get_enum_payload(payload)
-                        .map(|v| r(v, current))
-                        .collect::<Result<Vec<_>, _>>()?
-                        .into(),
-                },
-                AirInstData::EnumPayloadGet {
-                    base,
-                    enum_id,
-                    variant_index,
                     field_index,
-                } => SemanticBodyInstData::EnumPayloadGet {
-                    base: r(*base, current)?,
-                    enum_key: self.body_enum_identity(*enum_id)?,
-                    variant_index: *variant_index,
+                } => SemanticBodyProjection::Field {
+                    struct_key: host.body_struct_identity(*struct_id)?,
                     field_index: *field_index,
                 },
-                AirInstData::IntCast { value, from_ty } => SemanticBodyInstData::IntCast {
-                    value: r(*value, current)?,
-                    from_ty: self.export_body_type(*from_ty)?,
-                },
-                AirInstData::Drop { value } => SemanticBodyInstData::Drop {
-                    value: r(*value, current)?,
-                },
-                AirInstData::StorageLive { slot } => {
-                    SemanticBodyInstData::StorageLive { slot: *slot }
+                AirProjection::Index { array_type, index } => {
+                    if index.as_u32() as usize >= instruction_count {
+                        return Err(F::InvalidInstructionReference);
+                    }
+                    SemanticBodyProjection::Index {
+                        array_type: host.export_body_type(*array_type)?,
+                        index: index.as_u32(),
+                    }
                 }
-                AirInstData::StorageDead { slot } => {
-                    SemanticBodyInstData::StorageDead { slot: *slot }
-                }
-                AirInstData::MarkMoved {
-                    value,
-                    slot,
-                    is_param,
-                    place: p,
-                } => SemanticBodyInstData::MarkMoved {
-                    value: r(*value, current)?,
-                    slot: *slot,
-                    is_param: *is_param,
-                    place: p.map(place).transpose()?,
-                },
-            };
-            instructions.push(SemanticBodyInst {
-                data,
-                ty: self.export_body_type(inst.ty)?,
-                anchor: SemanticBodyAnchor {
-                    start: inst.span.start - body_span.start,
-                    end: inst.span.end - body_span.start,
-                },
             });
         }
+        places.push(SemanticBodyPlace {
+            base: source.base,
+            base_type: host.export_body_type(source.base_type)?,
+            projections: Arc::from(projections),
+        });
+    }
 
-        let param_drops = body
-            .param_drops()
-            .iter()
-            .map(|(slot, ty)| Ok((*slot, self.export_body_type(*ty)?)))
-            .collect::<Result<Vec<_>, F>>()?;
-        let borrow_slots = (0..analyzed.num_locals)
-            .filter(|slot| body.is_borrow_slot(*slot))
-            .collect::<Vec<_>>();
-        Ok(SemanticBodyExport {
-            owner,
-            body: SemanticBody {
-                return_type: self.export_body_type(body.return_type())?,
-                instructions: Arc::from(instructions),
-                places: Arc::from(places),
-                strings: strings
-                    .iter()
-                    .map(|value| Arc::from(value.as_str()))
-                    .collect(),
-                local_atoms: analyzed
-                    .local_atoms
-                    .iter()
-                    .map(|atom| crate::SemanticBodyLocalAtom {
-                        identity: atom.identity.clone(),
-                        content: atom.content.clone(),
+    let mut instructions = Vec::with_capacity(instruction_count);
+    for (current, (_, inst)) in body.iter().enumerate() {
+        if inst.span.file_id != body_span.file_id
+            || inst.span.start < body_span.start
+            || inst.span.end < inst.span.start
+            || inst.span.end > body_span.end
+        {
+            return Err(F::ForeignSpan);
+        }
+        let unary = |v| r(v, current);
+        let binary = |a, b| Ok::<_, F>((r(a, current)?, r(b, current)?));
+        let call_args = |range| -> Result<Arc<[SemanticBodyCallArg]>, F> {
+            body.get_call_args(range)
+                .map(|arg| {
+                    Ok(SemanticBodyCallArg {
+                        value: r(arg.value, current)?,
+                        mode: arg.mode,
                     })
-                    .collect(),
-                param_drops: Arc::from(param_drops),
-                borrow_slots: Arc::from(borrow_slots),
-                num_locals: analyzed.num_locals,
-                num_param_slots: analyzed.num_param_slots,
-                param_by_ref: Arc::from(analyzed.param_modes.by_ref()),
-                param_writable: Arc::from(analyzed.param_modes.writable()),
-                allow_unreachable_code: analyzed.allow_unreachable_code,
-                warnings: warnings.into(),
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map(Arc::from)
+        };
+        let intrinsic_args = |range| -> Result<Arc<[SemanticBodyCallArg]>, F> {
+            body.get_intrinsic_args(range)
+                .map(|value| {
+                    Ok(SemanticBodyCallArg {
+                        value: r(value, current)?,
+                        mode: crate::AirArgMode::Normal,
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map(Arc::from)
+        };
+        let data = match &inst.data {
+            AirInstData::Const(v) => SemanticBodyInstData::Const(*v),
+            AirInstData::BoolConst(v) => SemanticBodyInstData::BoolConst(*v),
+            AirInstData::StringConst(v) => {
+                if *v as usize >= strings.len() {
+                    return Err(F::InvalidStringReference);
+                }
+                SemanticBodyInstData::StringConst(*v)
+            }
+            AirInstData::UnitConst => SemanticBodyInstData::UnitConst,
+            AirInstData::TypeConst(v) => {
+                SemanticBodyInstData::TypeConst(host.export_body_type(*v)?)
+            }
+            AirInstData::Add(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::Add(a, b)
+            }
+            AirInstData::Sub(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::Sub(a, b)
+            }
+            AirInstData::Mul(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::Mul(a, b)
+            }
+            AirInstData::WrappingAdd(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::WrappingAdd(a, b)
+            }
+            AirInstData::WrappingSub(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::WrappingSub(a, b)
+            }
+            AirInstData::WrappingMul(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::WrappingMul(a, b)
+            }
+            AirInstData::Div(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::Div(a, b)
+            }
+            AirInstData::Mod(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::Mod(a, b)
+            }
+            AirInstData::Eq(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::Eq(a, b)
+            }
+            AirInstData::Ne(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::Ne(a, b)
+            }
+            AirInstData::Lt(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::Lt(a, b)
+            }
+            AirInstData::Gt(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::Gt(a, b)
+            }
+            AirInstData::Le(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::Le(a, b)
+            }
+            AirInstData::Ge(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::Ge(a, b)
+            }
+            AirInstData::And(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::And(a, b)
+            }
+            AirInstData::Or(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::Or(a, b)
+            }
+            AirInstData::BitAnd(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::BitAnd(a, b)
+            }
+            AirInstData::BitOr(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::BitOr(a, b)
+            }
+            AirInstData::BitXor(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::BitXor(a, b)
+            }
+            AirInstData::Shl(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::Shl(a, b)
+            }
+            AirInstData::Shr(a, b) => {
+                let (a, b) = binary(*a, *b)?;
+                SemanticBodyInstData::Shr(a, b)
+            }
+            AirInstData::Neg(v) => SemanticBodyInstData::Neg(unary(*v)?),
+            AirInstData::Not(v) => SemanticBodyInstData::Not(unary(*v)?),
+            AirInstData::BitNot(v) => SemanticBodyInstData::BitNot(unary(*v)?),
+            AirInstData::Branch {
+                cond,
+                then_value,
+                else_value,
+            } => SemanticBodyInstData::Branch {
+                cond: r(*cond, current)?,
+                then_value: r(*then_value, current)?,
+                else_value: else_value.map(|v| r(v, current)).transpose()?,
             },
-        })
+            AirInstData::Loop { cond, body: value } => SemanticBodyInstData::Loop {
+                cond: r(*cond, current)?,
+                body: r(*value, current)?,
+            },
+            AirInstData::InfiniteLoop { body: value } => SemanticBodyInstData::InfiniteLoop {
+                body: r(*value, current)?,
+            },
+            AirInstData::Match { scrutinee, arms } => {
+                let arms = body
+                    .get_match_arms(arms)
+                    .map(|(pattern, value)| {
+                        let pattern = match pattern {
+                            AirPattern::Wildcard => SemanticBodyPattern::Wildcard,
+                            AirPattern::Int(v) => SemanticBodyPattern::Int(v),
+                            AirPattern::Bool(v) => SemanticBodyPattern::Bool(v),
+                            AirPattern::EnumVariant {
+                                enum_id,
+                                variant_index,
+                            } => SemanticBodyPattern::EnumVariant {
+                                enum_key: host.body_enum_identity(enum_id)?,
+                                variant_index,
+                            },
+                        };
+                        Ok(SemanticBodyMatchArm {
+                            pattern,
+                            body: r(value, current)?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, F>>()?;
+                SemanticBodyInstData::Match {
+                    scrutinee: r(*scrutinee, current)?,
+                    arms: Arc::from(arms),
+                }
+            }
+            AirInstData::Break => SemanticBodyInstData::Break,
+            AirInstData::Continue => SemanticBodyInstData::Continue,
+            AirInstData::Alloc { slot, init } => SemanticBodyInstData::Alloc {
+                slot: *slot,
+                init: r(*init, current)?,
+            },
+            AirInstData::Load { slot } => SemanticBodyInstData::Load { slot: *slot },
+            AirInstData::Store { slot, value } => SemanticBodyInstData::Store {
+                slot: *slot,
+                value: r(*value, current)?,
+            },
+            AirInstData::ParamStore { param_slot, value } => SemanticBodyInstData::ParamStore {
+                param_slot: *param_slot,
+                value: r(*value, current)?,
+            },
+            AirInstData::Ret(value) => {
+                SemanticBodyInstData::Ret(value.map(|value| r(value, current)).transpose()?)
+            }
+            AirInstData::Call {
+                runtime,
+                name,
+                args,
+            } => {
+                if let Some(runtime) = runtime {
+                    SemanticBodyInstData::RuntimeCall {
+                        runtime: *runtime,
+                        args: call_args(args)?,
+                    }
+                } else {
+                    match specialized_calls.and_then(|calls| calls.get(name)) {
+                        Some(identity) => SemanticBodyInstData::CallSpecialized {
+                            identity: identity.clone(),
+                            args: call_args(args)?,
+                        },
+                        None => SemanticBodyInstData::Call {
+                            function: host.body_function_identity(*name)?,
+                            args: call_args(args)?,
+                        },
+                    }
+                }
+            }
+            AirInstData::CallGeneric { .. } => return Err(F::UnsupportedGenericCall),
+            AirInstData::Intrinsic {
+                runtime,
+                name,
+                args,
+            } => SemanticBodyInstData::Intrinsic {
+                runtime: *runtime,
+                name: Arc::from(host.resolve_publication_symbol(name)),
+                args: intrinsic_args(args)?,
+            },
+            AirInstData::Param { index } => SemanticBodyInstData::Param { index: *index },
+            AirInstData::Block { statements, value } => SemanticBodyInstData::Block {
+                statements: body
+                    .get_block_statements(statements)
+                    .map(|v| r(v, current))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into(),
+                value: r(*value, current)?,
+            },
+            AirInstData::StructInit {
+                struct_id,
+                fields,
+                source_order,
+            } => SemanticBodyInstData::StructInit {
+                struct_key: host.body_struct_identity(*struct_id)?,
+                fields: body
+                    .get_struct_fields(fields)
+                    .map(|value| r(value, current))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into(),
+                source_order: body
+                    .get_source_order(source_order)
+                    .map(|value| u32::try_from(value).map_err(|_| F::SizeOverflow))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into(),
+            },
+            AirInstData::ArrayInit { elements } => SemanticBodyInstData::ArrayInit {
+                elements: body
+                    .get_array_elements(elements)
+                    .map(|v| r(v, current))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into(),
+            },
+            AirInstData::PlaceRead { place: value } => SemanticBodyInstData::PlaceRead {
+                place: place(*value)?,
+            },
+            AirInstData::PlaceWrite { place: p, value } => SemanticBodyInstData::PlaceWrite {
+                place: place(*p)?,
+                value: r(*value, current)?,
+            },
+            AirInstData::EnumVariant {
+                enum_id,
+                variant_index,
+                payload,
+            } => SemanticBodyInstData::EnumVariant {
+                enum_key: host.body_enum_identity(*enum_id)?,
+                variant_index: *variant_index,
+                payload: body
+                    .get_enum_payload(payload)
+                    .map(|v| r(v, current))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into(),
+            },
+            AirInstData::EnumPayloadGet {
+                base,
+                enum_id,
+                variant_index,
+                field_index,
+            } => SemanticBodyInstData::EnumPayloadGet {
+                base: r(*base, current)?,
+                enum_key: host.body_enum_identity(*enum_id)?,
+                variant_index: *variant_index,
+                field_index: *field_index,
+            },
+            AirInstData::IntCast { value, from_ty } => SemanticBodyInstData::IntCast {
+                value: r(*value, current)?,
+                from_ty: host.export_body_type(*from_ty)?,
+            },
+            AirInstData::Drop { value } => SemanticBodyInstData::Drop {
+                value: r(*value, current)?,
+            },
+            AirInstData::StorageLive { slot } => SemanticBodyInstData::StorageLive { slot: *slot },
+            AirInstData::StorageDead { slot } => SemanticBodyInstData::StorageDead { slot: *slot },
+            AirInstData::MarkMoved {
+                value,
+                slot,
+                is_param,
+                place: p,
+            } => SemanticBodyInstData::MarkMoved {
+                value: r(*value, current)?,
+                slot: *slot,
+                is_param: *is_param,
+                place: p.map(place).transpose()?,
+            },
+        };
+        instructions.push(SemanticBodyInst {
+            data,
+            ty: host.export_body_type(inst.ty)?,
+            anchor: SemanticBodyAnchor {
+                start: inst.span.start - body_span.start,
+                end: inst.span.end - body_span.start,
+            },
+        });
+    }
+
+    let param_drops = body
+        .param_drops()
+        .iter()
+        .map(|(slot, ty)| Ok((*slot, host.export_body_type(*ty)?)))
+        .collect::<Result<Vec<_>, F>>()?;
+    let borrow_slots = (0..analyzed.num_locals)
+        .filter(|slot| body.is_borrow_slot(*slot))
+        .collect::<Vec<_>>();
+    Ok(SemanticBodyExport {
+        owner,
+        body: SemanticBody {
+            return_type: host.export_body_type(body.return_type())?,
+            instructions: Arc::from(instructions),
+            places: Arc::from(places),
+            strings: strings
+                .iter()
+                .map(|value| Arc::from(value.as_str()))
+                .collect(),
+            local_atoms: analyzed
+                .local_atoms
+                .iter()
+                .map(|atom| crate::SemanticBodyLocalAtom {
+                    identity: atom.identity.clone(),
+                    content: atom.content.clone(),
+                })
+                .collect(),
+            param_drops: Arc::from(param_drops),
+            borrow_slots: Arc::from(borrow_slots),
+            num_locals: analyzed.num_locals,
+            num_param_slots: analyzed.num_param_slots,
+            param_by_ref: Arc::from(analyzed.param_modes.by_ref()),
+            param_writable: Arc::from(analyzed.param_modes.writable()),
+            allow_unreachable_code: analyzed.allow_unreachable_code,
+            warnings: warnings.into(),
+        },
+    })
+}
+
+impl SemanticBodyExportHost for BodySema<'_> {
+    fn export_body_type(
+        &self,
+        ty: Type,
+    ) -> Result<SemanticImportType<SemanticDefinitionToken, SemanticModuleToken>, F> {
+        BodySema::export_body_type(self, ty)
+    }
+
+    fn body_struct_identity(
+        &self,
+        id: crate::StructId,
+    ) -> Result<crate::NominalInstanceKey<SemanticDefinitionToken, SemanticModuleToken>, F> {
+        BodySema::body_struct_identity(self, id)
+    }
+
+    fn body_enum_identity(
+        &self,
+        id: crate::EnumId,
+    ) -> Result<crate::NominalInstanceKey<SemanticDefinitionToken, SemanticModuleToken>, F> {
+        BodySema::body_enum_identity(self, id)
+    }
+
+    fn body_function_identity(
+        &self,
+        symbol: Spur,
+    ) -> Result<crate::FunctionInstanceKey<SemanticDefinitionToken, SemanticModuleToken>, F> {
+        BodySema::body_function_identity(self, symbol)
+    }
+
+    fn resolve_publication_symbol(&self, symbol: &Spur) -> &str {
+        self.interner.resolve(symbol)
     }
 }
 


### PR DESCRIPTION
## Summary

- make AIR-to-stable body serialization one non-overridable generic algorithm over narrow identity and type projections
- generalize the canonical ordinary success, deterministic-failure, positive-reference, and produced-anonymous publication funnel over a representation-neutral host
- keep the existing production `BodySema` path as thin point-operation adapters and move anonymous export ordering to a representation-neutral free helper
- add structural inventory that pins the single exporter, exact wrapper routes, publication-host neutrality, and comparator ownership

## Why

The registered provider-backed ordinary-body evaluator cannot publish honestly while stable body export and reference projection are inherent to `BodySema`. This removes that publication-side dependency without adding a provider-specific peer algorithm or claiming the evaluator cutover prematurely. The remaining prerequisite is provider-backed inference/type materialization and callee signature facts for `ProviderBodyAnalysisState`.

## Validation

- `scripts/rue fmt`
- focused AIR publication ownership test (1/1)
- full AIR unit suite (654/654)
- focused compiler one-body/body-transaction tests (4/4)
- `scripts/rue quick` (36/36; zero failures or timeouts)
- independent adversarial review, including semantic-drift and single-authority checks

Part of RUE-1092.
