### PR TITLE
RUE-1154: stream frontend-diff progress and run it as a heavy suite

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -309,6 +309,29 @@ sh_test(
     },
 )
 
+# The independent stage-1 frontend differential: compile `examples/ruelex` with
+# the production compiler, then diff its token dump and AST shape against the
+# production lexer/parser for every corpus file.
+#
+# RUE-1154 moved this here from crates/rue-frontend-diff/BUCK and labeled it.
+# It is a corpus-scale harness — one ruelex compile plus two child processes per
+# corpus file, ~2900 in all, about a minute of wall clock — so leaving it in the
+# crate package had it running inside `buck2 test //crates/...` (contradicting
+# that pattern's unit-only contract, and quick-test.sh's advertised few seconds)
+# and inside the broad `--exclude rue_heavy_suite` pass, contending with every
+# other test on the runner. Heavy-labeled at the root, it runs alone through
+# scripts/ci-heavy-suite like every peer corpus harness.
+sh_test(
+    name = "frontend-diff-test",
+    labels = ["rue_heavy_suite"],
+    test = "//crates/rue-frontend-diff:rue-frontend-diff",
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_FRONTEND_DIFF_CORPUS": "$(location :frontend-diff-corpus)",
+        "RUE_STD_PATH": "$(location :std)/std",
+    },
+)
+
 # A fixed generated differential corpus in every full test run. The generator
 # unit contract pins that seeds 0..63 retain every required fragile source
 # shape; this target then compiles and runs those programs through both the

--- a/crates/rue-frontend-diff/BUCK
+++ b/crates/rue-frontend-diff/BUCK
@@ -11,12 +11,6 @@ rue_binary(
     ],
 )
 
-sh_test(
-    name = "frontend-diff-test",
-    test = ":rue-frontend-diff",
-    env = {
-        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
-        "RUE_FRONTEND_DIFF_CORPUS": "$(location root//:frontend-diff-corpus)",
-        "RUE_STD_PATH": "$(location root//:std)/std",
-    },
-)
+# The corpus differential itself is a repo-level suite and lives in the root
+# BUCK file with its peers (RUE-1154), so `buck2 test //crates/...` keeps
+# meaning "unit tests only".

--- a/crates/rue-frontend-diff/src/main.rs
+++ b/crates/rue-frontend-diff/src/main.rs
@@ -14,7 +14,7 @@ use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const BORROW: u64 = 10;
 const INOUT: u64 = 12;
@@ -25,6 +25,10 @@ const UNDERSCORE: u64 = 95;
 const MANIFEST_PATH: &str = "crates/rue-frontend-diff/src/corpus_manifest.rs";
 const PROCESS_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_CAPTURE_BYTES: usize = 16 * 1024 * 1024;
+/// How often the corpus walk emits a progress checkpoint (RUE-1154). Roughly
+/// fifteen lines over the full corpus: enough to bracket where a killed run
+/// stopped, small enough not to bury a real diagnostic.
+const PROGRESS_INTERVAL: usize = 100;
 const SYNTAX_PROBES: &[(&str, &str)] = &[
     (
         "intrinsic-placeholders.rue",
@@ -1214,11 +1218,32 @@ fn compare_source(frontend: &Path, path: &Path, source: &str) -> Result<(), Stri
     Ok(())
 }
 
+/// Emit a progress checkpoint every [`PROGRESS_INTERVAL`] files and on the last
+/// one, so the final line printed by a killed run brackets where it stopped.
+fn is_progress_checkpoint(index: usize, total: usize) -> bool {
+    index + 1 == total || (index + 1) % PROGRESS_INTERVAL == 0
+}
+
+/// Write one checkpoint to stderr (RUE-1154).
+///
+/// Rust's stderr is unbuffered, so each line reaches Buck's capture pipe before
+/// the next comparison starts. That matters because this harness can die by
+/// signal rather than by returning an error: a SIGKILL is reported by Buck as a
+/// bare `Fail` with empty stdout and stderr, with the signal discarded. Anything
+/// printed only at the end of the run is lost in exactly the case worth
+/// diagnosing, so progress is streamed instead of summarized.
+fn checkpoint(message: &str) {
+    eprintln!("frontend-diff: {message}");
+}
+
 fn run_differential() -> Result<usize, String> {
     let compiler = env::var_os("RUE_BINARY").ok_or("RUE_BINARY is not set")?;
     let corpus =
         PathBuf::from(env::var_os("RUE_FRONTEND_DIFF_CORPUS").unwrap_or_else(|| ".".into()));
+    checkpoint(&format!("auditing corpus at {}", corpus.display()));
     let files = audit_corpus(&corpus, corpus_manifest::ROOTS)?;
+    let total = files.len();
+    checkpoint(&format!("corpus audit passed: {total} files"));
     let root = corpus.join("examples/ruelex/main.rue");
     if !root.is_file() {
         return Err(format!(
@@ -1230,6 +1255,8 @@ fn run_differential() -> Result<usize, String> {
     let frontend = temp.path().join("ruelex");
     let mut compile = Command::new(compiler);
     compile.arg(&root).arg("-o").arg(&frontend);
+    checkpoint(&format!("compiling ruelex from {}", root.display()));
+    let started = Instant::now();
     let compile = bounded_run(compile, "compile ruelex")?;
     if !compile.status.success() {
         return Err(format!(
@@ -1240,17 +1267,33 @@ fn run_differential() -> Result<usize, String> {
             String::from_utf8_lossy(&compile.stderr)
         ));
     }
-    for path in &files {
+    checkpoint(&format!(
+        "ruelex compiled in {:.1}s of a {}s budget",
+        started.elapsed().as_secs_f64(),
+        PROCESS_TIMEOUT.as_secs()
+    ));
+    for (index, path) in files.iter().enumerate() {
         let source =
             fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
         compare_source(&frontend, path, &source)?;
+        if is_progress_checkpoint(index, total) {
+            checkpoint(&format!(
+                "compared {}/{total} corpus files (last: {})",
+                index + 1,
+                path.display()
+            ));
+        }
     }
+    checkpoint(&format!(
+        "corpus agrees; running {} syntax probes",
+        SYNTAX_PROBES.len()
+    ));
     for (name, source) in SYNTAX_PROBES {
         let path = temp.path().join(name);
         fs::write(&path, source).map_err(|error| format!("write {}: {error}", path.display()))?;
         compare_source(&frontend, &path, source)?;
     }
-    Ok(files.len())
+    Ok(total)
 }
 
 enum Success {
@@ -1369,6 +1412,35 @@ mod tests {
         ] {
             assert!(shape.contains(needle), "missing {needle} in {shape}");
         }
+    }
+
+    #[test]
+    fn progress_checkpoints_bracket_the_walk_and_always_include_the_last_file() {
+        let total = 1443;
+        let reported: Vec<usize> = (0..total)
+            .filter(|&index| is_progress_checkpoint(index, total))
+            .map(|index| index + 1)
+            .collect();
+
+        assert_eq!(reported.first(), Some(&PROGRESS_INTERVAL));
+        assert_eq!(
+            reported.last(),
+            Some(&total),
+            "a completed walk must checkpoint its final file"
+        );
+        // Consecutive checkpoints stay within one interval of each other, so a
+        // killed run's last line pins the failure to a bounded window.
+        for pair in reported.windows(2) {
+            assert!(
+                pair[1] - pair[0] <= PROGRESS_INTERVAL,
+                "gap {pair:?} exceeds the checkpoint interval"
+            );
+        }
+    }
+
+    #[test]
+    fn progress_checkpoints_report_a_single_file_corpus() {
+        assert!(is_progress_checkpoint(0, 1));
     }
 
     #[test]

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -256,6 +256,7 @@ if [[ "${1:-}" == "uquery" ]]; then
         printf '%s\n' \
             root//:cli-tests \
             root//:cli-tests-caldera \
+            root//:frontend-diff-test \
             root//:oracle-diff-generated-smoke \
             root//:reproducible-programs \
             root//:spec-tests \
@@ -292,7 +293,7 @@ EOF
     check "suite: monolithic CLI corpus receives the extended executor timeout" \
         "$(grep -Fxq 'test //:cli-tests -- --timeout 1800' "$sb/calls" && echo 0 || echo 1)"
     check "suite: every other heavy target uses the default executor timeout" \
-        "$([ "$(grep -Ec '^test //:(cli-tests-caldera|spec-tests|ui-tests|oracle-diff-generated-smoke|reproducible-programs)$' "$sb/calls")" -eq 5 ] && echo 0 || echo 1)"
+        "$([ "$(grep -Ec '^test //:(cli-tests-caldera|spec-tests|ui-tests|oracle-diff-generated-smoke|reproducible-programs|frontend-diff-test)$' "$sb/calls")" -eq 6 ] && echo 0 || echo 1)"
     check "suite: no concurrent heavy label sweep occurs" \
         "$(! grep -Fq -- '--include rue_heavy_suite' "$sb/calls" && echo 0 || echo 1)"
     check "suite: host lock is released" "$([[ ! -e "$sb/lock" ]] && echo 0 || echo 1)"

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -861,7 +861,7 @@ exit 90
 EOF
   chmod +x "$sb/buck2"
 
-  local all="//:cli-tests //:cli-tests-caldera //:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests"
+  local all="//:cli-tests //:cli-tests-caldera //:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests //:frontend-diff-test"
 
   # (1) Full corpus present + buck2 green -> test.sh reports success.
   local rc=0 out
@@ -871,7 +871,7 @@ EOF
 
   # (2) A corpus harness OMITTED while every buck2 invocation still exits 0 is
   #     the RUE-924 false-green: it must become a hard failure naming the suite.
-  local partial="//:cli-tests-caldera //:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests"
+  local partial="//:cli-tests-caldera //:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests //:frontend-diff-test"
   rc=0
   out="$(cd "$sb" && RUE_CI_DEFER_HEAVY_SUITES= RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$partial" ./test.sh 2>&1)" || rc=$?
   check "test.sh: a silently omitted corpus harness fails the run" \
@@ -891,7 +891,7 @@ EOF
   # (4) Required CI may explicitly defer known live heavy targets to separate
   # jobs. The owning invocation must skip and stop auditing exactly those
   # targets while retaining every other corpus assertion.
-  local owned="//:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests"
+  local owned="//:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests //:frontend-diff-test"
   : >"$sb/calls.log"; rc=0
   out="$(cd "$sb" && CI=true RUE_FULL_SUITE_LOCK_HELD=1 \
       RUE_CI_DEFER_HEAVY_SUITES='//:cli-tests //:cli-tests-caldera //:spec-tests' \

--- a/test.sh
+++ b/test.sh
@@ -91,6 +91,7 @@ REQUIRED_CORPUS_HARNESSES=(
     //:oracle-diff-generated-smoke
     //:reproducible-programs
     //:tutorial-snippet-tests
+    //:frontend-diff-test
 )
 
 if [[ $# -eq 0 ]]; then


### PR DESCRIPTION
`//:frontend-diff-test` has dequeued two unrelated PRs, failing only in `merge_group` runs and emitting nothing — no assertion, no stdout, no stderr.

## What the silence actually is

I reproduced each reporting signature against the real target rather than reasoning from the log excerpt:

| scenario | Buck output | tally |
| -- | -- | -- |
| harness returns `Err` (`RUE_BINARY=/bin/false`) | `✗ Fail:` + **populated** STDERR carrying the diagnostic | `Fail 1` |
| process `kill -9`'d | `✗ Fail:` + **empty** STDOUT *and* STDERR | `Fail 1` |
| executor timeout (`-- --timeout 12`) | `✉ Timeout:` | **`Timeout 1`** |
| normal run | `✓ Pass` | `Pass 1` |

Only a signal death produces the reported signature, and Buck discards the signal itself. The executor timeout is distinguishable and the issue's tally reads `Fail 1`, so it is ruled out.

The harness was never at fault: every failure path in `run_differential` already returns `Err`, and `main` prints it. But it printed **only on completion**, so a kill erased the whole run. That is why two investigations concluded nothing.

## Changes

**Stream progress to stderr.** Corpus audit, ruelex compile time against its budget, and a checkpoint every 100 corpus files. Rust's stderr is unbuffered, so Buck's capture retains everything written before a `SIGKILL` — verified by killing a real run mid-walk (exit 137, zero stdout) and by the `-- --timeout` run above. A killed run now names the phase it died in and brackets the file to a 100-entry window.

**Move the `sh_test` to the root BUCK file and label it `rue_heavy_suite`.** It is a corpus-scale harness — one ruelex compile plus two child processes per corpus file, ~2900 in all, **43–55s** of wall clock measured — and was the only compiler-consuming corpus harness left unlabeled, so it ran inside the broad `--exclude rue_heavy_suite` pass contending with every other test on the runner. That contention is the setting for the kills, and it explains the `merge_group` correlation better than materialization does: a fork `pull_request` run has no cache key and spends the job building, while a 100%-cache-hit `merge_group` run makes all 64 tests runnable at once on a machine that just pulled 876 MiB. Cache hits don't cause bad materialization — they cause maximum test concurrency.

The root BUCK file is also where it belonged. Its own comment explains these suites live there so `buck2 test //crates/...` still means unit tests only — but this target sat in the crate package, so `quick-test.sh` was pulling the full differential into the run it advertises as taking a few seconds. Relocating also satisfies `scripts/ci-heavy-suite`, which accepts only `//:` targets and is how `test.sh` dispatches every heavy suite; labeling in place would have failed with exit 2.

**Add it to `REQUIRED_CORPUS_HARNESSES`** so a silent omission fails the run (RUE-924), and update the two fixtures that pin the corpus set.

## On the issue's other suggestions

Two are already closed on trunk and one is refuted as an explanation of the symptom:

- *Confirm the corpus materializes completely* — cannot produce silence. `audit_corpus` compares the materialized tree name-by-name against `corpus_manifest.rs` and reports missing roots / removed / added paths. Incomplete materialization gives a long, specific error, so the RUE-1152 silent-skip class cannot reproduce here.
- *Audit the corpus for missing subpackage entries* — nothing missing. On-disk `.rue` count and manifest entries both 1443; the only subpackage under the globbed roots (`benchmarks/scenarios/representative`) has all 8 files hand-listed and present.
- *Check for resource exhaustion* — not the harness: peak RSS 21 MB, peak 8 open fds across 2886 sequential spawns. Heaviest child is the `rue` compile of ruelex at 89 MB. I also checked the `kill_process_group` self-kill theory; `process_group(0)` + `kill(-pid)` is correct.

This does not claim to have found what sends the signal. It removes the most likely source of contention and makes the next occurrence self-describing, which the issue calls the most valuable fix regardless of root cause.

## Follow-up

RUE-1156 tracks a separate finding from this investigation: `test_rule_timeout_ms` is inert under the OSS Buck test executor — a 30s test under `test_rule_timeout_ms = 3000` passes at 30.0s with `Timeout 0`. `//:oracle-diff-generated-smoke` sets `test_rule_timeout_ms = 600000` and its comment claims an outer margin it does not have. Left alone here to keep this change scoped.

## Validation

- `fmt.sh check` — 281 files clean
- `clippy.sh` — 66 targets, no violations
- `//crates/rue-frontend-diff:rue-frontend-diff-test` — 11/11, including two new tests for the checkpoint schedule
- `//:wrapper-script-tests` + `//:build-sharing-tests` — 83 checks green after fixture updates
- `scripts/ci-heavy-suite //:frontend-diff-test` — the new dispatch path end to end: label check, run, result audit, exit 0
- unfiltered `./test.sh` — `=== TEST SUITE: PASSED ===`, exit 0. `//:frontend-diff-test` ran in the heavy-suite sequence at its new path and passed (43.6s), and the RUE-924 corpus audit was satisfied with it in the required set.

Fixes RUE-1154
