### PR TITLE
RUE-1157: define canonical Buck test tiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Check production debug assertions
         run: scripts/validate-debug-assert-policy.py
 
+      - name: Validate Buck test-tier ownership
+        run: ./buck2 bxl //test_tiers.bxl:validate
+
   clippy:
     runs-on: ubuntu-latest
     steps:
@@ -210,6 +213,7 @@ jobs:
         # target in one invocation.
         env:
           RUE_CI_DEFER_HEAVY_SUITES: '//:cli-tests //:cli-tests-caldera //:spec-tests'
+          RUE_CI_DEFER_DEDICATED_SUITES: '//crates/rue-compiler:scaling-matrix-test'
         run: scripts/ci-timed "${{ matrix.name }} tests" -- ./test.sh
 
   # RUE-617/RUE-1019: keep the byte-reproducibility proof independent of the

--- a/BUCK
+++ b/BUCK
@@ -22,6 +22,8 @@
 # files so that `buck2 test //crates/...` (quick-test.sh, test.sh's filtered
 # path) still means "unit tests only".
 
+load("//:test_defs.bzl", "rue_sh_test", "rue_test_suite")
+
 # The formatting gate lives in fmt.sh, not here. A `fmt-check` sh_test used to
 # sit at this spot, taking its file list from `glob(["crates/**/*.rs"])`. A
 # Buck glob does not descend into subpackages, and all 30 crates that own a
@@ -164,7 +166,7 @@ filegroup(
     ]),
 )
 
-sh_test(
+rue_sh_test(
     name = "spec-tests",
     labels = ["rue_heavy_suite"],
     test = "//crates/rue-spec:rue-spec",
@@ -176,7 +178,7 @@ sh_test(
     },
 )
 
-sh_test(
+rue_sh_test(
     name = "spec-traceability",
     test = "//crates/rue-spec:rue-spec",
     args = ["--traceability"],
@@ -186,7 +188,7 @@ sh_test(
     },
 )
 
-sh_test(
+rue_sh_test(
     name = "ui-tests",
     labels = ["rue_heavy_suite"],
     test = "//crates/rue-ui-tests:rue-ui-tests",
@@ -226,7 +228,7 @@ _CLI_TEST_ENV = {
 # The full CLI corpus in one invocation: the canonical target that a local
 # `./test.sh` full run executes and that the RUE-924 corpus-omission audit
 # tracks (REQUIRED_CORPUS_HARNESSES in test.sh).
-sh_test(
+rue_sh_test(
     name = "cli-tests",
     labels = ["rue_heavy_suite"],
     test = "//crates/rue-cli-tests:rue-cli-tests",
@@ -239,7 +241,7 @@ sh_test(
 # differential-opt corpus through that release-built compiler. The scheduled
 # full-release workflow owns exhaustive //... coverage off the PR critical
 # path (RUE-1129).
-sh_test(
+rue_sh_test(
     name = "release-smoke",
     test = "//crates/rue-cli-tests:rue-cli-tests",
     args = ["--quiet", "differential_opt"],
@@ -261,7 +263,7 @@ sh_test(
 CLI_TEST_SHARD_COUNT = 4
 
 [
-    sh_test(
+    rue_sh_test(
         name = "cli-tests-shard-{}".format(_shard),
         labels = ["rue_heavy_suite", "rue_cli_shard"],
         test = "//crates/rue-cli-tests:rue-cli-tests",
@@ -284,7 +286,7 @@ CLI_TEST_SHARD_COUNT = 4
 # UTC). This exact target stays a transparent success stub until the
 # remaining per-body incremental work brings the stress compile back into a
 # reasonable budget. Every other example family runs real cases above.
-sh_test(
+rue_sh_test(
     name = "cli-tests-caldera",
     labels = ["rue_heavy_suite"],
     test = "//crates/rue-cli-tests:rue-cli-tests",
@@ -297,7 +299,7 @@ sh_test(
 # RUE-1083: `examples/` is a declared input because this suite now also checks a
 # real maintained program (rill) for byte-stable output, not just the
 # purpose-built fixture. An edit under examples/ must therefore re-run it.
-sh_test(
+rue_sh_test(
     name = "reproducible-programs",
     labels = ["rue_heavy_suite"],
     test = "scripts/test-reproducible-output.sh",
@@ -321,7 +323,7 @@ sh_test(
 # and inside the broad `--exclude rue_heavy_suite` pass, contending with every
 # other test on the runner. Heavy-labeled at the root, it runs alone through
 # scripts/ci-heavy-suite like every peer corpus harness.
-sh_test(
+rue_sh_test(
     name = "frontend-diff-test",
     labels = ["rue_heavy_suite"],
     test = "//crates/rue-frontend-diff:rue-frontend-diff",
@@ -337,7 +339,7 @@ sh_test(
 # shape; this target then compiles and runs those programs through both the
 # reference oracle and native codegen. It lives at the root so full/no-argument
 # `test.sh` and CI include it while `quick-test.sh` remains unit-only.
-sh_test(
+rue_sh_test(
     name = "oracle-diff-generated-smoke",
     labels = ["rue_heavy_suite"],
     test = "scripts/oracle-diff-generated-smoke.sh",
@@ -350,7 +352,7 @@ sh_test(
     test_rule_timeout_ms = 600000,
 )
 
-sh_test(
+rue_sh_test(
     name = "tutorial-snippet-tests",
     test = "scripts/check-tutorial-snippets.py",
     args = [
@@ -363,7 +365,7 @@ sh_test(
     },
 )
 
-sh_test(
+rue_sh_test(
     name = "tutorial-snippet-tool-tests",
     test = "scripts/test-tutorial-snippets.py",
     env = {
@@ -372,7 +374,7 @@ sh_test(
     },
 )
 
-sh_test(
+rue_sh_test(
     name = "adr-registry-validation",
     test = "scripts/validate-adrs.py",
     args = [
@@ -381,13 +383,13 @@ sh_test(
     ],
 )
 
-sh_test(
+rue_sh_test(
     name = "required-ci-container-pin-validation",
     test = "scripts/validate-required-ci-container-pins.py",
     args = ["$(location :required-ci-workflows)/.github/workflows/ci.yml"],
 )
 
-sh_test(
+rue_sh_test(
     name = "required-ci-container-pin-tool-tests",
     test = "scripts/test-required-ci-container-pins.py",
     resources = ["scripts/validate-required-ci-container-pins.py"],
@@ -396,7 +398,7 @@ sh_test(
     },
 )
 
-sh_test(
+rue_sh_test(
     name = "debug-assert-policy-tool-tests",
     test = "scripts/test-debug-assert-policy.py",
     env = {
@@ -404,7 +406,7 @@ sh_test(
     },
 )
 
-sh_test(
+rue_sh_test(
     name = "release-configuration-tool-tests",
     test = "scripts/test-release-configuration.py",
     env = {
@@ -423,7 +425,7 @@ filegroup(
 # listed in the required CI matrix drift apart. A shard present in BUCK but
 # missing from the matrix would silently drop that fraction of the corpus on CI
 # (the RUE-924 false-green failure mode), since nothing else re-runs the slices.
-sh_test(
+rue_sh_test(
     name = "cli-shard-coverage-validation",
     test = "scripts/validate-cli-shard-coverage.py",
     args = [
@@ -434,7 +436,7 @@ sh_test(
     ],
 )
 
-sh_test(
+rue_sh_test(
     name = "cli-shard-coverage-tool-tests",
     test = "scripts/test-cli-shard-coverage.py",
     resources = ["scripts/validate-cli-shard-coverage.py"],
@@ -448,7 +450,7 @@ sh_test(
 # scripts/affected-targets and the fail-open gate in scripts/ci-corpus-selected.
 # The test uses local stubs for the BTD/Buck contract, so it proves a selective
 # decision without requiring a network download or a real Buck graph.
-sh_test(
+rue_sh_test(
     name = "affected-targets-tool-tests",
     test = "scripts/test-affected-targets.sh",
     resources = [
@@ -459,7 +461,7 @@ sh_test(
     ],
 )
 
-sh_test(
+rue_sh_test(
     name = "runtime-abi-inventory-validation",
     test = "scripts/validate-runtime-abi-inventory.py",
     args = [
@@ -473,7 +475,7 @@ sh_test(
     ],
 )
 
-sh_test(
+rue_sh_test(
     name = "runtime-abi-inventory-tool-tests",
     test = "scripts/test-runtime-abi-inventory.py",
     resources = ["scripts/validate-runtime-abi-inventory.py"],
@@ -482,7 +484,7 @@ sh_test(
     },
 )
 
-sh_test(
+rue_sh_test(
     name = "type-architecture-inventory-validation",
     test = "scripts/validate-type-architecture.py",
     args = [
@@ -495,7 +497,7 @@ sh_test(
     ],
 )
 
-sh_test(
+rue_sh_test(
     name = "type-architecture-inventory-tool-tests",
     test = "scripts/test-type-architecture.py",
     resources = ["scripts/validate-type-architecture.py"],
@@ -504,7 +506,7 @@ sh_test(
     },
 )
 
-sh_test(
+rue_sh_test(
     name = "payload-ownership-inventory-validation",
     test = "scripts/validate-payload-ownership.py",
     args = [
@@ -515,7 +517,7 @@ sh_test(
     ],
 )
 
-sh_test(
+rue_sh_test(
     name = "payload-ownership-inventory-tool-tests",
     test = "scripts/test-payload-ownership.py",
     resources = ["scripts/validate-payload-ownership.py"],
@@ -524,7 +526,7 @@ sh_test(
     },
 )
 
-sh_test(
+rue_sh_test(
     name = "body-analysis-capability-inventory-validation",
     test = "scripts/validate-body-analysis-capabilities.py",
     args = [
@@ -533,7 +535,7 @@ sh_test(
     ],
 )
 
-sh_test(
+rue_sh_test(
     name = "body-analysis-capability-inventory-tool-tests",
     test = "scripts/test-body-analysis-capabilities.py",
     resources = ["scripts/validate-body-analysis-capabilities.py"],
@@ -542,12 +544,12 @@ sh_test(
     },
 )
 
-test_suite(
+rue_test_suite(
     name = "payload-ownership-compile-fail-tests",
     tests = ["//crates/rue-rir:rue-rir[doc]"],
 )
 
-sh_test(
+rue_sh_test(
     name = "benchmark-tool-tests",
     test = "scripts/test-benchmark-tools.py",
     env = {
@@ -560,7 +562,7 @@ sh_test(
 # RUE-1091: the value-audit protocol and adversarial fail-closed tests are
 # repository gates. Declare every script and checked-in manifest they import so
 # Buck cannot reuse a result after the protocol or fixture changes.
-sh_test(
+rue_sh_test(
     name = "value-audit-tool-tests",
     test = "scripts/test-value-audit.py",
     resources = [
@@ -587,7 +589,7 @@ filegroup(
     ],
 )
 
-sh_test(
+rue_sh_test(
     name = "cleanup-script-tests",
     test = "scripts/test-cleanup-scripts.sh",
     env = {
@@ -619,7 +621,7 @@ filegroup(
     ],
 )
 
-sh_test(
+rue_sh_test(
     name = "wrapper-script-tests",
     test = "scripts/test-wrapper-scripts.sh",
     env = {
@@ -639,7 +641,7 @@ filegroup(
     ],
 )
 
-sh_test(
+rue_sh_test(
     name = "build-sharing-tests",
     test = "scripts/test-build-sharing.sh",
     env = {

--- a/crates/defs.bzl
+++ b/crates/defs.bzl
@@ -21,10 +21,13 @@
 # (toolchains/rust/BUCK sets `deny_lints = ["warnings"]`), so these macros
 # do not pass any per-target lint flags.
 
+load("//:test_defs.bzl", "rue_test_labels")
+
 def rue_crate(
         name,
         deps = [],
         test_deps = [],
+        test_tier = "premerge",
         tests = True,
         visibility = ["PUBLIC"],
         **kwargs):
@@ -48,6 +51,7 @@ def rue_crate(
             name = name + "-test",
             srcs = srcs,
             deps = deps + test_deps,
+            labels = rue_test_labels(test_tier),
             **kwargs
         )
 
@@ -55,6 +59,7 @@ def rue_binary(
         name,
         deps = [],
         test_deps = [],
+        test_tier = "premerge",
         tests = True,
         visibility = ["PUBLIC"],
         **kwargs):
@@ -77,5 +82,6 @@ def rue_binary(
             name = name + "-test",
             srcs = srcs,
             deps = deps + test_deps,
+            labels = rue_test_labels(test_tier),
             **kwargs
         )

--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -1,4 +1,5 @@
 load("//crates:defs.bzl", "rue_crate")
+load("//:test_defs.bzl", "rue_rust_test")
 
 filegroup(
     name = "runtime-abi-inventory-sources",
@@ -71,8 +72,9 @@ rue_crate(
 # target excludes. CI runs this as its own job, filtered to `scaling_matrix`, so
 # only the matrix cases execute here. Marking the CI check required in branch
 # protection is a maintainer action.
-rust_test(
+rue_rust_test(
     name = "scaling-matrix-test",
+    labels = ["rue_dedicated_suite"],
     srcs = glob(["src/**/*.rs"]),
     mapped_srcs = _RUNTIME_MAPPED_SRCS,
     deps = _DEPS,
@@ -85,7 +87,7 @@ rust_test(
 
 # Compiles against rue-compiler as an external crate so curated reexports and
 # visibility cannot be satisfied accidentally by crate-private test access.
-rust_test(
+rue_rust_test(
     name = "rue-compiler-public-api-test",
     srcs = ["tests/public_api.rs"],
     crate_root = "tests/public_api.rs",
@@ -98,7 +100,7 @@ rust_test(
 # A bounded, deterministic corpus comparing a long-lived session with
 # step-matched fresh sessions. Keeping this separate gives local and CI callers
 # a focused regression target for incremental correctness.
-rust_test(
+rue_rust_test(
     name = "rue-compiler-differential-oracle-test",
     srcs = ["tests/differential_oracle.rs"],
     crate_root = "tests/differential_oracle.rs",
@@ -113,7 +115,7 @@ rust_test(
 
 # Cross-phase payload-schema verification. This intentionally compiles as an
 # external consumer so it can exercise only production publication/query APIs.
-rust_test(
+rue_rust_test(
     name = "rue-compiler-payload-schema-test",
     srcs = ["tests/payload_schemas.rs"],
     crate_root = "tests/payload_schemas.rs",

--- a/crates/rue-oracle-diff/BUCK
+++ b/crates/rue-oracle-diff/BUCK
@@ -1,4 +1,5 @@
 load("//crates:defs.bzl", "rue_binary")
+load("//:test_defs.bzl", "rue_sh_test")
 
 # The differential harness. Two modes:
 #  * default: runs the concrete rue-cli-tests corpus through the rue-oracle
@@ -47,8 +48,9 @@ rue_binary(
 # violations fail the harness; only typed model gaps remain coverage debt.
 # Preview-gated cases run when their declared preview flags can be mapped onto
 # the single-source oracle.
-sh_test(
+rue_sh_test(
     name = "oracle-diff-test",
+    labels = ["rue_not_quick"],
     test = ":rue-oracle-diff",
     env = {
         "RUE_ORACLE_DIFF_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
@@ -62,8 +64,9 @@ sh_test(
 # are expanded via rue-test-runner; golden-IR-only / compile-fail cases are
 # skipped by the harness, not counted as disagreements. Preview-gated cases run
 # with their declared preview feature.
-sh_test(
+rue_sh_test(
     name = "oracle-diff-spec-test",
+    labels = ["rue_not_quick"],
     test = ":rue-oracle-diff",
     args = ["spec"],
     env = {

--- a/crates/rue-runtime/BUCK
+++ b/crates/rue-runtime/BUCK
@@ -1,4 +1,5 @@
 load("//crates:defs.bzl", "rue_crate")
+load("//:test_defs.bzl", "rue_rust_test", "rue_sh_test")
 load(
     ":runtime.bzl",
     "RUNTIME_AARCH64_RUSTC_FLAGS",
@@ -53,8 +54,9 @@ runtime_staticlib(
     visibility = ["PUBLIC"],
 )
 
-sh_test(
+rue_sh_test(
     name = "runtime-archives-test",
+    labels = ["rue_not_quick"],
     test = "tests/validate_runtime_archives.py",
     env = {
         "RUNTIME_X86_64_LINUX": "$(location :rue-runtime-x86_64-unknown-linux-gnu)",
@@ -68,7 +70,7 @@ sh_test(
 # runtime. The crate is test-aware (the panic handler and _start/_main entry
 # points are #[cfg(not(test))]), and only the host's platform module compiles,
 # so each CI platform exercises its own syscall layer.
-rust_test(
+rue_rust_test(
     name = "rue-runtime-test",
     srcs = glob(["src/**/*.rs"]),
     crate = "rue_runtime",
@@ -81,8 +83,9 @@ rust_test(
 # The x86-64 Linux entry point is raw process-entry code and cannot be exercised
 # by libtest. Inspect the optimized staticlib and link a real Rue program through
 # a register probe at the kernel, helper, and generated-main boundaries.
-sh_test(
+rue_sh_test(
     name = "x86-64-linux-entry-test",
+    labels = ["rue_not_quick"],
     test = "tests/test-x86-64-linux-entry.sh",
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -40,6 +40,34 @@ code generation, and linking have no allowances: an invariant whose violation
 could change emitted code must be an always-on assertion or a real compiler
 diagnostic.
 
+## Test execution tiers
+
+Every first-party Buck test target carries exactly one execution-tier label:
+`rue_test_tier_premerge`, `rue_test_tier_slow`, or
+`rue_test_tier_stress`. The wrappers in `test_defs.bzl` attach those labels to
+repository, crate, and toolchain tests; generated crate unit tests default to
+`premerge`. A test that belongs outside pre-merge must opt into `slow` or
+`stress` at its definition rather than returning success from a skipped body.
+
+`./buck2 bxl //test_tiers.bxl:validate` queries Buck's live first-party test
+graph and fails unless every target has exactly one tier. Required formatting
+CI runs that validation, so adding a raw test rule or conflicting tier label
+cannot silently change suite ownership. Vendored `//third-party/...` targets
+are excluded because their generated BUCK metadata is upstream-owned.
+
+Execution tier and scheduling are separate concerns. A required pre-merge test
+may also carry `rue_heavy_suite` or `rue_dedicated_suite` so it runs in an
+isolated lane without being misrepresented as scheduled-only coverage.
+`scripts/rue quick` excludes non-unit integration harnesses via
+`rue_not_quick` and dedicated suites such as the structural scaling matrix.
+The full local suite still discovers and runs them once. Required CI
+sets `RUE_CI_DEFER_DEDICATED_SUITES` to the exact live set of
+`rue_dedicated_suite` targets, so the platform broad passes exclude work owned
+by explicit parallel jobs. `test.sh` fails unless the environment and Buck
+graph match exactly; a new dedicated target therefore cannot be silently
+dropped. The scaling matrix now runs only in its dedicated Linux job instead
+of once in each platform broad pass and then again in that job.
+
 The platform test lanes all retain broad target discovery. Every platform
 (linux-x64, linux-arm64, macOS) defers its three heaviest corpora —
 `//:cli-tests`, `//:cli-tests-caldera`, and `//:spec-tests` — to explicit

--- a/quick-test.sh
+++ b/quick-test.sh
@@ -15,11 +15,20 @@ cd "$(dirname "$0")"
 echo "Checking production debug-assertion policy..."
 scripts/validate-debug-assert-policy.py
 
+echo "Checking Buck test-tier ownership..."
+./buck2 bxl //test_tiers.bxl:validate
+
 echo "Running unit tests (quick mode)..."
 # Run every crate's unit tests; //... avoids a hand-maintained list that
 # silently goes stale as crates are added; scoping to //crates/ keeps vendored
-# third-party targets out of the test set. (RUE-132)
-./buck2 test //crates/...
+# third-party targets out of the test set. Non-unit integration harnesses and
+# dedicated suites such as the structural scaling matrix run in full/CI
+# coverage, not fast iteration.
+# (RUE-132, RUE-1157)
+./buck2 test //crates/... \
+    --exclude rue_not_quick \
+    --exclude rue_dedicated_suite \
+    --always-exclude
 
 echo ""
 echo "Unit tests passed! Run ./test.sh for full verification before committing."

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -835,10 +835,11 @@ test_testsh_unfiltered_audits_corpus_presence() {
 #!/usr/bin/env bash
 if [ "$1" = "uquery" ]; then
   # RUE-1116: test.sh issues a second uquery for the rue_cli_shard set and
-  # subtracts it from heavy-suite discovery. Serve FAKE_CLI_SHARDS (empty by
-  # default) for that query and FAKE_HEAVY_SUITES for the rue_heavy_suite one.
+  # subtracts it from heavy-suite discovery. RUE-1157 adds a dedicated-suite
+  # ownership query when required CI defers those tests to explicit jobs.
   case "$*" in
     *rue_cli_shard*) for t in ${FAKE_CLI_SHARDS:-}; do printf 'root%s\n' "$t"; done ;;
+    *rue_dedicated_suite*) for t in ${FAKE_DEDICATED_SUITES:-}; do printf 'root%s\n' "$t"; done ;;
     *) for t in $FAKE_HEAVY_SUITES; do printf 'root%s\n' "$t"; done ;;
   esac
   exit 0
@@ -902,7 +903,28 @@ EOF
   check "test.sh: deferred suites are not executed by the owning shard" \
     "$(! grep -Eq '^test (root)?//:(cli-tests(-caldera)?|spec-tests)' "$sb/calls.log" && echo 0 || echo 1)"
 
-  # (5) A stale shard name or local attempt to suppress coverage fails closed.
+  # (5) Dedicated pre-merge coverage may leave the broad CI pass only when the
+  # workflow-owned set exactly matches Buck's live scheduling metadata.
+  : >"$sb/calls.log"; rc=0
+  out="$(cd "$sb" && CI=true RUE_FULL_SUITE_LOCK_HELD=1 \
+      RUE_CI_DEFER_HEAVY_SUITES= \
+      RUE_CI_DEFER_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
+      FAKE_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
+      FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" \
+      FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
+  check "test.sh: required CI may defer the exact live dedicated-suite set" \
+    "$([ "$rc" -eq 0 ] && grep -Fq -- '--exclude rue_dedicated_suite' "$sb/calls.log" && echo 0 || echo 1)"
+
+  rc=0
+  out="$(cd "$sb" && CI=true RUE_FULL_SUITE_LOCK_HELD=1 \
+      RUE_CI_DEFER_HEAVY_SUITES= \
+      RUE_CI_DEFER_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
+      FAKE_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test //:unowned-dedicated' \
+      FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
+  check "test.sh: a live dedicated target without a CI owner fails closed" \
+    "$([ "$rc" -ne 0 ] && grep -Fq 'has no explicit CI owner' <<<"$out" && echo 0 || echo 1)"
+
+  # (6) A stale shard name or local attempt to suppress coverage fails closed.
   rc=0
   out="$(cd "$sb" && CI=true RUE_FULL_SUITE_LOCK_HELD=1 \
       RUE_CI_DEFER_HEAVY_SUITES='//:missing-suite' \
@@ -917,7 +939,16 @@ EOF
   check "test.sh: local callers cannot defer corpus coverage" \
     "$([ "$rc" -ne 0 ] && grep -Fq 'reserved for required CI' <<<"$out" && echo 0 || echo 1)"
 
-  # (6) RUE-1116: the CI-only CLI shards are labeled rue_heavy_suite but must be
+  rc=0
+  out="$(cd "$sb" && CI= RUE_FULL_SUITE_LOCK_HELD=1 \
+      RUE_CI_DEFER_HEAVY_SUITES= \
+      RUE_CI_DEFER_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
+      FAKE_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
+      FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
+  check "test.sh: local callers cannot defer dedicated coverage" \
+    "$([ "$rc" -ne 0 ] && grep -Fq 'reserved for required CI' <<<"$out" && echo 0 || echo 1)"
+
+  # (7) RUE-1116: the CI-only CLI shards are labeled rue_heavy_suite but must be
   #     excluded from a local full run, which covers their union once via the
   #     monolithic //:cli-tests. The run still succeeds (full corpus present).
   local with_shards="$all //:cli-tests-shard-0 //:cli-tests-shard-1"

--- a/test.sh
+++ b/test.sh
@@ -164,7 +164,40 @@ if [[ $# -eq 0 ]]; then
     overall_status=0
     set +e
     echo "Running unit tests and lightweight repository checks..."
-    ./buck2 test //... --exclude rue_heavy_suite --always-exclude 2>&1 | tee "$run_log"
+    broad_test_args=(//... --exclude rue_heavy_suite --always-exclude)
+    if [[ -n "${RUE_CI_DEFER_DEDICATED_SUITES:-}" ]]; then
+        if [[ "${CI:-}" != "true" ]]; then
+            echo "error: RUE_CI_DEFER_DEDICATED_SUITES is reserved for required CI" >&2
+            exit 1
+        fi
+
+        # Dedicated targets remain pre-merge coverage, but their explicit CI
+        # jobs must not also execute inside every platform's broad pass. Require
+        # the workflow's declared set to match Buck's live scheduling metadata
+        # exactly before excluding the label, so a newly tagged target cannot
+        # disappear behind a stale environment variable.
+        dedicated_targets="$(./buck2 uquery 'attrfilter(labels, rue_dedicated_suite, //...)')"
+        read -r -a deferred_dedicated <<<"$RUE_CI_DEFER_DEDICATED_SUITES"
+        for deferred in "${deferred_dedicated[@]}"; do
+            if ! grep -Fxq "root${deferred#root}" <<<"$dedicated_targets"; then
+                echo "error: deferred CI target is not labeled rue_dedicated_suite: $deferred" >&2
+                exit 1
+            fi
+        done
+        while IFS= read -r dedicated; do
+            [[ -n "$dedicated" ]] || continue
+            found=0
+            for deferred in "${deferred_dedicated[@]}"; do
+                [[ "${dedicated#root}" == "${deferred#root}" ]] && found=1
+            done
+            if [[ "$found" -ne 1 ]]; then
+                echo "error: dedicated Buck target has no explicit CI owner: $dedicated" >&2
+                exit 1
+            fi
+        done <<<"$dedicated_targets"
+        broad_test_args+=(--exclude rue_dedicated_suite)
+    fi
+    ./buck2 test "${broad_test_args[@]}" 2>&1 | tee "$run_log"
     step_status=${PIPESTATUS[0]}
     [[ "$step_status" -ne 0 && "$overall_status" -eq 0 ]] && overall_status=$step_status
     for suite in "${HEAVY_SUITES[@]}"; do

--- a/test_defs.bzl
+++ b/test_defs.bzl
@@ -1,0 +1,55 @@
+"""Shared metadata wrappers for Rue's first-party Buck test targets."""
+
+TEST_TIER_PREMERGE = "rue_test_tier_premerge"
+TEST_TIER_SLOW = "rue_test_tier_slow"
+TEST_TIER_STRESS = "rue_test_tier_stress"
+
+_TEST_TIER_LABELS = {
+    "premerge": TEST_TIER_PREMERGE,
+    "slow": TEST_TIER_SLOW,
+    "stress": TEST_TIER_STRESS,
+}
+
+def rue_test_labels(tier, labels = []):
+    """Returns labels with exactly one validated Rue execution tier."""
+    if tier not in _TEST_TIER_LABELS:
+        fail("unknown Rue test tier '{}'; expected one of {}".format(
+            tier,
+            sorted(_TEST_TIER_LABELS.keys()),
+        ))
+
+    caller_tiers = [
+        label
+        for label in labels
+        if label in _TEST_TIER_LABELS.values()
+    ]
+    if caller_tiers:
+        fail("pass tier = instead of adding Rue test-tier labels directly: {}".format(
+            caller_tiers,
+        ))
+
+    return labels + [_TEST_TIER_LABELS[tier]]
+
+def rue_sh_test(name, tier = "premerge", labels = [], **kwargs):
+    """Defines a sh_test with explicit Rue execution-tier ownership."""
+    native.sh_test(
+        name = name,
+        labels = rue_test_labels(tier, labels),
+        **kwargs
+    )
+
+def rue_rust_test(name, tier = "premerge", labels = [], **kwargs):
+    """Defines a rust_test with explicit Rue execution-tier ownership."""
+    native.rust_test(
+        name = name,
+        labels = rue_test_labels(tier, labels),
+        **kwargs
+    )
+
+def rue_test_suite(name, tier = "premerge", labels = [], **kwargs):
+    """Defines a test_suite with explicit Rue execution-tier ownership."""
+    native.test_suite(
+        name = name,
+        labels = rue_test_labels(tier, labels),
+        **kwargs
+    )

--- a/test_tiers.bxl
+++ b/test_tiers.bxl
@@ -1,0 +1,55 @@
+"""Buck-graph validation for Rue's first-party test execution tiers."""
+
+_TEST_TIER_LABELS = [
+    "rue_test_tier_premerge",
+    "rue_test_tier_slow",
+    "rue_test_tier_stress",
+]
+
+def _validate(ctx):
+    # Vendored third-party tests follow their upstream-generated BUCK metadata.
+    # Rue owns every other test target in the cell and requires it to declare
+    # exactly one execution tier.
+    tests = ctx.uquery().eval(
+        'kind("^(.*_test|test_suite)$", //...) except //third-party/...',
+    ) + ctx.uquery().eval(
+        'kind("^(.*_test|test_suite)$", toolchains//...)',
+    )
+
+    errors = []
+    counts = {}
+    for tier in _TEST_TIER_LABELS:
+        counts[tier] = 0
+
+    for test in tests:
+        labels = test.get_attr("labels")
+        target_tiers = [
+            tier
+            for tier in _TEST_TIER_LABELS
+            if tier in labels
+        ]
+        if len(target_tiers) != 1:
+            errors.append("{} has {}; expected exactly one Rue test tier".format(
+                test.label,
+                target_tiers,
+            ))
+        else:
+            counts[target_tiers[0]] += 1
+
+    if errors:
+        fail("invalid Rue test-tier ownership:\n{}".format(
+            "\n".join(sorted(errors)),
+        ))
+
+    ctx.output.print(
+        "Rue test tiers valid: {} premerge, {} slow, {} stress".format(
+            counts["rue_test_tier_premerge"],
+            counts["rue_test_tier_slow"],
+            counts["rue_test_tier_stress"],
+        ),
+    )
+
+validate = bxl_main(
+    impl = _validate,
+    cli_args = {},
+)

--- a/toolchains/rust/BUCK
+++ b/toolchains/rust/BUCK
@@ -4,13 +4,14 @@
 # The toolchain includes rustc, cargo, rust-lld, and the standard library.
 
 load(":defs.bzl", "RUST_VERSION", "RUST_RELEASES", "RUST_STD_RELEASES", "hermetic_rust_toolchain", "rustfmt", "host_rustfmt")
+load("@root//:test_defs.bzl", "rue_sh_test")
 
 export_file(
     name = "merge-sysroot",
     src = "merge_sysroot.sh",
 )
 
-sh_test(
+rue_sh_test(
     name = "merge-sysroot-test",
     test = "merge_sysroot_test.sh",
     args = ["$(location :merge-sysroot)"],


### PR DESCRIPTION
## Summary

- add shared Buck wrappers that assign every first-party test exactly one premerge, slow, or stress execution tier
- validate tier ownership against the live Buck graph in quick tests and required CI
- distinguish execution tier from scheduling metadata, keeping the scaling matrix required while removing it from duplicate platform-wide broad passes
- keep non-unit differential and runtime harnesses in full coverage without running them during quick iteration
- document the tier and dedicated-suite contracts

## Why

Rue's test membership was implicit in target location, shell entrypoints, and CI-specific exclusions. That made it difficult to tell whether a test was required, scheduled, or accidentally omitted, and caused the structural scaling matrix to run redundantly in each platform lane plus its dedicated job.

This establishes graph-validated ownership and makes CI deferral fail closed when the workflow's declared dedicated set differs from Buck's live metadata.

## Validation

- `scripts/rue quick` — 30 targets passed in about 13 seconds
- `./buck2 bxl //test_tiers.bxl:validate` — 73 premerge, 0 slow, 0 stress
- `./buck2 test //:wrapper-script-tests //:spec-traceability toolchains//rust:merge-sysroot-test`
- `./buck2 build //crates/rue-compiler:scaling-matrix-test`
- `git diff --check`

Refs RUE-1157. Canonical named tier entrypoints and initial real slow/stress membership remain follow-up work; RUE-1162 separately owns restoring real Caldera/Meridian coverage.
