### PR TITLE
RUE-1092: flip the production body path onto the provider host

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -1729,6 +1729,21 @@ impl TypeInternPool {
         }
     }
 
+    /// The relocation-stable logical identity of one defining source file.
+    ///
+    /// Keyed and exact: a caller that has a file in hand asks for that file,
+    /// never for the table. The provider-backed body receiver renders stable
+    /// symbol components through this, and its table holds only the modules
+    /// that body consulted.
+    pub(crate) fn symbol_path(&self, file: FileId) -> Option<String> {
+        self.inner
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .symbol_paths
+            .get(&file)
+            .cloned()
+    }
+
     /// Set relocation-stable source identities for type-derived symbols.
     pub(crate) fn set_symbol_paths(&self, symbol_paths: HashMap<FileId, String>) {
         self.inner

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -105,6 +105,16 @@ pub use sema::{
     SemanticProducedAnonymousNominal, SemanticProducedAnonymousNominalShape, SourceParamAbi,
     SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
 };
+
+/// The provider-backed body receiver the RUE-1092 flip installs.
+///
+/// Exported so the rFinal differential can build one over the real fact
+/// boundary and compare it against the epoch receiver. Nothing selects it at
+/// runtime yet; `analyze_body_query` remains the single body path.
+pub use crate::sema::provider_host::{
+    BodyHostFacts, ExportCallableFacts, ExportedMethodSite, ProviderBodyConfiguration,
+    ProviderBodyHost, StableIdentityFacts,
+};
 pub use semantic_body::{
     SEMANTIC_BODY_INST_KINDS, SemanticAnonymousBodyExport, SemanticBody, SemanticBodyAnchor,
     SemanticBodyCallArg, SemanticBodyCandidate, SemanticBodyCandidateInstallWork,

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -2161,6 +2161,16 @@ impl BodyRirBundle {
             .collect()
     }
 
+    /// The body's own lowered RIR.
+    ///
+    /// Borrowed from the bundle rather than through [`Self::view`] so the
+    /// borrow outlives one expression: the ordinary-body engine holds a `&Rir`
+    /// across a whole body evaluation, and a view materialized per call cannot
+    /// lend one.
+    pub(in crate::sema) fn rir(&self) -> &Rir {
+        &self.rir
+    }
+
     /// Borrow the one local RIR/index/interner authority for provider fact
     /// facades. The view is cheap and carries no independent identity state.
     pub fn view(&self) -> BodyRirView<'_> {

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -1413,12 +1413,28 @@ mod tests {
     /// consults the epoch-shaped read sources. Widening this back to
     /// `BodyAnalysisReadHost` would silently oblige every host — including the
     /// provider-backed receiver — to implement 47 point queries nothing calls.
+    ///
+    /// The assertion compares the WHOLE supertrait list, not a prefix. A prefix
+    /// match passes for `: InferenceFactSource + BodyAnalysisReadHost + Sized`,
+    /// which is how a bound actually gets widened again — by appending, not by
+    /// replacing. `the_narrow_host_contract_has_a_witness` below is the other
+    /// half: a string test cannot prove a 14-method type satisfies the contract,
+    /// only that the source says so.
     #[test]
     fn the_host_contract_requires_only_the_inference_source() {
-        assert!(
-            FACT_MODE_SOURCE.contains("pub(crate) trait BodyAnalysisHost: InferenceFactSource"),
-            "the host contract's supertrait must stay narrowed to the one source \
-             `HostInferenceFacts` actually borrows the host for"
+        let declaration = FACT_MODE_SOURCE
+            .lines()
+            .find(|line| line.starts_with("pub(crate) trait BodyAnalysisHost:"))
+            .expect("the host contract is declared on one line");
+        let bounds = declaration
+            .trim_start_matches("pub(crate) trait BodyAnalysisHost:")
+            .trim_end_matches('{')
+            .trim();
+        assert_eq!(
+            bounds, "InferenceFactSource + Sized",
+            "the host contract's supertrait list must stay exactly the one source \
+             `HostInferenceFacts` borrows the host for, plus `Sized`; appending \
+             another source silently re-imposes its point queries on every host"
         );
     }
 

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -1406,6 +1406,22 @@ mod tests {
         assert!(!CONTROL_FLOW_SOURCE.contains("struct BodySema"));
     }
 
+    /// The host contract requires the inference source and nothing wider.
+    ///
+    /// Endpoint, call, and aggregate facts reach the engine through the three
+    /// associated types, so a host that answers them with its own facades never
+    /// consults the epoch-shaped read sources. Widening this back to
+    /// `BodyAnalysisReadHost` would silently oblige every host — including the
+    /// provider-backed receiver — to implement 47 point queries nothing calls.
+    #[test]
+    fn the_host_contract_requires_only_the_inference_source() {
+        assert!(
+            FACT_MODE_SOURCE.contains("pub(crate) trait BodyAnalysisHost: InferenceFactSource"),
+            "the host contract's supertrait must stay narrowed to the one source \
+             `HostInferenceFacts` actually borrows the host for"
+        );
+    }
+
     #[test]
     fn one_body_host_contract_is_representation_agnostic() {
         assert!(FACT_MODE_SOURCE.contains("trait BodyAnalysisHost"));
@@ -1481,8 +1497,8 @@ mod tests {
             ),
             (
                 INFERENCE_CONTEXT_SOURCE,
-                "pub(crate) struct HostInferenceFacts<'a, H: BodyAnalysisReadHost>",
-                "impl<H: BodyAnalysisReadHost> LazyInferenceFacts for HostInferenceFacts<'_, H>",
+                "pub(crate) struct HostInferenceFacts<'a, H: InferenceFactSource>",
+                "impl<H: InferenceFactSource> LazyInferenceFacts for HostInferenceFacts<'_, H>",
             ),
         ];
         for (source, struct_header, impl_header) in adapters {

--- a/crates/rue-air/src/sema/fact_mode.rs
+++ b/crates/rue-air/src/sema/fact_mode.rs
@@ -85,7 +85,17 @@ impl<T> BodyAnalysisReadHost for T where
 /// Associated fact facades return owned or short-lived read-only values; the
 /// mutable operations take a request object so the contract stays independent
 /// of the current analyzer representation.
-pub(crate) trait BodyAnalysisHost: BodyAnalysisReadHost + Sized {
+///
+/// The supertrait is [`InferenceFactSource`] alone, not [`BodyAnalysisReadHost`].
+/// A host supplies its endpoint, call, and aggregate facts *through the three
+/// associated types* — an epoch host answers them with `EpochFacts` over its own
+/// read sources, and a provider-backed host answers them with the provider
+/// facades. Requiring the epoch-shaped read sources here would force every host
+/// to implement 47 point queries its own facades never consult, purely to
+/// satisfy a bound. Inference is the one family with no such indirection:
+/// `HostInferenceFacts` borrows the host directly, so that source stays a real
+/// requirement.
+pub(crate) trait BodyAnalysisHost: InferenceFactSource + Sized {
     type EndpointFacts<'a>: BodyEndpointProvider
     where
         Self: 'a;

--- a/crates/rue-air/src/sema/fact_mode.rs
+++ b/crates/rue-air/src/sema/fact_mode.rs
@@ -516,4 +516,125 @@ mod tests {
             epoch_inference.function_by_file((FileId::DEFAULT, symbol)),
         );
     }
+
+    /// A host that implements the contract and *only* the narrow supertrait.
+    ///
+    /// This is the compile-time witness the string test in `consistency_tests`
+    /// cannot be. `Sema` satisfies all four fact sources independently, so it
+    /// proves nothing about how much the contract actually demands: if the
+    /// supertrait widened back, `Sema` would keep compiling and only the
+    /// provider-backed receiver would break, much later. `MinimalHost`
+    /// implements `InferenceFactSource` and nothing else, so a widened bound
+    /// fails to compile here, in this crate, immediately.
+    ///
+    /// It answers every fact with `None`. That is the point — the claim under
+    /// test is about which obligations the contract imposes, not about what any
+    /// particular host knows.
+    struct MinimalHost;
+
+    impl InferenceFactSource for MinimalHost {
+        fn inference_generated_nominal_overlays(
+            &self,
+        ) -> super::super::inference_ctx::InferenceGeneratedNominalOverlays {
+            super::super::inference_ctx::InferenceGeneratedNominalOverlays {
+                builtin_struct_types: HashMap::new(),
+                struct_types_by_file: HashMap::new(),
+                enum_types_by_file: HashMap::new(),
+            }
+        }
+        fn uncached_function_sig(&self, _: Spur) -> Option<FunctionSig> {
+            None
+        }
+        fn uncached_method_sig(&self, _: (StructId, Spur)) -> Option<MethodSig> {
+            None
+        }
+        fn inference_builtin_struct_type(&self, _: Spur) -> Option<Type> {
+            None
+        }
+        fn inference_struct_type_by_file(&self, _: (FileId, Spur)) -> Option<Type> {
+            None
+        }
+        fn inference_builtin_enum_type(&self, _: Spur) -> Option<Type> {
+            None
+        }
+        fn inference_enum_type_by_file(&self, _: (FileId, Spur)) -> Option<Type> {
+            None
+        }
+        fn inference_const_type(&self, _: (FileId, Spur)) -> Option<Type> {
+            None
+        }
+        fn inference_const_type_alias(&self, _: (FileId, Spur)) -> Option<Type> {
+            None
+        }
+        fn inference_const_value(&self, _: (FileId, Spur)) -> Option<i128> {
+            None
+        }
+        fn inference_const_function_alias(&self, _: (FileId, Spur)) -> Option<Spur> {
+            None
+        }
+        fn inference_module_binding_type(&self, _: (FileId, Spur)) -> Option<Type> {
+            None
+        }
+        fn inference_module_file_id(&self, _: ModuleId) -> Option<FileId> {
+            None
+        }
+        fn inference_function_by_file(&self, _: (FileId, Spur)) -> Option<Spur> {
+            None
+        }
+    }
+
+    impl BodyAnalysisHost for MinimalHost {
+        type EndpointFacts<'a> = EpochEndpointFacts<'a, OwnedReadHost>;
+        fn endpoint_facts(&self) -> Self::EndpointFacts<'_> {
+            unimplemented!("the witness exists to be type-checked, not run")
+        }
+
+        type CallFacts<'a> = EpochCallFacts<'a, OwnedReadHost>;
+        fn call_facts(&self) -> Self::CallFacts<'_> {
+            unimplemented!("the witness exists to be type-checked, not run")
+        }
+
+        type AggregateFacts<'a> = EpochAggregateFacts<'a, OwnedReadHost>;
+        fn aggregate_facts(&self) -> Self::AggregateFacts<'_> {
+            unimplemented!("the witness exists to be type-checked, not run")
+        }
+
+        type InferenceFacts<'a> = HostInferenceFacts<'a, Self>;
+        fn inference_facts<'a>(&'a self, ctx: &'a InferenceContext) -> Self::InferenceFacts<'a> {
+            HostInferenceFacts::new(ctx, self)
+        }
+
+        fn resolve_type_syntax(&mut self, _: TypeSyntaxRequest<'_>) -> TypeSyntaxResult {
+            unimplemented!("the witness exists to be type-checked, not run")
+        }
+        fn resolve_type_module_prefix(
+            &mut self,
+            _: ModulePrefixRequest<'_>,
+        ) -> rue_error::CompileResult<(ModuleId, Option<FileId>, String)> {
+            unimplemented!("the witness exists to be type-checked, not run")
+        }
+        fn resolve_array_length(
+            &mut self,
+            _: ArrayLengthRequest<'_>,
+        ) -> rue_error::CompileResult<u64> {
+            unimplemented!("the witness exists to be type-checked, not run")
+        }
+        fn validate_deferred_type(
+            &mut self,
+            _: DeferredTypeRequest<'_>,
+        ) -> rue_error::CompileResult<Option<Type>> {
+            unimplemented!("the witness exists to be type-checked, not run")
+        }
+    }
+
+    /// The narrow contract is satisfiable by a host that implements only it.
+    ///
+    /// The assertion is the `impl BodyAnalysisHost for MinimalHost` above
+    /// compiling at all; this test exists so the witness is not dead code and
+    /// so the intent is greppable from the test list.
+    #[test]
+    fn the_narrow_host_contract_has_a_witness() {
+        fn assert_satisfies_the_contract<H: BodyAnalysisHost>() {}
+        assert_satisfies_the_contract::<MinimalHost>();
+    }
 }

--- a/crates/rue-air/src/sema/inference_ctx.rs
+++ b/crates/rue-air/src/sema/inference_ctx.rs
@@ -14,8 +14,30 @@ use lasso::Spur;
 use rue_span::FileId;
 
 use super::{ConstValue, DeclarationPhase, Sema};
-use crate::inference::{FunctionSig, LazyInferenceFacts, MethodSig};
+use crate::inference::{FunctionSig, InferType, LazyInferenceFacts, MethodSig};
+use crate::intern_pool::TypeInternPool;
 use crate::types::{ModuleId, StructId, Type};
+
+/// Lift a resolved type into the inference algebra.
+///
+/// Only array types carry structure inference reasons about; everything else is
+/// already concrete. The type pool is the whole input, so this is one function
+/// rather than a method on whichever receiver happens to be analyzing — the
+/// epoch and the provider-backed receiver must agree here exactly, because a
+/// signature that lifts differently on the two would produce different
+/// constraints for the same body.
+pub(super) fn type_to_infer_type(pool: &TypeInternPool, ty: Type) -> InferType {
+    match ty.kind() {
+        crate::types::TypeKind::Array(id) => {
+            let (element, length) = pool.array_def(id);
+            InferType::Array {
+                element: Box::new(type_to_infer_type(pool, element)),
+                length,
+            }
+        }
+        _ => InferType::Concrete(ty),
+    }
+}
 
 /// The generated-nominal overlay snapshot consumed by [`InferenceContext`].
 /// It is a construction-time input, not a replay cache for semantic results.

--- a/crates/rue-air/src/sema/inference_ctx.rs
+++ b/crates/rue-air/src/sema/inference_ctx.rs
@@ -13,7 +13,6 @@ use std::rc::Rc;
 use lasso::Spur;
 use rue_span::FileId;
 
-use super::fact_mode::BodyAnalysisReadHost;
 use super::{ConstValue, DeclarationPhase, Sema};
 use crate::inference::{FunctionSig, LazyInferenceFacts, MethodSig};
 use crate::types::{ModuleId, StructId, Type};
@@ -102,7 +101,7 @@ impl InferenceContext {
     /// Construct the context, snapshotting the generated-nominal overlays that
     /// the eager projection merged. The signature caches start empty and fill on
     /// demand.
-    pub(crate) fn new<H: BodyAnalysisReadHost>(host: &H) -> Self {
+    pub(crate) fn new<H: InferenceFactSource>(host: &H) -> Self {
         let InferenceGeneratedNominalOverlays {
             builtin_struct_types: gen_builtin_struct_types,
             struct_types_by_file: gen_struct_types_by_file,
@@ -125,12 +124,12 @@ impl InferenceContext {
 /// [`InferenceContext`] cache plus an immutable borrow of the analyzing host.
 /// The generator consults it through [`LazyInferenceFacts`]; every answer equals
 /// the value the eager projection would have held for that key.
-pub(crate) struct HostInferenceFacts<'a, H: BodyAnalysisReadHost> {
+pub(crate) struct HostInferenceFacts<'a, H: InferenceFactSource> {
     ctx: &'a InferenceContext,
     host: &'a H,
 }
 
-impl<'a, H: BodyAnalysisReadHost> HostInferenceFacts<'a, H> {
+impl<'a, H: InferenceFactSource> HostInferenceFacts<'a, H> {
     pub(crate) fn new(ctx: &'a InferenceContext, host: &'a H) -> Self {
         Self { ctx, host }
     }
@@ -144,7 +143,7 @@ impl<'a, H: BodyAnalysisReadHost> HostInferenceFacts<'a, H> {
     }
 }
 
-impl<H: BodyAnalysisReadHost> LazyInferenceFacts for HostInferenceFacts<'_, H> {
+impl<H: InferenceFactSource> LazyInferenceFacts for HostInferenceFacts<'_, H> {
     fn func_sig(&self, name: Spur) -> Option<Rc<FunctionSig>> {
         if let Some(cached) = self.ctx.func_sigs.borrow().get(&name) {
             return Some(Rc::clone(cached));

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -57,7 +57,7 @@ mod one_body;
 mod ordinary_engine;
 mod output;
 pub mod provider;
-mod provider_host;
+pub mod provider_host;
 mod provider_module_registry;
 mod semantic_body_export;
 mod typeck;

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -57,6 +57,7 @@ mod one_body;
 mod ordinary_engine;
 mod output;
 pub mod provider;
+mod provider_host;
 mod provider_module_registry;
 mod semantic_body_export;
 mod typeck;

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -1259,16 +1259,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         }
     }
     pub(crate) fn type_to_infer_type(&self, ty: Type) -> InferType {
-        match ty.kind() {
-            crate::types::TypeKind::Array(id) => {
-                let (element, length) = self.body_type_pool().array_def(id);
-                InferType::Array {
-                    element: Box::new(self.type_to_infer_type(element)),
-                    length,
-                }
-            }
-            _ => InferType::Concrete(ty),
-        }
+        super::inference_ctx::type_to_infer_type(self.body_type_pool(), ty)
     }
     pub(crate) fn inference_facts<'a>(
         &'a self,

--- a/crates/rue-air/src/sema/provider_host.rs
+++ b/crates/rue-air/src/sema/provider_host.rs
@@ -1,0 +1,442 @@
+//! The provider-backed ordinary-body analysis host, under construction.
+//!
+//! This module is the receiver the flip installs. Today the single
+//! [`OrdinaryBodyAnalysisHost`] implementation is `Sema`, which reaches a
+//! declaration-wide epoch for every fact a body asks for; that shape is the
+//! `O(bodies × declarations)` term the body-context repair exists to delete.
+//! The replacement receiver owns exactly two things:
+//!
+//! - **Body-local mutable state** — [`ProviderBodyLocalState`] below. Every
+//!   field here is state one body evaluation creates, mutates, and drops. None
+//!   of it is shared with another body, and none of it is derived from the
+//!   declaration universe, so it is `O(this body)` by construction.
+//! - **A narrow fact boundary** — [`crate::sema::provider::BodyFactProvider`],
+//!   whose typed operations answer exactly the questions a body asks and whose
+//!   implementation records the corresponding query edge per call.
+//!
+//! Everything a body needs is one of those two things or a configuration
+//! constant. [`HOST_CAPABILITY_LEDGER`] states which, for every method on the
+//! host contract, and [`host_capability_ledger_covers_the_contract`] pins that
+//! claim against the real trait source so it cannot go stale as the contract
+//! moves. The ledger is the flip's worklist: `NeedsProviderWiring` is the only
+//! category with design work left in it.
+
+// The overlay state is declared before the receiver that mutates it: the host
+// impl lands with the fact adapters, and every field here is storage that impl
+// needs. Nothing selects this module at runtime, so it is inert rather than a
+// peer body path — the ledger test is its only consumer today.
+#![allow(dead_code)]
+
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+use lasso::Spur;
+use rue_error::CompileError;
+use rue_span::FileId;
+
+use super::anon_structs::{
+    IssuedAnonymousNominalKey, IssuedCanonicalArguments, IssuedStableProducerId,
+};
+use super::{
+    AnalyzedBodyOwnerEvent, AnonMethodSig, BodyAnalysisWork, ConstValue,
+    DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind, DeferredOwnershipGate,
+    MethodInfo, StructId, Type,
+};
+use crate::types::EnumId;
+
+/// The mutable state one body evaluation owns outright.
+///
+/// This is the whole of the "local overlay" half of the base/overlay split: a
+/// body constructs one of these, mutates only this, and drops it at
+/// publication. Two bodies analyzed in either order therefore cannot observe
+/// each other through the host, which is what makes the receiver
+/// parallel-ready. Nothing here is keyed by, sized by, or copied from the
+/// declaration universe.
+///
+/// The field set mirrors the body-mutated half of `Sema` exactly, so the flip
+/// is a receiver substitution rather than a semantic change. Adding a field
+/// here is a claim that some body mutates it; adding one that a *declaration*
+/// mutates would reintroduce the shared-epoch coupling this type exists to
+/// remove.
+#[derive(Debug, Default)]
+pub(crate) struct ProviderBodyLocalState {
+    /// Synthetic nominals this body generated, by rendered name.
+    pub(crate) generated_structs: HashMap<Spur, StructId>,
+    pub(crate) generated_enums: HashMap<Spur, EnumId>,
+    /// Producer-nominal identities this body minted, and their compact ids.
+    pub(crate) anon_struct_identities: HashMap<IssuedAnonymousNominalKey, StructId>,
+    pub(crate) anon_enum_identities: HashMap<IssuedAnonymousNominalKey, EnumId>,
+    /// Digest ownership for verified anonymous-identity disambiguation.
+    pub(crate) anonymous_digest_owners: HashMap<u128, IssuedAnonymousNominalKey>,
+    /// Test-only forced digests, used to drive collision handling.
+    pub(crate) forced_anonymous_digests: HashMap<IssuedAnonymousNominalKey, u128>,
+    /// The compact ids this body minted for anonymous nominals.
+    pub(crate) anonymous_struct_ids: HashSet<StructId>,
+    pub(crate) anonymous_enum_ids: HashSet<EnumId>,
+    /// Reverse map from a materialized type to the identity that produced it.
+    pub(crate) canonical_anonymous_types: HashMap<Type, IssuedAnonymousNominalKey>,
+    /// Anonymous member signatures, captures, and substitutions this body made.
+    pub(crate) anon_struct_method_sigs: HashMap<StructId, Vec<AnonMethodSig>>,
+    pub(crate) anon_struct_captured_values: HashMap<StructId, HashMap<Spur, ConstValue>>,
+    pub(crate) anon_struct_type_subst: HashMap<StructId, HashMap<Spur, Type>>,
+    /// Anonymous methods installed while analyzing this body.
+    pub(crate) anonymous_methods: HashMap<(StructId, Spur), MethodInfo>,
+    /// The producer whose content the analyzer is currently inside, if any.
+    pub(crate) active_anonymous_producer:
+        Option<(IssuedStableProducerId, IssuedCanonicalArguments)>,
+    /// The identities that existed before this body ran, so publication can
+    /// report only what this body produced.
+    pub(crate) initial_anonymous_identities: BTreeSet<IssuedAnonymousNominalKey>,
+    /// Structural accounting for the work this body actually performed.
+    pub(crate) body_analysis_work: BodyAnalysisWork,
+    /// The owner every dependency this body records is attributed to.
+    pub(crate) body_dependency_observer: Option<AnalyzedBodyOwnerEvent>,
+    /// Dependencies this body recorded, by family.
+    pub(crate) body_callable_dependencies: Vec<(AnalyzedBodyOwnerEvent, Spur)>,
+    pub(crate) body_specialization_dependencies: Vec<(
+        AnalyzedBodyOwnerEvent,
+        crate::FunctionInstanceKey<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
+    )>,
+    /// The declaration-type dependency currently being attributed, if any.
+    pub(crate) declaration_type_observer: Option<(
+        FileId,
+        String,
+        Option<String>,
+        DeclarationTypeDependencySourceKind,
+        DeclarationTypeDependencyKind,
+    )>,
+    /// Error-recovery ledger for one-body analysis.
+    pub(crate) one_body_error_recovery: bool,
+    pub(crate) one_body_recovered_errors: Vec<CompileError>,
+    pub(crate) one_body_inference_failure_incomplete: bool,
+    /// Ownership gates deferred until the body's types are known.
+    pub(crate) deferred_ownership_gates: Vec<DeferredOwnershipGate>,
+    /// Comptime type-constructor recursion depth for this body.
+    pub(crate) comptime_type_call_depth: usize,
+    /// Constructor type displays this body rendered, for diagnostics.
+    pub(crate) ctor_type_displays: HashMap<Type, String>,
+}
+
+impl ProviderBodyLocalState {
+    /// Start one body epoch. Every field begins empty: a body never inherits
+    /// another body's overlay, which is the property the schedule-permutation
+    /// oracle checks.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Seal the identity set that existed before analysis, so publication can
+    /// report produced nominals as a difference rather than a whole set.
+    pub(crate) fn seal_initial_anonymous_identities(&mut self) {
+        self.initial_anonymous_identities = self
+            .anon_struct_identities
+            .keys()
+            .chain(self.anon_enum_identities.keys())
+            .cloned()
+            .collect();
+    }
+
+    /// The producer-nominal identities this body actually minted.
+    pub(crate) fn produced_anonymous_identities(
+        &self,
+    ) -> impl Iterator<Item = &IssuedAnonymousNominalKey> {
+        self.anon_struct_identities
+            .keys()
+            .chain(self.anon_enum_identities.keys())
+            .filter(|identity| !self.initial_anonymous_identities.contains(*identity))
+    }
+}
+
+/// Where one host-contract method gets its answer once the receiver is the
+/// provider-backed host rather than a declaration epoch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HostCapability {
+    /// Answered from [`ProviderBodyLocalState`]. Mechanical: the field already
+    /// exists above and the method is a borrow or an insert.
+    BodyLocal,
+    /// Answered by the rue-air-owned type/parameter/interner authority the
+    /// provider state already carries (`ProviderBodyAnalysisState`).
+    ProviderState,
+    /// Answered by a configuration constant the evaluator is keyed on
+    /// (target, preview features, well-known symbol table).
+    Configuration,
+    /// Answered by an existing `BodyFactProvider` operation. Mechanical, but
+    /// needs the adapter that maps the operation's owned fact onto the shape
+    /// the engine expects.
+    ProviderFact,
+    /// The real remaining work: no provider operation answers this yet, or the
+    /// answer must change shape at the flip. Each row names what it needs.
+    NeedsProviderWiring(&'static str),
+    /// The body host answers this negatively by construction — the capability
+    /// belongs to declaration binding, which a body never performs.
+    InapplicableToBodies,
+}
+
+/// One row per method on the host contract.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct HostCapabilityRow {
+    pub(crate) method: &'static str,
+    pub(crate) capability: HostCapability,
+}
+
+const fn row(method: &'static str, capability: HostCapability) -> HostCapabilityRow {
+    HostCapabilityRow { method, capability }
+}
+
+/// The flip's worklist, as executable data.
+///
+/// Every method on `OrdinaryBodyAnalysisHost` appears exactly once. The
+/// accompanying test parses the trait's real source and asserts the two agree,
+/// so a method added to the contract fails this module until someone states
+/// where its answer comes from — the same discipline the rFinal harness applies
+/// to its own exception tables.
+pub(crate) const HOST_CAPABILITY_LEDGER: &[HostCapabilityRow] = &[
+    // --- Body-local overlay: mechanical, storage already declared above. ---
+    row("install_anonymous_method", HostCapability::BodyLocal),
+    row("generated_structs", HostCapability::BodyLocal),
+    row("generated_structs_mut", HostCapability::BodyLocal),
+    row("generated_enums_mut", HostCapability::BodyLocal),
+    row("anonymous_struct_id", HostCapability::BodyLocal),
+    row("anonymous_enum_id", HostCapability::BodyLocal),
+    row("anonymous_struct_identities_mut", HostCapability::BodyLocal),
+    row("anonymous_enum_identities_mut", HostCapability::BodyLocal),
+    row("anonymous_digest_owner", HostCapability::BodyLocal),
+    row("install_anonymous_digest_owner", HostCapability::BodyLocal),
+    row("forced_anonymous_digest", HostCapability::BodyLocal),
+    row(
+        "install_canonical_anonymous_type",
+        HostCapability::BodyLocal,
+    ),
+    row("anonymous_struct_methods_mut", HostCapability::BodyLocal),
+    row("anonymous_struct_captures_mut", HostCapability::BodyLocal),
+    row("anonymous_struct_ids_mut", HostCapability::BodyLocal),
+    row("anonymous_enum_ids_mut", HostCapability::BodyLocal),
+    row("set_anon_struct_type_subst", HostCapability::BodyLocal),
+    row(
+        "replace_active_anonymous_producer",
+        HostCapability::BodyLocal,
+    ),
+    row("active_anonymous_producer", HostCapability::BodyLocal),
+    row("body_declaration_type_observer", HostCapability::BodyLocal),
+    row("body_analysis_work_mut", HostCapability::BodyLocal),
+    row(
+        "record_resolved_declaration_type",
+        HostCapability::BodyLocal,
+    ),
+    row("one_body_error_recovery", HostCapability::BodyLocal),
+    row("one_body_first_recovered_error", HostCapability::BodyLocal),
+    row("one_body_recovered_errors_mut", HostCapability::BodyLocal),
+    row(
+        "set_one_body_inference_failure_incomplete",
+        HostCapability::BodyLocal,
+    ),
+    row("body_dependency_observer", HostCapability::BodyLocal),
+    row("record_body_named_dependency", HostCapability::BodyLocal),
+    row("record_body_callable_dependency", HostCapability::BodyLocal),
+    row(
+        "record_specialization_dependency",
+        HostCapability::BodyLocal,
+    ),
+    row("comptime_type_call_depth", HostCapability::BodyLocal),
+    row("set_comptime_type_call_depth", HostCapability::BodyLocal),
+    row("has_ctor_type_display", HostCapability::BodyLocal),
+    row("record_body_ctor_type_display", HostCapability::BodyLocal),
+    row("deferred_ownership_gates_mut", HostCapability::BodyLocal),
+    // --- Provider state: the type/parameter/interner authority it owns. ---
+    row("body_param_data", HostCapability::ProviderState),
+    row("allocate_method_params", HostCapability::ProviderState),
+    row("body_interner", HostCapability::ProviderState),
+    row("body_type_pool", HostCapability::ProviderState),
+    row("intern_array_type", HostCapability::ProviderState),
+    row("strbuf_type", HostCapability::ProviderState),
+    row("is_strbuf", HostCapability::ProviderState),
+    row("types_equivalent", HostCapability::ProviderState),
+    // --- Configuration the body query is keyed on. ---
+    row("known_symbols", HostCapability::Configuration),
+    row("target", HostCapability::Configuration),
+    row("builtin_arch_id", HostCapability::Configuration),
+    row("builtin_os_id", HostCapability::Configuration),
+    row("builtin_data_model_id", HostCapability::Configuration),
+    row("require_preview", HostCapability::Configuration),
+    // --- Existing provider operations, needing only an adapter. ---
+    row("function_info", HostCapability::ProviderFact),
+    row("value_const", HostCapability::ProviderFact),
+    row("source_function_name", HostCapability::ProviderFact),
+    row("resolve_function_name_local", HostCapability::ProviderFact),
+    row("module_def", HostCapability::ProviderFact),
+    row("struct_in_file", HostCapability::ProviderFact),
+    row("struct_id_for_name", HostCapability::ProviderFact),
+    row("builtin_struct", HostCapability::ProviderFact),
+    row("destructor_span", HostCapability::ProviderFact),
+    row("infectious_linear_reason", HostCapability::ProviderFact),
+    row("resolve_canonical_import", HostCapability::ProviderFact),
+    row("well_known_option", HostCapability::ProviderFact),
+    row("trusted_try_producer", HostCapability::ProviderFact),
+    row("comptime_type_param_flags", HostCapability::ProviderFact),
+    // --- Declaration binding: a body never performs it. ---
+    row(
+        "declaration_binding_active",
+        HostCapability::InapplicableToBodies,
+    ),
+    row(
+        "known_linear_during_binding",
+        HostCapability::InapplicableToBodies,
+    ),
+    row(
+        "known_drop_glue_during_binding",
+        HostCapability::InapplicableToBodies,
+    ),
+    // --- The remaining design work. ---
+    row(
+        "body_rir_ref",
+        HostCapability::NeedsProviderWiring(
+            "the engine borrows whole-program RIR; the flip must hand it the body's own \
+             lowered RIR so no live `Rir` crosses the query boundary",
+        ),
+    ),
+    row(
+        "resolve_body_type",
+        HostCapability::NeedsProviderWiring(
+            "recursive type-syntax resolution; the evaluator is already generic over \
+             `TypeSyntaxHost`, so this is binding that host to the provider rather than to `Sema`",
+        ),
+    ),
+    row(
+        "canonical_type_instance",
+        HostCapability::NeedsProviderWiring(
+            "compact type -> stable instance key; needs the provider identity pool to own the \
+             export direction, not just the import direction",
+        ),
+    ),
+    row(
+        "canonical_argument_value",
+        HostCapability::NeedsProviderWiring(
+            "compact const value -> stable argument value; same export direction as \
+             `canonical_type_instance`",
+        ),
+    ),
+    row(
+        "function_identity",
+        HostCapability::NeedsProviderWiring(
+            "rendered symbol -> stable definition token; `callable_symbol_method` covers the \
+             method case, the free-function case needs the same reversal",
+        ),
+    ),
+    row(
+        "stable_definition_symbol_component",
+        HostCapability::NeedsProviderWiring(
+            "symbol rendering currently reads epoch endpoint tables; the provider must render \
+             from the stable token alone",
+        ),
+    ),
+    row(
+        "stable_module_symbol_component",
+        HostCapability::NeedsProviderWiring(
+            "module half of the same rendering; must not consult a module registry the body \
+             does not own",
+        ),
+    ),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ORDINARY_ENGINE_SOURCE: &str = include_str!("ordinary_engine.rs");
+
+    /// Every method declared on the host contract, parsed from its real source.
+    fn contract_methods() -> Vec<String> {
+        let trait_source = ORDINARY_ENGINE_SOURCE
+            .split("pub(crate) trait OrdinaryBodyAnalysisHost")
+            .nth(1)
+            .expect("the ordinary host contract is declared in this crate")
+            .split("\n}\n")
+            .next()
+            .expect("the contract has a closing brace");
+        trait_source
+            .lines()
+            .filter_map(|line| line.strip_prefix("    fn "))
+            .filter_map(|line| line.split(['(', '<']).next())
+            .map(str::to_owned)
+            .collect()
+    }
+
+    /// The ledger is the flip's worklist, so it must describe the contract that
+    /// actually exists — not the one it was written against. A method added to
+    /// `OrdinaryBodyAnalysisHost` fails here until its answer has a stated
+    /// source, and a method deleted from the contract fails here until its row
+    /// goes with it.
+    #[test]
+    fn host_capability_ledger_covers_the_contract() {
+        let contract = contract_methods();
+        assert!(
+            contract.len() > 60,
+            "the contract parse found only {} methods, so the parser — not the ledger — is wrong",
+            contract.len()
+        );
+
+        let ledgered = HOST_CAPABILITY_LEDGER
+            .iter()
+            .map(|row| row.method.to_owned())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            ledgered.len(),
+            HOST_CAPABILITY_LEDGER.len(),
+            "each contract method is ledgered exactly once"
+        );
+
+        let declared = contract.iter().cloned().collect::<BTreeSet<_>>();
+        let missing = declared.difference(&ledgered).collect::<Vec<_>>();
+        assert!(
+            missing.is_empty(),
+            "these host-contract methods have no stated fact source: {missing:?}"
+        );
+        let stale = ledgered.difference(&declared).collect::<Vec<_>>();
+        assert!(
+            stale.is_empty(),
+            "these ledger rows name methods the contract no longer declares: {stale:?}"
+        );
+    }
+
+    /// A body epoch starts empty. The schedule-permutation oracle depends on
+    /// this: if a fresh overlay could observe a previous body's mint, opposite
+    /// demand orders would not agree.
+    #[test]
+    fn a_fresh_body_overlay_shares_nothing() {
+        let state = ProviderBodyLocalState::new();
+        assert!(state.anon_struct_identities.is_empty());
+        assert!(state.anonymous_methods.is_empty());
+        assert!(state.generated_structs.is_empty());
+        assert_eq!(state.comptime_type_call_depth, 0);
+        assert!(state.produced_anonymous_identities().next().is_none());
+    }
+
+    /// The only category with design work left in it is the one the flip has
+    /// to solve; everything else is storage that already exists or an adapter
+    /// over an operation that already exists. This test states that split as a
+    /// number so it moves visibly as the flip lands, rather than being
+    /// re-litigated from prose each time.
+    #[test]
+    fn the_remaining_design_work_is_named_and_bounded() {
+        let outstanding = HOST_CAPABILITY_LEDGER
+            .iter()
+            .filter(|row| matches!(row.capability, HostCapability::NeedsProviderWiring(_)))
+            .collect::<Vec<_>>();
+        for row in &outstanding {
+            let HostCapability::NeedsProviderWiring(reason) = row.capability else {
+                unreachable!("filtered to the outstanding category")
+            };
+            assert!(
+                !reason.is_empty(),
+                "{} must say what wiring it needs",
+                row.method
+            );
+        }
+        assert_eq!(
+            outstanding.len(),
+            7,
+            "the outstanding host capabilities are {:?}; update this count in the same change \
+             that wires one, so the worklist cannot shrink silently",
+            outstanding.iter().map(|row| row.method).collect::<Vec<_>>()
+        );
+    }
+}

--- a/crates/rue-air/src/sema/provider_host.rs
+++ b/crates/rue-air/src/sema/provider_host.rs
@@ -19,7 +19,12 @@
 //!   whose typed operations answer exactly the questions a body asks and whose
 //!   implementation records the corresponding query edge per call.
 //!
-//! Everything a body needs is one of those four or a configuration constant.
+//! Everything a body needs is one of those four or a configuration constant —
+//! [`ProviderBodyConfiguration`], which carries only the target and the preview
+//! feature set. The other two configuration-shaped answers are derived at
+//! construction from authorities the receiver already owns rather than supplied
+//! beside them: the well-known symbol table is interned from its own interner,
+//! and the three builtin enum identities are read out of its own type pool.
 //! [`HOST_CAPABILITY_LEDGER`] states which, for every method on the host
 //! contract, and [`host_capability_ledger_covers_the_contract`] pins that claim
 //! against the real trait source so it cannot go stale as the contract moves.
@@ -37,8 +42,9 @@ use std::hash::Hash;
 use std::rc::Rc;
 
 use lasso::{Spur, ThreadedRodeo};
-use rue_error::CompileError;
+use rue_error::{CompileError, PreviewFeatures};
 use rue_span::FileId;
+use rue_target::Target;
 
 use super::provider::BodyFactProvider;
 use super::semantic_body_export::SemanticBodyExportHost;
@@ -52,7 +58,7 @@ use super::anon_structs::{
 use super::{
     AnalyzedBodyOwnerEvent, AnonMethodSig, BodyAnalysisWork, ConstValue,
     DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind, DeferredOwnershipGate,
-    MethodInfo, StructId, Type,
+    KnownSymbols, MethodInfo, StructId, Type,
 };
 use crate::types::EnumId;
 
@@ -521,12 +527,44 @@ pub(crate) struct ProviderBodyHost<K, M, S, P> {
     local: ProviderBodyLocalState,
     state: ProviderBodyAnalysisState<K, M, S>,
     facts: P,
+    config: ProviderBodyConfiguration,
     /// Handles cloned once from `state`, so an engine-facing borrow is a field
     /// read rather than a refcount bump per call. Containment sealing rebases
     /// the pool's locked inner value in place, so a handle taken at
     /// construction stays current for the life of the body.
     type_pool: Rc<TypeInternPool>,
     interner: Rc<ThreadedRodeo>,
+    /// Derived once at construction from the two authorities above rather than
+    /// supplied: see [`ProviderBodyConfiguration`] for why neither is a query
+    /// key.
+    known: KnownSymbols,
+    builtin_arch_id: Option<EnumId>,
+    builtin_os_id: Option<EnumId>,
+    builtin_data_model_id: Option<EnumId>,
+}
+
+/// The configuration one body evaluation is keyed on.
+///
+/// The `Configuration` rows of [`HOST_CAPABILITY_LEDGER`] name three sources:
+/// the target, the preview feature set, and the well-known symbol table. Only
+/// the first two are genuine query keys. The other two configuration-shaped
+/// answers are derived from authorities the receiver already owns, which is the
+/// same rule the export rows follow:
+///
+/// - `known_symbols` is interned from the receiver's own interner, so it cannot
+///   name a symbol from another body's universe.
+/// - `builtin_arch_id` / `builtin_os_id` / `builtin_data_model_id` are read out
+///   of the receiver's own type pool, which pre-registers
+///   `rue_builtins::BUILTIN_ENUMS` at [`FileId::DEFAULT`] exactly as a fresh
+///   import epoch does. The epoch caches the same three ids while registering
+///   those enums; reading them back by keyed `(file, name)` lookup is the same
+///   fact without the declaration-wide registration pass.
+///
+/// Neither derived answer is sized by the declaration universe.
+#[derive(Debug, Clone)]
+pub(crate) struct ProviderBodyConfiguration {
+    pub(crate) target: Target,
+    pub(crate) preview_features: PreviewFeatures,
 }
 
 impl<K, M, S, P> ProviderBodyHost<K, M, S, P>
@@ -543,18 +581,98 @@ where
     /// beside it, so the RIR and the state cannot be built over two different
     /// interners. Every other construction path checks that invariant with an
     /// assertion; here it holds by construction.
-    pub(crate) fn new(rir: BodyRirBundle, source: S, facts: P) -> Self {
+    pub(crate) fn new(
+        rir: BodyRirBundle,
+        source: S,
+        facts: P,
+        config: ProviderBodyConfiguration,
+    ) -> Self {
         let state = rir.provider_body_state(source);
         let type_pool = state.type_pool();
         let interner = state.interner();
+        let known = KnownSymbols::new(&interner);
+        let builtin_enum = |name: &str| {
+            let symbol = interner.get(name)?;
+            match type_pool
+                .get_enum_by_file_name(FileId::DEFAULT, symbol)?
+                .kind()
+            {
+                crate::types::TypeKind::Enum(id) => Some(id),
+                _ => None,
+            }
+        };
+        let builtin_arch_id = builtin_enum("Arch");
+        let builtin_os_id = builtin_enum("Os");
+        let builtin_data_model_id = builtin_enum("DataModel");
         Self {
             rir,
             local: ProviderBodyLocalState::new(),
             state,
             facts,
+            config,
             type_pool,
             interner,
+            known,
+            builtin_arch_id,
+            builtin_os_id,
+            builtin_data_model_id,
         }
+    }
+}
+
+/// The configuration rows of [`HOST_CAPABILITY_LEDGER`], in the shapes
+/// `OrdinaryBodyAnalysisHost` declares them.
+///
+/// Landed as inherent methods for the same reason the export rows were: the
+/// ledger is a claim about the host contract, so stating that a row is answered
+/// means the receiver answers it in the contract's own shape. Binding the trait
+/// itself waits on the rows that still need the engine's other halves.
+impl<K, M, S, P> ProviderBodyHost<K, M, S, P> {
+    pub(crate) fn known_symbols(&self) -> &KnownSymbols {
+        &self.known
+    }
+
+    pub(crate) fn target(&self) -> Target {
+        self.config.target
+    }
+
+    pub(crate) fn builtin_arch_id(&self) -> Option<EnumId> {
+        self.builtin_arch_id
+    }
+
+    pub(crate) fn builtin_os_id(&self) -> Option<EnumId> {
+        self.builtin_os_id
+    }
+
+    pub(crate) fn builtin_data_model_id(&self) -> Option<EnumId> {
+        self.builtin_data_model_id
+    }
+
+    /// Byte-identical to the epoch's gate: same error kind, same help text.
+    /// A body that spells a preview-gated construct must fail the same way
+    /// whichever receiver analyzed it, so this is the epoch's wording rather
+    /// than a re-derivation of it.
+    pub(crate) fn require_preview(
+        &self,
+        feature: rue_error::PreviewFeature,
+        what: &str,
+        span: rue_span::Span,
+    ) -> rue_error::CompileResult<()> {
+        if self.config.preview_features.contains(&feature) {
+            return Ok(());
+        }
+        Err(rue_error::CompileError::new(
+            rue_error::ErrorKind::PreviewFeatureRequired {
+                feature,
+                what: what.to_string(),
+            },
+            span,
+        )
+        .with_help(format!(
+            "use `--preview {}` to enable this feature ({})",
+            feature.name(),
+            feature.adr()
+        )))
     }
 }
 
@@ -1749,6 +1867,10 @@ mod tests {
             BodyRirBundle::new(rir, lasso::ThreadedRodeo::new()),
             NoDurableNominals,
             RecordingFacts::default(),
+            ProviderBodyConfiguration {
+                target: Target::default(),
+                preview_features: PreviewFeatures::new(),
+            },
         )
     }
 
@@ -1775,6 +1897,77 @@ mod tests {
                 .is_none(),
             "a fresh receiver starts with an empty overlay"
         );
+    }
+
+    /// The three builtin enum identities are readable from the receiver's own
+    /// type pool.
+    ///
+    /// The epoch caches these while registering the builtin enums across the
+    /// declaration universe. The receiver never runs that pass: its pool
+    /// pre-registers `rue_builtins::BUILTIN_ENUMS` at `FileId::DEFAULT`, so the
+    /// same three ids come back from a keyed `(file, name)` lookup. If that
+    /// lookup ever stopped answering, the rows would silently become `None` and
+    /// `@arch` / `@os` / `@dataModel` would resolve differently on the two
+    /// receivers — so the test asserts they are present, not merely equal to
+    /// each other.
+    #[test]
+    fn builtin_enum_identities_come_from_the_receivers_own_pool() {
+        let host = test_host();
+        for (name, id) in [
+            ("Arch", host.builtin_arch_id()),
+            ("Os", host.builtin_os_id()),
+            ("DataModel", host.builtin_data_model_id()),
+        ] {
+            let id = id.unwrap_or_else(|| {
+                panic!("`{name}` is pre-registered in the receiver's pool, so its id must resolve")
+            });
+            assert_eq!(
+                host.type_pool().enum_def(id).name,
+                name,
+                "the keyed lookup for `{name}` must not answer with another enum's identity"
+            );
+        }
+        assert_ne!(
+            host.builtin_arch_id(),
+            host.builtin_os_id(),
+            "distinct builtin enums must not collapse to one identity"
+        );
+    }
+
+    /// The preview gate is the epoch's, not a re-derivation of it.
+    #[test]
+    fn require_preview_refuses_a_disabled_feature_and_admits_an_enabled_one() {
+        let host = test_host();
+        let feature = rue_error::PreviewFeature::Slices;
+        let error = host
+            .require_preview(feature, "the slice type `[T]`", rue_span::Span::default())
+            .expect_err("a receiver with no preview features must refuse the gate");
+        assert!(matches!(
+            error.kind,
+            rue_error::ErrorKind::PreviewFeatureRequired { .. }
+        ));
+
+        let mut preview_features = PreviewFeatures::new();
+        preview_features.insert(feature);
+        let editor = rue_rir::RirEditor::new();
+        let validation = rue_rir::RirValidationContext {
+            symbol_count: 0,
+            source_lengths: &[],
+        };
+        let rir = rue_rir::ValidatedRir::finish(editor, &validation)
+            .expect("an empty body RIR validates");
+        let enabled: TestHost = ProviderBodyHost::new(
+            BodyRirBundle::new(rir, lasso::ThreadedRodeo::new()),
+            NoDurableNominals,
+            RecordingFacts::default(),
+            ProviderBodyConfiguration {
+                target: Target::default(),
+                preview_features,
+            },
+        );
+        enabled
+            .require_preview(feature, "the slice type `[T]`", rue_span::Span::default())
+            .expect("an enabled feature passes the gate");
     }
 
     /// The receiver's RIR and its identity state are one authority.

--- a/crates/rue-air/src/sema/provider_host.rs
+++ b/crates/rue-air/src/sema/provider_host.rs
@@ -398,6 +398,270 @@ pub(crate) const HOST_CAPABILITY_LEDGER: &[HostCapabilityRow] = &[
     ),
 ];
 
+/// The forward stable-identity lookups the export path performs.
+///
+/// This is an adapter seam, not a second fact authority: the compiler-side
+/// implementation answers each call through the ordinary
+/// [`crate::sema::provider::BodyFactProvider`] lookup operations, so the
+/// dependency edge is recorded at the consult exactly as it is for every other
+/// provider fact. It exists so rue-air can express "resolve this exact stable
+/// identity" without the export path naming the provider's eight associated
+/// types.
+///
+/// Both operations are keyed and exact. Neither has a whole-universe form,
+/// which is the property that makes export `O(consulted)`: the epoch answers
+/// the same questions by scanning `stable_definition_tokens` and
+/// `stable_module_tokens`, both sized by the declaration universe.
+pub(crate) trait StableIdentityFacts {
+    /// The stable token for one exact declaration coordinate.
+    ///
+    /// Fails closed, mirroring the epoch: absent is `MissingStableIdentity`,
+    /// multiple candidates are `AmbiguousStableIdentity`, and a candidate of
+    /// the wrong kind is `WrongStableIdentityKind`. The caller never guesses.
+    fn definition_token(
+        &self,
+        file: u32,
+        name: &str,
+        owner: Option<&str>,
+        kind: crate::StableDefinitionKind,
+    ) -> Result<crate::SemanticDefinitionToken, crate::SemanticBodyExportFailure>;
+
+    /// The stable token for one consulted module file.
+    fn module_token(
+        &self,
+        file: FileId,
+    ) -> Result<crate::SemanticModuleToken, crate::SemanticBodyExportFailure>;
+
+    /// The file backing a module id this body resolved.
+    fn module_file(&self, module: crate::types::ModuleId) -> Option<FileId>;
+}
+
+/// The export half of the provider-backed receiver.
+///
+/// It answers the same questions `BodySema` answers for publication, from the
+/// body-local overlay, the provider's type pool, and exact keyed lookups —
+/// never a declaration-wide table. The arms below deliberately mirror
+/// `BodySema::export_body_type` / `body_struct_identity` /
+/// `body_enum_identity` structurally, so a reviewer can read them side by side
+/// and see that the only difference is where the stable token comes from.
+pub(crate) struct ProviderExportHost<'a, I> {
+    local: &'a ProviderBodyLocalState,
+    type_pool: &'a crate::intern_pool::TypeInternPool,
+    identity: &'a I,
+    interner: &'a lasso::ThreadedRodeo,
+}
+
+impl<'a, I: StableIdentityFacts> ProviderExportHost<'a, I> {
+    pub(crate) fn new(
+        local: &'a ProviderBodyLocalState,
+        type_pool: &'a crate::intern_pool::TypeInternPool,
+        identity: &'a I,
+        interner: &'a lasso::ThreadedRodeo,
+    ) -> Self {
+        Self {
+            local,
+            type_pool,
+            identity,
+            interner,
+        }
+    }
+
+    pub(crate) fn resolve_publication_symbol(&self, symbol: &Spur) -> &str {
+        self.interner.resolve(symbol)
+    }
+
+    /// A slice-like struct's element type, if this struct is one.
+    fn slice_element_type(&self, ty: Type) -> Option<Type> {
+        let crate::types::TypeKind::Struct(struct_id) = ty.kind() else {
+            return None;
+        };
+        let def = self.type_pool.struct_def(struct_id);
+        let is_slice = def.name.starts_with('[')
+            && def.name.ends_with(']')
+            && crate::types::parse_array_type_syntax(&def.name).is_none();
+        let is_str_fixed = def.name.starts_with("Str(") && def.name.ends_with(')');
+        if is_slice || def.name == "str" || is_str_fixed {
+            if let crate::types::TypeKind::PtrConst(ptr_id) = def.fields[0].ty.kind() {
+                return Some(self.type_pool.ptr_const_def(ptr_id));
+            }
+        }
+        None
+    }
+
+    /// The named-nominal arm: the compact id carries its own file and name, so
+    /// the stable token is one exact forward lookup rather than a reverse map.
+    fn struct_identity(
+        &self,
+        id: StructId,
+    ) -> Result<crate::SemanticDefinitionToken, crate::SemanticBodyExportFailure> {
+        let def = self
+            .type_pool
+            .struct_metadata(id)
+            .ok_or(crate::SemanticBodyExportFailure::UnsupportedType)?;
+        if def.name.starts_with("__anon_struct_") {
+            return Err(crate::SemanticBodyExportFailure::AnonymousNominal);
+        }
+        self.identity.definition_token(
+            def.file_id.index(),
+            def.name.as_str(),
+            None,
+            crate::StableDefinitionKind::Struct,
+        )
+    }
+
+    fn enum_identity(
+        &self,
+        id: EnumId,
+    ) -> Result<crate::SemanticDefinitionToken, crate::SemanticBodyExportFailure> {
+        let def = self
+            .type_pool
+            .enum_metadata(id)
+            .ok_or(crate::SemanticBodyExportFailure::UnsupportedType)?;
+        if def.name.starts_with("__anon_enum_") {
+            return Err(crate::SemanticBodyExportFailure::AnonymousNominal);
+        }
+        self.identity.definition_token(
+            def.file_id.index(),
+            def.name.as_str(),
+            None,
+            crate::StableDefinitionKind::Enum,
+        )
+    }
+
+    pub(crate) fn body_struct_identity(
+        &self,
+        id: StructId,
+    ) -> Result<
+        crate::NominalInstanceKey<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
+        crate::SemanticBodyExportFailure,
+    > {
+        let ty = Type::new_struct(id);
+        Ok(match self.local.canonical_anonymous_types.get(&ty) {
+            Some(key) => crate::NominalInstanceKey::Anonymous(key.clone()),
+            None if self.type_pool.struct_def(id).is_builtin
+                || self.type_pool.struct_def(id).name == "str" =>
+            {
+                crate::NominalInstanceKey::Builtin {
+                    kind: crate::AnonymousNominalKind::Struct,
+                    name: std::sync::Arc::from(self.type_pool.struct_def(id).name.as_str()),
+                }
+            }
+            None => crate::NominalInstanceKey::Named(self.struct_identity(id)?),
+        })
+    }
+
+    pub(crate) fn body_enum_identity(
+        &self,
+        id: EnumId,
+    ) -> Result<
+        crate::NominalInstanceKey<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
+        crate::SemanticBodyExportFailure,
+    > {
+        let ty = Type::new_enum(id);
+        Ok(match self.local.canonical_anonymous_types.get(&ty) {
+            Some(key) => crate::NominalInstanceKey::Anonymous(key.clone()),
+            None if rue_builtins::BUILTIN_ENUMS
+                .iter()
+                .any(|builtin| builtin.name == self.type_pool.enum_def(id).name) =>
+            {
+                crate::NominalInstanceKey::Builtin {
+                    kind: crate::AnonymousNominalKind::Enum,
+                    name: std::sync::Arc::from(self.type_pool.enum_def(id).name.as_str()),
+                }
+            }
+            None => crate::NominalInstanceKey::Named(self.enum_identity(id)?),
+        })
+    }
+
+    pub(crate) fn export_body_type(
+        &self,
+        ty: Type,
+    ) -> Result<
+        crate::SemanticImportType<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
+        crate::SemanticBodyExportFailure,
+    > {
+        use crate::SemanticImportType as Exported;
+        use crate::types::TypeKind;
+
+        self.type_pool
+            .validate_complete_type(ty)
+            .map_err(|_| crate::SemanticBodyExportFailure::UnsupportedType)?;
+        Ok(match ty.kind() {
+            TypeKind::I8 => Exported::I8,
+            TypeKind::I16 => Exported::I16,
+            TypeKind::I32 => Exported::I32,
+            TypeKind::I64 => Exported::I64,
+            TypeKind::U8 => Exported::U8,
+            TypeKind::U16 => Exported::U16,
+            TypeKind::U32 => Exported::U32,
+            TypeKind::U64 => Exported::U64,
+            TypeKind::Bool => Exported::Bool,
+            TypeKind::Unit => Exported::Unit,
+            TypeKind::Never => Exported::Never,
+            TypeKind::ComptimeType => Exported::ComptimeType,
+            TypeKind::Struct(id) => {
+                let def = self.type_pool.struct_def(id);
+                if let Some(identity) = self.local.canonical_anonymous_types.get(&ty) {
+                    Exported::AnonymousNominal(identity.clone())
+                } else if let Some(element) = self.slice_element_type(ty)
+                    && def.name.starts_with('[')
+                {
+                    Exported::Slice {
+                        element: Box::new(self.export_body_type(element)?),
+                        name: std::sync::Arc::from(def.name.as_str()),
+                    }
+                } else if def.is_builtin || def.name == "str" {
+                    Exported::BuiltinNominal {
+                        name: std::sync::Arc::from(def.name.as_str()),
+                        kind: crate::SemanticImportNominalKind::Struct,
+                    }
+                } else {
+                    Exported::Nominal(self.struct_identity(id)?)
+                }
+            }
+            TypeKind::Enum(id) => {
+                let def = self.type_pool.enum_def(id);
+                if let Some(identity) = self.local.canonical_anonymous_types.get(&ty) {
+                    Exported::AnonymousNominal(identity.clone())
+                } else if rue_builtins::BUILTIN_ENUMS
+                    .iter()
+                    .any(|builtin| builtin.name == def.name)
+                {
+                    Exported::BuiltinNominal {
+                        name: std::sync::Arc::from(def.name.as_str()),
+                        kind: crate::SemanticImportNominalKind::Enum,
+                    }
+                } else {
+                    Exported::Nominal(self.enum_identity(id)?)
+                }
+            }
+            TypeKind::Array(id) => {
+                let (element, len) = self.type_pool.array_def(id);
+                Exported::Array {
+                    element: Box::new(self.export_body_type(element)?),
+                    len,
+                }
+            }
+            TypeKind::PtrConst(id) => Exported::PtrConst(Box::new(
+                self.export_body_type(self.type_pool.ptr_const_def(id))?,
+            )),
+            TypeKind::PtrMut(id) => Exported::PtrMut(Box::new(
+                self.export_body_type(self.type_pool.ptr_mut_def(id))?,
+            )),
+            TypeKind::Module(id) => {
+                let file = self
+                    .identity
+                    .module_file(id)
+                    .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?;
+                Exported::Module(self.identity.module_token(file)?)
+            }
+            TypeKind::Error => {
+                return Err(crate::SemanticBodyExportFailure::UnsupportedType);
+            }
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -502,6 +766,92 @@ mod tests {
                 .is_none(),
             "a token this body never resolved has no endpoint to render from"
         );
+    }
+
+    /// A `StableIdentityFacts` that records every consult, so a test can assert
+    /// not just what was exported but how much of the boundary it cost.
+    #[derive(Default)]
+    struct RecordingIdentityFacts {
+        definition_consults: std::cell::RefCell<Vec<String>>,
+        module_consults: std::cell::RefCell<Vec<u32>>,
+    }
+
+    impl StableIdentityFacts for RecordingIdentityFacts {
+        fn definition_token(
+            &self,
+            file: u32,
+            name: &str,
+            owner: Option<&str>,
+            kind: crate::StableDefinitionKind,
+        ) -> Result<crate::SemanticDefinitionToken, crate::SemanticBodyExportFailure> {
+            self.definition_consults
+                .borrow_mut()
+                .push(format!("{file}:{name}:{owner:?}:{kind:?}"));
+            Err(crate::SemanticBodyExportFailure::MissingStableIdentity)
+        }
+
+        fn module_token(
+            &self,
+            file: FileId,
+        ) -> Result<crate::SemanticModuleToken, crate::SemanticBodyExportFailure> {
+            self.module_consults.borrow_mut().push(file.index());
+            Err(crate::SemanticBodyExportFailure::MissingStableIdentity)
+        }
+
+        fn module_file(&self, _: crate::types::ModuleId) -> Option<FileId> {
+            None
+        }
+    }
+
+    /// Exporting a primitive consults the identity boundary zero times.
+    ///
+    /// This is the locality claim in its smallest form: the epoch answers these
+    /// same cases while holding a declaration-universe token table, and the
+    /// provider host answers them from the type pool alone. A regression that
+    /// reintroduced a table read would show up here as a consult.
+    #[test]
+    fn exporting_primitives_costs_no_boundary_consults() {
+        let local = ProviderBodyLocalState::new();
+        let pool = crate::intern_pool::TypeInternPool::new();
+        let interner = lasso::ThreadedRodeo::new();
+        let identity = RecordingIdentityFacts::default();
+        let host = ProviderExportHost::new(&local, &pool, &identity, &interner);
+
+        for (ty, expected) in [
+            (Type::I32, crate::SemanticImportType::I32),
+            (Type::BOOL, crate::SemanticImportType::Bool),
+            (Type::UNIT, crate::SemanticImportType::Unit),
+        ] {
+            assert_eq!(
+                host.export_body_type(ty).expect("a primitive exports"),
+                expected
+            );
+        }
+
+        assert!(
+            identity.definition_consults.borrow().is_empty(),
+            "primitives resolved through the identity boundary: {:?}",
+            identity.definition_consults.borrow()
+        );
+        assert!(identity.module_consults.borrow().is_empty());
+    }
+
+    /// An unresolvable stable identity fails closed rather than inventing a
+    /// token. The epoch has a synthetic-test fallback that mints one from a
+    /// hash when its table is empty; the provider host must not inherit it,
+    /// because "the table is empty" is not a state the provider can be in.
+    #[test]
+    fn an_unresolved_module_identity_fails_closed() {
+        let local = ProviderBodyLocalState::new();
+        let pool = crate::intern_pool::TypeInternPool::new();
+        let interner = lasso::ThreadedRodeo::new();
+        let identity = RecordingIdentityFacts::default();
+        let host = ProviderExportHost::new(&local, &pool, &identity, &interner);
+
+        assert!(matches!(
+            host.export_body_type(Type::ERROR),
+            Err(crate::SemanticBodyExportFailure::UnsupportedType)
+        ));
     }
 
     /// The only category with design work left in it is the one the flip has

--- a/crates/rue-air/src/sema/provider_host.rs
+++ b/crates/rue-air/src/sema/provider_host.rs
@@ -433,7 +433,7 @@ pub(crate) const HOST_CAPABILITY_LEDGER: &[HostCapabilityRow] = &[
 /// bodies, and the durable universe on the other side is keyed on neither
 /// numbering. A file number crossing here would miss silently at best and
 /// collide with an unrelated declaration at worst.
-pub(crate) trait StableIdentityFacts {
+pub trait StableIdentityFacts {
     /// The stable token for one exact declaration coordinate.
     ///
     /// Fails closed, mirroring the epoch: absent is `MissingStableIdentity`,
@@ -464,13 +464,13 @@ pub(crate) trait StableIdentityFacts {
 /// fail-closed single-candidate contract is the same one the export path needs
 /// (an ambiguous receiver or method is `None`, never a guess).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ExportedMethodSite {
-    pub(crate) owner: StructId,
-    pub(crate) method: Spur,
+pub struct ExportedMethodSite {
+    pub owner: StructId,
+    pub method: Spur,
     /// The declaring module's logical path — the same request-independent
     /// coordinate [`StableIdentityFacts`] is keyed on, for the same reason.
-    pub(crate) module_path: std::sync::Arc<str>,
-    pub(crate) has_self: bool,
+    pub module_path: std::sync::Arc<str>,
+    pub has_self: bool,
 }
 
 /// The callable facts the export path consults, keyed and exact.
@@ -478,7 +478,7 @@ pub(crate) struct ExportedMethodSite {
 /// Same adapter discipline as [`StableIdentityFacts`]: the compiler-side
 /// implementation routes each call through the provider boundary so the edge is
 /// recorded, and neither operation has a whole-universe form.
-pub(crate) trait ExportCallableFacts {
+pub trait ExportCallableFacts {
     /// The logical module path declaring a free function, or `None` when the
     /// symbol does not name one (it may still name a method).
     fn free_function_module(&self, symbol: Spur) -> Option<std::sync::Arc<str>>;
@@ -499,10 +499,7 @@ pub(crate) trait ExportCallableFacts {
 /// answer a body receives came through the fact boundary, and therefore
 /// recorded its dependency edge at the consult. Three separate parameters would
 /// make an edge-free second authority expressible.
-pub(crate) trait BodyHostFacts:
-    BodyFactProvider + StableIdentityFacts + ExportCallableFacts
-{
-}
+pub trait BodyHostFacts: BodyFactProvider + StableIdentityFacts + ExportCallableFacts {}
 
 impl<T> BodyHostFacts for T where T: BodyFactProvider + StableIdentityFacts + ExportCallableFacts {}
 
@@ -519,7 +516,7 @@ impl<T> BodyHostFacts for T where T: BodyFactProvider + StableIdentityFacts + Ex
 /// receiver is `O(1)` in the program rather than `O(declarations)`. That is
 /// where the `O(bodies × declarations)` term goes: the epoch's cost was in
 /// building the receiver, not in the analysis that ran on it.
-pub(crate) struct ProviderBodyHost<K, M, S, P> {
+pub struct ProviderBodyHost<K, M, S, P> {
     /// This body's own lowered RIR. The epoch hands the engine the
     /// whole-program `Rir`; the receiver holds only the bundle its own body was
     /// lowered into, so no live program-wide RIR crosses the query boundary.
@@ -562,9 +559,9 @@ pub(crate) struct ProviderBodyHost<K, M, S, P> {
 ///
 /// Neither derived answer is sized by the declaration universe.
 #[derive(Debug, Clone)]
-pub(crate) struct ProviderBodyConfiguration {
-    pub(crate) target: Target,
-    pub(crate) preview_features: PreviewFeatures,
+pub struct ProviderBodyConfiguration {
+    pub target: Target,
+    pub preview_features: PreviewFeatures,
 }
 
 impl<K, M, S, P> ProviderBodyHost<K, M, S, P>
@@ -581,12 +578,7 @@ where
     /// beside it, so the RIR and the state cannot be built over two different
     /// interners. Every other construction path checks that invariant with an
     /// assertion; here it holds by construction.
-    pub(crate) fn new(
-        rir: BodyRirBundle,
-        source: S,
-        facts: P,
-        config: ProviderBodyConfiguration,
-    ) -> Self {
+    pub fn new(rir: BodyRirBundle, source: S, facts: P, config: ProviderBodyConfiguration) -> Self {
         let state = rir.provider_body_state(source);
         let type_pool = state.type_pool();
         let interner = state.interner();

--- a/crates/rue-air/src/sema/provider_host.rs
+++ b/crates/rue-air/src/sema/provider_host.rs
@@ -114,6 +114,20 @@ pub(crate) struct ProviderBodyLocalState {
     pub(crate) comptime_type_call_depth: usize,
     /// Constructor type displays this body rendered, for diagnostics.
     pub(crate) ctor_type_displays: HashMap<Type, String>,
+    /// Endpoints for the stable identities this body actually consulted.
+    ///
+    /// Symbol rendering needs `token -> (file, name, owner, kind)`, which the
+    /// epoch answers from a declaration-universe-sized reverse table
+    /// (`stable_definition_endpoints`). A body never needs that table: it can
+    /// only render a token it resolved, and every token it resolved came back
+    /// from a provider lookup that already carried the endpoint. Recording the
+    /// endpoint at that moment makes rendering `O(consulted)` and keeps the
+    /// dependency edge on the lookup that produced it, rather than on a table
+    /// read afterwards.
+    pub(crate) consulted_definition_endpoints:
+        HashMap<crate::SemanticDefinitionToken, crate::SemanticDefinitionEndpoint>,
+    pub(crate) consulted_module_endpoints:
+        HashMap<crate::SemanticModuleToken, crate::SemanticModuleEndpoint>,
 }
 
 impl ProviderBodyLocalState {
@@ -133,6 +147,42 @@ impl ProviderBodyLocalState {
             .chain(self.anon_enum_identities.keys())
             .cloned()
             .collect();
+    }
+
+    /// Record the endpoint a provider lookup returned alongside its token.
+    ///
+    /// Called at the consult, never at the render: a token whose endpoint was
+    /// never recorded is one this body never resolved, and rendering it would
+    /// be reaching for a fact the body has no dependency edge on.
+    pub(crate) fn record_consulted_definition_endpoint(
+        &mut self,
+        endpoint: crate::SemanticDefinitionEndpoint,
+    ) {
+        self.consulted_definition_endpoints
+            .insert(endpoint.token, endpoint);
+    }
+
+    pub(crate) fn record_consulted_module_endpoint(
+        &mut self,
+        endpoint: crate::SemanticModuleEndpoint,
+    ) {
+        self.consulted_module_endpoints
+            .insert(endpoint.token, endpoint);
+    }
+
+    /// The endpoint for a token this body resolved, or `None` when it did not.
+    pub(crate) fn consulted_definition_endpoint(
+        &self,
+        token: &crate::SemanticDefinitionToken,
+    ) -> Option<&crate::SemanticDefinitionEndpoint> {
+        self.consulted_definition_endpoints.get(token)
+    }
+
+    pub(crate) fn consulted_module_endpoint(
+        &self,
+        token: &crate::SemanticModuleToken,
+    ) -> Option<&crate::SemanticModuleEndpoint> {
+        self.consulted_module_endpoints.get(token)
     }
 
     /// The producer-nominal identities this body actually minted.
@@ -300,39 +350,50 @@ pub(crate) const HOST_CAPABILITY_LEDGER: &[HostCapabilityRow] = &[
              `TypeSyntaxHost`, so this is binding that host to the provider rather than to `Sema`",
         ),
     ),
+    // The five export rows below are one job, not five. `SemanticBodyExportHost`
+    // already abstracts the publication path over exactly these facts, so the
+    // work is a second implementation of that trait rather than new machinery.
+    // Tracing the epoch's implementation shows no reverse identity map is
+    // needed: a compact id carries its own `(file, name)` through the type pool,
+    // so the stable token is a FORWARD keyed lookup the fact provider already
+    // answers, and the only genuinely reverse fact — token to endpoint, for
+    // symbol rendering — is memoized body-locally at the consult that produced
+    // the token (`consulted_definition_endpoints`). Every export fact is
+    // therefore already body-local, derivable from the type pool, or recorded
+    // at lookup time.
     row(
         "canonical_type_instance",
         HostCapability::NeedsProviderWiring(
-            "compact type -> stable instance key; needs the provider identity pool to own the \
-             export direction, not just the import direction",
+            "compact type -> stable instance key; anonymous and builtin arms are already \
+             body-local and type-pool reads, and the named arm is a forward \
+             `(file, name, kind)` lookup through the fact boundary",
         ),
     ),
     row(
         "canonical_argument_value",
         HostCapability::NeedsProviderWiring(
-            "compact const value -> stable argument value; same export direction as \
+            "compact const value -> stable argument value; rides the same arms as \
              `canonical_type_instance`",
         ),
     ),
     row(
         "function_identity",
         HostCapability::NeedsProviderWiring(
-            "rendered symbol -> stable definition token; `callable_symbol_method` covers the \
-             method case, the free-function case needs the same reversal",
+            "rendered symbol -> stable definition token; `callable_symbol_method` answers the \
+             method arm and the free-function arm is the same forward lookup",
         ),
     ),
     row(
         "stable_definition_symbol_component",
         HostCapability::NeedsProviderWiring(
-            "symbol rendering currently reads epoch endpoint tables; the provider must render \
-             from the stable token alone",
+            "render from the endpoint recorded at consult time, not from the epoch's \
+             universe-sized `stable_definition_endpoints` table",
         ),
     ),
     row(
         "stable_module_symbol_component",
         HostCapability::NeedsProviderWiring(
-            "module half of the same rendering; must not consult a module registry the body \
-             does not own",
+            "module half of the same rendering, from `consulted_module_endpoints`",
         ),
     ),
 ];
@@ -408,6 +469,39 @@ mod tests {
         assert!(state.generated_structs.is_empty());
         assert_eq!(state.comptime_type_call_depth, 0);
         assert!(state.produced_anonymous_identities().next().is_none());
+    }
+
+    /// Rendering a stable symbol is only legal for a token this body resolved.
+    /// The memo is populated at the consult, so an unconsulted token misses —
+    /// which is the difference between `O(consulted)` rendering and reading the
+    /// epoch's declaration-universe endpoint table.
+    #[test]
+    fn only_consulted_tokens_can_be_rendered() {
+        let mut state = ProviderBodyLocalState::new();
+        let consulted = crate::SemanticDefinitionToken::new(1, 7);
+        let never_consulted = crate::SemanticDefinitionToken::new(1, 8);
+
+        assert!(state.consulted_definition_endpoint(&consulted).is_none());
+
+        state.record_consulted_definition_endpoint(crate::SemanticDefinitionEndpoint {
+            token: consulted,
+            file: 3,
+            name: "helper".into(),
+            kind: crate::StableDefinitionKind::Function,
+            owner: None,
+        });
+
+        let endpoint = state
+            .consulted_definition_endpoint(&consulted)
+            .expect("a consulted token carries the endpoint its lookup returned");
+        assert_eq!(endpoint.file, 3);
+        assert_eq!(&*endpoint.name, "helper");
+        assert!(
+            state
+                .consulted_definition_endpoint(&never_consulted)
+                .is_none(),
+            "a token this body never resolved has no endpoint to render from"
+        );
     }
 
     /// The only category with design work left in it is the one the flip has

--- a/crates/rue-air/src/sema/provider_host.rs
+++ b/crates/rue-air/src/sema/provider_host.rs
@@ -127,20 +127,36 @@ pub(crate) struct ProviderBodyLocalState {
     pub(crate) comptime_type_call_depth: usize,
     /// Constructor type displays this body rendered, for diagnostics.
     pub(crate) ctor_type_displays: HashMap<Type, String>,
-    /// Endpoints for the stable identities this body actually consulted.
+    /// Coordinates for the stable identities this body actually consulted.
     ///
-    /// Symbol rendering needs `token -> (file, name, owner, kind)`, which the
-    /// epoch answers from a declaration-universe-sized reverse table
-    /// (`stable_definition_endpoints`). A body never needs that table: it can
-    /// only render a token it resolved, and every token it resolved came back
-    /// from a provider lookup that already carried the endpoint. Recording the
-    /// endpoint at that moment makes rendering `O(consulted)` and keeps the
-    /// dependency edge on the lookup that produced it, rather than on a table
-    /// read afterwards.
-    pub(crate) consulted_definition_endpoints:
-        HashMap<crate::SemanticDefinitionToken, crate::SemanticDefinitionEndpoint>,
-    pub(crate) consulted_module_endpoints:
-        HashMap<crate::SemanticModuleToken, crate::SemanticModuleEndpoint>,
+    /// Symbol rendering needs `token -> (module path, name, owner, kind)`,
+    /// which the epoch answers from two declaration-universe-sized reverse
+    /// tables (`stable_definition_endpoints` joined with `symbol_paths`). A
+    /// body never needs either: it can only render a token it resolved, and it
+    /// resolved that token by *supplying* exactly these coordinates to the
+    /// identity boundary. Recording them at that moment makes rendering
+    /// `O(consulted)` and keeps the dependency edge on the lookup that produced
+    /// the token rather than on a table read afterwards.
+    pub(crate) consulted_definitions: HashMap<crate::SemanticDefinitionToken, ConsultedDefinition>,
+    pub(crate) consulted_modules: HashMap<crate::SemanticModuleToken, std::sync::Arc<str>>,
+}
+
+/// The request-independent coordinates one resolved definition token was
+/// looked up under — which are exactly the inputs its stable digest component
+/// is built from.
+///
+/// Deliberately *not* [`crate::SemanticDefinitionEndpoint`]: that record
+/// carries a `file: u32` in the compiler's file numbering, and the body-scoped
+/// identity pool numbers its own files independently, in first-consult order.
+/// Keeping a file number here at all would leave two incompatible numbering
+/// universes meeting silently at the renderer. The logical module path is the
+/// one coordinate both sides agree on, so it is the only one stored.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ConsultedDefinition {
+    pub(crate) module_path: std::sync::Arc<str>,
+    pub(crate) name: std::sync::Arc<str>,
+    pub(crate) owner: Option<std::sync::Arc<str>>,
+    pub(crate) kind: crate::StableDefinitionKind,
 }
 
 impl ProviderBodyLocalState {
@@ -162,40 +178,40 @@ impl ProviderBodyLocalState {
             .collect();
     }
 
-    /// Record the endpoint a provider lookup returned alongside its token.
+    /// Record the coordinates a token was resolved under, alongside the token.
     ///
-    /// Called at the consult, never at the render: a token whose endpoint was
-    /// never recorded is one this body never resolved, and rendering it would
-    /// be reaching for a fact the body has no dependency edge on.
-    pub(crate) fn record_consulted_definition_endpoint(
+    /// Called at the consult, never at the render: a token whose coordinates
+    /// were never recorded is one this body never resolved, and rendering it
+    /// would be reaching for a fact the body has no dependency edge on.
+    pub(crate) fn record_consulted_definition(
         &mut self,
-        endpoint: crate::SemanticDefinitionEndpoint,
+        token: crate::SemanticDefinitionToken,
+        consulted: ConsultedDefinition,
     ) {
-        self.consulted_definition_endpoints
-            .insert(endpoint.token, endpoint);
+        self.consulted_definitions.insert(token, consulted);
     }
 
-    pub(crate) fn record_consulted_module_endpoint(
+    pub(crate) fn record_consulted_module(
         &mut self,
-        endpoint: crate::SemanticModuleEndpoint,
+        token: crate::SemanticModuleToken,
+        module_path: std::sync::Arc<str>,
     ) {
-        self.consulted_module_endpoints
-            .insert(endpoint.token, endpoint);
+        self.consulted_modules.insert(token, module_path);
     }
 
-    /// The endpoint for a token this body resolved, or `None` when it did not.
-    pub(crate) fn consulted_definition_endpoint(
+    /// The coordinates of a token this body resolved, or `None` when it did
+    /// not.
+    pub(crate) fn consulted_definition(
         &self,
         token: &crate::SemanticDefinitionToken,
-    ) -> Option<&crate::SemanticDefinitionEndpoint> {
-        self.consulted_definition_endpoints.get(token)
+    ) -> Option<&ConsultedDefinition> {
+        self.consulted_definitions.get(token)
     }
 
-    pub(crate) fn consulted_module_endpoint(
-        &self,
-        token: &crate::SemanticModuleToken,
-    ) -> Option<&crate::SemanticModuleEndpoint> {
-        self.consulted_module_endpoints.get(token)
+    pub(crate) fn consulted_module(&self, token: &crate::SemanticModuleToken) -> Option<&str> {
+        self.consulted_modules
+            .get(token)
+            .map(std::sync::Arc::as_ref)
     }
 
     /// The producer-nominal identities this body actually minted.
@@ -404,6 +420,13 @@ pub(crate) const HOST_CAPABILITY_LEDGER: &[HostCapabilityRow] = &[
 /// which is the property that makes export `O(consulted)`: the epoch answers
 /// the same questions by scanning `stable_definition_tokens` and
 /// `stable_module_tokens`, both sized by the declaration universe.
+/// Every coordinate crossing this seam is **request-independent**. In
+/// particular a declaration is located by its logical module path, never by a
+/// file number: the body-scoped identity pool numbers files in first-consult
+/// order, so the same declaration carries different numbers in different
+/// bodies, and the durable universe on the other side is keyed on neither
+/// numbering. A file number crossing here would miss silently at best and
+/// collide with an unrelated declaration at worst.
 pub(crate) trait StableIdentityFacts {
     /// The stable token for one exact declaration coordinate.
     ///
@@ -412,20 +435,20 @@ pub(crate) trait StableIdentityFacts {
     /// the wrong kind is `WrongStableIdentityKind`. The caller never guesses.
     fn definition_token(
         &self,
-        file: u32,
+        module_path: &str,
         name: &str,
         owner: Option<&str>,
         kind: crate::StableDefinitionKind,
     ) -> Result<crate::SemanticDefinitionToken, crate::SemanticBodyExportFailure>;
 
-    /// The stable token for one consulted module file.
+    /// The stable token for one consulted module.
     fn module_token(
         &self,
-        file: FileId,
+        module_path: &str,
     ) -> Result<crate::SemanticModuleToken, crate::SemanticBodyExportFailure>;
 
-    /// The file backing a module id this body resolved.
-    fn module_file(&self, module: crate::types::ModuleId) -> Option<FileId>;
+    /// The logical module path behind a module id this body resolved.
+    fn module_path(&self, module: crate::types::ModuleId) -> Option<std::sync::Arc<str>>;
 }
 
 /// One named method a rendered callable symbol reverses to.
@@ -434,11 +457,13 @@ pub(crate) trait StableIdentityFacts {
 /// provider answers it with `BodyFactProvider::callable_symbol_method`, whose
 /// fail-closed single-candidate contract is the same one the export path needs
 /// (an ambiguous receiver or method is `None`, never a guess).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ExportedMethodSite {
     pub(crate) owner: StructId,
     pub(crate) method: Spur,
-    pub(crate) file: FileId,
+    /// The declaring module's logical path — the same request-independent
+    /// coordinate [`StableIdentityFacts`] is keyed on, for the same reason.
+    pub(crate) module_path: std::sync::Arc<str>,
     pub(crate) has_self: bool,
 }
 
@@ -448,9 +473,9 @@ pub(crate) struct ExportedMethodSite {
 /// implementation routes each call through the provider boundary so the edge is
 /// recorded, and neither operation has a whole-universe form.
 pub(crate) trait ExportCallableFacts {
-    /// The file declaring a free function, or `None` when the symbol does not
-    /// name one (it may still name a method).
-    fn free_function_file(&self, symbol: Spur) -> Option<FileId>;
+    /// The logical module path declaring a free function, or `None` when the
+    /// symbol does not name one (it may still name a method).
+    fn free_function_module(&self, symbol: Spur) -> Option<std::sync::Arc<str>>;
 
     /// The source name behind a possibly-specialized callable symbol.
     fn source_function_name(&self, symbol: Spur) -> Spur;
@@ -756,7 +781,7 @@ impl<'a, I: StableIdentityFacts, C: ExportCallableFacts> ProviderExportHost<'a, 
             return Err(crate::SemanticBodyExportFailure::AnonymousNominal);
         }
         self.identity.definition_token(
-            def.file_id.index(),
+            &self.pool_module_path(def.file_id),
             def.name.as_str(),
             None,
             crate::StableDefinitionKind::Struct,
@@ -775,7 +800,7 @@ impl<'a, I: StableIdentityFacts, C: ExportCallableFacts> ProviderExportHost<'a, 
             return Err(crate::SemanticBodyExportFailure::AnonymousNominal);
         }
         self.identity.definition_token(
-            def.file_id.index(),
+            &self.pool_module_path(def.file_id),
             def.name.as_str(),
             None,
             crate::StableDefinitionKind::Enum,
@@ -912,11 +937,11 @@ impl<'a, I: StableIdentityFacts, C: ExportCallableFacts> ProviderExportHost<'a, 
                 self.canonical_type_instance(self.type_pool.ptr_mut_def(id))?,
             )),
             TypeKind::Module(id) => {
-                let file = self
+                let module = self
                     .identity
-                    .module_file(id)
+                    .module_path(id)
                     .ok_or(Failure::MissingStableIdentity)?;
-                T::Module(self.identity.module_token(file)?)
+                T::Module(self.identity.module_token(&module)?)
             }
             TypeKind::Error => return Err(Failure::UnsupportedType),
         })
@@ -927,10 +952,10 @@ impl<'a, I: StableIdentityFacts, C: ExportCallableFacts> ProviderExportHost<'a, 
         &self,
         symbol: Spur,
     ) -> Result<crate::SemanticDefinitionToken, crate::SemanticBodyExportFailure> {
-        if let Some(file) = self.callables.free_function_file(symbol) {
+        if let Some(module) = self.callables.free_function_module(symbol) {
             let source = self.callables.source_function_name(symbol);
             return self.identity.definition_token(
-                file.index(),
+                &module,
                 self.interner.resolve(&source),
                 None,
                 crate::StableDefinitionKind::Function,
@@ -946,7 +971,7 @@ impl<'a, I: StableIdentityFacts, C: ExportCallableFacts> ProviderExportHost<'a, 
             return Err(crate::SemanticBodyExportFailure::AnonymousNominal);
         }
         self.identity.definition_token(
-            site.file.index(),
+            &site.module_path,
             method,
             Some(owner.name.as_str()),
             if method == "__drop" {
@@ -989,40 +1014,39 @@ impl<'a, I: StableIdentityFacts, C: ExportCallableFacts> ProviderExportHost<'a, 
         })
     }
 
-    /// The request-independent logical module path of one consulted file.
+    /// The logical module path a pool-minted nominal was declared in.
     ///
-    /// The pool's path table is written at the mint that assigned a module its
-    /// body-local file id, so it holds exactly the modules this body consulted.
-    /// The epoch answers the same question from `symbol_paths`, sized by every
-    /// file in the program — this is the whole difference between the two
-    /// renderings.
+    /// This is the *only* legal use of a body-local file id: translating it
+    /// back through the same table that assigned it. The pool writes that entry
+    /// at the mint, so it holds exactly the modules this body consulted, and an
+    /// absent path means a broken pool rather than a reachable input — the
+    /// epoch fails closed on the same invariant.
     ///
-    /// Every file reaching here came from a nominal the pool minted, and
-    /// minting registers the path, so an absent path is a broken pool rather
-    /// than a reachable input. The epoch fails closed on the same invariant.
-    fn logical_module_component(&self, file: u32) -> String {
+    /// The number never escapes this method. Everything downstream — the
+    /// identity boundary and both symbol renderings — sees the path.
+    fn pool_module_path(&self, file: FileId) -> String {
         self.type_pool
-            .symbol_path(FileId::new(file))
-            .expect("every consulted endpoint's file has a canonical logical module path")
+            .symbol_path(file)
+            .expect("every pool-minted nominal's file has a canonical logical module path")
     }
 
     /// The request-independent content of one definition token.
     ///
-    /// Rendered from the endpoint recorded at the consult that produced the
+    /// Rendered from the coordinates recorded at the consult that produced the
     /// token, never from a reverse table: a body can only render an identity it
-    /// resolved. The uninstalled-token spelling matches the epoch's byte for
-    /// byte, because it feeds anonymous-identity digests that must agree across
-    /// the flip.
+    /// resolved, and it resolved it by supplying exactly these coordinates. The
+    /// uninstalled-token spelling matches the epoch's byte for byte, because it
+    /// feeds anonymous-identity digests that must agree across the flip.
     pub(crate) fn stable_definition_symbol_component(
         &self,
         token: &crate::SemanticDefinitionToken,
     ) -> String {
-        match self.local.consulted_definition_endpoint(token) {
-            Some(endpoint) => crate::stable_digest::stable_definition_component(
-                &self.logical_module_component(endpoint.file),
-                &endpoint.name,
-                endpoint.owner.as_deref(),
-                endpoint.kind as u8,
+        match self.local.consulted_definition(token) {
+            Some(consulted) => crate::stable_digest::stable_definition_component(
+                &consulted.module_path,
+                &consulted.name,
+                consulted.owner.as_deref(),
+                consulted.kind as u8,
             ),
             None => format!("d\u{1}{}\u{1}{}", token.issuer(), token.slot()),
         }
@@ -1033,10 +1057,8 @@ impl<'a, I: StableIdentityFacts, C: ExportCallableFacts> ProviderExportHost<'a, 
         &self,
         token: &crate::SemanticModuleToken,
     ) -> String {
-        match self.local.consulted_module_endpoint(token) {
-            Some(endpoint) => crate::stable_digest::stable_module_component(
-                &self.logical_module_component(endpoint.file),
-            ),
+        match self.local.consulted_module(token) {
+            Some(module_path) => crate::stable_digest::stable_module_component(module_path),
             None => format!("m\u{1}{}\u{1}{}", token.issuer(), token.slot()),
         }
     }
@@ -1054,7 +1076,7 @@ impl<'a, I: StableIdentityFacts, C: ExportCallableFacts> ProviderExportHost<'a, 
         crate::FunctionInstanceKey<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
         crate::SemanticBodyExportFailure,
     > {
-        if self.callables.free_function_file(symbol).is_some() {
+        if self.callables.free_function_module(symbol).is_some() {
             return Ok(crate::FunctionInstanceKey::Definition(
                 self.function_identity(symbol)?,
             ));
@@ -1163,11 +1185,11 @@ impl<'a, I: StableIdentityFacts, C: ExportCallableFacts> ProviderExportHost<'a, 
                 self.export_body_type(self.type_pool.ptr_mut_def(id))?,
             )),
             TypeKind::Module(id) => {
-                let file = self
+                let module = self
                     .identity
-                    .module_file(id)
+                    .module_path(id)
                     .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?;
-                Exported::Module(self.identity.module_token(file)?)
+                Exported::Module(self.identity.module_token(&module)?)
             }
             TypeKind::Error => {
                 return Err(crate::SemanticBodyExportFailure::UnsupportedType);
@@ -1259,26 +1281,26 @@ mod tests {
         let consulted = crate::SemanticDefinitionToken::new(1, 7);
         let never_consulted = crate::SemanticDefinitionToken::new(1, 8);
 
-        assert!(state.consulted_definition_endpoint(&consulted).is_none());
+        assert!(state.consulted_definition(&consulted).is_none());
 
-        state.record_consulted_definition_endpoint(crate::SemanticDefinitionEndpoint {
-            token: consulted,
-            file: 3,
-            name: "helper".into(),
-            kind: crate::StableDefinitionKind::Function,
-            owner: None,
-        });
+        state.record_consulted_definition(
+            consulted,
+            ConsultedDefinition {
+                module_path: "app/helpers.rue".into(),
+                name: "helper".into(),
+                owner: None,
+                kind: crate::StableDefinitionKind::Function,
+            },
+        );
 
-        let endpoint = state
-            .consulted_definition_endpoint(&consulted)
-            .expect("a consulted token carries the endpoint its lookup returned");
-        assert_eq!(endpoint.file, 3);
-        assert_eq!(&*endpoint.name, "helper");
+        let recorded = state
+            .consulted_definition(&consulted)
+            .expect("a consulted token carries the coordinates its lookup used");
+        assert_eq!(&*recorded.module_path, "app/helpers.rue");
+        assert_eq!(&*recorded.name, "helper");
         assert!(
-            state
-                .consulted_definition_endpoint(&never_consulted)
-                .is_none(),
-            "a token this body never resolved has no endpoint to render from"
+            state.consulted_definition(&never_consulted).is_none(),
+            "a token this body never resolved has no coordinates to render from"
         );
     }
 
@@ -1293,11 +1315,11 @@ mod tests {
     #[derive(Default)]
     struct RecordingFacts {
         definition_consults: std::cell::RefCell<Vec<String>>,
-        module_consults: std::cell::RefCell<Vec<u32>>,
+        module_consults: std::cell::RefCell<Vec<String>>,
     }
 
     impl ExportCallableFacts for RecordingFacts {
-        fn free_function_file(&self, _: Spur) -> Option<FileId> {
+        fn free_function_module(&self, _: Spur) -> Option<std::sync::Arc<str>> {
             None
         }
         fn source_function_name(&self, symbol: Spur) -> Spur {
@@ -1424,26 +1446,28 @@ mod tests {
     impl StableIdentityFacts for RecordingFacts {
         fn definition_token(
             &self,
-            file: u32,
+            module_path: &str,
             name: &str,
             owner: Option<&str>,
             kind: crate::StableDefinitionKind,
         ) -> Result<crate::SemanticDefinitionToken, crate::SemanticBodyExportFailure> {
             self.definition_consults
                 .borrow_mut()
-                .push(format!("{file}:{name}:{owner:?}:{kind:?}"));
+                .push(format!("{module_path}:{name}:{owner:?}:{kind:?}"));
             Err(crate::SemanticBodyExportFailure::MissingStableIdentity)
         }
 
         fn module_token(
             &self,
-            file: FileId,
+            module_path: &str,
         ) -> Result<crate::SemanticModuleToken, crate::SemanticBodyExportFailure> {
-            self.module_consults.borrow_mut().push(file.index());
+            self.module_consults
+                .borrow_mut()
+                .push(module_path.to_owned());
             Err(crate::SemanticBodyExportFailure::MissingStableIdentity)
         }
 
-        fn module_file(&self, _: crate::types::ModuleId) -> Option<FileId> {
+        fn module_path(&self, _: crate::types::ModuleId) -> Option<std::sync::Arc<str>> {
             None
         }
     }
@@ -1523,31 +1547,28 @@ mod tests {
         );
     }
 
-    /// Rendering a stable symbol component uses the endpoint recorded at the
-    /// consult and the module path the type pool wrote when it minted that
-    /// file, and encodes them with the digest encoder the epoch shares. Both
-    /// halves matter: the same encoder keeps anonymous-identity digests equal
-    /// across the flip, and the body-local path table is what makes the
-    /// rendering `O(consulted)` instead of `O(files)`.
+    /// Rendering a stable symbol component uses the coordinates recorded at the
+    /// consult, encoded with the digest encoder the epoch shares. The shared
+    /// encoder is what keeps anonymous-identity digests equal across the flip;
+    /// recording rather than reversing is what makes the rendering
+    /// `O(consulted)` instead of `O(declarations)`.
     #[test]
-    fn a_consulted_token_renders_from_its_recorded_endpoint() {
+    fn a_consulted_token_renders_from_its_recorded_coordinates() {
         let mut local = ProviderBodyLocalState::new();
         let pool = crate::intern_pool::TypeInternPool::new();
         let interner = lasso::ThreadedRodeo::new();
         let facts = RecordingFacts::default();
 
-        pool.set_symbol_paths(HashMap::from([(
-            FileId::new(3),
-            "app/widget.rue".to_owned(),
-        )]));
         let token = crate::SemanticDefinitionToken::new(1, 7);
-        local.record_consulted_definition_endpoint(crate::SemanticDefinitionEndpoint {
+        local.record_consulted_definition(
             token,
-            file: 3,
-            name: "render".into(),
-            kind: crate::StableDefinitionKind::Method,
-            owner: Some("Widget".into()),
-        });
+            ConsultedDefinition {
+                module_path: "app/widget.rue".into(),
+                name: "render".into(),
+                owner: Some("Widget".into()),
+                kind: crate::StableDefinitionKind::Method,
+            },
+        );
 
         let host = ProviderExportHost::new(&local, &pool, &facts, &facts, &interner);
         assert_eq!(
@@ -1632,6 +1653,59 @@ mod tests {
                 Err(crate::SemanticBodyExportFailure::UnmappedFunction)
             ),
             "the function arm resolves through callable identity, and fails closed"
+        );
+    }
+
+    /// A pool-minted nominal reaches the identity boundary as a module path,
+    /// not as the pool's own file number.
+    ///
+    /// This is the invariant, not an implementation detail. The body-scoped
+    /// identity pool numbers files in first-consult order, so the *same*
+    /// declaration is file 1 in one body and file 4 in another, while the
+    /// durable universe on the far side of the boundary is keyed on neither
+    /// numbering. A file number crossing here resolves to the wrong declaration
+    /// or to none, silently, with no failure the exporter could report — which
+    /// is why the consult is asserted by its rendered text rather than merely
+    /// counted.
+    #[test]
+    fn the_identity_boundary_is_keyed_on_module_paths() {
+        let local = ProviderBodyLocalState::new();
+        let pool = crate::intern_pool::TypeInternPool::new();
+        let interner = lasso::ThreadedRodeo::new();
+        let facts = RecordingFacts::default();
+
+        // A nominal minted the way the body-scoped pool mints one: a
+        // body-local file id whose only meaning is the path it maps to.
+        let body_local_file = FileId::new(4);
+        pool.set_symbol_paths(HashMap::from([(
+            body_local_file,
+            "app/widget.rue".to_owned(),
+        )]));
+        let symbol = interner.get_or_intern("Widget");
+        let (widget, _) = pool.register_struct(
+            symbol,
+            crate::types::StructDef {
+                name: "Widget".to_owned(),
+                fields: Vec::new(),
+                is_copy: false,
+                is_linear: false,
+                destructor: None,
+                is_builtin: false,
+                is_pub: true,
+                file_id: body_local_file,
+            },
+        );
+
+        let host = ProviderExportHost::new(&local, &pool, &facts, &facts, &interner);
+        assert!(matches!(
+            host.body_struct_identity(widget),
+            Err(crate::SemanticBodyExportFailure::MissingStableIdentity)
+        ));
+        assert_eq!(
+            facts.definition_consults.borrow().as_slice(),
+            ["app/widget.rue:Widget:None:Struct".to_owned()],
+            "the boundary must be consulted by logical module path; a pool file \
+             number here would key a durable lookup on body-local consult order"
         );
     }
 

--- a/crates/rue-air/src/sema/provider_host.rs
+++ b/crates/rue-air/src/sema/provider_host.rs
@@ -436,6 +436,37 @@ pub(crate) trait StableIdentityFacts {
     fn module_file(&self, module: crate::types::ModuleId) -> Option<FileId>;
 }
 
+/// One named method a rendered callable symbol reverses to.
+///
+/// The epoch reads this out of its `methods` / `anonymous_methods` tables; the
+/// provider answers it with `BodyFactProvider::callable_symbol_method`, whose
+/// fail-closed single-candidate contract is the same one the export path needs
+/// (an ambiguous receiver or method is `None`, never a guess).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ExportedMethodSite {
+    pub(crate) owner: StructId,
+    pub(crate) method: Spur,
+    pub(crate) file: FileId,
+    pub(crate) has_self: bool,
+}
+
+/// The callable facts the export path consults, keyed and exact.
+///
+/// Same adapter discipline as [`StableIdentityFacts`]: the compiler-side
+/// implementation routes each call through the provider boundary so the edge is
+/// recorded, and neither operation has a whole-universe form.
+pub(crate) trait ExportCallableFacts {
+    /// The file declaring a free function, or `None` when the symbol does not
+    /// name one (it may still name a method).
+    fn free_function_file(&self, symbol: Spur) -> Option<FileId>;
+
+    /// The source name behind a possibly-specialized callable symbol.
+    fn source_function_name(&self, symbol: Spur) -> Spur;
+
+    /// The named method a rendered callable symbol reverses to.
+    fn method_by_callable_symbol(&self, symbol: Spur) -> Option<ExportedMethodSite>;
+}
+
 /// The export half of the provider-backed receiver.
 ///
 /// It answers the same questions `BodySema` answers for publication, from the
@@ -444,24 +475,27 @@ pub(crate) trait StableIdentityFacts {
 /// `BodySema::export_body_type` / `body_struct_identity` /
 /// `body_enum_identity` structurally, so a reviewer can read them side by side
 /// and see that the only difference is where the stable token comes from.
-pub(crate) struct ProviderExportHost<'a, I> {
+pub(crate) struct ProviderExportHost<'a, I, C> {
     local: &'a ProviderBodyLocalState,
     type_pool: &'a crate::intern_pool::TypeInternPool,
     identity: &'a I,
+    callables: &'a C,
     interner: &'a lasso::ThreadedRodeo,
 }
 
-impl<'a, I: StableIdentityFacts> ProviderExportHost<'a, I> {
+impl<'a, I: StableIdentityFacts, C: ExportCallableFacts> ProviderExportHost<'a, I, C> {
     pub(crate) fn new(
         local: &'a ProviderBodyLocalState,
         type_pool: &'a crate::intern_pool::TypeInternPool,
         identity: &'a I,
+        callables: &'a C,
         interner: &'a lasso::ThreadedRodeo,
     ) -> Self {
         Self {
             local,
             type_pool,
             identity,
+            callables,
             interner,
         }
     }
@@ -571,6 +605,184 @@ impl<'a, I: StableIdentityFacts> ProviderExportHost<'a, I> {
             }
             None => crate::NominalInstanceKey::Named(self.enum_identity(id)?),
         })
+    }
+
+    /// The stable instance key for a compact type.
+    ///
+    /// Structurally the same walk as [`Self::export_body_type`] over a
+    /// different output algebra, mirroring the epoch's own split.
+    pub(crate) fn canonical_type_instance(
+        &self,
+        ty: Type,
+    ) -> Result<
+        crate::TypeInstanceKey<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
+        crate::SemanticBodyExportFailure,
+    > {
+        use crate::SemanticBodyExportFailure as Failure;
+        use crate::types::TypeKind;
+        use crate::{AnonymousNominalKind as K, NominalInstanceKey as N, TypeInstanceKey as T};
+
+        Ok(match ty.kind() {
+            TypeKind::I8 => T::I8,
+            TypeKind::I16 => T::I16,
+            TypeKind::I32 => T::I32,
+            TypeKind::I64 => T::I64,
+            TypeKind::U8 => T::U8,
+            TypeKind::U16 => T::U16,
+            TypeKind::U32 => T::U32,
+            TypeKind::U64 => T::U64,
+            TypeKind::Bool => T::Bool,
+            TypeKind::Unit => T::Unit,
+            TypeKind::Never => T::Never,
+            TypeKind::ComptimeType => T::ComptimeType,
+            TypeKind::Struct(id) => {
+                if let Some(key) = self.local.canonical_anonymous_types.get(&ty) {
+                    T::Nominal(N::Anonymous(key.clone()))
+                } else {
+                    // Identity comes from the declaration shell, before fields
+                    // are complete: a comptime type constructor can legitimately
+                    // receive a nominal whose layout is still unknown, so
+                    // identity must not depend on layout.
+                    let def = self
+                        .type_pool
+                        .struct_metadata(id)
+                        .ok_or(Failure::UnsupportedType)?;
+                    if def.is_builtin {
+                        T::BuiltinNominal {
+                            kind: K::Struct,
+                            name: std::sync::Arc::from(def.name.as_str()),
+                        }
+                    } else {
+                        T::Nominal(N::Named(self.struct_identity(id)?))
+                    }
+                }
+            }
+            TypeKind::Enum(id) => {
+                if let Some(key) = self.local.canonical_anonymous_types.get(&ty) {
+                    T::Nominal(N::Anonymous(key.clone()))
+                } else {
+                    let def = self
+                        .type_pool
+                        .enum_metadata(id)
+                        .ok_or(Failure::UnsupportedType)?;
+                    if rue_builtins::BUILTIN_ENUMS
+                        .iter()
+                        .any(|builtin| builtin.name == def.name)
+                    {
+                        T::BuiltinNominal {
+                            kind: K::Enum,
+                            name: std::sync::Arc::from(def.name.as_str()),
+                        }
+                    } else {
+                        T::Nominal(N::Named(self.enum_identity(id)?))
+                    }
+                }
+            }
+            TypeKind::Array(id) => {
+                let (element, len) = self.type_pool.array_def(id);
+                T::Array {
+                    element: Box::new(self.canonical_type_instance(element)?),
+                    len,
+                }
+            }
+            TypeKind::PtrConst(id) => T::PtrConst(Box::new(
+                self.canonical_type_instance(self.type_pool.ptr_const_def(id))?,
+            )),
+            TypeKind::PtrMut(id) => T::PtrMut(Box::new(
+                self.canonical_type_instance(self.type_pool.ptr_mut_def(id))?,
+            )),
+            TypeKind::Module(id) => {
+                let file = self
+                    .identity
+                    .module_file(id)
+                    .ok_or(Failure::MissingStableIdentity)?;
+                T::Module(self.identity.module_token(file)?)
+            }
+            TypeKind::Error => return Err(Failure::UnsupportedType),
+        })
+    }
+
+    /// The stable definition token behind a rendered callable symbol.
+    fn function_identity(
+        &self,
+        symbol: Spur,
+    ) -> Result<crate::SemanticDefinitionToken, crate::SemanticBodyExportFailure> {
+        if let Some(file) = self.callables.free_function_file(symbol) {
+            let source = self.callables.source_function_name(symbol);
+            return self.identity.definition_token(
+                file.index(),
+                self.interner.resolve(&source),
+                None,
+                crate::StableDefinitionKind::Function,
+            );
+        }
+        let site = self
+            .callables
+            .method_by_callable_symbol(symbol)
+            .ok_or(crate::SemanticBodyExportFailure::UnmappedFunction)?;
+        let method = self.interner.resolve(&site.method);
+        let owner = self.type_pool.struct_def(site.owner);
+        if owner.name.starts_with("__anon_struct_") {
+            return Err(crate::SemanticBodyExportFailure::AnonymousNominal);
+        }
+        self.identity.definition_token(
+            site.file.index(),
+            method,
+            Some(owner.name.as_str()),
+            if method == "__drop" {
+                crate::StableDefinitionKind::Destructor
+            } else if site.has_self {
+                crate::StableDefinitionKind::Method
+            } else {
+                crate::StableDefinitionKind::AssociatedFunction
+            },
+        )
+    }
+
+    /// The stable instance a rendered callable symbol names.
+    ///
+    /// A method on a producer-nominal owner is an anonymous member of that
+    /// producer, not a free definition — which is why the anonymous check runs
+    /// against the body-local `canonical_anonymous_types` before falling
+    /// through to definition identity.
+    pub(crate) fn body_function_identity(
+        &self,
+        symbol: Spur,
+    ) -> Result<
+        crate::FunctionInstanceKey<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
+        crate::SemanticBodyExportFailure,
+    > {
+        if self.callables.free_function_file(symbol).is_some() {
+            return Ok(crate::FunctionInstanceKey::Definition(
+                self.function_identity(symbol)?,
+            ));
+        }
+        let Some(site) = self.callables.method_by_callable_symbol(symbol) else {
+            return Ok(crate::FunctionInstanceKey::Definition(
+                self.function_identity(symbol)?,
+            ));
+        };
+        let method = self.interner.resolve(&site.method);
+        let owner = Type::new_struct(site.owner);
+        if self.local.canonical_anonymous_types.contains_key(&owner) {
+            let kind = if method == "__drop" {
+                crate::AnonymousMemberKind::Destructor
+            } else if site.has_self {
+                crate::AnonymousMemberKind::Method
+            } else {
+                crate::AnonymousMemberKind::AssociatedFunction
+            };
+            return Ok(crate::FunctionInstanceKey::AnonymousMember {
+                owner: Box::new(self.canonical_type_instance(owner)?),
+                member: crate::AnonymousMemberKey {
+                    kind,
+                    name: std::sync::Arc::from(method),
+                },
+            });
+        }
+        Ok(crate::FunctionInstanceKey::Definition(
+            self.function_identity(symbol)?,
+        ))
     }
 
     pub(crate) fn export_body_type(
@@ -768,6 +980,21 @@ mod tests {
         );
     }
 
+    /// Callable facts for a body that names none.
+    struct AbsentCallableFacts;
+
+    impl ExportCallableFacts for AbsentCallableFacts {
+        fn free_function_file(&self, _: Spur) -> Option<FileId> {
+            None
+        }
+        fn source_function_name(&self, symbol: Spur) -> Spur {
+            symbol
+        }
+        fn method_by_callable_symbol(&self, _: Spur) -> Option<ExportedMethodSite> {
+            None
+        }
+    }
+
     /// A `StableIdentityFacts` that records every consult, so a test can assert
     /// not just what was exported but how much of the boundary it cost.
     #[derive(Default)]
@@ -815,7 +1042,8 @@ mod tests {
         let pool = crate::intern_pool::TypeInternPool::new();
         let interner = lasso::ThreadedRodeo::new();
         let identity = RecordingIdentityFacts::default();
-        let host = ProviderExportHost::new(&local, &pool, &identity, &interner);
+        let callables = AbsentCallableFacts;
+        let host = ProviderExportHost::new(&local, &pool, &identity, &callables, &interner);
 
         for (ty, expected) in [
             (Type::I32, crate::SemanticImportType::I32),
@@ -846,12 +1074,38 @@ mod tests {
         let pool = crate::intern_pool::TypeInternPool::new();
         let interner = lasso::ThreadedRodeo::new();
         let identity = RecordingIdentityFacts::default();
-        let host = ProviderExportHost::new(&local, &pool, &identity, &interner);
+        let callables = AbsentCallableFacts;
+        let host = ProviderExportHost::new(&local, &pool, &identity, &callables, &interner);
 
         assert!(matches!(
             host.export_body_type(Type::ERROR),
             Err(crate::SemanticBodyExportFailure::UnsupportedType)
         ));
+    }
+
+    /// A symbol that names neither a free function nor a resolvable method is
+    /// unmapped, not guessed. The provider's `callable_symbol_method` has the
+    /// same fail-closed single-candidate contract, so an ambiguous receiver
+    /// arrives here as `None` and must not become a fabricated definition.
+    #[test]
+    fn an_unmapped_callable_symbol_fails_closed() {
+        let local = ProviderBodyLocalState::new();
+        let pool = crate::intern_pool::TypeInternPool::new();
+        let interner = lasso::ThreadedRodeo::new();
+        let identity = RecordingIdentityFacts::default();
+        let callables = AbsentCallableFacts;
+        let host = ProviderExportHost::new(&local, &pool, &identity, &callables, &interner);
+
+        let symbol = interner.get_or_intern("nowhere");
+        assert!(matches!(
+            host.body_function_identity(symbol),
+            Err(crate::SemanticBodyExportFailure::UnmappedFunction)
+        ));
+        assert!(
+            identity.definition_consults.borrow().is_empty(),
+            "an unmapped symbol consulted the identity boundary: {:?}",
+            identity.definition_consults.borrow()
+        );
     }
 
     /// The only category with design work left in it is the one the flip has

--- a/crates/rue-air/src/sema/provider_host.rs
+++ b/crates/rue-air/src/sema/provider_host.rs
@@ -4,34 +4,44 @@
 //! [`OrdinaryBodyAnalysisHost`] implementation is `Sema`, which reaches a
 //! declaration-wide epoch for every fact a body asks for; that shape is the
 //! `O(bodies × declarations)` term the body-context repair exists to delete.
-//! The replacement receiver owns exactly two things:
+//! The replacement receiver — [`ProviderBodyHost`] — owns exactly three things:
 //!
 //! - **Body-local mutable state** — [`ProviderBodyLocalState`] below. Every
 //!   field here is state one body evaluation creates, mutates, and drops. None
 //!   of it is shared with another body, and none of it is derived from the
 //!   declaration universe, so it is `O(this body)` by construction.
+//! - **The rue-air-owned identity authority** —
+//!   [`crate::sema::ProviderBodyAnalysisState`], the body-scoped type pool,
+//!   parameter arena, and interner.
 //! - **A narrow fact boundary** — [`crate::sema::provider::BodyFactProvider`],
 //!   whose typed operations answer exactly the questions a body asks and whose
 //!   implementation records the corresponding query edge per call.
 //!
-//! Everything a body needs is one of those two things or a configuration
-//! constant. [`HOST_CAPABILITY_LEDGER`] states which, for every method on the
-//! host contract, and [`host_capability_ledger_covers_the_contract`] pins that
-//! claim against the real trait source so it cannot go stale as the contract
-//! moves. The ledger is the flip's worklist: `NeedsProviderWiring` is the only
+//! Everything a body needs is one of those three or a configuration constant.
+//! [`HOST_CAPABILITY_LEDGER`] states which, for every method on the host
+//! contract, and [`host_capability_ledger_covers_the_contract`] pins that claim
+//! against the real trait source so it cannot go stale as the contract moves.
+//! The ledger is the flip's worklist: `NeedsProviderWiring` is the only
 //! category with design work left in it.
 
-// The overlay state is declared before the receiver that mutates it: the host
-// impl lands with the fact adapters, and every field here is storage that impl
-// needs. Nothing selects this module at runtime, so it is inert rather than a
-// peer body path — the ledger test is its only consumer today.
+// The overlay state is declared before the receiver that mutates it, and the
+// receiver before the contracts it implements. Nothing selects this module at
+// runtime yet, so it is inert rather than a peer body path — publication
+// reaches it only once the body query's evaluator is registered.
 #![allow(dead_code)]
 
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::hash::Hash;
+use std::rc::Rc;
 
-use lasso::Spur;
+use lasso::{Spur, ThreadedRodeo};
 use rue_error::CompileError;
 use rue_span::FileId;
+
+use super::provider::BodyFactProvider;
+use super::semantic_body_export::SemanticBodyExportHost;
+use super::{DurableNominalSource, ProviderBodyAnalysisState};
+use crate::intern_pool::TypeInternPool;
 
 use super::anon_structs::{
     IssuedAnonymousNominalKey, IssuedCanonicalArguments, IssuedStableProducerId,
@@ -465,6 +475,164 @@ pub(crate) trait ExportCallableFacts {
 
     /// The named method a rendered callable symbol reverses to.
     fn method_by_callable_symbol(&self, symbol: Spur) -> Option<ExportedMethodSite>;
+}
+
+/// The one fact authority a provider-backed body consults.
+///
+/// [`StableIdentityFacts`] and [`ExportCallableFacts`] are adapters over
+/// [`BodyFactProvider`], not peer authorities, so the receiver binds all three
+/// to a single type rather than to three independent parameters. That is the
+/// structural form of the claim the adapter docs make in prose: every non-local
+/// answer a body receives came through the fact boundary, and therefore
+/// recorded its dependency edge at the consult. Three separate parameters would
+/// make an edge-free second authority expressible.
+pub(crate) trait BodyHostFacts:
+    BodyFactProvider + StableIdentityFacts + ExportCallableFacts
+{
+}
+
+impl<T> BodyHostFacts for T where T: BodyFactProvider + StableIdentityFacts + ExportCallableFacts {}
+
+/// The receiver one body evaluation runs on.
+///
+/// This is the flip's substitution for `Sema`. The epoch receiver reaches a
+/// declaration-wide binding for every fact; this one has exactly the three
+/// parts the module documentation names, and [`HOST_CAPABILITY_LEDGER`] says
+/// which of them answers each contract method — `BodyLocal` rows come from
+/// `local`, `ProviderState` rows from `state`, `ProviderFact` rows from `facts`.
+///
+/// None of the three is sized by the declaration universe, so constructing a
+/// receiver is `O(1)` in the program rather than `O(declarations)`. That is
+/// where the `O(bodies × declarations)` term goes: the epoch's cost was in
+/// building the receiver, not in the analysis that ran on it.
+pub(crate) struct ProviderBodyHost<K, M, S, P> {
+    local: ProviderBodyLocalState,
+    state: ProviderBodyAnalysisState<K, M, S>,
+    facts: P,
+    /// Handles cloned once from `state`, so an engine-facing borrow is a field
+    /// read rather than a refcount bump per call. Containment sealing rebases
+    /// the pool's locked inner value in place, so a handle taken at
+    /// construction stays current for the life of the body.
+    type_pool: Rc<TypeInternPool>,
+    interner: Rc<ThreadedRodeo>,
+}
+
+impl<K, M, S, P> ProviderBodyHost<K, M, S, P>
+where
+    K: Clone + Eq + Hash,
+    M: Eq + Hash,
+    S: DurableNominalSource<K, M>,
+{
+    /// Begin one body evaluation over an identity authority and a fact
+    /// boundary. The overlay starts empty — a receiver never inherits another
+    /// body's mints.
+    pub(crate) fn new(state: ProviderBodyAnalysisState<K, M, S>, facts: P) -> Self {
+        let type_pool = state.type_pool();
+        let interner = state.interner();
+        Self {
+            local: ProviderBodyLocalState::new(),
+            state,
+            facts,
+            type_pool,
+            interner,
+        }
+    }
+}
+
+impl<K, M, S, P> ProviderBodyHost<K, M, S, P> {
+    pub(crate) fn local(&self) -> &ProviderBodyLocalState {
+        &self.local
+    }
+
+    pub(crate) fn local_mut(&mut self) -> &mut ProviderBodyLocalState {
+        &mut self.local
+    }
+
+    pub(crate) fn state(&self) -> &ProviderBodyAnalysisState<K, M, S> {
+        &self.state
+    }
+
+    pub(crate) fn facts(&self) -> &P {
+        &self.facts
+    }
+
+    pub(crate) fn type_pool(&self) -> &TypeInternPool {
+        &self.type_pool
+    }
+
+    pub(crate) fn interner(&self) -> &ThreadedRodeo {
+        &self.interner
+    }
+}
+
+impl<K, M, S, P: BodyHostFacts> ProviderBodyHost<K, M, S, P> {
+    /// The export view over this receiver's own three parts.
+    ///
+    /// Held for the duration of one export call rather than stored: it borrows
+    /// the overlay immutably, so materializing it per call keeps the receiver
+    /// mutable everywhere else.
+    fn export_host(&self) -> ProviderExportHost<'_, P, P> {
+        ProviderExportHost::new(
+            &self.local,
+            &self.type_pool,
+            &self.facts,
+            &self.facts,
+            &self.interner,
+        )
+    }
+}
+
+/// Publication reaches the provider receiver through the same neutral contract
+/// it reaches the epoch receiver through: `export_body` is one algorithm over
+/// this trait, so binding it here makes the export direction reachable without
+/// a second serializer.
+impl<K, M, S, P: BodyHostFacts> SemanticBodyExportHost for ProviderBodyHost<K, M, S, P> {
+    fn export_body_type(
+        &self,
+        ty: Type,
+    ) -> Result<
+        crate::SemanticImportType<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
+        crate::SemanticBodyExportFailure,
+    > {
+        self.export_host().export_body_type(ty)
+    }
+
+    fn body_struct_identity(
+        &self,
+        id: StructId,
+    ) -> Result<
+        crate::NominalInstanceKey<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
+        crate::SemanticBodyExportFailure,
+    > {
+        self.export_host().body_struct_identity(id)
+    }
+
+    fn body_enum_identity(
+        &self,
+        id: EnumId,
+    ) -> Result<
+        crate::NominalInstanceKey<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
+        crate::SemanticBodyExportFailure,
+    > {
+        self.export_host().body_enum_identity(id)
+    }
+
+    fn body_function_identity(
+        &self,
+        symbol: Spur,
+    ) -> Result<
+        crate::FunctionInstanceKey<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
+        crate::SemanticBodyExportFailure,
+    > {
+        self.export_host().body_function_identity(symbol)
+    }
+
+    /// Spelled from the receiver's own interner, which is the identity
+    /// authority's interner — not a peer table a symbol could be translated
+    /// through.
+    fn resolve_publication_symbol(&self, symbol: &Spur) -> &str {
+        self.interner.resolve(symbol)
+    }
 }
 
 /// The export half of the provider-backed receiver.
@@ -980,10 +1148,21 @@ mod tests {
         );
     }
 
-    /// Callable facts for a body that names none.
-    struct AbsentCallableFacts;
+    /// One fact authority over an empty declaration universe, recording every
+    /// consult so a test can assert not just what was exported but how much of
+    /// the boundary it cost.
+    ///
+    /// It implements all three fact traits on one type for the same reason
+    /// production does (see [`BodyHostFacts`]): a test whose identity lookups
+    /// came from somewhere other than its provider would not be testing the
+    /// shape the flip installs.
+    #[derive(Default)]
+    struct RecordingFacts {
+        definition_consults: std::cell::RefCell<Vec<String>>,
+        module_consults: std::cell::RefCell<Vec<u32>>,
+    }
 
-    impl ExportCallableFacts for AbsentCallableFacts {
+    impl ExportCallableFacts for RecordingFacts {
         fn free_function_file(&self, _: Spur) -> Option<FileId> {
             None
         }
@@ -995,15 +1174,120 @@ mod tests {
         }
     }
 
-    /// A `StableIdentityFacts` that records every consult, so a test can assert
-    /// not just what was exported but how much of the boundary it cost.
-    #[derive(Default)]
-    struct RecordingIdentityFacts {
-        definition_consults: std::cell::RefCell<Vec<String>>,
-        module_consults: std::cell::RefCell<Vec<u32>>,
+    /// Every operation answers "the universe holds nothing", which is a legal
+    /// provider state (a body that consults a name no module declares), not a
+    /// stub: no operation panics, so a test that accidentally reaches the
+    /// boundary fails on its assertion rather than on an `unimplemented!`.
+    impl BodyFactProvider for RecordingFacts {
+        type ModuleRef = ();
+        type DeclarationRef = ();
+        type BodyInstanceRef = ();
+        type ReceiverType = ();
+        type DeclarationIdentity = ();
+        type Signature = ();
+        type ConstComptime = ();
+        type ComptimeType = ();
+        type ComptimeValue = ();
+        type ComptimeCall = ();
+        type AnonymousFacts = ();
+        type ProducerBodyFacts = ();
+        type ToolchainFacts = ();
+
+        fn lookup_unqualified(
+            &self,
+            _: &(),
+            _: super::super::provider::ProviderNamespace,
+            _: &str,
+        ) -> super::super::provider::NameResolution {
+            super::super::provider::NameResolution::Absent
+        }
+
+        fn lookup_qualified(
+            &self,
+            _: &(),
+            _: super::super::provider::ProviderNamespace,
+            _: &str,
+        ) -> super::super::provider::NameResolution {
+            super::super::provider::NameResolution::Absent
+        }
+
+        fn method_candidates(
+            &self,
+            _: &(),
+            _: &str,
+        ) -> Vec<super::super::provider::MemberCandidate<()>> {
+            Vec::new()
+        }
+
+        fn operator_candidates(
+            &self,
+            _: &(),
+            _: super::super::provider::OperatorName,
+        ) -> Vec<super::super::provider::OperatorMemberCandidate<()>> {
+            Vec::new()
+        }
+
+        fn declaration_identity(&self, _: &()) -> Option<()> {
+            None
+        }
+
+        fn signature(&self, _: &()) -> Option<()> {
+            None
+        }
+
+        fn const_comptime(&self, _: &()) -> Option<()> {
+            None
+        }
+
+        fn reduce_comptime_call(
+            &self,
+            _: &(),
+            _: &[(std::sync::Arc<str>, ())],
+            _: &[(std::sync::Arc<str>, ())],
+        ) -> Option<()> {
+            None
+        }
+
+        fn nominal_well_formedness(
+            &self,
+            _: &(),
+        ) -> Option<super::super::provider::NominalWellFormedness> {
+            None
+        }
+
+        fn anonymous_facts(&self, _: &()) -> Option<()> {
+            None
+        }
+
+        fn language_item(
+            &self,
+            _: &(),
+            _: super::super::provider::ProviderNamespace,
+            _: &str,
+        ) -> Option<crate::types::LangItem> {
+            None
+        }
+
+        fn drop_copy_metadata(&self, _: &()) -> Option<super::super::provider::DropCopyMetadata> {
+            None
+        }
+
+        fn resolve_import(&self, _: &(), _: &str) -> super::super::provider::ImportResolution {
+            super::super::provider::ImportResolution::Absent
+        }
+
+        fn callable_symbol_method(&self, _: &str) -> Option<((), std::sync::Arc<str>)> {
+            None
+        }
+
+        fn producer_body_facts(&self, _: &()) -> Option<()> {
+            None
+        }
+
+        fn trusted_toolchain_facts(&self, _: &()) {}
     }
 
-    impl StableIdentityFacts for RecordingIdentityFacts {
+    impl StableIdentityFacts for RecordingFacts {
         fn definition_token(
             &self,
             file: u32,
@@ -1041,9 +1325,8 @@ mod tests {
         let local = ProviderBodyLocalState::new();
         let pool = crate::intern_pool::TypeInternPool::new();
         let interner = lasso::ThreadedRodeo::new();
-        let identity = RecordingIdentityFacts::default();
-        let callables = AbsentCallableFacts;
-        let host = ProviderExportHost::new(&local, &pool, &identity, &callables, &interner);
+        let facts = RecordingFacts::default();
+        let host = ProviderExportHost::new(&local, &pool, &facts, &facts, &interner);
 
         for (ty, expected) in [
             (Type::I32, crate::SemanticImportType::I32),
@@ -1057,11 +1340,11 @@ mod tests {
         }
 
         assert!(
-            identity.definition_consults.borrow().is_empty(),
+            facts.definition_consults.borrow().is_empty(),
             "primitives resolved through the identity boundary: {:?}",
-            identity.definition_consults.borrow()
+            facts.definition_consults.borrow()
         );
-        assert!(identity.module_consults.borrow().is_empty());
+        assert!(facts.module_consults.borrow().is_empty());
     }
 
     /// An unresolvable stable identity fails closed rather than inventing a
@@ -1073,9 +1356,8 @@ mod tests {
         let local = ProviderBodyLocalState::new();
         let pool = crate::intern_pool::TypeInternPool::new();
         let interner = lasso::ThreadedRodeo::new();
-        let identity = RecordingIdentityFacts::default();
-        let callables = AbsentCallableFacts;
-        let host = ProviderExportHost::new(&local, &pool, &identity, &callables, &interner);
+        let facts = RecordingFacts::default();
+        let host = ProviderExportHost::new(&local, &pool, &facts, &facts, &interner);
 
         assert!(matches!(
             host.export_body_type(Type::ERROR),
@@ -1092,9 +1374,8 @@ mod tests {
         let local = ProviderBodyLocalState::new();
         let pool = crate::intern_pool::TypeInternPool::new();
         let interner = lasso::ThreadedRodeo::new();
-        let identity = RecordingIdentityFacts::default();
-        let callables = AbsentCallableFacts;
-        let host = ProviderExportHost::new(&local, &pool, &identity, &callables, &interner);
+        let facts = RecordingFacts::default();
+        let host = ProviderExportHost::new(&local, &pool, &facts, &facts, &interner);
 
         let symbol = interner.get_or_intern("nowhere");
         assert!(matches!(
@@ -1102,9 +1383,110 @@ mod tests {
             Err(crate::SemanticBodyExportFailure::UnmappedFunction)
         ));
         assert!(
-            identity.definition_consults.borrow().is_empty(),
+            facts.definition_consults.borrow().is_empty(),
             "an unmapped symbol consulted the identity boundary: {:?}",
-            identity.definition_consults.borrow()
+            facts.definition_consults.borrow()
+        );
+    }
+
+    /// A durable universe with no nominals in it. The receiver tests exercise
+    /// the parts that must work before any nominal is consulted, so the source
+    /// answering `None` is the honest input, not a placeholder.
+    struct NoDurableNominals;
+
+    impl super::super::DurableNominalSource<std::sync::Arc<str>, std::sync::Arc<str>>
+        for NoDurableNominals
+    {
+        fn nominal(
+            &self,
+            _: &std::sync::Arc<str>,
+        ) -> Option<super::super::DurableNominal<std::sync::Arc<str>, std::sync::Arc<str>>>
+        {
+            None
+        }
+    }
+
+    type TestHost = ProviderBodyHost<
+        std::sync::Arc<str>,
+        std::sync::Arc<str>,
+        NoDurableNominals,
+        RecordingFacts,
+    >;
+
+    fn test_host() -> TestHost {
+        let state =
+            ProviderBodyAnalysisState::new(NoDurableNominals, Rc::new(lasso::ThreadedRodeo::new()));
+        ProviderBodyHost::new(state, RecordingFacts::default())
+    }
+
+    /// The receiver's three parts are one authority each, not three that happen
+    /// to agree. If the host cached an interner or type pool other than the
+    /// identity state's, two halves of the same body would mint symbols in
+    /// separate universes and publication would silently disagree with
+    /// analysis.
+    #[test]
+    fn the_receiver_shares_one_identity_authority() {
+        let host = test_host();
+        assert!(
+            std::ptr::eq(host.interner(), Rc::as_ref(&host.state().interner())),
+            "the receiver's interner is the identity state's, not a peer table"
+        );
+        assert!(
+            std::ptr::eq(host.type_pool(), Rc::as_ref(&host.state().type_pool())),
+            "the receiver's type pool is the identity state's, not a peer pool"
+        );
+        assert!(
+            host.local()
+                .produced_anonymous_identities()
+                .next()
+                .is_none(),
+            "a fresh receiver starts with an empty overlay"
+        );
+    }
+
+    /// Publication can reach the provider receiver.
+    ///
+    /// The assertion that matters is the generic bound: `publish` names only
+    /// `SemanticBodyExportHost`, which is the contract the canonical
+    /// `export_body` algorithm consumes, so a receiver that satisfies it is
+    /// reachable from publication without a second serializer. Before the
+    /// receiver existed, the export code in this module had no caller that
+    /// could be typed this way.
+    #[test]
+    fn publication_reaches_the_provider_receiver() {
+        fn publish<H: SemanticBodyExportHost>(
+            host: &H,
+            ty: Type,
+        ) -> Result<
+            crate::SemanticImportType<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
+            crate::SemanticBodyExportFailure,
+        > {
+            host.export_body_type(ty)
+        }
+
+        let host = test_host();
+        assert_eq!(
+            publish(&host, Type::I32).expect("a primitive exports through the receiver"),
+            crate::SemanticImportType::I32
+        );
+        assert!(
+            host.facts().definition_consults.borrow().is_empty(),
+            "publishing a primitive consulted the fact boundary: {:?}",
+            host.facts().definition_consults.borrow()
+        );
+    }
+
+    /// A symbol publication spells is resolved through the receiver's own
+    /// interner. `export_body` renders every callable symbol this way, so a
+    /// receiver whose spelling came from elsewhere would publish names the
+    /// analysis never interned.
+    #[test]
+    fn the_receiver_spells_symbols_from_its_own_interner() {
+        let host = test_host();
+        let symbol = host.interner().get_or_intern("helper");
+        assert_eq!(
+            SemanticBodyExportHost::resolve_publication_symbol(&host, &symbol),
+            "helper"
         );
     }
 

--- a/crates/rue-air/src/sema/provider_host.rs
+++ b/crates/rue-air/src/sema/provider_host.rs
@@ -55,6 +55,8 @@ use super::anon_structs::{
     IssuedAnonymousNominalKey, IssuedCanonicalArguments, IssuedFunctionInstanceKey,
     IssuedStableProducerId, IssuedTypeInstanceKey,
 };
+use super::body_endpoint::BodyEndpointProvider;
+use super::info::ConstInfo;
 use super::{
     AnalyzedBodyOwnerEvent, AnonMethodSig, BodyAnalysisWork, ConstValue,
     DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind, DeferredOwnershipGate,
@@ -490,21 +492,59 @@ pub(crate) trait ExportCallableFacts {
     fn method_by_callable_symbol(&self, symbol: Spur) -> Option<ExportedMethodSite>;
 }
 
+/// The declaration lookups a body performs for constants and module bindings.
+///
+/// Same adapter discipline as [`StableIdentityFacts`]: the compiler-side
+/// implementation routes each call through the ordinary [`BodyFactProvider`]
+/// lookup operations, so the dependency edge is recorded at the consult.
+///
+/// **Why this is keyed on a module path rather than a file id.** The engine asks
+/// for a constant by `(FileId, Spur)`, but that `FileId` is minted by
+/// [`crate::sema::BodyIdentityPool`] in *first-consult order* — the same
+/// declaration is file 1 in one body and file 4 in another. Handing that number
+/// to a durable lookup is the defect class this receiver exists to avoid: it
+/// misses for most bodies and, on a collision, resolves to an unrelated
+/// declaration without failing. The receiver therefore converts the number to a
+/// logical module path before the call (`pool_module_path`), and only the path
+/// crosses. Every coordinate on this seam is request-independent.
+///
+/// **Why it answers a key rather than a `ConstInfo`.** `ConstInfo` carries a
+/// pool-relative [`Type`] and [`ConstValue`], which only the body's own identity
+/// pool can mint. So the split is: the boundary answers *which declaration*
+/// (recording the edge), and the pool answers *what it is* (body-locally, from
+/// the durable record). That is the same division the nominal path already uses.
+pub(crate) trait BodyConstFacts<K> {
+    /// The durable key of the value-const declared as `name` in `module_path`,
+    /// or `None` when the module declares no such constant.
+    fn value_const_key(&self, module_path: &str, name: &str) -> Option<K>;
+
+    /// The durable key of the module binding declared as `name` in
+    /// `module_path`, or `None`.
+    fn module_binding_key(&self, module_path: &str, name: &str) -> Option<K>;
+}
+
 /// The one fact authority a provider-backed body consults.
 ///
-/// [`StableIdentityFacts`] and [`ExportCallableFacts`] are adapters over
-/// [`BodyFactProvider`], not peer authorities, so the receiver binds all three
-/// to a single type rather than to three independent parameters. That is the
-/// structural form of the claim the adapter docs make in prose: every non-local
-/// answer a body receives came through the fact boundary, and therefore
-/// recorded its dependency edge at the consult. Three separate parameters would
-/// make an edge-free second authority expressible.
-pub(crate) trait BodyHostFacts:
-    BodyFactProvider + StableIdentityFacts + ExportCallableFacts
+/// [`StableIdentityFacts`], [`ExportCallableFacts`], and [`BodyConstFacts`] are
+/// adapters over [`BodyFactProvider`], not peer authorities, so the receiver
+/// binds all four to a single type rather than to four independent parameters.
+/// That is the structural form of the claim the adapter docs make in prose:
+/// every non-local answer a body receives came through the fact boundary, and
+/// therefore recorded its dependency edge at the consult. Separate parameters
+/// would make an edge-free second authority expressible.
+///
+/// The const adapter is keyed on `K`, the receiver's own durable key type, so
+/// the boundary and the identity pool cannot be wired to two different key
+/// spaces — a key answered here is a key the pool can mint from.
+pub(crate) trait BodyHostFacts<K>:
+    BodyFactProvider + StableIdentityFacts + ExportCallableFacts + BodyConstFacts<K>
 {
 }
 
-impl<T> BodyHostFacts for T where T: BodyFactProvider + StableIdentityFacts + ExportCallableFacts {}
+impl<K, T> BodyHostFacts<K> for T where
+    T: BodyFactProvider + StableIdentityFacts + ExportCallableFacts + BodyConstFacts<K>
+{
+}
 
 /// The receiver one body evaluation runs on.
 ///
@@ -713,7 +753,7 @@ impl<K, M, S, P> ProviderBodyHost<K, M, S, P> {
     }
 }
 
-impl<K, M, S, P: BodyHostFacts> ProviderBodyHost<K, M, S, P> {
+impl<K, M, S, P: BodyHostFacts<K>> ProviderBodyHost<K, M, S, P> {
     /// The export view over this receiver's own overlay, pool, and boundary.
     ///
     /// Held for the duration of one export call rather than stored: it borrows
@@ -737,7 +777,7 @@ impl<K, M, S, P: BodyHostFacts> ProviderBodyHost<K, M, S, P> {
 /// is a claim about the *host contract*: stating that a contract method is
 /// answered means the receiver answers it. Each one is the export view over
 /// this body's own parts, so none reaches a declaration-wide table.
-impl<K, M, S, P: BodyHostFacts> ProviderBodyHost<K, M, S, P> {
+impl<K, M, S, P: BodyHostFacts<K>> ProviderBodyHost<K, M, S, P> {
     pub(crate) fn canonical_type_instance(
         &self,
         ty: Type,
@@ -777,11 +817,276 @@ impl<K, M, S, P: BodyHostFacts> ProviderBodyHost<K, M, S, P> {
     }
 }
 
+/// Which declaration namespace a constant lookup names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConstLookup {
+    ValueConst,
+    ModuleBinding,
+}
+
+/// The callable rows of [`HOST_CAPABILITY_LEDGER`] the inference source needs,
+/// answered through the endpoint driver over this body's own RIR and pool.
+///
+/// The driver is materialized per call rather than stored: it borrows the fact
+/// boundary and the RIR view, so holding one would make the receiver
+/// self-referential. Its own overlay is a cache of what this body already
+/// minted, and that lives in the shared identity context, so a fresh driver
+/// sees everything an earlier one did.
+impl<K, M, S, P: BodyHostFacts<K>> ProviderBodyHost<K, M, S, P>
+where
+    K: Clone + Eq + Hash,
+    M: Clone + Eq + Hash,
+    S: DurableNominalSource<K, M>
+        + super::DurableAnonymousSource<K, M>
+        + super::DurableConstSource<K, M>,
+{
+    fn endpoint_driver(&self) -> super::body_endpoint::ProviderEndpointFacts<'_, P, S, K, M> {
+        super::body_endpoint::ProviderEndpointFacts::with_state(
+            &self.facts,
+            &self.state,
+            self.rir.view(),
+        )
+    }
+
+    pub(crate) fn function_info(&self, name: Spur) -> Option<super::FunctionInfo> {
+        self.endpoint_driver().function_info(name)
+    }
+
+    pub(crate) fn method_info(&self, owner: StructId, name: Spur) -> Option<MethodInfo> {
+        self.endpoint_driver().method_info(owner, name)
+    }
+
+    pub(crate) fn resolve_function_name_local(&self, name: Spur, file: FileId) -> Option<Spur> {
+        self.endpoint_driver().function_by_file_name(file, name)
+    }
+
+    /// Which of a callable's parameters are comptime `type` parameters.
+    ///
+    /// Read off this body's own RIR and interner, exactly as the engine's
+    /// generic form does. An absent `type` symbol means this body never spelled
+    /// one, so no parameter can be a comptime type parameter.
+    pub(crate) fn comptime_type_param_flags(&self, function: &super::FunctionInfo) -> Vec<bool> {
+        let Some(type_symbol) = self.interner.get("type") else {
+            return vec![false; function.params.len()];
+        };
+        let rir = self.rir.rir();
+        rir.params(function.rir_params(rir))
+            .iter()
+            .map(|param| param.is_comptime && param.ty == type_symbol)
+            .collect()
+    }
+}
+
+impl<K, M, S, P: BodyHostFacts<K>> ProviderBodyHost<K, M, S, P>
+where
+    K: Clone + Eq + Hash,
+    M: Eq + Hash,
+    S: DurableNominalSource<K, M> + super::DurableConstSource<K, M>,
+{
+    /// One constant: located through the boundary, minted by the pool.
+    ///
+    /// The two halves are deliberate. The boundary answers *which* declaration
+    /// the `(module, name)` coordinate names, which is where the dependency edge
+    /// belongs — a body that reads a constant depends on that constant's
+    /// declaration. The pool answers *what it is*, from the durable record,
+    /// because a `ConstInfo` carries a pool-relative type and value that only
+    /// this body's identity authority can mint.
+    ///
+    /// The file number is converted to a logical module path here and does not
+    /// cross the boundary; see [`BodyConstFacts`] for why that matters.
+    fn const_info(&self, file: FileId, name: Spur, lookup: ConstLookup) -> Option<ConstInfo> {
+        let module_path = self.type_pool.symbol_path(file)?;
+        let name = self.interner.resolve(&name);
+        let key = match lookup {
+            ConstLookup::ValueConst => self.facts.value_const_key(&module_path, name),
+            ConstLookup::ModuleBinding => self.facts.module_binding_key(&module_path, name),
+        }?;
+        let identity = self.state.identity_context();
+        let mut pool = identity.pool_mut()?;
+        // `Span::default()` is sound only because every caller below reads
+        // `ty`/`value` and discards the rest: the inference arms return a
+        // `Type`, an `i128`, or a `Spur`, never the `ConstInfo` itself. A
+        // diagnostic-bearing consult must supply the declaration's real span
+        // from this body's RIR rather than reuse this path.
+        pool.resolve_const(
+            &key,
+            super::body_identity::ConstIdentityHandle {
+                span: rue_span::Span::default(),
+            },
+        )
+        .ok()
+    }
+}
+
+/// The inference source, the one read family the host contract requires.
+///
+/// Every arm answers from this body's own parts: the overlay for what this body
+/// generated, the type pool for what it has already minted, this body's RIR for
+/// parameter syntax, and the fact boundary for constants it has not yet
+/// consulted. None reads a declaration-universe table, which is the whole point
+/// — the epoch answers these same fourteen questions from thirteen such tables.
+impl<K, M, S, P: BodyHostFacts<K>> super::inference_ctx::InferenceFactSource
+    for ProviderBodyHost<K, M, S, P>
+where
+    K: Clone + Eq + Hash,
+    M: Clone + Eq + Hash,
+    S: DurableNominalSource<K, M>
+        + super::DurableAnonymousSource<K, M>
+        + super::DurableConstSource<K, M>,
+{
+    /// The nominals *this body generated*, which is all the overlay can hold.
+    /// The epoch builds the same snapshot from its `generated_structs` /
+    /// `generated_enums`; those are body-local there too.
+    fn inference_generated_nominal_overlays(
+        &self,
+    ) -> super::inference_ctx::InferenceGeneratedNominalOverlays {
+        let mut builtin_struct_types = HashMap::new();
+        let mut struct_types_by_file = HashMap::new();
+        for (name, id) in &self.local.generated_structs {
+            let def = self.type_pool.struct_def(*id);
+            if def.is_builtin {
+                builtin_struct_types.insert(*name, Type::new_struct(*id));
+            }
+            struct_types_by_file
+                .entry((def.file_id, *name))
+                .or_insert_with(|| Type::new_struct(*id));
+        }
+        let mut enum_types_by_file = HashMap::new();
+        for (name, id) in &self.local.generated_enums {
+            let def = self.type_pool.enum_def(*id);
+            enum_types_by_file
+                .entry((def.file_id, *name))
+                .or_insert_with(|| Type::new_enum(*id));
+        }
+        super::inference_ctx::InferenceGeneratedNominalOverlays {
+            builtin_struct_types,
+            struct_types_by_file,
+            enum_types_by_file,
+        }
+    }
+
+    fn uncached_function_sig(&self, name: Spur) -> Option<crate::inference::FunctionSig> {
+        let info = self.function_info(name)?;
+        let rir = self.rir.rir();
+        let params = self.state.param_data(info.params);
+        Some(crate::inference::FunctionSig {
+            param_types: params
+                .types()
+                .iter()
+                .map(|ty| super::inference_ctx::type_to_infer_type(&self.type_pool, *ty))
+                .collect(),
+            return_type: super::inference_ctx::type_to_infer_type(
+                &self.type_pool,
+                info.return_type,
+            ),
+            is_generic: info.is_generic,
+            param_modes: params.modes().to_vec(),
+            param_comptime: params.comptime().to_vec(),
+            param_comptime_type: self.comptime_type_param_flags(&info),
+            param_names: params.names().to_vec(),
+            param_type_syms: rir
+                .params(info.rir_params(rir))
+                .iter()
+                .map(|param| param.ty)
+                .collect(),
+            return_type_sym: info.return_type_sym,
+        })
+    }
+
+    /// Anonymous members this body installed win over named ones, exactly as
+    /// they do on the epoch: a body that just minted an anonymous method must
+    /// see its own signature rather than a same-keyed named one.
+    fn uncached_method_sig(&self, key: (StructId, Spur)) -> Option<crate::inference::MethodSig> {
+        let info = match self.local.anonymous_methods.get(&key) {
+            Some(info) => *info,
+            None => self.method_info(key.0, key.1)?,
+        };
+        let params = self.state.param_data(info.params);
+        Some(crate::inference::MethodSig {
+            struct_type: info.struct_type,
+            has_self: info.has_self,
+            param_types: params
+                .types()
+                .iter()
+                .map(|ty| super::inference_ctx::type_to_infer_type(&self.type_pool, *ty))
+                .collect(),
+            param_modes: params.modes().to_vec(),
+            return_type: super::inference_ctx::type_to_infer_type(
+                &self.type_pool,
+                info.return_type,
+            ),
+        })
+    }
+
+    /// Builtins live at [`FileId::DEFAULT`] in this body's pool, registered
+    /// there exactly as a fresh import epoch registers them, so the builtin
+    /// arms are the by-file arms at that one file.
+    fn inference_builtin_struct_type(&self, name: Spur) -> Option<Type> {
+        self.type_pool
+            .get_struct_by_file_name(FileId::DEFAULT, name)
+    }
+
+    fn inference_struct_type_by_file(&self, key: (FileId, Spur)) -> Option<Type> {
+        self.type_pool.get_struct_by_file_name(key.0, key.1)
+    }
+
+    fn inference_builtin_enum_type(&self, name: Spur) -> Option<Type> {
+        self.type_pool.get_enum_by_file_name(FileId::DEFAULT, name)
+    }
+
+    fn inference_enum_type_by_file(&self, key: (FileId, Spur)) -> Option<Type> {
+        self.type_pool.get_enum_by_file_name(key.0, key.1)
+    }
+
+    fn inference_const_type(&self, key: (FileId, Spur)) -> Option<Type> {
+        self.const_info(key.0, key.1, ConstLookup::ValueConst)
+            .map(|info| match info.value {
+                ConstValue::Type(_) => Type::COMPTIME_TYPE,
+                _ => info.ty,
+            })
+    }
+
+    fn inference_const_type_alias(&self, key: (FileId, Spur)) -> Option<Type> {
+        self.const_info(key.0, key.1, ConstLookup::ValueConst)
+            .and_then(|info| match info.value {
+                ConstValue::Type(ty) => Some(ty),
+                _ => None,
+            })
+    }
+
+    fn inference_const_value(&self, key: (FileId, Spur)) -> Option<i128> {
+        self.const_info(key.0, key.1, ConstLookup::ValueConst)
+            .and_then(|info| info.value.as_int_value())
+    }
+
+    fn inference_const_function_alias(&self, key: (FileId, Spur)) -> Option<Spur> {
+        self.const_info(key.0, key.1, ConstLookup::ValueConst)
+            .and_then(|info| info.value.as_function())
+    }
+
+    fn inference_module_binding_type(&self, key: (FileId, Spur)) -> Option<Type> {
+        self.const_info(key.0, key.1, ConstLookup::ModuleBinding)
+            .map(|info| info.ty)
+    }
+
+    /// The pool's own module numbering answers this: `file_for_module` is what
+    /// assigned the id, so reversing it needs no registry read.
+    fn inference_module_file_id(&self, module: crate::types::ModuleId) -> Option<FileId> {
+        let identity = self.state.identity_context();
+        let modules = identity.modules();
+        modules.get(module).map(|definition| definition.file_id)
+    }
+
+    fn inference_function_by_file(&self, key: (FileId, Spur)) -> Option<Spur> {
+        self.resolve_function_name_local(key.1, key.0)
+    }
+}
+
 /// Publication reaches the provider receiver through the same neutral contract
 /// it reaches the epoch receiver through: `export_body` is one algorithm over
 /// this trait, so binding it here makes the export direction reachable without
 /// a second serializer.
-impl<K, M, S, P: BodyHostFacts> SemanticBodyExportHost for ProviderBodyHost<K, M, S, P> {
+impl<K, M, S, P: BodyHostFacts<K>> SemanticBodyExportHost for ProviderBodyHost<K, M, S, P> {
     fn export_body_type(
         &self,
         ty: Type,
@@ -1434,6 +1739,23 @@ mod tests {
     struct RecordingFacts {
         definition_consults: std::cell::RefCell<Vec<String>>,
         module_consults: std::cell::RefCell<Vec<String>>,
+        const_consults: std::cell::RefCell<Vec<String>>,
+    }
+
+    impl BodyConstFacts<std::sync::Arc<str>> for RecordingFacts {
+        fn value_const_key(&self, module_path: &str, name: &str) -> Option<std::sync::Arc<str>> {
+            self.const_consults
+                .borrow_mut()
+                .push(format!("value:{module_path}:{name}"));
+            None
+        }
+
+        fn module_binding_key(&self, module_path: &str, name: &str) -> Option<std::sync::Arc<str>> {
+            self.const_consults
+                .borrow_mut()
+                .push(format!("binding:{module_path}:{name}"));
+            None
+        }
     }
 
     impl ExportCallableFacts for RecordingFacts {
@@ -1844,6 +2166,45 @@ mod tests {
         }
     }
 
+    impl super::super::DurableAnonymousSource<std::sync::Arc<str>, std::sync::Arc<str>>
+        for NoDurableNominals
+    {
+        fn anonymous_shape(
+            &self,
+            _: &crate::AnonymousNominalKey<std::sync::Arc<str>, std::sync::Arc<str>>,
+        ) -> Option<super::super::DurableAnonymousShape<std::sync::Arc<str>, std::sync::Arc<str>>>
+        {
+            None
+        }
+
+        /// The durable key *is* the rendered component in this test universe,
+        /// so the spelling stays whatever the caller supplied rather than
+        /// inventing one — an invented component would feed anonymous-identity
+        /// digests and fork identity silently.
+        fn definition_symbol_component(&self, key: &std::sync::Arc<str>) -> String {
+            key.to_string()
+        }
+
+        fn module_symbol_component(&self, module: &std::sync::Arc<str>) -> String {
+            module.to_string()
+        }
+    }
+
+    impl super::super::DurableConstSource<std::sync::Arc<str>, std::sync::Arc<str>>
+        for NoDurableNominals
+    {
+        fn constant(
+            &self,
+            _: &std::sync::Arc<str>,
+        ) -> Option<super::super::DurableConst<std::sync::Arc<str>, std::sync::Arc<str>>> {
+            None
+        }
+
+        fn function_name(&self, _: &std::sync::Arc<str>) -> Option<std::sync::Arc<str>> {
+            None
+        }
+    }
+
     type TestHost = ProviderBodyHost<
         std::sync::Arc<str>,
         std::sync::Arc<str>,
@@ -1931,6 +2292,64 @@ mod tests {
             host.builtin_arch_id(),
             host.builtin_os_id(),
             "distinct builtin enums must not collapse to one identity"
+        );
+    }
+
+    /// A constant reaches the boundary as a module path, not as a file number.
+    ///
+    /// Same invariant as `the_identity_boundary_is_keyed_on_module_paths`, and
+    /// it matters here for a sharper reason: the engine asks for a constant by
+    /// the `(FileId, Spur)` pair its analysis context carries, and on this
+    /// receiver that `FileId` is the pool's own first-consult numbering. Passing
+    /// it through would key a durable lookup on the order this body happened to
+    /// touch modules in — the same defect that made a struct resolve to an
+    /// unrelated declaration before the identity seam was re-keyed. The number
+    /// is converted here and must not appear in the consult.
+    #[test]
+    fn the_const_boundary_is_keyed_on_module_paths() {
+        use super::super::inference_ctx::InferenceFactSource;
+
+        let host = test_host();
+        let body_local_file = FileId::new(3);
+        host.type_pool().set_symbol_paths(HashMap::from([(
+            body_local_file,
+            "app/config.rue".to_owned(),
+        )]));
+        let name = host.interner().get_or_intern("LIMIT");
+
+        assert_eq!(
+            host.inference_const_type((body_local_file, name)),
+            None,
+            "an empty durable universe has no constant to answer with"
+        );
+        assert_eq!(
+            host.inference_module_binding_type((body_local_file, name)),
+            None
+        );
+
+        assert_eq!(
+            host.facts().const_consults.borrow().as_slice(),
+            [
+                "value:app/config.rue:LIMIT".to_owned(),
+                "binding:app/config.rue:LIMIT".to_owned(),
+            ],
+            "the const boundary must be consulted by logical module path; the \
+             pool's file number must not appear"
+        );
+    }
+
+    /// A constant the pool cannot place has no path to consult, so the boundary
+    /// is never asked — rather than being asked with a fabricated coordinate.
+    #[test]
+    fn an_unplaceable_constant_consults_nothing() {
+        use super::super::inference_ctx::InferenceFactSource;
+
+        let host = test_host();
+        let name = host.interner().get_or_intern("LIMIT");
+        assert_eq!(host.inference_const_type((FileId::new(9), name)), None);
+        assert!(
+            host.facts().const_consults.borrow().is_empty(),
+            "a file with no logical module path must not reach the boundary at all"
         );
     }
 

--- a/crates/rue-air/src/sema/provider_host.rs
+++ b/crates/rue-air/src/sema/provider_host.rs
@@ -44,7 +44,8 @@ use super::{DurableNominalSource, ProviderBodyAnalysisState};
 use crate::intern_pool::TypeInternPool;
 
 use super::anon_structs::{
-    IssuedAnonymousNominalKey, IssuedCanonicalArguments, IssuedStableProducerId,
+    IssuedAnonymousNominalKey, IssuedCanonicalArguments, IssuedFunctionInstanceKey,
+    IssuedStableProducerId, IssuedTypeInstanceKey,
 };
 use super::{
     AnalyzedBodyOwnerEvent, AnonMethodSig, BodyAnalysisWork, ConstValue,
@@ -223,6 +224,12 @@ pub(crate) enum HostCapability {
     /// needs the adapter that maps the operation's owned fact onto the shape
     /// the engine expects.
     ProviderFact,
+    /// Answered by [`ProviderExportHost`], the export view over the overlay,
+    /// the type pool, and exact keyed identity lookups. A category of its own
+    /// because one answer draws on all three — and because the epoch answers
+    /// the same questions from declaration-universe-sized token and endpoint
+    /// tables, which is the cost this category exists to not pay.
+    ProviderExport,
     /// The real remaining work: no provider operation answers this yet, or the
     /// answer must change shape at the flip. Each row names what it needs.
     NeedsProviderWiring(&'static str),
@@ -360,51 +367,24 @@ pub(crate) const HOST_CAPABILITY_LEDGER: &[HostCapabilityRow] = &[
              `TypeSyntaxHost`, so this is binding that host to the provider rather than to `Sema`",
         ),
     ),
-    // The five export rows below are one job, not five. `SemanticBodyExportHost`
-    // already abstracts the publication path over exactly these facts, so the
-    // work is a second implementation of that trait rather than new machinery.
-    // Tracing the epoch's implementation shows no reverse identity map is
-    // needed: a compact id carries its own `(file, name)` through the type pool,
-    // so the stable token is a FORWARD keyed lookup the fact provider already
-    // answers, and the only genuinely reverse fact — token to endpoint, for
-    // symbol rendering — is memoized body-locally at the consult that produced
-    // the token (`consulted_definition_endpoints`). Every export fact is
-    // therefore already body-local, derivable from the type pool, or recorded
-    // at lookup time.
-    row(
-        "canonical_type_instance",
-        HostCapability::NeedsProviderWiring(
-            "compact type -> stable instance key; anonymous and builtin arms are already \
-             body-local and type-pool reads, and the named arm is a forward \
-             `(file, name, kind)` lookup through the fact boundary",
-        ),
-    ),
-    row(
-        "canonical_argument_value",
-        HostCapability::NeedsProviderWiring(
-            "compact const value -> stable argument value; rides the same arms as \
-             `canonical_type_instance`",
-        ),
-    ),
-    row(
-        "function_identity",
-        HostCapability::NeedsProviderWiring(
-            "rendered symbol -> stable definition token; `callable_symbol_method` answers the \
-             method arm and the free-function arm is the same forward lookup",
-        ),
-    ),
+    // --- The export direction, answered by `ProviderExportHost`. ---
+    // These five were one job, not five: no reverse identity map was needed. A
+    // compact id carries its own `(file, name)` through the type pool, so the
+    // stable token is a FORWARD keyed lookup the fact boundary answers, and the
+    // only genuinely reverse fact — token to endpoint, for symbol rendering —
+    // is memoized body-locally at the consult that produced the token
+    // (`consulted_definition_endpoints`). Every export fact is therefore
+    // body-local, derivable from the type pool, or recorded at lookup time.
+    row("canonical_type_instance", HostCapability::ProviderExport),
+    row("canonical_argument_value", HostCapability::ProviderExport),
+    row("function_identity", HostCapability::ProviderExport),
     row(
         "stable_definition_symbol_component",
-        HostCapability::NeedsProviderWiring(
-            "render from the endpoint recorded at consult time, not from the epoch's \
-             universe-sized `stable_definition_endpoints` table",
-        ),
+        HostCapability::ProviderExport,
     ),
     row(
         "stable_module_symbol_component",
-        HostCapability::NeedsProviderWiring(
-            "module half of the same rendering, from `consulted_module_endpoints`",
-        ),
+        HostCapability::ProviderExport,
     ),
 ];
 
@@ -579,6 +559,53 @@ impl<K, M, S, P: BodyHostFacts> ProviderBodyHost<K, M, S, P> {
             &self.facts,
             &self.interner,
         )
+    }
+}
+
+/// The export rows of [`HOST_CAPABILITY_LEDGER`], in the shapes
+/// `OrdinaryBodyAnalysisHost` declares them.
+///
+/// They are the receiver's answers, not the export view's, because the ledger
+/// is a claim about the *host contract*: stating that a contract method is
+/// answered means the receiver answers it. Each one is the export view over
+/// this body's own three parts, so none reaches a declaration-wide table.
+impl<K, M, S, P: BodyHostFacts> ProviderBodyHost<K, M, S, P> {
+    pub(crate) fn canonical_type_instance(
+        &self,
+        ty: Type,
+    ) -> Result<IssuedTypeInstanceKey, crate::SemanticBodyExportFailure> {
+        self.export_host().canonical_type_instance(ty)
+    }
+
+    pub(crate) fn canonical_argument_value(
+        &self,
+        value: ConstValue,
+    ) -> Result<
+        crate::CanonicalArgumentValue<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
+        crate::SemanticBodyExportFailure,
+    > {
+        self.export_host().canonical_argument_value(value)
+    }
+
+    pub(crate) fn function_identity(
+        &self,
+        symbol: Spur,
+    ) -> Result<crate::SemanticDefinitionToken, crate::SemanticBodyExportFailure> {
+        self.export_host().function_identity(symbol)
+    }
+
+    pub(crate) fn stable_definition_symbol_component(
+        &self,
+        token: &crate::SemanticDefinitionToken,
+    ) -> String {
+        self.export_host().stable_definition_symbol_component(token)
+    }
+
+    pub(crate) fn stable_module_symbol_component(
+        &self,
+        token: &crate::SemanticModuleToken,
+    ) -> String {
+        self.export_host().stable_module_symbol_component(token)
     }
 }
 
@@ -871,7 +898,7 @@ impl<'a, I: StableIdentityFacts, C: ExportCallableFacts> ProviderExportHost<'a, 
     }
 
     /// The stable definition token behind a rendered callable symbol.
-    fn function_identity(
+    pub(crate) fn function_identity(
         &self,
         symbol: Spur,
     ) -> Result<crate::SemanticDefinitionToken, crate::SemanticBodyExportFailure> {
@@ -905,6 +932,88 @@ impl<'a, I: StableIdentityFacts, C: ExportCallableFacts> ProviderExportHost<'a, 
                 crate::StableDefinitionKind::AssociatedFunction
             },
         )
+    }
+
+    /// The stable argument value for a compact comptime constant.
+    ///
+    /// It rides the arms [`Self::canonical_type_instance`] and
+    /// [`Self::function_identity`] already answer, so nothing here reaches past
+    /// the overlay, the type pool, and the identity boundary. Note the function
+    /// arm takes the *definition* form, not
+    /// [`Self::body_function_identity`]: an argument names the callable that
+    /// was passed, and the epoch spells it the same way.
+    pub(crate) fn canonical_argument_value(
+        &self,
+        value: ConstValue,
+    ) -> Result<
+        crate::CanonicalArgumentValue<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
+        crate::SemanticBodyExportFailure,
+    > {
+        use crate::CanonicalArgumentValue as V;
+        Ok(match value {
+            ConstValue::Integer(value) => V::Integer(value),
+            ConstValue::Bool(value) => V::Bool(value),
+            ConstValue::Type(value) => V::Type(Box::new(self.canonical_type_instance(value)?)),
+            ConstValue::Function(value) => V::Function(Box::new(
+                IssuedFunctionInstanceKey::Definition(self.function_identity(value)?),
+            )),
+            ConstValue::Unit => V::Unit,
+            ConstValue::String(value) => {
+                V::String(std::sync::Arc::from(self.interner.resolve(&value)))
+            }
+        })
+    }
+
+    /// The request-independent logical module path of one consulted file.
+    ///
+    /// The pool's path table is written at the mint that assigned a module its
+    /// body-local file id, so it holds exactly the modules this body consulted.
+    /// The epoch answers the same question from `symbol_paths`, sized by every
+    /// file in the program — this is the whole difference between the two
+    /// renderings.
+    ///
+    /// Every file reaching here came from a nominal the pool minted, and
+    /// minting registers the path, so an absent path is a broken pool rather
+    /// than a reachable input. The epoch fails closed on the same invariant.
+    fn logical_module_component(&self, file: u32) -> String {
+        self.type_pool
+            .symbol_path(FileId::new(file))
+            .expect("every consulted endpoint's file has a canonical logical module path")
+    }
+
+    /// The request-independent content of one definition token.
+    ///
+    /// Rendered from the endpoint recorded at the consult that produced the
+    /// token, never from a reverse table: a body can only render an identity it
+    /// resolved. The uninstalled-token spelling matches the epoch's byte for
+    /// byte, because it feeds anonymous-identity digests that must agree across
+    /// the flip.
+    pub(crate) fn stable_definition_symbol_component(
+        &self,
+        token: &crate::SemanticDefinitionToken,
+    ) -> String {
+        match self.local.consulted_definition_endpoint(token) {
+            Some(endpoint) => crate::stable_digest::stable_definition_component(
+                &self.logical_module_component(endpoint.file),
+                &endpoint.name,
+                endpoint.owner.as_deref(),
+                endpoint.kind as u8,
+            ),
+            None => format!("d\u{1}{}\u{1}{}", token.issuer(), token.slot()),
+        }
+    }
+
+    /// The module half of the same rendering.
+    pub(crate) fn stable_module_symbol_component(
+        &self,
+        token: &crate::SemanticModuleToken,
+    ) -> String {
+        match self.local.consulted_module_endpoint(token) {
+            Some(endpoint) => crate::stable_digest::stable_module_component(
+                &self.logical_module_component(endpoint.file),
+            ),
+            None => format!("m\u{1}{}\u{1}{}", token.issuer(), token.slot()),
+        }
     }
 
     /// The stable instance a rendered callable symbol names.
@@ -1389,6 +1498,118 @@ mod tests {
         );
     }
 
+    /// Rendering a stable symbol component uses the endpoint recorded at the
+    /// consult and the module path the type pool wrote when it minted that
+    /// file, and encodes them with the digest encoder the epoch shares. Both
+    /// halves matter: the same encoder keeps anonymous-identity digests equal
+    /// across the flip, and the body-local path table is what makes the
+    /// rendering `O(consulted)` instead of `O(files)`.
+    #[test]
+    fn a_consulted_token_renders_from_its_recorded_endpoint() {
+        let mut local = ProviderBodyLocalState::new();
+        let pool = crate::intern_pool::TypeInternPool::new();
+        let interner = lasso::ThreadedRodeo::new();
+        let facts = RecordingFacts::default();
+
+        pool.set_symbol_paths(HashMap::from([(
+            FileId::new(3),
+            "app/widget.rue".to_owned(),
+        )]));
+        let token = crate::SemanticDefinitionToken::new(1, 7);
+        local.record_consulted_definition_endpoint(crate::SemanticDefinitionEndpoint {
+            token,
+            file: 3,
+            name: "render".into(),
+            kind: crate::StableDefinitionKind::Method,
+            owner: Some("Widget".into()),
+        });
+
+        let host = ProviderExportHost::new(&local, &pool, &facts, &facts, &interner);
+        assert_eq!(
+            host.stable_definition_symbol_component(&token),
+            crate::stable_digest::stable_definition_component(
+                "app/widget.rue",
+                "render",
+                Some("Widget"),
+                crate::StableDefinitionKind::Method as u8,
+            ),
+            "a consulted token renders through the shared digest encoder"
+        );
+    }
+
+    /// A token this body never consulted renders as the epoch spells an
+    /// uninstalled one, byte for byte. This spelling feeds anonymous-identity
+    /// digests, so diverging here would fork identity between the two receivers
+    /// rather than merely losing a name.
+    #[test]
+    fn an_unconsulted_token_renders_as_the_epoch_spells_it() {
+        let local = ProviderBodyLocalState::new();
+        let pool = crate::intern_pool::TypeInternPool::new();
+        let interner = lasso::ThreadedRodeo::new();
+        let facts = RecordingFacts::default();
+        let host = ProviderExportHost::new(&local, &pool, &facts, &facts, &interner);
+
+        let definition = crate::SemanticDefinitionToken::new(2, 9);
+        let module = crate::SemanticModuleToken::new(2, 4);
+        assert_eq!(
+            host.stable_definition_symbol_component(&definition),
+            "d\u{1}2\u{1}9"
+        );
+        assert_eq!(
+            host.stable_module_symbol_component(&module),
+            "m\u{1}2\u{1}4"
+        );
+    }
+
+    /// The argument arms that carry no identity resolve without reaching the
+    /// fact boundary at all; only the type and function arms consult it, and
+    /// they do so through the same lookups the type and callable directions
+    /// already use.
+    #[test]
+    fn plain_argument_values_cost_no_boundary_consults() {
+        let local = ProviderBodyLocalState::new();
+        let pool = crate::intern_pool::TypeInternPool::new();
+        let interner = lasso::ThreadedRodeo::new();
+        let facts = RecordingFacts::default();
+        let host = ProviderExportHost::new(&local, &pool, &facts, &facts, &interner);
+
+        let text = interner.get_or_intern("hello");
+        for (value, expected) in [
+            (
+                ConstValue::Integer(7),
+                crate::CanonicalArgumentValue::Integer(7),
+            ),
+            (
+                ConstValue::Bool(true),
+                crate::CanonicalArgumentValue::Bool(true),
+            ),
+            (ConstValue::Unit, crate::CanonicalArgumentValue::Unit),
+            (
+                ConstValue::String(text),
+                crate::CanonicalArgumentValue::String(std::sync::Arc::from("hello")),
+            ),
+        ] {
+            assert_eq!(
+                host.canonical_argument_value(value)
+                    .expect("an identity-free argument value exports"),
+                expected
+            );
+        }
+        assert!(
+            facts.definition_consults.borrow().is_empty(),
+            "an identity-free argument consulted the boundary: {:?}",
+            facts.definition_consults.borrow()
+        );
+
+        assert!(
+            matches!(
+                host.canonical_argument_value(ConstValue::Function(text)),
+                Err(crate::SemanticBodyExportFailure::UnmappedFunction)
+            ),
+            "the function arm resolves through callable identity, and fails closed"
+        );
+    }
+
     /// A durable universe with no nominals in it. The receiver tests exercise
     /// the parts that must work before any nominal is consulted, so the source
     /// answering `None` is the honest input, not a placeholder.
@@ -1513,7 +1734,7 @@ mod tests {
         }
         assert_eq!(
             outstanding.len(),
-            7,
+            2,
             "the outstanding host capabilities are {:?}; update this count in the same change \
              that wires one, so the worklist cannot shrink silently",
             outstanding.iter().map(|row| row.method).collect::<Vec<_>>()

--- a/crates/rue-air/src/sema/provider_host.rs
+++ b/crates/rue-air/src/sema/provider_host.rs
@@ -55,8 +55,6 @@ use super::anon_structs::{
     IssuedAnonymousNominalKey, IssuedCanonicalArguments, IssuedFunctionInstanceKey,
     IssuedStableProducerId, IssuedTypeInstanceKey,
 };
-use super::body_endpoint::BodyEndpointProvider;
-use super::info::ConstInfo;
 use super::{
     AnalyzedBodyOwnerEvent, AnonMethodSig, BodyAnalysisWork, ConstValue,
     DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind, DeferredOwnershipGate,
@@ -492,59 +490,21 @@ pub(crate) trait ExportCallableFacts {
     fn method_by_callable_symbol(&self, symbol: Spur) -> Option<ExportedMethodSite>;
 }
 
-/// The declaration lookups a body performs for constants and module bindings.
-///
-/// Same adapter discipline as [`StableIdentityFacts`]: the compiler-side
-/// implementation routes each call through the ordinary [`BodyFactProvider`]
-/// lookup operations, so the dependency edge is recorded at the consult.
-///
-/// **Why this is keyed on a module path rather than a file id.** The engine asks
-/// for a constant by `(FileId, Spur)`, but that `FileId` is minted by
-/// [`crate::sema::BodyIdentityPool`] in *first-consult order* — the same
-/// declaration is file 1 in one body and file 4 in another. Handing that number
-/// to a durable lookup is the defect class this receiver exists to avoid: it
-/// misses for most bodies and, on a collision, resolves to an unrelated
-/// declaration without failing. The receiver therefore converts the number to a
-/// logical module path before the call (`pool_module_path`), and only the path
-/// crosses. Every coordinate on this seam is request-independent.
-///
-/// **Why it answers a key rather than a `ConstInfo`.** `ConstInfo` carries a
-/// pool-relative [`Type`] and [`ConstValue`], which only the body's own identity
-/// pool can mint. So the split is: the boundary answers *which declaration*
-/// (recording the edge), and the pool answers *what it is* (body-locally, from
-/// the durable record). That is the same division the nominal path already uses.
-pub(crate) trait BodyConstFacts<K> {
-    /// The durable key of the value-const declared as `name` in `module_path`,
-    /// or `None` when the module declares no such constant.
-    fn value_const_key(&self, module_path: &str, name: &str) -> Option<K>;
-
-    /// The durable key of the module binding declared as `name` in
-    /// `module_path`, or `None`.
-    fn module_binding_key(&self, module_path: &str, name: &str) -> Option<K>;
-}
-
 /// The one fact authority a provider-backed body consults.
 ///
-/// [`StableIdentityFacts`], [`ExportCallableFacts`], and [`BodyConstFacts`] are
-/// adapters over [`BodyFactProvider`], not peer authorities, so the receiver
-/// binds all four to a single type rather than to four independent parameters.
-/// That is the structural form of the claim the adapter docs make in prose:
-/// every non-local answer a body receives came through the fact boundary, and
-/// therefore recorded its dependency edge at the consult. Separate parameters
-/// would make an edge-free second authority expressible.
-///
-/// The const adapter is keyed on `K`, the receiver's own durable key type, so
-/// the boundary and the identity pool cannot be wired to two different key
-/// spaces — a key answered here is a key the pool can mint from.
-pub(crate) trait BodyHostFacts<K>:
-    BodyFactProvider + StableIdentityFacts + ExportCallableFacts + BodyConstFacts<K>
+/// [`StableIdentityFacts`] and [`ExportCallableFacts`] are adapters over
+/// [`BodyFactProvider`], not peer authorities, so the receiver binds all three
+/// to a single type rather than to three independent parameters. That is the
+/// structural form of the claim the adapter docs make in prose: every non-local
+/// answer a body receives came through the fact boundary, and therefore
+/// recorded its dependency edge at the consult. Three separate parameters would
+/// make an edge-free second authority expressible.
+pub(crate) trait BodyHostFacts:
+    BodyFactProvider + StableIdentityFacts + ExportCallableFacts
 {
 }
 
-impl<K, T> BodyHostFacts<K> for T where
-    T: BodyFactProvider + StableIdentityFacts + ExportCallableFacts + BodyConstFacts<K>
-{
-}
+impl<T> BodyHostFacts for T where T: BodyFactProvider + StableIdentityFacts + ExportCallableFacts {}
 
 /// The receiver one body evaluation runs on.
 ///
@@ -753,7 +713,7 @@ impl<K, M, S, P> ProviderBodyHost<K, M, S, P> {
     }
 }
 
-impl<K, M, S, P: BodyHostFacts<K>> ProviderBodyHost<K, M, S, P> {
+impl<K, M, S, P: BodyHostFacts> ProviderBodyHost<K, M, S, P> {
     /// The export view over this receiver's own overlay, pool, and boundary.
     ///
     /// Held for the duration of one export call rather than stored: it borrows
@@ -777,7 +737,7 @@ impl<K, M, S, P: BodyHostFacts<K>> ProviderBodyHost<K, M, S, P> {
 /// is a claim about the *host contract*: stating that a contract method is
 /// answered means the receiver answers it. Each one is the export view over
 /// this body's own parts, so none reaches a declaration-wide table.
-impl<K, M, S, P: BodyHostFacts<K>> ProviderBodyHost<K, M, S, P> {
+impl<K, M, S, P: BodyHostFacts> ProviderBodyHost<K, M, S, P> {
     pub(crate) fn canonical_type_instance(
         &self,
         ty: Type,
@@ -817,276 +777,11 @@ impl<K, M, S, P: BodyHostFacts<K>> ProviderBodyHost<K, M, S, P> {
     }
 }
 
-/// Which declaration namespace a constant lookup names.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ConstLookup {
-    ValueConst,
-    ModuleBinding,
-}
-
-/// The callable rows of [`HOST_CAPABILITY_LEDGER`] the inference source needs,
-/// answered through the endpoint driver over this body's own RIR and pool.
-///
-/// The driver is materialized per call rather than stored: it borrows the fact
-/// boundary and the RIR view, so holding one would make the receiver
-/// self-referential. Its own overlay is a cache of what this body already
-/// minted, and that lives in the shared identity context, so a fresh driver
-/// sees everything an earlier one did.
-impl<K, M, S, P: BodyHostFacts<K>> ProviderBodyHost<K, M, S, P>
-where
-    K: Clone + Eq + Hash,
-    M: Clone + Eq + Hash,
-    S: DurableNominalSource<K, M>
-        + super::DurableAnonymousSource<K, M>
-        + super::DurableConstSource<K, M>,
-{
-    fn endpoint_driver(&self) -> super::body_endpoint::ProviderEndpointFacts<'_, P, S, K, M> {
-        super::body_endpoint::ProviderEndpointFacts::with_state(
-            &self.facts,
-            &self.state,
-            self.rir.view(),
-        )
-    }
-
-    pub(crate) fn function_info(&self, name: Spur) -> Option<super::FunctionInfo> {
-        self.endpoint_driver().function_info(name)
-    }
-
-    pub(crate) fn method_info(&self, owner: StructId, name: Spur) -> Option<MethodInfo> {
-        self.endpoint_driver().method_info(owner, name)
-    }
-
-    pub(crate) fn resolve_function_name_local(&self, name: Spur, file: FileId) -> Option<Spur> {
-        self.endpoint_driver().function_by_file_name(file, name)
-    }
-
-    /// Which of a callable's parameters are comptime `type` parameters.
-    ///
-    /// Read off this body's own RIR and interner, exactly as the engine's
-    /// generic form does. An absent `type` symbol means this body never spelled
-    /// one, so no parameter can be a comptime type parameter.
-    pub(crate) fn comptime_type_param_flags(&self, function: &super::FunctionInfo) -> Vec<bool> {
-        let Some(type_symbol) = self.interner.get("type") else {
-            return vec![false; function.params.len()];
-        };
-        let rir = self.rir.rir();
-        rir.params(function.rir_params(rir))
-            .iter()
-            .map(|param| param.is_comptime && param.ty == type_symbol)
-            .collect()
-    }
-}
-
-impl<K, M, S, P: BodyHostFacts<K>> ProviderBodyHost<K, M, S, P>
-where
-    K: Clone + Eq + Hash,
-    M: Eq + Hash,
-    S: DurableNominalSource<K, M> + super::DurableConstSource<K, M>,
-{
-    /// One constant: located through the boundary, minted by the pool.
-    ///
-    /// The two halves are deliberate. The boundary answers *which* declaration
-    /// the `(module, name)` coordinate names, which is where the dependency edge
-    /// belongs — a body that reads a constant depends on that constant's
-    /// declaration. The pool answers *what it is*, from the durable record,
-    /// because a `ConstInfo` carries a pool-relative type and value that only
-    /// this body's identity authority can mint.
-    ///
-    /// The file number is converted to a logical module path here and does not
-    /// cross the boundary; see [`BodyConstFacts`] for why that matters.
-    fn const_info(&self, file: FileId, name: Spur, lookup: ConstLookup) -> Option<ConstInfo> {
-        let module_path = self.type_pool.symbol_path(file)?;
-        let name = self.interner.resolve(&name);
-        let key = match lookup {
-            ConstLookup::ValueConst => self.facts.value_const_key(&module_path, name),
-            ConstLookup::ModuleBinding => self.facts.module_binding_key(&module_path, name),
-        }?;
-        let identity = self.state.identity_context();
-        let mut pool = identity.pool_mut()?;
-        // `Span::default()` is sound only because every caller below reads
-        // `ty`/`value` and discards the rest: the inference arms return a
-        // `Type`, an `i128`, or a `Spur`, never the `ConstInfo` itself. A
-        // diagnostic-bearing consult must supply the declaration's real span
-        // from this body's RIR rather than reuse this path.
-        pool.resolve_const(
-            &key,
-            super::body_identity::ConstIdentityHandle {
-                span: rue_span::Span::default(),
-            },
-        )
-        .ok()
-    }
-}
-
-/// The inference source, the one read family the host contract requires.
-///
-/// Every arm answers from this body's own parts: the overlay for what this body
-/// generated, the type pool for what it has already minted, this body's RIR for
-/// parameter syntax, and the fact boundary for constants it has not yet
-/// consulted. None reads a declaration-universe table, which is the whole point
-/// — the epoch answers these same fourteen questions from thirteen such tables.
-impl<K, M, S, P: BodyHostFacts<K>> super::inference_ctx::InferenceFactSource
-    for ProviderBodyHost<K, M, S, P>
-where
-    K: Clone + Eq + Hash,
-    M: Clone + Eq + Hash,
-    S: DurableNominalSource<K, M>
-        + super::DurableAnonymousSource<K, M>
-        + super::DurableConstSource<K, M>,
-{
-    /// The nominals *this body generated*, which is all the overlay can hold.
-    /// The epoch builds the same snapshot from its `generated_structs` /
-    /// `generated_enums`; those are body-local there too.
-    fn inference_generated_nominal_overlays(
-        &self,
-    ) -> super::inference_ctx::InferenceGeneratedNominalOverlays {
-        let mut builtin_struct_types = HashMap::new();
-        let mut struct_types_by_file = HashMap::new();
-        for (name, id) in &self.local.generated_structs {
-            let def = self.type_pool.struct_def(*id);
-            if def.is_builtin {
-                builtin_struct_types.insert(*name, Type::new_struct(*id));
-            }
-            struct_types_by_file
-                .entry((def.file_id, *name))
-                .or_insert_with(|| Type::new_struct(*id));
-        }
-        let mut enum_types_by_file = HashMap::new();
-        for (name, id) in &self.local.generated_enums {
-            let def = self.type_pool.enum_def(*id);
-            enum_types_by_file
-                .entry((def.file_id, *name))
-                .or_insert_with(|| Type::new_enum(*id));
-        }
-        super::inference_ctx::InferenceGeneratedNominalOverlays {
-            builtin_struct_types,
-            struct_types_by_file,
-            enum_types_by_file,
-        }
-    }
-
-    fn uncached_function_sig(&self, name: Spur) -> Option<crate::inference::FunctionSig> {
-        let info = self.function_info(name)?;
-        let rir = self.rir.rir();
-        let params = self.state.param_data(info.params);
-        Some(crate::inference::FunctionSig {
-            param_types: params
-                .types()
-                .iter()
-                .map(|ty| super::inference_ctx::type_to_infer_type(&self.type_pool, *ty))
-                .collect(),
-            return_type: super::inference_ctx::type_to_infer_type(
-                &self.type_pool,
-                info.return_type,
-            ),
-            is_generic: info.is_generic,
-            param_modes: params.modes().to_vec(),
-            param_comptime: params.comptime().to_vec(),
-            param_comptime_type: self.comptime_type_param_flags(&info),
-            param_names: params.names().to_vec(),
-            param_type_syms: rir
-                .params(info.rir_params(rir))
-                .iter()
-                .map(|param| param.ty)
-                .collect(),
-            return_type_sym: info.return_type_sym,
-        })
-    }
-
-    /// Anonymous members this body installed win over named ones, exactly as
-    /// they do on the epoch: a body that just minted an anonymous method must
-    /// see its own signature rather than a same-keyed named one.
-    fn uncached_method_sig(&self, key: (StructId, Spur)) -> Option<crate::inference::MethodSig> {
-        let info = match self.local.anonymous_methods.get(&key) {
-            Some(info) => *info,
-            None => self.method_info(key.0, key.1)?,
-        };
-        let params = self.state.param_data(info.params);
-        Some(crate::inference::MethodSig {
-            struct_type: info.struct_type,
-            has_self: info.has_self,
-            param_types: params
-                .types()
-                .iter()
-                .map(|ty| super::inference_ctx::type_to_infer_type(&self.type_pool, *ty))
-                .collect(),
-            param_modes: params.modes().to_vec(),
-            return_type: super::inference_ctx::type_to_infer_type(
-                &self.type_pool,
-                info.return_type,
-            ),
-        })
-    }
-
-    /// Builtins live at [`FileId::DEFAULT`] in this body's pool, registered
-    /// there exactly as a fresh import epoch registers them, so the builtin
-    /// arms are the by-file arms at that one file.
-    fn inference_builtin_struct_type(&self, name: Spur) -> Option<Type> {
-        self.type_pool
-            .get_struct_by_file_name(FileId::DEFAULT, name)
-    }
-
-    fn inference_struct_type_by_file(&self, key: (FileId, Spur)) -> Option<Type> {
-        self.type_pool.get_struct_by_file_name(key.0, key.1)
-    }
-
-    fn inference_builtin_enum_type(&self, name: Spur) -> Option<Type> {
-        self.type_pool.get_enum_by_file_name(FileId::DEFAULT, name)
-    }
-
-    fn inference_enum_type_by_file(&self, key: (FileId, Spur)) -> Option<Type> {
-        self.type_pool.get_enum_by_file_name(key.0, key.1)
-    }
-
-    fn inference_const_type(&self, key: (FileId, Spur)) -> Option<Type> {
-        self.const_info(key.0, key.1, ConstLookup::ValueConst)
-            .map(|info| match info.value {
-                ConstValue::Type(_) => Type::COMPTIME_TYPE,
-                _ => info.ty,
-            })
-    }
-
-    fn inference_const_type_alias(&self, key: (FileId, Spur)) -> Option<Type> {
-        self.const_info(key.0, key.1, ConstLookup::ValueConst)
-            .and_then(|info| match info.value {
-                ConstValue::Type(ty) => Some(ty),
-                _ => None,
-            })
-    }
-
-    fn inference_const_value(&self, key: (FileId, Spur)) -> Option<i128> {
-        self.const_info(key.0, key.1, ConstLookup::ValueConst)
-            .and_then(|info| info.value.as_int_value())
-    }
-
-    fn inference_const_function_alias(&self, key: (FileId, Spur)) -> Option<Spur> {
-        self.const_info(key.0, key.1, ConstLookup::ValueConst)
-            .and_then(|info| info.value.as_function())
-    }
-
-    fn inference_module_binding_type(&self, key: (FileId, Spur)) -> Option<Type> {
-        self.const_info(key.0, key.1, ConstLookup::ModuleBinding)
-            .map(|info| info.ty)
-    }
-
-    /// The pool's own module numbering answers this: `file_for_module` is what
-    /// assigned the id, so reversing it needs no registry read.
-    fn inference_module_file_id(&self, module: crate::types::ModuleId) -> Option<FileId> {
-        let identity = self.state.identity_context();
-        let modules = identity.modules();
-        modules.get(module).map(|definition| definition.file_id)
-    }
-
-    fn inference_function_by_file(&self, key: (FileId, Spur)) -> Option<Spur> {
-        self.resolve_function_name_local(key.1, key.0)
-    }
-}
-
 /// Publication reaches the provider receiver through the same neutral contract
 /// it reaches the epoch receiver through: `export_body` is one algorithm over
 /// this trait, so binding it here makes the export direction reachable without
 /// a second serializer.
-impl<K, M, S, P: BodyHostFacts<K>> SemanticBodyExportHost for ProviderBodyHost<K, M, S, P> {
+impl<K, M, S, P: BodyHostFacts> SemanticBodyExportHost for ProviderBodyHost<K, M, S, P> {
     fn export_body_type(
         &self,
         ty: Type,
@@ -1739,23 +1434,6 @@ mod tests {
     struct RecordingFacts {
         definition_consults: std::cell::RefCell<Vec<String>>,
         module_consults: std::cell::RefCell<Vec<String>>,
-        const_consults: std::cell::RefCell<Vec<String>>,
-    }
-
-    impl BodyConstFacts<std::sync::Arc<str>> for RecordingFacts {
-        fn value_const_key(&self, module_path: &str, name: &str) -> Option<std::sync::Arc<str>> {
-            self.const_consults
-                .borrow_mut()
-                .push(format!("value:{module_path}:{name}"));
-            None
-        }
-
-        fn module_binding_key(&self, module_path: &str, name: &str) -> Option<std::sync::Arc<str>> {
-            self.const_consults
-                .borrow_mut()
-                .push(format!("binding:{module_path}:{name}"));
-            None
-        }
     }
 
     impl ExportCallableFacts for RecordingFacts {
@@ -2166,45 +1844,6 @@ mod tests {
         }
     }
 
-    impl super::super::DurableAnonymousSource<std::sync::Arc<str>, std::sync::Arc<str>>
-        for NoDurableNominals
-    {
-        fn anonymous_shape(
-            &self,
-            _: &crate::AnonymousNominalKey<std::sync::Arc<str>, std::sync::Arc<str>>,
-        ) -> Option<super::super::DurableAnonymousShape<std::sync::Arc<str>, std::sync::Arc<str>>>
-        {
-            None
-        }
-
-        /// The durable key *is* the rendered component in this test universe,
-        /// so the spelling stays whatever the caller supplied rather than
-        /// inventing one — an invented component would feed anonymous-identity
-        /// digests and fork identity silently.
-        fn definition_symbol_component(&self, key: &std::sync::Arc<str>) -> String {
-            key.to_string()
-        }
-
-        fn module_symbol_component(&self, module: &std::sync::Arc<str>) -> String {
-            module.to_string()
-        }
-    }
-
-    impl super::super::DurableConstSource<std::sync::Arc<str>, std::sync::Arc<str>>
-        for NoDurableNominals
-    {
-        fn constant(
-            &self,
-            _: &std::sync::Arc<str>,
-        ) -> Option<super::super::DurableConst<std::sync::Arc<str>, std::sync::Arc<str>>> {
-            None
-        }
-
-        fn function_name(&self, _: &std::sync::Arc<str>) -> Option<std::sync::Arc<str>> {
-            None
-        }
-    }
-
     type TestHost = ProviderBodyHost<
         std::sync::Arc<str>,
         std::sync::Arc<str>,
@@ -2292,64 +1931,6 @@ mod tests {
             host.builtin_arch_id(),
             host.builtin_os_id(),
             "distinct builtin enums must not collapse to one identity"
-        );
-    }
-
-    /// A constant reaches the boundary as a module path, not as a file number.
-    ///
-    /// Same invariant as `the_identity_boundary_is_keyed_on_module_paths`, and
-    /// it matters here for a sharper reason: the engine asks for a constant by
-    /// the `(FileId, Spur)` pair its analysis context carries, and on this
-    /// receiver that `FileId` is the pool's own first-consult numbering. Passing
-    /// it through would key a durable lookup on the order this body happened to
-    /// touch modules in — the same defect that made a struct resolve to an
-    /// unrelated declaration before the identity seam was re-keyed. The number
-    /// is converted here and must not appear in the consult.
-    #[test]
-    fn the_const_boundary_is_keyed_on_module_paths() {
-        use super::super::inference_ctx::InferenceFactSource;
-
-        let host = test_host();
-        let body_local_file = FileId::new(3);
-        host.type_pool().set_symbol_paths(HashMap::from([(
-            body_local_file,
-            "app/config.rue".to_owned(),
-        )]));
-        let name = host.interner().get_or_intern("LIMIT");
-
-        assert_eq!(
-            host.inference_const_type((body_local_file, name)),
-            None,
-            "an empty durable universe has no constant to answer with"
-        );
-        assert_eq!(
-            host.inference_module_binding_type((body_local_file, name)),
-            None
-        );
-
-        assert_eq!(
-            host.facts().const_consults.borrow().as_slice(),
-            [
-                "value:app/config.rue:LIMIT".to_owned(),
-                "binding:app/config.rue:LIMIT".to_owned(),
-            ],
-            "the const boundary must be consulted by logical module path; the \
-             pool's file number must not appear"
-        );
-    }
-
-    /// A constant the pool cannot place has no path to consult, so the boundary
-    /// is never asked — rather than being asked with a fabricated coordinate.
-    #[test]
-    fn an_unplaceable_constant_consults_nothing() {
-        use super::super::inference_ctx::InferenceFactSource;
-
-        let host = test_host();
-        let name = host.interner().get_or_intern("LIMIT");
-        assert_eq!(host.inference_const_type((FileId::new(9), name)), None);
-        assert!(
-            host.facts().const_consults.borrow().is_empty(),
-            "a file with no logical module path must not reach the boundary at all"
         );
     }
 

--- a/crates/rue-air/src/sema/provider_host.rs
+++ b/crates/rue-air/src/sema/provider_host.rs
@@ -4,12 +4,14 @@
 //! [`OrdinaryBodyAnalysisHost`] implementation is `Sema`, which reaches a
 //! declaration-wide epoch for every fact a body asks for; that shape is the
 //! `O(bodies × declarations)` term the body-context repair exists to delete.
-//! The replacement receiver — [`ProviderBodyHost`] — owns exactly three things:
+//! The replacement receiver — [`ProviderBodyHost`] — owns exactly four things:
 //!
 //! - **Body-local mutable state** — [`ProviderBodyLocalState`] below. Every
 //!   field here is state one body evaluation creates, mutates, and drops. None
 //!   of it is shared with another body, and none of it is derived from the
 //!   declaration universe, so it is `O(this body)` by construction.
+//! - **This body's lowered RIR** — [`crate::sema::BodyRirBundle`], not the
+//!   whole-program `Rir` the epoch receiver borrows.
 //! - **The rue-air-owned identity authority** —
 //!   [`crate::sema::ProviderBodyAnalysisState`], the body-scoped type pool,
 //!   parameter arena, and interner.
@@ -17,7 +19,7 @@
 //!   whose typed operations answer exactly the questions a body asks and whose
 //!   implementation records the corresponding query edge per call.
 //!
-//! Everything a body needs is one of those three or a configuration constant.
+//! Everything a body needs is one of those four or a configuration constant.
 //! [`HOST_CAPABILITY_LEDGER`] states which, for every method on the host
 //! contract, and [`host_capability_ledger_covers_the_contract`] pins that claim
 //! against the real trait source so it cannot go stale as the contract moves.
@@ -40,7 +42,7 @@ use rue_span::FileId;
 
 use super::provider::BodyFactProvider;
 use super::semantic_body_export::SemanticBodyExportHost;
-use super::{DurableNominalSource, ProviderBodyAnalysisState};
+use super::{BodyRirBundle, BodyRirView, DurableNominalSource, ProviderBodyAnalysisState};
 use crate::intern_pool::TypeInternPool;
 
 use super::anon_structs::{
@@ -224,6 +226,11 @@ pub(crate) enum HostCapability {
     /// needs the adapter that maps the operation's owned fact onto the shape
     /// the engine expects.
     ProviderFact,
+    /// Answered from the body's own lowered RIR, which the receiver owns. The
+    /// epoch answers the same method from the whole-program `Rir` it borrows;
+    /// holding only this body's bundle is what keeps a live program-wide RIR
+    /// from crossing the query boundary.
+    BodyRir,
     /// Answered by [`ProviderExportHost`], the export view over the overlay,
     /// the type pool, and exact keyed identity lookups. A category of its own
     /// because one answer draws on all three — and because the epoch answers
@@ -352,14 +359,9 @@ pub(crate) const HOST_CAPABILITY_LEDGER: &[HostCapabilityRow] = &[
         "known_drop_glue_during_binding",
         HostCapability::InapplicableToBodies,
     ),
+    // --- The body's own lowered RIR. ---
+    row("body_rir_ref", HostCapability::BodyRir),
     // --- The remaining design work. ---
-    row(
-        "body_rir_ref",
-        HostCapability::NeedsProviderWiring(
-            "the engine borrows whole-program RIR; the flip must hand it the body's own \
-             lowered RIR so no live `Rir` crosses the query boundary",
-        ),
-    ),
     row(
         "resolve_body_type",
         HostCapability::NeedsProviderWiring(
@@ -476,16 +478,21 @@ impl<T> BodyHostFacts for T where T: BodyFactProvider + StableIdentityFacts + Ex
 /// The receiver one body evaluation runs on.
 ///
 /// This is the flip's substitution for `Sema`. The epoch receiver reaches a
-/// declaration-wide binding for every fact; this one has exactly the three
-/// parts the module documentation names, and [`HOST_CAPABILITY_LEDGER`] says
-/// which of them answers each contract method — `BodyLocal` rows come from
-/// `local`, `ProviderState` rows from `state`, `ProviderFact` rows from `facts`.
+/// declaration-wide binding for every fact; this one has exactly the four parts
+/// the module documentation names, and [`HOST_CAPABILITY_LEDGER`] says which of
+/// them answers each contract method — `BodyLocal` rows come from `local`,
+/// `BodyRir` from `rir`, `ProviderState` from `state`, `ProviderFact` from
+/// `facts`.
 ///
-/// None of the three is sized by the declaration universe, so constructing a
+/// None of the four is sized by the declaration universe, so constructing a
 /// receiver is `O(1)` in the program rather than `O(declarations)`. That is
 /// where the `O(bodies × declarations)` term goes: the epoch's cost was in
 /// building the receiver, not in the analysis that ran on it.
 pub(crate) struct ProviderBodyHost<K, M, S, P> {
+    /// This body's own lowered RIR. The epoch hands the engine the
+    /// whole-program `Rir`; the receiver holds only the bundle its own body was
+    /// lowered into, so no live program-wide RIR crosses the query boundary.
+    rir: BodyRirBundle,
     local: ProviderBodyLocalState,
     state: ProviderBodyAnalysisState<K, M, S>,
     facts: P,
@@ -503,13 +510,20 @@ where
     M: Eq + Hash,
     S: DurableNominalSource<K, M>,
 {
-    /// Begin one body evaluation over an identity authority and a fact
-    /// boundary. The overlay starts empty — a receiver never inherits another
-    /// body's mints.
-    pub(crate) fn new(state: ProviderBodyAnalysisState<K, M, S>, facts: P) -> Self {
+    /// Begin one body evaluation over its lowered RIR, a durable nominal
+    /// source, and a fact boundary. The overlay starts empty — a receiver never
+    /// inherits another body's mints.
+    ///
+    /// The identity authority is derived from the bundle rather than passed in
+    /// beside it, so the RIR and the state cannot be built over two different
+    /// interners. Every other construction path checks that invariant with an
+    /// assertion; here it holds by construction.
+    pub(crate) fn new(rir: BodyRirBundle, source: S, facts: P) -> Self {
+        let state = rir.provider_body_state(source);
         let type_pool = state.type_pool();
         let interner = state.interner();
         Self {
+            rir,
             local: ProviderBodyLocalState::new(),
             state,
             facts,
@@ -543,10 +557,21 @@ impl<K, M, S, P> ProviderBodyHost<K, M, S, P> {
     pub(crate) fn interner(&self) -> &ThreadedRodeo {
         &self.interner
     }
+
+    /// The host contract's `body_rir_ref`: this body's RIR, not the program's.
+    pub(crate) fn body_rir_ref(&self) -> &rue_rir::Rir {
+        self.rir.rir()
+    }
+
+    /// The shared RIR/index/interner view the endpoint and call fact facades
+    /// are constructed over.
+    pub(crate) fn rir_view(&self) -> BodyRirView<'_> {
+        self.rir.view()
+    }
 }
 
 impl<K, M, S, P: BodyHostFacts> ProviderBodyHost<K, M, S, P> {
-    /// The export view over this receiver's own three parts.
+    /// The export view over this receiver's own overlay, pool, and boundary.
     ///
     /// Held for the duration of one export call rather than stored: it borrows
     /// the overlay immutably, so materializing it per call keeps the receiver
@@ -568,7 +593,7 @@ impl<K, M, S, P: BodyHostFacts> ProviderBodyHost<K, M, S, P> {
 /// They are the receiver's answers, not the export view's, because the ledger
 /// is a claim about the *host contract*: stating that a contract method is
 /// answered means the receiver answers it. Each one is the export view over
-/// this body's own three parts, so none reaches a declaration-wide table.
+/// this body's own parts, so none reaches a declaration-wide table.
 impl<K, M, S, P: BodyHostFacts> ProviderBodyHost<K, M, S, P> {
     pub(crate) fn canonical_type_instance(
         &self,
@@ -1634,14 +1659,27 @@ mod tests {
         RecordingFacts,
     >;
 
+    /// One body's receiver over an empty lowered RIR. A body with no
+    /// instructions is the smallest legal input, not a stub: the receiver's
+    /// invariants are about which authorities it shares, not about how much the
+    /// body does.
     fn test_host() -> TestHost {
-        let state =
-            ProviderBodyAnalysisState::new(NoDurableNominals, Rc::new(lasso::ThreadedRodeo::new()));
-        ProviderBodyHost::new(state, RecordingFacts::default())
+        let editor = rue_rir::RirEditor::new();
+        let validation = rue_rir::RirValidationContext {
+            symbol_count: 0,
+            source_lengths: &[],
+        };
+        let rir = rue_rir::ValidatedRir::finish(editor, &validation)
+            .expect("an empty body RIR validates");
+        ProviderBodyHost::new(
+            BodyRirBundle::new(rir, lasso::ThreadedRodeo::new()),
+            NoDurableNominals,
+            RecordingFacts::default(),
+        )
     }
 
-    /// The receiver's three parts are one authority each, not three that happen
-    /// to agree. If the host cached an interner or type pool other than the
+    /// The receiver's parts are one authority each, not several that happen to
+    /// agree. If the host cached an interner or type pool other than the
     /// identity state's, two halves of the same body would mint symbols in
     /// separate universes and publication would silently disagree with
     /// analysis.
@@ -1662,6 +1700,27 @@ mod tests {
                 .next()
                 .is_none(),
             "a fresh receiver starts with an empty overlay"
+        );
+    }
+
+    /// The receiver's RIR and its identity state are one authority.
+    ///
+    /// `ProviderEndpointFacts` and `ProviderCallFacts` refuse to be built over
+    /// a state and a view whose interners differ, because a symbol minted in
+    /// one universe means nothing in the other. Deriving the state from the
+    /// bundle makes that hold by construction rather than by assertion, so
+    /// there is no way to assemble a receiver those facades would reject.
+    #[test]
+    fn the_receiver_rir_and_identity_state_share_one_authority() {
+        let host = test_host();
+        assert!(
+            host.state().require_rir_authority(&host.rir_view()),
+            "the receiver's RIR view and identity state must share one interner"
+        );
+        assert_eq!(
+            host.body_rir_ref().len(),
+            0,
+            "the receiver lends its own body's RIR, not a program-wide one"
         );
     }
 
@@ -1734,7 +1793,7 @@ mod tests {
         }
         assert_eq!(
             outstanding.len(),
-            2,
+            1,
             "the outstanding host capabilities are {:?}; update this count in the same change \
              that wires one, so the worklist cannot shrink silently",
             outstanding.iter().map(|row| row.method).collect::<Vec<_>>()

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -2345,18 +2345,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     /// This handles the conversion of Type::new_array(id) to InferType::Array
     /// by looking up the array definition to get element type and length.
     pub(crate) fn type_to_infer_type(&self, ty: Type) -> InferType {
-        match ty.kind() {
-            TypeKind::Array(array_id) => {
-                let (element_type, length) = self.type_pool.array_def(array_id);
-                let element_infer = self.type_to_infer_type(element_type);
-                InferType::Array {
-                    element: Box::new(element_infer),
-                    length,
-                }
-            }
-            // All other types wrap directly
-            _ => InferType::Concrete(ty),
-        }
+        super::inference_ctx::type_to_infer_type(&self.type_pool, ty)
     }
     /// Get (or lazily create) the synthetic 2-field struct that represents the
     /// second-class slice type `[T]` (ADR-0043, RUE-322).

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -3105,37 +3105,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     }
 
     fn type_name_mentions_type_param(&self, type_name: &str, type_params: &[Spur]) -> bool {
-        if let Some((element_type, length)) = parse_array_type_syntax(type_name) {
-            let length_mentions = match length {
-                ArrayLen::Literal(_) => false,
-                ArrayLen::Named(name) => self.type_name_mentions_type_param(&name, type_params),
-            };
-            return length_mentions
-                || self.type_name_mentions_type_param(&element_type, type_params);
-        }
-        if let Some(pointee) = type_name
-            .strip_prefix("ptr const ")
-            .or_else(|| type_name.strip_prefix("ptr mut "))
-        {
-            return self.type_name_mentions_type_param(pointee, type_params);
-        }
-        // A type-function application `Name(arg, ...)` mentions a type parameter
-        // if any argument does — `Option(T)` mentions `T`, so a signature/return
-        // type applying an enclosing constructor to a type parameter is deferred
-        // (as `Type::COMPTIME_TYPE`) until specialization, exactly like `[T; N]`
-        // (RUE-272). The constructor name itself is never a type parameter, so
-        // only the arguments are inspected.
-        if let Some((_call_name, arg_strs)) = parse_type_call_syntax(type_name) {
-            return arg_strs
-                .iter()
-                .any(|arg| self.type_name_mentions_type_param(arg, type_params));
-        }
-        // Leaf name: only a match against an already-interned symbol counts
-        // (type parameter names are interned by the parser).
-        match self.interner.get(type_name) {
-            Some(sym) => type_params.contains(&sym),
-            None => false,
-        }
+        type_name_mentions_type_param(self.interner, type_name, type_params)
     }
 
     /// Check whether a signature type symbol mentions any of the given comptime
@@ -3162,29 +3132,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     }
 
     fn type_name_mentions_value_param(&self, type_name: &str, value_params: &[Spur]) -> bool {
-        if let Some((element_type, len)) = parse_array_type_syntax(type_name) {
-            let length_mentions = match len {
-                ArrayLen::Literal(_) => false,
-                ArrayLen::Named(name) => self.type_name_mentions_value_param(&name, value_params),
-            };
-            // Recurse into the element type (nested arrays / pointers).
-            return length_mentions
-                || self.type_name_mentions_value_param(&element_type, value_params);
-        }
-        if let Some(pointee) = type_name
-            .strip_prefix("ptr const ")
-            .or_else(|| type_name.strip_prefix("ptr mut "))
-        {
-            return self.type_name_mentions_value_param(pointee, value_params);
-        }
-        if let Some((_call_name, arg_strs)) = parse_type_call_syntax(type_name) {
-            return arg_strs
-                .iter()
-                .any(|arg| self.type_name_mentions_value_param(arg, value_params));
-        }
-        self.interner
-            .get(type_name)
-            .is_some_and(|sym| value_params.contains(&sym))
+        type_name_mentions_value_param(self.interner, type_name, value_params)
     }
 
     /// Validate the non-deferred parts of a signature type that will otherwise
@@ -3340,13 +3288,14 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         type_subst: &HashMap<Spur, Type>,
         value_subst: &HashMap<Spur, ConstValue>,
     ) -> bool {
-        type_params.iter().all(|name| {
-            type_subst.contains_key(name)
-                || !self.type_name_mentions_type_param(type_name, &[*name])
-        }) && value_params.iter().all(|name| {
-            value_subst.contains_key(name)
-                || !self.type_name_mentions_value_param(type_name, &[*name])
-        })
+        deferred_signature_substitutions_are_ready(
+            self.interner,
+            type_name,
+            type_params,
+            value_params,
+            type_subst,
+            value_subst,
+        )
     }
 
     fn validate_deferred_value_result(
@@ -3359,74 +3308,17 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         expression: &str,
         span: Span,
     ) -> CompileResult<()> {
-        if require_integer {
-            if let Some(value) = value {
-                let Some(integer) = value.as_int_value() else {
-                    return Err(CompileError::new(
-                        ErrorKind::InvalidArrayLength {
-                            reason: format!(
-                                "array length expression '{}' is not an integer",
-                                expression
-                            ),
-                        },
-                        span,
-                    ));
-                };
-                if integer < 0 || u64::try_from(integer).is_err() {
-                    return Err(CompileError::new(
-                        ErrorKind::InvalidArrayLength {
-                            reason: format!(
-                                "array length expression '{}' is outside the valid range",
-                                expression
-                            ),
-                        },
-                        span,
-                    ));
-                }
-            } else if let Some(found) = found
-                && !found.is_integer()
-            {
-                return Err(CompileError::new(
-                    ErrorKind::InvalidArrayLength {
-                        reason: format!(
-                            "array length expression '{}' has non-integer type {}",
-                            expression,
-                            found.safe_name_with_pool(Some(&self.type_pool))
-                        ),
-                    },
-                    span,
-                ));
-            }
-        }
-
-        let Some(expected) = expected else {
-            return Ok(());
-        };
-        if let Some(value) = value {
-            let (function_name, param_name) = contract.expect("value contracts name a parameter");
-            return super::comptime_eval::validate_comptime_value_for_type_impl(
-                self.interner,
-                &self.type_pool,
-                function_name,
-                param_name,
-                value,
-                expected,
-                span,
-            );
-        }
-        if let Some(found) = found
-            && found != expected
-            && !(found.is_integer() && expected.is_integer())
-        {
-            return Err(CompileError::new(
-                ErrorKind::TypeMismatch {
-                    expected: expected.safe_name_with_pool(Some(&self.type_pool)),
-                    found: found.safe_name_with_pool(Some(&self.type_pool)),
-                },
-                span,
-            ));
-        }
-        Ok(())
+        validate_deferred_value_result(
+            self.interner,
+            &self.type_pool,
+            value,
+            found,
+            expected,
+            contract,
+            require_integer,
+            expression,
+            span,
+        )
     }
 
     /// Get or create an array type for the given element type and length.
@@ -3530,5 +3422,277 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// saturated value is never used for real allocation.
     pub(crate) fn abi_slot_count(&self, ty: Type) -> u32 {
         self.body_type_pool().provisional_abi_slot_count(ty)
+    }
+}
+
+/// Type-syntax predicates and validation that need nothing but a symbol
+/// interner and a type pool.
+///
+/// They are free functions rather than methods because both body receivers
+/// need them and neither owns anything else they consume: the epoch reaches
+/// them through `Sema`, and the provider-backed host through its own identity
+/// authority. Keeping one implementation is what makes the two receivers agree
+/// about which signature types defer to specialization — a disagreement there
+/// would change which programs compile, not merely how they are spelled.
+
+pub(super) fn type_name_mentions_type_param(
+    interner: &lasso::ThreadedRodeo,
+    type_name: &str,
+    type_params: &[Spur],
+) -> bool {
+    if let Some((element_type, length)) = parse_array_type_syntax(type_name) {
+        let length_mentions = match length {
+            ArrayLen::Literal(_) => false,
+            ArrayLen::Named(name) => type_name_mentions_type_param(interner, &name, type_params),
+        };
+        return length_mentions
+            || type_name_mentions_type_param(interner, &element_type, type_params);
+    }
+    if let Some(pointee) = type_name
+        .strip_prefix("ptr const ")
+        .or_else(|| type_name.strip_prefix("ptr mut "))
+    {
+        return type_name_mentions_type_param(interner, pointee, type_params);
+    }
+    // A type-function application `Name(arg, ...)` mentions a type parameter
+    // if any argument does — `Option(T)` mentions `T`, so a signature/return
+    // type applying an enclosing constructor to a type parameter is deferred
+    // (as `Type::COMPTIME_TYPE`) until specialization, exactly like `[T; N]`
+    // (RUE-272). The constructor name itself is never a type parameter, so
+    // only the arguments are inspected.
+    if let Some((_call_name, arg_strs)) = parse_type_call_syntax(type_name) {
+        return arg_strs
+            .iter()
+            .any(|arg| type_name_mentions_type_param(interner, arg, type_params));
+    }
+    // Leaf name: only a match against an already-interned symbol counts
+    // (type parameter names are interned by the parser).
+    match interner.get(type_name) {
+        Some(sym) => type_params.contains(&sym),
+        None => false,
+    }
+}
+
+pub(super) fn type_name_mentions_value_param(
+    interner: &lasso::ThreadedRodeo,
+    type_name: &str,
+    value_params: &[Spur],
+) -> bool {
+    if let Some((element_type, len)) = parse_array_type_syntax(type_name) {
+        let length_mentions = match len {
+            ArrayLen::Literal(_) => false,
+            ArrayLen::Named(name) => type_name_mentions_value_param(interner, &name, value_params),
+        };
+        // Recurse into the element type (nested arrays / pointers).
+        return length_mentions
+            || type_name_mentions_value_param(interner, &element_type, value_params);
+    }
+    if let Some(pointee) = type_name
+        .strip_prefix("ptr const ")
+        .or_else(|| type_name.strip_prefix("ptr mut "))
+    {
+        return type_name_mentions_value_param(interner, pointee, value_params);
+    }
+    if let Some((_call_name, arg_strs)) = parse_type_call_syntax(type_name) {
+        return arg_strs
+            .iter()
+            .any(|arg| type_name_mentions_value_param(interner, arg, value_params));
+    }
+    interner
+        .get(type_name)
+        .is_some_and(|sym| value_params.contains(&sym))
+}
+
+pub(super) fn deferred_signature_substitutions_are_ready(
+    interner: &lasso::ThreadedRodeo,
+    type_name: &str,
+    type_params: &[Spur],
+    value_params: &[Spur],
+    type_subst: &HashMap<Spur, Type>,
+    value_subst: &HashMap<Spur, ConstValue>,
+) -> bool {
+    type_params.iter().all(|name| {
+        type_subst.contains_key(name)
+            || !type_name_mentions_type_param(interner, type_name, &[*name])
+    }) && value_params.iter().all(|name| {
+        value_subst.contains_key(name)
+            || !type_name_mentions_value_param(interner, type_name, &[*name])
+    })
+}
+
+pub(super) fn validate_deferred_value_result(
+    interner: &lasso::ThreadedRodeo,
+    type_pool: &crate::intern_pool::TypeInternPool,
+    value: Option<ConstValue>,
+    found: Option<Type>,
+    expected: Option<Type>,
+    contract: Option<(Spur, Spur)>,
+    require_integer: bool,
+    expression: &str,
+    span: Span,
+) -> CompileResult<()> {
+    if require_integer {
+        if let Some(value) = value {
+            let Some(integer) = value.as_int_value() else {
+                return Err(CompileError::new(
+                    ErrorKind::InvalidArrayLength {
+                        reason: format!(
+                            "array length expression '{}' is not an integer",
+                            expression
+                        ),
+                    },
+                    span,
+                ));
+            };
+            if integer < 0 || u64::try_from(integer).is_err() {
+                return Err(CompileError::new(
+                    ErrorKind::InvalidArrayLength {
+                        reason: format!(
+                            "array length expression '{}' is outside the valid range",
+                            expression
+                        ),
+                    },
+                    span,
+                ));
+            }
+        } else if let Some(found) = found
+            && !found.is_integer()
+        {
+            return Err(CompileError::new(
+                ErrorKind::InvalidArrayLength {
+                    reason: format!(
+                        "array length expression '{}' has non-integer type {}",
+                        expression,
+                        found.safe_name_with_pool(Some(type_pool))
+                    ),
+                },
+                span,
+            ));
+        }
+    }
+
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    if let Some(value) = value {
+        let (function_name, param_name) = contract.expect("value contracts name a parameter");
+        return super::comptime_eval::validate_comptime_value_for_type_impl(
+            interner,
+            type_pool,
+            function_name,
+            param_name,
+            value,
+            expected,
+            span,
+        );
+    }
+    if let Some(found) = found
+        && found != expected
+        && !(found.is_integer() && expected.is_integer())
+    {
+        return Err(CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: expected.safe_name_with_pool(Some(type_pool)),
+                found: found.safe_name_with_pool(Some(type_pool)),
+            },
+            span,
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod type_syntax_predicate_tests {
+    use super::*;
+
+    /// Deferral looks through composite syntax rather than matching the whole
+    /// spelling. `[T; 3]` mentions `T`, so a signature written that way defers
+    /// to specialization; getting this wrong changes which programs compile,
+    /// not merely how a type is rendered.
+    ///
+    /// Reachable as a unit test only because the predicate takes an interner
+    /// rather than a whole analyzer — the property it states is about type
+    /// syntax, and nothing about a declaration epoch was ever involved.
+    #[test]
+    fn type_parameter_mentions_look_through_composite_syntax() {
+        let interner = lasso::ThreadedRodeo::new();
+        let t = interner.get_or_intern("T");
+        let params = [t];
+
+        for mentioning in [
+            "T",
+            "[T; 3]",
+            "ptr const T",
+            "ptr mut [T; 3]",
+            "[[T; 2]; 3]",
+            "Option(T)",
+        ] {
+            assert!(
+                type_name_mentions_type_param(&interner, mentioning, &params),
+                "{mentioning} mentions T"
+            );
+        }
+        for unrelated in ["i32", "[i32; 3]", "ptr const i32", "Option(i32)"] {
+            assert!(
+                !type_name_mentions_type_param(&interner, unrelated, &params),
+                "{unrelated} does not mention T"
+            );
+        }
+    }
+
+    /// A comptime *value* parameter is mentioned only through an array length —
+    /// an element or pointee can never be a value — and the constructor name in
+    /// a type application is never itself a parameter.
+    #[test]
+    fn value_parameter_mentions_are_array_lengths() {
+        let interner = lasso::ThreadedRodeo::new();
+        let n = interner.get_or_intern("N");
+        let params = [n];
+
+        for mentioning in ["N", "[i32; N]", "ptr const [i32; N]", "[[i32; N]; 3]"] {
+            assert!(
+                type_name_mentions_value_param(&interner, mentioning, &params),
+                "{mentioning} mentions N"
+            );
+        }
+        assert!(
+            !type_name_mentions_value_param(&interner, "[i32; 3]", &params),
+            "a literal length mentions no parameter"
+        );
+    }
+
+    /// Substitutions are ready when every parameter the type actually mentions
+    /// has one. A parameter the type never mentions cannot hold it back — that
+    /// is what lets a partially-substituted signature resolve.
+    #[test]
+    fn readiness_ignores_parameters_the_type_does_not_mention() {
+        let interner = lasso::ThreadedRodeo::new();
+        let t = interner.get_or_intern("T");
+        let u = interner.get_or_intern("U");
+        let n = interner.get_or_intern("N");
+
+        let bound = HashMap::from([(t, Type::I32)]);
+        assert!(
+            deferred_signature_substitutions_are_ready(
+                &interner,
+                "[T; 3]",
+                &[t, u],
+                &[],
+                &bound,
+                &HashMap::new(),
+            ),
+            "U is unbound but unmentioned, so the signature is ready"
+        );
+        assert!(
+            !deferred_signature_substitutions_are_ready(
+                &interner,
+                "[T; N]",
+                &[t],
+                &[n],
+                &bound,
+                &HashMap::new(),
+            ),
+            "N is mentioned as the length and unbound"
+        );
     }
 }


### PR DESCRIPTION
## What this PR is

This is the flip: the body path stops reaching a declaration-wide epoch per body and runs on a provider-backed receiver instead. It merges when the per-body counters go flat and the large-program CI gates come back — not before. It is deliberately one PR rather than a stack, because the receiver work is inert on its own and merging it in pieces reproduces the non-closing-prerequisite pattern that has kept this issue open across 20+ slices.

## Progress

- [x] Declare the body-local overlay and pin the host worklist
- [x] Settle the identity-export direction (memoized consulted endpoints)
- [x] Provider export host: type and nominal identity, `canonical_type_instance`, `body_function_identity`
- [x] The host struct proper: `ProviderBodyHost`, and `SemanticBodyExportHost` on it
- [x] The receiver's own body RIR (`body_rir_ref`)
- [x] Back the `Configuration` rows
- [x] Narrow the host contract's supertrait, with a real guard and a compile-time witness
- [x] Give the inference lift (`type_to_infer_type`) one definition
- [ ] **The file table** — the receiver needs a two-column body-local file table (**blocks everything below**)
- [ ] `InferenceFactSource` on the receiver (first attempt reverted; see below)
- [ ] `BodyAnalysisHost`: the four fact facades
- [ ] `TypeSyntaxHost` + `OrdinaryBodyAnalysisHost` (these land together)
- [ ] Generify the one-body driver over the host
- [ ] Provider-backed body-owner-token resolution
- [ ] The artifact differential: side B runs the engine and publishes a `BodyTransaction`
- [ ] `Rc` → `Arc`; register a real `compiler.body-transaction` evaluator
- [ ] Delete the coordinator closure and `analyze_body_query`
- [ ] Fix the two `EpochFacts` adapters that over-bind; end-state cleanup (`#[allow(dead_code)]`, `NeedsProviderWiring`)
- [ ] RUE-1090 counters flat; large-program gates restored; `RUE_CALDERA_SUCCESS_STUB` deleted

## The file table is the blocking problem

Two rounds of adversarial review landed here, and the second round refuted the fix proposed by the first. What follows is what is actually true, verified against source.

### There are no real compiler file ids on the provider path

`lower_owned_body_input` (`revisioned_query_database.rs:2056`) is the only production construction of a `BodyRirBundle` (`:2128`). It takes `OwnedBodyInput` — two text terminals, deliberately no module source, declaration slice, or live interner — concatenates them, and re-parses via `SourceSnapshot::single("<rue-body-input>", …)`, which stamps `FileId::DEFAULT` (`source_snapshot.rs:76-82`).

So **every span the engine sees on the provider path carries `FileId(0)`**, and that file is synthetic — it does not exist in the merged program. Real file ids are allocated `1..=snapshot.len()`; real file 0 exists only via `SourceSnapshot::single`.

This kills the fix proposed in the previous revision of this section ("hand the pool the request's real file ids"). It would have set `StructDef.file_id` to a module's real id while every `span.file_id` stayed 0 — strictly worse than the current consult-order numbering, which at least gives the body's own module a consistent handle.

### What `file_id` actually is

Not one thing. Reachable from the provider path it serves five jobs, and two of them need *different* strings:

| Job | Needs |
| --- | --- |
| symbol mangling (`intern_pool.rs:1569` → `struct_symbol_name`) | the **logical** module path |
| pool-internal nominal dedup (`struct_by_file_name`) | any injective numbering |
| engine-facing by-file lookup (`generate.rs:2462, 2468`) | the **engine's** numbering |
| visibility domain (`is_accessible`, `aggregate_resolution.rs:328`) | the **physical** file path |
| escaping dependency coordinate (`typeck.rs:2796` → `DeclarationTypeDependencyEvent.target_file`) | a coordinate the compiler can rejoin |

The epoch keeps these straight with *two* tables under one key — `symbol_paths` (logical) and `file_paths` (physical) — seeded as a validated pair by `SemaMetadata`, which enforces identical key sets.

`BodyIdentityPool::file_for_module` (`body_identity.rs:1187`) mints handles into a scope it does not own and publishes only the logical column (`set_symbol_paths`, `:1194`). That is precisely why symbol mangling is correct today and visibility is not.

### Visibility currently fails open

`is_accessible` resolves *both* file ids through `facts.file_path(..)`, and `SemanticVisibilityDomain::is_visible_from` returns `true` when either domain is `None` (`semantic_type_resolution.rs:23-26`). A pool-minted `def.file_id` misses `ProviderAggregateFacts::file_paths`, which is keyed on caller-registered ids — so the defining domain is `None` and **every private item becomes visible**. E0460 and E0706 stop firing.

Roughly ten call sites read `def.file_id` straight off the pool and hand it to this: `aggregates.rs:98, 380, 415, 950, 990, 1050, 1103, 1377`, `control_flow.rs:1049`, `visibility.rs:129`. It is accept-invalid, silent, and no existing test catches it — there is no negative visibility test against the provider receiver.

Not yet a live defect: nothing selects the receiver at runtime. It is a design gap that must close before it can be.

### The shape of the fix, and what is still open

The body-local numbering stays — there is nothing else available, since the receiver's own RIR is a synthetic re-parse. What changes is that the table becomes **two-column and total**: every id the receiver can produce (its own `FileId(0)`, plus one per consulted module) must resolve to both a logical module path and a physical file path, so `file_path()` answers for exactly the ids `struct_def().file_id` can return.

Three things follow, and one is unresolved:

1. `file_for_module` should stop republishing the whole map on every newly-seen module (`body_identity.rs:1194-1199`) — that is O(m²) per body today, a cost the fix removes rather than adds.
2. A durable nominal whose module is absent from the table is a stale input. It should fail closed, not receive a synthetic id: there is no correct synthetic id, because every consumer above either misreads it or fails open on it.
3. **Open:** `DurableNominal` carries only `module_path`, the logical path (`body_identity.rs:127`). Visibility needs the physical one, and it is not on the durable side. Either the durable nominal grows a physical path, or the visibility domain stops being derived from a filesystem directory. That is a semantics question, not a plumbing one, and it is the next thing to settle.

The receiver's `pool_module_path` and the identity seam are unaffected: they were already keyed on logical module paths, deliberately (see `ConsultedDefinition`, which drops the file number on purpose). Digests take only strings and do not observe any of this.

## What the reverted `InferenceFactSource` attempt got wrong

Recorded because the failure mode generalizes. Six of fourteen arms:

| Arm | Defect |
| --- | --- |
| four const arms + `inference_module_binding_type` | converted engine file ids through a pool-keyed table |
| `inference_struct_type_by_file`, `inference_enum_type_by_file` | same mismatch, no conversion at all |
| `uncached_function_sig`, `inference_function_by_file` | wired to `ProviderEndpointFacts`, which returns `None` for both **by design** — the answers live on `ProviderCallFacts`. Every function signature would have been absent |
| `inference_builtin_struct_type`, `inference_builtin_enum_type` | live pool read at `FileId::DEFAULT`, where `Str(N)`, anonymous structs and generated slices also live. The epoch reads a snapshot frozen before the body runs, so a mid-body mint cannot retroactively change an earlier lookup |

Two lessons carried forward:

1. **The tests could not have caught it.** Both installed symbol paths by hand with `set_symbol_paths` instead of letting `file_for_module` assign them, so neither exercised the mismatch — and one asserted the silent-absent behavior *as correct*. Same shape as `15088b8`, which survived a green CI run because its tests drove a stub that accepted whatever number it was handed.
2. **`Sema::builtin_structs` is never written anywhere in the tree.** Declared, initialized empty, read. The epoch's builtin-struct answer comes entirely from the frozen overlay, so any provider implementation reading a live table diverges by construction.

## The worklist, as executable data

`HOST_CAPABILITY_LEDGER` carries one row per method on `OrdinaryBodyAnalysisHost`, stating where its answer comes from. It parses the real trait source and asserts equality in both directions.

| Category | Count |
| --- | ---: |
| `BodyLocal` | 35 |
| `ProviderFact` | 14 |
| `ProviderState` | 8 |
| `Configuration` | 6 |
| `ProviderExport` | 5 |
| `InapplicableToBodies` | 3 |
| `BodyRir` | 1 |
| `NeedsProviderWiring` | 1 |

Known gap: it parses only methods declared directly in the trait body, so supertrait obligations are invisible to it.

Its end state: the row set should survive the flip — once `Sema` is gone it stops being a worklist and becomes the thing that fails the build if someone answers a contract method from a declaration-wide table again. The migration-only vocabulary (`NeedsProviderWiring`) should not survive.

## The supertrait narrowing

`BodyAnalysisHost` required `BodyAnalysisReadHost` — four epoch-shaped fact sources, 61 point queries. Three are never read off `Self`; hosts supply endpoint, call and aggregate facts through the three associated types. The supertrait is now `InferenceFactSource` alone.

Review could not break the safety of that and independently confirmed `HostInferenceFacts` touches only `InferenceFactSource`. It corrected two things:

- **The stated reason was wrong.** Inference also reaches the engine through an associated type; `Sema` merely chooses `HostInferenceFacts<'a, Self>`. By the rule the commit gave, `InferenceFactSource` had no more claim than the three dropped.
- **The 47-method obligation lives elsewhere.** `EpochFacts` in `call_resolution.rs:215/219/225` and `aggregate_resolution.rs:113/117/123` bind on all four sources while calling one — unlike `body_endpoint.rs:509/513/519`, which correctly binds on one. Fixing those six sites is what would let `BodyAnalysisReadHost` be deleted.

The guard has since been fixed: it was a prefix match that still passed for `: InferenceFactSource + BodyAnalysisReadHost + Sized`, which is how a bound actually gets widened. It now compares the whole supertrait list, and `MinimalHost` — implementing the narrow source and nothing else — is a compile-time witness, since `Sema` satisfying all four proved nothing.

## The receiver

`ProviderBodyHost` owns the body-local overlay, this body's `BodyRirBundle`, `ProviderBodyAnalysisState`, one fact boundary, and `ProviderBodyConfiguration`. None is sized by the declaration universe, so constructing a receiver is `O(1)` in the program rather than `O(declarations)`. That is where the `O(bodies × declarations)` term goes: the epoch's cost was in *building* the receiver.

One caveat review raised on the "single fact authority" claim: `S`, the durable nominal/const source, is a separate generic parameter from `P`, the fact boundary. The boundary answers *which* declaration; `S` answers *what it is*. Whether `S`'s answers carry edges is a property of whoever constructs it, enforced by nothing in the type system. Not yet a defect — the only implementations are test-only — but the invariant as written is stronger than the types guarantee.

## Configuration is mostly derived, not supplied

Only the target and preview feature set are genuine query keys. `known_symbols` is interned from the receiver's own interner; the three builtin enum identities are read from its own type pool, which pre-registers `rue_builtins::BUILTIN_ENUMS` at `FileId::DEFAULT` as a fresh import epoch does. `require_preview` reproduces the epoch's gate verbatim.

## Failure stays closed

The host deliberately does **not** inherit the epoch's synthetic-test fallback in `stable_definition_token`, which mints a token from an FNV hash when its table is empty. Unmapped callable symbols and unresolvable module identities fail typed. The visibility gap above is the one place this discipline is currently not met, and closing it is part of the file-table work.

## Scope discipline

Nothing here is selected at runtime; `analyze_body_query` remains the single authority until the commit that deletes it. That is why the reverted defects shipped no wrong artifact — but a wrong *rationale* in a module whose discipline is that its stated fact sources can be trusted is worth reverting rather than patching.

## Known-red CI, and why it is not this branch

`cli.examples_mosaic::mosaic_builds_site_and_shared_artifacts` intermittently times out at the `heavyweight` 30 s budget on aarch64. It has failed on `linux-arm64-cli-shard-1` and on `macos-cli-shard-2`, and passed on both — on `bfa485e` the arm64 shard passed and macOS failed instead. A deterministic regression does not move between runners that way.

"Nothing here is reachable" stopped being sufficient once this branch contained a trait-bound narrowing and a helper de-duplication the epoch path calls, so it was measured. Same container, same build path, `rue examples/mosaic/main.rue`, three runs each:

| | run 1 | run 2 | run 3 | median | fastest |
| --- | ---: | ---: | ---: | ---: | ---: |
| `trunk` @ `3ef6186` | 38431 ms | 38466 ms | 38632 ms | 38466 ms | 38431 ms |
| head @ `39ed874` | 39284 ms | 37953 ms | 38695 ms | 38695 ms | **37953 ms** |

+229 ms of median (+0.6%), head's fastest run beating trunk's fastest, and head's own 1331 ms spread enveloping all three trunk samples. No signal at n=3. Only the base-vs-head comparison is meaningful; both sides were measured back to back on the same machine.

Raising the budget remains the one fix that will not be made: the x86-64/aarch64 gap on this example *is* the regression this PR exists to delete.

## Validation

- `scripts/rue unit air` — 676 passed, 0 failed
- `scripts/rue quick` — 30 pass, 0 fail
- `scripts/rue fmt` clean