### PR TITLE
RUE-1157: finish canonical Buck test tiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,7 @@ jobs:
         # per-matrix expression. Local full suites still own every discovered
         # target in one invocation.
         env:
+          RUE_TEST_TIER: premerge
           RUE_CI_DEFER_HEAVY_SUITES: '//:cli-tests //:cli-tests-caldera //:spec-tests'
           RUE_CI_DEFER_DEDICATED_SUITES: '//crates/rue-compiler:scaling-matrix-test'
         run: scripts/ci-timed "${{ matrix.name }} tests" -- ./test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,5 +48,6 @@ jobs:
       - name: Run full release suite
         run: >-
           scripts/ci-timed "full release suite" --
-          ./buck2 test //... --exclude rue_cli_shard
+          ./buck2 test //... toolchains//... --exclude rue_cli_shard
+          --ignore-tests-attribute
           --target-platforms //platforms:release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,9 @@ jobs:
           scripts/provision-build-cache install
           scripts/provision-build-cache apply
 
-      # The monolithic //:cli-tests target owns the complete CLI corpus here.
-      # Exclude its CI-only shards so the same corpus is not repeated four
-      # additional times by the //... expansion.
+      # //:cli-tests owns the premerge shards' complete union; //:cli-tests-slow
+      # owns declarative slow sections. Exclude the CI-only shards so the
+      # premerge inventory is not repeated four times by the //... expansion.
       - name: Run full release suite
         run: >-
           scripts/ci-timed "full release suite" --

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,10 @@ scripts/rue build                    # build the compiler and print its path
 scripts/rue exec prog.rue            # compile and run a quick program
 RUE="$(scripts/rue-bin)"; "$RUE" main.rue -o out
 scripts/rue quick                    # fast unit suite
+scripts/rue premerge                 # canonical required-CI tier
+scripts/rue slow                     # canonical scheduled slow tier
+scripts/rue stress                   # canonical opt-in stress tier
+scripts/rue all                      # canonical union of all tiers
 scripts/rue unit compiler durable_   # one compiler unit test
 scripts/rue spec 4.2                 # filtered specification tests
 scripts/rue cli abi                  # filtered CLI integration tests

--- a/BUCK
+++ b/BUCK
@@ -217,7 +217,7 @@ _CLI_TEST_ARGS = [
     "--skip", "cli.examples_meridian",
 ]
 
-_CLI_TEST_ENV = {
+_CLI_TEST_BASE_ENV = {
     "RUE_BINARY": "$(exe_target //crates/rue:rue)",
     "RUE_CLI_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
     "RUE_EXAMPLES_DIR": "$(location :examples)/examples",
@@ -225,15 +225,33 @@ _CLI_TEST_ENV = {
     "RUE_STD_DIR": "$(location :std)/std",
 }
 
-# The full CLI corpus in one invocation: the canonical target that a local
-# `./test.sh` full run executes and that the RUE-924 corpus-omission audit
-# tracks (REQUIRED_CORPUS_HARNESSES in test.sh).
+_CLI_TEST_ENV = dict(_CLI_TEST_BASE_ENV.items() + [
+    ("RUE_CLI_CASE_TIER", "premerge"),
+])
+
+# The bounded premerge CLI corpus. Explicit slow sections are registered by
+# //:cli-tests-slow instead; their automatic examples remain here as one
+# compile/run canary per maintained large program.
 rue_sh_test(
     name = "cli-tests",
     labels = ["rue_heavy_suite"],
     test = "//crates/rue-cli-tests:rue-cli-tests",
     args = _CLI_TEST_ARGS,
     env = _CLI_TEST_ENV,
+)
+
+# Exhaustive behavior for declarative `tier = "slow"` CLI sections. This is a
+# separate real Buck target, not a skipped body: standard/full local runs and
+# scheduled release coverage execute it, while required premerge shards do not.
+rue_sh_test(
+    name = "cli-tests-slow",
+    tier = "slow",
+    labels = ["rue_heavy_suite"],
+    test = "//crates/rue-cli-tests:rue-cli-tests",
+    args = ["--quiet"],
+    env = dict(_CLI_TEST_BASE_ENV.items() + [
+        ("RUE_CLI_CASE_TIER", "slow"),
+    ]),
 )
 
 # Required release coverage is deliberately bounded: compile the real driver
@@ -250,11 +268,11 @@ rue_sh_test(
 
 # RUE-1116: parallel CI shards of the CLI corpus. Same harness and declared
 # inputs as //:cli-tests, but each sets RUE_CLI_TEST_SHARD=k/N so it runs one
-# deterministic cost-balanced slice; the shards' union is the full corpus. They
-# carry BOTH labels deliberately:
+# deterministic cost-balanced slice; the shards' union is the full premerge
+# inventory. They carry BOTH labels deliberately:
 #   * rue_heavy_suite — scripts/ci-heavy-suite accepts them unchanged, and the
 #     broad `buck2 test //... --exclude rue_heavy_suite` pass skips them;
-#   * rue_cli_shard — a local `./test.sh` full run runs the monolithic
+#   * rue_cli_shard — a local `./test.sh` full run runs the premerge
 #     //:cli-tests exactly once instead of re-running every slice (test.sh
 #     subtracts rue_cli_shard from its heavy-suite discovery).
 # The `platform-corpus` matrix in .github/workflows/ci.yml MUST list all

--- a/BUCK
+++ b/BUCK
@@ -229,9 +229,8 @@ _CLI_TEST_ENV = dict(_CLI_TEST_BASE_ENV.items() + [
     ("RUE_CLI_CASE_TIER", "premerge"),
 ])
 
-# The bounded premerge CLI corpus. Explicit slow sections are registered by
-# //:cli-tests-slow instead; their automatic examples remain here as one
-# compile/run canary per maintained large program.
+# The bounded premerge CLI corpus. Explicit slow sections and automatic
+# examples are registered by //:cli-tests-slow instead.
 rue_sh_test(
     name = "cli-tests",
     labels = ["rue_heavy_suite"],

--- a/crates/rue-cli-tests/cases/examples_mosaic.toml
+++ b/crates/rue-cli-tests/cases/examples_mosaic.toml
@@ -3,6 +3,7 @@
 id = "cli.examples_mosaic"
 name = "Mosaic static-site generator written in Rue"
 description = "exercise manifests, front matter, block/inline markup, graph validation, deterministic rendering, filesystem output, audits, and scaling"
+tier = "slow"
 # Every case below compiles the same maintained large Mosaic program, so the
 # whole section carries the bounded heavyweight contract, matching the
 # automatic mosaic example.

--- a/crates/rue-cli-tests/cases/execution_contracts.toml
+++ b/crates/rue-cli-tests/cases/execution_contracts.toml
@@ -33,6 +33,7 @@ contract = "heavyweight_long"
 [[automatic_example]]
 path = "mosaic/main.rue"
 contract = "heavyweight"
+tier = "slow"
 
 [[automatic_example]]
 path = "rill/main.rue"

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -74,6 +74,9 @@
 //! - `exit_code`: expected program exit code (default 0)
 //! - `contract`: named execution contract supplying scheduling class and
 //!   separate compile/runtime budgets (ordinary cases default to 10s for each)
+//! - section-level `tier = "slow"`: keep exhaustive large-program behavior
+//!   behind the dedicated slow Buck target while the automatic example remains
+//!   a bounded premerge compile/run canary
 //! - `known_bug = "RUE-NN"`: expected failure (xfail). An ordinary assertion
 //!   failure is ignored with the bug reference. A fatal subprocess failure or
 //!   unexpected pass fails loudly.
@@ -823,6 +826,58 @@ struct Section {
     /// cases may override it when only one scenario is heavyweight.
     #[serde(default)]
     contract: Option<String>,
+    /// Logical execution tier for this section's explicit cases. Automatic
+    /// example smoke tests are independently owned premerge canaries.
+    #[serde(default)]
+    tier: CliCaseTier,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum CliCaseTier {
+    #[default]
+    Premerge,
+    Slow,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CliCaseTierSelection {
+    All,
+    Premerge,
+    Slow,
+}
+
+impl CliCaseTierSelection {
+    fn parse(value: Option<&str>) -> Result<Self, String> {
+        match value {
+            None | Some("") | Some("all") => Ok(Self::All),
+            Some("premerge") => Ok(Self::Premerge),
+            Some("slow") => Ok(Self::Slow),
+            Some(other) => Err(format!(
+                "unknown RUE_CLI_CASE_TIER {other:?} (expected all, premerge, or slow)"
+            )),
+        }
+    }
+
+    fn from_env() -> Result<Self, String> {
+        match std::env::var("RUE_CLI_CASE_TIER") {
+            Ok(value) => Self::parse(Some(&value)),
+            Err(std::env::VarError::NotPresent) => Self::parse(None),
+            Err(error) => Err(error.to_string()),
+        }
+    }
+
+    fn includes(self, tier: CliCaseTier) -> bool {
+        self == Self::All
+            || matches!(
+                (self, tier),
+                (Self::Premerge, CliCaseTier::Premerge) | (Self::Slow, CliCaseTier::Slow)
+            )
+    }
+
+    fn includes_automatic_examples(self) -> bool {
+        matches!(self, Self::All | Self::Premerge)
+    }
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
@@ -2427,6 +2482,17 @@ fn main() {
         eprintln!("error: invalid RUE_CLI_TEST_SHARD: {error}");
         std::process::exit(2);
     });
+    let case_tier = CliCaseTierSelection::from_env().unwrap_or_else(|error| {
+        eprintln!("error: {error}");
+        std::process::exit(2);
+    });
+    if shard_selector.is_some() && case_tier != CliCaseTierSelection::Premerge {
+        eprintln!(
+            "error: RUE_CLI_TEST_SHARD requires RUE_CLI_CASE_TIER=premerge \
+             so shards partition exactly the required CLI inventory"
+        );
+        std::process::exit(2);
+    }
     let timings = CaseTimingRecorder::from_env().unwrap_or_else(|error| {
         eprintln!("error: {error}");
         std::process::exit(2);
@@ -2469,14 +2535,17 @@ fn main() {
         .flat_map(|(_, file)| {
             file.cases
                 .iter()
+                .filter(|_| case_tier.includes(file.section.tier))
                 .map(|case| format!("{}::{}", file.section.id, case.name))
         })
         .chain(
             examples
                 .iter()
+                .filter(|_| case_tier.includes_automatic_examples())
                 .map(|example| example_test_name(&example.relative_path)),
         )
         .collect::<Vec<_>>();
+    let selected_discovered = discovered_names.len();
     let shard = shard_selector.map(|selector| {
         let weights_path = std::env::var_os("RUE_CLI_SHARD_WEIGHTS").unwrap_or_else(|| {
             eprintln!("error: RUE_CLI_SHARD_WEIGHTS is required when RUE_CLI_TEST_SHARD is set");
@@ -2496,11 +2565,11 @@ fn main() {
         std::process::exit(1);
     }
     let mut tests: Vec<Trial> = Vec::with_capacity(total);
-    // Full count of discovered cases (corpus + examples), before shard
-    // selection, for the visibility line printed below.
-    let discovered = total + examples.len();
 
     for (_, file) in corpus.files {
+        if !case_tier.includes(file.section.tier) {
+            continue;
+        }
         let section_id = file.section.id.clone();
         for case in file.cases {
             let contract_name = case_contract_name(&file.section, &case);
@@ -2534,14 +2603,16 @@ fn main() {
     // RUE-48: compile+run every examples/**/*.rue through the real driver, so a
     // regression that breaks a shipped example (or an example referencing a
     // removed flag) can't slip past CI unnoticed.
-    tests.extend(example_trials(
-        examples,
-        &automatic_contracts,
-        &rue_binary,
-        &real_std,
-        shard.as_ref(),
-        &timings,
-    ));
+    if case_tier.includes_automatic_examples() {
+        tests.extend(example_trials(
+            examples,
+            &automatic_contracts,
+            &rue_binary,
+            &real_std,
+            shard.as_ref(),
+            &timings,
+        ));
+    }
 
     if let Some(shard) = &shard {
         eprintln!(
@@ -2550,7 +2621,7 @@ fn main() {
             shard_selector.unwrap().count(),
             shard.platform(),
             tests.len(),
-            discovered,
+            selected_discovered,
             shard.selected_estimated_load_ms(),
             shard.selected_case_count(),
         );
@@ -2608,6 +2679,26 @@ mod tests {
             automatic_examples: file.automatic_example.clone(),
             files: vec![("inline.toml".to_string(), file)],
         }
+    }
+
+    #[test]
+    fn cli_case_tier_selection_is_explicit_and_fail_closed() {
+        let all = CliCaseTierSelection::parse(None).unwrap();
+        assert!(all.includes(CliCaseTier::Premerge));
+        assert!(all.includes(CliCaseTier::Slow));
+        assert!(all.includes_automatic_examples());
+
+        let premerge = CliCaseTierSelection::parse(Some("premerge")).unwrap();
+        assert!(premerge.includes(CliCaseTier::Premerge));
+        assert!(!premerge.includes(CliCaseTier::Slow));
+        assert!(premerge.includes_automatic_examples());
+
+        let slow = CliCaseTierSelection::parse(Some("slow")).unwrap();
+        assert!(!slow.includes(CliCaseTier::Premerge));
+        assert!(slow.includes(CliCaseTier::Slow));
+        assert!(!slow.includes_automatic_examples());
+
+        assert!(CliCaseTierSelection::parse(Some("slwo")).is_err());
     }
 
     #[test]

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -74,9 +74,9 @@
 //! - `exit_code`: expected program exit code (default 0)
 //! - `contract`: named execution contract supplying scheduling class and
 //!   separate compile/runtime budgets (ordinary cases default to 10s for each)
-//! - section-level `tier = "slow"`: keep exhaustive large-program behavior
-//!   behind the dedicated slow Buck target while the automatic example remains
-//!   a bounded premerge compile/run canary
+//! - `tier = "slow"` on a section or `[[automatic_example]]`: keep exhaustive
+//!   or full-program large-example coverage behind the dedicated slow Buck
+//!   target
 //! - `known_bug = "RUE-NN"`: expected failure (xfail). An ordinary assertion
 //!   failure is ignored with the bug reference. A fatal subprocess failure or
 //!   unexpected pass fails loudly.
@@ -805,8 +805,8 @@ struct TestFile {
     /// cases share one scheduling and timeout policy.
     #[serde(default, rename = "contract")]
     contracts: HashMap<String, ExecutionContract>,
-    /// Contracts for recursively discovered examples, keyed by the path that
-    /// also determines their `cli.examples::...` test name.
+    /// Contracts and tiers for recursively discovered examples, keyed by the
+    /// path that also determines their `cli.examples::...` test name.
     #[serde(default)]
     automatic_example: Vec<AutomaticExampleContract>,
     #[serde(default, rename = "case")]
@@ -827,7 +827,7 @@ struct Section {
     #[serde(default)]
     contract: Option<String>,
     /// Logical execution tier for this section's explicit cases. Automatic
-    /// example smoke tests are independently owned premerge canaries.
+    /// examples declare their tier independently.
     #[serde(default)]
     tier: CliCaseTier,
 }
@@ -874,10 +874,6 @@ impl CliCaseTierSelection {
                 (Self::Premerge, CliCaseTier::Premerge) | (Self::Slow, CliCaseTier::Slow)
             )
     }
-
-    fn includes_automatic_examples(self) -> bool {
-        matches!(self, Self::All | Self::Premerge)
-    }
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
@@ -922,6 +918,14 @@ impl ExecutionContract {
 struct AutomaticExampleContract {
     path: String,
     contract: String,
+    #[serde(default)]
+    tier: CliCaseTier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AutomaticExampleMetadata {
+    contract: ExecutionContract,
+    tier: CliCaseTier,
 }
 
 #[derive(Debug)]
@@ -2184,7 +2188,7 @@ fn resolve_contract(
 fn validate_contract_metadata(
     corpus: &LoadedCorpus,
     discovered_examples: &HashSet<String>,
-) -> Result<HashMap<String, ExecutionContract>, String> {
+) -> Result<HashMap<String, AutomaticExampleMetadata>, String> {
     let mut used_contracts = HashSet::new();
 
     for (source, file) in &corpus.files {
@@ -2216,7 +2220,13 @@ fn validate_contract_metadata(
             )
         })?;
         if automatic_contracts
-            .insert(entry.path.clone(), contract.clone())
+            .insert(
+                entry.path.clone(),
+                AutomaticExampleMetadata {
+                    contract: contract.clone(),
+                    tier: entry.tier,
+                },
+            )
             .is_some()
         {
             return Err(format!(
@@ -2422,7 +2432,8 @@ fn discover_examples() -> Result<Vec<DiscoveredExample>, String> {
 /// Build one automatic smoke-test trial per discovered example (RUE-48).
 fn example_trials(
     examples: Vec<DiscoveredExample>,
-    automatic_contracts: &HashMap<String, ExecutionContract>,
+    automatic_contracts: &HashMap<String, AutomaticExampleMetadata>,
+    case_tier: CliCaseTierSelection,
     rue_binary: &Path,
     real_std: &Path,
     shard: Option<&CliShardPlan>,
@@ -2432,9 +2443,13 @@ fn example_trials(
     for example in examples {
         let path = example.path;
         let relative_path = example.relative_path;
-        let contract = automatic_contracts
-            .get(&relative_path)
-            .cloned()
+        let metadata = automatic_contracts.get(&relative_path);
+        let tier = metadata.map_or(CliCaseTier::Premerge, |metadata| metadata.tier);
+        if !case_tier.includes(tier) {
+            continue;
+        }
+        let contract = metadata
+            .map(|metadata| metadata.contract.clone())
             .unwrap_or_else(ExecutionContract::ordinary);
         let heavyweight = contract.is_heavyweight();
         let rue_binary = rue_binary.to_path_buf();
@@ -2541,7 +2556,12 @@ fn main() {
         .chain(
             examples
                 .iter()
-                .filter(|_| case_tier.includes_automatic_examples())
+                .filter(|example| {
+                    let tier = automatic_contracts
+                        .get(&example.relative_path)
+                        .map_or(CliCaseTier::Premerge, |metadata| metadata.tier);
+                    case_tier.includes(tier)
+                })
                 .map(|example| example_test_name(&example.relative_path)),
         )
         .collect::<Vec<_>>();
@@ -2603,16 +2623,15 @@ fn main() {
     // RUE-48: compile+run every examples/**/*.rue through the real driver, so a
     // regression that breaks a shipped example (or an example referencing a
     // removed flag) can't slip past CI unnoticed.
-    if case_tier.includes_automatic_examples() {
-        tests.extend(example_trials(
-            examples,
-            &automatic_contracts,
-            &rue_binary,
-            &real_std,
-            shard.as_ref(),
-            &timings,
-        ));
-    }
+    tests.extend(example_trials(
+        examples,
+        &automatic_contracts,
+        case_tier,
+        &rue_binary,
+        &real_std,
+        shard.as_ref(),
+        &timings,
+    ));
 
     if let Some(shard) = &shard {
         eprintln!(
@@ -2686,26 +2705,33 @@ mod tests {
         let all = CliCaseTierSelection::parse(None).unwrap();
         assert!(all.includes(CliCaseTier::Premerge));
         assert!(all.includes(CliCaseTier::Slow));
-        assert!(all.includes_automatic_examples());
 
         let premerge = CliCaseTierSelection::parse(Some("premerge")).unwrap();
         assert!(premerge.includes(CliCaseTier::Premerge));
         assert!(!premerge.includes(CliCaseTier::Slow));
-        assert!(premerge.includes_automatic_examples());
 
         let slow = CliCaseTierSelection::parse(Some("slow")).unwrap();
         assert!(!slow.includes(CliCaseTier::Premerge));
         assert!(slow.includes(CliCaseTier::Slow));
-        assert!(!slow.includes_automatic_examples());
 
         assert!(CliCaseTierSelection::parse(Some("slwo")).is_err());
     }
 
     #[test]
     fn maintained_large_example_sections_share_their_automatic_contract() {
-        for (section_id, example_path) in [
-            ("cli.examples_mosaic", "mosaic/main.rue"),
-            ("cli.examples_rill", "rill/main.rue"),
+        for (section_id, example_path, tier_line, expected_tier) in [
+            (
+                "cli.examples_mosaic",
+                "mosaic/main.rue",
+                r#"tier = "slow""#,
+                CliCaseTier::Slow,
+            ),
+            (
+                "cli.examples_rill",
+                "rill/main.rue",
+                "",
+                CliCaseTier::Premerge,
+            ),
         ] {
             let corpus = corpus_from_toml(&format!(
                 r#"
@@ -2722,6 +2748,7 @@ mod tests {
                     [[automatic_example]]
                     path = "{example_path}"
                     contract = "heavyweight"
+                    {tier_line}
 
                     [[case]]
                     name = "ordinary_behavior"
@@ -2737,7 +2764,8 @@ mod tests {
                 assert!(case.contract.is_none(), "case contract must stay inherited");
                 let explicit =
                     resolve_contract(&corpus.contracts, case_contract_name(&file.section, case));
-                assert_eq!(automatic[example_path], explicit);
+                assert_eq!(automatic[example_path].contract, explicit);
+                assert_eq!(automatic[example_path].tier, expected_tier);
                 assert!(explicit.is_heavyweight());
                 assert_eq!(explicit.compile_timeout(), Duration::from_secs(30));
                 assert_eq!(explicit.runtime_timeout(), Duration::from_secs(30));

--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -1,5 +1,5 @@
 load("//crates:defs.bzl", "rue_crate")
-load("//:test_defs.bzl", "rue_rust_test")
+load("//:test_defs.bzl", "rue_rust_test", "rue_sh_test")
 
 filegroup(
     name = "runtime-abi-inventory-sources",
@@ -66,23 +66,40 @@ rue_crate(
     ],
 )
 
-# Dedicated heavy-matrix test target (Finding 6, RUE-1086). Compiling with
-# `--cfg=scaling_matrix` turns on the `#[cfg(scaling_matrix)]` 100/1k (opt-in
-# 10k via RUE_SCALING_LARGE=1) structural scaling tests that the default unit
-# target excludes. CI runs this as its own job, filtered to `scaling_matrix`, so
-# only the matrix cases execute here. Marking the CI check required in branch
-# protection is a maintainer action.
+# Dedicated heavy-matrix test targets (Finding 6, RUE-1086). Compiling with
+# `--cfg=scaling_matrix` turns on the `#[cfg(scaling_matrix)]` structural
+# scaling tests that the default unit target excludes.
+_SCALING_MATRIX_SRCS = glob(["src/**/*.rs"])
+_SCALING_MATRIX_RUSTC_FLAGS = [
+    "--cfg=scaling_matrix",
+    "--check-cfg=cfg(scaling_matrix)",
+    "--check-cfg=cfg(test)",
+]
+
+# The bounded 100/1k matrix is a required premerge canary. CI runs it as its
+# own job, filtered to `scaling_matrix`, so it is not duplicated in each broad
+# platform pass.
 rue_rust_test(
     name = "scaling-matrix-test",
     labels = ["rue_dedicated_suite"],
-    srcs = glob(["src/**/*.rs"]),
+    srcs = _SCALING_MATRIX_SRCS,
     mapped_srcs = _RUNTIME_MAPPED_SRCS,
     deps = _DEPS,
-    rustc_flags = [
-        "--cfg=scaling_matrix",
-        "--check-cfg=cfg(scaling_matrix)",
-        "--check-cfg=cfg(test)",
-    ],
+    rustc_flags = _SCALING_MATRIX_RUSTC_FLAGS,
+)
+
+# The opt-in 10k-per-axis ladder is intentionally absent from premerge. This
+# real stress target uses the same compiler test binary but enables the extreme
+# cases explicitly, making their suite ownership visible and reproducible.
+rue_sh_test(
+    name = "scaling-matrix-stress-test",
+    tier = "stress",
+    args = ["scaling_matrix", "--nocapture"],
+    env = {
+        "RUE_SCALING_LARGE": "1",
+    },
+    labels = ["rue_dedicated_suite"],
+    test = ":scaling-matrix-test",
 )
 
 # Compiles against rue-compiler as an external crate so curated reexports and

--- a/crates/rue-oracle-diff/BUCK
+++ b/crates/rue-oracle-diff/BUCK
@@ -50,6 +50,7 @@ rue_binary(
 # the single-source oracle.
 rue_sh_test(
     name = "oracle-diff-test",
+    tier = "slow",
     labels = ["rue_not_quick"],
     test = ":rue-oracle-diff",
     env = {
@@ -66,6 +67,7 @@ rue_sh_test(
 # with their declared preview feature.
 rue_sh_test(
     name = "oracle-diff-spec-test",
+    tier = "slow",
     labels = ["rue_not_quick"],
     test = ":rue-oracle-diff",
     args = ["spec"],

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,6 +19,10 @@ scripts/rue build                    # build the compiler
 scripts/rue exec program.rue         # compile and run a program
 scripts/rue quick                    # Rust unit tests
 scripts/rue test [pattern]           # full suite, optionally filtered
+scripts/rue premerge                 # required-CI test tier
+scripts/rue slow                     # scheduled exhaustive tests
+scripts/rue stress                   # opt-in resource stress tests
+scripts/rue all                      # union of every test tier
 scripts/rue spec 4.2                 # filtered specification cases
 scripts/rue cli abi                  # filtered CLI integration cases
 scripts/rue fmt                      # format first-party Rust

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -29,8 +29,9 @@ It does not build every crate target or run the exhaustive suite.
 
 `.github/workflows/release.yml` runs the complete release-configured `//...`
 suite nightly and on manual dispatch. Its `rue_cli_shard` exclusion is
-intentional: the monolithic `//:cli-tests` target owns the full CLI corpus, so
-also running the four CI-only shards would execute that corpus twice.
+intentional: `//:cli-tests` owns the shards' complete premerge union, while
+`//:cli-tests-slow` owns declarative slow sections. Also running the four
+CI-only shards would execute the premerge inventory twice.
 
 Production `debug_assert*` use is governed by
 `scripts/validate-debug-assert-policy.py`, run by required formatting CI and
@@ -69,8 +70,8 @@ The same BXL file exposes the canonical named selections:
 
 Each prints the exact live Buck targets in that selection. The `all` and
 per-tier selections omit `rue_cli_shard` scheduling alternatives because the
-canonical monolithic CLI target already owns their union. CI invokes those
-shards explicitly on separate runners.
+canonical premerge CLI target already owns their union. CI invokes those shards
+explicitly on separate runners.
 
 Use `scripts/rue premerge`, `scripts/rue slow`, `scripts/rue stress`, or
 `scripts/rue all` to execute a named selection. `scripts/rue test` retains its
@@ -81,9 +82,16 @@ scheduled full-release workflow exercise the complete union.
 
 The exhaustive CLI- and specification-oracle differential harnesses are
 `slow`: premerge retains the fixed generated oracle smoke corpus as its bounded
-codegen canary. The normal 100/1k structural scaling matrix remains a dedicated
-premerge canary; `//crates/rue-compiler:scaling-matrix-stress-test` enables the
-real 10k-per-axis ladder and belongs to `stress`. Caldera and Meridian remain
+codegen canary. CLI corpus sections may likewise declare `tier = "slow"`.
+`//:cli-tests-slow` owns those real cases, while each maintained large
+program's automatic example remains a single premerge compile/run canary.
+Mosaic's 17 exhaustive behavior cases use that split, so the four required CLI
+shards do not each spend their critical path recompiling the same large
+program.
+
+The normal 100/1k structural scaling matrix remains a dedicated premerge
+canary; `//crates/rue-compiler:scaling-matrix-stress-test` enables the real
+10k-per-axis ladder and belongs to `stress`. Caldera and Meridian remain
 explicitly tracked by RUE-1162 until their real release-built slow targets and
 reduced premerge canaries replace the current skips/stub.
 

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -48,12 +48,44 @@ Every first-party Buck test target carries exactly one execution-tier label:
 repository, crate, and toolchain tests; generated crate unit tests default to
 `premerge`. A test that belongs outside pre-merge must opt into `slow` or
 `stress` at its definition rather than returning success from a skipped body.
+The required Valgrind and ASan jobs are logical `premerge` coverage but remain
+explicit workflow jobs: Valgrind provisions an external runtime tool, while
+ASan requires a pinned nightly Cargo toolchain that Buck does not model.
 
 `./buck2 bxl //test_tiers.bxl:validate` queries Buck's live first-party test
 graph and fails unless every target has exactly one tier. Required formatting
 CI runs that validation, so adding a raw test rule or conflicting tier label
 cannot silently change suite ownership. Vendored `//third-party/...` targets
 are excluded because their generated BUCK metadata is upstream-owned.
+
+The same BXL file exposes the canonical named selections:
+
+```bash
+./buck2 bxl //test_tiers.bxl:premerge
+./buck2 bxl //test_tiers.bxl:slow
+./buck2 bxl //test_tiers.bxl:stress
+./buck2 bxl //test_tiers.bxl:all
+```
+
+Each prints the exact live Buck targets in that selection. The `all` and
+per-tier selections omit `rue_cli_shard` scheduling alternatives because the
+canonical monolithic CLI target already owns their union. CI invokes those
+shards explicitly on separate runners.
+
+Use `scripts/rue premerge`, `scripts/rue slow`, `scripts/rue stress`, or
+`scripts/rue all` to execute a named selection. `scripts/rue test` retains its
+standard full-suite behavior: premerge plus slow, with resource-stress tests
+remaining opt in. Filtered `scripts/rue test PATTERN` behavior is unchanged.
+Required CI sets `RUE_TEST_TIER=premerge`, while `scripts/rue all` and the
+scheduled full-release workflow exercise the complete union.
+
+The exhaustive CLI- and specification-oracle differential harnesses are
+`slow`: premerge retains the fixed generated oracle smoke corpus as its bounded
+codegen canary. The normal 100/1k structural scaling matrix remains a dedicated
+premerge canary; `//crates/rue-compiler:scaling-matrix-stress-test` enables the
+real 10k-per-axis ladder and belongs to `stress`. Caldera and Meridian remain
+explicitly tracked by RUE-1162 until their real release-built slow targets and
+reduced premerge canaries replace the current skips/stub.
 
 Execution tier and scheduling are separate concerns. A required pre-merge test
 may also carry `rue_heavy_suite` or `rue_dedicated_suite` so it runs in an

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -83,11 +83,12 @@ scheduled full-release workflow exercise the complete union.
 The exhaustive CLI- and specification-oracle differential harnesses are
 `slow`: premerge retains the fixed generated oracle smoke corpus as its bounded
 codegen canary. CLI corpus sections may likewise declare `tier = "slow"`.
-`//:cli-tests-slow` owns those real cases, while each maintained large
-program's automatic example remains a single premerge compile/run canary.
-Mosaic's 17 exhaustive behavior cases use that split, so the four required CLI
-shards do not each spend their critical path recompiling the same large
-program.
+Automatic examples have the same declarative tier field.
+`//:cli-tests-slow` owns those real cases. Mosaic's shipped-program smoke and
+17 exhaustive behavior cases are slow, so the four required CLI shards do not
+spend their critical path compiling that large program. A genuinely reduced
+premerge large-program canary remains part of the RUE-1162 follow-up rather
+than being approximated by the full program with a wider timeout.
 
 The normal 100/1k structural scaling matrix remains a dedicated premerge
 canary; `//crates/rue-compiler:scaling-matrix-stress-test` enables the real

--- a/quick-test.sh
+++ b/quick-test.sh
@@ -26,9 +26,11 @@ echo "Running unit tests (quick mode)..."
 # coverage, not fast iteration.
 # (RUE-132, RUE-1157)
 ./buck2 test //crates/... \
+    --include rue_test_tier_premerge \
     --exclude rue_not_quick \
     --exclude rue_dedicated_suite \
-    --always-exclude
+    --always-exclude \
+    --ignore-tests-attribute
 
 echo ""
 echo "Unit tests passed! Run ./test.sh for full verification before committing."

--- a/scripts/ci-heavy-suite
+++ b/scripts/ci-heavy-suite
@@ -33,7 +33,7 @@ trap cleanup EXIT
 test_args=("$target")
 timings=""
 case "$target" in
-    //:cli-tests)
+    //:cli-tests|//:cli-tests-slow)
         test_args+=(-- --timeout 1800)
         ;;
     //:cli-tests-shard-*)

--- a/scripts/rue
+++ b/scripts/rue
@@ -8,6 +8,10 @@
 #   scripts/rue exec prog.rue      Compile prog.rue to a temp file AND run it
 #   scripts/rue test [pattern]     Full suite (./test.sh), optional filter
 #   scripts/rue quick              Unit tests only (./quick-test.sh)
+#   scripts/rue premerge           Canonical required test tier
+#   scripts/rue slow               Canonical scheduled slow tier
+#   scripts/rue stress             Canonical opt-in stress tier
+#   scripts/rue all                Canonical union of every test tier
 #   scripts/rue unit <crate> [args] One crate's Rust unit tests, case-filtered
 #                                  (crate name with or without the rue- prefix,
 #                                  or an explicit <crate>:<target>; forwards
@@ -87,6 +91,13 @@ case "$cmd" in
         ;;
     test)
         ./test.sh "$@"
+        ;;
+    premerge|slow|stress|all)
+        if [[ $# -ne 0 ]]; then
+            echo "usage: scripts/rue $cmd" >&2
+            exit 2
+        fi
+        RUE_TEST_TIER="$cmd" ./test.sh
         ;;
     quick)
         ./quick-test.sh "$@"

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -287,7 +287,7 @@ EOF
     fi
     check "suite: unfiltered orchestration succeeds" "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
     check "suite: broad discovery excludes opaque heavy tests" \
-        "$(grep -Fxq 'test //... --exclude rue_heavy_suite --always-exclude' "$sb/calls" && echo 0 || echo 1)"
+        "$(grep -Fxq 'test //... toolchains//... --exclude rue_heavy_suite --always-exclude --ignore-tests-attribute --exclude rue_test_tier_stress' "$sb/calls" && echo 0 || echo 1)"
     check "suite: heavy targets are discovered from the live graph" \
         "$(grep -Fxq 'uquery attrfilter(labels, rue_heavy_suite, //...)' "$sb/calls" && echo 0 || echo 1)"
     check "suite: monolithic CLI corpus receives the extended executor timeout" \

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -256,6 +256,7 @@ if [[ "${1:-}" == "uquery" ]]; then
         printf '%s\n' \
             root//:cli-tests \
             root//:cli-tests-caldera \
+            root//:cli-tests-slow \
             root//:frontend-diff-test \
             root//:oracle-diff-generated-smoke \
             root//:reproducible-programs \
@@ -290,8 +291,10 @@ EOF
         "$(grep -Fxq 'test //... toolchains//... --exclude rue_heavy_suite --always-exclude --ignore-tests-attribute --exclude rue_test_tier_stress' "$sb/calls" && echo 0 || echo 1)"
     check "suite: heavy targets are discovered from the live graph" \
         "$(grep -Fxq 'uquery attrfilter(labels, rue_heavy_suite, //...)' "$sb/calls" && echo 0 || echo 1)"
-    check "suite: monolithic CLI corpus receives the extended executor timeout" \
+    check "suite: premerge CLI corpus receives the extended executor timeout" \
         "$(grep -Fxq 'test //:cli-tests -- --timeout 1800' "$sb/calls" && echo 0 || echo 1)"
+    check "suite: slow CLI corpus receives the extended executor timeout" \
+        "$(grep -Fxq 'test //:cli-tests-slow -- --timeout 1800' "$sb/calls" && echo 0 || echo 1)"
     check "suite: every other heavy target uses the default executor timeout" \
         "$([ "$(grep -Ec '^test //:(cli-tests-caldera|spec-tests|ui-tests|oracle-diff-generated-smoke|reproducible-programs|frontend-diff-test)$' "$sb/calls")" -eq 6 ] && echo 0 || echo 1)"
     check "suite: no concurrent heavy label sweep occurs" \

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -812,8 +812,14 @@ EOF
   : >"$sb/calls.log"
   rc=0
   (cd "$sb" && FAKE_CALL_LOG="$sb/calls.log" ./ci-heavy-suite //:cli-tests) >/dev/null 2>&1 || rc=$?
-  check "ci-heavy-suite: monolithic CLI corpus receives the extended executor timeout" \
+  check "ci-heavy-suite: premerge CLI corpus receives the extended executor timeout" \
     "$([ "$rc" -eq 0 ] && grep -Fxq 'test //:cli-tests -- --timeout 1800' "$sb/calls.log" && echo 0 || echo 1)"
+
+  : >"$sb/calls.log"
+  rc=0
+  (cd "$sb" && FAKE_LABELED_TARGET=//:cli-tests-slow FAKE_CALL_LOG="$sb/calls.log" ./ci-heavy-suite //:cli-tests-slow) >/dev/null 2>&1 || rc=$?
+  check "ci-heavy-suite: slow CLI corpus receives the extended executor timeout" \
+    "$([ "$rc" -eq 0 ] && grep -Fxq 'test //:cli-tests-slow -- --timeout 1800' "$sb/calls.log" && echo 0 || echo 1)"
 
   : >"$sb/calls.log"
   rc=0
@@ -882,6 +888,12 @@ if [ "$1" = "uquery" ]; then
   case "$*" in
     *rue_cli_shard*) for t in ${FAKE_CLI_SHARDS:-}; do printf 'root%s\n' "$t"; done ;;
     *rue_dedicated_suite*) for t in ${FAKE_DEDICATED_SUITES:-}; do printf 'root%s\n' "$t"; done ;;
+    *rue_test_tier_slow*) printf 'root//:cli-tests-slow\n' ;;
+    *rue_test_tier_premerge*)
+      for t in $FAKE_HEAVY_SUITES; do
+        [ "$t" = "//:cli-tests-slow" ] || printf 'root%s\n' "$t"
+      done
+      ;;
     *) for t in $FAKE_HEAVY_SUITES; do printf 'root%s\n' "$t"; done ;;
   esac
   exit 0
@@ -908,7 +920,7 @@ exit 90
 EOF
   chmod +x "$sb/buck2"
 
-  local all="//:cli-tests //:cli-tests-caldera //:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests //:frontend-diff-test"
+  local all="//:cli-tests //:cli-tests-caldera //:cli-tests-slow //:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests //:frontend-diff-test"
 
   # (1) Full corpus present + buck2 green -> test.sh reports success.
   local rc=0 out
@@ -917,8 +929,8 @@ EOF
     "$([ "$rc" -eq 0 ] && grep -Fxq '=== TEST SUITE: PASSED ===' <<< "$out" && echo 0 || echo 1)"
 
   # The required-CI spelling selects premerge from canonical Buck metadata,
-  # while slow selections are allowed to have no heavy corpus targets and do
-  # not claim the premerge omission sentinels executed.
+  # while slow selections audit their own real corpus target without claiming
+  # the premerge omission sentinels executed.
   : >"$sb/calls.log"; rc=0
   out="$(cd "$sb" && RUE_TEST_TIER=premerge RUE_CI_DEFER_HEAVY_SUITES= \
       RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" \
@@ -928,14 +940,14 @@ EOF
 
   : >"$sb/calls.log"; rc=0
   out="$(cd "$sb" && RUE_TEST_TIER=slow RUE_CI_DEFER_HEAVY_SUITES= \
-      RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES= \
-      FAKE_PASS_TARGETS= FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
-  check "test.sh: slow selection is valid without premerge corpus claims" \
-    "$([ "$rc" -eq 0 ] && grep -Fq -- '--include rue_test_tier_slow' "$sb/calls.log" && echo 0 || echo 1)"
+      RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" \
+      FAKE_PASS_TARGETS='//:cli-tests-slow' FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
+  check "test.sh: slow selection audits its real CLI corpus target" \
+    "$([ "$rc" -eq 0 ] && grep -Fq -- '--include rue_test_tier_slow' "$sb/calls.log" && grep -Fq 'test //:cli-tests-slow -- --timeout 1800' "$sb/calls.log" && echo 0 || echo 1)"
 
   # (2) A corpus harness OMITTED while every buck2 invocation still exits 0 is
   #     the RUE-924 false-green: it must become a hard failure naming the suite.
-  local partial="//:cli-tests-caldera //:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests //:frontend-diff-test"
+  local partial="//:cli-tests-caldera //:cli-tests-slow //:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests //:frontend-diff-test"
   rc=0
   out="$(cd "$sb" && RUE_CI_DEFER_HEAVY_SUITES= RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$partial" ./test.sh 2>&1)" || rc=$?
   check "test.sh: a silently omitted corpus harness fails the run" \
@@ -957,7 +969,7 @@ EOF
   # targets while retaining every other corpus assertion.
   local owned="//:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests //:frontend-diff-test"
   : >"$sb/calls.log"; rc=0
-  out="$(cd "$sb" && CI=true RUE_FULL_SUITE_LOCK_HELD=1 \
+  out="$(cd "$sb" && CI=true RUE_TEST_TIER=premerge RUE_FULL_SUITE_LOCK_HELD=1 \
       RUE_CI_DEFER_HEAVY_SUITES='//:cli-tests //:cli-tests-caldera //:spec-tests' \
       FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$owned" \
       FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
@@ -969,7 +981,7 @@ EOF
   # (5) Dedicated pre-merge coverage may leave the broad CI pass only when the
   # workflow-owned set exactly matches Buck's live scheduling metadata.
   : >"$sb/calls.log"; rc=0
-  out="$(cd "$sb" && CI=true RUE_FULL_SUITE_LOCK_HELD=1 \
+  out="$(cd "$sb" && CI=true RUE_TEST_TIER=premerge RUE_FULL_SUITE_LOCK_HELD=1 \
       RUE_CI_DEFER_HEAVY_SUITES= \
       RUE_CI_DEFER_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
       FAKE_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
@@ -979,7 +991,7 @@ EOF
     "$([ "$rc" -eq 0 ] && grep -Fq -- '--exclude rue_dedicated_suite' "$sb/calls.log" && echo 0 || echo 1)"
 
   rc=0
-  out="$(cd "$sb" && CI=true RUE_FULL_SUITE_LOCK_HELD=1 \
+  out="$(cd "$sb" && CI=true RUE_TEST_TIER=premerge RUE_FULL_SUITE_LOCK_HELD=1 \
       RUE_CI_DEFER_HEAVY_SUITES= \
       RUE_CI_DEFER_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
       FAKE_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test //:unowned-dedicated' \
@@ -989,7 +1001,7 @@ EOF
 
   # (6) A stale shard name or local attempt to suppress coverage fails closed.
   rc=0
-  out="$(cd "$sb" && CI=true RUE_FULL_SUITE_LOCK_HELD=1 \
+  out="$(cd "$sb" && CI=true RUE_TEST_TIER=premerge RUE_FULL_SUITE_LOCK_HELD=1 \
       RUE_CI_DEFER_HEAVY_SUITES='//:missing-suite' \
       FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
   check "test.sh: unknown deferred CI suite fails closed" \
@@ -1013,14 +1025,15 @@ EOF
 
   # (7) RUE-1116: the CI-only CLI shards are labeled rue_heavy_suite but must be
   #     excluded from a local full run, which covers their union once via the
-  #     monolithic //:cli-tests. The run still succeeds (full corpus present).
+  #     premerge //:cli-tests. The slow target independently owns its cases,
+  #     and the standard run still succeeds with the full union present.
   local with_shards="$all //:cli-tests-shard-0 //:cli-tests-shard-1"
   : >"$sb/calls.log"; rc=0
   out="$(cd "$sb" && RUE_CI_DEFER_HEAVY_SUITES= RUE_FULL_SUITE_LOCK_HELD=1 \
       FAKE_HEAVY_SUITES="$with_shards" \
       FAKE_CLI_SHARDS='//:cli-tests-shard-0 //:cli-tests-shard-1' \
       FAKE_PASS_TARGETS="$all" FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
-  check "test.sh: local full run runs the monolithic CLI corpus, not the shards" \
+  check "test.sh: local full run runs the premerge CLI target, not the shards" \
     "$([ "$rc" -eq 0 ] && ! grep -Eq '(^| )//:cli-tests-shard-' "$sb/calls.log" && echo 0 || echo 1)"
 
   rm -rf "$sb"

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -277,6 +277,33 @@ test_rue_cli_examples_survive_case_chdir() {
   rm -rf "$sb"
 }
 
+# Canonical tier commands are intentionally thin: scripts/rue names the
+# selection while test.sh owns execution and reads Buck's tier metadata.
+test_rue_named_test_tiers_delegate_to_testsh() {
+  local sb; sb="$(make_rue_sandbox)"
+  cat >"$sb/test.sh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${RUE_TEST_TIER:-unset}" >>"$TIER_LOG"
+EOF
+  chmod +x "$sb/test.sh"
+
+  local tier rc
+  for tier in premerge slow stress all; do
+    rc=0
+    (cd "$sb/work" && TIER_LOG="$sb/tiers.log" "$sb/scripts/rue" "$tier") \
+      >/dev/null 2>&1 || rc=$?
+    check "scripts/rue $tier: delegates the named tier to test.sh" \
+      "$([ "$rc" -eq 0 ] && tail -1 "$sb/tiers.log" | grep -Fxq "$tier" && echo 0 || echo 1)"
+  done
+
+  rc=0
+  (cd "$sb/work" && TIER_LOG="$sb/tiers.log" "$sb/scripts/rue" slow unexpected) \
+    >/dev/null 2>&1 || rc=$?
+  check "scripts/rue slow: rejects case-filter arguments" \
+    "$([ "$rc" -eq 2 ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
 # Filtered `test.sh` reaches the same CLI path after its unit/spec/UI steps. Its
 # absolute path must survive the cwd change, and its sentinel must agree with
 # the propagated harness status.
@@ -756,6 +783,10 @@ if [ "$1" = "uquery" ]; then
   printf 'root%s\n' "${FAKE_LABELED_TARGET:-//:cli-tests}"
   exit 0
 fi
+if [ "$1" = "bxl" ]; then
+  printf 'Rue test tiers valid\n'
+  exit 0
+fi
 if [ "$1" = "test" ]; then
   if [ -n "${FAKE_CALL_LOG:-}" ]; then printf '%s\n' "$*" >>"$FAKE_CALL_LOG"; fi
   for arg in "$@"; do
@@ -855,6 +886,10 @@ if [ "$1" = "uquery" ]; then
   esac
   exit 0
 fi
+if [ "$1" = "bxl" ]; then
+  printf 'Rue test tiers valid\n'
+  exit 0
+fi
 if [ "$1" = "test" ]; then
   if [ -n "${FAKE_CALL_LOG:-}" ]; then printf '%s\n' "$*" >>"$FAKE_CALL_LOG"; fi
   tgt="$2"
@@ -880,6 +915,23 @@ EOF
   out="$(cd "$sb" && RUE_CI_DEFER_HEAVY_SUITES= RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
   check "test.sh: unfiltered run with the full corpus reports success" \
     "$([ "$rc" -eq 0 ] && grep -Fxq '=== TEST SUITE: PASSED ===' <<< "$out" && echo 0 || echo 1)"
+
+  # The required-CI spelling selects premerge from canonical Buck metadata,
+  # while slow selections are allowed to have no heavy corpus targets and do
+  # not claim the premerge omission sentinels executed.
+  : >"$sb/calls.log"; rc=0
+  out="$(cd "$sb" && RUE_TEST_TIER=premerge RUE_CI_DEFER_HEAVY_SUITES= \
+      RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" \
+      FAKE_PASS_TARGETS="$all" FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
+  check "test.sh: premerge selection uses the canonical Buck tier label" \
+    "$([ "$rc" -eq 0 ] && grep -Fq -- '--include rue_test_tier_premerge' "$sb/calls.log" && echo 0 || echo 1)"
+
+  : >"$sb/calls.log"; rc=0
+  out="$(cd "$sb" && RUE_TEST_TIER=slow RUE_CI_DEFER_HEAVY_SUITES= \
+      RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES= \
+      FAKE_PASS_TARGETS= FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
+  check "test.sh: slow selection is valid without premerge corpus claims" \
+    "$([ "$rc" -eq 0 ] && grep -Fq -- '--include rue_test_tier_slow' "$sb/calls.log" && echo 0 || echo 1)"
 
   # (2) A corpus harness OMITTED while every buck2 invocation still exits 0 is
   #     the RUE-924 false-green: it must become a hard failure naming the suite.
@@ -984,6 +1036,7 @@ test_fmt_uses_one_buck_run_and_preserves_paths
 test_rue_exec_resolves_from_caller_cwd
 test_rue_run_resolves_relative_output
 test_rue_cli_examples_survive_case_chdir
+test_rue_named_test_tiers_delegate_to_testsh
 test_testsh_cli_examples_survive_case_chdir
 test_rue_unit_maps_crate_and_forwards_args
 test_rue_unit_zero_match_fails_loud

--- a/test.sh
+++ b/test.sh
@@ -103,7 +103,7 @@ REPOSITORY_QUALITY_GATES=(
 # binary, so a silent omission (cache, pattern narrowing, platform gate) is
 # exactly the failure that hides miscompilations behind a green tally. The
 # unfiltered path audits that every one of these produced a result line.
-REQUIRED_CORPUS_HARNESSES=(
+REQUIRED_PREMERGE_CORPUS_HARNESSES=(
     //:cli-tests
     //:cli-tests-caldera
     //:spec-tests
@@ -112,6 +112,10 @@ REQUIRED_CORPUS_HARNESSES=(
     //:reproducible-programs
     //:tutorial-snippet-tests
     //:frontend-diff-test
+)
+
+REQUIRED_SLOW_CORPUS_HARNESSES=(
+    //:cli-tests-slow
 )
 
 if [[ $# -eq 0 ]]; then
@@ -266,13 +270,14 @@ if [[ $# -eq 0 ]]; then
     # such line for a required harness means it never ran under this invocation
     # — neither in the broad pass nor as a heavy suite.
     missing_corpus=()
-    for target in "${REQUIRED_CORPUS_HARNESSES[@]}"; do
-        # The current omission sentinels are all premerge corpora. Slow and
-        # stress selections have their own explicit targets and must not claim
-        # these premerge harnesses executed.
-        if [[ "$test_tier" == slow || "$test_tier" == stress ]]; then
-            continue
-        fi
+    required_corpus=()
+    if [[ "$test_tier" == standard || "$test_tier" == all || "$test_tier" == premerge ]]; then
+        required_corpus+=("${REQUIRED_PREMERGE_CORPUS_HARNESSES[@]}")
+    fi
+    if [[ "$test_tier" == standard || "$test_tier" == all || "$test_tier" == slow ]]; then
+        required_corpus+=("${REQUIRED_SLOW_CORPUS_HARNESSES[@]}")
+    fi
+    for target in "${required_corpus[@]}"; do
         if suite_is_deferred "$target"; then
             continue
         fi

--- a/test.sh
+++ b/test.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Run all tests for the rue compiler.
+# Run the canonical Rue test selection.
 #
-# Every suite is a Buck test target, so one `buck2 test //...` runs the unit
+# Every suite is a Buck test target. With no environment override this retains
+# the standard full-suite behavior (premerge + slow, with resource-stress tests
+# opt in); `RUE_TEST_TIER=premerge|slow|stress|all` selects a canonical
+# execution tier or their complete union from the same Buck metadata used by
+# `//test_tiers.bxl:{premerge,slow,stress,all}`.
+#
+# One broad `buck2 test //...` runs the unit
 # tests for ALL crates plus the spec/UI/CLI harness suites, tutorial snippet
 # checker, spec traceability gate, and ADR registry validator (the root BUCK
 # file's sh_tests, which declare the rue binary, cases/, std/, docs/, and
@@ -43,6 +49,20 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 repo_root="$PWD"
+
+requested_test_tier="${RUE_TEST_TIER:-}"
+test_tier="${requested_test_tier:-standard}"
+case "$test_tier" in
+    standard|all|premerge|slow|stress) ;;
+    *)
+        echo "error: unknown RUE_TEST_TIER '$test_tier' (expected all, premerge, slow, or stress)" >&2
+        exit 2
+        ;;
+esac
+if [[ $# -gt 0 && -n "$requested_test_tier" ]]; then
+    echo "error: filtered test.sh runs cannot be combined with RUE_TEST_TIER=$test_tier" >&2
+    exit 2
+fi
 
 # Direct full-suite invocations also bootstrap an already-installed private
 # cache config. This is a no-op when the user has not opted in.
@@ -95,6 +115,10 @@ REQUIRED_CORPUS_HARNESSES=(
 )
 
 if [[ $# -eq 0 ]]; then
+    # Fail closed before executing anything if a target is unowned, multiply
+    # owned, or a named tier has no real members.
+    ./buck2 bxl //test_tiers.bxl:validate
+
     # Keep discovery broad so new crate and repository tests cannot disappear
     # behind a hand-maintained list. Heavy opaque harnesses are labeled in BUCK:
     # query that label from the live graph, exclude it from the broad pass, then
@@ -106,13 +130,22 @@ if [[ $# -eq 0 ]]; then
     # exactly once instead of re-running every 1/N slice, so subtract the
     # rue_cli_shard set from heavy-suite discovery here.
     cli_shard_targets="$(./buck2 uquery 'attrfilter(labels, rue_cli_shard, //...)')"
+    heavy_query='attrfilter(labels, rue_heavy_suite, //...)'
+    tier_label=""
+    if [[ "$test_tier" == standard ]]; then
+        heavy_query='attrfilter(labels, rue_heavy_suite, //...) except attrfilter(labels, rue_test_tier_stress, //...)'
+    elif [[ "$test_tier" != all ]]; then
+        tier_label="rue_test_tier_$test_tier"
+        heavy_query="attrfilter(labels, rue_heavy_suite, attrfilter(labels, $tier_label, //...))"
+    fi
+
     HEAVY_SUITES=()
     while IFS= read -r suite; do
         [[ -n "$suite" ]] || continue
         grep -Fxq "$suite" <<<"$cli_shard_targets" && continue
         HEAVY_SUITES+=("$suite")
-    done < <(./buck2 uquery 'attrfilter(labels, rue_heavy_suite, //...)')
-    if [[ ${#HEAVY_SUITES[@]} -eq 0 ]]; then
+    done < <(./buck2 uquery "$heavy_query")
+    if [[ ${#HEAVY_SUITES[@]} -eq 0 && "$test_tier" != slow && "$test_tier" != stress ]]; then
         echo "error: Buck query found no rue_heavy_suite targets" >&2
         exit 1
     fi
@@ -163,8 +196,13 @@ if [[ $# -eq 0 ]]; then
     run_log="$(mktemp)"
     overall_status=0
     set +e
-    echo "Running unit tests and lightweight repository checks..."
-    broad_test_args=(//... --exclude rue_heavy_suite --always-exclude)
+    echo "Running $test_tier unit tests and lightweight repository checks..."
+    broad_test_args=(//... toolchains//... --exclude rue_heavy_suite --always-exclude --ignore-tests-attribute)
+    if [[ "$test_tier" == standard ]]; then
+        broad_test_args+=(--exclude rue_test_tier_stress)
+    elif [[ -n "$tier_label" ]]; then
+        broad_test_args+=(--include "$tier_label")
+    fi
     if [[ -n "${RUE_CI_DEFER_DEDICATED_SUITES:-}" ]]; then
         if [[ "${CI:-}" != "true" ]]; then
             echo "error: RUE_CI_DEFER_DEDICATED_SUITES is reserved for required CI" >&2
@@ -176,7 +214,13 @@ if [[ $# -eq 0 ]]; then
         # the workflow's declared set to match Buck's live scheduling metadata
         # exactly before excluding the label, so a newly tagged target cannot
         # disappear behind a stale environment variable.
-        dedicated_targets="$(./buck2 uquery 'attrfilter(labels, rue_dedicated_suite, //...)')"
+        dedicated_query='attrfilter(labels, rue_dedicated_suite, //...)'
+        if [[ "$test_tier" == standard ]]; then
+            dedicated_query='attrfilter(labels, rue_dedicated_suite, //...) except attrfilter(labels, rue_test_tier_stress, //...)'
+        elif [[ -n "$tier_label" ]]; then
+            dedicated_query="attrfilter(labels, rue_dedicated_suite, attrfilter(labels, $tier_label, //...))"
+        fi
+        dedicated_targets="$(./buck2 uquery "$dedicated_query")"
         read -r -a deferred_dedicated <<<"$RUE_CI_DEFER_DEDICATED_SUITES"
         for deferred in "${deferred_dedicated[@]}"; do
             if ! grep -Fxq "root${deferred#root}" <<<"$dedicated_targets"; then
@@ -200,19 +244,21 @@ if [[ $# -eq 0 ]]; then
     ./buck2 test "${broad_test_args[@]}" 2>&1 | tee "$run_log"
     step_status=${PIPESTATUS[0]}
     [[ "$step_status" -ne 0 && "$overall_status" -eq 0 ]] && overall_status=$step_status
-    for suite in "${HEAVY_SUITES[@]}"; do
-        if suite_is_deferred "$suite"; then
-            echo "Deferring heavy suite $suite to its required CI shard..."
-            continue
-        fi
-        echo "Running heavy suite $suite..."
-        # Normalize Buck's configured-cell spelling before handing execution
-        # to the single audited heavy-suite runner. It owns target-specific
-        # executor arguments as well as the per-target result check.
-        ./scripts/ci-heavy-suite "${suite#root}" 2>&1 | tee -a "$run_log"
-        step_status=${PIPESTATUS[0]}
-        [[ "$step_status" -ne 0 && "$overall_status" -eq 0 ]] && overall_status=$step_status
-    done
+    if [[ ${#HEAVY_SUITES[@]} -gt 0 ]]; then
+        for suite in "${HEAVY_SUITES[@]}"; do
+            if suite_is_deferred "$suite"; then
+                echo "Deferring heavy suite $suite to its required CI shard..."
+                continue
+            fi
+            echo "Running heavy suite $suite..."
+            # Normalize Buck's configured-cell spelling before handing execution
+            # to the single audited heavy-suite runner. It owns target-specific
+            # executor arguments as well as the per-target result check.
+            ./scripts/ci-heavy-suite "${suite#root}" 2>&1 | tee -a "$run_log"
+            step_status=${PIPESTATUS[0]}
+            [[ "$step_status" -ne 0 && "$overall_status" -eq 0 ]] && overall_status=$step_status
+        done
+    fi
     set -e
 
     # buck2 prints exactly one "<Status>: root<target> (<time>)" summary line
@@ -221,6 +267,12 @@ if [[ $# -eq 0 ]]; then
     # — neither in the broad pass nor as a heavy suite.
     missing_corpus=()
     for target in "${REQUIRED_CORPUS_HARNESSES[@]}"; do
+        # The current omission sentinels are all premerge corpora. Slow and
+        # stress selections have their own explicit targets and must not claim
+        # these premerge harnesses executed.
+        if [[ "$test_tier" == slow || "$test_tier" == stress ]]; then
+            continue
+        fi
         if suite_is_deferred "$target"; then
             continue
         fi

--- a/test_tiers.bxl
+++ b/test_tiers.bxl
@@ -1,4 +1,4 @@
-"""Buck-graph validation for Rue's first-party test execution tiers."""
+"""Canonical Buck selections and validation for Rue's test execution tiers."""
 
 _TEST_TIER_LABELS = [
     "rue_test_tier_premerge",
@@ -6,28 +6,35 @@ _TEST_TIER_LABELS = [
     "rue_test_tier_stress",
 ]
 
-def _validate(ctx):
+_CLI_SHARD_LABEL = "rue_cli_shard"
+
+def _owned_tests(ctx):
     # Vendored third-party tests follow their upstream-generated BUCK metadata.
     # Rue owns every other test target in the cell and requires it to declare
     # exactly one execution tier.
-    tests = ctx.uquery().eval(
+    return ctx.uquery().eval(
         'kind("^(.*_test|test_suite)$", //...) except //third-party/...',
     ) + ctx.uquery().eval(
         'kind("^(.*_test|test_suite)$", toolchains//...)',
     )
 
+def _target_tiers(test):
+    labels = test.get_attr("labels")
+    return [
+        tier
+        for tier in _TEST_TIER_LABELS
+        if tier in labels
+    ]
+
+def _validate(ctx):
+    tests = _owned_tests(ctx)
     errors = []
     counts = {}
     for tier in _TEST_TIER_LABELS:
         counts[tier] = 0
 
     for test in tests:
-        labels = test.get_attr("labels")
-        target_tiers = [
-            tier
-            for tier in _TEST_TIER_LABELS
-            if tier in labels
-        ]
+        target_tiers = _target_tiers(test)
         if len(target_tiers) != 1:
             errors.append("{} has {}; expected exactly one Rue test tier".format(
                 test.label,
@@ -35,6 +42,10 @@ def _validate(ctx):
             ))
         else:
             counts[target_tiers[0]] += 1
+
+    for tier in _TEST_TIER_LABELS:
+        if counts[tier] == 0:
+            errors.append("{} has no real test targets".format(tier))
 
     if errors:
         fail("invalid Rue test-tier ownership:\n{}".format(
@@ -49,7 +60,70 @@ def _validate(ctx):
         ),
     )
 
+def _select(ctx, tiers):
+    selected = []
+    errors = []
+    for test in _owned_tests(ctx):
+        labels = test.get_attr("labels")
+        target_tiers = _target_tiers(test)
+        if len(target_tiers) != 1:
+            errors.append("{} has {}; expected exactly one Rue test tier".format(
+                test.label,
+                target_tiers,
+            ))
+            continue
+
+        # The four CI shards are scheduling alternatives for the canonical
+        # monolithic CLI target. Selecting both would execute the same logical
+        # corpus twice locally, so named tier entry points expose the canonical
+        # target and leave shards to their explicit platform jobs.
+        if _CLI_SHARD_LABEL in labels:
+            continue
+        if target_tiers[0] in tiers:
+            selected.append("{}".format(test.label))
+
+    if errors:
+        fail("invalid Rue test-tier ownership:\n{}".format(
+            "\n".join(sorted(errors)),
+        ))
+    if not selected:
+        fail("Rue test-tier selection is empty: {}".format(tiers))
+
+    ctx.output.print("\n".join(sorted(selected)))
+
+def _premerge(ctx):
+    _select(ctx, ["rue_test_tier_premerge"])
+
+def _slow(ctx):
+    _select(ctx, ["rue_test_tier_slow"])
+
+def _stress(ctx):
+    _select(ctx, ["rue_test_tier_stress"])
+
+def _all(ctx):
+    _select(ctx, _TEST_TIER_LABELS)
+
 validate = bxl_main(
     impl = _validate,
+    cli_args = {},
+)
+
+premerge = bxl_main(
+    impl = _premerge,
+    cli_args = {},
+)
+
+slow = bxl_main(
+    impl = _slow,
+    cli_args = {},
+)
+
+stress = bxl_main(
+    impl = _stress,
+    cli_args = {},
+)
+
+all = bxl_main(
+    impl = _all,
     cli_args = {},
 )


### PR DESCRIPTION
## Summary

- add canonical Buck entrypoints for premerge, slow, stress, and their complete union, backed by fail-closed ownership validation
- classify the exhaustive CLI/spec oracle harnesses as slow and add a real opt-in 10k-per-axis compiler scaling stress target
- give both explicit CLI sections and automatic examples declarative premerge/slow ownership, with separate Buck targets for each corpus
- move the shipped Mosaic smoke and all 17 Mosaic behavior cases out of the four premerge shards after queue-loaded macOS and Linux compiles crossed their already-tight 30s budget
- preserve scripts/rue quick, filtered test workflows, and the standard full suite while keeping resource-stress work out of pre-merge
- make required CI select premerge explicitly and make scheduled release testing exercise the full graph without following Buck tests attributes into duplicate toolchain outputs
- document the standalone Valgrind/ASan premerge exceptions and the RUE-1162 reduced-canary follow-up

## Impact

CI and local tooling now select tests from one Buck-owned tier model. New first-party tests cannot be silently unclassified or multiply classified. Large programs have explicit, reproducible ownership instead of relying on timeout margins in required shards; the full Mosaic program runs in scheduled and opt-in slow coverage, while a genuinely reduced premerge canary remains follow-up work.

## Validation

- ./buck2 bxl //test_tiers.bxl:validate (73 premerge, 3 slow, 1 stress)
- scripts/rue quick (30 targets)
- scripts/rue slow (both exhaustive oracle corpora plus 18/18 Mosaic tests)
- RUE_CLI_CASE_TIER=premerge scripts/rue cli --list mosaic (0 tests)
- RUE_CLI_CASE_TIER=slow scripts/rue cli --list mosaic (18 tests)
- ./buck2 test //:build-sharing-tests //:wrapper-script-tests (31/31 and 95/95 wrapper checks)
- ./buck2 test //:cli-shard-coverage-validation //:cli-shard-weights-validation
- ./buck2 test toolchains//... --include rue_test_tier_premerge --ignore-tests-attribute
- ./fmt.sh check
- full standard suite before the queue repairs: every product and corpus target passed; its sole stale exact-command assertion was updated and passed in the focused rerun above

Fixes RUE-1157.

Refs RUE-1162.