### PR TITLE
RUE-1159: separate correctness hang guards from performance budgets

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -72,7 +72,9 @@ jobs:
           restore-keys: |
             dotslash-${{ matrix.platform }}-
 
-      - name: Run benchmarks
+      # Performance budgets are enforced here, separately from correctness
+      # hang guards in the CLI corpus.
+      - name: Run benchmarks and enforce performance thresholds
         run: |
           iterations="${{ github.event.inputs.iterations || '5' }}"
           export RUE_BENCH_RUNNER_IMAGE="${ImageOS:-${{ runner.os }}}:${ImageVersion:-unknown}:${{ runner.arch }}"

--- a/.github/workflows/correctness-repetitions.yml
+++ b/.github/workflows/correctness-repetitions.yml
@@ -1,0 +1,42 @@
+name: Correctness repetitions
+
+on:
+  schedule:
+    - cron: "17 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      repetitions:
+        description: Independent executions per shard (failures are never cleared)
+        default: "5"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  repeat-cli-shards:
+    name: repeat (linux-x64 shard ${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: facebook/install-dotslash@v2
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/dotslash
+          key: dotslash-repetitions-linux-x64-${{ hashFiles('buck2') }}
+          restore-keys: dotslash-repetitions-linux-x64-
+      - name: Repeat correctness shard and retain every failure
+        env:
+          RUE_REPETITION_LOG_DIR: ${{ runner.temp }}/repetitions
+        run: scripts/ci-repeat-correctness "//:cli-tests-shard-${{ matrix.shard }}" "${{ inputs.repetitions || '5' }}"
+      - name: Upload independent-run report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: correctness-repetitions-linux-x64-shard-${{ matrix.shard }}
+          path: ${{ runner.temp }}/repetitions
+          if-no-files-found: error

--- a/BUCK
+++ b/BUCK
@@ -513,6 +513,52 @@ rue_sh_test(
     },
 )
 
+rue_sh_test(
+    name = "cli-timeout-policy-validation",
+    test = "scripts/cli-timeout-policy.py",
+    args = [
+        "--policy",
+        "$(location //crates/rue-cli-tests:cases)/cases/execution_contracts.toml",
+        "--weights",
+        "$(location //crates/rue-cli-tests:shard-weights)",
+    ],
+)
+
+rue_sh_test(
+    name = "cli-timeout-policy-tool-tests",
+    test = "scripts/test-cli-timeout-policy.py",
+    resources = ["scripts/cli-timeout-policy.py"],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "RUE_CLI_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
+    },
+)
+
+rue_sh_test(
+    name = "correctness-repetition-script-tests",
+    test = "scripts/test-ci-repeat-correctness.sh",
+    resources = ["scripts/ci-repeat-correctness"],
+)
+
+filegroup(
+    name = "timeout-workflow-test-inputs",
+    srcs = [
+        ".github/workflows/benchmarks.yml",
+        ".github/workflows/ci.yml",
+        ".github/workflows/correctness-repetitions.yml",
+        "scripts/ci-repeat-correctness",
+    ],
+)
+
+rue_sh_test(
+    name = "timeout-workflow-contract-tests",
+    test = "scripts/test-timeout-workflow-contracts.py",
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "RUE_TIMEOUT_WORKFLOW_ROOT": "$(location :timeout-workflow-test-inputs)",
+    },
+)
+
 # RUE-1119: pin the deterministic, coverage-deciding logic of the affected-
 # corpus selection — the out-of-graph force-full matcher in
 # scripts/affected-targets and the fail-open gate in scripts/ci-corpus-selected.
@@ -678,6 +724,7 @@ filegroup(
     srcs = [
         "fmt.sh",
         "scripts/ci-heavy-suite",
+        "scripts/cli-timeout-policy.py",
         "scripts/ci-timed",
         "scripts/check-cache-probe",
         "scripts/rue",
@@ -704,6 +751,7 @@ filegroup(
         "buck2",
         "buck2-bin",
         "scripts/ci-heavy-suite",
+        "scripts/cli-timeout-policy.py",
         "scripts/provision-build-cache",
         "scripts/with-full-suite-lock",
         "test.sh",

--- a/crates/rue-cli-tests/cases/examples_mosaic.toml
+++ b/crates/rue-cli-tests/cases/examples_mosaic.toml
@@ -7,7 +7,7 @@ tier = "slow"
 # Every case below compiles the same maintained large Mosaic program, so the
 # whole section carries the bounded heavyweight contract, matching the
 # automatic mosaic example.
-contract = "heavyweight"
+contract = "heavyweight_long"
 
 [[case]]
 name = "mosaic_builds_site_and_shared_artifacts"

--- a/crates/rue-cli-tests/cases/execution_contracts.toml
+++ b/crates/rue-cli-tests/cases/execution_contracts.toml
@@ -5,22 +5,44 @@
 [section]
 id = "cli.execution_contracts"
 name = "CLI execution contracts"
-description = "bounded scheduling and phase-specific budgets for heavyweight dogfood programs"
+description = "scheduling classes and generous correctness hang guards"
+
+# These are correctness hang guards with deliberate headroom for loaded CI
+# hosts. They are not performance promises. Performance regressions are
+# assessed separately by the benchmark workflow.
+[timeout_profile.ordinary]
+compile_hang_timeout_ms = 180000
+runtime_hang_timeout_ms = 120000
+
+[timeout_profile.slow]
+compile_hang_timeout_ms = 900000
+runtime_hang_timeout_ms = 300000
+
+[timeout_profile.stress]
+compile_hang_timeout_ms = 1800000
+runtime_hang_timeout_ms = 600000
+
+# Whole-corpus deadlines are derived from measured expected cost plus both
+# proportional and fixed headroom. Minima protect sparse or stale weight data;
+# none of these values is a performance threshold.
+[timeout_policy]
+expected_cost_multiplier_percent = 150
+fixed_headroom_ms = 300000
+minimum_shard_timeout_ms = 900000
+minimum_monolith_timeout_ms = 3600000
+minimum_slow_suite_timeout_ms = 7200000
 
 [contract.heavyweight]
 class = "heavyweight"
-compile_timeout_ms = 30000
-runtime_timeout_ms = 30000
+timeout_profile = "ordinary"
 
 [contract.heavyweight_long]
 class = "heavyweight"
-compile_timeout_ms = 120000
-runtime_timeout_ms = 120000
+timeout_profile = "slow"
 
 [contract.heavyweight_extra_long]
 class = "heavyweight"
-compile_timeout_ms = 300000
-runtime_timeout_ms = 120000
+timeout_profile = "stress"
 
 [[automatic_example]]
 path = "harbor/main.rue"
@@ -32,7 +54,7 @@ contract = "heavyweight_long"
 
 [[automatic_example]]
 path = "mosaic/main.rue"
-contract = "heavyweight"
+contract = "heavyweight_long"
 tier = "slow"
 
 [[automatic_example]]

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -98,9 +98,10 @@
 //! # Timeouts
 //!
 //! Both the COMPILE step and the compiled program run under phase-specific
-//! wall-clock budgets (default [`rue_test_runner::DEFAULT_TIMEOUT_MS`]). Named
-//! contracts can raise either budget and move heavyweight cases into the
-//! harness's bounded serial lane. If either phase runs long — an infinite loop
+//! wall-clock hang guards selected from the declarative `ordinary`, `slow`, and
+//! `stress` profiles. Named contracts also move heavyweight cases into the
+//! harness's bounded serial lane. These generous guards are correctness
+//! backstops, not performance promises. If either phase runs long — an infinite loop
 //! in generated code, or a compile-time hang in comptime evaluation — its whole
 //! process group is killed and the diagnostic names the phase, elapsed time,
 //! and budget. `compile_only = true` still skips the run entirely for sources
@@ -117,9 +118,9 @@ use std::time::{Duration, Instant};
 use libtest2_mimic::{Harness, RunContext, RunError, Trial};
 use rue_target::{Arch, Target};
 use rue_test_runner::{
-    DEFAULT_TIMEOUT_MS, ExpectedFailureOutcome, KNOWN_TARGETS, ShardSelector, TestFailure,
-    TestResult, classify_expected_failure, compiler_command, find_dir, find_rue_binary,
-    ice_message, run_with_timeout, validate_nonempty_case_corpus,
+    ExpectedFailureOutcome, KNOWN_TARGETS, ShardSelector, TestFailure, TestResult,
+    classify_expected_failure, compiler_command, find_dir, find_rue_binary, ice_message,
+    run_with_timeout, validate_nonempty_case_corpus,
 };
 use serde::{Deserialize, Serialize};
 
@@ -804,7 +805,15 @@ struct TestFile {
     /// the same declarative corpus as cases lets automatic examples and TOML
     /// cases share one scheduling and timeout policy.
     #[serde(default, rename = "contract")]
-    contracts: HashMap<String, ExecutionContract>,
+    contracts: HashMap<String, ExecutionContractDeclaration>,
+    /// The one declarative authority for correctness hang guards. Contracts
+    /// select a named profile instead of inventing raw deadlines.
+    #[serde(default, rename = "timeout_profile")]
+    timeout_profiles: HashMap<TimeoutProfile, HangTimeoutProfile>,
+    /// Parsed here so unknown policy fields fail closed. The CI wrapper owns
+    /// the whole-suite derivation from these values.
+    #[serde(default)]
+    timeout_policy: Option<TimeoutPolicy>,
     /// Contracts and tiers for recursively discovered examples, keyed by the
     /// path that also determines their `cli.examples::...` test name.
     #[serde(default)]
@@ -883,8 +892,39 @@ enum ExecutionClass {
     Heavyweight,
 }
 
+#[derive(Debug, Clone, Copy, Deserialize, Hash, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum TimeoutProfile {
+    Ordinary,
+    Slow,
+    Stress,
+}
+
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
+struct HangTimeoutProfile {
+    compile_hang_timeout_ms: u64,
+    runtime_hang_timeout_ms: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct TimeoutPolicy {
+    expected_cost_multiplier_percent: u64,
+    fixed_headroom_ms: u64,
+    minimum_shard_timeout_ms: u64,
+    minimum_monolith_timeout_ms: u64,
+    minimum_slow_suite_timeout_ms: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct ExecutionContractDeclaration {
+    class: ExecutionClass,
+    timeout_profile: TimeoutProfile,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct ExecutionContract {
     class: ExecutionClass,
     compile_timeout_ms: u64,
@@ -892,14 +932,6 @@ struct ExecutionContract {
 }
 
 impl ExecutionContract {
-    fn ordinary() -> Self {
-        Self {
-            class: ExecutionClass::Ordinary,
-            compile_timeout_ms: DEFAULT_TIMEOUT_MS,
-            runtime_timeout_ms: DEFAULT_TIMEOUT_MS,
-        }
-    }
-
     fn compile_timeout(&self) -> Duration {
         Duration::from_millis(self.compile_timeout_ms)
     }
@@ -931,7 +963,8 @@ struct AutomaticExampleMetadata {
 #[derive(Debug)]
 struct LoadedCorpus {
     files: Vec<(String, TestFile)>,
-    contracts: HashMap<String, ExecutionContract>,
+    contracts: HashMap<String, ExecutionContractDeclaration>,
+    timeout_profiles: HashMap<TimeoutProfile, HangTimeoutProfile>,
     automatic_examples: Vec<AutomaticExampleContract>,
 }
 
@@ -2043,6 +2076,9 @@ fn load_cases(cases_dir: &Path) -> LoadedCorpus {
     let mut out = Vec::new();
     let mut contracts = HashMap::new();
     let mut contract_origins = HashMap::<String, String>::new();
+    let mut timeout_profiles = HashMap::new();
+    let mut timeout_profile_origins = HashMap::<TimeoutProfile, String>::new();
+    let mut timeout_policy_origin = None::<String>;
     let mut automatic_examples = Vec::new();
     for path in toml_files {
         let content = match std::fs::read_to_string(&path) {
@@ -2129,14 +2165,6 @@ fn load_cases(cases_dir: &Path) -> LoadedCorpus {
                 }
 
                 for (name, contract) in &tf.contracts {
-                    if contract.compile_timeout_ms == 0 || contract.runtime_timeout_ms == 0 {
-                        eprintln!(
-                            "error: {}: contract '{}' must use non-zero compile and runtime budgets",
-                            path.display(),
-                            name,
-                        );
-                        std::process::exit(1);
-                    }
                     if let Some(previous) =
                         contract_origins.insert(name.clone(), path.display().to_string())
                     {
@@ -2150,6 +2178,49 @@ fn load_cases(cases_dir: &Path) -> LoadedCorpus {
                     }
                     contracts.insert(name.clone(), contract.clone());
                 }
+                for (name, profile) in &tf.timeout_profiles {
+                    if profile.compile_hang_timeout_ms == 0 || profile.runtime_hang_timeout_ms == 0
+                    {
+                        eprintln!(
+                            "error: {}: timeout profile '{name:?}' must use non-zero hang guards",
+                            path.display(),
+                        );
+                        std::process::exit(1);
+                    }
+                    if let Some(previous) =
+                        timeout_profile_origins.insert(*name, path.display().to_string())
+                    {
+                        eprintln!(
+                            "error: {}: duplicate timeout profile '{name:?}' (already defined in {previous})",
+                            path.display(),
+                        );
+                        std::process::exit(1);
+                    }
+                    timeout_profiles.insert(*name, profile.clone());
+                }
+                if let Some(policy) = &tf.timeout_policy {
+                    if let Some(previous) =
+                        timeout_policy_origin.replace(path.display().to_string())
+                    {
+                        eprintln!(
+                            "error: {}: duplicate timeout_policy (already defined in {previous})",
+                            path.display(),
+                        );
+                        std::process::exit(1);
+                    }
+                    if policy.expected_cost_multiplier_percent < 100
+                        || policy.fixed_headroom_ms == 0
+                        || policy.minimum_shard_timeout_ms == 0
+                        || policy.minimum_monolith_timeout_ms == 0
+                        || policy.minimum_slow_suite_timeout_ms == 0
+                    {
+                        eprintln!(
+                            "error: {}: invalid zero or sub-100 timeout_policy value",
+                            path.display()
+                        );
+                        std::process::exit(1);
+                    }
+                }
                 automatic_examples.extend(tf.automatic_example.iter().cloned());
                 out.push((path.display().to_string(), tf));
             }
@@ -2162,6 +2233,7 @@ fn load_cases(cases_dir: &Path) -> LoadedCorpus {
     LoadedCorpus {
         files: out,
         contracts,
+        timeout_profiles,
         automatic_examples,
     }
 }
@@ -2171,15 +2243,30 @@ fn case_contract_name<'a>(section: &'a Section, case: &'a Case) -> Option<&'a st
 }
 
 fn resolve_contract(
-    contracts: &HashMap<String, ExecutionContract>,
+    contracts: &HashMap<String, ExecutionContractDeclaration>,
+    timeout_profiles: &HashMap<TimeoutProfile, HangTimeoutProfile>,
     name: Option<&str>,
 ) -> ExecutionContract {
-    name.map_or_else(ExecutionContract::ordinary, |name| {
-        contracts
-            .get(name)
-            .unwrap_or_else(|| panic!("contract '{name}' was not validated"))
-            .clone()
-    })
+    let declaration = name.map_or(
+        ExecutionContractDeclaration {
+            class: ExecutionClass::Ordinary,
+            timeout_profile: TimeoutProfile::Ordinary,
+        },
+        |name| {
+            contracts
+                .get(name)
+                .unwrap_or_else(|| panic!("contract '{name}' was not validated"))
+                .clone()
+        },
+    );
+    let profile = timeout_profiles
+        .get(&declaration.timeout_profile)
+        .unwrap_or_else(|| panic!("timeout profile was not validated"));
+    ExecutionContract {
+        class: declaration.class,
+        compile_timeout_ms: profile.compile_hang_timeout_ms,
+        runtime_timeout_ms: profile.runtime_hang_timeout_ms,
+    }
 }
 
 /// Validate the contract graph against the complete, unfiltered inventory.
@@ -2189,6 +2276,26 @@ fn validate_contract_metadata(
     corpus: &LoadedCorpus,
     discovered_examples: &HashSet<String>,
 ) -> Result<HashMap<String, AutomaticExampleMetadata>, String> {
+    for required in [
+        TimeoutProfile::Ordinary,
+        TimeoutProfile::Slow,
+        TimeoutProfile::Stress,
+    ] {
+        if !corpus.timeout_profiles.contains_key(&required) {
+            return Err(format!("missing required timeout profile '{required:?}'"));
+        }
+    }
+    for (name, contract) in &corpus.contracts {
+        if !corpus
+            .timeout_profiles
+            .contains_key(&contract.timeout_profile)
+        {
+            return Err(format!(
+                "execution contract '{name}' references missing timeout profile '{:?}'",
+                contract.timeout_profile
+            ));
+        }
+    }
     let mut used_contracts = HashSet::new();
 
     for (source, file) in &corpus.files {
@@ -2213,17 +2320,22 @@ fn validate_contract_metadata(
                 entry.path,
             ));
         }
-        let contract = corpus.contracts.get(&entry.contract).ok_or_else(|| {
-            format!(
+        if !corpus.contracts.contains_key(&entry.contract) {
+            return Err(format!(
                 "automatic example '{}' references unknown contract '{}'",
                 entry.path, entry.contract,
-            )
-        })?;
+            ));
+        }
+        let contract = resolve_contract(
+            &corpus.contracts,
+            &corpus.timeout_profiles,
+            Some(&entry.contract),
+        );
         if automatic_contracts
             .insert(
                 entry.path.clone(),
                 AutomaticExampleMetadata {
-                    contract: contract.clone(),
+                    contract,
                     tier: entry.tier,
                 },
             )
@@ -2433,6 +2545,7 @@ fn discover_examples() -> Result<Vec<DiscoveredExample>, String> {
 fn example_trials(
     examples: Vec<DiscoveredExample>,
     automatic_contracts: &HashMap<String, AutomaticExampleMetadata>,
+    timeout_profiles: &HashMap<TimeoutProfile, HangTimeoutProfile>,
     case_tier: CliCaseTierSelection,
     rue_binary: &Path,
     real_std: &Path,
@@ -2450,7 +2563,7 @@ fn example_trials(
         }
         let contract = metadata
             .map(|metadata| metadata.contract.clone())
-            .unwrap_or_else(ExecutionContract::ordinary);
+            .unwrap_or_else(|| resolve_contract(&HashMap::new(), timeout_profiles, None));
         let heavyweight = contract.is_heavyweight();
         let rue_binary = rue_binary.to_path_buf();
         let real_std = real_std.to_path_buf();
@@ -2577,6 +2690,7 @@ fn main() {
         std::process::exit(1);
     }
     let mut tests: Vec<Trial> = Vec::with_capacity(total);
+    let timeout_profiles = corpus.timeout_profiles.clone();
 
     for (_, file) in corpus.files {
         if !case_tier.includes(file.section.tier) {
@@ -2585,7 +2699,7 @@ fn main() {
         let section_id = file.section.id.clone();
         for case in file.cases {
             let contract_name = case_contract_name(&file.section, &case);
-            let contract = resolve_contract(&corpus.contracts, contract_name);
+            let contract = resolve_contract(&corpus.contracts, &timeout_profiles, contract_name);
             let heavyweight = contract.is_heavyweight();
             let test_name = format!("{}::{}", section_id, case.name);
             // RUE-1116: keep only the cases this shard owns (unset shard = all).
@@ -2618,6 +2732,7 @@ fn main() {
     tests.extend(example_trials(
         examples,
         &automatic_contracts,
+        &timeout_profiles,
         case_tier,
         &rue_binary,
         &real_std,
@@ -2684,9 +2799,22 @@ mod tests {
     }
 
     fn corpus_from_toml(source: &str) -> LoadedCorpus {
-        let file = toml::from_str::<TestFile>(source).expect("valid test corpus TOML");
+        let profiles = r#"
+            [timeout_profile.ordinary]
+            compile_hang_timeout_ms = 180000
+            runtime_hang_timeout_ms = 120000
+            [timeout_profile.slow]
+            compile_hang_timeout_ms = 900000
+            runtime_hang_timeout_ms = 300000
+            [timeout_profile.stress]
+            compile_hang_timeout_ms = 1800000
+            runtime_hang_timeout_ms = 600000
+        "#;
+        let source = format!("{profiles}\n{source}");
+        let file = toml::from_str::<TestFile>(&source).expect("valid test corpus TOML");
         LoadedCorpus {
             contracts: file.contracts.clone(),
+            timeout_profiles: file.timeout_profiles.clone(),
             automatic_examples: file.automatic_example.clone(),
             files: vec![("inline.toml".to_string(), file)],
         }
@@ -2734,8 +2862,7 @@ mod tests {
 
                     [contract.heavyweight]
                     class = "heavyweight"
-                    compile_timeout_ms = 30000
-                    runtime_timeout_ms = 30000
+                    timeout_profile = "slow"
 
                     [[automatic_example]]
                     path = "{example_path}"
@@ -2754,23 +2881,33 @@ mod tests {
             let file = &corpus.files[0].1;
             for case in &file.cases {
                 assert!(case.contract.is_none(), "case contract must stay inherited");
-                let explicit =
-                    resolve_contract(&corpus.contracts, case_contract_name(&file.section, case));
+                let explicit = resolve_contract(
+                    &corpus.contracts,
+                    &corpus.timeout_profiles,
+                    case_contract_name(&file.section, case),
+                );
                 assert_eq!(automatic[example_path].contract, explicit);
                 assert_eq!(automatic[example_path].tier, expected_tier);
                 assert!(explicit.is_heavyweight());
-                assert_eq!(explicit.compile_timeout(), Duration::from_secs(30));
-                assert_eq!(explicit.runtime_timeout(), Duration::from_secs(30));
+                assert_eq!(explicit.compile_timeout(), Duration::from_secs(900));
+                assert_eq!(explicit.runtime_timeout(), Duration::from_secs(300));
             }
         }
     }
 
     #[test]
-    fn ordinary_contract_keeps_strict_ten_second_defaults() {
-        let contract = ExecutionContract::ordinary();
+    fn ordinary_profile_has_generous_correctness_headroom() {
+        let corpus = corpus_from_toml(
+            r#"
+                [section]
+                id = "cli.contracts"
+                name = "contracts"
+            "#,
+        );
+        let contract = resolve_contract(&corpus.contracts, &corpus.timeout_profiles, None);
         assert!(!contract.is_heavyweight());
-        assert_eq!(contract.compile_timeout(), Duration::from_secs(10));
-        assert_eq!(contract.runtime_timeout(), Duration::from_secs(10));
+        assert_eq!(contract.compile_timeout(), Duration::from_secs(180));
+        assert_eq!(contract.runtime_timeout(), Duration::from_secs(120));
     }
 
     #[test]
@@ -2783,8 +2920,7 @@ mod tests {
 
                 [contract.heavy]
                 class = "heavyweight"
-                compile_timeout_ms = 30000
-                runtime_timeout_ms = 30000
+                timeout_profile = "ordinary"
 
                 [[automatic_example]]
                 path = "renamed/main.rue"
@@ -2843,7 +2979,7 @@ mod tests {
             class: ExecutionClass::Ordinary,
             // Keep fixture setup comfortably outside the forced runtime budget
             // so loaded hosts cannot turn this into a compiler-phase timeout.
-            compile_timeout_ms: DEFAULT_TIMEOUT_MS,
+            compile_timeout_ms: rue_test_runner::DEFAULT_TIMEOUT_MS,
             runtime_timeout_ms: 10,
         };
         let runtime_error = run_case(
@@ -3021,7 +3157,11 @@ mod tests {
 
         let result = run_case_differential(
             &case,
-            &ExecutionContract::ordinary(),
+            &ExecutionContract {
+                class: ExecutionClass::Ordinary,
+                compile_timeout_ms: rue_test_runner::DEFAULT_TIMEOUT_MS,
+                runtime_timeout_ms: rue_test_runner::DEFAULT_TIMEOUT_MS,
+            },
             &binary,
             Path::new("std"),
             Path::new("."),

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -174,6 +174,33 @@ heavy-suite discovery). Nothing else re-runs the slices on CI, so
 `CLI_TEST_SHARD_COUNT` therefore means updating the matrix (and branch
 protection) to match.
 
+### Correctness hang guards and performance budgets
+
+`crates/rue-cli-tests/cases/execution_contracts.toml` is the single authority
+for CLI timeout profiles. `ordinary`, `slow`, and `stress` are generous
+correctness hang guards, not promises about compiler speed. Cases select a
+named execution contract; raw per-case or per-contract millisecond deadlines
+are rejected so one-off budgets cannot drift into the corpus.
+
+The same file defines whole-suite headroom. `scripts/ci-heavy-suite` derives
+each shard's executor deadline from that shard's LPT-assigned expected cost,
+then adds proportional and fixed headroom and applies a conservative minimum.
+This lets a truly stuck compiler fail while leaving loaded CI hosts room to
+finish. Mosaic remains in the slow tier and uses the slow hang profile; stress
+programs remain opt-in or scheduled.
+
+Performance thresholds live in `benchmarks/manifest.toml` and are enforced by
+the separate Benchmarks workflow. A correctness timeout therefore never
+asserts that a case is fast enough. Conversely, benchmark regressions are
+reported as performance failures rather than being recast as correctness
+timeouts.
+
+The weekly Correctness repetitions workflow runs every ordinary CLI shard
+multiple independent times. It uploads per-run logs and a summary, continues
+after a failure only to gather flake evidence, and exits failed if *any*
+repetition failed; a later pass never masks an earlier failure. Required
+correctness jobs do not automatically retry failed cases.
+
 ## Affected-corpus selection on pull requests (RUE-1119)
 
 On a `pull_request` run, the heavy `platform-corpus` suites are selected down to

--- a/scripts/ci-heavy-suite
+++ b/scripts/ci-heavy-suite
@@ -23,28 +23,37 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# RUE-1083 recalibrated several per-case heavyweight compile budgets upward
-# while per-body incremental work continues, so the CLI corpus's serialized
-# heavyweight aggregate can exceed the test executor's 600-second default
-# (linux-arm64 shard 1 hit the outer timeout at 10:00 with zero case
-# failures). The outer margin is plumbing; the per-case contract budgets in
-# execution_contracts.toml remain the honest gates. Re-tighten when the
-# per-case budgets come back down.
+# CLI correctness deadlines come from the same declarative authority as the
+# per-case hang profiles. They include generous headroom and are deliberately
+# not performance promises; benchmark jobs own regression thresholds.
 test_args=("$target")
 timings=""
 case "$target" in
     //:cli-tests|//:cli-tests-slow)
-        test_args+=(-- --timeout 1800)
+        timeout_tool="${RUE_CLI_TIMEOUT_POLICY_TOOL:-scripts/cli-timeout-policy.py}"
+        timeout="$("$timeout_tool" \
+            --policy "${RUE_CLI_TIMEOUT_POLICY:-crates/rue-cli-tests/cases/execution_contracts.toml}" \
+            --weights "${RUE_CLI_SHARD_WEIGHTS:-crates/rue-cli-tests/shard-weights.json}" \
+            --target "$target")" || exit $?
+        test_args+=(-- --timeout "$timeout")
         ;;
     //:cli-tests-shard-*)
+        timeout_tool="${RUE_CLI_TIMEOUT_POLICY_TOOL:-scripts/cli-timeout-policy.py}"
+        timeout="$("$timeout_tool" \
+            --policy "${RUE_CLI_TIMEOUT_POLICY:-crates/rue-cli-tests/cases/execution_contracts.toml}" \
+            --weights "${RUE_CLI_SHARD_WEIGHTS:-crates/rue-cli-tests/shard-weights.json}" \
+            --target "$target")" || exit $?
         if [[ -n "${RUNNER_TEMP:-}" ]]; then
             timings="$RUNNER_TEMP/rue-cli-case-timings.jsonl"
         else
             timings="$(mktemp "${TMPDIR:-/tmp}/rue-cli-case-timings.XXXXXX")"
         fi
-        test_args+=(-- --timeout 1200 --env "RUE_CLI_CASE_TIMINGS=$timings")
+        test_args+=(-- --timeout "$timeout" --env "RUE_CLI_CASE_TIMINGS=$timings")
         ;;
 esac
+if [[ -n "${RUE_CORRECTNESS_REPETITION:-}" ]]; then
+    test_args+=(--env "RUE_CORRECTNESS_REPETITION=$RUE_CORRECTNESS_REPETITION")
+fi
 
 ./buck2 test "${test_args[@]}" 2>&1 | tee "$log"
 status=${PIPESTATUS[0]}

--- a/scripts/ci-repeat-correctness
+++ b/scripts/ci-repeat-correctness
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Repeat a correctness shard for flake detection. Every failure is retained:
+# later success is evidence of a flake, never an automatic retry that clears it.
+set -uo pipefail
+
+if [[ $# -ne 2 || "$1" != //:cli-tests-shard-* || ! "$2" =~ ^[1-9][0-9]*$ ]]; then
+    echo "usage: scripts/ci-repeat-correctness //:cli-tests-shard-N REPETITIONS" >&2
+    exit 2
+fi
+target="$1"
+repetitions="$2"
+if (( repetitions > 20 )); then
+    echo "error: repetitions must not exceed 20" >&2
+    exit 2
+fi
+
+log_dir="${RUE_REPETITION_LOG_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/rue-correctness-repetitions}"
+mkdir -p "$log_dir"
+failures=0
+for ((iteration = 1; iteration <= repetitions; iteration++)); do
+    log="$log_dir/repetition-$iteration.log"
+    echo "correctness repetition $iteration/$repetitions: $target"
+    if RUE_CORRECTNESS_REPETITION="$iteration" scripts/ci-heavy-suite "$target" 2>&1 | tee "$log"; then
+        result=PASS
+    else
+        result=FAIL
+        failures=$((failures + 1))
+    fi
+    printf '%s\t%s\t%s\n' "$iteration" "$result" "$log" >>"$log_dir/results.tsv"
+done
+
+{
+    echo "## Correctness repetition report"
+    echo
+    echo "\`$target\`: $failures failure(s) across $repetitions independent runs."
+    echo "Failures remain failures even if a later repetition passes; inspect the uploaded logs for the case name."
+} | tee "$log_dir/summary.md"
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    cat "$log_dir/summary.md" >>"$GITHUB_STEP_SUMMARY"
+fi
+(( failures == 0 ))

--- a/scripts/cli-timeout-policy.py
+++ b/scripts/cli-timeout-policy.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Validate CLI hang guards and derive whole-suite executor deadlines.
+
+The result is correctness plumbing, not a performance threshold. Shard
+deadlines deliberately combine measured expected cost with proportional and
+fixed headroom so a loaded worker does not turn a healthy case into a flake.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import platform
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+PROFILE_NAMES = ("ordinary", "slow", "stress")
+PROFILE_KEYS = {"compile_hang_timeout_ms", "runtime_hang_timeout_ms"}
+POLICY_KEYS = {
+    "expected_cost_multiplier_percent",
+    "fixed_headroom_ms",
+    "minimum_shard_timeout_ms",
+    "minimum_monolith_timeout_ms",
+    "minimum_slow_suite_timeout_ms",
+}
+
+
+def load_policy(path: Path) -> tuple[dict[str, dict[str, int]], dict[str, int]]:
+    data = tomllib.loads(path.read_text())
+    profiles = data.get("timeout_profile")
+    policy = data.get("timeout_policy")
+    if not isinstance(profiles, dict) or set(profiles) != set(PROFILE_NAMES):
+        raise ValueError(f"{path}: timeout_profile must define exactly {', '.join(PROFILE_NAMES)}")
+    for name in PROFILE_NAMES:
+        profile = profiles[name]
+        if not isinstance(profile, dict) or set(profile) != PROFILE_KEYS:
+            raise ValueError(f"{path}: timeout_profile.{name} has ambiguous or missing fields")
+        if any(type(profile[key]) is not int or profile[key] <= 0 for key in PROFILE_KEYS):
+            raise ValueError(f"{path}: timeout_profile.{name} values must be positive integers")
+    for phase in PROFILE_KEYS:
+        values = [profiles[name][phase] for name in PROFILE_NAMES]
+        if values != sorted(values) or len(set(values)) != len(values):
+            raise ValueError(f"{path}: {phase} must increase from ordinary through stress")
+    if not isinstance(policy, dict) or set(policy) != POLICY_KEYS:
+        raise ValueError(f"{path}: timeout_policy has ambiguous or missing fields")
+    if any(type(policy[key]) is not int or policy[key] <= 0 for key in POLICY_KEYS):
+        raise ValueError(f"{path}: timeout_policy values must be positive integers")
+    if policy["expected_cost_multiplier_percent"] < 100:
+        raise ValueError(f"{path}: expected_cost_multiplier_percent must be at least 100")
+
+    contracts = data.get("contract", {})
+    for name, contract in contracts.items():
+        if set(contract) != {"class", "timeout_profile"}:
+            raise ValueError(
+                f"{path}: contract.{name} must select class and timeout_profile; "
+                "raw deadlines are forbidden"
+            )
+        if contract["timeout_profile"] not in profiles:
+            raise ValueError(f"{path}: contract.{name} selects an unknown timeout profile")
+    return profiles, policy
+
+
+def host_platform() -> str:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if system == "darwin":
+        return "macos"
+    if system == "linux" and machine in ("aarch64", "arm64"):
+        return "linux-arm64"
+    if system == "linux" and machine in ("x86_64", "amd64"):
+        return "linux-x64"
+    return "other"
+
+
+def shard_loads(path: Path, platform_name: str, count: int) -> list[int]:
+    data = json.loads(path.read_text())
+    if data.get("version") != 1:
+        raise ValueError(f"{path}: unsupported weights version")
+    common = data.get("common", {})
+    platform_weights = data.get("platforms", {}).get(platform_name, {})
+    names = set(common) | set(platform_weights)
+    weighted = [(name, platform_weights.get(name, common.get(name))) for name in names]
+    if not weighted or any(type(weight) is not int or weight <= 0 for _, weight in weighted):
+        raise ValueError(f"{path}: weights must be non-empty positive integers")
+    weighted.sort(key=lambda item: (-item[1], item[0]))
+    loads = [0] * count
+    case_counts = [0] * count
+    for _, weight in weighted:
+        index = min(range(count), key=lambda i: (loads[i], case_counts[i], i))
+        loads[index] += weight
+        case_counts[index] += 1
+    return loads
+
+
+def derive_timeout_ms(expected_ms: int, minimum_ms: int, policy: dict[str, int]) -> int:
+    scaled = math.ceil(
+        expected_ms * policy["expected_cost_multiplier_percent"] / 100
+    )
+    return max(minimum_ms, scaled + policy["fixed_headroom_ms"])
+
+
+def timeout_for_target(
+    target: str, weights_path: Path, platform_name: str, policy: dict[str, int]
+) -> tuple[int, int | None]:
+    match = re.fullmatch(r"//:cli-tests-shard-(\d+)", target)
+    if match:
+        index = int(match.group(1))
+        count = 4
+        if index >= count:
+            raise ValueError(f"invalid CLI shard index {index}")
+        expected = shard_loads(weights_path, platform_name, count)[index]
+        return (
+            derive_timeout_ms(expected, policy["minimum_shard_timeout_ms"], policy),
+            expected,
+        )
+    if target == "//:cli-tests":
+        expected = sum(shard_loads(weights_path, platform_name, 1))
+        return (
+            derive_timeout_ms(expected, policy["minimum_monolith_timeout_ms"], policy),
+            expected,
+        )
+    if target == "//:cli-tests-slow":
+        return policy["minimum_slow_suite_timeout_ms"], None
+    raise ValueError(f"no CLI timeout policy for target {target}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--policy",
+        type=Path,
+        default=Path("crates/rue-cli-tests/cases/execution_contracts.toml"),
+    )
+    parser.add_argument(
+        "--weights", type=Path, default=Path("crates/rue-cli-tests/shard-weights.json")
+    )
+    parser.add_argument("--platform", default=host_platform())
+    parser.add_argument("--target")
+    args = parser.parse_args()
+    try:
+        _, policy = load_policy(args.policy)
+        if args.target is None:
+            print("CLI timeout policy valid")
+            return 0
+        timeout_ms, expected_ms = timeout_for_target(
+            args.target, args.weights, args.platform, policy
+        )
+        detail = (
+            "fixed slow-suite guard"
+            if expected_ms is None
+            else f"expected={expected_ms}ms plus declarative headroom"
+        )
+        print(
+            f"cli timeout policy: {args.target} {detail}; "
+            f"correctness deadline={timeout_ms}ms (not a performance threshold)",
+            file=sys.stderr,
+        )
+        print(math.ceil(timeout_ms / 1000))
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError, tomllib.TOMLDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -243,7 +243,25 @@ test_full_suite_orchestration() {
     cp "$SRC_ROOT/test.sh" "$sb/test.sh"
     cp "$SRC_ROOT/scripts/ci-heavy-suite" "$sb/scripts/ci-heavy-suite"
     cp "$SRC_ROOT/scripts/with-full-suite-lock" "$sb/scripts/with-full-suite-lock"
-    chmod +x "$sb/test.sh" "$sb/scripts/ci-heavy-suite" "$sb/scripts/with-full-suite-lock"
+    cat >"$sb/scripts/cli-timeout-policy.py" <<'EOF'
+#!/usr/bin/env bash
+target=""
+while [[ "$#" -gt 0 ]]; do
+    if [[ "$1" == "--target" ]]; then
+        target="$2"
+        shift 2
+    else
+        shift
+    fi
+done
+case "$target" in
+    //:cli-tests) echo 3600 ;;
+    //:cli-tests-slow) echo 7200 ;;
+    *) exit 2 ;;
+esac
+EOF
+    chmod +x "$sb/test.sh" "$sb/scripts/ci-heavy-suite" \
+        "$sb/scripts/cli-timeout-policy.py" "$sb/scripts/with-full-suite-lock"
     cat >"$sb/buck2" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$BUCK_LOG"
@@ -292,10 +310,10 @@ EOF
         "$(grep -Fxq 'test //... toolchains//... --exclude rue_heavy_suite --always-exclude --ignore-tests-attribute --exclude rue_test_tier_stress' "$sb/calls" && echo 0 || echo 1)"
     check "suite: heavy targets are discovered from the live graph" \
         "$(grep -Fxq 'uquery attrfilter(labels, rue_heavy_suite, //...)' "$sb/calls" && echo 0 || echo 1)"
-    check "suite: premerge CLI corpus receives the extended executor timeout" \
-        "$(grep -Fxq 'test //:cli-tests -- --timeout 1800' "$sb/calls" && echo 0 || echo 1)"
-    check "suite: slow CLI corpus receives the extended executor timeout" \
-        "$(grep -Fxq 'test //:cli-tests-slow -- --timeout 1800' "$sb/calls" && echo 0 || echo 1)"
+    check "suite: premerge CLI corpus receives the derived executor timeout" \
+        "$(grep -Fxq 'test //:cli-tests -- --timeout 3600' "$sb/calls" && echo 0 || echo 1)"
+    check "suite: slow CLI corpus receives the declarative executor timeout" \
+        "$(grep -Fxq 'test //:cli-tests-slow -- --timeout 7200' "$sb/calls" && echo 0 || echo 1)"
     check "suite: every other heavy target uses the default executor timeout" \
         "$([ "$(grep -Ec '^test //:(spec-tests|ui-tests|oracle-diff-generated-smoke|reproducible-programs|frontend-diff-test)$' "$sb/calls")" -eq 5 ] && echo 0 || echo 1)"
     check "suite: no concurrent heavy label sweep occurs" \

--- a/scripts/test-ci-repeat-correctness.sh
+++ b/scripts/test-ci-repeat-correctness.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/scripts" "$tmp/logs"
+cp "$root/scripts/ci-repeat-correctness" "$tmp/scripts/"
+chmod +x "$tmp/scripts/ci-repeat-correctness"
+cat >"$tmp/scripts/ci-heavy-suite" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$RUE_CORRECTNESS_REPETITION" >>"${FAKE_CALLS:?}"
+[[ "$RUE_CORRECTNESS_REPETITION" != "${FAKE_FAIL_ON:-}" ]]
+EOF
+chmod +x "$tmp/scripts/ci-heavy-suite"
+
+status=0
+(cd "$tmp" && FAKE_CALLS="$tmp/calls" FAKE_FAIL_ON=1 RUE_REPETITION_LOG_DIR="$tmp/logs" \
+    scripts/ci-repeat-correctness //:cli-tests-shard-0 3) >/dev/null 2>&1 || status=$?
+[[ "$status" -ne 0 ]]
+[[ "$(wc -l <"$tmp/calls" | tr -d ' ')" = 3 ]]
+grep -Fq $'1\tFAIL' "$tmp/logs/results.tsv"
+grep -Fq $'2\tPASS' "$tmp/logs/results.tsv"
+
+: >"$tmp/calls"
+rm -rf "$tmp/logs"
+status=0
+(cd "$tmp" && FAKE_CALLS="$tmp/calls" RUE_REPETITION_LOG_DIR="$tmp/logs" \
+    scripts/ci-repeat-correctness //:cli-tests-shard-1 2) >/dev/null 2>&1 || status=$?
+[[ "$status" -eq 0 ]]
+[[ "$(wc -l <"$tmp/calls" | tr -d ' ')" = 2 ]]

--- a/scripts/test-cli-timeout-policy.py
+++ b/scripts/test-cli-timeout-policy.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+import importlib.util
+import os
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("cli-timeout-policy.py")
+SPEC = importlib.util.spec_from_file_location("cli_timeout_policy", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class TimeoutPolicyTests(unittest.TestCase):
+    def test_mosaic_section_and_automatic_example_use_slow_profile(self):
+        cases = Path(os.environ["RUE_CLI_CASES"])
+        authority = tomllib.loads((cases / "execution_contracts.toml").read_text())
+        mosaic = tomllib.loads((cases / "examples_mosaic.toml").read_text())
+        automatic = next(
+            entry
+            for entry in authority["automatic_example"]
+            if entry["path"] == "mosaic/main.rue"
+        )
+        self.assertEqual(automatic["tier"], "slow")
+        self.assertEqual(automatic["contract"], "heavyweight_long")
+        self.assertEqual(mosaic["section"]["tier"], "slow")
+        self.assertEqual(mosaic["section"]["contract"], "heavyweight_long")
+        self.assertEqual(
+            authority["contract"]["heavyweight_long"]["timeout_profile"], "slow"
+        )
+
+    def test_shards_use_lpt_expected_cost_plus_headroom(self):
+        with tempfile.TemporaryDirectory() as directory:
+            weights = Path(directory) / "weights.json"
+            weights.write_text(
+                '{"version":1,"default_ms":1,"common":{"a":1000,"b":800,"c":600},'
+                '"platforms":{"macos":{"c":1000}}}'
+            )
+            policy = {
+                "expected_cost_multiplier_percent": 150,
+                "fixed_headroom_ms": 500,
+                "minimum_shard_timeout_ms": 1,
+                "minimum_monolith_timeout_ms": 1,
+                "minimum_slow_suite_timeout_ms": 9000,
+            }
+            timeout, expected = MODULE.timeout_for_target(
+                "//:cli-tests-shard-0", weights, "macos", policy
+            )
+            self.assertEqual(expected, 1000)
+            self.assertEqual(timeout, 2000)
+
+    def test_minimum_prevents_sparse_weight_underbudget(self):
+        policy = {
+            "expected_cost_multiplier_percent": 150,
+            "fixed_headroom_ms": 500,
+            "minimum_shard_timeout_ms": 5000,
+        }
+        self.assertEqual(MODULE.derive_timeout_ms(10, 5000, policy), 5000)
+
+    def test_raw_contract_deadlines_are_rejected(self):
+        text = """
+[timeout_profile.ordinary]
+compile_hang_timeout_ms=1
+runtime_hang_timeout_ms=1
+[timeout_profile.slow]
+compile_hang_timeout_ms=2
+runtime_hang_timeout_ms=2
+[timeout_profile.stress]
+compile_hang_timeout_ms=3
+runtime_hang_timeout_ms=3
+[timeout_policy]
+expected_cost_multiplier_percent=100
+fixed_headroom_ms=1
+minimum_shard_timeout_ms=1
+minimum_monolith_timeout_ms=1
+minimum_slow_suite_timeout_ms=1
+[contract.bad]
+class="ordinary"
+compile_timeout_ms=10
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "policy.toml"
+            path.write_text(text)
+            with self.assertRaisesRegex(ValueError, "raw deadlines are forbidden"):
+                MODULE.load_policy(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-timeout-workflow-contracts.py
+++ b/scripts/test-timeout-workflow-contracts.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Pin the separation between correctness repetition and performance gates."""
+
+import os
+import unittest
+from pathlib import Path
+
+ROOT = Path(os.environ.get("RUE_TIMEOUT_WORKFLOW_ROOT", Path(__file__).parent.parent))
+
+
+class WorkflowContractTests(unittest.TestCase):
+    def test_correctness_repetitions_are_scheduled_and_never_mask_failure(self):
+        workflow = (ROOT / ".github/workflows/correctness-repetitions.yml").read_text()
+        script = (ROOT / "scripts/ci-repeat-correctness").read_text()
+        self.assertIn("schedule:", workflow)
+        self.assertIn("fail-fast: false", workflow)
+        self.assertIn("if: always()", workflow)
+        self.assertIn("scripts/ci-repeat-correctness", workflow)
+        self.assertIn("failures=$((failures + 1))", script)
+        self.assertIn("(( failures == 0 ))", script)
+        self.assertNotIn("until scripts/ci-heavy-suite", script.lower())
+        self.assertNotIn("while scripts/ci-heavy-suite", script.lower())
+
+    def test_performance_thresholds_live_in_benchmark_workflow(self):
+        benchmark = (ROOT / ".github/workflows/benchmarks.yml").read_text()
+        correctness = (ROOT / ".github/workflows/correctness-repetitions.yml").read_text()
+        self.assertIn("enforce performance thresholds", benchmark)
+        self.assertIn("./bench.sh", benchmark)
+        self.assertNotIn("bench.sh", correctness)
+        self.assertNotIn("enforce-budgets", correctness)
+
+    def test_required_correctness_workflow_has_no_retry_action(self):
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text().lower()
+        self.assertNotIn("retry@", workflow)
+        self.assertNotIn("nick-fields/retry", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -788,6 +788,21 @@ test_cache_probe_counter_validation() {
 test_ci_heavy_suite_audits_its_target() {
   local sb; sb="$(mktemp -d)"
   cp "$SRC_ROOT/scripts/ci-heavy-suite" "$sb/ci-heavy-suite"; chmod +x "$sb/ci-heavy-suite"
+  mkdir -p "$sb/scripts"
+  cat >"$sb/scripts/cli-timeout-policy.py" <<'EOF'
+#!/usr/bin/env bash
+target=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--target" ]; then target="$2"; shift 2; else shift; fi
+done
+case "$target" in
+  //:cli-tests) echo 3600 ;;
+  //:cli-tests-slow) echo 7200 ;;
+  //:cli-tests-shard-*) echo 1234 ;;
+  *) exit 2 ;;
+esac
+EOF
+  chmod +x "$sb/scripts/cli-timeout-policy.py"
   cat >"$sb/buck2" <<'EOF'
 #!/usr/bin/env bash
 if [ "$1" = "uquery" ]; then
@@ -823,20 +838,20 @@ EOF
   : >"$sb/calls.log"
   rc=0
   (cd "$sb" && FAKE_CALL_LOG="$sb/calls.log" ./ci-heavy-suite //:cli-tests) >/dev/null 2>&1 || rc=$?
-  check "ci-heavy-suite: premerge CLI corpus receives the extended executor timeout" \
-    "$([ "$rc" -eq 0 ] && grep -Fxq 'test //:cli-tests -- --timeout 1800' "$sb/calls.log" && echo 0 || echo 1)"
+  check "ci-heavy-suite: premerge CLI corpus receives the derived executor timeout" \
+    "$([ "$rc" -eq 0 ] && grep -Fxq 'test //:cli-tests -- --timeout 3600' "$sb/calls.log" && echo 0 || echo 1)"
 
   : >"$sb/calls.log"
   rc=0
   (cd "$sb" && FAKE_LABELED_TARGET=//:cli-tests-slow FAKE_CALL_LOG="$sb/calls.log" ./ci-heavy-suite //:cli-tests-slow) >/dev/null 2>&1 || rc=$?
-  check "ci-heavy-suite: slow CLI corpus receives the extended executor timeout" \
-    "$([ "$rc" -eq 0 ] && grep -Fxq 'test //:cli-tests-slow -- --timeout 1800' "$sb/calls.log" && echo 0 || echo 1)"
+  check "ci-heavy-suite: slow CLI corpus receives the declarative executor timeout" \
+    "$([ "$rc" -eq 0 ] && grep -Fxq 'test //:cli-tests-slow -- --timeout 7200' "$sb/calls.log" && echo 0 || echo 1)"
 
   : >"$sb/calls.log"
   rc=0
   (cd "$sb" && FAKE_LABELED_TARGET=//:cli-tests-shard-1 FAKE_CALL_LOG="$sb/calls.log" ./ci-heavy-suite //:cli-tests-shard-1) >/dev/null 2>&1 || rc=$?
-  check "ci-heavy-suite: CLI shard receives the extended executor timeout" \
-    "$([ "$rc" -eq 0 ] && grep -Eq '^test //:cli-tests-shard-1 -- --timeout 1200 --env RUE_CLI_CASE_TIMINGS=' "$sb/calls.log" && echo 0 || echo 1)"
+  check "ci-heavy-suite: CLI shard receives the cost-derived executor timeout" \
+    "$([ "$rc" -eq 0 ] && grep -Eq '^test //:cli-tests-shard-1 -- --timeout 1234 --env RUE_CLI_CASE_TIMINGS=' "$sb/calls.log" && echo 0 || echo 1)"
 
   local other_target
   for other_target in \
@@ -888,7 +903,20 @@ test_testsh_unfiltered_audits_corpus_presence() {
   mkdir -p "$sb/scripts"
   cp "$SRC_ROOT/test.sh" "$sb/test.sh"
   cp "$SRC_ROOT/scripts/ci-heavy-suite" "$sb/scripts/ci-heavy-suite"
-  chmod +x "$sb/test.sh" "$sb/scripts/ci-heavy-suite"
+  cat >"$sb/scripts/cli-timeout-policy.py" <<'EOF'
+#!/usr/bin/env bash
+target=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--target" ]; then target="$2"; shift 2; else shift; fi
+done
+case "$target" in
+  //:cli-tests) echo 3600 ;;
+  //:cli-tests-slow) echo 7200 ;;
+  //:cli-tests-shard-*) echo 1234 ;;
+  *) exit 2 ;;
+esac
+EOF
+  chmod +x "$sb/test.sh" "$sb/scripts/ci-heavy-suite" "$sb/scripts/cli-timeout-policy.py"
   cat >"$sb/buck2" <<'EOF'
 #!/usr/bin/env bash
 if [ "$1" = "uquery" ]; then
@@ -953,7 +981,7 @@ EOF
       RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" \
       FAKE_PASS_TARGETS='//:cli-tests-slow' FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
   check "test.sh: slow selection audits its real CLI corpus target" \
-    "$([ "$rc" -eq 0 ] && grep -Fq -- '--include rue_test_tier_slow' "$sb/calls.log" && grep -Fq 'test //:cli-tests-slow -- --timeout 1800' "$sb/calls.log" && echo 0 || echo 1)"
+    "$([ "$rc" -eq 0 ] && grep -Fq -- '--include rue_test_tier_slow' "$sb/calls.log" && grep -Fq 'test //:cli-tests-slow -- --timeout 7200' "$sb/calls.log" && echo 0 || echo 1)"
 
   # (2) A corpus harness OMITTED while every buck2 invocation still exits 0 is
   #     the RUE-924 false-green: it must become a hard failure naming the suite.


### PR DESCRIPTION
## Summary

- replace raw CLI case deadlines with declarative ordinary, slow, and stress correctness hang profiles
- derive whole-shard executor limits from measured LPT shard cost plus fixed and proportional headroom
- keep Mosaic in scheduled slow coverage and keep benchmark thresholds in the benchmark workflow
- add a weekly/manual correctness-repetition workflow that preserves every failed attempt and uploads its logs
- validate timeout metadata, workflow separation, exact wrapper arguments, and no-retry behavior

## Why

Correct CLI cases could fail under runner contention when performance-shaped deadlines were used as semantic correctness gates. The new profiles are generous hang protection, while performance regressions remain independently measured and reported by the benchmark workflow.

## Validation

- `scripts/rue quick`
- focused timeout-policy, repetition, workflow-contract, and wrapper tests
- all CLI harness unit tests and a real CLI welcome smoke
- `scripts/rue fmt check`
- Actionlint 1.7.12

Fixes RUE-1159.
