### PR TITLE
RUE-1175: optimize wrapping arithmetic

### DIFF
--- a/crates/rue-cfg/src/opt/constfold.rs
+++ b/crates/rue-cfg/src/opt/constfold.rs
@@ -6,7 +6,7 @@
 //!
 //! ## What gets folded
 //!
-//! - Binary arithmetic: add, sub, mul, div, mod
+//! - Binary arithmetic: add, sub, mul, wrapping add/sub/mul, div, mod
 //! - Comparisons: eq, ne, lt, gt, le, ge
 //! - Bitwise: and, or, xor, shl, shr
 //! - Logical: and, or (on booleans)
@@ -52,6 +52,27 @@ pub(super) fn fold_instruction(cfg: &mut Cfg, value: CfgValue) -> bool {
                     (get_const_int(cfg, *lhs) == Some(0) || get_const_int(cfg, *rhs) == Some(0))
                         .then_some(CfgInstData::Const(0))
                 })
+        }
+        CfgInstData::WrappingAdd(lhs, rhs) => fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| {
+            Some(truncate_to_type(a.wrapping_add(b), ty))
+        }),
+        CfgInstData::WrappingSub(lhs, rhs) => {
+            fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| {
+                Some(truncate_to_type(a.wrapping_sub(b), ty))
+            })
+            // x wrapping_sub x is always zero and cannot trap.
+            .or_else(|| (lhs == rhs).then_some(CfgInstData::Const(0)))
+        }
+        CfgInstData::WrappingMul(lhs, rhs) => {
+            fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| {
+                Some(truncate_to_type(a.wrapping_mul(b), ty))
+            })
+            // Wrapping multiplication never traps, so either zero operand
+            // annihilates the result even when the other operand is dynamic.
+            .or_else(|| {
+                (get_const_int(cfg, *lhs) == Some(0) || get_const_int(cfg, *rhs) == Some(0))
+                    .then_some(CfgInstData::Const(0))
+            })
         }
         CfgInstData::Div(lhs, rhs) => {
             fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| checked_div(a, b, ty))
@@ -554,6 +575,36 @@ mod tests {
         )
     }
 
+    fn assert_wrapping_fold(
+        ty: Type,
+        lhs: u64,
+        rhs: u64,
+        op: fn(CfgValue, CfgValue) -> CfgInstData,
+        expected: u64,
+    ) {
+        let mut cfg = make_cfg();
+        let lhs = add_const(&mut cfg, lhs, ty);
+        let rhs = add_const(&mut cfg, rhs, ty);
+        let entry = cfg.entry;
+        let result = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: op(lhs, rhs),
+                ty,
+                span: Span::new(0, 0),
+            },
+        );
+        finalize_cfg(&mut cfg, result);
+
+        crate::opt::constopt::run(&mut cfg);
+
+        assert!(
+            matches!(cfg.get_inst(result).data, CfgInstData::Const(v) if v == expected),
+            "{ty:?}: expected Const({expected}), got {:?}",
+            cfg.get_inst(result).data
+        );
+    }
+
     fn finalize_cfg(cfg: &mut Cfg, ret_val: CfgValue) {
         let entry = cfg.entry;
         cfg.set_terminator(
@@ -579,6 +630,111 @@ mod tests {
             CfgInstData::Const(5) => {}
             other => panic!("Expected Const(5), got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_fold_wrapping_arithmetic_all_integer_types() {
+        #[allow(clippy::type_complexity)]
+        let cases: [(Type, u64, u64, u64, u64, u64, u64); 8] = [
+            (
+                Type::I8,
+                i8::MAX as u64,
+                (i8::MIN as i64) as u64,
+                (i8::MIN as i64) as u64,
+                i8::MAX as u64,
+                64,
+                (i8::MIN as i64) as u64,
+            ),
+            (
+                Type::I16,
+                i16::MAX as u64,
+                (i16::MIN as i64) as u64,
+                (i16::MIN as i64) as u64,
+                i16::MAX as u64,
+                16_384,
+                (i16::MIN as i64) as u64,
+            ),
+            (
+                Type::I32,
+                i32::MAX as u64,
+                (i32::MIN as i64) as u64,
+                (i32::MIN as i64) as u64,
+                i32::MAX as u64,
+                1_073_741_824,
+                (i32::MIN as i64) as u64,
+            ),
+            (
+                Type::I64,
+                i64::MAX as u64,
+                i64::MIN as u64,
+                i64::MIN as u64,
+                i64::MAX as u64,
+                4_611_686_018_427_387_904,
+                i64::MIN as u64,
+            ),
+            (Type::U8, u8::MAX as u64, 0, 0, u8::MAX as u64, 128, 0),
+            (Type::U16, u16::MAX as u64, 0, 0, u16::MAX as u64, 32_768, 0),
+            (
+                Type::U32,
+                u32::MAX as u64,
+                0,
+                0,
+                u32::MAX as u64,
+                2_147_483_648,
+                0,
+            ),
+            (
+                Type::U64,
+                u64::MAX,
+                0,
+                0,
+                u64::MAX,
+                9_223_372_036_854_775_808,
+                0,
+            ),
+        ];
+
+        for (ty, add_lhs, add_expected, sub_lhs, sub_expected, mul_lhs, mul_expected) in cases {
+            assert_wrapping_fold(ty, add_lhs, 1, CfgInstData::WrappingAdd, add_expected);
+            assert_wrapping_fold(ty, sub_lhs, 1, CfgInstData::WrappingSub, sub_expected);
+            assert_wrapping_fold(ty, mul_lhs, 2, CfgInstData::WrappingMul, mul_expected);
+        }
+    }
+
+    #[test]
+    fn test_fold_dynamic_wrapping_annihilators() {
+        let mut cfg = make_cfg();
+        let x = cfg.add_inst_to_block(
+            cfg.entry,
+            CfgInst {
+                data: CfgInstData::Param { index: 0 },
+                ty: Type::U32,
+                span: Span::new(0, 0),
+            },
+        );
+        let zero = add_const(&mut cfg, 0, Type::U32);
+        let sub = cfg.add_inst_to_block(
+            cfg.entry,
+            CfgInst {
+                data: CfgInstData::WrappingSub(x, x),
+                ty: Type::U32,
+                span: Span::new(0, 0),
+            },
+        );
+        let mul = cfg.add_inst_to_block(
+            cfg.entry,
+            CfgInst {
+                data: CfgInstData::WrappingMul(sub, zero),
+                ty: Type::U32,
+                span: Span::new(0, 0),
+            },
+        );
+        finalize_cfg(&mut cfg, mul);
+
+        crate::opt::constopt::run(&mut cfg);
+
+        assert!(matches!(cfg.get_inst(sub).data, CfgInstData::Const(0)));
+        assert!(matches!(cfg.get_inst(mul).data, CfgInstData::Const(0)));
     }
 
     #[test]

--- a/crates/rue-cfg/src/opt/constopt.rs
+++ b/crates/rue-cfg/src/opt/constopt.rs
@@ -574,6 +574,25 @@ mod tests {
         push(cfg, CfgInstData::Load { slot: len - 1 }, Type::I64)
     }
 
+    fn build_wrapping_let_chain(cfg: &mut Cfg, len: u32) -> CfgValue {
+        let zero = push(cfg, CfgInstData::Const(0), Type::U64);
+        push(
+            cfg,
+            CfgInstData::Alloc {
+                slot: 0,
+                init: zero,
+            },
+            Type::UNIT,
+        );
+        for i in 1..len {
+            let prev = push(cfg, CfgInstData::Load { slot: i - 1 }, Type::U64);
+            let one = push(cfg, CfgInstData::Const(1), Type::U64);
+            let sum = push(cfg, CfgInstData::WrappingAdd(prev, one), Type::U64);
+            push(cfg, CfgInstData::Alloc { slot: i, init: sum }, Type::UNIT);
+        }
+        push(cfg, CfgInstData::Load { slot: len - 1 }, Type::U64)
+    }
+
     #[test]
     fn test_let_chain_fully_propagates() {
         // The RUE-794 workload: every binding's constant is exposed only by
@@ -616,6 +635,31 @@ mod tests {
             // Every Add folded and every Load was rewritten.
             assert_eq!(stats.folded, (len - 1) as u64);
             assert_eq!(stats.loads_rewritten, len as u64);
+        }
+    }
+
+    #[test]
+    fn test_wrapping_let_chain_work_is_linear() {
+        for len in [100, 200, 400] {
+            let mut cfg = make_cfg(len);
+            let last = build_wrapping_let_chain(&mut cfg, len);
+            cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(last) });
+
+            let stats = run(&mut cfg);
+            let values = cfg.value_count() as u64;
+            assert!(
+                stats.fold_attempts <= 3 * values,
+                "wrapping chain len {}: {} fold attempts for {} values exceeds the sparse bound",
+                len,
+                stats.fold_attempts,
+                values
+            );
+            assert_eq!(stats.folded, (len - 1) as u64);
+            assert_eq!(stats.loads_rewritten, len as u64);
+            assert!(matches!(
+                cfg.get_inst(last).data,
+                CfgInstData::Const(v) if v == (len - 1) as u64
+            ));
         }
     }
 }

--- a/crates/rue-cfg/src/opt/cse.rs
+++ b/crates/rue-cfg/src/opt/cse.rs
@@ -19,10 +19,10 @@
 //!
 //! Only pure-by-value instructions whose result is a deterministic function of
 //! their SSA operands: `Const`, `BoolConst`, `StringConst`, the binary
-//! arithmetic/comparison/bitwise/shift ops, the unary `Neg`/`Not`/`BitNot`, and
-//! reads of a never-written parameter (see below). These read only SSA values,
-//! never memory, so there are no memory barriers to track. Deliberately NOT
-//! keyed:
+//! arithmetic (including wrapping arithmetic)/comparison/bitwise/shift ops, the
+//! unary `Neg`/`Not`/`BitNot`, and reads of a never-written parameter (see
+//! below). These read only SSA values, never memory, so there are no memory
+//! barriers to track. Deliberately NOT keyed:
 //!
 //! * `Load`/`PlaceRead` — read memory, which needs versioning to dedupe safely
 //!   (a store between two loads can change the result). Out of scope here.
@@ -65,10 +65,10 @@
 //! `c = a+b; d = a+b; e = c+1; f = d+1`, numbering `d` records `d -> c`, which
 //! makes `f`'s resolved key equal `e`'s. The result type is part of the key so
 //! same-shape ops that produce different types never merge. For the commutative
-//! ops only — `Add`, `Mul`, `Eq`, `Ne`, `BitAnd`, `BitOr`, `BitXor` — the two
-//! operand ids are sorted so `Add(a,b)` and `Add(b,a)` share a key.
-//! `Sub`/`Div`/`Mod`/`Shl`/`Shr` and the ordered comparisons are order-sensitive
-//! and keyed as written.
+//! ops only — `Add`, `Mul`, `WrappingAdd`, `WrappingMul`, `Eq`, `Ne`, `BitAnd`,
+//! `BitOr`, `BitXor` — the two operand ids are sorted so `Add(a,b)` and
+//! `Add(b,a)` share a key. `Sub`/`WrappingSub`/`Div`/`Mod`/`Shl`/`Shr` and the
+//! ordered comparisons are order-sensitive and keyed as written.
 //!
 //! ### Replacing a duplicate
 //!
@@ -174,6 +174,8 @@ fn key_of(
         CfgInstData::BitAnd(a, b) => commutative(4, r(a), r(b), ty),
         CfgInstData::BitOr(a, b) => commutative(5, r(a), r(b), ty),
         CfgInstData::BitXor(a, b) => commutative(6, r(a), r(b), ty),
+        CfgInstData::WrappingAdd(a, b) => commutative(19, r(a), r(b), ty),
+        CfgInstData::WrappingMul(a, b) => commutative(20, r(a), r(b), ty),
 
         // Order-sensitive binary ops: operands kept as written.
         CfgInstData::Sub(a, b) => VnKey::Binary(7, r(a), r(b), ty),
@@ -185,6 +187,7 @@ fn key_of(
         CfgInstData::Ge(a, b) => VnKey::Binary(13, r(a), r(b), ty),
         CfgInstData::Shl(a, b) => VnKey::Binary(14, r(a), r(b), ty),
         CfgInstData::Shr(a, b) => VnKey::Binary(15, r(a), r(b), ty),
+        CfgInstData::WrappingSub(a, b) => VnKey::Binary(21, r(a), r(b), ty),
 
         // Unary ops.
         CfgInstData::Neg(a) => VnKey::Unary(16, r(a), ty),
@@ -375,6 +378,45 @@ mod tests {
         assert!(matches!(
             cfg.get_block(cfg.entry).terminator,
             Terminator::Return { value: Some(v) } if v == add1
+        ));
+    }
+
+    #[test]
+    fn test_wrapping_arithmetic_dedupes_with_correct_commutativity() {
+        let mut cfg = make_cfg();
+        let a = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let b = push(&mut cfg, CfgInstData::Param { index: 1 }, Type::I32);
+        let add1 = push(&mut cfg, CfgInstData::WrappingAdd(a, b), Type::I32);
+        let add2 = push(&mut cfg, CfgInstData::WrappingAdd(b, a), Type::I32);
+        let mul1 = push(&mut cfg, CfgInstData::WrappingMul(a, b), Type::I32);
+        let mul2 = push(&mut cfg, CfgInstData::WrappingMul(b, a), Type::I32);
+        let sub1 = push(&mut cfg, CfgInstData::WrappingSub(a, b), Type::I32);
+        let sub2 = push(&mut cfg, CfgInstData::WrappingSub(a, b), Type::I32);
+        let reversed_sub = push(&mut cfg, CfgInstData::WrappingSub(b, a), Type::I32);
+        let result = push(&mut cfg, CfgInstData::Add(add2, sub2), Type::I32);
+        cfg.set_terminator(
+            cfg.entry,
+            Terminator::Return {
+                value: Some(result),
+            },
+        );
+
+        let stats = run(&mut cfg).unwrap();
+        assert_eq!(stats.duplicates_replaced, 3);
+        assert!(matches!(cfg.get_inst(add2).data, CfgInstData::Const(0)));
+        assert!(matches!(cfg.get_inst(mul2).data, CfgInstData::Const(0)));
+        assert!(matches!(cfg.get_inst(sub2).data, CfgInstData::Const(0)));
+        assert!(matches!(
+            cfg.get_inst(result).data,
+            CfgInstData::Add(x, y) if x == add1 && y == sub1
+        ));
+        assert!(matches!(
+            cfg.get_inst(mul1).data,
+            CfgInstData::WrappingMul(..)
+        ));
+        assert!(matches!(
+            cfg.get_inst(reversed_sub).data,
+            CfgInstData::WrappingSub(x, y) if x == b && y == a
         ));
     }
 

--- a/crates/rue-cfg/src/opt/peephole.rs
+++ b/crates/rue-cfg/src/opt/peephole.rs
@@ -13,9 +13,10 @@
 //!   would elide a mandatory trap (the RUE-57 class).
 //!
 //! * **Identity rewiring**: operations that provably return one operand
-//!   unchanged and cannot trap — `x+0`, `0+x`, `x-0`, `x*1`, `1*x`, `x/1`,
-//!   `x|0`, `x^0`, `x<<0`, `x>>0`, `x&x`, `x|x`, `!!x` — have every use
-//!   re-pointed at the operand through one batched
+//!   unchanged and cannot trap — `x+0`, `0+x`, `x-0`, `x*1`, `1*x`, their
+//!   wrapping-arithmetic counterparts, `x/1`, `x|0`, `x^0`, `x<<0`, `x>>0`,
+//!   `x&x`, `x|x`, `!!x` — have every use re-pointed at the operand through one
+//!   batched
 //!   [`Cfg::rewrite_value_uses`] sweep. The identity instruction itself is
 //!   rewritten to a dead placeholder constant: DCE conservatively keeps any
 //!   arithmetic that might trap, so simply orphaning an `Add` would leave it
@@ -161,6 +162,25 @@ fn identity_target(cfg: &Cfg, value: CfgValue) -> Option<CfgValue> {
                 None
             }
         }
+        CfgInstData::WrappingAdd(a, b) => {
+            if is0(b) {
+                Some(a)
+            } else if is0(a) {
+                Some(b)
+            } else {
+                None
+            }
+        }
+        CfgInstData::WrappingSub(a, b) if is0(b) => Some(a),
+        CfgInstData::WrappingMul(a, b) => {
+            if is1(b) {
+                Some(a)
+            } else if is1(a) {
+                Some(b)
+            } else {
+                None
+            }
+        }
         CfgInstData::Div(a, b) if is1(b) => Some(a),
         // Bitwise ops and shifts never trap. (x & 0, x ^ x fold to constants
         // in the constfold kernel instead.)
@@ -261,6 +281,28 @@ mod tests {
     }
 
     #[test]
+    fn test_wrapping_identity_chain_rewired_to_operand() {
+        let mut cfg = make_cfg();
+        let x = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let zero = push(&mut cfg, CfgInstData::Const(0), Type::I32);
+        let one = push(&mut cfg, CfgInstData::Const(1), Type::I32);
+        let add = push(&mut cfg, CfgInstData::WrappingAdd(zero, x), Type::I32);
+        let sub = push(&mut cfg, CfgInstData::WrappingSub(add, zero), Type::I32);
+        let mul = push(&mut cfg, CfgInstData::WrappingMul(one, sub), Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(mul) });
+
+        let stats = run(&mut cfg).unwrap();
+        assert_eq!(stats.identities_rewired, 3);
+        assert!(matches!(
+            cfg.get_block(cfg.entry).terminator,
+            Terminator::Return { value: Some(v) } if v == x
+        ));
+        assert!(matches!(cfg.get_inst(add).data, CfgInstData::Const(0)));
+        assert!(matches!(cfg.get_inst(sub).data, CfgInstData::Const(0)));
+        assert!(matches!(cfg.get_inst(mul).data, CfgInstData::Const(0)));
+    }
+
+    #[test]
     fn test_identity_chain_resolves_transitively() {
         // ((x + 0) | 0) << 0 — every layer is an identity; the final use
         // must land on x itself.
@@ -316,16 +358,22 @@ mod tests {
 
     #[test]
     fn test_non_identity_untouched() {
-        // x + 1 and x - x-with-different-values must not be rewired.
+        // x + 1 and x wrapping_mul 2 must not be rewired.
         let mut cfg = make_cfg();
         let x = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
         let one = push(&mut cfg, CfgInstData::Const(1), Type::I32);
+        let two = push(&mut cfg, CfgInstData::Const(2), Type::I32);
         let add = push(&mut cfg, CfgInstData::Add(x, one), Type::I32);
-        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(add) });
+        let mul = push(&mut cfg, CfgInstData::WrappingMul(add, two), Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(mul) });
 
         let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.identities_rewired, 0);
         assert!(matches!(cfg.get_inst(add).data, CfgInstData::Add(..)));
+        assert!(matches!(
+            cfg.get_inst(mul).data,
+            CfgInstData::WrappingMul(..)
+        ));
     }
 
     #[test]

--- a/crates/rue-cli-tests/cases/differential_opt.toml
+++ b/crates/rue-cli-tests/cases/differential_opt.toml
@@ -45,6 +45,108 @@ stdout = """59
 """
 exit_code = 59
 
+# Wrapping arithmetic: every operation at every integer width and signedness.
+# The constant-heavy shape exercises folding at -O1+, while -O0 anchors each
+# modular result to native execution.
+[[case]]
+name = "wrapping_arithmetic_across_opt_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let i8_max: i8 = 127;
+    let i8_min: i8 = -128;
+    let i8_one: i8 = 1;
+    let i8_half: i8 = 64;
+    @dbg(@wrapping_add(i8_max, i8_one));
+    @dbg(@wrapping_sub(i8_min, i8_one));
+    @dbg(@wrapping_mul(i8_half, 2));
+
+    let i16_max: i16 = 32767;
+    let i16_min: i16 = -32768;
+    let i16_one: i16 = 1;
+    let i16_half: i16 = 16384;
+    @dbg(@wrapping_add(i16_max, i16_one));
+    @dbg(@wrapping_sub(i16_min, i16_one));
+    @dbg(@wrapping_mul(i16_half, 2));
+
+    let i32_max: i32 = 2147483647;
+    let i32_min: i32 = -2147483648;
+    let i32_one: i32 = 1;
+    let i32_half: i32 = 1073741824;
+    @dbg(@wrapping_add(i32_max, i32_one));
+    @dbg(@wrapping_sub(i32_min, i32_one));
+    @dbg(@wrapping_mul(i32_half, 2));
+
+    let i64_max: i64 = 9223372036854775807;
+    let i64_min: i64 = -9223372036854775808;
+    let i64_one: i64 = 1;
+    let i64_half: i64 = 4611686018427387904;
+    @dbg(@wrapping_add(i64_max, i64_one));
+    @dbg(@wrapping_sub(i64_min, i64_one));
+    @dbg(@wrapping_mul(i64_half, 2));
+
+    let u8_max: u8 = 255;
+    let u8_zero: u8 = 0;
+    let u8_one: u8 = 1;
+    let u8_half: u8 = 128;
+    @dbg(@wrapping_add(u8_max, u8_one));
+    @dbg(@wrapping_sub(u8_zero, u8_one));
+    @dbg(@wrapping_mul(u8_half, 2));
+
+    let u16_max: u16 = 65535;
+    let u16_zero: u16 = 0;
+    let u16_one: u16 = 1;
+    let u16_half: u16 = 32768;
+    @dbg(@wrapping_add(u16_max, u16_one));
+    @dbg(@wrapping_sub(u16_zero, u16_one));
+    @dbg(@wrapping_mul(u16_half, 2));
+
+    let u32_max: u32 = 4294967295;
+    let u32_zero: u32 = 0;
+    let u32_one: u32 = 1;
+    let u32_half: u32 = 2147483648;
+    @dbg(@wrapping_add(u32_max, u32_one));
+    @dbg(@wrapping_sub(u32_zero, u32_one));
+    @dbg(@wrapping_mul(u32_half, 2));
+
+    let u64_max: u64 = 18446744073709551615;
+    let u64_zero: u64 = 0;
+    let u64_one: u64 = 1;
+    let u64_half: u64 = 9223372036854775808;
+    @dbg(@wrapping_add(u64_max, u64_one));
+    @dbg(@wrapping_sub(u64_zero, u64_one));
+    @dbg(@wrapping_mul(u64_half, 2));
+
+    0
+}
+""" }]
+stdout = """-128
+127
+-128
+-32768
+32767
+-32768
+-2147483648
+2147483647
+-2147483648
+-9223372036854775808
+9223372036854775807
+-9223372036854775808
+0
+255
+0
+0
+65535
+0
+0
+4294967295
+0
+0
+18446744073709551615
+0
+"""
+exit_code = 0
+
 # Control flow: nested loops, branches, mutation, early-ish exits. Exercises
 # CFG-shaped code where a bad block-simplification would show up.
 [[case]]


### PR DESCRIPTION
## Summary

- fold wrapping add, subtract, and multiply with width-correct canonical results
- CSE wrapping expressions with the right commutativity and simplify safe identities
- preserve sparse optimizer work and add differential coverage for every signed and unsigned integer width

## Validation

- scripts/rue unit cfg
- scripts/rue cli differential_opt
- scripts/rue quick
- scripts/rue fmt

Fixes RUE-1175.