### PR TITLE
RUE-1166: bound lexer diagnostics per file

### DIFF
--- a/crates/rue-compiler/src/syntax.rs
+++ b/crates/rue-compiler/src/syntax.rs
@@ -170,6 +170,54 @@ mod tests {
     }
 
     #[test]
+    fn lexer_budget_is_per_file_and_later_files_are_still_lexed() {
+        fn malformed_tokens() -> String {
+            "$".repeat(rue_lexer::LEXER_DIAGNOSTIC_BUDGET + 25)
+        }
+
+        let first = malformed_tokens();
+        let second = malformed_tokens();
+        let snapshot = snapshot(&[
+            (10, "first.rue", &first),
+            (20, "good.rue", "fn good() {}"),
+            (30, "second.rue", &second),
+        ]);
+
+        let mut session = CompilerSession::new();
+        let update = session.update(&snapshot);
+        let work = update.work();
+        let errors = update.into_result().unwrap_err();
+        let summaries = errors
+            .iter()
+            .filter(|error| matches!(error.kind, ErrorKind::LexerDiagnosticsOmitted { .. }))
+            .collect::<Vec<_>>();
+
+        assert_eq!(errors.len(), 2 * (rue_lexer::LEXER_DIAGNOSTIC_BUDGET + 1));
+        assert_eq!(summaries.len(), 2);
+        assert_eq!(summaries[0].span().unwrap().file_id, FileId::new(10));
+        assert_eq!(summaries[1].span().unwrap().file_id, FileId::new(30));
+        assert_eq!(work.syntax.lexer_invocations, 3);
+        assert_eq!(work.syntax.parser_invocations, 1);
+
+        let source_info = SourceInfo::new(&first, "first.rue");
+        let text = DiagnosticFormatter::with_color_choice(&source_info, ColorChoice::Never)
+            .format_error(summaries[0]);
+        assert!(
+            text.contains(
+                "[E0010]: additional lexer diagnostics omitted after the first 100 errors"
+            )
+        );
+
+        let json_formatter = JsonDiagnosticFormatter::new(&source_info);
+        let json = json_formatter.format_error(summaries[0]).to_json();
+        assert_eq!(json, json_formatter.format_error(summaries[0]).to_json());
+        assert!(json.contains("\"code\":\"E0010\""));
+        assert!(json.contains(
+            "\"message\":\"additional lexer diagnostics omitted after the first 100 errors\""
+        ));
+    }
+
+    #[test]
     fn returned_interner_survives_lex_and_parse_failures() {
         let lex_source = SourceView::new("lex.rue", "fn lex_name() { $ }", FileId::new(1));
         let FileParseOutcome {

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -91,6 +91,9 @@ impl ErrorCode {
     pub const EMPTY_BASED_LITERAL: Self = Self(7);
     pub const INVALID_DIGIT_FOR_BASE: Self = Self(8);
     pub const MALFORMED_BYTE_LITERAL: Self = Self(9);
+    /// The per-file lexer diagnostic budget was exceeded. The detailed
+    /// diagnostics before this summary remain available.
+    pub const LEXER_DIAGNOSTICS_OMITTED: Self = Self(10);
 
     // ========================================================================
     // Parser errors (E0100-E0199)
@@ -1110,6 +1113,10 @@ pub enum ErrorKind {
     /// single ASCII byte (RUE-1042).
     #[error("{0}")]
     MalformedByteLiteral(String),
+    /// Summary emitted after lexing reaches its per-file diagnostic budget.
+    /// `limit` is the number of detailed diagnostics retained.
+    #[error("additional lexer diagnostics omitted after the first {limit} errors")]
+    LexerDiagnosticsOmitted { limit: usize },
 
     // Parser errors
     #[error("expected {expected}, found {found}")]
@@ -1780,6 +1787,7 @@ impl ErrorKind {
             ErrorKind::EmptyBasedLiteral { .. } => ErrorCode::EMPTY_BASED_LITERAL,
             ErrorKind::MalformedByteLiteral(_) => ErrorCode::MALFORMED_BYTE_LITERAL,
             ErrorKind::InvalidDigitForBase { .. } => ErrorCode::INVALID_DIGIT_FOR_BASE,
+            ErrorKind::LexerDiagnosticsOmitted { .. } => ErrorCode::LEXER_DIAGNOSTICS_OMITTED,
 
             // Parser errors (E0100-E0199)
             ErrorKind::UnexpectedToken { .. } => ErrorCode::UNEXPECTED_TOKEN,
@@ -3091,6 +3099,10 @@ mod tests {
         assert_eq!(
             ErrorKind::UnterminatedString.code(),
             ErrorCode::UNTERMINATED_STRING
+        );
+        assert_eq!(
+            ErrorKind::LexerDiagnosticsOmitted { limit: 100 }.code(),
+            ErrorCode::LEXER_DIAGNOSTICS_OMITTED
         );
     }
 

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -11,6 +11,12 @@ pub use logos_lexer::LogosLexer as Lexer;
 pub use rue_span::FileId;
 use rue_span::Span;
 
+/// Maximum number of detailed lexer diagnostics retained for one source file.
+/// On the next error, lexing appends one
+/// [`rue_error::ErrorKind::LexerDiagnosticsOmitted`] summary and stops scanning
+/// that failed file. The compiler still advances to later source files.
+pub const LEXER_DIAGNOSTIC_BUDGET: usize = 100;
+
 /// Token kinds in the Rue language.
 ///
 /// This enum is `Copy` since all variants contain only small, copyable data:

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -578,7 +578,7 @@ pub enum LogosTokenKind {
     Question,
 }
 
-use crate::{Token, TokenKind};
+use crate::{LEXER_DIAGNOSTIC_BUDGET, Token, TokenKind};
 
 impl From<LogosTokenKind> for TokenKind {
     fn from(logos_kind: LogosTokenKind) -> Self {
@@ -839,6 +839,16 @@ impl<'a> LogosLexer<'a> {
                                     )
                                 }
                             };
+                            if errors.len() == LEXER_DIAGNOSTIC_BUDGET {
+                                errors.push(CompileError::new(
+                                    ErrorKind::LexerDiagnosticsOmitted {
+                                        limit: LEXER_DIAGNOSTIC_BUDGET,
+                                    },
+                                    rue_span,
+                                ));
+                                break;
+                            }
+
                             let mut error = CompileError::new(kind, rue_span);
                             if matches!(error.kind, ErrorKind::UnexpectedCharacter('\u{feff}')) {
                                 // A *leading* BOM is skipped before we get here
@@ -936,6 +946,45 @@ mod tests {
         let kinds: Vec<_> = errors.iter().map(|error| &error.kind).collect();
         assert!(matches!(kinds[0], ErrorKind::UnexpectedCharacter('$')));
         assert!(matches!(kinds[1], ErrorKind::UnexpectedCharacter('#')));
+    }
+
+    #[test]
+    fn test_logos_malformed_token_diagnostics_are_bounded() {
+        let source = "$".repeat(10_000);
+        let (errors, _interner) = LogosLexer::new(&source)
+            .tokenize_preserving_interner()
+            .expect_err("invalid characters should report");
+
+        assert_eq!(errors.len(), LEXER_DIAGNOSTIC_BUDGET + 1);
+        assert!(
+            errors
+                .iter()
+                .take(LEXER_DIAGNOSTIC_BUDGET)
+                .all(|error| matches!(error.kind, ErrorKind::UnexpectedCharacter('$')))
+        );
+        assert_eq!(
+            errors.as_slice()[LEXER_DIAGNOSTIC_BUDGET - 1]
+                .span()
+                .unwrap()
+                .start,
+            (LEXER_DIAGNOSTIC_BUDGET - 1) as u32
+        );
+
+        let summary = &errors.as_slice()[LEXER_DIAGNOSTIC_BUDGET];
+        assert_eq!(
+            summary.span().unwrap().start,
+            LEXER_DIAGNOSTIC_BUDGET as u32
+        );
+        assert_eq!(
+            summary.kind,
+            ErrorKind::LexerDiagnosticsOmitted {
+                limit: LEXER_DIAGNOSTIC_BUDGET
+            }
+        );
+        assert_eq!(
+            summary.to_string(),
+            "additional lexer diagnostics omitted after the first 100 errors"
+        );
     }
 
     #[test]

--- a/crates/rue-parser/src/lib.rs
+++ b/crates/rue-parser/src/lib.rs
@@ -13,8 +13,8 @@ pub use validate::KNOWN_DIRECTIVES;
 /// produced, the parser appends one
 /// [`rue_error::ErrorKind::ParserDiagnosticsOmitted`] summary.
 ///
-/// The budget is local to each [`Parser`] invocation. Lexer diagnostics come
-/// from the preceding lexer phase and are intentionally outside this budget.
+/// The budget is local to each [`Parser`] invocation. The preceding lexer phase
+/// uses its own independent per-file diagnostic budget.
 pub const PARSER_DIAGNOSTIC_BUDGET: usize = 100;
 
 pub use ast::{


### PR DESCRIPTION
## Summary

- retain at most 100 detailed lexer diagnostics per source file
- append one deterministic E0010 omission summary at the first suppressed error and stop scanning the failed file
- add a 10,000-token stress test plus multi-file coverage proving later files are still visited

## Validation

- scripts/rue unit error error_kind_code_lexer
- scripts/rue unit lexer malformed_token_diagnostics
- scripts/rue unit compiler lexer_budget
- scripts/rue quick
- scripts/rue fmt

Fixes RUE-1166.