### PR TITLE
RUE-959: bound IntMap insertion probing

### DIFF
--- a/crates/rue-cli-tests/cases/std_collections.toml
+++ b/crates/rue-cli-tests/cases/std_collections.toml
@@ -85,3 +85,73 @@ fn main() -> i32 {
     if score == 17 { 42 } else { @intCast(score) }
 }
 """ }]
+
+[[case]]
+name = "intmap_tombstone_churn"
+description = "IntMap reuses a tombstone after bounded probing when churn leaves no empty slots."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 42
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let M = std.intmap.IntMap(i64);
+    let O = std.option.Option(i64);
+    let mut m = M.new(0);
+
+    // With capacity 8, these keys occupy slots 0 through 4. Removing them
+    // leaves five tombstones and three empty slots.
+    let mut i: i64 = 0;
+    while i < 5 {
+        m.insert(i, i * 10);
+        i = i + 1;
+    }
+    i = 0;
+    while i < 5 {
+        if !m.remove(i) {
+            return 1;
+        }
+        i = i + 1;
+    }
+
+    // Small positive keys hash to their value modulo 8. These fill the three
+    // remaining empty slots without crossing the live-count growth threshold.
+    i = 5;
+    while i < 8 {
+        m.insert(i, i * 10);
+        i = i + 1;
+    }
+
+    // The table now contains only occupied slots and tombstones. This insert
+    // previously probed forever; it must reuse the first tombstone.
+    m.insert(8, 80);
+    if m.len() != 4 {
+        return 2;
+    }
+
+    i = 5;
+    while i < 9 {
+        match m.get(i) {
+            O.Some(v) => {
+                if v != i * 10 {
+                    return 3;
+                }
+            },
+            O.None => {
+                return 4;
+            },
+        }
+        i = i + 1;
+    }
+
+    i = 0;
+    while i < 5 {
+        if m.contains(i) {
+            return 5;
+        }
+        i = i + 1;
+    }
+    42
+}
+""" }]

--- a/std/intmap.rue
+++ b/std/intmap.rue
@@ -139,7 +139,11 @@ pub fn IntMap(comptime V: type) -> type {
             }
             let mut idx = self._slot(k);
             let mut first_tomb: u64 = self.cap;
-            loop {
+            // Probe at most `cap` slots: insert/remove churn can turn every
+            // non-live slot into a tombstone while `count` remains below the
+            // growth threshold, leaving no EMPTY slot to stop an open loop.
+            let mut probes: u64 = 0;
+            while probes < self.cap {
                 let st = self.states.get_or(idx, _EMPTY());
                 if st == _EMPTY() {
                     let target = if first_tomb < self.cap { first_tomb } else { idx };
@@ -147,11 +151,11 @@ pub fn IntMap(comptime V: type) -> type {
                     self.vals.set(target, v);
                     self.states.set(target, _OCCUPIED());
                     self.count = self.count + 1;
-                    break;
+                    return;
                 } else if st == _OCCUPIED() {
                     if self.keys.get_or(idx, 0) == k {
                         self.vals.set(idx, v);
-                        break;
+                        return;
                     }
                 } else {
                     if first_tomb >= self.cap {
@@ -159,7 +163,14 @@ pub fn IntMap(comptime V: type) -> type {
                     }
                 }
                 idx = (idx + 1) % self.cap;
+                probes = probes + 1;
             }
+            // Every slot was probed without finding an EMPTY slot or matching
+            // key. Growth keeps `count` below `cap`, so reuse the first tombstone.
+            self.keys.set(first_tomb, k);
+            self.vals.set(first_tomb, v);
+            self.states.set(first_tomb, _OCCUPIED());
+            self.count = self.count + 1;
         }
 
         // The value for `k`, or `None`.


### PR DESCRIPTION
## Summary

- bound `IntMap.insert` probing to at most one full table traversal
- reuse the first tombstone when churn leaves no empty slots
- add a CLI regression that constructs a full occupied-or-tombstone table and verifies insertion and lookup behavior

## Why

`IntMap` grows based on its live entry count. Repeated insertion and removal could therefore convert every free slot into a tombstone while remaining below the growth threshold. Inserting an absent key then used an unbounded probe loop that could never encounter an empty slot.

## Impact

Insertion now terminates and reuses an available tombstone in this state, matching the bounded-probe invariant already used by `StrMap`.

## Validation

- `scripts/rue cli intmap_tombstone_churn`
- `scripts/rue cli std_collections`
- `scripts/rue quick` (30 targets passed)

Fixes RUE-959.
