### PR TITLE
RUE-1169: use production rematerialization

### DIFF
--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -269,7 +269,7 @@ fn uses(inst: &Aarch64Inst) -> Vec<VReg> {
 }
 
 /// Get virtual registers defined (written) by an instruction.
-fn defs(inst: &Aarch64Inst) -> Vec<VReg> {
+pub(crate) fn defs(inst: &Aarch64Inst) -> Vec<VReg> {
     // Most instructions define 0-1 registers; pre-allocate for common case
     let mut result = Vec::with_capacity(1);
 

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -13,13 +13,12 @@
 use rue_error::{CompileError, CompileResult, ErrorKind};
 
 use super::liveness;
-#[cfg(test)]
 use super::mir::VReg;
 use super::mir::{Aarch64Inst, Aarch64Mir, Operand, Reg};
 use crate::alloc_dst;
 use crate::regalloc::{
     Allocation, AllocationContext, CoalesceCandidate, LivenessInfo, LoopInfo, RegAllocBackend,
-    RegAllocDebugInfo, RegAllocDriver, RewriteBuffer,
+    RegAllocDebugInfo, RegAllocDriver, RematerializeOp, RewriteBuffer,
 };
 
 /// Available registers for allocation.
@@ -1231,6 +1230,32 @@ impl RegAllocBackend for Aarch64Backend {
         mir.instructions()
     }
 
+    fn defs(inst: &Self::Inst) -> Vec<VReg> {
+        liveness::defs(inst)
+    }
+
+    fn rematerialization(inst: &Self::Inst) -> Option<(VReg, RematerializeOp)> {
+        match inst {
+            Aarch64Inst::MovImm {
+                dst: Operand::Virtual(dst),
+                imm,
+            } => Some((*dst, RematerializeOp::Const64(*imm))),
+            Aarch64Inst::StringConstPtr {
+                dst: Operand::Virtual(dst),
+                string_id,
+            } => Some((*dst, RematerializeOp::StringPtr(*string_id))),
+            Aarch64Inst::StringConstLen {
+                dst: Operand::Virtual(dst),
+                string_id,
+            } => Some((*dst, RematerializeOp::StringLen(*string_id))),
+            Aarch64Inst::StringConstCap {
+                dst: Operand::Virtual(dst),
+                string_id,
+            } => Some((*dst, RematerializeOp::StringCap(*string_id))),
+            _ => None,
+        }
+    }
+
     fn analyze(mir: &Self::Mir) -> LivenessInfo<Self::Reg> {
         liveness::analyze(mir)
     }
@@ -1299,7 +1324,18 @@ impl RegAllocBackend for Aarch64Backend {
 #[cfg(test)]
 mod tests {
     use super::liveness;
-    use super::{Aarch64Inst, Aarch64Mir, Operand, Reg, RegAlloc, VReg};
+    use super::{ALLOCATABLE_REGS, Aarch64Inst, Aarch64Mir, Operand, Reg, RegAlloc, VReg};
+    use crate::regalloc::{Allocation, RematerializeOp};
+
+    fn define_loaded_values(mir: &mut Aarch64Mir, vregs: &[VReg]) {
+        for (index, &vreg) in vregs.iter().enumerate() {
+            mir.push(Aarch64Inst::Ldr {
+                dst: Operand::Virtual(vreg),
+                base: Reg::X1,
+                offset: (index as i32) * 8,
+            });
+        }
+    }
 
     #[test]
     fn test_simple_allocation() {
@@ -1351,13 +1387,7 @@ mod tests {
         // Create 11 vregs to force spilling (we only have 10 allocatable regs: X19-X28)
         let vregs: Vec<VReg> = (0..11).map(|_| mir.alloc_vreg()).collect();
 
-        // Define all vregs
-        for (i, &vreg) in vregs.iter().enumerate() {
-            mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Virtual(vreg),
-                imm: i as i64,
-            });
-        }
+        define_loaded_values(&mut mir, &vregs);
 
         // Use Msub with the last vreg as destination (likely to be spilled)
         // msub dst, src1, src2, src3 computes: dst = src3 - (src1 * src2)
@@ -1447,12 +1477,7 @@ mod tests {
         let vregs: Vec<VReg> = (0..15).map(|_| mir.alloc_vreg()).collect();
 
         // Define all vregs
-        for (i, &vreg) in vregs.iter().enumerate() {
-            mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Virtual(vreg),
-                imm: i as i64,
-            });
-        }
+        define_loaded_values(&mut mir, &vregs);
 
         // Use all vregs to keep them live
         for &vreg in &vregs {
@@ -1504,12 +1529,7 @@ mod tests {
         // Create 11 vregs to force spilling (10 allocatable regs: X19-X28)
         let vregs: Vec<VReg> = (0..11).map(|_| mir.alloc_vreg()).collect();
 
-        for (i, &vreg) in vregs.iter().enumerate() {
-            mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Virtual(vreg),
-                imm: i as i64,
-            });
-        }
+        define_loaded_values(&mut mir, &vregs);
 
         for &vreg in &vregs {
             mir.push(Aarch64Inst::MovRR {
@@ -1556,8 +1576,198 @@ mod tests {
             store_index
                 .checked_sub(1)
                 .and_then(|index| instructions.get(index)),
-            Some(Aarch64Inst::MovImm { .. })
+            Some(Aarch64Inst::Ldr { base: Reg::X1, .. })
         ));
+    }
+
+    #[test]
+    fn test_production_rematerializes_constants_and_strings_without_spills() {
+        let mut mir = Aarch64Mir::new();
+        let vregs: Vec<VReg> = (0..12).map(|_| mir.alloc_vreg()).collect();
+
+        for (index, &vreg) in vregs[..10].iter().enumerate() {
+            mir.push(Aarch64Inst::MovImm {
+                dst: Operand::Virtual(vreg),
+                imm: index as i64,
+            });
+        }
+        mir.push(Aarch64Inst::StringConstPtr {
+            dst: Operand::Virtual(vregs[10]),
+            string_id: 7,
+        });
+        mir.push(Aarch64Inst::MovImm {
+            dst: Operand::Virtual(vregs[11]),
+            imm: 99,
+        });
+        for &vreg in &vregs {
+            mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Virtual(vreg),
+            });
+        }
+
+        let baseline_liveness = liveness::analyze(&mir);
+        let baseline_loops = liveness::analyze_loops(&mir);
+        let (_, baseline_spills, _) = crate::regalloc::linear_scan_with_cost_model(
+            mir.vreg_count(),
+            &baseline_liveness,
+            ALLOCATABLE_REGS,
+            0,
+            &crate::regalloc::CostModel::default(),
+            &baseline_loops,
+        );
+        let (mir, num_spills, _, debug) = RegAlloc::new(mir, 0).allocate_with_debug().unwrap();
+
+        assert_eq!(baseline_spills, 2);
+        assert!(num_spills < baseline_spills);
+        assert_eq!(num_spills, 0, "rematerialized values need no frame slots");
+        assert!(debug.allocations.iter().any(|(_, allocation)| matches!(
+            allocation,
+            crate::regalloc::Allocation::Rematerialize(
+                crate::regalloc::RematerializeOp::StringPtr(7)
+            )
+        )));
+        assert!(debug.allocations.iter().any(|(_, allocation)| matches!(
+            allocation,
+            crate::regalloc::Allocation::Rematerialize(crate::regalloc::RematerializeOp::Const64(
+                99
+            ))
+        )));
+        assert!(!mir.instructions().iter().any(|inst| matches!(
+            inst,
+            Aarch64Inst::Str { base: Reg::Fp, .. } | Aarch64Inst::Ldr { base: Reg::Fp, .. }
+        )));
+    }
+
+    #[test]
+    fn test_rematerialization_recipe_survives_coalescing() {
+        let mut mir = Aarch64Mir::new();
+        let loaded: Vec<VReg> = (0..ALLOCATABLE_REGS.len())
+            .map(|_| mir.alloc_vreg())
+            .collect();
+        let constant = mir.alloc_vreg();
+        let moved = mir.alloc_vreg();
+
+        define_loaded_values(&mut mir, &loaded);
+        mir.push(Aarch64Inst::MovImm {
+            dst: Operand::Virtual(constant),
+            imm: 42,
+        });
+        mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Virtual(moved),
+            src: Operand::Virtual(constant),
+        });
+        for &vreg in &loaded {
+            mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Virtual(vreg),
+            });
+        }
+        mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Physical(Reg::X0),
+            src: Operand::Virtual(moved),
+        });
+
+        let (mir, num_spills, _, debug) = RegAlloc::new(mir, 0).allocate_with_debug().unwrap();
+
+        assert_eq!(num_spills, 0);
+        assert!(debug.allocations.contains(&(
+            constant.index(),
+            Allocation::Rematerialize(RematerializeOp::Const64(42))
+        )));
+        assert!(mir.instructions().iter().any(|inst| matches!(
+            inst,
+            Aarch64Inst::MovImm {
+                dst: Operand::Physical(Reg::X9),
+                imm: 42
+            }
+        )));
+    }
+
+    #[test]
+    fn test_rematerialization_requires_identical_definitions() {
+        fn allocate(second_value: i64) -> (u32, Allocation<Reg>) {
+            let mut mir = Aarch64Mir::new();
+            let loaded: Vec<VReg> = (0..ALLOCATABLE_REGS.len())
+                .map(|_| mir.alloc_vreg())
+                .collect();
+            let constant = mir.alloc_vreg();
+
+            define_loaded_values(&mut mir, &loaded);
+            mir.push(Aarch64Inst::MovImm {
+                dst: Operand::Virtual(constant),
+                imm: 42,
+            });
+            mir.push(Aarch64Inst::MovImm {
+                dst: Operand::Virtual(constant),
+                imm: second_value,
+            });
+            for &vreg in &loaded {
+                mir.push(Aarch64Inst::MovRR {
+                    dst: Operand::Physical(Reg::X0),
+                    src: Operand::Virtual(vreg),
+                });
+            }
+            mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Virtual(constant),
+            });
+
+            let (_, num_spills, _, debug) = RegAlloc::new(mir, 0).allocate_with_debug().unwrap();
+            let allocation = debug
+                .allocations
+                .iter()
+                .find_map(|(vreg, allocation)| (*vreg == constant.index()).then_some(*allocation))
+                .unwrap();
+            (num_spills, allocation)
+        }
+
+        assert_eq!(
+            allocate(42),
+            (0, Allocation::Rematerialize(RematerializeOp::Const64(42)))
+        );
+        assert!(matches!(allocate(43), (1, Allocation::Spill(_))));
+    }
+
+    #[test]
+    fn test_rematerialization_rejects_in_place_updates() {
+        let mut mir = Aarch64Mir::new();
+        let loaded: Vec<VReg> = (0..ALLOCATABLE_REGS.len())
+            .map(|_| mir.alloc_vreg())
+            .collect();
+        let updated = mir.alloc_vreg();
+
+        define_loaded_values(&mut mir, &loaded);
+        mir.push(Aarch64Inst::MovImm {
+            dst: Operand::Virtual(updated),
+            imm: 42,
+        });
+        mir.push(Aarch64Inst::AddImm {
+            dst: Operand::Virtual(updated),
+            src: Operand::Virtual(updated),
+            imm: 1,
+        });
+        for &vreg in &loaded {
+            mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Virtual(vreg),
+            });
+        }
+        mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Physical(Reg::X0),
+            src: Operand::Virtual(updated),
+        });
+
+        let (_, num_spills, _, debug) = RegAlloc::new(mir, 0).allocate_with_debug().unwrap();
+
+        assert_eq!(num_spills, 1);
+        assert!(
+            debug
+                .allocations
+                .iter()
+                .any(|(vreg, allocation)| *vreg == updated.index()
+                    && matches!(allocation, Allocation::Spill(_)))
+        );
     }
 
     #[test]
@@ -1611,12 +1821,7 @@ mod tests {
         let vregs: Vec<VReg> = (0..11).map(|_| mir.alloc_vreg()).collect();
         let loop_label = mir.alloc_label();
 
-        for (i, &vreg) in vregs.iter().enumerate() {
-            mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Virtual(vreg),
-                imm: i as i64,
-            });
-        }
+        define_loaded_values(&mut mir, &vregs);
         mir.push(Aarch64Inst::Label { id: loop_label });
         mir.push(Aarch64Inst::SubImm {
             dst: Operand::Virtual(vregs[0]),
@@ -1692,12 +1897,7 @@ mod tests {
         // Create 15 vregs to force 5 spills (10 allocatable regs)
         let vregs: Vec<VReg> = (0..15).map(|_| mir.alloc_vreg()).collect();
 
-        for (i, &vreg) in vregs.iter().enumerate() {
-            mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Virtual(vreg),
-                imm: i as i64,
-            });
-        }
+        define_loaded_values(&mut mir, &vregs);
 
         for &vreg in &vregs {
             mir.push(Aarch64Inst::MovRR {
@@ -1748,12 +1948,7 @@ mod tests {
         // 11 vregs forces 1 spill
         let vregs: Vec<VReg> = (0..11).map(|_| mir.alloc_vreg()).collect();
 
-        for vreg in &vregs {
-            mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Virtual(*vreg),
-                imm: 42,
-            });
-        }
+        define_loaded_values(&mut mir, &vregs);
         for vreg in &vregs {
             mir.push(Aarch64Inst::MovRR {
                 dst: Operand::Physical(Reg::X0),
@@ -1796,12 +1991,7 @@ mod tests {
         // Create 25 vregs (10 registers + 15 spills)
         let vregs: Vec<VReg> = (0..25).map(|_| mir.alloc_vreg()).collect();
 
-        for (i, &vreg) in vregs.iter().enumerate() {
-            mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Virtual(vreg),
-                imm: i as i64,
-            });
-        }
+        define_loaded_values(&mut mir, &vregs);
 
         for &vreg in &vregs {
             mir.push(Aarch64Inst::MovRR {
@@ -1843,12 +2033,7 @@ mod tests {
         // 11 vregs forces 1 spill
         let vregs: Vec<VReg> = (0..11).map(|_| mir.alloc_vreg()).collect();
 
-        for vreg in &vregs {
-            mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Virtual(*vreg),
-                imm: 1,
-            });
-        }
+        define_loaded_values(&mut mir, &vregs);
         for vreg in &vregs {
             mir.push(Aarch64Inst::MovRR {
                 dst: Operand::Physical(Reg::X0),
@@ -1885,13 +2070,7 @@ mod tests {
         // Create enough vregs to force spilling
         let vregs: Vec<VReg> = (0..13).map(|_| mir.alloc_vreg()).collect();
 
-        // Initialize all
-        for (i, &vreg) in vregs.iter().enumerate() {
-            mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Virtual(vreg),
-                imm: i as i64,
-            });
-        }
+        define_loaded_values(&mut mir, &vregs);
 
         // Add using potentially spilled operands
         mir.push(Aarch64Inst::AddRR {
@@ -1925,12 +2104,7 @@ mod tests {
         let mut mir = Aarch64Mir::new();
         let vregs: Vec<VReg> = (0..12).map(|_| mir.alloc_vreg()).collect();
 
-        for (i, &vreg) in vregs.iter().enumerate() {
-            mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Virtual(vreg),
-                imm: i as i64,
-            });
-        }
+        define_loaded_values(&mut mir, &vregs);
         mir.push(Aarch64Inst::AddRR {
             dst: Operand::Virtual(vregs[11]),
             src1: Operand::Virtual(vregs[10]),

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -943,6 +943,8 @@ pub trait RegAllocBackend {
 
     fn vreg_count(mir: &Self::Mir) -> u32;
     fn instructions(mir: &Self::Mir) -> &[Self::Inst];
+    fn defs(inst: &Self::Inst) -> Vec<VReg>;
+    fn rematerialization(inst: &Self::Inst) -> Option<(VReg, RematerializeOp)>;
     fn analyze(mir: &Self::Mir) -> LivenessInfo<Self::Reg>;
     fn analyze_with_debug(mir: &Self::Mir) -> (LivenessInfo<Self::Reg>, LivenessDebugInfo);
     fn analyze_loops(mir: &Self::Mir) -> LoopInfo;
@@ -959,6 +961,65 @@ pub trait RegAllocBackend {
         buffer: &mut RewriteBuffer<Self::Inst>,
         inst: Self::Inst,
     ) -> CompileResult<()>;
+}
+
+#[derive(Clone, Copy)]
+enum RematerializationState {
+    Unknown,
+    Eligible(RematerializeOp),
+    Ineligible,
+}
+
+/// Derive one conservative rematerialization recipe per coalesced live range.
+///
+/// Eliminated register-to-register moves do not count as definitions: their
+/// source and destination are the same coalesced value. Every remaining
+/// definition in the class must reproduce the same cheap value. This prevents
+/// rematerializing a register that is later updated in place or assigned
+/// different values along separate control-flow paths.
+fn rematerialization_info<B: RegAllocBackend>(
+    mir: &B::Mir,
+    coalesce_result: &CoalesceResult,
+) -> IndexMap<VReg, VRegInfo> {
+    let vreg_count = B::vreg_count(mir) as usize;
+    let mut states = IndexMap::with_capacity(vreg_count);
+    states.resize(vreg_count, RematerializationState::Unknown);
+
+    for (inst_idx, inst) in B::instructions(mir).iter().enumerate() {
+        if coalesce_result.is_eliminated(inst_idx) {
+            continue;
+        }
+
+        let candidate = B::rematerialization(inst);
+        for defined in B::defs(inst) {
+            let representative = coalesce_result.representative(defined);
+            let recipe = candidate
+                .filter(|(candidate_vreg, _)| *candidate_vreg == defined)
+                .map(|(_, recipe)| recipe);
+
+            states[representative] = match (states[representative], recipe) {
+                (RematerializationState::Ineligible, _) => RematerializationState::Ineligible,
+                (RematerializationState::Unknown, Some(recipe)) => {
+                    RematerializationState::Eligible(recipe)
+                }
+                (RematerializationState::Eligible(existing), Some(recipe))
+                    if existing == recipe =>
+                {
+                    RematerializationState::Eligible(existing)
+                }
+                _ => RematerializationState::Ineligible,
+            };
+        }
+    }
+
+    let mut info = IndexMap::with_capacity(vreg_count);
+    info.resize(vreg_count, VRegInfo::none());
+    for (vreg, state) in states.iter_enumerated() {
+        if let RematerializationState::Eligible(recipe) = state {
+            info[vreg] = VRegInfo::rematerializable(*recipe);
+        }
+    }
+    info
 }
 
 /// Read-only allocation state exposed to a target's instruction rewriter.
@@ -1036,6 +1097,7 @@ impl<I> RewriteBuffer<I> {
 pub struct RegAllocDriver<B: RegAllocBackend> {
     mir: B::Mir,
     allocation: IndexMap<VReg, Option<Allocation<B::Reg>>>,
+    vreg_info: IndexMap<VReg, VRegInfo>,
     liveness: LivenessInfo<B::Reg>,
     liveness_debug: Option<LivenessDebugInfo>,
     loop_info: LoopInfo,
@@ -1064,6 +1126,7 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
         let loop_info = B::analyze_loops(&mir);
         let candidates = B::coalesce_candidates(B::instructions(&mir));
         let coalesce_result = coalesce(&candidates, &mut liveness);
+        let vreg_info = rematerialization_info::<B>(&mir, &coalesce_result);
 
         let mut allocation = IndexMap::with_capacity(vreg_count);
         allocation.resize(vreg_count, None);
@@ -1071,6 +1134,7 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
         Self {
             mir,
             allocation,
+            vreg_info,
             liveness,
             liveness_debug,
             loop_info,
@@ -1147,13 +1211,15 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
     }
 
     fn assign_registers(&mut self) {
-        let (allocation, num_spills, used_callee_saved) = linear_scan_with_cost_model(
+        let (allocation, num_spills, used_callee_saved, _debug_info) = linear_scan_impl_with_remat(
             B::vreg_count(&self.mir),
             &self.liveness,
             B::allocatable_regs(),
             self.existing_locals,
+            false,
             &CostModel::default(),
             &self.loop_info,
+            &self.vreg_info,
         );
         self.allocation = allocation;
         self.num_spills = num_spills;
@@ -1161,15 +1227,16 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
     }
 
     fn assign_registers_with_debug(&mut self) -> RegAllocDebugInfo<B::Reg> {
-        let (allocation, num_spills, used_callee_saved, debug_info) =
-            linear_scan_with_cost_model_and_debug(
-                B::vreg_count(&self.mir),
-                &self.liveness,
-                B::allocatable_regs(),
-                self.existing_locals,
-                &CostModel::default(),
-                &self.loop_info,
-            );
+        let (allocation, num_spills, used_callee_saved, debug_info) = linear_scan_impl_with_remat(
+            B::vreg_count(&self.mir),
+            &self.liveness,
+            B::allocatable_regs(),
+            self.existing_locals,
+            true,
+            &CostModel::default(),
+            &self.loop_info,
+            &self.vreg_info,
+        );
         self.allocation = allocation;
         self.num_spills = num_spills;
         self.used_callee_saved = used_callee_saved;
@@ -1201,6 +1268,14 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
 
         for (idx, inst) in old_instructions.into_iter().enumerate() {
             if self.coalesce_result.is_eliminated(idx) {
+                continue;
+            }
+            if let Some((defined, recipe)) = B::rematerialization(&inst)
+                && matches!(
+                    context.allocation(defined),
+                    Some(Allocation::Rematerialize(selected)) if selected == recipe
+                )
+            {
                 continue;
             }
             let mut buffer = RewriteBuffer::new();

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -14,13 +14,12 @@
 use rue_error::{CompileError, CompileResult, ErrorKind};
 
 use super::liveness;
-#[cfg(test)]
 use super::mir::VReg;
 use super::mir::{Operand, Reg, X86Inst, X86Mir};
 use crate::alloc_dst;
 use crate::regalloc::{
     Allocation, AllocationContext, CoalesceCandidate, LivenessInfo, LoopInfo, RegAllocBackend,
-    RegAllocDebugInfo, RegAllocDriver, RewriteBuffer,
+    RegAllocDebugInfo, RegAllocDriver, RematerializeOp, RewriteBuffer,
 };
 
 /// Available registers for allocation.
@@ -1264,6 +1263,36 @@ impl RegAllocBackend for X86Backend {
         mir.instructions()
     }
 
+    fn defs(inst: &Self::Inst) -> Vec<VReg> {
+        liveness::defs(inst)
+    }
+
+    fn rematerialization(inst: &Self::Inst) -> Option<(VReg, RematerializeOp)> {
+        match inst {
+            X86Inst::MovRI32 {
+                dst: Operand::Virtual(dst),
+                imm,
+            } => Some((*dst, RematerializeOp::Const32(*imm))),
+            X86Inst::MovRI64 {
+                dst: Operand::Virtual(dst),
+                imm,
+            } => Some((*dst, RematerializeOp::Const64(*imm))),
+            X86Inst::StringConstPtr {
+                dst: Operand::Virtual(dst),
+                string_id,
+            } => Some((*dst, RematerializeOp::StringPtr(*string_id))),
+            X86Inst::StringConstLen {
+                dst: Operand::Virtual(dst),
+                string_id,
+            } => Some((*dst, RematerializeOp::StringLen(*string_id))),
+            X86Inst::StringConstCap {
+                dst: Operand::Virtual(dst),
+                string_id,
+            } => Some((*dst, RematerializeOp::StringCap(*string_id))),
+            _ => None,
+        }
+    }
+
     fn analyze(mir: &Self::Mir) -> LivenessInfo<Self::Reg> {
         liveness::analyze(mir)
     }
@@ -1332,7 +1361,18 @@ impl RegAllocBackend for X86Backend {
 #[cfg(test)]
 mod tests {
     use super::liveness;
-    use super::{Operand, Reg, RegAlloc, VReg, X86Inst, X86Mir};
+    use super::{ALLOCATABLE_REGS, Operand, Reg, RegAlloc, VReg, X86Inst, X86Mir};
+    use crate::regalloc::{Allocation, RematerializeOp};
+
+    fn define_loaded_values(mir: &mut X86Mir, vregs: &[VReg]) {
+        for (index, &vreg) in vregs.iter().enumerate() {
+            mir.push(X86Inst::MovRM {
+                dst: Operand::Virtual(vreg),
+                base: Reg::Rsi,
+                offset: (index as i32) * 8,
+            });
+        }
+    }
 
     #[test]
     fn test_simple_allocation() {
@@ -1521,13 +1561,7 @@ mod tests {
         // Create 6 vregs to force spilling (only 5 allocatable regs: R12-R15, Rbx)
         let vregs: Vec<VReg> = (0..6).map(|_| mir.alloc_vreg()).collect();
 
-        // Define all vregs
-        for (i, &vreg) in vregs.iter().enumerate() {
-            mir.push(X86Inst::MovRI32 {
-                dst: Operand::Virtual(vreg),
-                imm: i as i32,
-            });
-        }
+        define_loaded_values(&mut mir, &vregs);
 
         // Use all vregs to keep them live
         for &vreg in &vregs {
@@ -1575,8 +1609,197 @@ mod tests {
             store_index
                 .checked_sub(1)
                 .and_then(|index| instructions.get(index)),
-            Some(X86Inst::MovRI32 { .. })
+            Some(X86Inst::MovRM { base: Reg::Rsi, .. })
         ));
+    }
+
+    #[test]
+    fn test_production_rematerializes_constants_and_strings_without_spills() {
+        let mut mir = X86Mir::new();
+        let vregs: Vec<VReg> = (0..7).map(|_| mir.alloc_vreg()).collect();
+
+        for (index, &vreg) in vregs[..5].iter().enumerate() {
+            mir.push(X86Inst::MovRI32 {
+                dst: Operand::Virtual(vreg),
+                imm: index as i32,
+            });
+        }
+        mir.push(X86Inst::StringConstPtr {
+            dst: Operand::Virtual(vregs[5]),
+            string_id: 7,
+        });
+        mir.push(X86Inst::MovRI64 {
+            dst: Operand::Virtual(vregs[6]),
+            imm: 99,
+        });
+        for &vreg in &vregs {
+            mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rdi),
+                src: Operand::Virtual(vreg),
+            });
+        }
+
+        let baseline_liveness = liveness::analyze(&mir);
+        let baseline_loops = liveness::analyze_loops(&mir);
+        let (_, baseline_spills, _) = crate::regalloc::linear_scan_with_cost_model(
+            mir.vreg_count(),
+            &baseline_liveness,
+            ALLOCATABLE_REGS,
+            0,
+            &crate::regalloc::CostModel::default(),
+            &baseline_loops,
+        );
+        let (mir, num_spills, _, debug) = RegAlloc::new(mir, 0).allocate_with_debug().unwrap();
+
+        assert_eq!(baseline_spills, 2);
+        assert!(num_spills < baseline_spills);
+        assert_eq!(num_spills, 0, "rematerialized values need no frame slots");
+        assert!(debug.allocations.iter().any(|(_, allocation)| matches!(
+            allocation,
+            crate::regalloc::Allocation::Rematerialize(
+                crate::regalloc::RematerializeOp::StringPtr(7)
+            )
+        )));
+        assert!(debug.allocations.iter().any(|(_, allocation)| matches!(
+            allocation,
+            crate::regalloc::Allocation::Rematerialize(crate::regalloc::RematerializeOp::Const64(
+                99
+            ))
+        )));
+        assert!(!mir.instructions().iter().any(|inst| matches!(
+            inst,
+            X86Inst::MovMR { base: Reg::Rbp, .. } | X86Inst::MovRM { base: Reg::Rbp, .. }
+        )));
+    }
+
+    #[test]
+    fn test_rematerialization_recipe_survives_coalescing() {
+        let mut mir = X86Mir::new();
+        let loaded: Vec<VReg> = (0..ALLOCATABLE_REGS.len())
+            .map(|_| mir.alloc_vreg())
+            .collect();
+        let constant = mir.alloc_vreg();
+        let moved = mir.alloc_vreg();
+
+        define_loaded_values(&mut mir, &loaded);
+        mir.push(X86Inst::MovRI64 {
+            dst: Operand::Virtual(constant),
+            imm: 42,
+        });
+        mir.push(X86Inst::MovRR {
+            dst: Operand::Virtual(moved),
+            src: Operand::Virtual(constant),
+        });
+        for &vreg in &loaded {
+            mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rdi),
+                src: Operand::Virtual(vreg),
+            });
+        }
+        mir.push(X86Inst::MovRR {
+            dst: Operand::Physical(Reg::Rdi),
+            src: Operand::Virtual(moved),
+        });
+
+        let (mir, num_spills, _, debug) = RegAlloc::new(mir, 0).allocate_with_debug().unwrap();
+
+        assert_eq!(num_spills, 0);
+        assert!(debug.allocations.contains(&(
+            constant.index(),
+            Allocation::Rematerialize(RematerializeOp::Const64(42))
+        )));
+        assert!(mir.instructions().iter().any(|inst| matches!(
+            inst,
+            X86Inst::MovRI64 {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 42
+            }
+        )));
+    }
+
+    #[test]
+    fn test_rematerialization_requires_identical_definitions() {
+        fn allocate(second_value: i64) -> (u32, Allocation<Reg>) {
+            let mut mir = X86Mir::new();
+            let loaded: Vec<VReg> = (0..ALLOCATABLE_REGS.len())
+                .map(|_| mir.alloc_vreg())
+                .collect();
+            let constant = mir.alloc_vreg();
+
+            define_loaded_values(&mut mir, &loaded);
+            mir.push(X86Inst::MovRI64 {
+                dst: Operand::Virtual(constant),
+                imm: 42,
+            });
+            mir.push(X86Inst::MovRI64 {
+                dst: Operand::Virtual(constant),
+                imm: second_value,
+            });
+            for &vreg in &loaded {
+                mir.push(X86Inst::MovRR {
+                    dst: Operand::Physical(Reg::Rdi),
+                    src: Operand::Virtual(vreg),
+                });
+            }
+            mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rdi),
+                src: Operand::Virtual(constant),
+            });
+
+            let (_, num_spills, _, debug) = RegAlloc::new(mir, 0).allocate_with_debug().unwrap();
+            let allocation = debug
+                .allocations
+                .iter()
+                .find_map(|(vreg, allocation)| (*vreg == constant.index()).then_some(*allocation))
+                .unwrap();
+            (num_spills, allocation)
+        }
+
+        assert_eq!(
+            allocate(42),
+            (0, Allocation::Rematerialize(RematerializeOp::Const64(42)))
+        );
+        assert!(matches!(allocate(43), (1, Allocation::Spill(_))));
+    }
+
+    #[test]
+    fn test_rematerialization_rejects_in_place_updates() {
+        let mut mir = X86Mir::new();
+        let loaded: Vec<VReg> = (0..ALLOCATABLE_REGS.len())
+            .map(|_| mir.alloc_vreg())
+            .collect();
+        let updated = mir.alloc_vreg();
+
+        define_loaded_values(&mut mir, &loaded);
+        mir.push(X86Inst::MovRI64 {
+            dst: Operand::Virtual(updated),
+            imm: 42,
+        });
+        mir.push(X86Inst::AddRI {
+            dst: Operand::Virtual(updated),
+            imm: 1,
+        });
+        for &vreg in &loaded {
+            mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rdi),
+                src: Operand::Virtual(vreg),
+            });
+        }
+        mir.push(X86Inst::MovRR {
+            dst: Operand::Physical(Reg::Rdi),
+            src: Operand::Virtual(updated),
+        });
+
+        let (_, num_spills, _, debug) = RegAlloc::new(mir, 0).allocate_with_debug().unwrap();
+
+        assert_eq!(num_spills, 1);
+        assert!(
+            debug
+                .allocations
+                .iter()
+                .any(|(vreg, allocation)| *vreg == updated.index()
+                    && matches!(allocation, Allocation::Spill(_)))
+        );
     }
 
     #[test]
@@ -1662,12 +1885,7 @@ mod tests {
         let vregs: Vec<VReg> = (0..6).map(|_| mir.alloc_vreg()).collect();
         let loop_label = mir.alloc_label();
 
-        for (i, &vreg) in vregs.iter().enumerate() {
-            mir.push(X86Inst::MovRI32 {
-                dst: Operand::Virtual(vreg),
-                imm: i as i32,
-            });
-        }
+        define_loaded_values(&mut mir, &vregs);
         mir.push(X86Inst::Label { id: loop_label });
         mir.push(X86Inst::AddRI {
             dst: Operand::Virtual(vregs[0]),
@@ -1743,12 +1961,7 @@ mod tests {
         // Create 10 vregs to force 5 spills
         let vregs: Vec<VReg> = (0..10).map(|_| mir.alloc_vreg()).collect();
 
-        for (i, &vreg) in vregs.iter().enumerate() {
-            mir.push(X86Inst::MovRI32 {
-                dst: Operand::Virtual(vreg),
-                imm: i as i32,
-            });
-        }
+        define_loaded_values(&mut mir, &vregs);
 
         for &vreg in &vregs {
             mir.push(X86Inst::MovRR {
@@ -1803,13 +2016,8 @@ mod tests {
         let v4 = mir.alloc_vreg();
         let v5 = mir.alloc_vreg();
 
-        // Define and use all vregs
-        for vreg in [v0, v1, v2, v3, v4, v5] {
-            mir.push(X86Inst::MovRI32 {
-                dst: Operand::Virtual(vreg),
-                imm: 42,
-            });
-        }
+        // Define and use all vregs.
+        define_loaded_values(&mut mir, &[v0, v1, v2, v3, v4, v5]);
         for vreg in [v0, v1, v2, v3, v4, v5] {
             mir.push(X86Inst::MovRR {
                 dst: Operand::Physical(Reg::Rdi),
@@ -1852,12 +2060,7 @@ mod tests {
         // Create 20 vregs (5 registers + 15 spills)
         let vregs: Vec<VReg> = (0..20).map(|_| mir.alloc_vreg()).collect();
 
-        for (i, &vreg) in vregs.iter().enumerate() {
-            mir.push(X86Inst::MovRI32 {
-                dst: Operand::Virtual(vreg),
-                imm: i as i32,
-            });
-        }
+        define_loaded_values(&mut mir, &vregs);
 
         for &vreg in &vregs {
             mir.push(X86Inst::MovRR {
@@ -1899,12 +2102,7 @@ mod tests {
         // 6 vregs forces 1 spill
         let vregs: Vec<VReg> = (0..6).map(|_| mir.alloc_vreg()).collect();
 
-        for vreg in &vregs {
-            mir.push(X86Inst::MovRI32 {
-                dst: Operand::Virtual(*vreg),
-                imm: 1,
-            });
-        }
+        define_loaded_values(&mut mir, &vregs);
         for vreg in &vregs {
             mir.push(X86Inst::MovRR {
                 dst: Operand::Physical(Reg::Rdi),
@@ -1941,13 +2139,7 @@ mod tests {
         // Create enough vregs to force spilling
         let vregs: Vec<VReg> = (0..8).map(|_| mir.alloc_vreg()).collect();
 
-        // Initialize all
-        for (i, &vreg) in vregs.iter().enumerate() {
-            mir.push(X86Inst::MovRI32 {
-                dst: Operand::Virtual(vreg),
-                imm: i as i32,
-            });
-        }
+        define_loaded_values(&mut mir, &vregs);
 
         // Add using potentially spilled operands
         mir.push(X86Inst::AddRR {
@@ -1980,12 +2172,7 @@ mod tests {
         let mut mir = X86Mir::new();
         let vregs: Vec<VReg> = (0..7).map(|_| mir.alloc_vreg()).collect();
 
-        for (i, &vreg) in vregs.iter().enumerate() {
-            mir.push(X86Inst::MovRI32 {
-                dst: Operand::Virtual(vreg),
-                imm: i as i32,
-            });
-        }
+        define_loaded_values(&mut mir, &vregs);
         mir.push(X86Inst::AddRR {
             dst: Operand::Virtual(vregs[6]),
             src: Operand::Virtual(vregs[5]),


### PR DESCRIPTION
## Summary

- derive conservative rematerialization recipes from production MIR definitions
- enable constant and string rematerialization in both register-allocation backends
- preserve ordinary spilling for coalescing conflicts, differing definitions, and in-place updates
- add high-pressure coverage proving fewer spill slots and no frame spill traffic

## Validation

- `scripts/rue fmt`
- `scripts/rue unit codegen regalloc`
- `scripts/rue quick`

Fixes RUE-1169.