### PR TITLE
RUE-1009: align qualified pattern type arguments in Ruelex

### DIFF
--- a/crates/rue-frontend-diff/src/main.rs
+++ b/crates/rue-frontend-diff/src/main.rs
@@ -42,6 +42,10 @@ const SYNTAX_PROBES: &[(&str, &str)] = &[
         "wildcard-payload-pattern.rue",
         "enum Maybe { None, Some(u64) } fn f(value: Maybe) -> u64 { match value { Maybe.Some(_) => 1, Maybe.None => 0 } }",
     ),
+    (
+        "qualified-type-arguments.rue",
+        "fn f(value: outer.Result(inner.Value, inner.Error)) { match value { outer.Result(inner.Value, inner.Error).Ok(v) => {} } }",
+    ),
 ];
 
 fn node(kind: &str, meta: &str, a: String, b: String, c: String, d: String) -> String {

--- a/examples/harbor/decode.rue
+++ b/examples/harbor/decode.rue
@@ -517,8 +517,10 @@ fn parse_error_position(error: ParseError) -> u64 {
 pub fn source(text: StrBuf) -> model.Scenario {
     let mut scenario = model.new_scenario();
     match std.json.parse(text) {
-        std.result.Result(Json, ParseError).Ok(value) => parse_root(value, inout scenario),
-        std.result.Result(Json, ParseError).Err(error) => {
+        std.result.Result(std.json.Json, std.json.ParseError).Ok(value) => {
+            parse_root(value, inout scenario)
+        },
+        std.result.Result(std.json.Json, std.json.ParseError).Err(error) => {
             let at = parse_error_position(error);
             model.add_error(inout scenario, 100, "scenario", "invalid JSON at byte " + @to_string(at));
         },

--- a/examples/harbor/io.rue
+++ b/examples/harbor/io.rue
@@ -3,11 +3,9 @@ const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
 const Bytes = std.arraybuf.ArrayBuf(u8);
 const OptBytes = std.option.Option(Bytes);
-const File = std.fs.File;
-const FileError = std.fs.FileError;
-const FileRes = std.result.Result(File, FileError);
-const ReadRes = std.result.Result(u64, FileError);
-const WriteRes = std.result.Result((), FileError);
+const FileRes = std.result.Result(std.fs.File, std.fs.FileError);
+const ReadRes = std.result.Result(u64, std.fs.FileError);
+const WriteRes = std.result.Result((), std.fs.FileError);
 
 pub fn read_bytes(borrow path: StrBuf) -> OptBytes {
     let O = OptBytes;

--- a/examples/harbor/json_report.rue
+++ b/examples/harbor/json_report.rue
@@ -10,8 +10,6 @@ const state = @import("state.rue");
 const text = @import("text.rue");
 const utilization = @import("utilization.rue");
 const StrBuf = std.strbuf.StrBuf;
-const Json = std.json.Json;
-const ParseError = std.json.ParseError;
 
 fn key(inout out: StrBuf, name: str) {
     let mut value = StrBuf.new();
@@ -205,7 +203,7 @@ pub fn reparses(borrow report: StrBuf) -> bool {
     let mut copy = StrBuf.new();
     text.append_string(inout copy, borrow report);
     match std.json.parse(copy) {
-        std.result.Result(Json, ParseError).Ok(value) => true,
-        std.result.Result(Json, ParseError).Err(error) => false,
+        std.result.Result(std.json.Json, std.json.ParseError).Ok(value) => true,
+        std.result.Result(std.json.Json, std.json.ParseError).Err(error) => false,
     }
 }

--- a/examples/ruelex/parse.rue
+++ b/examples/ruelex/parse.rue
@@ -387,7 +387,7 @@ pub struct Parser {
         let mut path = self.add(ast.IDENT, first.value, first.start, first.end, 0, 0, 0);
         loop {
             if self.at(token.LPAREN) && self.paren_followed_by_dot() {
-                let args = self.parse_type_args();
+                let args = self.parse_pattern_type_args();
                 path = self.add(ast.TYPE_CALL, 0, first.start, self.previous().end, path, args, 0);
             } else if self.eat(token.DOT) {
                 let seg = self.expect(token.IDENT);
@@ -408,6 +408,26 @@ pub struct Parser {
             let _ = self.expect(token.RPAREN);
         }
         self.add(ast.PATTERN, 0, start, self.previous().end, path, binds, 0)
+    }
+
+    fn parse_pattern_type_args(inout self) -> u64 {
+        let _ = self.expect(token.LPAREN);
+        let mut args: u64 = 0;
+        while !self.at(token.RPAREN) && !self.eof() {
+            let parsed = self.parse_type_arg();
+            let node = self.arena.at(parsed);
+            // Generic pattern arguments are expression-shaped in the production AST:
+            // bare names retain a type node, while qualified paths are field chains.
+            let arg = if node.kind == ast.TYPE && node.a != 0 && self.arena.at(node.a).kind == ast.FIELD {
+                node.a
+            } else {
+                parsed
+            };
+            args = self.append(args, arg);
+            if !self.eat(token.COMMA) { break; }
+        }
+        let _ = self.expect(token.RPAREN);
+        args
     }
 
     fn paren_followed_by_dot(borrow self) -> bool {
@@ -618,16 +638,19 @@ pub struct Parser {
         let _ = self.expect(token.LPAREN);
         let mut args: u64 = 0;
         while !self.at(token.RPAREN) && !self.eof() {
-            let arg = if Self.is_primitive(self.kind()) || self.at(token.SELFTYPE) || self.at(token.LBRACKET) || self.at(token.PTR) || self.at(token.STRUCT) || self.at(token.ENUM) {
-                self.parse_type()
-            } else if self.at(token.MINUS) || self.at(token.INT) {
-                self.parse_expr(0, true)
-            } else { self.parse_type() };
-            args = self.append(args, arg);
+            args = self.append(args, self.parse_type_arg());
             if !self.eat(token.COMMA) { break; }
         }
         let _ = self.expect(token.RPAREN);
         args
+    }
+
+    fn parse_type_arg(inout self) -> u64 {
+        if self.at(token.MINUS) || self.at(token.INT) {
+            self.parse_expr(0, true)
+        } else {
+            self.parse_type()
+        }
     }
 
     fn parse_directives(inout self) -> u64 {


### PR DESCRIPTION
## Summary

- normalize qualified type arguments specifically in Ruelex generic pattern heads
- add a focused production-vs-Ruelex structural differential probe
- remove Harbor's seven local-alias workarounds so the maintained corpus exercises qualified nested type arguments directly

## Root cause

The production parser represents generic pattern arguments through expression-shaped call arguments: bare type names retain a type node, while qualified names are field chains. Ruelex reused its ordinary type-argument parser in pattern heads, leaving an extra `type form=named` wrapper around qualified paths.

The fix retains one shared type-argument parser and removes only that qualified wrapper at the pattern boundary.

## Validation

- `scripts/rue fmt`
- `./buck2 test //:frontend-diff-test` — 1,445 corpus files and 4 syntax probes agree
- `scripts/rue cli examples_harbor` — 4 passed
- `scripts/rue quick` — 30 targets passed

Fixes RUE-1009.
