### PR TITLE
RUE-1172: buffer read_line input

### DIFF
--- a/crates/rue-cli-tests/cases/stdin.toml
+++ b/crates/rue-cli-tests/cases/stdin.toml
@@ -87,6 +87,80 @@ Too high!
 You got it!
 """
 
+# RUE-1172: a single chunked stdin read can contain several logical lines.
+# Every byte after a newline must remain available to the next @read_line call.
+[[case]]
+name = "read_line_preserves_buffered_consecutive_lines"
+description = "Consecutive read_line calls consume retained bytes after each newline and reach None at EOF."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+  { path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const OptStr = std.option.Option(StrBuf);
+const OptInt = std.option.Option(i32);
+
+fn read_num() -> i32 {
+    let line: OptStr = @read_line();
+    match line {
+        OptStr.Some(text) => {
+            match @parse_i32(text) {
+                OptInt.Some(value) => value,
+                OptInt.None => -100,
+            }
+        },
+        OptStr.None => -200,
+    }
+}
+
+fn main() -> i32 {
+    let first = read_num();
+    let second = read_num();
+    let third = read_num();
+    let eof = read_num();
+    if first == 11 && second == 22 && third == 33 && eof == -200 {
+        0
+    } else {
+        1
+    }
+}
+""" },
+]
+stdin = "11\n22\n33\n"
+exit_code = 0
+
+# RUE-1172: the first newline lands at the end of a full stdin chunk. The next
+# line is already available to a subsequent @read_line call.
+[[case]]
+name = "read_line_chunk_boundary_newline"
+description = "A long line ending at the retained-buffer boundary does not lose the following line."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+  { path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const OptStr = std.option.Option(StrBuf);
+
+fn read_len() -> i32 {
+    let line: OptStr = @read_line();
+    match line {
+        OptStr.Some(text) => @intCast(text.len()),
+        OptStr.None => -1,
+    }
+}
+
+fn main() -> i32 {
+    let first = read_len();
+    let second = read_len();
+    let eof = read_len();
+    if first == 4095 && second == 1 && eof == -1 { 0 } else { 1 }
+}
+""" },
+]
+stdin = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nz\n"
+exit_code = 0
+
+
 # Recoverable error model (RUE-6, ADR-0038). Before error handling landed these
 # two cases trapped with exit 101 ("parse error" / "unexpected end of input").
 # Now a bad parse is `None` and EOF is `None` — the program chooses what to do.

--- a/crates/rue-runtime/src/io.rs
+++ b/crates/rue-runtime/src/io.rs
@@ -5,6 +5,11 @@
 //! - `__rue_print` - Write a String's raw bytes to stdout (no newline)
 //! - `__rue_println` - Write a String's raw bytes to stdout, then a newline
 
+use core::cell::UnsafeCell;
+#[cfg(test)]
+use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::{AtomicBool, Ordering};
+
 use crate::heap;
 use crate::platform;
 use crate::string::STRING_MIN_CAPACITY;
@@ -119,6 +124,161 @@ crate::define_runtime_implementation! {
 /// This is a reasonable size for most interactive input.
 const READ_LINE_INITIAL_CAPACITY: u64 = 128;
 
+/// Bytes requested from stdin by each buffered read.
+///
+/// One retained chunk is shared by consecutive `read_line` calls so bytes
+/// following a newline do not require another syscall and are not discarded.
+const STDIN_CHUNK_SIZE: usize = 4096;
+
+#[derive(Debug)]
+struct InputSegment<'a> {
+    bytes: &'a [u8],
+    ends_line: bool,
+}
+
+struct StdinBuffer {
+    bytes: [u8; STDIN_CHUNK_SIZE],
+    cursor: usize,
+    filled: usize,
+}
+
+impl StdinBuffer {
+    const fn new() -> Self {
+        Self {
+            bytes: [0; STDIN_CHUNK_SIZE],
+            cursor: 0,
+            filled: 0,
+        }
+    }
+
+    /// Return the next in-memory segment, refilling the retained chunk only
+    /// when every byte from the preceding read has been consumed.
+    fn next_segment<'a>(
+        &'a mut self,
+        read: &mut impl FnMut(*mut u8, usize) -> i64,
+    ) -> Result<Option<InputSegment<'a>>, i64> {
+        if self.cursor == self.filled {
+            let result = read(self.bytes.as_mut_ptr(), self.bytes.len());
+            if result < 0 {
+                return Err(result);
+            }
+            if result == 0 {
+                return Ok(None);
+            }
+
+            let filled = result as usize;
+            if filled > self.bytes.len() {
+                // A platform read must never claim more bytes than requested.
+                // Treat a violated platform contract like EIO instead of
+                // exposing uninitialized memory.
+                return Err(-5);
+            }
+            self.cursor = 0;
+            self.filled = filled;
+        }
+
+        let start = self.cursor;
+        let mut end = start;
+        while end < self.filled && self.bytes[end] != b'\n' {
+            end += 1;
+        }
+        let ends_line = end < self.filled;
+        self.cursor = end + usize::from(ends_line);
+
+        Ok(Some(InputSegment {
+            bytes: &self.bytes[start..end],
+            ends_line,
+        }))
+    }
+}
+
+/// Process-global stdin state.
+///
+/// Rue does not currently expose threads, but keeping the state synchronized
+/// makes the runtime ABI sound for native embedders too. The lock spans the
+/// blocking read so one logical line cannot interleave with another caller.
+struct GlobalStdinBuffer {
+    locked: AtomicBool,
+    buffer: UnsafeCell<StdinBuffer>,
+}
+
+// SAFETY: `with` serializes every access to `buffer`.
+unsafe impl Sync for GlobalStdinBuffer {}
+
+impl GlobalStdinBuffer {
+    const fn new() -> Self {
+        Self {
+            locked: AtomicBool::new(false),
+            buffer: UnsafeCell::new(StdinBuffer::new()),
+        }
+    }
+
+    fn with<R>(&self, operation: impl FnOnce(&mut StdinBuffer) -> R) -> R {
+        while self
+            .locked
+            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            core::hint::spin_loop();
+        }
+
+        struct Unlock<'a>(&'a AtomicBool);
+        impl Drop for Unlock<'_> {
+            fn drop(&mut self) {
+                self.0.store(false, Ordering::Release);
+            }
+        }
+
+        let _unlock = Unlock(&self.locked);
+        // SAFETY: the acquired lock gives this invocation exclusive access to
+        // the cell until `_unlock` releases it.
+        operation(unsafe { &mut *self.buffer.get() })
+    }
+}
+
+static STDIN_BUFFER: GlobalStdinBuffer = GlobalStdinBuffer::new();
+
+#[cfg(test)]
+static READ_LINE_SYSCALLS: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReadLineFailure {
+    Allocation,
+    Input,
+}
+
+impl ReadLineFailure {
+    fn trap(self) -> ! {
+        match self {
+            Self::Allocation => crate::error::allocation_failure(),
+            Self::Input => {
+                let mut msg = [0u8; 19];
+                msg[0] = b'e';
+                msg[1] = b'r';
+                msg[2] = b'r';
+                msg[3] = b'o';
+                msg[4] = b'r';
+                msg[5] = b':';
+                msg[6] = b' ';
+                msg[7] = b'i';
+                msg[8] = b'n';
+                msg[9] = b'p';
+                msg[10] = b'u';
+                msg[11] = b't';
+                msg[12] = b' ';
+                msg[13] = b'e';
+                msg[14] = b'r';
+                msg[15] = b'r';
+                msg[16] = b'o';
+                msg[17] = b'r';
+                msg[18] = b'\n';
+                platform::write_stderr(&msg);
+                platform::exit(101);
+            }
+        }
+    }
+}
+
 /// Read a line from standard input, returning `Option(StrBuf)`.
 ///
 /// Reads bytes from stdin (file descriptor 0) until a newline character (`\n`)
@@ -163,56 +323,66 @@ pub unsafe fn __rue_read_line(out: *mut OptionStrBufResult, some_disc: u64, none
 
 /// Implementation of read_line shared across platforms.
 ///
-/// This function reads from stdin byte-by-byte until:
+/// This function scans retained stdin chunks until:
 /// - A newline character is found (returns `Some` line without the newline)
 /// - EOF is reached with some data (returns `Some` partial line)
 /// - EOF is reached with no data (returns `None`)
 /// - A read error occurs (panics)
 #[inline]
 fn read_line_impl(out: *mut OptionStrBufResult, some_disc: u64, none_disc: u64) {
+    let result = STDIN_BUFFER
+        .with(|input| read_line_from_fd(input, out, some_disc, none_disc, platform::STDIN));
+    if let Err(failure) = result {
+        // Trap only after `with` releases the process-global input lock. On
+        // Linux, the raw exit syscall terminates only the calling thread, so a
+        // native embedder may legitimately invoke the runtime again.
+        failure.trap();
+    }
+}
+
+fn read_line_from_fd(
+    input: &mut StdinBuffer,
+    out: *mut OptionStrBufResult,
+    some_disc: u64,
+    none_disc: u64,
+    fd: u64,
+) -> Result<(), ReadLineFailure> {
+    let mut read = |destination, capacity| {
+        #[cfg(test)]
+        READ_LINE_SYSCALLS.fetch_add(1, Ordering::Relaxed);
+        platform::read(fd, destination, capacity)
+    };
+    read_line_from(input, out, some_disc, none_disc, &mut read)
+}
+
+fn read_line_from(
+    input: &mut StdinBuffer,
+    out: *mut OptionStrBufResult,
+    some_disc: u64,
+    none_disc: u64,
+    read: &mut impl FnMut(*mut u8, usize) -> i64,
+) -> Result<(), ReadLineFailure> {
     // Allocate initial buffer
     let mut cap = READ_LINE_INITIAL_CAPACITY;
     let mut ptr = heap::alloc(cap, 1);
     if ptr.is_null() {
-        crate::error::allocation_failure();
+        return Err(ReadLineFailure::Allocation);
     }
 
     let mut len: u64 = 0;
-    let mut byte_buf = [0u8; 1];
 
     loop {
-        // Read one byte at a time
-        let result = platform::read(platform::STDIN, byte_buf.as_mut_ptr(), 1);
+        let segment = match input.next_segment(read) {
+            Ok(segment) => segment,
+            Err(_) => {
+                // Read error - free the buffer before reporting the failure.
+                // SAFETY: ptr is the live cap-byte buffer allocated above.
+                unsafe { heap::free(ptr, cap, 1) };
+                return Err(ReadLineFailure::Input);
+            }
+        };
 
-        if result < 0 {
-            // Read error - free buffer and panic
-            // SAFETY: ptr is the live cap-byte buffer allocated above.
-            unsafe { heap::free(ptr, cap, 1) };
-            let mut msg = [0u8; 19];
-            msg[0] = b'e';
-            msg[1] = b'r';
-            msg[2] = b'r';
-            msg[3] = b'o';
-            msg[4] = b'r';
-            msg[5] = b':';
-            msg[6] = b' ';
-            msg[7] = b'i';
-            msg[8] = b'n';
-            msg[9] = b'p';
-            msg[10] = b'u';
-            msg[11] = b't';
-            msg[12] = b' ';
-            msg[13] = b'e';
-            msg[14] = b'r';
-            msg[15] = b'r';
-            msg[16] = b'o';
-            msg[17] = b'r';
-            msg[18] = b'\n';
-            platform::write_stderr(&msg);
-            platform::exit(101);
-        }
-
-        if result == 0 {
+        let Some(segment) = segment else {
             // EOF reached
             if len == 0 {
                 // EOF with no data: this is not an error (RUE-6, ADR-0038).
@@ -230,46 +400,62 @@ fn read_line_impl(out: *mut OptionStrBufResult, some_disc: u64, none_disc: u64) 
                     (*out).len = 0;
                     (*out).cap = 0;
                 }
-                return;
+                return Ok(());
             }
             // EOF with data - return partial line
             break;
-        }
+        };
 
-        // Got a byte
-        let byte = byte_buf[0];
-
-        // Check for newline - line is complete (don't include the newline)
-        if byte == b'\n' {
-            break;
-        }
-
-        // Need to store this byte - ensure we have capacity
-        if len >= cap {
+        let segment_len = match u64::try_from(segment.bytes.len()) {
+            Ok(segment_len) => segment_len,
+            Err(_) => {
+                // SAFETY: ptr is the live cap-byte allocation.
+                unsafe { heap::free(ptr, cap, 1) };
+                return Err(ReadLineFailure::Allocation);
+            }
+        };
+        let Some(required) = len.checked_add(segment_len) else {
+            // SAFETY: ptr is the live cap-byte allocation.
+            unsafe { heap::free(ptr, cap, 1) };
+            return Err(ReadLineFailure::Allocation);
+        };
+        if required > cap {
             // Grow the buffer (2x strategy)
-            let Some(new_cap) = cap.checked_mul(2) else {
-                crate::error::allocation_failure();
-            };
-            let new_cap = new_cap.max(STRING_MIN_CAPACITY);
+            let mut new_cap = cap;
+            while new_cap < required {
+                let Some(grown) = new_cap.checked_mul(2) else {
+                    // SAFETY: ptr is the live cap-byte allocation.
+                    unsafe { heap::free(ptr, cap, 1) };
+                    return Err(ReadLineFailure::Allocation);
+                };
+                new_cap = grown.max(STRING_MIN_CAPACITY);
+            }
             // SAFETY: ptr is live and readable for cap bytes.
             let new_ptr = unsafe { heap::realloc(ptr, cap, new_cap, 1) };
             if new_ptr.is_null() {
-                // Keep the old allocation intact until the canonical trap.
-                crate::error::allocation_failure();
+                // Failed realloc leaves the old allocation live.
+                // SAFETY: ptr still identifies the live cap-byte allocation.
+                unsafe { heap::free(ptr, cap, 1) };
+                return Err(ReadLineFailure::Allocation);
             }
             ptr = new_ptr;
             cap = new_cap;
         }
 
-        // Store the byte
-        // SAFETY: Writing is safe because:
-        // - We checked `len < cap` above and grew the buffer if needed
-        // - `ptr` points to valid heap memory from our allocation
-        // - u8 has no alignment requirements
+        // SAFETY: `required <= cap`, and `segment` is an initialized,
+        // non-overlapping range within the retained stdin chunk.
         unsafe {
-            *ptr.add(len as usize) = byte;
+            core::ptr::copy_nonoverlapping(
+                segment.bytes.as_ptr(),
+                ptr.add(len as usize),
+                segment.bytes.len(),
+            );
         }
-        len += 1;
+        len = required;
+
+        if segment.ends_line {
+            break;
+        }
     }
 
     // Return `Some(string)`.
@@ -280,13 +466,163 @@ fn read_line_impl(out: *mut OptionStrBufResult, some_disc: u64, none_disc: u64) 
         (*out).len = len;
         (*out).cap = cap;
     }
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     extern crate std;
 
+    use self::std::io::Write;
+    use self::std::os::fd::AsRawFd;
+    use self::std::os::unix::net::UnixStream;
     use self::std::process::Command;
+    use self::std::time::Instant;
+    use self::std::vec;
+    use self::std::vec::Vec;
+
+    struct FakeStdin {
+        bytes: Vec<u8>,
+        cursor: usize,
+        reads: usize,
+        max_read: usize,
+    }
+
+    impl FakeStdin {
+        fn new(bytes: Vec<u8>) -> Self {
+            Self {
+                bytes,
+                cursor: 0,
+                reads: 0,
+                max_read: usize::MAX,
+            }
+        }
+
+        fn read(&mut self, destination: *mut u8, capacity: usize) -> i64 {
+            self.reads += 1;
+            let available = self.bytes.len() - self.cursor;
+            let count = available.min(capacity).min(self.max_read);
+            if count == 0 {
+                return 0;
+            }
+            // SAFETY: the buffer contract supplies `capacity` writable bytes,
+            // and `count` is bounded by both source and destination.
+            unsafe {
+                core::ptr::copy_nonoverlapping(
+                    self.bytes.as_ptr().add(self.cursor),
+                    destination,
+                    count,
+                );
+            }
+            self.cursor += count;
+            count as i64
+        }
+    }
+
+    fn read_one(input: &mut super::StdinBuffer, source: &mut FakeStdin) -> Option<Vec<u8>> {
+        let mut out = super::OptionStrBufResult {
+            disc: u64::MAX,
+            ptr: core::ptr::null_mut(),
+            len: 0,
+            cap: 0,
+        };
+        super::read_line_from(input, &mut out, 1, 0, &mut |destination, capacity| {
+            source.read(destination, capacity)
+        })
+        .expect("fake stdin read succeeds");
+
+        if out.disc == 0 {
+            assert!(out.ptr.is_null());
+            assert_eq!(out.len, 0);
+            assert_eq!(out.cap, 0);
+            return None;
+        }
+        assert_eq!(out.disc, 1);
+        // SAFETY: `Some` transfers the live `cap`-byte allocation to this
+        // test, with `len` initialized bytes.
+        let bytes = unsafe { core::slice::from_raw_parts(out.ptr, out.len as usize) }.to_vec();
+        // SAFETY: the test now owns the exact allocation returned above.
+        unsafe { crate::heap::free(out.ptr, out.cap, 1) };
+        Some(bytes)
+    }
+
+    #[test]
+    fn buffered_lines_preserve_bytes_after_each_newline() {
+        let mut input = super::StdinBuffer::new();
+        let mut source = FakeStdin::new(b"first\n\nthird\xff\npartial".to_vec());
+
+        assert_eq!(read_one(&mut input, &mut source), Some(b"first".to_vec()));
+        assert_eq!(source.reads, 1);
+        assert_eq!(read_one(&mut input, &mut source), Some(Vec::new()));
+        assert_eq!(source.reads, 1);
+        assert_eq!(
+            read_one(&mut input, &mut source),
+            Some(b"third\xff".to_vec())
+        );
+        assert_eq!(source.reads, 1);
+        assert_eq!(read_one(&mut input, &mut source), Some(b"partial".to_vec()));
+        assert_eq!(source.reads, 2);
+        assert_eq!(read_one(&mut input, &mut source), None);
+        assert_eq!(source.reads, 3);
+    }
+
+    #[test]
+    fn newlines_at_both_sides_of_the_chunk_boundary_are_preserved() {
+        let mut bytes = vec![b'a'; super::STDIN_CHUNK_SIZE - 1];
+        bytes.extend_from_slice(b"\nnext\n");
+        bytes.extend(vec![b'b'; super::STDIN_CHUNK_SIZE]);
+        bytes.extend_from_slice(b"\nafter\n");
+
+        let mut input = super::StdinBuffer::new();
+        let mut source = FakeStdin::new(bytes);
+
+        assert_eq!(
+            read_one(&mut input, &mut source).unwrap(),
+            vec![b'a'; super::STDIN_CHUNK_SIZE - 1]
+        );
+        assert_eq!(read_one(&mut input, &mut source), Some(b"next".to_vec()));
+        assert_eq!(
+            read_one(&mut input, &mut source).unwrap(),
+            vec![b'b'; super::STDIN_CHUNK_SIZE]
+        );
+        assert_eq!(read_one(&mut input, &mut source), Some(b"after".to_vec()));
+        assert_eq!(read_one(&mut input, &mut source), None);
+
+        let mut bytes = vec![b'c'; super::STDIN_CHUNK_SIZE];
+        bytes.extend_from_slice(b"\nlast\n");
+        let mut input = super::StdinBuffer::new();
+        let mut source = FakeStdin::new(bytes);
+
+        assert_eq!(
+            read_one(&mut input, &mut source).unwrap(),
+            vec![b'c'; super::STDIN_CHUNK_SIZE]
+        );
+        assert_eq!(source.reads, 2, "newline begins the second chunk");
+        assert_eq!(read_one(&mut input, &mut source), Some(b"last".to_vec()));
+        assert_eq!(read_one(&mut input, &mut source), None);
+    }
+
+    #[test]
+    fn partial_reads_are_assembled_without_extra_syscalls_per_byte() {
+        let mut input = super::StdinBuffer::new();
+        let mut source = FakeStdin::new(b"abcdefghij\n".to_vec());
+        source.max_read = 3;
+
+        assert_eq!(
+            read_one(&mut input, &mut source),
+            Some(b"abcdefghij".to_vec())
+        );
+        assert_eq!(source.reads, 4);
+    }
+
+    #[test]
+    fn interrupted_read_is_still_an_input_error() {
+        let mut input = super::StdinBuffer::new();
+        let error = input
+            .next_segment(&mut |_destination, _capacity| -4)
+            .unwrap_err();
+        assert_eq!(error, -4);
+    }
 
     #[test]
     fn read_line_allocation_failure_uses_canonical_trap() {
@@ -315,5 +651,140 @@ mod tests {
 
         assert_eq!(output.status.code(), Some(101));
         assert_eq!(output.stderr, b"panic: out of memory\n");
+    }
+
+    #[test]
+    fn read_line_reallocation_failure_uses_canonical_trap() {
+        const CHILD_ENV: &str = "RUE_READ_LINE_REALLOC_OOM_CHILD";
+        if self::std::env::var_os(CHILD_ENV).is_some() {
+            crate::heap::fail_allocations_after_for_test(1);
+            let mut input = super::StdinBuffer::new();
+            let mut source = FakeStdin::new(vec![b'x'; 256]);
+            let mut out = super::OptionStrBufResult {
+                disc: 0,
+                ptr: core::ptr::null_mut(),
+                len: 0,
+                cap: 0,
+            };
+            let failure =
+                super::read_line_from(&mut input, &mut out, 1, 0, &mut |destination, capacity| {
+                    source.read(destination, capacity)
+                })
+                .unwrap_err();
+            failure.trap();
+        }
+
+        let output = Command::new(self::std::env::current_exe().expect("current test binary"))
+            .args([
+                "--exact",
+                "io::tests::read_line_reallocation_failure_uses_canonical_trap",
+                "--nocapture",
+            ])
+            .env(CHILD_ENV, "1")
+            .output()
+            .expect("spawn reallocation-failure child");
+
+        assert_eq!(output.status.code(), Some(101));
+        assert_eq!(output.stderr, b"panic: out of memory\n");
+    }
+
+    #[test]
+    fn read_line_error_uses_canonical_trap() {
+        const CHILD_ENV: &str = "RUE_READ_LINE_ERROR_CHILD";
+        if self::std::env::var_os(CHILD_ENV).is_some() {
+            let mut input = super::StdinBuffer::new();
+            let mut out = super::OptionStrBufResult {
+                disc: 0,
+                ptr: core::ptr::null_mut(),
+                len: 0,
+                cap: 0,
+            };
+            let failure =
+                super::read_line_from(&mut input, &mut out, 1, 0, &mut |_, _| -4).unwrap_err();
+            failure.trap();
+        }
+
+        let output = Command::new(self::std::env::current_exe().expect("current test binary"))
+            .args([
+                "--exact",
+                "io::tests::read_line_error_uses_canonical_trap",
+                "--nocapture",
+            ])
+            .env(CHILD_ENV, "1")
+            .output()
+            .expect("spawn read-error child");
+
+        assert_eq!(output.status.code(), Some(101));
+        assert_eq!(output.stderr, b"error: input error\n");
+    }
+
+    #[test]
+    fn read_failure_releases_the_global_input_lock() {
+        let input = super::GlobalStdinBuffer::new();
+        let mut out = super::OptionStrBufResult {
+            disc: 0,
+            ptr: core::ptr::null_mut(),
+            len: 0,
+            cap: 0,
+        };
+
+        let failure = input
+            .with(|buffer| super::read_line_from(buffer, &mut out, 1, 0, &mut |_, _| -4))
+            .unwrap_err();
+        assert_eq!(failure, super::ReadLineFailure::Input);
+
+        // A Linux runtime trap exits only the invoking thread. Returning the
+        // failure through `with` must therefore release this lock first.
+        assert_eq!(input.with(|_| 42), 42);
+    }
+
+    /// Focused manual benchmark for RUE-1172. A Unix stream feeds the same
+    /// platform-read helper used for production stdin, so the metric counts
+    /// actual kernel reads and times the runtime allocation/copy path.
+    #[test]
+    #[ignore = "manual benchmark; run this exact test with --ignored --nocapture"]
+    fn buffered_read_line_benchmark() {
+        const LINE_BYTES: usize = 16 * 1024 * 1024;
+
+        let (reader, mut writer) = UnixStream::pair().expect("create benchmark stream");
+        let writer_thread = self::std::thread::spawn(move || {
+            let mut bytes = vec![b'x'; LINE_BYTES];
+            bytes.push(b'\n');
+            writer.write_all(&bytes).expect("feed benchmark stream");
+        });
+
+        let mut input = super::StdinBuffer::new();
+        let mut out = super::OptionStrBufResult {
+            disc: 0,
+            ptr: core::ptr::null_mut(),
+            len: 0,
+            cap: 0,
+        };
+        let fd = reader.as_raw_fd() as u64;
+        super::READ_LINE_SYSCALLS.store(0, super::Ordering::Relaxed);
+
+        let started = Instant::now();
+        super::read_line_from_fd(&mut input, &mut out, 1, 0, fd).expect("benchmark line read");
+        assert_eq!(out.disc, 1);
+        assert_eq!(out.len, LINE_BYTES as u64);
+        // SAFETY: `Some` transferred this exact live allocation.
+        unsafe { crate::heap::free(out.ptr, out.cap, 1) };
+
+        super::read_line_from_fd(&mut input, &mut out, 1, 0, fd).expect("benchmark EOF read");
+        let elapsed = started.elapsed();
+        assert_eq!(out.disc, 0);
+        writer_thread.join().expect("benchmark writer thread");
+
+        let read_syscalls = super::READ_LINE_SYSCALLS.load(super::Ordering::Relaxed);
+        let total_bytes = LINE_BYTES + 1;
+        let throughput_mib_s = total_bytes as f64 / (1024.0 * 1024.0) / elapsed.as_secs_f64();
+        assert!(read_syscalls > 1);
+        assert!(read_syscalls < total_bytes / 128);
+        self::std::eprintln!(
+            "read_line: bytes={total_bytes} lines=1 \
+             read_syscalls={read_syscalls} elapsed_ms={:.3} \
+             throughput_mib_s={throughput_mib_s:.1}",
+            elapsed.as_secs_f64() * 1000.0,
+        );
     }
 }


### PR DESCRIPTION
## Summary

- buffer stdin reads in retained 4 KiB chunks
- preserve bytes after a newline for consecutive `readLine` calls
- cover boundary, error, allocation, and performance behavior

## Validation

- `scripts/rue quick`
- `scripts/rue cli stdin`
- `scripts/rue unit runtime io::tests`
- `scripts/rue unit runtime buffered_read_line_benchmark --ignored --nocapture`
- runtime archives built for all three supported targets
- the broad local suite passed all completed checks; the Caldera slow example hit its fixed 10-minute host timeout and is left to CI per maintainer direction

Fixes RUE-1172.
