### PR TITLE
RUE-1184: define the compiler-performance measurement schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,7 @@ Crate ownership, when locating changes:
 | `rue-allocator`, `rue-runtime`, `rue-runtime-abi` | heap policy, target runtime, and compiler/runtime ABI contract |
 | `rue-error`, `rue-span` | diagnostics and source locations |
 | `rue-spec`, `rue-ui-tests`, `rue-cli-tests` | language and integration tests |
+| `rue-perf-schema` | compiler-performance measurement contract (ADR-0067) |
 
 ## Testing strategy
 

--- a/crates/rue-perf-schema/BUCK
+++ b/crates/rue-perf-schema/BUCK
@@ -1,0 +1,14 @@
+load("//crates:defs.bzl", "rue_crate")
+
+# The ADR-0067 measurement contract. Deliberately dependency-light: it is
+# shared by the runner, the collector, and the site build, and none of them
+# should have to link the compiler to read a run object.
+rue_crate(
+    name = "rue-perf-schema",
+    deps = [
+        "//third-party:serde",
+        "//third-party:serde_json",
+        "//third-party:sha2",
+        "//third-party:toml",
+    ],
+)

--- a/crates/rue-perf-schema/src/canonical.rs
+++ b/crates/rue-perf-schema/src/canonical.rs
@@ -1,0 +1,229 @@
+//! Canonical serialization and content addressing.
+//!
+//! A run object's name is the SHA-256 digest of its canonical form. For that
+//! name to be stable, serialization must be a function of the value alone:
+//! object keys sorted, no insignificant whitespace, and no floating-point
+//! numbers anywhere. The float rule is the reason raw records hold integer
+//! nanoseconds and integer bytes — hashing must never depend on how some
+//! writer chose to format `0.1`.
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+/// Why a value could not be canonically serialized.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CanonicalError {
+    /// The value contained a floating-point number.
+    ///
+    /// Raw records are integers by construction. A float here means a derived
+    /// statistic leaked into storage, which is the thing this rule prevents.
+    FloatingPoint {
+        /// JSON pointer to the offending value, for example `/workloads/0/x`.
+        path: String,
+    },
+    /// The value could not be represented as JSON at all.
+    NotSerializable {
+        /// The underlying serialization error, rendered.
+        detail: String,
+    },
+}
+
+impl std::fmt::Display for CanonicalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CanonicalError::FloatingPoint { path } => {
+                write!(f, "floating-point value at {path} is not canonicalizable")
+            }
+            CanonicalError::NotSerializable { detail } => {
+                write!(f, "value is not serializable as JSON: {detail}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CanonicalError {}
+
+/// Serialize a value to canonical JSON.
+///
+/// Object keys are sorted by their Unicode scalar sequence, no whitespace is
+/// emitted, and any floating-point number is an error rather than a rounding
+/// decision.
+pub fn canonical_json<T: Serialize + ?Sized>(value: &T) -> Result<String, CanonicalError> {
+    let value = serde_json::to_value(value).map_err(|error| CanonicalError::NotSerializable {
+        detail: error.to_string(),
+    })?;
+    let mut out = String::new();
+    write_canonical(&value, "", &mut out)?;
+    Ok(out)
+}
+
+/// The content address of a value: SHA-256 of its canonical JSON, in lowercase
+/// hexadecimal.
+///
+/// This is the filename a run object is stored under. Equal addresses mean
+/// byte-identical canonical forms, so a run object can be verified against its
+/// own name without trusting whoever wrote it.
+pub fn content_address<T: Serialize + ?Sized>(value: &T) -> Result<String, CanonicalError> {
+    let canonical = canonical_json(value)?;
+    let digest = Sha256::digest(canonical.as_bytes());
+    Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+fn write_canonical(
+    value: &serde_json::Value,
+    path: &str,
+    out: &mut String,
+) -> Result<(), CanonicalError> {
+    match value {
+        serde_json::Value::Null => out.push_str("null"),
+        serde_json::Value::Bool(true) => out.push_str("true"),
+        serde_json::Value::Bool(false) => out.push_str("false"),
+        serde_json::Value::Number(number) => {
+            if let Some(unsigned) = number.as_u64() {
+                out.push_str(&unsigned.to_string());
+            } else if let Some(signed) = number.as_i64() {
+                out.push_str(&signed.to_string());
+            } else {
+                return Err(CanonicalError::FloatingPoint {
+                    path: if path.is_empty() {
+                        "/".to_string()
+                    } else {
+                        path.to_string()
+                    },
+                });
+            }
+        }
+        // Delegating string escaping to serde_json keeps this writer honest
+        // about control characters, surrogate pairs, and quoting.
+        serde_json::Value::String(text) => {
+            let encoded =
+                serde_json::to_string(text).map_err(|error| CanonicalError::NotSerializable {
+                    detail: error.to_string(),
+                })?;
+            out.push_str(&encoded);
+        }
+        serde_json::Value::Array(items) => {
+            out.push('[');
+            for (index, item) in items.iter().enumerate() {
+                if index > 0 {
+                    out.push(',');
+                }
+                write_canonical(item, &format!("{path}/{index}"), out)?;
+            }
+            out.push(']');
+        }
+        serde_json::Value::Object(entries) => {
+            // serde_json's map is ordered by key under the default feature set,
+            // but sorting explicitly means the canonical form does not depend
+            // on which features a downstream build happens to enable.
+            let mut keys: Vec<&String> = entries.keys().collect();
+            keys.sort();
+            out.push('{');
+            for (index, key) in keys.into_iter().enumerate() {
+                if index > 0 {
+                    out.push(',');
+                }
+                let encoded = serde_json::to_string(key).map_err(|error| {
+                    CanonicalError::NotSerializable {
+                        detail: error.to_string(),
+                    }
+                })?;
+                out.push_str(&encoded);
+                out.push(':');
+                let child = entries.get(key).expect("key came from this map");
+                write_canonical(child, &format!("{path}/{key}"), out)?;
+            }
+            out.push('}');
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn object_keys_are_sorted_regardless_of_insertion_order() {
+        let forward = canonical_json(&json!({"a": 1, "b": 2, "c": 3})).unwrap();
+        let reverse = canonical_json(&json!({"c": 3, "b": 2, "a": 1})).unwrap();
+        assert_eq!(forward, reverse);
+        assert_eq!(forward, r#"{"a":1,"b":2,"c":3}"#);
+    }
+
+    #[test]
+    fn nested_objects_are_sorted_at_every_depth() {
+        let canonical =
+            canonical_json(&json!({"z": {"y": 1, "x": 2}, "a": [{"n": 1, "m": 2}]})).unwrap();
+        assert_eq!(canonical, r#"{"a":[{"m":2,"n":1}],"z":{"x":2,"y":1}}"#);
+    }
+
+    #[test]
+    fn no_insignificant_whitespace_is_emitted() {
+        let canonical = canonical_json(&json!({"a": [1, 2], "b": {"c": "d"}})).unwrap();
+        assert!(!canonical.contains(' '));
+        assert!(!canonical.contains('\n'));
+    }
+
+    #[test]
+    fn strings_are_escaped_like_json() {
+        let canonical = canonical_json(&json!({"k": "a\"b\\c\nd"})).unwrap();
+        assert_eq!(canonical, r#"{"k":"a\"b\\c\nd"}"#);
+    }
+
+    #[test]
+    fn control_characters_round_trip_through_the_canonical_form() {
+        // Round-tripping proves the escaping is real JSON, not an approximation.
+        let awkward = "tab\there\u{1}\u{7f}\u{2028}end";
+        let canonical = canonical_json(&json!({"k": awkward})).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&canonical).unwrap();
+        assert_eq!(parsed["k"], awkward);
+    }
+
+    #[test]
+    fn non_ascii_keys_sort_by_scalar_sequence() {
+        let canonical = canonical_json(&json!({"é": 1, "e": 2, "z": 3})).unwrap();
+        assert_eq!(canonical, "{\"e\":2,\"z\":3,\"\u{e9}\":1}");
+    }
+
+    #[test]
+    fn floats_are_rejected_with_their_location() {
+        let error = canonical_json(&json!({"outer": [{"inner": 0.5}]})).unwrap_err();
+        assert_eq!(
+            error,
+            CanonicalError::FloatingPoint {
+                path: "/outer/0/inner".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn negative_and_large_integers_survive() {
+        let canonical = canonical_json(&json!({"a": -7, "b": u64::MAX})).unwrap();
+        assert_eq!(canonical, format!(r#"{{"a":-7,"b":{}}}"#, u64::MAX));
+    }
+
+    #[test]
+    fn content_address_is_sha256_of_the_canonical_bytes() {
+        let value = json!({"b": 2, "a": 1});
+        let expected = {
+            let digest = Sha256::digest(r#"{"a":1,"b":2}"#.as_bytes());
+            digest
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect::<String>()
+        };
+        assert_eq!(content_address(&value).unwrap(), expected);
+        assert_eq!(content_address(&value).unwrap().len(), 64);
+    }
+
+    #[test]
+    fn content_address_ignores_key_order_but_not_content() {
+        let one = content_address(&json!({"a": 1, "b": 2})).unwrap();
+        let same = content_address(&json!({"b": 2, "a": 1})).unwrap();
+        let different = content_address(&json!({"a": 1, "b": 3})).unwrap();
+        assert_eq!(one, same);
+        assert_ne!(one, different);
+    }
+}

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -1,0 +1,60 @@
+//! The compiler-performance measurement contract (ADR-0067).
+//!
+//! This crate owns the vocabulary that every other part of the performance
+//! system speaks: what a workload is, what pins a comparison, what a raw
+//! observation looks like on disk, and which observations may enter a series.
+//!
+//! Four ideas carry the design.
+//!
+//! **Wall-clock phase accounting is additive by construction.** A sample's
+//! [`PhaseAccounting`] partitions compiler-root wall time into mutually
+//! exclusive bands whose integer nanoseconds sum *exactly* to
+//! [`PhaseAccounting::compiler_root_ns`]. The equality is checked, not assumed
+//! ([`PhaseAccounting::attributed_ns`]). Inclusive tracing spans are a separate
+//! machinery and never appear here.
+//!
+//! **Versioning has two layers.** A [`SuiteRevision`] pins the
+//! platform-independent logical contract — which workloads exist, the published
+//! phase taxonomy, the runner protocol. A [`PlatformEpoch`] pins everything that
+//! can vary per platform — invocation, resolved content hashes, sampling policy,
+//! environment policy, baseline. Together they make a configuration-invalid
+//! observation *unappendable* rather than merely detectable after the fact.
+//!
+//! **Storage is raw only.** A [`RunObject`] holds complete raw samples in
+//! integer nanoseconds plus structured evidence of whatever failed. Medians,
+//! dispersion, indexes, and chart data are derived by consumers and never
+//! stored. [`content_address`] gives a run object its immutable name.
+//!
+//! **Failure is evidence.** A run is stored whatever happened. Appendability
+//! errors ([`ValidationError`]) reject a run outright; per-sample invalidity
+//! ([`InvalidSample`]) excludes a sample from publication while keeping it on
+//! disk. [`ValidationOutcome`] reports both, plus the run's
+//! [`Completeness`].
+
+mod canonical;
+mod manifest;
+mod run;
+mod series;
+mod validate;
+
+pub use canonical::{CanonicalError, canonical_json, content_address};
+pub use manifest::{
+    Baseline, EnvironmentPolicy, FlaggingPolicy, Manifest, ManifestError, PlatformEpoch,
+    SamplingPolicy, SuiteRevision, Workload,
+};
+pub use run::{
+    Band, EnvironmentFingerprint, FailureRecord, Invocation, Phase, PhaseAccounting, ResolvedPins,
+    RunIdentity, RunObject, Sample, WorkloadObservation,
+};
+pub use series::{Metric, SeriesId};
+pub use validate::{
+    Completeness, InvalidSample, InvalidSampleReason, ValidationError, ValidationOutcome,
+    validate_run,
+};
+
+/// The schema version of [`RunObject`] as defined by this crate.
+///
+/// A run object records the version it was written under. Readers refuse
+/// versions they do not implement rather than guessing: there is no
+/// compatibility path, by design.
+pub const RUN_SCHEMA_VERSION: u32 = 1;

--- a/crates/rue-perf-schema/src/manifest.rs
+++ b/crates/rue-perf-schema/src/manifest.rs
@@ -1,0 +1,737 @@
+//! Suite revisions and platform epochs: the two-layer versioning model.
+//!
+//! Logical facts are declared once, and everything that can vary by platform
+//! lives with the platform. A [`SuiteRevision`] says what the suite *is*; a
+//! [`PlatformEpoch`] says how one platform measures it.
+//!
+//! The division has a practical consequence. Changing what a workload is
+//! creates a new suite revision and therefore new epochs on every participating
+//! platform. Raising only the macOS sample count creates a new epoch only
+//! there. Either way the change is a declared, reviewable event rather than a
+//! silent shift under a continuing headline.
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+use crate::run::EnvironmentFingerprint;
+
+/// One workload in the suite.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Workload {
+    /// The workload's logical identifier, stable across suite revisions that
+    /// do not change what the workload is.
+    pub id: String,
+    /// Path to the workload's root source, relative to the repository root.
+    pub source: String,
+    /// The question this workload exists to answer.
+    ///
+    /// Required, and not decoration: a probe that cannot name its question is
+    /// corpus mass rather than a measurement, and growing the corpus is a new
+    /// suite revision precisely so this stays deliberate.
+    pub question: String,
+}
+
+/// The platform-independent logical contract.
+///
+/// A suite revision pins what the suite means, not how any platform runs it:
+/// which workloads exist and what program each one is, the published phase
+/// taxonomy and timing schema version, and the runner protocol semantics —
+/// what a sample is, how batching is defined, what a run object contains.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SuiteRevision {
+    /// The revision number. Monotonic; never reused.
+    pub revision: u32,
+    /// The timing schema version this revision's phase taxonomy belongs to.
+    pub timing_schema_version: u32,
+    /// The runner protocol version this revision's run objects conform to.
+    pub protocol_version: u32,
+    /// The suite's workloads.
+    pub workloads: Vec<Workload>,
+}
+
+impl SuiteRevision {
+    /// Workload identifiers, sorted.
+    pub fn workload_ids(&self) -> Vec<&str> {
+        let mut ids: Vec<&str> = self
+            .workloads
+            .iter()
+            .map(|workload| workload.id.as_str())
+            .collect();
+        ids.sort_unstable();
+        ids
+    }
+
+    /// Whether the suite declares a workload with this identifier.
+    pub fn declares(&self, workload: &str) -> bool {
+        self.workloads.iter().any(|entry| entry.id == workload)
+    }
+}
+
+/// The environment class an epoch requires, as a policy rather than a machine.
+///
+/// Hosted runners change underneath a policy. The epoch declares what class of
+/// environment is acceptable; each run records the exact
+/// [`EnvironmentFingerprint`] it found, and drift within the policy is
+/// annotated rather than prevented.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EnvironmentPolicy {
+    /// Required runner environment class, for example `github-hosted`.
+    pub runner_label: String,
+    /// Required runner image label, for example `ubuntu-24.04`.
+    pub runner_image: String,
+}
+
+impl EnvironmentPolicy {
+    /// Whether a fingerprint satisfies this policy.
+    ///
+    /// Only the declared class and image are required. The image *version*,
+    /// CPU model, and core count are recorded but unconstrained — pinning them
+    /// is not available on hosted hardware, and pretending otherwise would make
+    /// collection fail rather than make measurements comparable.
+    pub fn admits(&self, fingerprint: &EnvironmentFingerprint) -> bool {
+        fingerprint.runner_label == self.runner_label
+            && fingerprint.runner_image == self.runner_image
+    }
+}
+
+/// How many samples to take for one workload, and how to batch them.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SamplingPolicy {
+    /// How many samples to collect.
+    pub samples: u32,
+    /// How many compilations make up one sample.
+    ///
+    /// `1` for ordinary workloads. Very short workloads use a larger factor so
+    /// timer resolution and per-process jitter do not dominate.
+    pub batch_size: u32,
+}
+
+/// When a workload's movement counts as movement.
+///
+/// A workload is flagged only when the difference between its current median
+/// and the trailing-window median exceeds `k` times the pooled uncertainty of
+/// the two. Differences inside that bound are rendered as uncertain, not as
+/// movement.
+///
+/// Both constants come from the unpublished calibration phase and are pinned
+/// here, so changing either is a visible epoch event rather than a quiet
+/// retuning of what counts as a regression.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FlaggingPolicy {
+    /// The multiplier applied to pooled uncertainty.
+    ///
+    /// This is configuration, reviewed in ordinary pull requests. It is never
+    /// serialized into a content-addressed run object, which is why a
+    /// floating-point value is admissible here and nowhere in raw records.
+    pub k: f64,
+    /// How many prior runs form the trailing window.
+    pub window: u32,
+}
+
+/// The run whose per-workload medians define ratio 1.0 for an epoch.
+///
+/// Only the first *complete, valid* run at a declared trunk revision may serve.
+/// An attempted or partial run is never a baseline.
+///
+/// The medians themselves are not stored: they are derived from the referenced
+/// run object, in keeping with storing raw observations and nothing else.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Baseline {
+    /// The compiler revision the baseline was measured at.
+    pub commit: String,
+    /// The content address of the baseline run object.
+    pub run: String,
+}
+
+/// Everything that can vary by platform.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlatformEpoch {
+    /// The epoch number, unique within its platform. Monotonic; never reused.
+    pub id: u32,
+    /// The platform this epoch measures, for example `x86_64-linux`.
+    pub platform: String,
+    /// The suite revision this epoch implements.
+    pub suite_revision: u32,
+    /// The compilation target triple.
+    pub target: String,
+    /// Every behavior-affecting compiler argument, in order.
+    pub args: Vec<String>,
+    /// Content hash of the toolchain as built for this target.
+    pub toolchain_hash: String,
+    /// Content hash of the standard library.
+    pub stdlib_hash: String,
+    /// Content hash of each workload's full source closure, keyed by workload.
+    pub workload_source_hashes: BTreeMap<String, String>,
+    /// The environment class this epoch requires.
+    pub environment: EnvironmentPolicy,
+    /// Sampling policy per workload.
+    pub sampling: BTreeMap<String, SamplingPolicy>,
+    /// The regression-flagging rule.
+    pub flagging: FlaggingPolicy,
+    /// The headline baseline, once a complete valid run has established one.
+    ///
+    /// Absent until then: an epoch may exist and collect observations before it
+    /// can express them as an index.
+    #[serde(default)]
+    pub baseline: Option<Baseline>,
+}
+
+/// Why a manifest could not be loaded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ManifestError {
+    /// The manifest is not well-formed TOML, or does not match the schema.
+    Malformed {
+        /// The underlying parse error, rendered.
+        detail: String,
+    },
+    /// Two suite revisions share a revision number.
+    DuplicateSuiteRevision {
+        /// The repeated revision number.
+        revision: u32,
+    },
+    /// Two epochs on one platform share an identifier.
+    DuplicateEpoch {
+        /// The platform carrying the collision.
+        platform: String,
+        /// The repeated epoch identifier.
+        id: u32,
+    },
+    /// A suite revision declares the same workload identifier twice.
+    DuplicateWorkload {
+        /// The suite revision containing the duplicate.
+        revision: u32,
+        /// The repeated workload identifier.
+        workload: String,
+    },
+    /// A workload declares no question it answers.
+    WorkloadWithoutQuestion {
+        /// The suite revision containing the workload.
+        revision: u32,
+        /// The workload with an empty question.
+        workload: String,
+    },
+    /// An epoch implements a suite revision the manifest does not declare.
+    UnknownSuiteRevision {
+        /// The platform of the offending epoch.
+        platform: String,
+        /// The offending epoch.
+        epoch: u32,
+        /// The revision it claims to implement.
+        revision: u32,
+    },
+    /// An epoch's per-workload declarations do not match its suite revision.
+    ///
+    /// Every workload needs a source hash and a sampling policy, and neither
+    /// may name a workload the suite does not declare. An epoch that is
+    /// incomplete or over-specified cannot pin what a run must match.
+    EpochWorkloadMismatch {
+        /// The platform of the offending epoch.
+        platform: String,
+        /// The offending epoch.
+        epoch: u32,
+        /// What is being declared: `source hashes` or `sampling policies`.
+        field: String,
+        /// Suite workloads with no declaration.
+        missing: Vec<String>,
+        /// Declarations naming no suite workload.
+        unexpected: Vec<String>,
+    },
+    /// A sampling policy asks for zero samples or a zero batch size.
+    ///
+    /// Both are protocol nonsense rather than an aggressive setting: a series
+    /// cannot have a median of nothing, and a sample cannot measure zero
+    /// compilations.
+    EmptySamplingPolicy {
+        /// The platform of the offending epoch.
+        platform: String,
+        /// The offending epoch.
+        epoch: u32,
+        /// The workload whose policy is empty.
+        workload: String,
+    },
+}
+
+impl std::fmt::Display for ManifestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ManifestError::Malformed { detail } => write!(f, "malformed manifest: {detail}"),
+            ManifestError::DuplicateSuiteRevision { revision } => {
+                write!(f, "suite revision {revision} is declared more than once")
+            }
+            ManifestError::DuplicateEpoch { platform, id } => {
+                write!(f, "epoch {id} on {platform} is declared more than once")
+            }
+            ManifestError::DuplicateWorkload { revision, workload } => write!(
+                f,
+                "suite revision {revision} declares workload {workload:?} more than once"
+            ),
+            ManifestError::WorkloadWithoutQuestion { revision, workload } => write!(
+                f,
+                "workload {workload:?} in suite revision {revision} names no question it answers"
+            ),
+            ManifestError::UnknownSuiteRevision {
+                platform,
+                epoch,
+                revision,
+            } => write!(
+                f,
+                "epoch {epoch} on {platform} implements undeclared suite revision {revision}"
+            ),
+            ManifestError::EpochWorkloadMismatch {
+                platform,
+                epoch,
+                field,
+                missing,
+                unexpected,
+            } => write!(
+                f,
+                "epoch {epoch} on {platform} has {field} that do not match its suite revision \
+                 (missing: {missing:?}, unexpected: {unexpected:?})"
+            ),
+            ManifestError::EmptySamplingPolicy {
+                platform,
+                epoch,
+                workload,
+            } => write!(
+                f,
+                "epoch {epoch} on {platform} samples workload {workload:?} zero times or in \
+                 zero-sized batches"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ManifestError {}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawManifest {
+    #[serde(default)]
+    suite: Vec<SuiteRevision>,
+    #[serde(default)]
+    epoch: Vec<PlatformEpoch>,
+}
+
+/// The declared suite revisions and platform epochs.
+///
+/// Loaded from `performance/manifest.toml`. Parsing is not enough: [`Manifest::parse`]
+/// also enforces that the two layers agree, so a later validation failure
+/// against an epoch always means the *run* is wrong rather than the manifest.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Manifest {
+    suites: BTreeMap<u32, SuiteRevision>,
+    epochs: Vec<PlatformEpoch>,
+}
+
+impl Manifest {
+    /// Parse and check a manifest.
+    pub fn parse(text: &str) -> Result<Manifest, ManifestError> {
+        let raw: RawManifest = toml::from_str(text).map_err(|error| ManifestError::Malformed {
+            detail: error.to_string(),
+        })?;
+
+        let mut suites: BTreeMap<u32, SuiteRevision> = BTreeMap::new();
+        for suite in raw.suite {
+            let mut seen: Vec<&str> = Vec::new();
+            for workload in &suite.workloads {
+                if seen.contains(&workload.id.as_str()) {
+                    return Err(ManifestError::DuplicateWorkload {
+                        revision: suite.revision,
+                        workload: workload.id.clone(),
+                    });
+                }
+                if workload.question.trim().is_empty() {
+                    return Err(ManifestError::WorkloadWithoutQuestion {
+                        revision: suite.revision,
+                        workload: workload.id.clone(),
+                    });
+                }
+                seen.push(&workload.id);
+            }
+            if suites.contains_key(&suite.revision) {
+                return Err(ManifestError::DuplicateSuiteRevision {
+                    revision: suite.revision,
+                });
+            }
+            suites.insert(suite.revision, suite);
+        }
+
+        let manifest = Manifest {
+            suites,
+            epochs: raw.epoch,
+        };
+        manifest.check_epochs()?;
+        Ok(manifest)
+    }
+
+    fn check_epochs(&self) -> Result<(), ManifestError> {
+        let mut seen: Vec<(&str, u32)> = Vec::new();
+        for epoch in &self.epochs {
+            let key = (epoch.platform.as_str(), epoch.id);
+            if seen.contains(&key) {
+                return Err(ManifestError::DuplicateEpoch {
+                    platform: epoch.platform.clone(),
+                    id: epoch.id,
+                });
+            }
+            seen.push(key);
+
+            let Some(suite) = self.suites.get(&epoch.suite_revision) else {
+                return Err(ManifestError::UnknownSuiteRevision {
+                    platform: epoch.platform.clone(),
+                    epoch: epoch.id,
+                    revision: epoch.suite_revision,
+                });
+            };
+
+            let declared = suite.workload_ids();
+            check_coverage(
+                epoch,
+                "source hashes",
+                &declared,
+                epoch.workload_source_hashes.keys(),
+            )?;
+            check_coverage(epoch, "sampling policies", &declared, epoch.sampling.keys())?;
+
+            for (workload, policy) in &epoch.sampling {
+                if policy.samples == 0 || policy.batch_size == 0 {
+                    return Err(ManifestError::EmptySamplingPolicy {
+                        platform: epoch.platform.clone(),
+                        epoch: epoch.id,
+                        workload: workload.clone(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// The suite revision with this number, if declared.
+    pub fn suite(&self, revision: u32) -> Option<&SuiteRevision> {
+        self.suites.get(&revision)
+    }
+
+    /// The epoch with this identifier on this platform, if declared.
+    pub fn epoch(&self, platform: &str, id: u32) -> Option<&PlatformEpoch> {
+        self.epochs
+            .iter()
+            .find(|epoch| epoch.platform == platform && epoch.id == id)
+    }
+
+    /// Every declared suite revision, in ascending revision order.
+    pub fn suites(&self) -> impl Iterator<Item = &SuiteRevision> {
+        self.suites.values()
+    }
+
+    /// Every declared epoch, in declaration order.
+    pub fn epochs(&self) -> impl Iterator<Item = &PlatformEpoch> {
+        self.epochs.iter()
+    }
+}
+
+fn check_coverage<'a>(
+    epoch: &PlatformEpoch,
+    field: &str,
+    declared: &[&str],
+    provided: impl Iterator<Item = &'a String>,
+) -> Result<(), ManifestError> {
+    let provided: Vec<&str> = provided.map(String::as_str).collect();
+    let missing: Vec<String> = declared
+        .iter()
+        .filter(|id| !provided.contains(*id))
+        .map(|id| (*id).to_string())
+        .collect();
+    let unexpected: Vec<String> = provided
+        .iter()
+        .filter(|id| !declared.contains(*id))
+        .map(|id| (*id).to_string())
+        .collect();
+    if missing.is_empty() && unexpected.is_empty() {
+        return Ok(());
+    }
+    Err(ManifestError::EpochWorkloadMismatch {
+        platform: epoch.platform.clone(),
+        epoch: epoch.id,
+        field: field.to_string(),
+        missing,
+        unexpected,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SUITE: &str = r#"
+[[suite]]
+revision = 1
+timing_schema_version = 1
+protocol_version = 1
+
+[[suite.workloads]]
+id = "startup"
+source = "performance/workloads/startup/main.rue"
+question = "What does a minimal compilation cost end to end?"
+
+[[suite.workloads]]
+id = "caldera"
+source = "examples/caldera/main.rue"
+question = "How does a large single-program compilation behave?"
+"#;
+
+    const EPOCH: &str = r#"
+[[epoch]]
+id = 1
+platform = "x86_64-linux"
+suite_revision = 1
+target = "x86_64-unknown-linux-gnu"
+args = ["-O2"]
+toolchain_hash = "toolchain-aaa"
+stdlib_hash = "stdlib-bbb"
+
+[epoch.workload_source_hashes]
+startup = "startup-ccc"
+caldera = "caldera-ddd"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+[epoch.sampling.startup]
+samples = 25
+batch_size = 40
+
+[epoch.sampling.caldera]
+samples = 15
+batch_size = 1
+
+[epoch.flagging]
+k = 3.0
+window = 10
+"#;
+
+    fn manifest() -> Manifest {
+        Manifest::parse(&format!("{SUITE}{EPOCH}")).expect("fixture manifest is valid")
+    }
+
+    #[test]
+    fn a_well_formed_manifest_parses_both_layers() {
+        let manifest = manifest();
+        let suite = manifest.suite(1).expect("suite 1 is declared");
+        assert_eq!(suite.workload_ids(), vec!["caldera", "startup"]);
+        assert!(suite.declares("startup"));
+        assert!(!suite.declares("meridian"));
+
+        let epoch = manifest
+            .epoch("x86_64-linux", 1)
+            .expect("epoch 1 is declared");
+        assert_eq!(epoch.args, vec!["-O2".to_string()]);
+        assert_eq!(epoch.sampling["startup"].batch_size, 40);
+        assert!(
+            epoch.baseline.is_none(),
+            "an epoch may exist before its baseline"
+        );
+    }
+
+    #[test]
+    fn an_epoch_may_carry_a_baseline() {
+        let text =
+            format!("{SUITE}{EPOCH}\n[epoch.baseline]\ncommit = \"abc123\"\nrun = \"deadbeef\"\n");
+        let manifest = Manifest::parse(&text).expect("baseline is well formed");
+        let baseline = manifest
+            .epoch("x86_64-linux", 1)
+            .and_then(|epoch| epoch.baseline.clone())
+            .expect("baseline is present");
+        assert_eq!(baseline.commit, "abc123");
+        assert_eq!(baseline.run, "deadbeef");
+    }
+
+    #[test]
+    fn a_workload_must_name_the_question_it_answers() {
+        let text = SUITE.replace(
+            r#"question = "What does a minimal compilation cost end to end?""#,
+            r#"question = "  ""#,
+        );
+        assert_eq!(
+            Manifest::parse(&text).unwrap_err(),
+            ManifestError::WorkloadWithoutQuestion {
+                revision: 1,
+                workload: "startup".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn duplicate_workload_identifiers_are_rejected() {
+        let text = format!(
+            "{SUITE}\n[[suite.workloads]]\nid = \"startup\"\nsource = \"x\"\nquestion = \"q\"\n"
+        );
+        assert_eq!(
+            Manifest::parse(&text).unwrap_err(),
+            ManifestError::DuplicateWorkload {
+                revision: 1,
+                workload: "startup".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn duplicate_suite_revisions_are_rejected() {
+        assert_eq!(
+            Manifest::parse(&format!("{SUITE}{SUITE}")).unwrap_err(),
+            ManifestError::DuplicateSuiteRevision { revision: 1 }
+        );
+    }
+
+    #[test]
+    fn duplicate_epochs_on_one_platform_are_rejected() {
+        assert_eq!(
+            Manifest::parse(&format!("{SUITE}{EPOCH}{EPOCH}")).unwrap_err(),
+            ManifestError::DuplicateEpoch {
+                platform: "x86_64-linux".to_string(),
+                id: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn the_same_epoch_number_on_another_platform_is_fine() {
+        let other = EPOCH
+            .replace(
+                r#"platform = "x86_64-linux""#,
+                r#"platform = "aarch64-macos""#,
+            )
+            .replace(
+                r#"runner_image = "ubuntu-24.04""#,
+                r#"runner_image = "macos-15""#,
+            );
+        let manifest = Manifest::parse(&format!("{SUITE}{EPOCH}{other}"))
+            .expect("epoch numbering is per platform");
+        assert!(manifest.epoch("aarch64-macos", 1).is_some());
+        assert_eq!(manifest.epochs().count(), 2);
+    }
+
+    #[test]
+    fn an_epoch_implementing_an_undeclared_suite_revision_is_rejected() {
+        let text = format!(
+            "{SUITE}{}",
+            EPOCH.replace("suite_revision = 1", "suite_revision = 7")
+        );
+        assert_eq!(
+            Manifest::parse(&text).unwrap_err(),
+            ManifestError::UnknownSuiteRevision {
+                platform: "x86_64-linux".to_string(),
+                epoch: 1,
+                revision: 7,
+            }
+        );
+    }
+
+    #[test]
+    fn an_epoch_missing_a_workload_source_hash_is_rejected() {
+        let text = format!(
+            "{SUITE}{}",
+            EPOCH.replace("caldera = \"caldera-ddd\"\n", "")
+        );
+        assert_eq!(
+            Manifest::parse(&text).unwrap_err(),
+            ManifestError::EpochWorkloadMismatch {
+                platform: "x86_64-linux".to_string(),
+                epoch: 1,
+                field: "source hashes".to_string(),
+                missing: vec!["caldera".to_string()],
+                unexpected: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn an_epoch_sampling_an_undeclared_workload_is_rejected() {
+        let text =
+            format!("{SUITE}{EPOCH}\n[epoch.sampling.meridian]\nsamples = 5\nbatch_size = 1\n");
+        assert_eq!(
+            Manifest::parse(&text).unwrap_err(),
+            ManifestError::EpochWorkloadMismatch {
+                platform: "x86_64-linux".to_string(),
+                epoch: 1,
+                field: "sampling policies".to_string(),
+                missing: Vec::new(),
+                unexpected: vec!["meridian".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn a_zero_sample_policy_is_rejected() {
+        let text = format!("{SUITE}{}", EPOCH.replace("samples = 15", "samples = 0"));
+        assert_eq!(
+            Manifest::parse(&text).unwrap_err(),
+            ManifestError::EmptySamplingPolicy {
+                platform: "x86_64-linux".to_string(),
+                epoch: 1,
+                workload: "caldera".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_zero_batch_size_is_rejected() {
+        let text = format!(
+            "{SUITE}{}",
+            EPOCH.replace("batch_size = 40", "batch_size = 0")
+        );
+        assert_eq!(
+            Manifest::parse(&text).unwrap_err(),
+            ManifestError::EmptySamplingPolicy {
+                platform: "x86_64-linux".to_string(),
+                epoch: 1,
+                workload: "startup".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_manifest_keys_are_rejected_rather_than_ignored() {
+        let text = format!("{SUITE}{EPOCH}\n[[suite]]\nrevision = 2\ntimings = 1\n");
+        assert!(matches!(
+            Manifest::parse(&text).unwrap_err(),
+            ManifestError::Malformed { .. }
+        ));
+    }
+
+    #[test]
+    fn environment_policy_admits_only_its_declared_class_and_image() {
+        let policy = EnvironmentPolicy {
+            runner_label: "github-hosted".to_string(),
+            runner_image: "ubuntu-24.04".to_string(),
+        };
+        let mut fingerprint = crate::EnvironmentFingerprint {
+            runner_label: "github-hosted".to_string(),
+            runner_image: "ubuntu-24.04".to_string(),
+            runner_image_version: "ubuntu24/20250720.1.0".to_string(),
+            cpu_model: "probe".to_string(),
+            core_count: 4,
+            memory_bytes: 1,
+            kernel_version: "probe".to_string(),
+            os_version: "probe".to_string(),
+            architecture: "x86_64".to_string(),
+        };
+        assert!(policy.admits(&fingerprint));
+
+        // Image version drift is recorded, never rejected: it is the drift the
+        // policy deliberately cannot prevent on hosted hardware.
+        fingerprint.runner_image_version = "ubuntu24/20250901.2.0".to_string();
+        assert!(policy.admits(&fingerprint));
+
+        fingerprint.runner_image = "ubuntu-22.04".to_string();
+        assert!(!policy.admits(&fingerprint));
+    }
+}

--- a/crates/rue-perf-schema/src/run.rs
+++ b/crates/rue-perf-schema/src/run.rs
@@ -1,0 +1,630 @@
+//! Raw observation records: what a run object contains on disk.
+//!
+//! Everything here is raw. Durations are integer nanoseconds, sizes are integer
+//! bytes, and no field holds a derived statistic. Milliseconds, percentages,
+//! medians, and dispersion are presentation-time computations that consumers
+//! rebuild from these records.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::RUN_SCHEMA_VERSION;
+
+/// A published wall-clock phase.
+///
+/// These are the mutually exclusive, explicitly instrumented top-level phases
+/// whose durations sum — with the two structural buckets of [`Band`] — to
+/// compiler-root elapsed time. They are the only bands that may appear in an
+/// additive visualization.
+///
+/// The phase set is part of the logical contract a [`crate::SuiteRevision`]
+/// pins. Adding, removing, or redrawing a phase is a timing-schema change and
+/// therefore requires a new suite revision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Phase {
+    /// Locating source files and lexing/parsing them into module syntax.
+    SourceDiscoveryAndParsing,
+    /// Assembling parsed modules into the canonical merged program.
+    ProgramConstruction,
+    /// Type checking, inference, ownership, and the rest of semantic analysis.
+    SemanticAnalysis,
+    /// CFG construction and the optimization pipeline over it.
+    CfgAndOptimization,
+    /// Instruction selection, register allocation, scheduling, and emission.
+    Backend,
+    /// Producing object files from emitted machine code.
+    ObjectGeneration,
+    /// Linking objects and runtime archives into the output binary.
+    Linking,
+}
+
+impl Phase {
+    /// Every published phase, in the order the compiler reaches them.
+    ///
+    /// This order is presentational only; correctness never depends on it.
+    pub const ALL: [Phase; 7] = [
+        Phase::SourceDiscoveryAndParsing,
+        Phase::ProgramConstruction,
+        Phase::SemanticAnalysis,
+        Phase::CfgAndOptimization,
+        Phase::Backend,
+        Phase::ObjectGeneration,
+        Phase::Linking,
+    ];
+
+    /// The stable wire name used in run objects and chart data.
+    pub const fn wire_name(self) -> &'static str {
+        match self {
+            Phase::SourceDiscoveryAndParsing => "source_discovery_and_parsing",
+            Phase::ProgramConstruction => "program_construction",
+            Phase::SemanticAnalysis => "semantic_analysis",
+            Phase::CfgAndOptimization => "cfg_and_optimization",
+            Phase::Backend => "backend",
+            Phase::ObjectGeneration => "object_generation",
+            Phase::Linking => "linking",
+        }
+    }
+}
+
+/// A band of the additive stack: a published phase or a structural bucket.
+///
+/// `MixedParallel` and `Unattributed` are published bands, not artifacts to be
+/// hidden. Sustained growth in `MixedParallel` means the phase boundaries no
+/// longer describe the compiler's parallel structure and should be redrawn;
+/// growth in `Unattributed` means compiler time is moving somewhere the
+/// instrumentation does not describe. Fractional attribution of parallel work
+/// across phases is deliberately not offered: if the partition is unsatisfying,
+/// the fix is better phase boundaries, not invented weights.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Band {
+    /// Exactly one published phase was active over the interval.
+    Phase(Phase),
+    /// More than one distinct phase was active over the interval.
+    MixedParallel,
+    /// Compiler root was active with no phase active over the interval.
+    Unattributed,
+}
+
+impl Band {
+    /// Every band of the additive stack, phases first.
+    pub fn all() -> Vec<Band> {
+        let mut bands: Vec<Band> = Phase::ALL.into_iter().map(Band::Phase).collect();
+        bands.push(Band::MixedParallel);
+        bands.push(Band::Unattributed);
+        bands
+    }
+
+    /// The stable wire name used in run objects and chart data.
+    pub const fn wire_name(self) -> &'static str {
+        match self {
+            Band::Phase(phase) => phase.wire_name(),
+            Band::MixedParallel => "mixed_parallel",
+            Band::Unattributed => "unattributed",
+        }
+    }
+}
+
+/// The wall-clock partition of one compilation's compiler-root time.
+///
+/// The compiler produces this directly. It is never reconstructed from span
+/// names downstream, because inclusive spans nest and overlap and summing them
+/// double-counts.
+///
+/// The defining property, in exact integer nanoseconds:
+///
+/// ```text
+/// sum(phase_ns) + mixed_parallel_ns + unattributed_ns == compiler_root_ns
+/// ```
+///
+/// [`PhaseAccounting::holds`] checks it. A sample that violates it is evidence
+/// of an instrumentation bug: it is excluded from every derived statistic and
+/// kept on disk with a [`FailureRecord::PhaseInvariant`] record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PhaseAccounting {
+    /// Nanoseconds attributed to each published phase.
+    ///
+    /// Every phase in [`Phase::ALL`] is present, including those that measured
+    /// zero. A missing or unknown key is a schema violation, not a default.
+    pub phase_ns: BTreeMap<Phase, u64>,
+    /// Nanoseconds during which more than one distinct phase was active.
+    pub mixed_parallel_ns: u64,
+    /// Nanoseconds during which compiler root was active but no phase was.
+    pub unattributed_ns: u64,
+    /// Compiler-root elapsed nanoseconds: the total the stack must sum to.
+    ///
+    /// This is the union of active root intervals, not a sum of spans.
+    pub compiler_root_ns: u64,
+}
+
+impl PhaseAccounting {
+    /// Nanoseconds in a single band.
+    ///
+    /// A phase absent from `phase_ns` reads as zero here; use
+    /// [`PhaseAccounting::missing_phases`] to detect that absence, which is a
+    /// schema violation rather than a measurement of zero.
+    pub fn band_ns(&self, band: Band) -> u64 {
+        match band {
+            Band::Phase(phase) => self.phase_ns.get(&phase).copied().unwrap_or(0),
+            Band::MixedParallel => self.mixed_parallel_ns,
+            Band::Unattributed => self.unattributed_ns,
+        }
+    }
+
+    /// Total nanoseconds attributed across every band.
+    ///
+    /// Saturating arithmetic keeps a corrupt record from panicking a reader;
+    /// the resulting mismatch with `compiler_root_ns` is reported as an
+    /// invariant violation instead.
+    pub fn attributed_ns(&self) -> u64 {
+        Band::all()
+            .into_iter()
+            .fold(0u64, |total, band| total.saturating_add(self.band_ns(band)))
+    }
+
+    /// Whether the exact phase-sum invariant holds for this sample.
+    pub fn holds(&self) -> bool {
+        self.attributed_ns() == self.compiler_root_ns
+    }
+
+    /// Published phases with no entry in `phase_ns`.
+    ///
+    /// A phase that genuinely took no time records `0`. An absent key means the
+    /// producer and this schema disagree about the taxonomy.
+    pub fn missing_phases(&self) -> Vec<Phase> {
+        Phase::ALL
+            .into_iter()
+            .filter(|phase| !self.phase_ns.contains_key(phase))
+            .collect()
+    }
+}
+
+/// One measured compilation, or one measured batch of them.
+///
+/// A **fresh build**: a newly launched compiler process with no retained
+/// compiler-session state. Operating-system state (filesystem and page cache)
+/// is not controlled, so these are not "cold" measurements.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Sample {
+    /// How many compilations this sample measures as one unit.
+    ///
+    /// `1` for ordinary workloads. Short workloads such as the startup probe
+    /// use a larger factor so that timer resolution and per-process jitter do
+    /// not dominate. The factor is pinned by the epoch's
+    /// [`crate::SamplingPolicy`], so changing it is a visible epoch event.
+    pub batch_size: u32,
+    /// Externally measured process wall time, in nanoseconds.
+    ///
+    /// The difference from `phases.compiler_root_ns` — process startup, output
+    /// publication, other driver overhead — is real time the user experiences.
+    /// It is reported, but it is outside the phase stack.
+    pub process_elapsed_ns: u64,
+    /// Externally measured peak resident memory, in bytes.
+    pub peak_memory_bytes: u64,
+    /// Size of the produced binary, in bytes.
+    pub output_binary_bytes: u64,
+    /// The compiler's own wall-clock partition for this sample.
+    pub phases: PhaseAccounting,
+}
+
+impl Sample {
+    /// Driver overhead: process wall time outside compiler root.
+    ///
+    /// Returns `None` when the process was measured as shorter than the
+    /// compiler root it contains, which cannot happen physically and marks the
+    /// sample as invalid.
+    pub fn driver_overhead_ns(&self) -> Option<u64> {
+        self.process_elapsed_ns
+            .checked_sub(self.phases.compiler_root_ns)
+    }
+}
+
+/// Every sample collected for one workload in one run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkloadObservation {
+    /// The workload's logical identifier, as declared by the suite revision.
+    pub workload: String,
+    /// Raw samples in collection order.
+    ///
+    /// All samples are stored, including invalid ones. Consumers exclude
+    /// invalid samples from statistics; nothing deletes them.
+    pub samples: Vec<Sample>,
+}
+
+/// Structured evidence about something that went wrong during a run.
+///
+/// Failures are recorded, never silently dropped. A run with failures is still
+/// stored: a persistently broken workload should be visible rather than
+/// appearing as an unexplained hole in the data.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum FailureRecord {
+    /// The compiler under measurement could not be built. No workload ran.
+    Build {
+        /// Human-readable description of the build failure.
+        detail: String,
+    },
+    /// A measured compilation exited abnormally.
+    WorkloadCrashed {
+        /// The workload whose compilation crashed.
+        workload: String,
+        /// Which sample of that workload crashed.
+        sample_index: u32,
+        /// Human-readable description, typically exit status and stderr tail.
+        detail: String,
+    },
+    /// The runner refused to record a compilation that ran.
+    ValidationRejected {
+        /// The workload that was rejected.
+        workload: String,
+        /// Why the runner refused it.
+        detail: String,
+    },
+    /// A sample's phase accounting did not sum to compiler-root time.
+    ///
+    /// This is an instrumentation bug, not a discarded measurement. The sample
+    /// stays in the run object; only its contribution to statistics is removed.
+    PhaseInvariant {
+        /// The workload whose sample violated the invariant.
+        workload: String,
+        /// Which sample violated it.
+        sample_index: u32,
+        /// The compiler-root total the bands should have summed to.
+        compiler_root_ns: u64,
+        /// What the bands actually summed to.
+        attributed_ns: u64,
+    },
+    /// A measured compilation exceeded its time limit and was stopped.
+    Timeout {
+        /// The workload that timed out.
+        workload: String,
+        /// Which sample timed out.
+        sample_index: u32,
+        /// The limit that was exceeded, in nanoseconds.
+        limit_ns: u64,
+    },
+}
+
+impl FailureRecord {
+    /// The workload this failure concerns, if it concerns one.
+    ///
+    /// A [`FailureRecord::Build`] failure is run-level and names no workload.
+    pub fn workload(&self) -> Option<&str> {
+        match self {
+            FailureRecord::Build { .. } => None,
+            FailureRecord::WorkloadCrashed { workload, .. }
+            | FailureRecord::ValidationRejected { workload, .. }
+            | FailureRecord::PhaseInvariant { workload, .. }
+            | FailureRecord::Timeout { workload, .. } => Some(workload),
+        }
+    }
+}
+
+/// The complete compiler invocation a platform epoch pins.
+///
+/// "Complete" is the point: optimization level, linker mode, feature flags, and
+/// every other behavior-affecting argument. Two runs whose invocations differ
+/// are not measuring the same thing, and validation refuses to put them in one
+/// series.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Invocation {
+    /// The compilation target triple.
+    pub target: String,
+    /// Every behavior-affecting compiler argument, in order.
+    pub args: Vec<String>,
+}
+
+/// The content identity a run claims to have measured.
+///
+/// The runner resolves these from the tree it actually measured; validation
+/// compares them against the epoch's declaration. A workload edit changes its
+/// source hash, fails that comparison, and therefore requires a new suite
+/// revision — a workload can never silently reset its own baseline while the
+/// headline continues.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResolvedPins {
+    /// Content hash of the toolchain as built for this target.
+    pub toolchain_hash: String,
+    /// Content hash of the standard library.
+    pub stdlib_hash: String,
+    /// Content hash of each workload's full source closure, keyed by workload.
+    pub workload_source_hashes: BTreeMap<String, String>,
+    /// The compiler invocation used for every workload in this run.
+    pub invocation: Invocation,
+}
+
+/// What the measurement environment actually was.
+///
+/// An epoch pins the environment *policy*, not the exact machine. Hosted
+/// runners change underneath a policy, so every run records what it found. A
+/// fingerprint change within an epoch produces a structural environment
+/// annotation, and comparisons crossing it are rendered as advisory rather than
+/// used to declare a regression.
+///
+/// This is the honest statement for hosted hardware: points in a series satisfy
+/// the epoch's declared environment policy, and exact environment changes are
+/// recorded rather than prevented. Moving to controlled hardware would allow
+/// tightening a per-epoch policy to exact-fingerprint pinning.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EnvironmentFingerprint {
+    /// Runner environment class, for example `github-hosted`.
+    pub runner_label: String,
+    /// Runner image label, for example `ubuntu-24.04`.
+    pub runner_image: String,
+    /// Runner image version as the hosted runner exposes it, for example
+    /// `ubuntu24/20250720.1.0`.
+    pub runner_image_version: String,
+    /// CPU model string as reported by the host.
+    pub cpu_model: String,
+    /// Number of logical cores visible to the runner.
+    pub core_count: u32,
+    /// Total system memory in bytes.
+    pub memory_bytes: u64,
+    /// Kernel version string.
+    pub kernel_version: String,
+    /// Operating-system version string.
+    pub os_version: String,
+    /// Machine architecture, for example `x86_64`.
+    pub architecture: String,
+}
+
+impl EnvironmentFingerprint {
+    /// A stable identifier for this exact environment.
+    ///
+    /// Two runs with equal fingerprint identifiers ran somewhere
+    /// indistinguishable at this resolution. An inequality within an epoch is
+    /// what triggers a derived environment annotation.
+    pub fn fingerprint_id(&self) -> Result<String, crate::CanonicalError> {
+        crate::content_address(self)
+    }
+}
+
+/// Who, what, where, and when — everything but the measurements.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RunIdentity {
+    /// The suite revision whose logical contract this run implements.
+    pub suite_revision: u32,
+    /// The platform epoch this run belongs to.
+    pub epoch: u32,
+    /// The platform the epoch describes, for example `x86_64-linux`.
+    pub platform: String,
+    /// The compiler revision measured.
+    ///
+    /// The compiler revision is a *point within* a series, never part of the
+    /// series' identity.
+    pub commit: String,
+    /// When collection started, RFC 3339 in UTC.
+    pub started_at: String,
+    /// When collection finished, RFC 3339 in UTC.
+    pub finished_at: String,
+    /// The content identity this run claims to have measured.
+    pub pins: ResolvedPins,
+    /// The environment this run actually found.
+    pub environment: EnvironmentFingerprint,
+}
+
+/// One immutable raw observation record.
+///
+/// Run objects are content-addressed by [`crate::content_address`] and never
+/// rewritten. Everything derived from them — indexes, dispersion, chart data,
+/// summaries — is rebuilt by consumers and never stored alongside them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RunObject {
+    /// The schema version this object was written under.
+    pub schema_version: u32,
+    /// Identity and configuration of the run.
+    pub identity: RunIdentity,
+    /// Per-workload raw samples, sorted by workload identifier.
+    pub workloads: Vec<WorkloadObservation>,
+    /// Structured evidence of everything that failed.
+    pub failures: Vec<FailureRecord>,
+}
+
+impl RunObject {
+    /// Whether this object's schema version is the one this crate implements.
+    pub fn is_current_schema(&self) -> bool {
+        self.schema_version == RUN_SCHEMA_VERSION
+    }
+
+    /// The observation for one workload, if the run recorded it.
+    pub fn observation(&self, workload: &str) -> Option<&WorkloadObservation> {
+        self.workloads
+            .iter()
+            .find(|observation| observation.workload == workload)
+    }
+
+    /// This run's immutable name: the content address of its canonical form.
+    pub fn content_address(&self) -> Result<String, crate::CanonicalError> {
+        crate::content_address(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn accounting(
+        root_ns: u64,
+        parse_ns: u64,
+        mixed_ns: u64,
+        unattributed_ns: u64,
+    ) -> PhaseAccounting {
+        let mut phase_ns: BTreeMap<Phase, u64> =
+            Phase::ALL.into_iter().map(|phase| (phase, 0)).collect();
+        phase_ns.insert(Phase::SourceDiscoveryAndParsing, parse_ns);
+        PhaseAccounting {
+            phase_ns,
+            mixed_parallel_ns: mixed_ns,
+            unattributed_ns,
+            compiler_root_ns: root_ns,
+        }
+    }
+
+    #[test]
+    fn the_invariant_holds_when_the_bands_partition_root_time() {
+        let accounting = accounting(100, 60, 30, 10);
+        assert_eq!(accounting.attributed_ns(), 100);
+        assert!(accounting.holds());
+    }
+
+    #[test]
+    fn the_invariant_is_exact_rather_than_approximate() {
+        // One nanosecond of slack is a real instrumentation bug, not rounding.
+        assert!(!accounting(100, 60, 30, 9).holds());
+        assert!(!accounting(100, 60, 30, 11).holds());
+    }
+
+    #[test]
+    fn every_published_phase_participates_in_the_sum() {
+        for phase in Phase::ALL {
+            let mut accounting = accounting(0, 0, 0, 0);
+            accounting.phase_ns.insert(phase, 42);
+            accounting.compiler_root_ns = 42;
+            assert!(accounting.holds(), "{} is not counted", phase.wire_name());
+        }
+    }
+
+    #[test]
+    fn a_corrupt_record_reports_a_violation_rather_than_overflowing() {
+        let mut accounting = accounting(1, 0, 0, 0);
+        accounting.phase_ns.insert(Phase::Backend, u64::MAX);
+        accounting.mixed_parallel_ns = u64::MAX;
+        assert!(!accounting.holds());
+    }
+
+    #[test]
+    fn an_absent_phase_is_distinguishable_from_a_phase_that_took_no_time() {
+        let mut accounting = accounting(0, 0, 0, 0);
+        assert!(accounting.missing_phases().is_empty());
+        accounting.phase_ns.remove(&Phase::Linking);
+        assert_eq!(accounting.missing_phases(), vec![Phase::Linking]);
+        // It still reads as zero when summed, which is exactly why absence
+        // needs its own check rather than being inferred from the total.
+        assert_eq!(accounting.band_ns(Band::Phase(Phase::Linking)), 0);
+    }
+
+    #[test]
+    fn bands_cover_the_phases_plus_both_structural_buckets() {
+        let bands = Band::all();
+        assert_eq!(bands.len(), Phase::ALL.len() + 2);
+        assert!(bands.contains(&Band::MixedParallel));
+        assert!(bands.contains(&Band::Unattributed));
+    }
+
+    #[test]
+    fn band_wire_names_are_distinct() {
+        let mut names: Vec<&str> = Band::all().into_iter().map(Band::wire_name).collect();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), Phase::ALL.len() + 2);
+    }
+
+    #[test]
+    fn phase_wire_names_match_their_serialized_form() {
+        // Chart data keys and run-object map keys must be the same strings, or
+        // the dashboard silently renders empty bands.
+        for phase in Phase::ALL {
+            let serialized = serde_json::to_string(&phase).unwrap();
+            assert_eq!(serialized, format!("\"{}\"", phase.wire_name()));
+        }
+    }
+
+    #[test]
+    fn driver_overhead_is_process_time_outside_compiler_root() {
+        let sample = Sample {
+            batch_size: 1,
+            process_elapsed_ns: 150,
+            peak_memory_bytes: 1,
+            output_binary_bytes: 1,
+            phases: accounting(100, 100, 0, 0),
+        };
+        assert_eq!(sample.driver_overhead_ns(), Some(50));
+    }
+
+    #[test]
+    fn a_process_shorter_than_its_compiler_root_has_no_overhead_to_report() {
+        let sample = Sample {
+            batch_size: 1,
+            process_elapsed_ns: 50,
+            peak_memory_bytes: 1,
+            output_binary_bytes: 1,
+            phases: accounting(100, 100, 0, 0),
+        };
+        assert_eq!(sample.driver_overhead_ns(), None);
+    }
+
+    #[test]
+    fn a_run_object_round_trips_through_json() {
+        let run = crate::validate::tests::sample_run();
+        let text = serde_json::to_string(&run).unwrap();
+        let parsed: RunObject = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed, run);
+    }
+
+    #[test]
+    fn a_run_objects_content_address_is_stable_across_serializations() {
+        let run = crate::validate::tests::sample_run();
+        let first = run.content_address().unwrap();
+        let reparsed: RunObject =
+            serde_json::from_str(&serde_json::to_string(&run).unwrap()).unwrap();
+        assert_eq!(reparsed.content_address().unwrap(), first);
+    }
+
+    #[test]
+    fn changing_any_measurement_changes_the_content_address() {
+        let run = crate::validate::tests::sample_run();
+        let mut altered = run.clone();
+        altered.workloads[0].samples[0].process_elapsed_ns += 1;
+        assert_ne!(
+            run.content_address().unwrap(),
+            altered.content_address().unwrap()
+        );
+    }
+
+    #[test]
+    fn unknown_fields_are_refused_rather_than_ignored() {
+        let mut value = serde_json::to_value(crate::validate::tests::sample_run()).unwrap();
+        value["surprise"] = serde_json::json!(1);
+        let parsed: Result<RunObject, _> = serde_json::from_value(value);
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn a_failure_record_knows_whether_it_names_a_workload() {
+        assert_eq!(
+            FailureRecord::Build {
+                detail: "no compiler".to_string()
+            }
+            .workload(),
+            None
+        );
+        assert_eq!(
+            FailureRecord::Timeout {
+                workload: "caldera".to_string(),
+                sample_index: 2,
+                limit_ns: 5,
+            }
+            .workload(),
+            Some("caldera")
+        );
+    }
+
+    #[test]
+    fn environment_fingerprints_differ_exactly_when_the_environment_does() {
+        let run = crate::validate::tests::sample_run();
+        let base = run.identity.environment.fingerprint_id().unwrap();
+        let mut drifted = run.identity.environment.clone();
+        drifted.runner_image_version = "ubuntu24/20990101.9.0".to_string();
+        assert_ne!(drifted.fingerprint_id().unwrap(), base);
+        assert_eq!(run.identity.environment.fingerprint_id().unwrap(), base);
+    }
+}

--- a/crates/rue-perf-schema/src/series.rs
+++ b/crates/rue-perf-schema/src/series.rs
@@ -1,0 +1,140 @@
+//! Series identity: what makes two observations comparable.
+
+use serde::{Deserialize, Serialize};
+
+/// A tracked quantity.
+///
+/// Each metric gets the same per-workload treatment and its own headline index.
+/// Indexes for different metrics are never mixed, and none of them is a
+/// wall-clock quantity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Metric {
+    /// Wall-clock latency of a complete fresh compilation.
+    Latency,
+    /// Peak resident memory during a complete fresh compilation.
+    PeakMemory,
+    /// Size of the produced binary.
+    BinarySize,
+}
+
+impl Metric {
+    /// Every tracked metric.
+    pub const ALL: [Metric; 3] = [Metric::Latency, Metric::PeakMemory, Metric::BinarySize];
+
+    /// The stable wire name used in chart data and raw-record queries.
+    pub const fn wire_name(self) -> &'static str {
+        match self {
+            Metric::Latency => "latency",
+            Metric::PeakMemory => "peak_memory",
+            Metric::BinarySize => "binary_size",
+        }
+    }
+}
+
+/// The identity of one comparable sequence of observations.
+///
+/// A series is `(epoch, workload, metric)`. The suite revision and platform
+/// epoch pin everything else that could invalidate a comparison — workload
+/// source identity, invocation, toolchain, sampling policy, environment policy
+/// — so nothing further belongs in the identity.
+///
+/// The compiler revision is deliberately absent: it is a *point within* a
+/// series, never part of it.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SeriesId {
+    /// The platform the epoch describes.
+    pub platform: String,
+    /// The platform epoch, which transitively pins the suite revision.
+    pub epoch: u32,
+    /// The workload's logical identifier.
+    pub workload: String,
+    /// The tracked quantity.
+    pub metric: Metric,
+}
+
+impl SeriesId {
+    /// Construct a series identity.
+    pub fn new(
+        platform: impl Into<String>,
+        epoch: u32,
+        workload: impl Into<String>,
+        metric: Metric,
+    ) -> Self {
+        SeriesId {
+            platform: platform.into(),
+            epoch,
+            workload: workload.into(),
+            metric,
+        }
+    }
+}
+
+impl std::fmt::Display for SeriesId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}/epoch-{}/{}/{}",
+            self.platform,
+            self.epoch,
+            self.workload,
+            self.metric.wire_name()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn series_identity_excludes_the_compiler_revision() {
+        // Two observations at different compiler revisions are points in one
+        // series, so nothing in the identity can distinguish them.
+        let one = SeriesId::new("x86_64-linux", 1, "startup", Metric::Latency);
+        let two = SeriesId::new("x86_64-linux", 1, "startup", Metric::Latency);
+        assert_eq!(one, two);
+    }
+
+    #[test]
+    fn each_component_separates_series() {
+        let base = SeriesId::new("x86_64-linux", 1, "startup", Metric::Latency);
+        assert_ne!(
+            base,
+            SeriesId::new("aarch64-macos", 1, "startup", Metric::Latency)
+        );
+        assert_ne!(
+            base,
+            SeriesId::new("x86_64-linux", 2, "startup", Metric::Latency)
+        );
+        assert_ne!(
+            base,
+            SeriesId::new("x86_64-linux", 1, "caldera", Metric::Latency)
+        );
+        assert_ne!(
+            base,
+            SeriesId::new("x86_64-linux", 1, "startup", Metric::PeakMemory)
+        );
+    }
+
+    #[test]
+    fn display_is_stable_and_readable() {
+        let series = SeriesId::new("x86_64-linux", 3, "caldera", Metric::PeakMemory);
+        assert_eq!(
+            series.to_string(),
+            "x86_64-linux/epoch-3/caldera/peak_memory"
+        );
+    }
+
+    #[test]
+    fn metric_wire_names_are_distinct() {
+        let mut names: Vec<&str> = Metric::ALL
+            .iter()
+            .map(|metric| metric.wire_name())
+            .collect();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), Metric::ALL.len());
+    }
+}

--- a/crates/rue-perf-schema/src/validate.rs
+++ b/crates/rue-perf-schema/src/validate.rs
@@ -1,0 +1,1341 @@
+//! Validation: which observations may enter a series, and which samples count.
+//!
+//! Two kinds of wrongness are deliberately kept apart.
+//!
+//! A [`ValidationError`] is an *appendability* failure. The run does not
+//! describe the configuration it claims to, so it cannot enter a series at all.
+//! This is the guarantee that replaces after-the-fact comparability
+//! classification: rather than deciding whether two stored points may be
+//! compared, the system refuses to store a point that would not be comparable.
+//! Fixing one requires a maintainer to declare the next suite revision or
+//! epoch deliberately.
+//!
+//! An [`InvalidSample`] is a *measurement* failure. The run is well-formed and
+//! belongs in its series; one sample within it is not trustworthy. The sample
+//! stays on disk as evidence and is excluded from medians, dispersion, and
+//! every derived publication.
+//!
+//! [`Completeness`] is neither. A run that measured fewer workloads than the
+//! suite declares is a partial run: its valid workloads still publish
+//! per-workload observations, and only the headline point is withheld.
+
+use std::collections::BTreeMap;
+
+use crate::RUN_SCHEMA_VERSION;
+use crate::manifest::Manifest;
+use crate::run::{FailureRecord, Phase, RunObject, Sample};
+
+/// A reason a run may not enter a series at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidationError {
+    /// The run was written under a schema version this crate does not
+    /// implement. There is no compatibility path, by design.
+    UnsupportedSchemaVersion {
+        /// The version the run object declares.
+        found: u32,
+        /// The version this crate implements.
+        expected: u32,
+    },
+    /// The run names a suite revision the manifest does not declare.
+    UnknownSuiteRevision {
+        /// The undeclared revision.
+        revision: u32,
+    },
+    /// The run names an epoch the manifest does not declare for its platform.
+    UnknownEpoch {
+        /// The platform named by the run.
+        platform: String,
+        /// The undeclared epoch.
+        epoch: u32,
+    },
+    /// The run's suite revision is not the one its epoch implements.
+    EpochSuiteMismatch {
+        /// The revision the epoch implements.
+        epoch_revision: u32,
+        /// The revision the run claims.
+        run_revision: u32,
+    },
+    /// The run measured a workload the suite revision does not declare.
+    ///
+    /// Measuring *fewer* workloads is a partial run, not an error; measuring
+    /// something else is a different suite wearing this one's name.
+    UndeclaredWorkload {
+        /// The workload that is not in the suite.
+        workload: String,
+    },
+    /// The run recorded the same workload more than once.
+    DuplicateWorkloadObservation {
+        /// The repeated workload.
+        workload: String,
+    },
+    /// Workload observations are not in sorted order.
+    ///
+    /// Ordering is part of the canonical form, so an unsorted run object would
+    /// hash differently from the identical measurement written correctly.
+    WorkloadsNotSorted,
+    /// A pinned component of the run does not match its epoch's declaration.
+    PinMismatch {
+        /// Which pin disagrees, for example `toolchain_hash` or
+        /// `workload_source_hashes/caldera`.
+        field: String,
+        /// What the epoch declares.
+        expected: String,
+        /// What the run reports.
+        actual: String,
+    },
+    /// The run's environment does not satisfy the epoch's environment policy.
+    ///
+    /// Only the declared class and image are enforced. Drift in image version,
+    /// CPU model, or core count is recorded and annotated, never rejected.
+    EnvironmentPolicyViolated {
+        /// The runner label and image the epoch requires.
+        expected: (String, String),
+        /// The runner label and image the run found.
+        actual: (String, String),
+    },
+    /// A workload has more samples than its sampling policy allows.
+    TooManySamples {
+        /// The over-sampled workload.
+        workload: String,
+        /// How many the policy allows.
+        allowed: u32,
+        /// How many the run recorded.
+        actual: u32,
+    },
+    /// A sample batches a different number of compilations than the policy
+    /// pins, so it does not measure the unit the series is made of.
+    BatchSizeMismatch {
+        /// The workload whose sample is mis-batched.
+        workload: String,
+        /// Which sample.
+        sample_index: u32,
+        /// The batch size the policy pins.
+        expected: u32,
+        /// The batch size the sample reports.
+        actual: u32,
+    },
+    /// A sample violates the phase-sum invariant with no failure record.
+    ///
+    /// The violation is still detected — validation recomputes the invariant
+    /// rather than trusting the record — but a producer that hides its own
+    /// instrumentation bug is itself the defect.
+    UnrecordedInvariantFailure {
+        /// The workload holding the sample.
+        workload: String,
+        /// Which sample.
+        sample_index: u32,
+    },
+    /// A failure record claims an invariant violation that did not occur.
+    SpuriousInvariantRecord {
+        /// The workload named by the record.
+        workload: String,
+        /// The sample named by the record.
+        sample_index: u32,
+    },
+    /// A failure record names a workload the suite does not declare.
+    FailureForUndeclaredWorkload {
+        /// The workload named by the record.
+        workload: String,
+    },
+    /// A timestamp is not `YYYY-MM-DDTHH:MM:SSZ`.
+    MalformedTimestamp {
+        /// Which field, `started_at` or `finished_at`.
+        field: String,
+        /// The value found.
+        value: String,
+    },
+    /// The measured compiler revision is not a 40-character hexadecimal hash.
+    MalformedCommit {
+        /// The value found.
+        value: String,
+    },
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValidationError::UnsupportedSchemaVersion { found, expected } => {
+                write!(
+                    f,
+                    "run schema version {found} is not the supported version {expected}"
+                )
+            }
+            ValidationError::UnknownSuiteRevision { revision } => {
+                write!(f, "suite revision {revision} is not declared")
+            }
+            ValidationError::UnknownEpoch { platform, epoch } => {
+                write!(f, "epoch {epoch} is not declared for platform {platform}")
+            }
+            ValidationError::EpochSuiteMismatch {
+                epoch_revision,
+                run_revision,
+            } => write!(
+                f,
+                "run claims suite revision {run_revision} but its epoch implements {epoch_revision}"
+            ),
+            ValidationError::UndeclaredWorkload { workload } => {
+                write!(
+                    f,
+                    "workload {workload:?} is not declared by the suite revision"
+                )
+            }
+            ValidationError::DuplicateWorkloadObservation { workload } => {
+                write!(f, "workload {workload:?} is observed more than once")
+            }
+            ValidationError::WorkloadsNotSorted => {
+                write!(f, "workload observations are not sorted by identifier")
+            }
+            ValidationError::PinMismatch {
+                field,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "pin {field} is {actual:?} but the epoch declares {expected:?}"
+            ),
+            ValidationError::EnvironmentPolicyViolated { expected, actual } => write!(
+                f,
+                "environment {}/{} does not satisfy the epoch policy {}/{}",
+                actual.0, actual.1, expected.0, expected.1
+            ),
+            ValidationError::TooManySamples {
+                workload,
+                allowed,
+                actual,
+            } => write!(
+                f,
+                "workload {workload:?} has {actual} samples but its policy allows {allowed}"
+            ),
+            ValidationError::BatchSizeMismatch {
+                workload,
+                sample_index,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "workload {workload:?} sample {sample_index} batches {actual} compilations but \
+                 its policy pins {expected}"
+            ),
+            ValidationError::UnrecordedInvariantFailure {
+                workload,
+                sample_index,
+            } => write!(
+                f,
+                "workload {workload:?} sample {sample_index} violates the phase-sum invariant \
+                 with no failure record"
+            ),
+            ValidationError::SpuriousInvariantRecord {
+                workload,
+                sample_index,
+            } => write!(
+                f,
+                "a failure record claims workload {workload:?} sample {sample_index} violates \
+                 the phase-sum invariant, but it holds"
+            ),
+            ValidationError::FailureForUndeclaredWorkload { workload } => {
+                write!(f, "a failure record names undeclared workload {workload:?}")
+            }
+            ValidationError::MalformedTimestamp { field, value } => {
+                write!(f, "{field} {value:?} is not YYYY-MM-DDTHH:MM:SSZ")
+            }
+            ValidationError::MalformedCommit { value } => {
+                write!(f, "commit {value:?} is not a 40-character hexadecimal hash")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+/// Why a stored sample may not contribute to a statistic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InvalidSampleReason {
+    /// The bands did not sum to compiler-root time.
+    PhaseInvariantViolated {
+        /// The total the bands should have summed to.
+        compiler_root_ns: u64,
+        /// What they actually summed to.
+        attributed_ns: u64,
+    },
+    /// The accounting omitted published phases entirely.
+    ///
+    /// A phase that took no time records zero. An absent phase means the
+    /// producer and this schema disagree about the taxonomy.
+    MissingPhases {
+        /// The absent phases, by wire name.
+        phases: Vec<String>,
+    },
+    /// The process was measured as shorter than the compiler root inside it.
+    ProcessShorterThanCompilerRoot {
+        /// Externally measured process wall time.
+        process_elapsed_ns: u64,
+        /// Compiler-root elapsed time.
+        compiler_root_ns: u64,
+    },
+    /// Compiler root measured zero nanoseconds.
+    ZeroCompilerRoot,
+}
+
+impl std::fmt::Display for InvalidSampleReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InvalidSampleReason::PhaseInvariantViolated {
+                compiler_root_ns,
+                attributed_ns,
+            } => write!(
+                f,
+                "bands sum to {attributed_ns} ns but compiler root is {compiler_root_ns} ns"
+            ),
+            InvalidSampleReason::MissingPhases { phases } => {
+                write!(f, "phase accounting omits {phases:?}")
+            }
+            InvalidSampleReason::ProcessShorterThanCompilerRoot {
+                process_elapsed_ns,
+                compiler_root_ns,
+            } => write!(
+                f,
+                "process elapsed {process_elapsed_ns} ns is shorter than compiler root \
+                 {compiler_root_ns} ns"
+            ),
+            InvalidSampleReason::ZeroCompilerRoot => write!(f, "compiler root measured zero ns"),
+        }
+    }
+}
+
+/// A stored sample excluded from every derived statistic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidSample {
+    /// The workload holding the sample.
+    pub workload: String,
+    /// Which sample, by position in the workload's sample list.
+    pub sample_index: u32,
+    /// Why it is excluded.
+    pub reason: InvalidSampleReason,
+}
+
+/// Whether a run measured the whole suite validly.
+///
+/// Publication is tiered on this. A per-workload observation publishes for
+/// every workload that completed validly; a headline point publishes only when
+/// every suite workload did. A partial run therefore keeps its evidence and its
+/// per-workload signal without letting the index's cohort change underneath it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Completeness {
+    /// Every suite workload produced a full set of valid samples.
+    Complete,
+    /// Some suite workloads did not.
+    Partial {
+        /// The workloads that did not complete validly, sorted.
+        missing: Vec<String>,
+    },
+}
+
+impl Completeness {
+    /// Whether a headline point may be published from this run.
+    pub fn publishes_headline(&self) -> bool {
+        matches!(self, Completeness::Complete)
+    }
+}
+
+/// The full verdict on one run object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationOutcome {
+    /// Appendability failures. A non-empty list means the run may not be
+    /// stored in a series at all.
+    pub errors: Vec<ValidationError>,
+    /// Samples that are stored but excluded from statistics.
+    pub invalid_samples: Vec<InvalidSample>,
+    /// Whether the run covers the suite validly.
+    pub completeness: Completeness,
+}
+
+impl ValidationOutcome {
+    /// Whether this run may enter its series.
+    pub fn is_appendable(&self) -> bool {
+        self.errors.is_empty()
+    }
+
+    /// Whether a per-workload observation publishes for this workload.
+    ///
+    /// Requires the run to be appendable, the workload to have completed its
+    /// full sample count, and every one of those samples to be valid.
+    pub fn publishes_workload(&self, workload: &str) -> bool {
+        if !self.is_appendable() {
+            return false;
+        }
+        match &self.completeness {
+            Completeness::Complete => true,
+            Completeness::Partial { missing } => !missing.iter().any(|entry| entry == workload),
+        }
+    }
+
+    /// Whether a headline point publishes from this run.
+    pub fn publishes_headline(&self) -> bool {
+        self.is_appendable() && self.completeness.publishes_headline()
+    }
+}
+
+/// Check a run object against the manifest that governs it.
+///
+/// Every problem is reported rather than the first: a run with three mismatched
+/// pins should say so once, not across three collection attempts.
+pub fn validate_run(manifest: &Manifest, run: &RunObject) -> ValidationOutcome {
+    let mut errors = Vec::new();
+
+    if run.schema_version != RUN_SCHEMA_VERSION {
+        // Nothing below can be trusted to mean what it appears to mean, so this
+        // is the one failure that stops validation short.
+        return ValidationOutcome {
+            errors: vec![ValidationError::UnsupportedSchemaVersion {
+                found: run.schema_version,
+                expected: RUN_SCHEMA_VERSION,
+            }],
+            invalid_samples: Vec::new(),
+            completeness: Completeness::Partial {
+                missing: Vec::new(),
+            },
+        };
+    }
+
+    check_identity_shape(run, &mut errors);
+
+    let epoch = manifest.epoch(&run.identity.platform, run.identity.epoch);
+    let Some(epoch) = epoch else {
+        errors.push(ValidationError::UnknownEpoch {
+            platform: run.identity.platform.clone(),
+            epoch: run.identity.epoch,
+        });
+        return ValidationOutcome {
+            errors,
+            invalid_samples: Vec::new(),
+            completeness: Completeness::Partial {
+                missing: Vec::new(),
+            },
+        };
+    };
+
+    if epoch.suite_revision != run.identity.suite_revision {
+        errors.push(ValidationError::EpochSuiteMismatch {
+            epoch_revision: epoch.suite_revision,
+            run_revision: run.identity.suite_revision,
+        });
+    }
+
+    let Some(suite) = manifest.suite(epoch.suite_revision) else {
+        // Unreachable through Manifest::parse, which rejects an epoch naming an
+        // undeclared revision. Reported rather than asserted so a manifest
+        // constructed some other way still fails loudly.
+        errors.push(ValidationError::UnknownSuiteRevision {
+            revision: epoch.suite_revision,
+        });
+        return ValidationOutcome {
+            errors,
+            invalid_samples: Vec::new(),
+            completeness: Completeness::Partial {
+                missing: Vec::new(),
+            },
+        };
+    };
+
+    check_pins(run, epoch, &mut errors);
+    check_environment(run, epoch, &mut errors);
+    check_membership(run, suite, &mut errors);
+
+    let invalid_samples = collect_invalid_samples(run, epoch, &mut errors);
+    check_failure_records(run, suite, &invalid_samples, &mut errors);
+
+    let completeness = assess_completeness(run, suite, epoch, &invalid_samples);
+
+    ValidationOutcome {
+        errors,
+        invalid_samples,
+        completeness,
+    }
+}
+
+fn check_identity_shape(run: &RunObject, errors: &mut Vec<ValidationError>) {
+    let commit = &run.identity.commit;
+    if commit.len() != 40 || !commit.chars().all(|c| c.is_ascii_hexdigit()) {
+        errors.push(ValidationError::MalformedCommit {
+            value: commit.clone(),
+        });
+    }
+    for (field, value) in [
+        ("started_at", &run.identity.started_at),
+        ("finished_at", &run.identity.finished_at),
+    ] {
+        if !is_utc_timestamp(value) {
+            errors.push(ValidationError::MalformedTimestamp {
+                field: field.to_string(),
+                value: value.clone(),
+            });
+        }
+    }
+}
+
+/// Accepts exactly `YYYY-MM-DDTHH:MM:SSZ`.
+///
+/// One spelling, so two identical measurements cannot produce two content
+/// addresses by formatting the same instant differently.
+fn is_utc_timestamp(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.len() != 20 {
+        return false;
+    }
+    let digits = [0, 1, 2, 3, 5, 6, 8, 9, 11, 12, 14, 15, 17, 18];
+    let dashes = [4, 7];
+    let colons = [13, 16];
+    digits.iter().all(|&i| bytes[i].is_ascii_digit())
+        && dashes.iter().all(|&i| bytes[i] == b'-')
+        && colons.iter().all(|&i| bytes[i] == b':')
+        && bytes[10] == b'T'
+        && bytes[19] == b'Z'
+}
+
+fn check_pins(
+    run: &RunObject,
+    epoch: &crate::manifest::PlatformEpoch,
+    errors: &mut Vec<ValidationError>,
+) {
+    let pins = &run.identity.pins;
+    let mut compare = |field: &str, expected: &str, actual: &str| {
+        if expected != actual {
+            errors.push(ValidationError::PinMismatch {
+                field: field.to_string(),
+                expected: expected.to_string(),
+                actual: actual.to_string(),
+            });
+        }
+    };
+    compare(
+        "toolchain_hash",
+        &epoch.toolchain_hash,
+        &pins.toolchain_hash,
+    );
+    compare("stdlib_hash", &epoch.stdlib_hash, &pins.stdlib_hash);
+    compare("invocation/target", &epoch.target, &pins.invocation.target);
+
+    if epoch.args != pins.invocation.args {
+        errors.push(ValidationError::PinMismatch {
+            field: "invocation/args".to_string(),
+            expected: epoch.args.join(" "),
+            actual: pins.invocation.args.join(" "),
+        });
+    }
+
+    // Source hashes describe the tree that was measured, so they must match
+    // exactly even for workloads this run failed to complete.
+    for (workload, expected) in &epoch.workload_source_hashes {
+        let actual = pins
+            .workload_source_hashes
+            .get(workload)
+            .map(String::as_str)
+            .unwrap_or("");
+        if actual != expected {
+            errors.push(ValidationError::PinMismatch {
+                field: format!("workload_source_hashes/{workload}"),
+                expected: expected.clone(),
+                actual: actual.to_string(),
+            });
+        }
+    }
+    for workload in pins.workload_source_hashes.keys() {
+        if !epoch.workload_source_hashes.contains_key(workload) {
+            errors.push(ValidationError::PinMismatch {
+                field: format!("workload_source_hashes/{workload}"),
+                expected: String::new(),
+                actual: pins.workload_source_hashes[workload].clone(),
+            });
+        }
+    }
+}
+
+fn check_environment(
+    run: &RunObject,
+    epoch: &crate::manifest::PlatformEpoch,
+    errors: &mut Vec<ValidationError>,
+) {
+    if !epoch.environment.admits(&run.identity.environment) {
+        errors.push(ValidationError::EnvironmentPolicyViolated {
+            expected: (
+                epoch.environment.runner_label.clone(),
+                epoch.environment.runner_image.clone(),
+            ),
+            actual: (
+                run.identity.environment.runner_label.clone(),
+                run.identity.environment.runner_image.clone(),
+            ),
+        });
+    }
+}
+
+fn check_membership(
+    run: &RunObject,
+    suite: &crate::manifest::SuiteRevision,
+    errors: &mut Vec<ValidationError>,
+) {
+    let mut seen: Vec<&str> = Vec::new();
+    for observation in &run.workloads {
+        if !suite.declares(&observation.workload) {
+            errors.push(ValidationError::UndeclaredWorkload {
+                workload: observation.workload.clone(),
+            });
+        }
+        if seen.contains(&observation.workload.as_str()) {
+            errors.push(ValidationError::DuplicateWorkloadObservation {
+                workload: observation.workload.clone(),
+            });
+        }
+        seen.push(&observation.workload);
+    }
+    let mut sorted = seen.clone();
+    sorted.sort_unstable();
+    if seen != sorted {
+        errors.push(ValidationError::WorkloadsNotSorted);
+    }
+}
+
+fn collect_invalid_samples(
+    run: &RunObject,
+    epoch: &crate::manifest::PlatformEpoch,
+    errors: &mut Vec<ValidationError>,
+) -> Vec<InvalidSample> {
+    let mut invalid = Vec::new();
+    for observation in &run.workloads {
+        let policy = epoch.sampling.get(&observation.workload);
+        if let Some(policy) = policy
+            && observation.samples.len() as u64 > u64::from(policy.samples)
+        {
+            errors.push(ValidationError::TooManySamples {
+                workload: observation.workload.clone(),
+                allowed: policy.samples,
+                actual: observation.samples.len() as u32,
+            });
+        }
+
+        for (index, sample) in observation.samples.iter().enumerate() {
+            let index = index as u32;
+            if let Some(policy) = policy
+                && sample.batch_size != policy.batch_size
+            {
+                errors.push(ValidationError::BatchSizeMismatch {
+                    workload: observation.workload.clone(),
+                    sample_index: index,
+                    expected: policy.batch_size,
+                    actual: sample.batch_size,
+                });
+            }
+            if let Some(reason) = sample_invalidity(sample) {
+                invalid.push(InvalidSample {
+                    workload: observation.workload.clone(),
+                    sample_index: index,
+                    reason,
+                });
+            }
+        }
+    }
+    invalid
+}
+
+fn sample_invalidity(sample: &Sample) -> Option<InvalidSampleReason> {
+    let missing = sample.phases.missing_phases();
+    if !missing.is_empty() {
+        return Some(InvalidSampleReason::MissingPhases {
+            phases: missing
+                .into_iter()
+                .map(Phase::wire_name)
+                .map(String::from)
+                .collect(),
+        });
+    }
+    if !sample.phases.holds() {
+        return Some(InvalidSampleReason::PhaseInvariantViolated {
+            compiler_root_ns: sample.phases.compiler_root_ns,
+            attributed_ns: sample.phases.attributed_ns(),
+        });
+    }
+    if sample.phases.compiler_root_ns == 0 {
+        return Some(InvalidSampleReason::ZeroCompilerRoot);
+    }
+    if sample.driver_overhead_ns().is_none() {
+        return Some(InvalidSampleReason::ProcessShorterThanCompilerRoot {
+            process_elapsed_ns: sample.process_elapsed_ns,
+            compiler_root_ns: sample.phases.compiler_root_ns,
+        });
+    }
+    None
+}
+
+fn check_failure_records(
+    run: &RunObject,
+    suite: &crate::manifest::SuiteRevision,
+    invalid_samples: &[InvalidSample],
+    errors: &mut Vec<ValidationError>,
+) {
+    let violated: Vec<(&str, u32)> = invalid_samples
+        .iter()
+        .filter(|sample| {
+            matches!(
+                sample.reason,
+                InvalidSampleReason::PhaseInvariantViolated { .. }
+            )
+        })
+        .map(|sample| (sample.workload.as_str(), sample.sample_index))
+        .collect();
+
+    let mut recorded: Vec<(&str, u32)> = Vec::new();
+    for failure in &run.failures {
+        if let Some(workload) = failure.workload()
+            && !suite.declares(workload)
+        {
+            errors.push(ValidationError::FailureForUndeclaredWorkload {
+                workload: workload.to_string(),
+            });
+        }
+        if let FailureRecord::PhaseInvariant {
+            workload,
+            sample_index,
+            ..
+        } = failure
+        {
+            recorded.push((workload.as_str(), *sample_index));
+            if !violated.contains(&(workload.as_str(), *sample_index)) {
+                errors.push(ValidationError::SpuriousInvariantRecord {
+                    workload: workload.clone(),
+                    sample_index: *sample_index,
+                });
+            }
+        }
+    }
+
+    for (workload, sample_index) in violated {
+        if !recorded.contains(&(workload, sample_index)) {
+            errors.push(ValidationError::UnrecordedInvariantFailure {
+                workload: workload.to_string(),
+                sample_index,
+            });
+        }
+    }
+}
+
+fn assess_completeness(
+    run: &RunObject,
+    suite: &crate::manifest::SuiteRevision,
+    epoch: &crate::manifest::PlatformEpoch,
+    invalid_samples: &[InvalidSample],
+) -> Completeness {
+    let mut invalid_counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for sample in invalid_samples {
+        *invalid_counts.entry(sample.workload.as_str()).or_default() += 1;
+    }
+
+    let mut missing = Vec::new();
+    for workload in suite.workload_ids() {
+        let required = epoch.sampling.get(workload).map(|policy| policy.samples);
+        let observed = run.observation(workload).map(|entry| entry.samples.len());
+        let complete = match (required, observed) {
+            (Some(required), Some(observed)) => {
+                observed as u64 == u64::from(required)
+                    && invalid_counts.get(workload).copied().unwrap_or(0) == 0
+            }
+            _ => false,
+        };
+        if !complete {
+            missing.push(workload.to_string());
+        }
+    }
+
+    if missing.is_empty() {
+        Completeness::Complete
+    } else {
+        Completeness::Partial { missing }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::run::{
+        EnvironmentFingerprint, Invocation, PhaseAccounting, ResolvedPins, RunIdentity,
+        WorkloadObservation,
+    };
+
+    pub(crate) const MANIFEST: &str = r#"
+[[suite]]
+revision = 1
+timing_schema_version = 1
+protocol_version = 1
+
+[[suite.workloads]]
+id = "caldera"
+source = "examples/caldera/main.rue"
+question = "How does a large single-program compilation behave?"
+
+[[suite.workloads]]
+id = "startup"
+source = "performance/workloads/startup/main.rue"
+question = "What does a minimal compilation cost end to end?"
+
+[[epoch]]
+id = 1
+platform = "x86_64-linux"
+suite_revision = 1
+target = "x86_64-unknown-linux-gnu"
+args = ["-O2"]
+toolchain_hash = "toolchain-aaa"
+stdlib_hash = "stdlib-bbb"
+
+[epoch.workload_source_hashes]
+caldera = "caldera-ccc"
+startup = "startup-ddd"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+[epoch.sampling.caldera]
+samples = 2
+batch_size = 1
+
+[epoch.sampling.startup]
+samples = 2
+batch_size = 40
+
+[epoch.flagging]
+k = 3.0
+window = 10
+"#;
+
+    pub(crate) fn manifest() -> Manifest {
+        Manifest::parse(MANIFEST).expect("fixture manifest is valid")
+    }
+
+    pub(crate) fn accounting(root_ns: u64) -> PhaseAccounting {
+        let mut phase_ns: BTreeMap<Phase, u64> =
+            Phase::ALL.into_iter().map(|phase| (phase, 0)).collect();
+        phase_ns.insert(Phase::SemanticAnalysis, root_ns);
+        PhaseAccounting {
+            phase_ns,
+            mixed_parallel_ns: 0,
+            unattributed_ns: 0,
+            compiler_root_ns: root_ns,
+        }
+    }
+
+    pub(crate) fn sample(batch_size: u32, root_ns: u64) -> Sample {
+        Sample {
+            batch_size,
+            process_elapsed_ns: root_ns + 1_000,
+            peak_memory_bytes: 64 * 1024 * 1024,
+            output_binary_bytes: 131_072,
+            phases: accounting(root_ns),
+        }
+    }
+
+    pub(crate) fn sample_run() -> RunObject {
+        RunObject {
+            schema_version: RUN_SCHEMA_VERSION,
+            identity: RunIdentity {
+                suite_revision: 1,
+                epoch: 1,
+                platform: "x86_64-linux".to_string(),
+                commit: "a".repeat(40),
+                started_at: "2026-07-28T04:00:00Z".to_string(),
+                finished_at: "2026-07-28T04:12:00Z".to_string(),
+                pins: ResolvedPins {
+                    toolchain_hash: "toolchain-aaa".to_string(),
+                    stdlib_hash: "stdlib-bbb".to_string(),
+                    workload_source_hashes: BTreeMap::from([
+                        ("caldera".to_string(), "caldera-ccc".to_string()),
+                        ("startup".to_string(), "startup-ddd".to_string()),
+                    ]),
+                    invocation: Invocation {
+                        target: "x86_64-unknown-linux-gnu".to_string(),
+                        args: vec!["-O2".to_string()],
+                    },
+                },
+                environment: EnvironmentFingerprint {
+                    runner_label: "github-hosted".to_string(),
+                    runner_image: "ubuntu-24.04".to_string(),
+                    runner_image_version: "ubuntu24/20250720.1.0".to_string(),
+                    cpu_model: "AMD EPYC 7763".to_string(),
+                    core_count: 4,
+                    memory_bytes: 16 * 1024 * 1024 * 1024,
+                    kernel_version: "6.8.0-1014-azure".to_string(),
+                    os_version: "Ubuntu 24.04.2 LTS".to_string(),
+                    architecture: "x86_64".to_string(),
+                },
+            },
+            workloads: vec![
+                WorkloadObservation {
+                    workload: "caldera".to_string(),
+                    samples: vec![sample(1, 900_000_000), sample(1, 910_000_000)],
+                },
+                WorkloadObservation {
+                    workload: "startup".to_string(),
+                    samples: vec![sample(40, 400_000_000), sample(40, 404_000_000)],
+                },
+            ],
+            failures: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_complete_well_formed_run_is_appendable_and_publishes_a_headline() {
+        let outcome = validate_run(&manifest(), &sample_run());
+        assert_eq!(outcome.errors, Vec::new());
+        assert_eq!(outcome.invalid_samples, Vec::new());
+        assert_eq!(outcome.completeness, Completeness::Complete);
+        assert!(outcome.is_appendable());
+        assert!(outcome.publishes_headline());
+        assert!(outcome.publishes_workload("caldera"));
+    }
+
+    #[test]
+    fn an_unsupported_schema_version_stops_validation_immediately() {
+        let mut run = sample_run();
+        run.schema_version = RUN_SCHEMA_VERSION + 1;
+        let outcome = validate_run(&manifest(), &run);
+        assert_eq!(
+            outcome.errors,
+            vec![ValidationError::UnsupportedSchemaVersion {
+                found: RUN_SCHEMA_VERSION + 1,
+                expected: RUN_SCHEMA_VERSION,
+            }]
+        );
+        assert!(!outcome.is_appendable());
+    }
+
+    #[test]
+    fn a_run_naming_an_undeclared_epoch_cannot_be_appended() {
+        let mut run = sample_run();
+        run.identity.epoch = 9;
+        let outcome = validate_run(&manifest(), &run);
+        assert!(outcome.errors.contains(&ValidationError::UnknownEpoch {
+            platform: "x86_64-linux".to_string(),
+            epoch: 9,
+        }));
+    }
+
+    #[test]
+    fn a_run_naming_another_platform_cannot_borrow_this_epoch() {
+        let mut run = sample_run();
+        run.identity.platform = "aarch64-macos".to_string();
+        let outcome = validate_run(&manifest(), &run);
+        assert!(!outcome.is_appendable());
+    }
+
+    #[test]
+    fn a_run_claiming_the_wrong_suite_revision_is_rejected() {
+        let mut run = sample_run();
+        run.identity.suite_revision = 2;
+        let outcome = validate_run(&manifest(), &run);
+        assert!(
+            outcome
+                .errors
+                .contains(&ValidationError::EpochSuiteMismatch {
+                    epoch_revision: 1,
+                    run_revision: 2,
+                })
+        );
+    }
+
+    #[test]
+    fn an_edited_workload_cannot_silently_reset_its_own_baseline() {
+        // This is the property the whole pin mechanism exists for: changing what
+        // a workload *is* must fail validation rather than continue the series.
+        let mut run = sample_run();
+        run.identity
+            .pins
+            .workload_source_hashes
+            .insert("caldera".to_string(), "caldera-edited".to_string());
+        let outcome = validate_run(&manifest(), &run);
+        assert!(outcome.errors.contains(&ValidationError::PinMismatch {
+            field: "workload_source_hashes/caldera".to_string(),
+            expected: "caldera-ccc".to_string(),
+            actual: "caldera-edited".to_string(),
+        }));
+        assert!(!outcome.is_appendable());
+    }
+
+    #[test]
+    fn each_pinned_component_is_checked() {
+        let cases: Vec<(&str, Box<dyn Fn(&mut RunObject)>)> = vec![
+            (
+                "toolchain_hash",
+                Box::new(|run: &mut RunObject| {
+                    run.identity.pins.toolchain_hash = "other".to_string()
+                }),
+            ),
+            (
+                "stdlib_hash",
+                Box::new(|run: &mut RunObject| run.identity.pins.stdlib_hash = "other".to_string()),
+            ),
+            (
+                "invocation/target",
+                Box::new(|run: &mut RunObject| {
+                    run.identity.pins.invocation.target = "other".to_string()
+                }),
+            ),
+            (
+                "invocation/args",
+                Box::new(|run: &mut RunObject| {
+                    run.identity.pins.invocation.args = vec!["-O0".to_string()]
+                }),
+            ),
+        ];
+        for (field, mutate) in cases {
+            let mut run = sample_run();
+            mutate(&mut run);
+            let outcome = validate_run(&manifest(), &run);
+            assert!(
+                outcome
+                    .errors
+                    .iter()
+                    .any(|error| matches!(error, ValidationError::PinMismatch { field: f, .. } if f == field)),
+                "{field} was not checked"
+            );
+        }
+    }
+
+    #[test]
+    fn a_pin_for_a_workload_the_epoch_does_not_declare_is_rejected() {
+        let mut run = sample_run();
+        run.identity
+            .pins
+            .workload_source_hashes
+            .insert("meridian".to_string(), "meridian-eee".to_string());
+        let outcome = validate_run(&manifest(), &run);
+        assert!(outcome.errors.iter().any(|error| matches!(
+            error,
+            ValidationError::PinMismatch { field, .. } if field == "workload_source_hashes/meridian"
+        )));
+    }
+
+    #[test]
+    fn an_environment_outside_the_policy_is_rejected() {
+        let mut run = sample_run();
+        run.identity.environment.runner_image = "ubuntu-22.04".to_string();
+        let outcome = validate_run(&manifest(), &run);
+        assert!(
+            outcome
+                .errors
+                .contains(&ValidationError::EnvironmentPolicyViolated {
+                    expected: ("github-hosted".to_string(), "ubuntu-24.04".to_string()),
+                    actual: ("github-hosted".to_string(), "ubuntu-22.04".to_string()),
+                })
+        );
+    }
+
+    #[test]
+    fn environment_drift_within_the_policy_stays_appendable() {
+        // Hosted hardware changes underneath an epoch. The system records that
+        // rather than refusing the measurement; the dashboard renders crossings
+        // as advisory.
+        let mut run = sample_run();
+        run.identity.environment.runner_image_version = "ubuntu24/20990101.9.0".to_string();
+        run.identity.environment.cpu_model = "Intel Xeon Platinum 8370C".to_string();
+        run.identity.environment.core_count = 8;
+        let outcome = validate_run(&manifest(), &run);
+        assert_eq!(outcome.errors, Vec::new());
+        assert!(outcome.publishes_headline());
+    }
+
+    #[test]
+    fn measuring_a_workload_the_suite_does_not_declare_is_rejected() {
+        let mut run = sample_run();
+        run.workloads.push(WorkloadObservation {
+            workload: "surprise".to_string(),
+            samples: vec![sample(1, 5)],
+        });
+        let outcome = validate_run(&manifest(), &run);
+        assert!(
+            outcome
+                .errors
+                .contains(&ValidationError::UndeclaredWorkload {
+                    workload: "surprise".to_string(),
+                })
+        );
+    }
+
+    #[test]
+    fn duplicate_and_unsorted_observations_are_rejected() {
+        let mut run = sample_run();
+        run.workloads.swap(0, 1);
+        let outcome = validate_run(&manifest(), &run);
+        assert!(
+            outcome
+                .errors
+                .contains(&ValidationError::WorkloadsNotSorted)
+        );
+
+        let mut run = sample_run();
+        let repeated = run.workloads[0].clone();
+        run.workloads.insert(1, repeated);
+        let outcome = validate_run(&manifest(), &run);
+        assert!(
+            outcome
+                .errors
+                .contains(&ValidationError::DuplicateWorkloadObservation {
+                    workload: "caldera".to_string(),
+                })
+        );
+    }
+
+    #[test]
+    fn more_samples_than_the_policy_allows_is_a_protocol_violation() {
+        let mut run = sample_run();
+        run.workloads[0].samples.push(sample(1, 905_000_000));
+        let outcome = validate_run(&manifest(), &run);
+        assert!(outcome.errors.contains(&ValidationError::TooManySamples {
+            workload: "caldera".to_string(),
+            allowed: 2,
+            actual: 3,
+        }));
+    }
+
+    #[test]
+    fn a_mis_batched_sample_is_a_protocol_violation() {
+        let mut run = sample_run();
+        run.workloads[1].samples[0].batch_size = 1;
+        let outcome = validate_run(&manifest(), &run);
+        assert!(
+            outcome
+                .errors
+                .contains(&ValidationError::BatchSizeMismatch {
+                    workload: "startup".to_string(),
+                    sample_index: 0,
+                    expected: 40,
+                    actual: 1,
+                })
+        );
+    }
+
+    #[test]
+    fn an_invariant_violation_invalidates_its_sample_without_rejecting_the_run() {
+        let mut run = sample_run();
+        run.workloads[0].samples[0].phases.unattributed_ns = 5;
+        run.failures.push(FailureRecord::PhaseInvariant {
+            workload: "caldera".to_string(),
+            sample_index: 0,
+            compiler_root_ns: 900_000_000,
+            attributed_ns: 900_000_005,
+        });
+        let outcome = validate_run(&manifest(), &run);
+
+        assert_eq!(outcome.errors, Vec::new(), "the run itself is well formed");
+        assert_eq!(
+            outcome.invalid_samples,
+            vec![InvalidSample {
+                workload: "caldera".to_string(),
+                sample_index: 0,
+                reason: InvalidSampleReason::PhaseInvariantViolated {
+                    compiler_root_ns: 900_000_000,
+                    attributed_ns: 900_000_005,
+                },
+            }]
+        );
+        // The sample is still on disk; only its contribution is withdrawn.
+        assert_eq!(run.workloads[0].samples.len(), 2);
+        assert!(outcome.is_appendable());
+        assert!(!outcome.publishes_headline());
+        assert!(!outcome.publishes_workload("caldera"));
+        assert!(outcome.publishes_workload("startup"));
+    }
+
+    #[test]
+    fn a_producer_cannot_hide_its_own_invariant_failure() {
+        let mut run = sample_run();
+        run.workloads[0].samples[0].phases.unattributed_ns = 5;
+        let outcome = validate_run(&manifest(), &run);
+        assert!(
+            outcome
+                .errors
+                .contains(&ValidationError::UnrecordedInvariantFailure {
+                    workload: "caldera".to_string(),
+                    sample_index: 0,
+                })
+        );
+    }
+
+    #[test]
+    fn a_failure_record_cannot_invent_a_violation_that_did_not_happen() {
+        let mut run = sample_run();
+        run.failures.push(FailureRecord::PhaseInvariant {
+            workload: "caldera".to_string(),
+            sample_index: 1,
+            compiler_root_ns: 1,
+            attributed_ns: 2,
+        });
+        let outcome = validate_run(&manifest(), &run);
+        assert!(
+            outcome
+                .errors
+                .contains(&ValidationError::SpuriousInvariantRecord {
+                    workload: "caldera".to_string(),
+                    sample_index: 1,
+                })
+        );
+    }
+
+    #[test]
+    fn a_failure_record_for_an_undeclared_workload_is_rejected() {
+        let mut run = sample_run();
+        run.failures.push(FailureRecord::Timeout {
+            workload: "phantom".to_string(),
+            sample_index: 0,
+            limit_ns: 1,
+        });
+        let outcome = validate_run(&manifest(), &run);
+        assert!(
+            outcome
+                .errors
+                .contains(&ValidationError::FailureForUndeclaredWorkload {
+                    workload: "phantom".to_string(),
+                })
+        );
+    }
+
+    #[test]
+    fn a_run_level_build_failure_names_no_workload_and_is_accepted() {
+        let mut run = sample_run();
+        run.failures.push(FailureRecord::Build {
+            detail: "linker unavailable".to_string(),
+        });
+        let outcome = validate_run(&manifest(), &run);
+        assert_eq!(outcome.errors, Vec::new());
+    }
+
+    #[test]
+    fn missing_phases_invalidate_a_sample_even_when_the_total_happens_to_match() {
+        let mut run = sample_run();
+        run.workloads[0].samples[0]
+            .phases
+            .phase_ns
+            .remove(&Phase::Linking);
+        let outcome = validate_run(&manifest(), &run);
+        assert_eq!(
+            outcome.invalid_samples,
+            vec![InvalidSample {
+                workload: "caldera".to_string(),
+                sample_index: 0,
+                reason: InvalidSampleReason::MissingPhases {
+                    phases: vec!["linking".to_string()],
+                },
+            }]
+        );
+    }
+
+    #[test]
+    fn a_process_shorter_than_its_compiler_root_invalidates_the_sample() {
+        let mut run = sample_run();
+        run.workloads[1].samples[1].process_elapsed_ns = 1;
+        let outcome = validate_run(&manifest(), &run);
+        assert_eq!(
+            outcome.invalid_samples,
+            vec![InvalidSample {
+                workload: "startup".to_string(),
+                sample_index: 1,
+                reason: InvalidSampleReason::ProcessShorterThanCompilerRoot {
+                    process_elapsed_ns: 1,
+                    compiler_root_ns: 404_000_000,
+                },
+            }]
+        );
+    }
+
+    #[test]
+    fn a_zero_length_compilation_invalidates_the_sample() {
+        let mut run = sample_run();
+        run.workloads[0].samples[0].phases = accounting(0);
+        run.workloads[0].samples[0].phases.compiler_root_ns = 0;
+        let outcome = validate_run(&manifest(), &run);
+        assert_eq!(
+            outcome.invalid_samples,
+            vec![InvalidSample {
+                workload: "caldera".to_string(),
+                sample_index: 0,
+                reason: InvalidSampleReason::ZeroCompilerRoot,
+            }]
+        );
+    }
+
+    #[test]
+    fn a_crashed_workload_makes_the_run_partial_but_keeps_the_others_publishing() {
+        let mut run = sample_run();
+        run.workloads[0].samples.truncate(1);
+        run.failures.push(FailureRecord::WorkloadCrashed {
+            workload: "caldera".to_string(),
+            sample_index: 1,
+            detail: "signal 11".to_string(),
+        });
+        let outcome = validate_run(&manifest(), &run);
+
+        assert_eq!(outcome.errors, Vec::new(), "a partial run is still stored");
+        assert_eq!(
+            outcome.completeness,
+            Completeness::Partial {
+                missing: vec!["caldera".to_string()],
+            }
+        );
+        assert!(outcome.is_appendable());
+        assert!(!outcome.publishes_headline());
+        assert!(!outcome.publishes_workload("caldera"));
+        assert!(outcome.publishes_workload("startup"));
+    }
+
+    #[test]
+    fn a_workload_absent_entirely_is_reported_as_missing() {
+        let mut run = sample_run();
+        run.workloads.remove(0);
+        let outcome = validate_run(&manifest(), &run);
+        assert_eq!(
+            outcome.completeness,
+            Completeness::Partial {
+                missing: vec!["caldera".to_string()],
+            }
+        );
+        assert_eq!(outcome.errors, Vec::new());
+    }
+
+    #[test]
+    fn nothing_publishes_from_a_run_that_cannot_be_appended() {
+        let mut run = sample_run();
+        run.identity.pins.toolchain_hash = "other".to_string();
+        let outcome = validate_run(&manifest(), &run);
+        assert!(!outcome.is_appendable());
+        assert!(!outcome.publishes_headline());
+        assert!(!outcome.publishes_workload("startup"));
+    }
+
+    #[test]
+    fn a_malformed_commit_or_timestamp_is_rejected() {
+        let mut run = sample_run();
+        run.identity.commit = "abc".to_string();
+        run.identity.started_at = "2026-07-28 04:00:00".to_string();
+        run.identity.finished_at = "2026-07-28T04:12:00.500Z".to_string();
+        let outcome = validate_run(&manifest(), &run);
+        assert!(outcome.errors.contains(&ValidationError::MalformedCommit {
+            value: "abc".to_string(),
+        }));
+        assert_eq!(
+            outcome
+                .errors
+                .iter()
+                .filter(|error| matches!(error, ValidationError::MalformedTimestamp { .. }))
+                .count(),
+            2,
+            "one spelling of an instant keeps content addresses stable"
+        );
+    }
+
+    #[test]
+    fn every_problem_is_reported_rather_than_the_first() {
+        let mut run = sample_run();
+        run.identity.pins.toolchain_hash = "other".to_string();
+        run.identity.pins.stdlib_hash = "other".to_string();
+        run.identity.environment.runner_image = "ubuntu-22.04".to_string();
+        let outcome = validate_run(&manifest(), &run);
+        assert_eq!(outcome.errors.len(), 3, "{:?}", outcome.errors);
+    }
+}

--- a/docs/designs/0067-compiler-performance-measurement.md
+++ b/docs/designs/0067-compiler-performance-measurement.md
@@ -351,25 +351,25 @@ keyboard-reachable and exposed to assistive technology.
 
 ## Implementation Phases
 
-- [ ] **Phase 1: Measurement schema** - RUE-NNN. Suite revisions, platform
+- [ ] **Phase 1: Measurement schema** - RUE-1184. Suite revisions, platform
       epochs, series identity, run-object schema, canonical serialization and
       SHA-256 content addressing, validation rules.
-- [ ] **Phase 2: Compiler phase accounting** - RUE-NNN. The reference-counted
+- [ ] **Phase 2: Compiler phase accounting** - RUE-1185. The reference-counted
       state machine of §2 in the timing collector, published alongside
       existing spans; measurement-boundary tests including Rayon-parallel and
       same-phase-concurrent workloads; exact nanosecond invariant under test;
       `compiler_root_ns` / `process_elapsed_ns` distinction.
-- [ ] **Phase 3: Runner** - RUE-NNN. `crates/rue-bench`, workload manifest,
+- [ ] **Phase 3: Runner** - RUE-1186. `crates/rue-bench`, workload manifest,
       sampling and batching, partial-failure records, run-object emission.
-- [ ] **Phase 4: Noise calibration (unpublished)** - RUE-NNN. Repeated runs
+- [ ] **Phase 4: Noise calibration (unpublished)** - RUE-1187. Repeated runs
       on hosted runners per platform as workflow artifacts or explicitly
       marked non-series records; establishes sample counts, batching factors,
       the flagging multiplier and window, and the environment-fingerprint
       annotation policy. Nothing from this phase enters any series.
-- [ ] **Phase 5: Declare and collect** - RUE-NNN. Suite revision 1 and the
+- [ ] **Phase 5: Declare and collect** - RUE-1188. Suite revision 1 and the
       initial platform epochs with calibrated policies; `performance-data-v1`
       orphan branch; serialized collector workflow; first baselines.
-- [ ] **Phase 6: Dashboard** - RUE-NNN. The page of §11, including
+- [ ] **Phase 6: Dashboard** - RUE-1189. The page of §11, including
       collection-health presentation.
 
 ## Consequences

--- a/rust-project.json
+++ b/rust-project.json
@@ -19,19 +19,19 @@
           "name": "rue_compiler"
         },
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_rir"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_span"
         },
         {
-          "crate": 65,
+          "crate": 66,
           "name": "lasso"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde_json"
         }
       ],
@@ -63,23 +63,23 @@
           "name": "rue_error"
         },
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_rir"
         },
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_span"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_target"
         },
         {
-          "crate": 65,
+          "crate": 66,
           "name": "lasso"
         }
       ],
@@ -119,27 +119,27 @@
           "name": "rue_parser"
         },
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_rir"
         },
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_span"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_target"
         },
         {
-          "crate": 65,
+          "crate": 66,
           "name": "lasso"
         },
         {
-          "crate": 95,
+          "crate": 96,
           "name": "rayon"
         }
       ],
@@ -182,7 +182,7 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_runtime_abi"
         }
       ],
@@ -214,11 +214,11 @@
           "name": "rue_error"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_span"
         },
         {
-          "crate": 65,
+          "crate": 66,
           "name": "lasso"
         }
       ],
@@ -250,11 +250,11 @@
           "name": "rue_error"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_span"
         },
         {
-          "crate": 65,
+          "crate": 66,
           "name": "lasso"
         }
       ],
@@ -282,31 +282,31 @@
           "name": "rue_linker"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_target"
         },
         {
-          "crate": 26,
+          "crate": 27,
           "name": "rue_test_runner"
         },
         {
-          "crate": 74,
+          "crate": 75,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "serde"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde_json"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "tempfile"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "toml"
         }
       ],
@@ -346,27 +346,27 @@
           "name": "rue_error"
         },
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_span"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_target"
         },
         {
-          "crate": 56,
+          "crate": 57,
           "name": "fixedbitset"
         },
         {
-          "crate": 65,
+          "crate": 66,
           "name": "lasso"
         },
         {
-          "crate": 116,
+          "crate": 117,
           "name": "tracing"
         }
       ],
@@ -422,59 +422,59 @@
           "name": "rue_parser"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_query"
         },
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_rir"
         },
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_span"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_target"
         },
         {
-          "crate": 37,
+          "crate": 38,
           "name": "annotate_snippets"
         },
         {
-          "crate": 65,
+          "crate": 66,
           "name": "lasso"
         },
         {
-          "crate": 70,
+          "crate": 71,
           "name": "libc"
         },
         {
-          "crate": 95,
+          "crate": 96,
           "name": "rayon"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "serde"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde_json"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "sha2"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "tempfile"
         },
         {
-          "crate": 116,
+          "crate": 117,
           "name": "tracing"
         }
       ],
@@ -498,11 +498,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_span"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "thiserror"
         }
       ],
@@ -534,15 +534,15 @@
           "name": "rue_parser"
         },
         {
-          "crate": 26,
+          "crate": 27,
           "name": "rue_test_runner"
         },
         {
-          "crate": 65,
+          "crate": 66,
           "name": "lasso"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "tempfile"
         }
       ],
@@ -602,27 +602,27 @@
           "name": "rue_parser"
         },
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_rir"
         },
         {
-          "crate": 20,
+          "crate": 21,
           "name": "rue_rir_fuzz_support"
         },
         {
-          "crate": 26,
+          "crate": 27,
           "name": "rue_test_runner"
         },
         {
-          "crate": 40,
+          "crate": 41,
           "name": "anyhow"
         },
         {
-          "crate": 70,
+          "crate": 71,
           "name": "libc"
         },
         {
-          "crate": 88,
+          "crate": 89,
           "name": "proptest"
         }
       ],
@@ -650,15 +650,15 @@
           "name": "rue_error"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_span"
         },
         {
-          "crate": 65,
+          "crate": 66,
           "name": "lasso"
         },
         {
-          "crate": 77,
+          "crate": 78,
           "name": "logos"
         }
       ],
@@ -682,11 +682,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_target"
         },
         {
-          "crate": 116,
+          "crate": 117,
           "name": "tracing"
         }
       ],
@@ -722,19 +722,19 @@
           "name": "rue_oracle"
         },
         {
-          "crate": 26,
+          "crate": 27,
           "name": "rue_test_runner"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "serde"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "tempfile"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "toml"
         }
       ],
@@ -770,7 +770,7 @@
           "name": "rue_compiler"
         },
         {
-          "crate": 65,
+          "crate": 66,
           "name": "lasso"
         }
       ],
@@ -802,19 +802,19 @@
           "name": "rue_lexer"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_span"
         },
         {
-          "crate": 65,
+          "crate": 66,
           "name": "lasso"
         },
         {
-          "crate": 107,
+          "crate": 108,
           "name": "smallvec"
         },
         {
-          "crate": 116,
+          "crate": 117,
           "name": "tracing"
         }
       ],
@@ -822,6 +822,42 @@
       "source": {
         "include_dirs": [
           "crates/rue-parser/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-perf-schema",
+      "root_module": "crates/rue-perf-schema/src/lib.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 102,
+          "name": "serde"
+        },
+        {
+          "crate": 104,
+          "name": "serde_json"
+        },
+        {
+          "crate": 106,
+          "name": "sha2"
+        },
+        {
+          "crate": 113,
+          "name": "toml"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-perf-schema/src"
         ],
         "exclude_dirs": []
       },
@@ -865,11 +901,11 @@
           "name": "rue_parser"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_span"
         },
         {
-          "crate": 65,
+          "crate": 66,
           "name": "lasso"
         }
       ],
@@ -901,11 +937,11 @@
           "name": "rue_parser"
         },
         {
-          "crate": 23,
+          "crate": 24,
           "name": "rue_span"
         },
         {
-          "crate": 65,
+          "crate": 66,
           "name": "lasso"
         }
       ],
@@ -952,7 +988,7 @@
           "name": "rue_allocator"
         },
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_runtime_abi"
         }
       ],
@@ -995,15 +1031,15 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 26,
+          "crate": 27,
           "name": "rue_test_runner"
         },
         {
-          "crate": 74,
+          "crate": 75,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "tempfile"
         }
       ],
@@ -1050,23 +1086,23 @@
           "name": "rue_error"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_target"
         },
         {
-          "crate": 70,
+          "crate": 71,
           "name": "libc"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "serde"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "tempfile"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "toml"
         }
       ],
@@ -1090,11 +1126,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 26,
+          "crate": 27,
           "name": "rue_test_runner"
         },
         {
-          "crate": 74,
+          "crate": 75,
           "name": "libtest2_mimic"
         }
       ],
@@ -1126,35 +1162,35 @@
           "name": "rue_error"
         },
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_rir"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_target"
         },
         {
-          "crate": 70,
+          "crate": 71,
           "name": "libc"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "serde"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde_json"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "sha2"
         },
         {
-          "crate": 116,
+          "crate": 117,
           "name": "tracing"
         },
         {
-          "crate": 120,
+          "crate": 121,
           "name": "tracing_subscriber"
         }
       ],
@@ -1186,35 +1222,35 @@
           "name": "rue_error"
         },
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_rir"
         },
         {
-          "crate": 25,
+          "crate": 26,
           "name": "rue_target"
         },
         {
-          "crate": 70,
+          "crate": 71,
           "name": "libc"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "serde"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde_json"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "sha2"
         },
         {
-          "crate": 116,
+          "crate": 117,
           "name": "tracing"
         },
         {
-          "crate": 120,
+          "crate": 121,
           "name": "tracing_subscriber"
         }
       ],
@@ -1238,7 +1274,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 78,
+          "crate": 79,
           "name": "logos_codegen"
         }
       ],
@@ -1262,15 +1298,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 87,
+          "crate": 88,
           "name": "proc_macro2"
         },
         {
-          "crate": 90,
+          "crate": 91,
           "name": "quote"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "syn"
         }
       ],
@@ -1295,15 +1331,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 87,
+          "crate": 88,
           "name": "proc_macro2"
         },
         {
-          "crate": 90,
+          "crate": 91,
           "name": "quote"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "syn"
         }
       ],
@@ -1327,15 +1363,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 87,
+          "crate": 88,
           "name": "proc_macro2"
         },
         {
-          "crate": 90,
+          "crate": 91,
           "name": "quote"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "syn"
         }
       ],
@@ -1359,15 +1395,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 46,
+          "crate": 47,
           "name": "cfg_if"
         },
         {
-          "crate": 83,
+          "crate": 84,
           "name": "once_cell"
         },
         {
-          "crate": 127,
+          "crate": 128,
           "name": "zerocopy"
         }
       ],
@@ -1391,7 +1427,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 80,
+          "crate": 81,
           "name": "memchr"
         }
       ],
@@ -1437,11 +1473,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 39,
+          "crate": 40,
           "name": "anstyle"
         },
         {
-          "crate": 124,
+          "crate": 125,
           "name": "unicode_width"
         }
       ],
@@ -1550,7 +1586,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 43,
+          "crate": 44,
           "name": "bit_vec"
         }
       ],
@@ -1618,7 +1654,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 58,
+          "crate": 59,
           "name": "generic_array"
         }
       ],
@@ -1680,11 +1716,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 49,
+          "crate": 50,
           "name": "crossbeam_epoch"
         },
         {
-          "crate": 50,
+          "crate": 51,
           "name": "crossbeam_utils"
         }
       ],
@@ -1710,7 +1746,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 50,
+          "crate": 51,
           "name": "crossbeam_utils"
         }
       ],
@@ -1757,11 +1793,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 58,
+          "crate": 59,
           "name": "generic_array"
         },
         {
-          "crate": 121,
+          "crate": 122,
           "name": "typenum"
         }
       ],
@@ -1785,27 +1821,27 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 46,
+          "crate": 47,
           "name": "cfg_if"
         },
         {
-          "crate": 50,
+          "crate": 51,
           "name": "crossbeam_utils"
         },
         {
-          "crate": 60,
+          "crate": 61,
           "name": "hashbrown"
         },
         {
-          "crate": 75,
+          "crate": 76,
           "name": "lock_api"
         },
         {
-          "crate": 83,
+          "crate": 84,
           "name": "once_cell"
         },
         {
-          "crate": 84,
+          "crate": 85,
           "name": "parking_lot_core"
         }
       ],
@@ -1830,11 +1866,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 45,
+          "crate": 46,
           "name": "block_buffer"
         },
         {
-          "crate": 51,
+          "crate": 52,
           "name": "crypto_common"
         }
       ],
@@ -1941,7 +1977,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 121,
+          "crate": 122,
           "name": "typenum"
         }
       ],
@@ -1986,11 +2022,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 34,
+          "crate": 35,
           "name": "ahash"
         },
         {
-          "crate": 36,
+          "crate": 37,
           "name": "allocator_api2"
         }
       ],
@@ -2038,11 +2074,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 55,
+          "crate": 56,
           "name": "equivalent"
         },
         {
-          "crate": 61,
+          "crate": 62,
           "name": "hashbrown"
         }
       ],
@@ -2109,11 +2145,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 52,
+          "crate": 53,
           "name": "dashmap"
         },
         {
-          "crate": 60,
+          "crate": 61,
           "name": "hashbrown"
         }
       ],
@@ -2159,11 +2195,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lexarg_error"
         },
         {
-          "crate": 69,
+          "crate": 70,
           "name": "lexarg_parser"
         }
       ],
@@ -2188,7 +2224,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 69,
+          "crate": 70,
           "name": "lexarg_parser"
         }
       ],
@@ -2254,7 +2290,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 64,
+          "crate": 65,
           "name": "json_write"
         }
       ],
@@ -2280,11 +2316,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lexarg"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lexarg_error"
         }
       ],
@@ -2309,27 +2345,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 38,
+          "crate": 39,
           "name": "anstream"
         },
         {
-          "crate": 39,
+          "crate": 40,
           "name": "anstyle"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lexarg_error"
         },
         {
-          "crate": 69,
+          "crate": 70,
           "name": "lexarg_parser"
         },
         {
-          "crate": 71,
+          "crate": 72,
           "name": "libtest_json"
         },
         {
-          "crate": 72,
+          "crate": 73,
           "name": "libtest_lexarg"
         }
       ],
@@ -2356,11 +2392,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 71,
+          "crate": 72,
           "name": "libtest_json"
         },
         {
-          "crate": 73,
+          "crate": 74,
           "name": "libtest2_harness"
         }
       ],
@@ -2387,7 +2423,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 100,
+          "crate": 101,
           "name": "scopeguard"
         }
       ],
@@ -2433,7 +2469,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 30,
+          "crate": 31,
           "name": "logos_derive"
         }
       ],
@@ -2461,31 +2497,31 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 41,
+          "crate": 42,
           "name": "beef"
         },
         {
-          "crate": 57,
+          "crate": 58,
           "name": "fnv"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "lazy_static"
         },
         {
-          "crate": 87,
+          "crate": 88,
           "name": "proc_macro2"
         },
         {
-          "crate": 90,
+          "crate": 91,
           "name": "quote"
         },
         {
-          "crate": 98,
+          "crate": 99,
           "name": "regex_syntax"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "syn"
         }
       ],
@@ -2509,7 +2545,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 97,
+          "crate": 98,
           "name": "regex_automata"
         }
       ],
@@ -2656,7 +2692,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 127,
+          "crate": 128,
           "name": "zerocopy"
         }
       ],
@@ -2682,7 +2718,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 123,
+          "crate": 124,
           "name": "unicode_ident"
         }
       ],
@@ -2708,47 +2744,47 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 42,
+          "crate": 43,
           "name": "bit_set"
         },
         {
-          "crate": 43,
+          "crate": 44,
           "name": "bit_vec"
         },
         {
-          "crate": 44,
+          "crate": 45,
           "name": "bitflags"
         },
         {
-          "crate": 82,
+          "crate": 83,
           "name": "num_traits"
         },
         {
-          "crate": 91,
+          "crate": 92,
           "name": "rand"
         },
         {
-          "crate": 92,
+          "crate": 93,
           "name": "rand_chacha"
         },
         {
-          "crate": 94,
+          "crate": 95,
           "name": "rand_xorshift"
         },
         {
-          "crate": 98,
+          "crate": 99,
           "name": "regex_syntax"
         },
         {
-          "crate": 99,
+          "crate": 100,
           "name": "rusty_fork"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "tempfile"
         },
         {
-          "crate": 122,
+          "crate": 123,
           "name": "unarray"
         }
       ],
@@ -2799,7 +2835,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 87,
+          "crate": 88,
           "name": "proc_macro2"
         }
       ],
@@ -2825,7 +2861,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 93,
+          "crate": 94,
           "name": "rand_core"
         }
       ],
@@ -2852,11 +2888,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 86,
+          "crate": 87,
           "name": "ppv_lite86"
         },
         {
-          "crate": 93,
+          "crate": 94,
           "name": "rand_core"
         }
       ],
@@ -2881,7 +2917,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 59,
+          "crate": 60,
           "name": "getrandom"
         }
       ],
@@ -2907,7 +2943,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 93,
+          "crate": 94,
           "name": "rand_core"
         }
       ],
@@ -2931,11 +2967,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 54,
+          "crate": 55,
           "name": "either"
         },
         {
-          "crate": 96,
+          "crate": 97,
           "name": "rayon_core"
         }
       ],
@@ -2959,11 +2995,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 48,
+          "crate": 49,
           "name": "crossbeam_deque"
         },
         {
-          "crate": 50,
+          "crate": 51,
           "name": "crossbeam_utils"
         }
       ],
@@ -2987,15 +3023,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 35,
+          "crate": 36,
           "name": "aho_corasick"
         },
         {
-          "crate": 80,
+          "crate": 81,
           "name": "memchr"
         },
         {
-          "crate": 98,
+          "crate": 99,
           "name": "regex_syntax"
         }
       ],
@@ -3072,19 +3108,19 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 57,
+          "crate": 58,
           "name": "fnv"
         },
         {
-          "crate": 89,
+          "crate": 90,
           "name": "quick_error"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "tempfile"
         },
         {
-          "crate": 125,
+          "crate": 126,
           "name": "wait_timeout"
         }
       ],
@@ -3129,11 +3165,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 31,
+          "crate": 32,
           "name": "serde_derive"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "serde_core"
         }
       ],
@@ -3182,19 +3218,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 63,
+          "crate": 64,
           "name": "itoa"
         },
         {
-          "crate": 80,
+          "crate": 81,
           "name": "memchr"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "serde_core"
         },
         {
-          "crate": 128,
+          "crate": 129,
           "name": "zmij"
         }
       ],
@@ -3220,7 +3256,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 101,
+          "crate": 102,
           "name": "serde"
         }
       ],
@@ -3245,15 +3281,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 46,
+          "crate": 47,
           "name": "cfg_if"
         },
         {
-          "crate": 47,
+          "crate": 48,
           "name": "cpufeatures"
         },
         {
-          "crate": 53,
+          "crate": 54,
           "name": "digest"
         }
       ],
@@ -3277,7 +3313,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 66,
+          "crate": 67,
           "name": "lazy_static"
         }
       ],
@@ -3320,15 +3356,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 87,
+          "crate": 88,
           "name": "proc_macro2"
         },
         {
-          "crate": 90,
+          "crate": 91,
           "name": "quote"
         },
         {
-          "crate": 123,
+          "crate": 124,
           "name": "unicode_ident"
         }
       ],
@@ -3382,7 +3418,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 32,
+          "crate": 33,
           "name": "thiserror_impl"
         }
       ],
@@ -3408,7 +3444,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 46,
+          "crate": 47,
           "name": "cfg_if"
         }
       ],
@@ -3432,19 +3468,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 101,
+          "crate": 102,
           "name": "serde"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde_spanned"
         },
         {
-          "crate": 113,
+          "crate": 114,
           "name": "toml_datetime"
         },
         {
-          "crate": 114,
+          "crate": 115,
           "name": "toml_edit"
         }
       ],
@@ -3471,7 +3507,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 101,
+          "crate": 102,
           "name": "serde"
         }
       ],
@@ -3496,27 +3532,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 62,
+          "crate": 63,
           "name": "indexmap"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "serde"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde_spanned"
         },
         {
-          "crate": 113,
+          "crate": 114,
           "name": "toml_datetime"
         },
         {
-          "crate": 115,
+          "crate": 116,
           "name": "toml_write"
         },
         {
-          "crate": 126,
+          "crate": 127,
           "name": "winnow"
         }
       ],
@@ -3565,15 +3601,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 33,
+          "crate": 34,
           "name": "tracing_attributes"
         },
         {
-          "crate": 85,
+          "crate": 86,
           "name": "pin_project_lite"
         },
         {
-          "crate": 117,
+          "crate": 118,
           "name": "tracing_core"
         }
       ],
@@ -3601,7 +3637,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 83,
+          "crate": 84,
           "name": "once_cell"
         }
       ],
@@ -3628,15 +3664,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 76,
+          "crate": 77,
           "name": "log"
         },
         {
-          "crate": 83,
+          "crate": 84,
           "name": "once_cell"
         },
         {
-          "crate": 117,
+          "crate": 118,
           "name": "tracing_core"
         }
       ],
@@ -3662,11 +3698,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 101,
+          "crate": 102,
           "name": "serde"
         },
         {
-          "crate": 117,
+          "crate": 118,
           "name": "tracing_core"
         }
       ],
@@ -3690,55 +3726,55 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 79,
+          "crate": 80,
           "name": "matchers"
         },
         {
-          "crate": 81,
+          "crate": 82,
           "name": "nu_ansi_term"
         },
         {
-          "crate": 83,
+          "crate": 84,
           "name": "once_cell"
         },
         {
-          "crate": 97,
+          "crate": 98,
           "name": "regex_automata"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "serde"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde_json"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "sharded_slab"
         },
         {
-          "crate": 107,
+          "crate": 108,
           "name": "smallvec"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "thread_local"
         },
         {
-          "crate": 116,
+          "crate": 117,
           "name": "tracing"
         },
         {
-          "crate": 117,
+          "crate": 118,
           "name": "tracing_core"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing_log"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing_serde"
         }
       ],


### PR DESCRIPTION
Phase 1 of ADR-0067. Adds `crates/rue-perf-schema`, the measurement contract, before anything produces or consumes performance data. No runner, no collector, no dashboard yet — this PR only fixes what the data means.

## What it defines

**Raw observation records.** A run object holds complete raw samples in integer nanoseconds plus structured evidence of whatever failed. `PhaseAccounting` partitions compiler-root wall time into mutually exclusive bands — the seven published phases plus `mixed_parallel` and `unattributed` — whose integer sum equals `compiler_root_ns` exactly. `process_elapsed_ns` is recorded separately so driver overhead is reportable without entering the additive stack.

**Two-layer versioning.** A suite revision pins the platform-independent logical contract (workload membership and source identity, phase taxonomy, protocol semantics). A platform epoch pins target, invocation, resolved content hashes, sampling and batching policy, environment policy, and baseline. `Manifest::parse` enforces that the two layers agree — every suite workload has a source hash and a sampling policy, and neither names a workload the suite does not declare — so a later validation failure always means the *run* is wrong rather than the manifest.

**Canonical serialization.** Sorted keys at every depth, no insignificant whitespace, and floating-point values rejected outright with a JSON pointer to the offender. A run object's SHA-256 content address is therefore a function of the measurement alone. `FlaggingPolicy::k` is the one float in the crate; it lives in the manifest, which is reviewed configuration and never hashed.

**Validation.** The two kinds of wrongness are kept apart:

- A `ValidationError` is an *appendability* failure — the run does not describe the configuration it claims to, so it cannot enter a series at all. This is what replaces after-the-fact comparability classification: rather than deciding whether two stored points may be compared, the system refuses to store a point that would not be comparable.
- An `InvalidSample` is a *measurement* failure. The run is well-formed and belongs in its series; one sample is not trustworthy. It stays on disk and stops counting.

Validation recomputes the phase-sum invariant rather than trusting the producer's own failure record, so a producer can neither hide a violation (`UnrecordedInvariantFailure`) nor invent one (`SpuriousInvariantRecord`).

**Partial runs are appendable by design.** `Completeness` drives the tiering: valid workloads still publish per-workload observations, and only the headline point is withheld.

## Notable choices

- Environment *policy* is enforced (runner label and image); image version, CPU model, and core count are recorded but unconstrained. Pinning them is not available on hosted hardware, and pretending otherwise would make collection fail rather than make measurements comparable. `environment_drift_within_the_policy_stays_appendable` pins that behavior.
- Timestamps accept exactly one spelling (`YYYY-MM-DDTHH:MM:SSZ`) so two identical measurements cannot produce two content addresses by formatting the same instant differently.
- Workload observations must be sorted, since ordering is part of the canonical form.
- A workload must name the question it answers, enforced at manifest parse.
- `deny_unknown_fields` throughout: an unrecognized key is a schema disagreement, not something to ignore.

## Also here

A second commit fills the `RUE-NNN` placeholders in the ADR's Implementation Phases list with the issues filed under the RUE-1182 epic (RUE-1184 through RUE-1189). The ADR landed with them unresolved.

## Validation

- `//crates/rue-perf-schema:rue-perf-schema-test` — 71 tests, 0 failures. Covers the exact-nanosecond invariant (including that one nanosecond of slack fails), canonical-hash stability across re-serialization, each pinned component independently, the edited-workload case, environment drift, protocol violations, and the publication tiering.
- `scripts/rue quick` — 29 targets pass.
- `scripts/rue fmt`, `./gen-rust-project.sh`, `python3 scripts/validate-rust-project.py` (131 crates, 32 first-party), `python3 scripts/validate-adrs.py` (68 records).

Rebased onto trunk after the ADR (`e967620`) and the benchmarking reset (`f6c7531`) landed. The only conflict was the generated `rust-project.json`, resolved by regenerating against the post-reset crate set; its remaining diff is index renumbering from the inserted crate.

Refs RUE-1182, RUE-1184.