### PR TITLE
RUE-1185: add wall-clock phase accounting to the timing collector

### DIFF
--- a/crates/rue-cli-tests/cases/benchmark_json.toml
+++ b/crates/rue-cli-tests/cases/benchmark_json.toml
@@ -4,6 +4,8 @@ name = "Benchmark JSON timing contract"
 description = """
 RUE-642 pins the honest inclusive-span schema and ensures a restrictive
 RUST_LOG filter affects log formatting without disabling timing collection.
+ADR-0067 adds the additive wall-clock partition alongside it, so this case
+also pins that both timing models are published and stay distinguishable.
 """
 
 [[case]]
@@ -13,8 +15,16 @@ args = ["--benchmark-json", "main.rue", "-o", "prog"]
 env = { RUST_LOG = "error" }
 exit_code = 42
 compile_stdout_contains = [
-  '"schema_version":2',
+  '"schema_version":3',
   '"timing_model":"inclusive_spans"',
+  # The additive partition, which is the only model that may be stacked. Its
+  # bands are integer nanoseconds summing exactly to compiler_root_ns.
+  '"phase_accounting":',
+  '"compiler_root_ns":',
+  '"mixed_parallel_ns":',
+  '"unattributed_ns":',
+  '"semantic_analysis":',
+  '"linking":',
   '"name":"compile"',
   '"root_invocations":1',
   '"name":"lexer"',

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -206,7 +206,7 @@ pub(crate) fn generate_backend_products(
     // reported as extra timing roots. Hold the span by value and re-enter it
     // inside the closure so every worker's subphases nest under this one
     // `codegen` aggregate (RUE-786).
-    let codegen_span = info_span!("codegen", arch = ?options.target.arch());
+    let codegen_span = info_span!("codegen", arch = ?options.target.arch(), phase = "backend");
     let _entered = codegen_span.clone().entered();
     let symbol_mappings = foreign_call_symbol_mappings(functions, foreign_symbols);
     let foreign_set: std::collections::BTreeSet<String> = foreign_symbols.iter().cloned().collect();
@@ -284,7 +284,7 @@ fn project_backend_object(
 ) -> CompileResult<Vec<u8>> {
     // Object serialization runs after the parallel codegen fan-out, so it is a
     // sibling leaf of `codegen` rather than one of its subphases (RUE-786).
-    let _span = info_span!("object_serialization").entered();
+    let _span = info_span!("object_serialization", phase = "object_generation").entered();
     let mut obj_builder = ObjectBuilder::new(target, &product.machine_name)
         .code(product.machine_code.code)
         .strings(product.machine_code.strings);

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -1122,7 +1122,7 @@ pub(crate) fn analyze_canonical_program_for_test_support(
         Vec::new(),
         Arc::from([]),
         crate::DurableBodyWork::default(),
-        info_span!("sema").entered(),
+        info_span!("sema", phase = "semantic_analysis").entered(),
         |bound, _candidates, _definitions, _merged| {
             bound
                 .analyze_all_bodies_for_test()
@@ -1450,7 +1450,7 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
     reuse.durable_records_reused = durable.len();
     reuse.ordinary_declaration_resolutions_skipped = 1;
     drop(declaration_reuse_span);
-    let sema_span = info_span!("sema").entered();
+    let sema_span = info_span!("sema", phase = "semantic_analysis").entered();
     finish_canonical_analysis(
         input,
         merged,
@@ -3595,6 +3595,11 @@ fn finish_canonical_analysis_with(
     }
     stable_cfg_inputs.sort_by(|left, right| left.stable.function.cmp(&right.stable.function));
     drop(sema_span);
+    // CFG construction is a sibling of semantic-proper, not nested inside it:
+    // `sema_span` closes above before this begins. Published phases must not
+    // overlap, so this boundary is load-bearing rather than stylistic. The
+    // `cfg_and_optimization` phase marker lives on `cfg_construction` inside
+    // `build_functions_and_cfgs`.
     let cfg = build_functions_and_cfgs(
         sema_output,
         options.opt_level,

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -483,7 +483,7 @@ pub(crate) fn link_internal_with_warnings(
     object_files: &[Vec<u8>],
     warnings: &[CompileWarning],
 ) -> MultiErrorResult<CompileOutput> {
-    let _span = info_span!("linker", mode = "internal").entered();
+    let _span = info_span!("linker", mode = "internal", phase = "linking").entered();
 
     let runtime_bytes = runtime_for_target(options.target);
 
@@ -584,7 +584,13 @@ pub(crate) fn link_system_with_warnings(
     linker_cmd: &str,
     warnings: &[CompileWarning],
 ) -> MultiErrorResult<CompileOutput> {
-    let _span = info_span!("linker", mode = "system", command = linker_cmd).entered();
+    let _span = info_span!(
+        "linker",
+        mode = "system",
+        command = linker_cmd,
+        phase = "linking"
+    )
+    .entered();
 
     let runtime_bytes = runtime_for_target(options.target);
     // The system linker consumes the archive bytes directly, so validate the

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -341,7 +341,9 @@ pub(crate) fn build_functions_and_cfgs(
     // identity shared by user, specialized, destructor, and glue functions.
     all_functions.sort_by(|left, right| left.4.cmp(&right.4));
 
-    let _span = info_span!("cfg_construction").entered();
+    // Entered once on the calling thread and held across the Rayon collect
+    // below, so the phase stays active for the whole parallel region.
+    let _span = info_span!("cfg_construction", phase = "cfg_and_optimization").entered();
 
     let results: Vec<_> = all_functions
         .into_par_iter()
@@ -840,7 +842,7 @@ pub(crate) fn pre_link_object_bytes_with_session(
 ) -> MultiErrorResult<usize> {
     let _span = info_span!("compile_pipeline_pre_link").entered();
     let rir = {
-        let _span = info_span!("semantic_astgen").entered();
+        let _span = info_span!("semantic_astgen", phase = "program_construction").entered();
         session.canonical_rir()?
     };
     let semantic = session.canonical_semantic(options)?;
@@ -893,7 +895,7 @@ pub(crate) fn compile_with_session(
     let _span = info_span!("compile_pipeline").entered();
 
     let rir = {
-        let _span = info_span!("semantic_astgen").entered();
+        let _span = info_span!("semantic_astgen", phase = "program_construction").entered();
         session.canonical_rir()?
     };
     let semantic = session.canonical_semantic(options)?;

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -5052,7 +5052,9 @@ impl CompilerSession {
             .saturating_add(demanded_modules.len() as u64);
         drop(key_span);
         let (modular_result, modular_work) = {
-            let _span = tracing::info_span!("parse_program").entered();
+            let _span =
+                tracing::info_span!("parse_program", phase = "source_discovery_and_parsing")
+                    .entered();
             self.queries.revisioned.parse_program(
                 revision,
                 snapshot.source_revision().root(),
@@ -6607,7 +6609,11 @@ impl CompilerSession {
         };
         drop(declaration_shells_span);
         let declaration_semantics = {
-            let _span = tracing::info_span!("declaration_semantics_projection").entered();
+            let _span = tracing::info_span!(
+                "declaration_semantics_projection",
+                phase = "semantic_analysis"
+            )
+            .entered();
             self.queries.revisioned.projected_declaration_semantics(
                 runtime_revision,
                 merged.ast(),
@@ -6943,7 +6949,8 @@ impl CompilerSession {
             // attributes the aggregate reach-and-analyze cost that RUE-1083
             // traced to the previously unspanned semantic-query path. The
             // per-body pipeline stages nest beneath it as timed leaves.
-            let _body_queries_span = tracing::info_span!("body_queries").entered();
+            let _body_queries_span =
+                tracing::info_span!("body_queries", phase = "semantic_analysis").entered();
             // Producer-nominal identity is exact and stable (RUE-1089): a reached
             // anonymous member owns its precise producer identity, so no reached
             // body can change an anonymous representative and force a re-traversal.

--- a/crates/rue-perf-schema/src/run.rs
+++ b/crates/rue-perf-schema/src/run.rs
@@ -66,6 +66,28 @@ impl Phase {
             Phase::Linking => "linking",
         }
     }
+
+    /// The phase with this wire name, if the taxonomy declares one.
+    ///
+    /// The compiler's instrumentation names its phases with these strings, so
+    /// parsing them here rather than in the collector keeps the producer and
+    /// this schema from drifting apart silently.
+    pub fn from_wire_name(name: &str) -> Option<Phase> {
+        Phase::ALL
+            .into_iter()
+            .find(|phase| phase.wire_name() == name)
+    }
+
+    /// This phase's position in [`Phase::ALL`].
+    ///
+    /// Collectors keep per-phase state in fixed-size arrays; this is the index
+    /// into them.
+    pub fn index(self) -> usize {
+        Phase::ALL
+            .into_iter()
+            .position(|phase| phase == self)
+            .expect("Phase::ALL covers every phase")
+    }
 }
 
 /// A band of the additive stack: a published phase or a structural bucket.
@@ -526,6 +548,27 @@ mod tests {
         names.sort_unstable();
         names.dedup();
         assert_eq!(names.len(), Phase::ALL.len() + 2);
+    }
+
+    #[test]
+    fn wire_names_round_trip_through_from_wire_name() {
+        for phase in Phase::ALL {
+            assert_eq!(Phase::from_wire_name(phase.wire_name()), Some(phase));
+        }
+        assert_eq!(Phase::from_wire_name("semantic"), None);
+        assert_eq!(Phase::from_wire_name(""), None);
+        // The structural buckets are bands, not phases, and must not parse as
+        // one: a producer marking a span `mixed_parallel` is a bug, not a
+        // declaration.
+        assert_eq!(Phase::from_wire_name("mixed_parallel"), None);
+        assert_eq!(Phase::from_wire_name("unattributed"), None);
+    }
+
+    #[test]
+    fn phase_indexes_are_unique_and_dense() {
+        let mut indexes: Vec<usize> = Phase::ALL.into_iter().map(Phase::index).collect();
+        indexes.sort_unstable();
+        assert_eq!(indexes, (0..Phase::ALL.len()).collect::<Vec<_>>());
     }
 
     #[test]

--- a/crates/rue/BUCK
+++ b/crates/rue/BUCK
@@ -3,6 +3,9 @@ load("//crates:defs.bzl", "rue_binary")
 _DEPS = [
     "//crates/rue-compiler:rue-compiler",
     "//crates/rue-error:rue-error",
+    # The published phase taxonomy lives with the measurement contract, so the
+    # collector and the run-object schema cannot drift on wire names.
+    "//crates/rue-perf-schema:rue-perf-schema",
     "//crates/rue-rir:rue-rir",
     "//crates/rue-target:rue-target",
     "//third-party:libc",

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -715,7 +715,8 @@ fn drive_import_discovery_to_close(
             witness = frontier;
             break;
         }
-        let _read_span = tracing::info_span!("import_read").entered();
+        let _read_span =
+            tracing::info_span!("import_read", phase = "source_discovery_and_parsing").entered();
         let observations = frontier
             .requests()
             .iter()

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -18,6 +18,56 @@
 //!    timing as a human-readable table. For machine-readable output, use
 //!    `TimingData::to_json()`.
 //!
+//! # Two timing models, kept distinct
+//!
+//! This module publishes two kinds of phase measurement, and they must never be
+//! mixed in one visualization (ADR-0067).
+//!
+//! **Inclusive spans** are the `passes` table. Spans nest and overlap, a child's
+//! duration is contained in its parent's, and codegen subphases run
+//! concurrently across Rayon workers. Summing them double-counts, which is why
+//! the root total is a union of active intervals rather than a sum.
+//!
+//! **Wall-clock phase accounting** is [`BenchmarkTiming::phase_accounting`]. A
+//! small set of explicitly instrumented, mutually exclusive phases partitions
+//! compiler-root wall time so that, in exact integer nanoseconds:
+//!
+//! ```text
+//! sum(phase_ns) + mixed_parallel_ns + unattributed_ns == compiler_root_ns
+//! ```
+//!
+//! Only this model may be stacked.
+//!
+//! ## Declaring a phase
+//!
+//! Membership is declared at the instrumentation site with a `phase = "..."`
+//! span field naming a `rue_perf_schema::Phase`, never inferred from span names.
+//! Compiler spans nest deeply, so a name-based mapping would read a nested span
+//! as a second concurrent phase and charge the interval to `mixed_parallel`.
+//! Unlike `driver_phase`, the marker is not inherited: a marker on a descendant
+//! is a phase *transition*, and an unmarked child simply continues its parent's
+//! phase.
+//!
+//! Two rules follow for anyone adding a marker:
+//!
+//! * **Mark the work, not the orchestration.** The session is demand-driven, so
+//!   a step that merely *drives* analysis is not itself a phase. Marking such a
+//!   wrapper makes it the sole active phase for the whole subtree and starves the
+//!   real phases inside it, which then only ever appear as `mixed_parallel`.
+//! * **Published phases must not nest.** If two markers can be active at once,
+//!   redraw the boundary rather than accepting the mixed band.
+//!
+//! Because attribution follows the demand context, work reached lazily is
+//! charged to the phase that demanded it — on-demand parsing inside semantic
+//! analysis counts as semantic analysis. Total parse cost remains available in
+//! the inclusive `passes` table, which is exactly what the two-model split is
+//! for.
+//!
+//! `mixed_parallel` and `unattributed` are published bands, not artifacts.
+//! Growth in the first means the boundaries no longer describe the compiler's
+//! parallel structure; growth in the second means compiler time is moving
+//! somewhere the instrumentation does not describe.
+//!
 //! # Example
 //!
 //! ```ignore
@@ -43,6 +93,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use rue_perf_schema::{Phase, PhaseAccounting};
 use serde::Serialize;
 
 use tracing::Subscriber;
@@ -99,6 +150,34 @@ struct TimingDataInner {
     /// deterministic regression test.
     last_root_transition: Option<Instant>,
 
+    /// Reference count per published phase, indexed by [`Phase::index`].
+    ///
+    /// A phase is active exactly while its count is greater than zero. The set
+    /// of active phases is always derived from these counts and never tracked
+    /// independently, so the two can never disagree. Multiple concurrent spans
+    /// of the same phase are expected — Rayon workers re-enter one `codegen`
+    /// span by value (RUE-786) — and the count absorbs them.
+    phase_counts: [u64; Phase::ALL.len()],
+    /// Wall time charged to each published phase, indexed by [`Phase::index`].
+    phase_durations: [Duration; Phase::ALL.len()],
+    /// Wall time during which more than one distinct phase was active.
+    ///
+    /// A published band, not an artifact. Sustained growth means the phase
+    /// boundaries no longer describe the compiler's parallel structure.
+    mixed_parallel: Duration,
+    /// Wall time during which the root was active but no phase was.
+    ///
+    /// Growth here means compiler time is moving somewhere the instrumentation
+    /// does not describe.
+    unattributed: Duration,
+    /// Start of the interval not yet charged to a bucket.
+    ///
+    /// Every root or phase transition charges the interval since this cursor to
+    /// the bucket the *previous* state implied, then advances it. That is what
+    /// makes the phase-sum invariant exact rather than approximate: the charged
+    /// intervals and `root_duration` are driven from the same clamped timeline.
+    charge_cursor: Option<Instant>,
+
     /// Direct parent-child span names captured by the real timing layer.
     ///
     /// This remains test-only so parentage regressions can be checked without
@@ -134,6 +213,14 @@ pub struct BenchmarkTiming {
     pub schema_version: u32,
     /// Pass durations are inclusive and may overlap their parents.
     pub timing_model: &'static str,
+    /// The additive wall-clock partition of compiler-root time.
+    ///
+    /// This is the only model that may be stacked. Its integer nanoseconds
+    /// satisfy `sum(phase_ns) + mixed_parallel_ns + unattributed_ns ==
+    /// compiler_root_ns` exactly. The `passes` table below is the *other*
+    /// model — inclusive spans that nest and overlap — and the two must never
+    /// be mixed in one visualization.
+    pub phase_accounting: PhaseAccounting,
     /// Metadata about this benchmark run.
     pub metadata: BenchmarkMetadata,
     /// Individual pass timings in milliseconds.
@@ -220,6 +307,11 @@ impl TimingData {
                 active_roots: 0,
                 root_active_since: None,
                 last_root_transition: None,
+                phase_counts: [0; Phase::ALL.len()],
+                phase_durations: [Duration::ZERO; Phase::ALL.len()],
+                mixed_parallel: Duration::ZERO,
+                unattributed: Duration::ZERO,
+                charge_cursor: None,
                 #[cfg(test)]
                 parent_edges: Vec::new(),
             })),
@@ -269,6 +361,10 @@ impl TimingData {
         if is_root {
             let mut inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
             inner.root_duration += duration;
+            // Synthetic root time has no phase active, so it is unattributed.
+            // Charging it keeps the phase-sum invariant true for tests that
+            // fabricate root spans instead of driving the span lifecycle.
+            inner.unattributed += duration;
         }
     }
 
@@ -289,6 +385,42 @@ impl TimingData {
             .unwrap_or_else(PoisonError::into_inner)
             .parent_edges
             .clone()
+    }
+
+    /// Enter a published phase.
+    ///
+    /// The span's extension lock is held by the caller, and the global timing
+    /// lock is acquired before sampling the clock — the same order root
+    /// transitions already use, so phase intervals join one serialized timeline
+    /// and no new lock ordering is introduced.
+    fn enter_phase(&self, phase: Phase) {
+        let mut inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        let now = ordered_root_timestamp(&mut inner, Instant::now());
+        charge_interval(&mut inner, now);
+        inner.phase_counts[phase.index()] += 1;
+    }
+
+    /// Exit a published phase.
+    fn exit_phase(&self, phase: Phase) {
+        let mut inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        let now = ordered_root_timestamp(&mut inner, Instant::now());
+        charge_interval(&mut inner, now);
+        let count = &mut inner.phase_counts[phase.index()];
+        // An unbalanced exit would underflow. Tolerating it keeps a broken
+        // instrumentation site from aborting the compiler; the resulting
+        // accounting still has to satisfy the invariant, so the bug surfaces as
+        // an invalidated sample rather than silently skewed bands.
+        *count = count.saturating_sub(1);
+    }
+
+    /// Snapshot the additive wall-clock partition of compiler-root time.
+    ///
+    /// Production readers reach this through the benchmark JSON, which snapshots
+    /// the partition and the root total together.
+    #[cfg(test)]
+    pub(crate) fn phase_accounting(&self) -> PhaseAccounting {
+        let mut inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        phase_accounting_locked(&mut inner)
     }
 
     /// Enter a root span and update both timing views as one serialized event.
@@ -322,6 +454,11 @@ impl TimingData {
     }
 
     fn root_enter_inner(inner: &mut TimingDataInner, now: Instant) {
+        // Charge before the count changes: the elapsed interval belongs to the
+        // previous state, which had the root inactive and is therefore excluded.
+        // This also seeds `charge_cursor` to the same instant as
+        // `root_active_since`, which is what makes the two totals agree exactly.
+        charge_interval(inner, now);
         if inner.active_roots == 0 {
             inner.root_active_since = Some(now);
         }
@@ -332,6 +469,9 @@ impl TimingData {
         if inner.active_roots == 0 {
             return;
         }
+        // Charge while the root is still active, so this interval lands in a
+        // band rather than being excluded.
+        charge_interval(inner, now);
         inner.active_roots -= 1;
         if inner.active_roots == 0 {
             if let Some(started) = inner.root_active_since.take() {
@@ -437,16 +577,22 @@ impl TimingData {
         source_metrics: Option<SourceMetrics>,
         peak_memory_bytes: Option<u64>,
     ) -> BenchmarkTiming {
-        let inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        let mut inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
 
-        let total_ms = current_root_duration(&inner).as_secs_f64() * 1000.0;
+        // Take the partition first so `total_ms` and the bands describe the same
+        // instant; `phase_accounting_locked` charges the in-flight interval.
+        let phase_accounting = phase_accounting_locked(&mut inner);
+        let total_ms = phase_accounting.compiler_root_ns as f64 / 1_000_000.0;
 
         let passes = inner
             .pass_order
             .iter()
             .filter_map(|pass| {
                 inner.passes.get(pass).map(|measurement| {
-                    let duration_ms = measurement.duration.as_secs_f64() * 1000.0;
+                    // Derived from integer nanoseconds, like every other
+                    // millisecond value here, so the root row and `total_ms`
+                    // agree bit for bit rather than to within rounding.
+                    let duration_ms = duration_ns(measurement.duration) as f64 / 1_000_000.0;
                     let percent = if total_ms > 0.0 {
                         (duration_ms / total_ms) * 100.0
                     } else {
@@ -473,7 +619,7 @@ impl TimingData {
                     .get(phase)
                     .map(|measurement| DriverPhaseTiming {
                         name: phase.clone(),
-                        duration_ms: measurement.duration.as_secs_f64() * 1000.0,
+                        duration_ms: duration_ns(measurement.duration) as f64 / 1_000_000.0,
                         invocations: measurement.invocations,
                     })
             })
@@ -486,8 +632,9 @@ impl TimingData {
         };
 
         BenchmarkTiming {
-            schema_version: 2,
+            schema_version: 3,
             timing_model: "inclusive_spans",
+            phase_accounting,
             metadata,
             passes,
             driver_phases,
@@ -534,6 +681,74 @@ fn ordered_root_timestamp(inner: &mut TimingDataInner, now: Instant) -> Instant 
         .map_or(now, |previous| previous.max(now));
     inner.last_root_transition = Some(now);
     now
+}
+
+/// Charge the interval since the last transition to the bucket the previous
+/// state implied, then advance the cursor.
+///
+/// Every interval of compiler-root wall time is partitioned into exactly one
+/// bucket:
+///
+/// * exactly one phase active -> that phase;
+/// * more than one distinct phase active -> `mixed_parallel`;
+/// * root active with no phase active -> `unattributed`;
+/// * root inactive -> excluded from compiler-root totals entirely.
+///
+/// Because this partitions a single timeline rather than summing independent
+/// measurements, the phase-sum invariant holds exactly.
+fn charge_interval(inner: &mut TimingDataInner, now: Instant) {
+    let Some(previous) = inner.charge_cursor.replace(now) else {
+        // First transition: there is no earlier interval to attribute.
+        return;
+    };
+    if inner.active_roots == 0 {
+        return;
+    }
+    let elapsed = now.saturating_duration_since(previous);
+    let mut active_phase = None;
+    let mut distinct = 0usize;
+    for (index, count) in inner.phase_counts.iter().enumerate() {
+        if *count > 0 {
+            distinct += 1;
+            active_phase = Some(index);
+        }
+    }
+    match (distinct, active_phase) {
+        (0, _) => inner.unattributed += elapsed,
+        (1, Some(index)) => inner.phase_durations[index] += elapsed,
+        _ => inner.mixed_parallel += elapsed,
+    }
+}
+
+/// Read the phase partition and the root total as of one instant.
+///
+/// Charging before reading is what lets an in-flight compilation report bands
+/// that still sum to its root total. Reading without charging would report a
+/// root total including the current interval while the bands excluded it.
+fn phase_accounting_locked(inner: &mut TimingDataInner) -> PhaseAccounting {
+    let now = ordered_root_timestamp(inner, Instant::now());
+    charge_interval(inner, now);
+    let in_flight = inner.root_active_since.map_or(Duration::ZERO, |started| {
+        now.saturating_duration_since(started)
+    });
+    PhaseAccounting {
+        phase_ns: Phase::ALL
+            .into_iter()
+            .map(|phase| (phase, duration_ns(inner.phase_durations[phase.index()])))
+            .collect(),
+        mixed_parallel_ns: duration_ns(inner.mixed_parallel),
+        unattributed_ns: duration_ns(inner.unattributed),
+        compiler_root_ns: duration_ns(inner.root_duration + in_flight),
+    }
+}
+
+/// A duration as integer nanoseconds.
+///
+/// Raw records are integers so that content addressing never depends on
+/// floating-point formatting. `u64` nanoseconds spans roughly 584 years, so the
+/// saturation arm is unreachable for a compilation.
+fn duration_ns(duration: Duration) -> u64 {
+    u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
 }
 
 /// Snapshot the union of intervals in which at least one root span was active.
@@ -665,18 +880,43 @@ struct SpanTiming {
     /// Set by a `driver_phase = true` span field, and inherited by children so
     /// nested driver work cannot be mistaken for a compiler pass.
     is_driver_phase: bool,
+    /// The published phase this span declares, if any.
+    ///
+    /// Deliberately NOT inherited from the parent, unlike `is_driver_phase`. A
+    /// phase marker on a nested span is a phase *transition*; inheriting it
+    /// would make every child re-enter its ancestor's phase and inflate the
+    /// reference count without a matching boundary.
+    phase: Option<Phase>,
 }
 
-/// Reads the `driver_phase` marker off a span's creation-time fields.
+/// Reads the `driver_phase` and `phase` markers off a span's creation-time
+/// fields.
+///
+/// Phase membership is declared at the instrumentation site rather than inferred
+/// from span names. The compiler's spans nest deeply — `parser_grammar_execution`
+/// under `parser` under `parse_file`, the MIR subphases under the backend — so a
+/// name-based mapping would read nested spans as concurrent phases and charge
+/// them to `mixed_parallel`. Declaring membership keeps the published phases
+/// genuinely top-level.
 #[derive(Default)]
-struct DriverPhaseVisitor {
+struct SpanMarkerVisitor {
     is_driver_phase: bool,
+    phase: Option<Phase>,
 }
 
-impl tracing::field::Visit for DriverPhaseVisitor {
+impl tracing::field::Visit for SpanMarkerVisitor {
     fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
         if field.name() == "driver_phase" {
             self.is_driver_phase = value;
+        }
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "phase" {
+            // An unrecognized name yields `None`, so the span simply marks no
+            // phase and its time falls to `unattributed`. That is visible in the
+            // published bands rather than silently misattributed.
+            self.phase = Phase::from_wire_name(value);
         }
     }
 
@@ -724,7 +964,7 @@ where
                 .parent()
                 .map(|parent| (parent.name().to_owned(), span.name().to_owned()));
             let is_root = parent_id.is_none();
-            let mut visitor = DriverPhaseVisitor::default();
+            let mut visitor = SpanMarkerVisitor::default();
             attrs.record(&mut visitor);
             let parent_is_driver_phase = parent_id
                 .as_ref()
@@ -743,6 +983,7 @@ where
                 has_children: false,
                 is_root,
                 is_driver_phase: visitor.is_driver_phase || parent_is_driver_phase,
+                phase: visitor.phase,
             });
             drop(extensions);
 
@@ -773,6 +1014,11 @@ where
                     // concurrent callbacks cannot apply stale timestamps.
                     timing.enter_at(Instant::now());
                 }
+                // A driver phase is outside the compiler root by construction,
+                // so it can never also be a published compiler phase.
+                if let Some(phase) = timing.phase.filter(|_| !timing.is_driver_phase) {
+                    self.data.enter_phase(phase);
+                }
             }
         }
     }
@@ -781,6 +1027,12 @@ where
         if let Some(span) = ctx.span(id) {
             let mut extensions = span.extensions_mut();
             if let Some(timing) = extensions.get_mut::<SpanTiming>() {
+                // Leave the phase before the root: the interval belongs to the
+                // phase that was running, and the root must still be active for
+                // it to be charged to a band at all.
+                if let Some(phase) = timing.phase.filter(|_| !timing.is_driver_phase) {
+                    self.data.exit_phase(phase);
+                }
                 if timing.is_root && !timing.is_driver_phase {
                     self.data.exit_root_span(timing);
                 } else {
@@ -1404,6 +1656,7 @@ mod tests {
             has_children: false,
             is_root: true,
             is_driver_phase: false,
+            phase: None,
         };
         let mut delayed = SpanTiming {
             active_enters: 0,
@@ -1412,6 +1665,7 @@ mod tests {
             has_children: false,
             is_root: true,
             is_driver_phase: false,
+            phase: None,
         };
 
         // Model a callback that captured t=10ms, stalled, and was applied
@@ -1447,6 +1701,7 @@ mod tests {
             has_children: false,
             is_root: false,
             is_driver_phase: false,
+            phase: None,
         };
         timing.enter_at(start);
         timing.enter_at(start + Duration::from_millis(10));
@@ -1475,7 +1730,7 @@ mod tests {
         data.record("lexer", Duration::from_millis(100));
 
         let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None);
-        assert!(json.contains("\"schema_version\":2"));
+        assert!(json.contains("\"schema_version\":3"));
         assert!(json.contains("\"timing_model\":\"inclusive_spans\""));
         assert!(json.contains("\"passes\""));
         assert!(json.contains("\"name\""));
@@ -1550,5 +1805,349 @@ mod tests {
         assert!(is_leap_year(2000)); // divisible by 400
         assert!(is_leap_year(2024)); // divisible by 4, not by 100
         assert!(!is_leap_year(2025)); // not divisible by 4
+    }
+}
+
+/// Measurement-boundary tests for the ADR-0067 wall-clock phase partition.
+///
+/// These drive the real tracing span lifecycle rather than poking the
+/// aggregate, because the properties under test are about *transitions* — which
+/// bucket an interval lands in depends on the state at the moment a span is
+/// entered or exited.
+#[cfg(test)]
+mod phase_accounting_tests {
+    use std::thread;
+    use std::time::Duration;
+
+    use tracing_subscriber::layer::SubscriberExt;
+
+    use super::*;
+
+    /// Long enough that a scheduler hiccup cannot make an interval read as zero,
+    /// short enough to keep the suite fast.
+    const TICK: Duration = Duration::from_millis(20);
+
+    fn collect(body: impl FnOnce()) -> PhaseAccounting {
+        let data = TimingData::new();
+        let subscriber = tracing_subscriber::registry().with(TimingLayer::new(data.clone()));
+        tracing::subscriber::with_default(subscriber, body);
+        data.phase_accounting()
+    }
+
+    fn phase_ns(accounting: &PhaseAccounting, phase: Phase) -> u64 {
+        accounting.phase_ns.get(&phase).copied().unwrap_or(0)
+    }
+
+    /// The property the whole design rests on: the bands partition root time
+    /// exactly, in integer nanoseconds, with no slack to absorb a mistake.
+    fn assert_invariant(accounting: &PhaseAccounting) {
+        assert!(
+            accounting.holds(),
+            "bands sum to {} ns but compiler root is {} ns: {accounting:?}",
+            accounting.attributed_ns(),
+            accounting.compiler_root_ns,
+        );
+        assert!(
+            accounting.missing_phases().is_empty(),
+            "every published phase must be present, including zero: {:?}",
+            accounting.missing_phases()
+        );
+    }
+
+    #[test]
+    fn a_single_phase_owns_its_interval_exactly() {
+        let accounting = collect(|| {
+            let _root = tracing::info_span!("compile").entered();
+            let _phase = tracing::info_span!("sema", phase = "semantic_analysis").entered();
+            thread::sleep(TICK);
+        });
+
+        assert_invariant(&accounting);
+        let semantic = phase_ns(&accounting, Phase::SemanticAnalysis);
+        assert!(semantic > 0, "the sole active phase must be charged");
+        // Everything under the root belongs to that one phase, so the two
+        // structural buckets stay empty.
+        assert_eq!(accounting.mixed_parallel_ns, 0);
+        assert!(
+            semantic * 2 > accounting.compiler_root_ns,
+            "the phase should dominate root time: {accounting:?}"
+        );
+    }
+
+    #[test]
+    fn time_under_the_root_with_no_phase_is_unattributed() {
+        let accounting = collect(|| {
+            let _root = tracing::info_span!("compile").entered();
+            thread::sleep(TICK);
+        });
+
+        assert_invariant(&accounting);
+        assert!(accounting.unattributed_ns > 0);
+        assert_eq!(accounting.mixed_parallel_ns, 0);
+        for phase in Phase::ALL {
+            assert_eq!(phase_ns(&accounting, phase), 0, "{}", phase.wire_name());
+        }
+    }
+
+    #[test]
+    fn time_outside_the_root_is_excluded_entirely() {
+        let accounting = collect(|| {
+            {
+                let _root = tracing::info_span!("compile").entered();
+                thread::sleep(TICK);
+            }
+            // The root has closed. This interval is real time the process
+            // spends, but it is driver overhead rather than compiler work, so it
+            // must not enter the phase stack at all.
+            thread::sleep(TICK * 2);
+        });
+
+        assert_invariant(&accounting);
+        // Root time covers only the first tick, not the three ticks elapsed.
+        assert!(
+            accounting.compiler_root_ns < duration_ns(TICK * 2),
+            "excluded time leaked into the root total: {accounting:?}"
+        );
+    }
+
+    #[test]
+    fn two_distinct_concurrent_phases_are_mixed_parallel() {
+        let accounting = collect(|| {
+            let _root = tracing::info_span!("compile").entered();
+            let _first = tracing::info_span!("sema", phase = "semantic_analysis").entered();
+            let _second = tracing::info_span!("codegen", phase = "backend").entered();
+            thread::sleep(TICK);
+        });
+
+        assert_invariant(&accounting);
+        assert!(
+            accounting.mixed_parallel_ns > 0,
+            "overlapping distinct phases must be mixed, never split: {accounting:?}"
+        );
+        // The first phase owns only the gap between the two `entered()` calls,
+        // which is two transitions apart and therefore tiny. The overlapping
+        // interval itself goes to neither: fractional attribution across
+        // concurrent phases is deliberately not offered.
+        let semantic = phase_ns(&accounting, Phase::SemanticAnalysis);
+        assert_eq!(phase_ns(&accounting, Phase::Backend), 0);
+        assert!(
+            accounting.mixed_parallel_ns > semantic * 4,
+            "the shared interval must dominate the entry gap: {accounting:?}"
+        );
+    }
+
+    #[test]
+    fn nesting_two_phases_is_reported_as_mixed_rather_than_innermost_wins() {
+        // Documents the rule that forces phase markers onto genuinely
+        // non-overlapping boundaries: a nested marker is not "more specific",
+        // it is two phases active at once.
+        let accounting = collect(|| {
+            let _root = tracing::info_span!("compile").entered();
+            let _outer = tracing::info_span!("outer", phase = "semantic_analysis").entered();
+            thread::sleep(TICK);
+            let _inner = tracing::info_span!("inner", phase = "cfg_and_optimization").entered();
+            thread::sleep(TICK);
+        });
+
+        assert_invariant(&accounting);
+        assert!(
+            phase_ns(&accounting, Phase::SemanticAnalysis) > 0,
+            "{accounting:?}"
+        );
+        assert!(accounting.mixed_parallel_ns > 0, "{accounting:?}");
+        assert_eq!(phase_ns(&accounting, Phase::CfgAndOptimization), 0);
+    }
+
+    #[test]
+    fn concurrent_spans_of_the_same_phase_are_that_phase_not_mixed() {
+        // This is the Rayon shape: RUE-786 has workers re-enter one `codegen`
+        // span by value, so the same phase is entered many times at once. The
+        // reference count must absorb that rather than reporting mixed.
+        let accounting = collect(|| {
+            let _root = tracing::info_span!("compile").entered();
+            let first = tracing::info_span!("codegen", phase = "backend");
+            let _a = first.clone().entered();
+            let _b = first.clone().entered();
+            let _c = first.entered();
+            thread::sleep(TICK);
+        });
+
+        assert_invariant(&accounting);
+        assert!(phase_ns(&accounting, Phase::Backend) > 0, "{accounting:?}");
+        assert_eq!(
+            accounting.mixed_parallel_ns, 0,
+            "same-phase concurrency is not mixed: {accounting:?}"
+        );
+    }
+
+    #[test]
+    fn a_phase_stays_active_until_its_last_concurrent_span_exits() {
+        let accounting = collect(|| {
+            let _root = tracing::info_span!("compile").entered();
+            let span = tracing::info_span!("codegen", phase = "backend");
+            let outer = span.clone().entered();
+            {
+                let _inner = span.entered();
+                thread::sleep(TICK);
+            }
+            // One span exited, but the count is still positive, so the phase
+            // owns this interval too.
+            thread::sleep(TICK);
+            drop(outer);
+            thread::sleep(TICK);
+        });
+
+        assert_invariant(&accounting);
+        let backend = phase_ns(&accounting, Phase::Backend);
+        assert!(
+            backend >= duration_ns(TICK),
+            "the phase must cover both concurrent intervals: {accounting:?}"
+        );
+        assert!(
+            accounting.unattributed_ns > 0,
+            "the interval after the last exit is unattributed: {accounting:?}"
+        );
+    }
+
+    #[test]
+    fn phases_entered_on_rayon_workers_are_accounted_across_threads() {
+        // Real threads, real contention on the aggregate lock. The partition is
+        // of wall time globally, not per thread, so overlapping workers in one
+        // phase still yield that phase.
+        let accounting = collect(|| {
+            let _root = tracing::info_span!("compile").entered();
+            let span = tracing::info_span!("codegen", phase = "backend");
+            thread::scope(|scope| {
+                for _ in 0..4 {
+                    let worker_span = span.clone();
+                    scope.spawn(move || {
+                        let _entered = worker_span.entered();
+                        thread::sleep(TICK);
+                    });
+                }
+            });
+        });
+
+        assert_invariant(&accounting);
+        assert!(phase_ns(&accounting, Phase::Backend) > 0, "{accounting:?}");
+        assert_eq!(
+            accounting.mixed_parallel_ns, 0,
+            "four workers in one phase is not mixed: {accounting:?}"
+        );
+    }
+
+    #[test]
+    fn the_invariant_holds_across_many_interleaved_transitions() {
+        let accounting = collect(|| {
+            let _root = tracing::info_span!("compile").entered();
+            for round in 0..12 {
+                let phase = Phase::ALL[round % Phase::ALL.len()];
+                let _span = tracing::info_span!("work", phase = phase.wire_name()).entered();
+                thread::sleep(Duration::from_millis(2));
+            }
+        });
+
+        assert_invariant(&accounting);
+    }
+
+    #[test]
+    fn a_phase_marker_is_not_inherited_by_child_spans() {
+        // Inheriting would make every descendant re-enter its ancestor's phase,
+        // inflating the reference count without a matching boundary. An
+        // unmarked child simply continues its parent's phase.
+        let accounting = collect(|| {
+            let _root = tracing::info_span!("compile").entered();
+            let _parent = tracing::info_span!("sema", phase = "semantic_analysis").entered();
+            let _child = tracing::info_span!("body_analysis").entered();
+            thread::sleep(TICK);
+        });
+
+        assert_invariant(&accounting);
+        assert!(phase_ns(&accounting, Phase::SemanticAnalysis) > 0);
+        assert_eq!(
+            accounting.mixed_parallel_ns, 0,
+            "an unmarked child must not register as a second phase: {accounting:?}"
+        );
+    }
+
+    #[test]
+    fn an_unrecognized_phase_name_marks_no_phase() {
+        let accounting = collect(|| {
+            let _root = tracing::info_span!("compile").entered();
+            let _span = tracing::info_span!("work", phase = "not_a_published_phase").entered();
+            thread::sleep(TICK);
+        });
+
+        assert_invariant(&accounting);
+        // Visible as unattributed rather than silently misfiled under some
+        // nearby phase.
+        assert!(accounting.unattributed_ns > 0);
+        for phase in Phase::ALL {
+            assert_eq!(phase_ns(&accounting, phase), 0, "{}", phase.wire_name());
+        }
+    }
+
+    #[test]
+    fn a_driver_phase_is_never_a_published_compiler_phase() {
+        // Driver work lives outside the compiler root by construction, so even
+        // an explicit phase marker on it must not enter the stack.
+        let accounting = collect(|| {
+            {
+                let _root = tracing::info_span!("compile").entered();
+                thread::sleep(Duration::from_millis(2));
+            }
+            let _driver =
+                tracing::info_span!("output_write", driver_phase = true, phase = "linking")
+                    .entered();
+            thread::sleep(TICK);
+        });
+
+        assert_invariant(&accounting);
+        assert_eq!(phase_ns(&accounting, Phase::Linking), 0, "{accounting:?}");
+    }
+
+    #[test]
+    fn an_unbalanced_phase_exit_does_not_panic_or_corrupt_the_partition() {
+        let data = TimingData::new();
+        data.exit_phase(Phase::Backend);
+        data.exit_phase(Phase::Backend);
+        data.enter_phase(Phase::Backend);
+        data.exit_phase(Phase::Backend);
+        let accounting = data.phase_accounting();
+        assert_invariant(&accounting);
+    }
+
+    #[test]
+    fn the_benchmark_json_reports_both_timing_models_without_mixing_them() {
+        let data = TimingData::new();
+        let subscriber = tracing_subscriber::registry().with(TimingLayer::new(data.clone()));
+        tracing::subscriber::with_default(subscriber, || {
+            let _root = tracing::info_span!("compile").entered();
+            let _phase = tracing::info_span!("sema", phase = "semantic_analysis").entered();
+            let _child = tracing::info_span!("body_analysis").entered();
+            thread::sleep(TICK);
+        });
+
+        let timing = data.to_benchmark_timing_with_metrics("probe-target", "probe", None, None);
+        assert_eq!(timing.schema_version, 3);
+        assert_eq!(timing.timing_model, "inclusive_spans");
+        assert_invariant(&timing.phase_accounting);
+
+        // The inclusive table still holds the nested child, which the additive
+        // partition deliberately does not surface as its own band.
+        assert!(
+            timing
+                .passes
+                .iter()
+                .any(|pass| pass.name == "body_analysis")
+        );
+
+        // total_ms and the partition describe the same instant.
+        let root_ms = timing.phase_accounting.compiler_root_ns as f64 / 1_000_000.0;
+        assert!(
+            (timing.total_ms - root_ms).abs() < f64::EPSILON,
+            "total_ms {} disagrees with compiler_root_ns {root_ms}",
+            timing.total_ms
+        );
     }
 }


### PR DESCRIPTION
Phase 2 of ADR-0067, on top of the Phase 1 schema (#2024). The compiler now publishes an additive wall-clock partition of compiler-root time alongside the existing inclusive spans, under an exact integer-nanosecond invariant:

```
sum(phase_ns) + mixed_parallel_ns + unattributed_ns == compiler_root_ns
```

## The state machine

A reference count per published phase. A phase is active exactly while its count is positive, and the active set is always *derived* from the counts rather than tracked alongside them, so the two cannot disagree. Every root or phase transition charges the interval since the last transition to the bucket the previous state implied: the sole active phase, `mixed_parallel` when more than one is active, `unattributed` when the root is active with none, and nothing at all when the root is inactive.

The invariant is exact by construction rather than by luck. `root_active_since` is seeded from the same clamped timestamp that seeds the charge cursor, and phase transitions join the timeline `ordered_root_timestamp` already serializes — so charged intervals and `root_duration` are driven from one ordered clock rather than two clocks that happen to agree.

Lock ordering is unchanged. Root enter/exit already took the span extension lock and then the aggregate lock; phase transitions follow the same order, and `on_close` still drops the extension lock before acquiring the aggregate.

## Membership is declared, not inferred

A `phase = "..."` span field names a `rue_perf_schema::Phase`, read by a visitor at span creation — the same pattern as the existing `driver_phase` marker.

Name-based mapping was the original plan and it does not work: the compiler's ~40 spans nest deeply (`parser_grammar_execution` under `parser` under `parse_file`; the MIR subphases under the backend), so mapping names would read nested spans as concurrent phases and charge almost everything to `mixed_parallel`. Truthful under the rules, useless as a chart.

Unlike `driver_phase`, the marker is **not** inherited. A marker on a descendant is a phase *transition*; inheriting it would make every child re-enter its ancestor's phase and inflate the count without a matching boundary. An unmarked child simply continues its parent's phase.

## Marker placement: mark the work, not the orchestration

This is the part I got wrong first, and it's worth recording because the invariant cannot catch it — the arithmetic was perfect and the attribution was misleading.

My first placement wrapped the driver's discovery and toolchain-acquisition steps in a `source_discovery_and_parsing` marker. But the session is demand-driven: those steps *drive* semantic analysis rather than being parsing. The result on `examples/hashmap`:

| band | before |
| --- | --- |
| `source_discovery_and_parsing` | 1305 ms (96.1%) |
| `semantic_analysis` | **0 ns** |
| `cfg_and_optimization` | **0 ns** |
| `mixed_parallel` | 16.0 ms |

`Sema` (14.2 ms) + `Cfg_construction` (2.1 ms) ≈ `mixed_parallel` (16.0 ms) — those spans ran *inside* the wrapper, so two phases were always active and neither was ever sole owner. Meanwhile `Declaration_semantics_projection`, the actual hot spot at 634 ms, carried no marker at all.

Markers now sit on the work: `import_read` and `parse_program`; `semantic_astgen`; `sema` plus `declaration_semantics_projection` and `body_queries`; `cfg_construction`; `codegen`; `object_serialization`; both `linker` modes.

| band | after |
| --- | --- |
| `semantic_analysis` | 1012.0 ms (78.0%) |
| `source_discovery_and_parsing` | 62.2 ms (4.8%) |
| `linking` | 20.1 ms (1.5%) |
| `backend` | 10.8 ms (0.8%) |
| `cfg_and_optimization` | 2.4 ms (0.2%) |
| `program_construction` | 0.8 ms (0.1%) |
| `object_generation` | 0.6 ms (0.0%) |
| `mixed_parallel` | **0.000 ms** |
| `unattributed` | 188.3 ms (14.5%) |

`mixed_parallel` at exactly zero is the evidence the boundaries are drawn correctly — no two published phases overlap in practice. `unattributed` at 14.5% names real orchestration time the instrumentation does not yet describe, which is a finding surfaced rather than hidden.

Two structural properties in the existing code made this land cleanly: `canonical_semantic.rs` already `drop(sema_span)` immediately before `build_functions_and_cfgs`, so semantic-proper and CFG building are already sequential siblings; and RUE-786 already has Rayon workers re-enter one `codegen` span by value, so same-phase concurrency was already reference-counted one level down.

## Consequence to document, not hide

Because attribution follows the demand context, lazily reached work is charged to the phase that demanded it — on-demand parsing inside semantic analysis counts as semantic analysis. So the parsing band under-reports total parse cost. That cost stays available in the inclusive `passes` table, which is exactly what the two-model split exists for. Documented in the module header along with the two placement rules.

## Cost, measured

I said I'd measure the added contention rather than assume it. On `examples/hashmap` (x86-64 Linux, arms interleaved to keep host drift off one side, 8 runs each):

- baseline (trunk): median 1.220 s
- with phase accounting: median 1.242 s
- **+22 ms, +1.8%**

The cost is the aggregate lock phase transitions now take, and it scales with transition count. `codegen` is entered once per function, so codegen-heavy programs pay more than this workload, where codegen is ~1% of root time. Worth revisiting if it shows up in the Phase 4 calibration.

## Contract change

Benchmark JSON moves to `schema_version: 3` with a `phase_accounting` object. Millisecond values now derive from the same integer-nanosecond base as the partition, so the root pass row and `total_ms` agree bit for bit rather than to within float rounding — an existing assertion caught that regression when I first derived them differently.

## Validation

- `//crates/rue:rue-test` — 202 tests. 15 new measurement-boundary tests drive the real span lifecycle: the exact invariant, single-phase ownership, distinct-concurrent vs same-phase-concurrent, four real threads sharing one phase, nesting, non-inheritance, root-inactive exclusion, unrecognized phase names, unbalanced exits, and that the JSON publishes both models without mixing them.
- `//crates/rue-perf-schema:rue-perf-schema-test` — 73 tests (2 new for `from_wire_name`/`index`, including that the structural buckets must not parse as phases).
- `scripts/rue cli benchmark_json` — 3 pass; the case now pins both models.
- `scripts/rue quick` — 29 targets. `scripts/rue fmt`.
- End-to-end invariant verified on real compiles (`hello`, `examples/hashmap`): bands sum to `compiler_root_ns` exactly.

`scripts/rue premerge` was still running locally when I opened this; I'll report the result and fix anything it finds.

Refs RUE-1182, RUE-1185.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKydRZPZurnmNTMHxDqZK2)_