### PR TITLE
RUE-1186: add the rue-bench measurement runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,7 @@ Crate ownership, when locating changes:
 | `rue-error`, `rue-span` | diagnostics and source locations |
 | `rue-spec`, `rue-ui-tests`, `rue-cli-tests` | language and integration tests |
 | `rue-perf-schema` | compiler-performance measurement contract (ADR-0067) |
+| `rue-bench` | compiler-performance measurement runner (ADR-0067) |
 
 ## Testing strategy
 

--- a/crates/rue-bench/BUCK
+++ b/crates/rue-bench/BUCK
@@ -1,0 +1,16 @@
+load("//crates:defs.bzl", "rue_binary")
+
+# The ADR-0067 measurement runner. One binary replaces the removed shell runner
+# and Python package, and runs identically locally and in CI so any recorded run
+# is rerunnable under the protocol it recorded.
+rue_binary(
+    name = "rue-bench",
+    deps = [
+        "//crates/rue-perf-schema:rue-perf-schema",
+        "//third-party:libc",
+        "//third-party:serde",
+        "//third-party:serde_json",
+        "//third-party:sha2",
+        "//third-party:tempfile",
+    ],
+)

--- a/crates/rue-bench/src/environment.rs
+++ b/crates/rue-bench/src/environment.rs
@@ -1,0 +1,163 @@
+//! Recording what the measurement environment actually was.
+//!
+//! An epoch pins the environment *policy*, not the exact machine. Hosted
+//! runners change underneath a policy, so every run records what it found and
+//! the dashboard renders comparisons across a change as advisory. Nothing here
+//! prevents drift; it makes drift visible, which is the honest arrangement for
+//! hardware nobody controls.
+//!
+//! Every probe degrades to a readable placeholder rather than failing. A run
+//! that measured successfully must not be thrown away because `/proc/meminfo`
+//! looked unfamiliar, and an `unknown` in the fingerprint is itself a fact
+//! worth recording.
+
+use std::process::Command;
+
+use rue_perf_schema::EnvironmentFingerprint;
+
+/// What a probe reports when the host does not answer.
+const UNKNOWN: &str = "unknown";
+
+/// Collect the current environment fingerprint.
+///
+/// The runner label and image come from the environment rather than being
+/// detected, because they name a *policy* the epoch declares. GitHub-hosted
+/// runners export `ImageOS` and `ImageVersion`; a local run says so plainly
+/// instead of impersonating CI.
+pub fn fingerprint() -> EnvironmentFingerprint {
+    EnvironmentFingerprint {
+        runner_label: var("RUE_BENCH_RUNNER_LABEL").unwrap_or_else(|| "local".to_string()),
+        runner_image: var("RUE_BENCH_RUNNER_IMAGE")
+            .or_else(|| var("ImageOS"))
+            .unwrap_or_else(|| "local".to_string()),
+        runner_image_version: var("ImageVersion").unwrap_or_else(|| UNKNOWN.to_string()),
+        cpu_model: cpu_model(),
+        core_count: core_count(),
+        memory_bytes: memory_bytes(),
+        kernel_version: command_output("uname", &["-r"]).unwrap_or_else(|| UNKNOWN.to_string()),
+        os_version: os_version(),
+        architecture: std::env::consts::ARCH.to_string(),
+    }
+}
+
+fn var(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+fn command_output(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!text.is_empty()).then_some(text)
+}
+
+fn core_count() -> u32 {
+    std::thread::available_parallelism()
+        .map(|count| count.get() as u32)
+        .unwrap_or(0)
+}
+
+fn cpu_model() -> String {
+    if cfg!(target_os = "macos") {
+        return command_output("sysctl", &["-n", "machdep.cpu.brand_string"])
+            .unwrap_or_else(|| UNKNOWN.to_string());
+    }
+    let Ok(cpuinfo) = std::fs::read_to_string("/proc/cpuinfo") else {
+        return UNKNOWN.to_string();
+    };
+    cpuinfo
+        .lines()
+        .find_map(|line| line.strip_prefix("model name"))
+        .and_then(|rest| rest.split_once(':'))
+        .map(|(_, value)| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| UNKNOWN.to_string())
+}
+
+fn memory_bytes() -> u64 {
+    if cfg!(target_os = "macos") {
+        return command_output("sysctl", &["-n", "hw.memsize"])
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(0);
+    }
+    let Ok(meminfo) = std::fs::read_to_string("/proc/meminfo") else {
+        return 0;
+    };
+    // `MemTotal:       16072456 kB`
+    meminfo
+        .lines()
+        .find_map(|line| line.strip_prefix("MemTotal:"))
+        .and_then(|rest| rest.split_whitespace().next())
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(|kilobytes| kilobytes.saturating_mul(1024))
+        .unwrap_or(0)
+}
+
+fn os_version() -> String {
+    if cfg!(target_os = "macos") {
+        return command_output("sw_vers", &["-productVersion"])
+            .map(|version| format!("macOS {version}"))
+            .unwrap_or_else(|| UNKNOWN.to_string());
+    }
+    let Ok(release) = std::fs::read_to_string("/etc/os-release") else {
+        return UNKNOWN.to_string();
+    };
+    release
+        .lines()
+        .find_map(|line| line.strip_prefix("PRETTY_NAME="))
+        .map(|value| value.trim_matches('"').to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| UNKNOWN.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_fingerprint_is_collectable_on_this_host() {
+        let fingerprint = fingerprint();
+        // Architecture is compiled in, so it is the one field that can never be
+        // unknown. Everything else may legitimately degrade.
+        assert!(!fingerprint.architecture.is_empty());
+        assert!(!fingerprint.runner_label.is_empty());
+        assert!(!fingerprint.runner_image.is_empty());
+        assert!(!fingerprint.cpu_model.is_empty());
+        assert!(!fingerprint.kernel_version.is_empty());
+        assert!(!fingerprint.os_version.is_empty());
+    }
+
+    #[test]
+    fn a_local_run_does_not_impersonate_a_hosted_runner() {
+        // Only an explicit environment variable may claim a runner class. A
+        // developer's laptop silently labelled `github-hosted` would violate the
+        // epoch's environment policy invisibly.
+        if var("RUE_BENCH_RUNNER_LABEL").is_none() {
+            assert_eq!(fingerprint().runner_label, "local");
+        }
+    }
+
+    #[test]
+    fn the_fingerprint_identity_changes_with_the_environment() {
+        let base = fingerprint();
+        let mut drifted = base.clone();
+        drifted.runner_image_version = "probe/99999999.9.0".to_string();
+        assert_ne!(
+            base.fingerprint_id().unwrap(),
+            drifted.fingerprint_id().unwrap()
+        );
+    }
+
+    #[test]
+    fn probes_degrade_to_a_readable_placeholder_rather_than_failing() {
+        // A missing program must yield `None`, which callers turn into
+        // `unknown`, rather than propagating an error that would discard a
+        // successful measurement.
+        assert_eq!(
+            command_output("definitely-not-a-real-program-xyz", &[]),
+            None
+        );
+    }
+}

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -1,0 +1,579 @@
+//! The ADR-0067 compiler-performance runner.
+//!
+//! One binary reads the manifest, runs the corpus under the epoch's sampling
+//! policy, validates what it measured, and emits one immutable run object. It
+//! runs identically locally and in CI, so any recorded run is rerunnable under
+//! the protocol it recorded. Rerunnable, not reproducible: hosted-hardware
+//! timings do not repeat byte for byte.
+//!
+//! The runner never decides whether a measurement is good. It records what
+//! happened — including crashes, unresolvable pins, and phase-sum violations —
+//! and hands the result to `rue_perf_schema::validate_run`. Keeping judgement
+//! out of the producer is what lets validation catch a producer that is itself
+//! wrong.
+
+mod environment;
+mod measure;
+mod pins;
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rue_perf_schema::{
+    Completeness, FailureRecord, Invocation, Manifest, RUN_SCHEMA_VERSION, ResolvedPins,
+    RunIdentity, RunObject, Sample, ValidationOutcome, WorkloadObservation, validate_run,
+};
+
+use crate::measure::{SampleOutcome, SampleRequest, measure_sample};
+
+/// Exit codes, so a workflow can tell "collection broke" from "this run may not
+/// be appended".
+mod exit {
+    /// The run object was written and is appendable.
+    pub const OK: u8 = 0;
+    /// The runner could not be configured or could not write its output.
+    pub const USAGE: u8 = 2;
+    /// A run object was written, but validation refuses it for its series.
+    ///
+    /// Distinct from `USAGE` because the evidence still exists and is worth
+    /// collecting; only publication is blocked.
+    pub const NOT_APPENDABLE: u8 = 3;
+}
+
+struct Options {
+    manifest: PathBuf,
+    platform: String,
+    epoch: u32,
+    compiler: PathBuf,
+    commit: String,
+    repo_root: PathBuf,
+    std_root: Option<PathBuf>,
+    output: PathBuf,
+    workdir: Option<PathBuf>,
+}
+
+const USAGE: &str = "\
+rue-bench — ADR-0067 compiler-performance runner
+
+Required:
+  --manifest <path>    performance manifest declaring suites and epochs
+  --platform <name>    platform whose epoch to run, e.g. x86_64-linux
+  --epoch <n>          epoch identifier within that platform
+  --compiler <path>    compiler binary under measurement
+  --commit <sha>       40-character compiler revision being measured
+  --out <path>         where to write the run object
+
+Optional:
+  --repo-root <path>   root for resolving workload sources (default: .)
+  --std-root <path>    standard-library root (default: <repo-root>/std)
+  --workdir <path>     directory for compiled outputs (default: a temp dir)
+";
+
+fn main() -> ExitCode {
+    let options = match parse_args() {
+        Ok(options) => options,
+        Err(message) => {
+            eprintln!("rue-bench: {message}\n\n{USAGE}");
+            return ExitCode::from(exit::USAGE);
+        }
+    };
+    match run(&options) {
+        Ok(code) => ExitCode::from(code),
+        Err(message) => {
+            eprintln!("rue-bench: {message}");
+            ExitCode::from(exit::USAGE)
+        }
+    }
+}
+
+fn parse_args() -> Result<Options, String> {
+    let mut manifest = None;
+    let mut platform = None;
+    let mut epoch = None;
+    let mut compiler = None;
+    let mut commit = None;
+    let mut output = None;
+    let mut repo_root = None;
+    let mut std_root = None;
+    let mut workdir = None;
+
+    let mut args = std::env::args().skip(1);
+    while let Some(flag) = args.next() {
+        let mut value = || {
+            args.next()
+                .ok_or_else(|| format!("{flag} requires a value"))
+        };
+        match flag.as_str() {
+            "--manifest" => manifest = Some(PathBuf::from(value()?)),
+            "--platform" => platform = Some(value()?),
+            "--epoch" => {
+                let raw = value()?;
+                epoch = Some(
+                    raw.parse::<u32>()
+                        .map_err(|_| format!("--epoch expects a number, got {raw:?}"))?,
+                );
+            }
+            "--compiler" => compiler = Some(PathBuf::from(value()?)),
+            "--commit" => commit = Some(value()?),
+            "--out" => output = Some(PathBuf::from(value()?)),
+            "--repo-root" => repo_root = Some(PathBuf::from(value()?)),
+            "--std-root" => std_root = Some(PathBuf::from(value()?)),
+            "--workdir" => workdir = Some(PathBuf::from(value()?)),
+            "-h" | "--help" => {
+                println!("{USAGE}");
+                std::process::exit(0);
+            }
+            other => return Err(format!("unrecognized argument {other:?}")),
+        }
+    }
+
+    let repo_root = repo_root.unwrap_or_else(|| PathBuf::from("."));
+    let std_root = std_root.or_else(|| {
+        let candidate = repo_root.join("std");
+        candidate.is_dir().then_some(candidate)
+    });
+
+    Ok(Options {
+        manifest: manifest.ok_or("--manifest is required")?,
+        platform: platform.ok_or("--platform is required")?,
+        epoch: epoch.ok_or("--epoch is required")?,
+        compiler: compiler.ok_or("--compiler is required")?,
+        commit: commit.ok_or("--commit is required")?,
+        output: output.ok_or("--out is required")?,
+        repo_root,
+        std_root,
+        workdir,
+    })
+}
+
+fn run(options: &Options) -> Result<u8, String> {
+    let text = std::fs::read_to_string(&options.manifest)
+        .map_err(|error| format!("could not read {}: {error}", options.manifest.display()))?;
+    let manifest = Manifest::parse(&text).map_err(|error| error.to_string())?;
+
+    let epoch = manifest
+        .epoch(&options.platform, options.epoch)
+        .ok_or_else(|| {
+            format!(
+                "the manifest declares no epoch {} for platform {}",
+                options.epoch, options.platform
+            )
+        })?;
+    let suite = manifest
+        .suite(epoch.suite_revision)
+        .ok_or_else(|| format!("suite revision {} is not declared", epoch.suite_revision))?;
+
+    let holder;
+    let workdir = match &options.workdir {
+        Some(directory) => {
+            std::fs::create_dir_all(directory)
+                .map_err(|error| format!("could not create {}: {error}", directory.display()))?;
+            directory.as_path()
+        }
+        None => {
+            holder = tempfile::tempdir()
+                .map_err(|error| format!("could not create a work directory: {error}"))?;
+            holder.path()
+        }
+    };
+
+    let started_at = utc_timestamp();
+    let mut failures: Vec<FailureRecord> = Vec::new();
+
+    // Pins are resolved from the tree, never read back from the epoch, so that
+    // validation compares two independently produced answers.
+    let mut workload_source_hashes = BTreeMap::new();
+    for workload in &suite.workloads {
+        let source = options.repo_root.join(&workload.source);
+        match pins::workload_source_hash(&options.compiler, &source, options.std_root.as_deref()) {
+            Ok(hash) => {
+                workload_source_hashes.insert(workload.id.clone(), hash);
+            }
+            Err(error) => {
+                // Recorded, not fatal. The run proceeds and validation reports
+                // the pin mismatch, which is more informative than aborting.
+                failures.push(FailureRecord::ValidationRejected {
+                    workload: workload.id.clone(),
+                    detail: error.to_string(),
+                });
+            }
+        }
+    }
+
+    let toolchain_hash =
+        pins::toolchain_hash(&options.repo_root).map_err(|error| error.to_string())?;
+    let stdlib_hash = match options.std_root.as_deref() {
+        Some(root) => pins::stdlib_hash(root).map_err(|error| error.to_string())?,
+        None => String::new(),
+    };
+
+    let mut observations: Vec<WorkloadObservation> = Vec::new();
+    for workload in &suite.workloads {
+        let Some(policy) = epoch.sampling.get(&workload.id) else {
+            // Manifest parsing rejects this, so reaching it means the manifest
+            // was constructed some other way.
+            failures.push(FailureRecord::ValidationRejected {
+                workload: workload.id.clone(),
+                detail: "the epoch declares no sampling policy".to_string(),
+            });
+            continue;
+        };
+
+        let source = options.repo_root.join(&workload.source);
+        let output = workdir.join(format!("{}-out", workload.id));
+        let mut samples: Vec<Sample> = Vec::new();
+
+        for index in 0..policy.samples {
+            let request = SampleRequest {
+                compiler: &options.compiler,
+                source: &source,
+                args: &epoch.args,
+                output: output.clone(),
+                std_root: options.std_root.as_deref(),
+                batch_size: policy.batch_size,
+                workload: &workload.id,
+                sample_index: index,
+            };
+            match measure_sample(&request) {
+                SampleOutcome::Measured(sample) => {
+                    // Record the producer's own view of an invariant violation.
+                    // Validation recomputes it independently, so a runner that
+                    // failed to notice is itself caught.
+                    if !sample.phases.holds() {
+                        failures.push(FailureRecord::PhaseInvariant {
+                            workload: workload.id.clone(),
+                            sample_index: index,
+                            compiler_root_ns: sample.phases.compiler_root_ns,
+                            attributed_ns: sample.phases.attributed_ns(),
+                        });
+                    }
+                    samples.push(*sample);
+                }
+                SampleOutcome::Failed(failure) => {
+                    failures.push(*failure);
+                    // Stop this workload but keep the run going: a partial run
+                    // still publishes every workload that completed validly.
+                    break;
+                }
+            }
+        }
+
+        if !samples.is_empty() {
+            observations.push(WorkloadObservation {
+                workload: workload.id.clone(),
+                samples,
+            });
+        }
+    }
+
+    // Sorted order is part of the canonical form, so an unsorted run object
+    // would hash differently from the identical measurement written correctly.
+    observations.sort_by(|left, right| left.workload.cmp(&right.workload));
+
+    let run = RunObject {
+        schema_version: RUN_SCHEMA_VERSION,
+        identity: RunIdentity {
+            suite_revision: epoch.suite_revision,
+            epoch: epoch.id,
+            platform: options.platform.clone(),
+            commit: options.commit.clone(),
+            started_at,
+            finished_at: utc_timestamp(),
+            pins: ResolvedPins {
+                toolchain_hash,
+                stdlib_hash,
+                workload_source_hashes,
+                invocation: Invocation {
+                    target: epoch.target.clone(),
+                    args: epoch.args.clone(),
+                },
+            },
+            environment: environment::fingerprint(),
+        },
+        workloads: observations,
+        failures,
+    };
+
+    let outcome = validate_run(&manifest, &run);
+
+    // The run object is written whatever the verdict. Evidence of a broken
+    // collection is worth more than a missing file.
+    let serialized = rue_perf_schema::canonical_json(&run)
+        .map_err(|error| format!("could not serialize the run object: {error}"))?;
+    if let Some(parent) = options
+        .output
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("could not create {}: {error}", parent.display()))?;
+    }
+    std::fs::write(&options.output, &serialized)
+        .map_err(|error| format!("could not write {}: {error}", options.output.display()))?;
+
+    report(&run, &outcome, &options.output);
+
+    Ok(if outcome.is_appendable() {
+        exit::OK
+    } else {
+        exit::NOT_APPENDABLE
+    })
+}
+
+fn report(run: &RunObject, outcome: &ValidationOutcome, output: &Path) {
+    let address = run
+        .content_address()
+        .unwrap_or_else(|_| "<unaddressable>".to_string());
+    eprintln!("rue-bench: wrote {} ({address})", output.display());
+
+    for error in &outcome.errors {
+        eprintln!("rue-bench: not appendable: {error}");
+    }
+    for sample in &outcome.invalid_samples {
+        eprintln!(
+            "rue-bench: invalid sample {}[{}]: {}",
+            sample.workload, sample.sample_index, sample.reason
+        );
+    }
+    match &outcome.completeness {
+        Completeness::Complete => {
+            eprintln!("rue-bench: complete run; a headline point may be published");
+        }
+        Completeness::Partial { missing } => {
+            eprintln!(
+                "rue-bench: partial run; no headline point. Incomplete workloads: {}",
+                missing.join(", ")
+            );
+        }
+    }
+}
+
+/// The current instant as `YYYY-MM-DDTHH:MM:SSZ`.
+///
+/// One spelling, because two identical measurements formatting the same instant
+/// differently would produce two content addresses. Computed from the Unix
+/// epoch rather than pulling in a date library for two fields.
+fn utc_timestamp() -> String {
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or(0);
+    let (days, rest) = (seconds / 86_400, seconds % 86_400);
+    let (hour, minute, second) = (rest / 3600, (rest % 3600) / 60, rest % 60);
+    let (year, month, day) = civil_from_days(days as i64);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+/// Howard Hinnant's `civil_from_days`, shifting the era to start in March so
+/// the leap day lands at the end of a cycle.
+fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let day_of_era = z.rem_euclid(146_097);
+    let year_of_era =
+        (day_of_era - day_of_era / 1460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let shifted_month = (5 * day_of_year + 2) / 153;
+    let day = (day_of_year - (153 * shifted_month + 2) / 5 + 1) as u32;
+    let month = if shifted_month < 10 {
+        shifted_month + 3
+    } else {
+        shifted_month - 9
+    } as u32;
+    (if month <= 2 { year + 1 } else { year }, month, day)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE_MANIFEST: &str = r#"
+[[suite]]
+revision = 1
+timing_schema_version = 1
+protocol_version = 1
+
+[[suite.workloads]]
+id = "startup"
+source = "performance/workloads/startup/main.rue"
+question = "What does a minimal compilation cost end to end?"
+
+[[epoch]]
+id = 1
+platform = "x86_64-linux"
+suite_revision = 1
+target = "x86_64-unknown-linux-gnu"
+args = ["-O2"]
+toolchain_hash = "toolchain"
+stdlib_hash = "stdlib"
+
+[epoch.workload_source_hashes]
+startup = "startup-hash"
+
+[epoch.environment]
+runner_label = "local"
+runner_image = "local"
+
+[epoch.sampling.startup]
+samples = 1
+batch_size = 1
+
+[epoch.flagging]
+k = 3.0
+window = 10
+"#;
+
+    fn fixture_run() -> RunObject {
+        use rue_perf_schema::{EnvironmentFingerprint, Phase, PhaseAccounting};
+
+        let phase_ns: BTreeMap<Phase, u64> =
+            Phase::ALL.into_iter().map(|phase| (phase, 0)).collect();
+        let mut phases = PhaseAccounting {
+            phase_ns,
+            mixed_parallel_ns: 0,
+            unattributed_ns: 0,
+            compiler_root_ns: 10,
+        };
+        phases.phase_ns.insert(Phase::SemanticAnalysis, 10);
+
+        RunObject {
+            schema_version: RUN_SCHEMA_VERSION,
+            identity: RunIdentity {
+                suite_revision: 1,
+                epoch: 1,
+                platform: "x86_64-linux".to_string(),
+                commit: "a".repeat(40),
+                started_at: "2026-07-28T00:00:00Z".to_string(),
+                finished_at: "2026-07-28T00:00:01Z".to_string(),
+                pins: ResolvedPins {
+                    toolchain_hash: "toolchain".to_string(),
+                    stdlib_hash: "stdlib".to_string(),
+                    workload_source_hashes: BTreeMap::from([(
+                        "startup".to_string(),
+                        "startup-hash".to_string(),
+                    )]),
+                    invocation: Invocation {
+                        target: "x86_64-unknown-linux-gnu".to_string(),
+                        args: vec!["-O2".to_string()],
+                    },
+                },
+                environment: EnvironmentFingerprint {
+                    runner_label: "local".to_string(),
+                    runner_image: "local".to_string(),
+                    runner_image_version: "unknown".to_string(),
+                    cpu_model: "probe".to_string(),
+                    core_count: 1,
+                    memory_bytes: 1,
+                    kernel_version: "probe".to_string(),
+                    os_version: "probe".to_string(),
+                    architecture: "x86_64".to_string(),
+                },
+            },
+            workloads: vec![WorkloadObservation {
+                workload: "startup".to_string(),
+                samples: vec![Sample {
+                    batch_size: 1,
+                    process_elapsed_ns: 20,
+                    peak_memory_bytes: 1,
+                    output_binary_bytes: 1,
+                    phases,
+                }],
+            }],
+            failures: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn timestamps_use_the_one_spelling_validation_accepts() {
+        let stamp = utc_timestamp();
+        assert_eq!(stamp.len(), 20, "{stamp}");
+        assert!(stamp.ends_with('Z'), "{stamp}");
+        assert_eq!(stamp.as_bytes()[10], b'T', "{stamp}");
+        // Sub-second precision would make two runs of the same instant hash
+        // differently, so it must not appear.
+        assert!(!stamp.contains('.'), "{stamp}");
+    }
+
+    #[test]
+    fn civil_dates_match_known_values() {
+        assert_eq!(civil_from_days(0), (1970, 1, 1));
+        assert_eq!(civil_from_days(19_723), (2024, 1, 1));
+        // A leap day, which the March-shifted era exists to get right.
+        assert_eq!(civil_from_days(19_782), (2024, 2, 29));
+        assert_eq!(civil_from_days(19_783), (2024, 3, 1));
+    }
+
+    #[test]
+    fn a_generated_timestamp_is_accepted_by_schema_validation() {
+        // The runner and the schema must agree on the format, and the schema is
+        // the authority. Building a run around a generated stamp proves it.
+        let manifest = Manifest::parse(FIXTURE_MANIFEST).expect("fixture manifest");
+        let mut run = fixture_run();
+        run.identity.started_at = utc_timestamp();
+        run.identity.finished_at = utc_timestamp();
+        let outcome = validate_run(&manifest, &run);
+        assert!(
+            !outcome.errors.iter().any(|error| matches!(
+                error,
+                rue_perf_schema::ValidationError::MalformedTimestamp { .. }
+            )),
+            "{:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_runner_shaped_run_object_is_appendable() {
+        // Guards the runner's own assembly against the schema: if the two ever
+        // disagree about field meanings, this fails before CI collects anything.
+        let manifest = Manifest::parse(FIXTURE_MANIFEST).expect("fixture manifest");
+        let outcome = validate_run(&manifest, &fixture_run());
+        assert_eq!(outcome.errors, Vec::new());
+        assert!(outcome.publishes_headline());
+    }
+
+    #[test]
+    fn an_unresolvable_pin_is_recorded_and_blocks_appending() {
+        // The runner records a resolution failure rather than substituting the
+        // epoch's declared value, so the mismatch surfaces instead of hiding.
+        let manifest = Manifest::parse(FIXTURE_MANIFEST).expect("fixture manifest");
+        let mut run = fixture_run();
+        run.identity.pins.workload_source_hashes.clear();
+        run.failures.push(FailureRecord::ValidationRejected {
+            workload: "startup".to_string(),
+            detail: "could not resolve the source closure".to_string(),
+        });
+        let outcome = validate_run(&manifest, &run);
+        assert!(!outcome.is_appendable());
+        assert!(outcome.errors.iter().any(|error| matches!(
+            error,
+            rue_perf_schema::ValidationError::PinMismatch { field, .. }
+                if field == "workload_source_hashes/startup"
+        )));
+    }
+
+    #[test]
+    fn a_crashed_workload_leaves_a_partial_but_appendable_run() {
+        // Collection health must be visible rather than appearing as a hole.
+        let manifest = Manifest::parse(FIXTURE_MANIFEST).expect("fixture manifest");
+        let mut run = fixture_run();
+        run.workloads.clear();
+        run.failures.push(FailureRecord::WorkloadCrashed {
+            workload: "startup".to_string(),
+            sample_index: 0,
+            detail: "signal 11".to_string(),
+        });
+        let outcome = validate_run(&manifest, &run);
+        assert!(outcome.is_appendable(), "{:?}", outcome.errors);
+        assert!(!outcome.publishes_headline());
+        assert_eq!(
+            outcome.completeness,
+            Completeness::Partial {
+                missing: vec!["startup".to_string()],
+            }
+        );
+    }
+}

--- a/crates/rue-bench/src/measure.rs
+++ b/crates/rue-bench/src/measure.rs
@@ -1,0 +1,301 @@
+//! Measuring one sample: spawn the compiler, time it from outside, and read
+//! back the partition it reports from inside.
+//!
+//! Two clocks meet here. `process_elapsed_ns` is measured by this process
+//! around the child, so it includes process startup, output publication, and
+//! every other driver cost the user actually waits for. `compiler_root_ns`
+//! comes from the child's own accounting and covers only compiler work. Their
+//! difference is real and is reported, but it never enters the phase stack.
+//!
+//! Peak memory is likewise external: `wait4` reports the child's resident high
+//! water mark, which includes allocator overhead the compiler's own probe
+//! cannot see.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Instant;
+
+use rue_perf_schema::{FailureRecord, PhaseAccounting, Sample};
+
+/// Everything needed to measure one sample.
+pub struct SampleRequest<'a> {
+    /// The compiler binary under measurement.
+    pub compiler: &'a Path,
+    /// The workload's root source.
+    pub source: &'a Path,
+    /// Behaviour-affecting compiler arguments, from the epoch.
+    pub args: &'a [String],
+    /// Where the compiled binary goes.
+    pub output: PathBuf,
+    /// Standard-library root, when the workload needs one.
+    pub std_root: Option<&'a Path>,
+    /// How many compilations make up this sample.
+    ///
+    /// Short workloads batch so that timer resolution and per-process jitter do
+    /// not dominate. The sample records the batch's totals plus this factor,
+    /// leaving per-compile figures to be derived — storage keeps what was
+    /// measured, not what a reader might want.
+    pub batch_size: u32,
+    /// The workload this sample belongs to, for failure records.
+    pub workload: &'a str,
+    /// Which sample this is, for failure records.
+    pub sample_index: u32,
+}
+
+/// What measuring one sample produced.
+pub enum SampleOutcome {
+    /// A sample that ran to completion. It may still be invalid; validation
+    /// decides that, not this module.
+    Measured(Box<Sample>),
+    /// The sample could not be produced, with structured evidence of why.
+    Failed(Box<FailureRecord>),
+}
+
+/// The compiler's `--benchmark-json` output, of which only the additive
+/// partition matters here.
+#[derive(serde::Deserialize)]
+struct BenchmarkJson {
+    phase_accounting: PhaseAccounting,
+}
+
+/// Measure one sample.
+///
+/// Runs `batch_size` compilations and reports their totals as one unit.
+/// Summing phase accountings is safe: each addend partitions its own timeline
+/// exactly, so the sums partition the concatenation exactly too.
+pub fn measure_sample(request: &SampleRequest<'_>) -> SampleOutcome {
+    let mut total: Option<PhaseAccounting> = None;
+    let mut peak_memory_bytes = 0u64;
+
+    let started = Instant::now();
+    for _ in 0..request.batch_size {
+        match run_once(request) {
+            Ok((accounting, peak)) => {
+                peak_memory_bytes = peak_memory_bytes.max(peak);
+                total = Some(match total {
+                    None => accounting,
+                    Some(running) => add_accounting(running, &accounting),
+                });
+            }
+            Err(detail) => {
+                return SampleOutcome::Failed(Box::new(FailureRecord::WorkloadCrashed {
+                    workload: request.workload.to_string(),
+                    sample_index: request.sample_index,
+                    detail,
+                }));
+            }
+        }
+    }
+    let process_elapsed_ns = u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+
+    let Some(phases) = total else {
+        // A zero batch size cannot measure anything. The manifest rejects it,
+        // so reaching here means the policy was bypassed.
+        return SampleOutcome::Failed(Box::new(FailureRecord::ValidationRejected {
+            workload: request.workload.to_string(),
+            detail: "batch size of zero measures no compilation".to_string(),
+        }));
+    };
+
+    let output_binary_bytes = std::fs::metadata(&request.output)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+
+    SampleOutcome::Measured(Box::new(Sample {
+        batch_size: request.batch_size,
+        process_elapsed_ns,
+        peak_memory_bytes,
+        output_binary_bytes,
+        phases,
+    }))
+}
+
+/// Add two phase partitions band by band.
+///
+/// Saturating throughout: a corrupt addend must not panic the runner. Any
+/// resulting inconsistency is caught by validation as an invariant violation,
+/// which is evidence rather than a crash.
+fn add_accounting(mut running: PhaseAccounting, next: &PhaseAccounting) -> PhaseAccounting {
+    for (phase, ns) in &next.phase_ns {
+        let entry = running.phase_ns.entry(*phase).or_insert(0);
+        *entry = entry.saturating_add(*ns);
+    }
+    running.mixed_parallel_ns = running
+        .mixed_parallel_ns
+        .saturating_add(next.mixed_parallel_ns);
+    running.unattributed_ns = running.unattributed_ns.saturating_add(next.unattributed_ns);
+    running.compiler_root_ns = running
+        .compiler_root_ns
+        .saturating_add(next.compiler_root_ns);
+    running
+}
+
+/// Run the compiler once, returning its partition and externally measured peak
+/// resident memory.
+fn run_once(request: &SampleRequest<'_>) -> Result<(PhaseAccounting, u64), String> {
+    let mut command = Command::new(request.compiler);
+    command
+        .arg(request.source)
+        .arg("-o")
+        .arg(&request.output)
+        .args(request.args)
+        .arg("--benchmark-json")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(std_root) = request.std_root {
+        command.env("RUE_STD_PATH", std_root);
+    }
+
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("could not spawn the compiler: {error}"))?;
+
+    // Drain both pipes on their own threads. Reading one to completion before
+    // the other deadlocks as soon as the unread pipe's buffer fills, and the
+    // benchmark JSON is large enough for that to be a live risk.
+    let mut stdout_pipe = child.stdout.take().expect("stdout was piped");
+    let mut stderr_pipe = child.stderr.take().expect("stderr was piped");
+    let (stdout, stderr) = std::thread::scope(|scope| {
+        let stderr_reader = scope.spawn(move || {
+            let mut buffer = String::new();
+            let _ = stderr_pipe.read_to_string(&mut buffer);
+            buffer
+        });
+        let mut stdout = String::new();
+        let _ = stdout_pipe.read_to_string(&mut stdout);
+        (stdout, stderr_reader.join().unwrap_or_default())
+    });
+
+    let peak = wait_for_peak_memory(&child)?;
+    // `wait4` above already reaped the child, so `child` must not be waited on
+    // again. `Child::drop` does not reap, so letting it fall out of scope is
+    // correct; calling `wait()` here would fail with ECHILD.
+    drop(child);
+
+    // A workload's exit status belongs to its own program, so a nonzero status
+    // is only a failure when nothing parseable came back.
+    let parsed: BenchmarkJson = serde_json::from_str(stdout.trim()).map_err(|error| {
+        let tail: String = stderr.lines().rev().take(5).collect::<Vec<_>>().join("\n");
+        format!("no benchmark JSON on stdout ({error}); stderr tail:\n{tail}")
+    })?;
+
+    Ok((parsed.phase_accounting, peak))
+}
+
+/// Reap one child and report *its* peak resident memory, in bytes.
+///
+/// Deliberately `wait4` rather than `getrusage(RUSAGE_CHILDREN)`. The latter
+/// reports a maximum across every child this process has ever reaped, so once
+/// the largest workload had run, every later workload would inherit its peak
+/// and the memory metric would be silently wrong for all but the biggest.
+fn wait_for_peak_memory(child: &std::process::Child) -> Result<u64, String> {
+    let mut status: libc::c_int = 0;
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::zeroed();
+    // SAFETY: `status` and `usage` are properly sized and aligned for `wait4`,
+    // which only writes through the pointers. The pid is this process's own
+    // un-reaped child, so it is valid to wait on exactly once.
+    let reaped = unsafe {
+        libc::wait4(
+            child.id() as libc::pid_t,
+            &mut status,
+            0,
+            usage.as_mut_ptr(),
+        )
+    };
+    if reaped < 0 {
+        return Err(format!(
+            "could not reap the compiler: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    // SAFETY: `wait4` succeeded, so the usage value is initialized.
+    let usage = unsafe { usage.assume_init() };
+    Ok(max_rss_bytes(usage.ru_maxrss))
+}
+
+/// Normalize `ru_maxrss` to bytes.
+///
+/// Darwin reports bytes; Linux reports kilobytes. Getting this wrong is a
+/// factor-of-1024 error that looks plausible on a chart, so it is separated out
+/// and tested rather than inlined.
+fn max_rss_bytes(ru_maxrss: libc::c_long) -> u64 {
+    let value = ru_maxrss.max(0) as u64;
+    if cfg!(target_os = "macos") {
+        value
+    } else {
+        value.saturating_mul(1024)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use rue_perf_schema::Phase;
+
+    use super::*;
+
+    fn accounting(root_ns: u64, semantic_ns: u64, unattributed_ns: u64) -> PhaseAccounting {
+        let mut phase_ns: BTreeMap<Phase, u64> =
+            Phase::ALL.into_iter().map(|phase| (phase, 0)).collect();
+        phase_ns.insert(Phase::SemanticAnalysis, semantic_ns);
+        PhaseAccounting {
+            phase_ns,
+            mixed_parallel_ns: 0,
+            unattributed_ns,
+            compiler_root_ns: root_ns,
+        }
+    }
+
+    #[test]
+    fn summing_partitions_preserves_the_invariant() {
+        // This is why a batch may be reported as one sample: each compilation
+        // partitions its own timeline exactly, so their sums partition the
+        // concatenation exactly.
+        let first = accounting(100, 60, 40);
+        let second = accounting(250, 200, 50);
+        assert!(first.holds() && second.holds());
+
+        let total = add_accounting(first, &second);
+        assert!(total.holds(), "{total:?}");
+        assert_eq!(total.compiler_root_ns, 350);
+        assert_eq!(total.phase_ns[&Phase::SemanticAnalysis], 260);
+        assert_eq!(total.unattributed_ns, 90);
+    }
+
+    #[test]
+    fn summing_keeps_every_published_phase_present() {
+        let total = add_accounting(accounting(10, 10, 0), &accounting(10, 10, 0));
+        assert!(
+            total.missing_phases().is_empty(),
+            "a summed partition must still describe the whole taxonomy"
+        );
+    }
+
+    #[test]
+    fn a_corrupt_addend_saturates_rather_than_panicking() {
+        // Validation reports the resulting mismatch as an invariant violation.
+        // Overflowing here would abort collection and destroy the evidence.
+        let huge = accounting(u64::MAX, u64::MAX, 0);
+        let total = add_accounting(accounting(10, 10, 0), &huge);
+        assert_eq!(total.compiler_root_ns, u64::MAX);
+    }
+
+    #[test]
+    fn max_rss_is_normalized_to_bytes_per_platform() {
+        // A factor-of-1024 mistake here looks entirely plausible on a chart,
+        // which is why the conversion is tested rather than trusted.
+        let expected: u64 = if cfg!(target_os = "macos") {
+            4096
+        } else {
+            4096 * 1024
+        };
+        assert_eq!(max_rss_bytes(4096), expected);
+    }
+
+    #[test]
+    fn a_negative_max_rss_reads_as_zero_rather_than_wrapping() {
+        assert_eq!(max_rss_bytes(-1), 0);
+    }
+}

--- a/crates/rue-bench/src/pins.rs
+++ b/crates/rue-bench/src/pins.rs
@@ -1,0 +1,273 @@
+//! Resolving what was actually measured.
+//!
+//! The epoch *declares* content hashes; this module *resolves* them from the
+//! tree in front of it. Validation then compares the two. That is the whole
+//! mechanism by which a configuration-invalid observation becomes unappendable
+//! rather than merely detectable: a workload edit changes its resolved hash,
+//! the comparison fails, and appending requires a maintainer to declare the
+//! next suite revision deliberately.
+//!
+//! Resolving must therefore never consult the epoch. A resolver that fell back
+//! to the declared value on error would defeat the check it exists to feed.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use sha2::{Digest, Sha256};
+
+/// A source closure could not be resolved.
+#[derive(Debug)]
+pub struct PinError {
+    /// What was being resolved.
+    pub subject: String,
+    /// Why it failed.
+    pub detail: String,
+}
+
+impl std::fmt::Display for PinError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "could not resolve {}: {}", self.subject, self.detail)
+    }
+}
+
+/// Hash a single file's contents.
+fn hash_file(path: &Path) -> Result<String, PinError> {
+    let bytes = std::fs::read(path).map_err(|error| PinError {
+        subject: path.display().to_string(),
+        detail: error.to_string(),
+    })?;
+    Ok(hex(Sha256::digest(&bytes).as_slice()))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+/// Fold a sorted set of `(name, content hash)` pairs into one hash.
+///
+/// Names are included, and lengths are framed, so that renaming a file or
+/// splitting one into two changes the result. Concatenating unframed values
+/// would let `("ab", "c")` and `("a", "bc")` collide.
+fn fold(entries: &BTreeMap<String, String>) -> String {
+    let mut hasher = Sha256::new();
+    for (name, content) in entries {
+        hasher.update(name.len().to_le_bytes());
+        hasher.update(name.as_bytes());
+        hasher.update(content.len().to_le_bytes());
+        hasher.update(content.as_bytes());
+    }
+    hex(hasher.finalize().as_slice())
+}
+
+/// Hash of the toolchain the compiler was built with.
+///
+/// Deliberately *not* the compiler binary. The compiler revision is a point
+/// within a series, never part of its identity, so hashing the artifact under
+/// test would make every commit fail its own epoch's pin check and no series
+/// could ever contain two points.
+///
+/// What must stay fixed is the build environment: the pinned Rust toolchain.
+/// Changing it changes generated code and therefore measurements, and it
+/// changes rarely and deliberately — exactly the profile a pin wants.
+pub fn toolchain_hash(repo_root: &Path) -> Result<String, PinError> {
+    hash_file(&repo_root.join("rust-toolchain.toml"))
+}
+
+/// Hash of the standard library's source tree.
+///
+/// Walks deterministically and keys each file by its path relative to the
+/// standard-library root, so the hash does not depend on where the checkout
+/// lives.
+pub fn stdlib_hash(std_root: &Path) -> Result<String, PinError> {
+    let mut entries = BTreeMap::new();
+    collect_tree(std_root, std_root, &mut entries)?;
+    Ok(fold(&entries))
+}
+
+fn collect_tree(
+    root: &Path,
+    directory: &Path,
+    entries: &mut BTreeMap<String, String>,
+) -> Result<(), PinError> {
+    let listing = std::fs::read_dir(directory).map_err(|error| PinError {
+        subject: directory.display().to_string(),
+        detail: error.to_string(),
+    })?;
+    for entry in listing {
+        let entry = entry.map_err(|error| PinError {
+            subject: directory.display().to_string(),
+            detail: error.to_string(),
+        })?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_tree(root, &path, entries)?;
+            continue;
+        }
+        let relative = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .into_owned();
+        entries.insert(relative, hash_file(&path)?);
+    }
+    Ok(())
+}
+
+/// The compiler's dependency report, of which only the resolved read set
+/// matters here.
+#[derive(serde::Deserialize)]
+struct DependencyReport {
+    status: String,
+    accepted_reads: Vec<AcceptedRead>,
+}
+
+#[derive(serde::Deserialize)]
+struct AcceptedRead {
+    module: String,
+    canonical_path: PathBuf,
+}
+
+/// Hash a workload's full transitive source closure.
+///
+/// The closure comes from the compiler's own `--emit deps`, so it is the set
+/// the compiler would actually read rather than a guess at the import graph.
+/// Contents are then hashed here with SHA-256 rather than trusting the report's
+/// own 64-bit fingerprints, which are sized for change detection inside one
+/// process rather than for identity across machines.
+///
+/// Files are keyed by module path, which is relative to the project root, so
+/// two checkouts of the same tree at different absolute paths resolve to the
+/// same hash.
+pub fn workload_source_hash(
+    compiler: &Path,
+    source: &Path,
+    std_root: Option<&Path>,
+) -> Result<String, PinError> {
+    let subject = source.display().to_string();
+    let mut command = Command::new(compiler);
+    command.arg("--emit").arg("deps").arg(source);
+    if let Some(std_root) = std_root {
+        command.env("RUE_STD_PATH", std_root);
+    }
+    let output = command.output().map_err(|error| PinError {
+        subject: subject.clone(),
+        detail: format!("could not run the compiler: {error}"),
+    })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let report: DependencyReport =
+        serde_json::from_str(stdout.trim()).map_err(|error| PinError {
+            subject: subject.clone(),
+            detail: format!(
+                "could not read the dependency report ({error}); stderr: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+        })?;
+
+    // A partial closure would hash to something stable but wrong, and every
+    // later run would silently agree with it.
+    if report.status != "complete" {
+        return Err(PinError {
+            subject,
+            detail: format!("dependency discovery reported status {:?}", report.status),
+        });
+    }
+
+    let mut entries = BTreeMap::new();
+    for read in &report.accepted_reads {
+        entries.insert(read.module.clone(), hash_file(&read.canonical_path)?);
+    }
+    if entries.is_empty() {
+        return Err(PinError {
+            subject,
+            detail: "dependency discovery accepted no reads".to_string(),
+        });
+    }
+    Ok(fold(&entries))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folding_is_order_independent_but_content_sensitive() {
+        let mut one = BTreeMap::new();
+        one.insert("a.rue".to_string(), "aaa".to_string());
+        one.insert("b.rue".to_string(), "bbb".to_string());
+
+        let mut reversed = BTreeMap::new();
+        reversed.insert("b.rue".to_string(), "bbb".to_string());
+        reversed.insert("a.rue".to_string(), "aaa".to_string());
+
+        assert_eq!(fold(&one), fold(&reversed));
+
+        let mut changed = one.clone();
+        changed.insert("b.rue".to_string(), "ccc".to_string());
+        assert_ne!(fold(&one), fold(&changed));
+    }
+
+    #[test]
+    fn renaming_a_file_changes_the_closure_hash() {
+        // Names participate, so moving a module is a source-identity change and
+        // therefore needs a new suite revision.
+        let mut original = BTreeMap::new();
+        original.insert("util.rue".to_string(), "aaa".to_string());
+        let mut renamed = BTreeMap::new();
+        renamed.insert("helper.rue".to_string(), "aaa".to_string());
+        assert_ne!(fold(&original), fold(&renamed));
+    }
+
+    #[test]
+    fn framing_prevents_boundary_collisions() {
+        // Without length framing these two would concatenate identically.
+        let mut left = BTreeMap::new();
+        left.insert("ab".to_string(), "c".to_string());
+        let mut right = BTreeMap::new();
+        right.insert("a".to_string(), "bc".to_string());
+        assert_ne!(fold(&left), fold(&right));
+    }
+
+    #[test]
+    fn adding_a_file_changes_the_closure_hash() {
+        let mut before = BTreeMap::new();
+        before.insert("main.rue".to_string(), "aaa".to_string());
+        let mut after = before.clone();
+        after.insert("extra.rue".to_string(), "bbb".to_string());
+        assert_ne!(fold(&before), fold(&after));
+    }
+
+    #[test]
+    fn hashing_a_missing_file_is_an_error_rather_than_a_default() {
+        // Silently hashing "nothing" would make a deleted workload resolve to a
+        // stable value that every later run would agree with.
+        let error = hash_file(Path::new("/definitely/not/here.rue")).unwrap_err();
+        assert!(error.to_string().contains("could not resolve"));
+    }
+
+    #[test]
+    fn a_stdlib_hash_is_stable_and_covers_its_files() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        std::fs::write(directory.path().join("a.rue"), "fn a() {}").unwrap();
+        std::fs::create_dir(directory.path().join("nested")).unwrap();
+        std::fs::write(directory.path().join("nested/b.rue"), "fn b() {}").unwrap();
+
+        let first = stdlib_hash(directory.path()).unwrap();
+        assert_eq!(first, stdlib_hash(directory.path()).unwrap());
+
+        std::fs::write(directory.path().join("nested/b.rue"), "fn b() { 1 }").unwrap();
+        assert_ne!(first, stdlib_hash(directory.path()).unwrap());
+    }
+
+    #[test]
+    fn a_stdlib_hash_does_not_depend_on_where_the_checkout_lives() {
+        let make = |root: &Path| {
+            std::fs::write(root.join("a.rue"), "fn a() {}").unwrap();
+            stdlib_hash(root).unwrap()
+        };
+        let one = tempfile::tempdir().expect("temp dir");
+        let two = tempfile::tempdir().expect("temp dir");
+        assert_eq!(make(one.path()), make(two.path()));
+    }
+}

--- a/performance/manifest.toml
+++ b/performance/manifest.toml
@@ -1,0 +1,60 @@
+# Compiler-performance suite and platform epochs (ADR-0067).
+#
+# Two layers. A `[[suite]]` pins the platform-independent logical contract:
+# which workloads exist, what program each one is, the phase taxonomy, and the
+# runner protocol. A `[[epoch]]` pins everything that varies per platform:
+# target and invocation, resolved content hashes, sampling policy, environment
+# policy, and the headline baseline.
+#
+# Changing what a workload *is* requires a new suite revision, and therefore new
+# epochs on every participating platform. Changing only one platform's sampling
+# creates a new epoch there alone. Both are deliberate, reviewable events.
+#
+# STATUS: the `local` epoch below exists so the runner can be exercised during
+# development. Its sampling counts are placeholders, not calibrated values, and
+# it declares no baseline. The published epochs — with counts, batching factors,
+# and the flagging multiplier established by the Phase 4 noise calibration —
+# arrive with suite revision 1's declaration in RUE-1188.
+#
+# Its `stdlib_hash` goes stale whenever the standard library changes, and a
+# local run then reports a pin mismatch and exits 3. That is the mechanism
+# working, not a bug: an epoch pins what was measured, so changing an input
+# means declaring a new epoch. Refresh the value from the mismatch the runner
+# prints. Whether a suite whose workloads never read `std` should pin `std` at
+# all is an open question for RUE-1188.
+
+[[suite]]
+revision = 1
+timing_schema_version = 1
+protocol_version = 1
+
+[[suite.workloads]]
+id = "startup"
+source = "performance/workloads/startup/main.rue"
+question = "What does a minimal fresh compilation cost end to end?"
+
+# A development epoch for local runs. Not a collection target: its environment
+# policy admits only `local`, so a hosted runner cannot append to it.
+[[epoch]]
+id = 1
+platform = "local"
+suite_revision = 1
+target = "x86_64-unknown-linux-gnu"
+args = []
+toolchain_hash = "30f50af0ac7111ffb25d5ef1a423642eaeb2e381931a57583e190a84634ee3fe"
+stdlib_hash = "6b6ecc2e8550c6efb353c8aec4a8db4e2341880549544fc4d26fc5d421aa212f"
+
+[epoch.workload_source_hashes]
+startup = "87869467f94e34b8df41900bda44546b610296077c14fab6defda8939fe22be7"
+
+[epoch.environment]
+runner_label = "local"
+runner_image = "local"
+
+[epoch.sampling.startup]
+samples = 3
+batch_size = 5
+
+[epoch.flagging]
+k = 3.0
+window = 10

--- a/performance/workloads/startup/main.rue
+++ b/performance/workloads/startup/main.rue
@@ -1,0 +1,10 @@
+// The startup probe: the smallest complete compilation the suite measures.
+//
+// It answers "what does a fresh compiler process cost before it does any
+// interesting work" — process startup, driver setup, and the fixed cost of
+// reaching every phase at least once. Because it is very short, its epoch
+// pins a batching factor so timer resolution and per-process jitter do not
+// dominate the measurement.
+fn main() -> i32 {
+    return 0;
+}

--- a/rust-project.json
+++ b/rust-project.json
@@ -11,27 +11,27 @@
           "name": "rue_air"
         },
         {
-          "crate": 5,
+          "crate": 6,
           "name": "rue_cfg"
         },
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 20,
+          "crate": 21,
           "name": "rue_rir"
         },
         {
-          "crate": 24,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "lasso"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde_json"
         }
       ],
@@ -55,31 +55,31 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 4,
+          "crate": 5,
           "name": "rue_builtins"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 20,
+          "crate": 21,
           "name": "rue_rir"
         },
         {
-          "crate": 22,
+          "crate": 23,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 24,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 26,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "lasso"
         }
       ],
@@ -103,43 +103,43 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 4,
+          "crate": 5,
           "name": "rue_builtins"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_parser"
         },
         {
-          "crate": 20,
+          "crate": 21,
           "name": "rue_rir"
         },
         {
-          "crate": 22,
+          "crate": 23,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 24,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 26,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "lasso"
         },
         {
-          "crate": 96,
+          "crate": 97,
           "name": "rayon"
         }
       ],
@@ -177,12 +177,56 @@
       "is_proc_macro": false
     },
     {
+      "display_name": "rue-bench",
+      "root_module": "crates/rue-bench/src/main.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 19,
+          "name": "rue_perf_schema"
+        },
+        {
+          "crate": 72,
+          "name": "libc"
+        },
+        {
+          "crate": 103,
+          "name": "serde"
+        },
+        {
+          "crate": 105,
+          "name": "serde_json"
+        },
+        {
+          "crate": 107,
+          "name": "sha2"
+        },
+        {
+          "crate": 111,
+          "name": "tempfile"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-bench/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
       "display_name": "rue-builtins",
       "root_module": "crates/rue-builtins/src/lib.rs",
       "edition": "2024",
       "deps": [
         {
-          "crate": 22,
+          "crate": 23,
           "name": "rue_runtime_abi"
         }
       ],
@@ -210,15 +254,15 @@
           "name": "rue_air"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 24,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "lasso"
         }
       ],
@@ -246,15 +290,15 @@
           "name": "rue_air"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 24,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "lasso"
         }
       ],
@@ -278,35 +322,35 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 14,
+          "crate": 15,
           "name": "rue_linker"
         },
         {
-          "crate": 26,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_test_runner"
         },
         {
-          "crate": 75,
+          "crate": 76,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde_json"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "tempfile"
         },
         {
-          "crate": 113,
+          "crate": 114,
           "name": "toml"
         }
       ],
@@ -334,39 +378,39 @@
           "name": "rue_air"
         },
         {
-          "crate": 4,
+          "crate": 5,
           "name": "rue_builtins"
         },
         {
-          "crate": 5,
+          "crate": 6,
           "name": "rue_cfg"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 22,
+          "crate": 23,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 24,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 26,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 57,
+          "crate": 58,
           "name": "fixedbitset"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "lasso"
         },
         {
-          "crate": 117,
+          "crate": 118,
           "name": "tracing"
         }
       ],
@@ -394,87 +438,87 @@
           "name": "rue_air"
         },
         {
-          "crate": 4,
+          "crate": 5,
           "name": "rue_builtins"
         },
         {
-          "crate": 5,
+          "crate": 6,
           "name": "rue_cfg"
         },
         {
-          "crate": 8,
+          "crate": 9,
           "name": "rue_codegen"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 14,
+          "crate": 15,
           "name": "rue_linker"
         },
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_parser"
         },
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_query"
         },
         {
-          "crate": 20,
+          "crate": 21,
           "name": "rue_rir"
         },
         {
-          "crate": 22,
+          "crate": 23,
           "name": "rue_runtime_abi"
         },
         {
-          "crate": 24,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 26,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 38,
+          "crate": 39,
           "name": "annotate_snippets"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "lasso"
         },
         {
-          "crate": 71,
+          "crate": 72,
           "name": "libc"
         },
         {
-          "crate": 96,
+          "crate": 97,
           "name": "rayon"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde_json"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "sha2"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "tempfile"
         },
         {
-          "crate": 117,
+          "crate": 118,
           "name": "tracing"
         }
       ],
@@ -498,11 +542,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 24,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "thiserror"
         }
       ],
@@ -526,23 +570,23 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_parser"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_test_runner"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "lasso"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "tempfile"
         }
       ],
@@ -574,55 +618,55 @@
           "name": "rue_air_fuzz_support"
         },
         {
-          "crate": 5,
+          "crate": 6,
           "name": "rue_cfg"
         },
         {
-          "crate": 6,
+          "crate": 7,
           "name": "rue_cfg_fuzz_support"
         },
         {
-          "crate": 8,
+          "crate": 9,
           "name": "rue_codegen"
         },
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_parser"
         },
         {
-          "crate": 20,
+          "crate": 21,
           "name": "rue_rir"
         },
         {
-          "crate": 21,
+          "crate": 22,
           "name": "rue_rir_fuzz_support"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_test_runner"
         },
         {
-          "crate": 41,
+          "crate": 42,
           "name": "anyhow"
         },
         {
-          "crate": 71,
+          "crate": 72,
           "name": "libc"
         },
         {
-          "crate": 89,
+          "crate": 90,
           "name": "proptest"
         }
       ],
@@ -646,19 +690,19 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 24,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "lasso"
         },
         {
-          "crate": 78,
+          "crate": 79,
           "name": "logos"
         }
       ],
@@ -682,11 +726,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 26,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 117,
+          "crate": 118,
           "name": "tracing"
         }
       ],
@@ -710,31 +754,31 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 16,
+          "crate": 17,
           "name": "rue_oracle"
         },
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_test_runner"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "tempfile"
         },
         {
-          "crate": 113,
+          "crate": 114,
           "name": "toml"
         }
       ],
@@ -762,15 +806,15 @@
           "name": "rue_air"
         },
         {
-          "crate": 5,
+          "crate": 6,
           "name": "rue_cfg"
         },
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "lasso"
         }
       ],
@@ -794,27 +838,27 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 24,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "lasso"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "smallvec"
         },
         {
-          "crate": 117,
+          "crate": 118,
           "name": "tracing"
         }
       ],
@@ -838,19 +882,19 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 102,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde_json"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "sha2"
         },
         {
-          "crate": 113,
+          "crate": 114,
           "name": "toml"
         }
       ],
@@ -893,19 +937,19 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_parser"
         },
         {
-          "crate": 24,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "lasso"
         }
       ],
@@ -929,19 +973,19 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_lexer"
         },
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_parser"
         },
         {
-          "crate": 24,
+          "crate": 25,
           "name": "rue_span"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "lasso"
         }
       ],
@@ -988,7 +1032,7 @@
           "name": "rue_allocator"
         },
         {
-          "crate": 22,
+          "crate": 23,
           "name": "rue_runtime_abi"
         }
       ],
@@ -1031,15 +1075,15 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_test_runner"
         },
         {
-          "crate": 75,
+          "crate": 76,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "tempfile"
         }
       ],
@@ -1082,27 +1126,27 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 26,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 71,
+          "crate": 72,
           "name": "libc"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "tempfile"
         },
         {
-          "crate": 113,
+          "crate": 114,
           "name": "toml"
         }
       ],
@@ -1126,11 +1170,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 27,
+          "crate": 28,
           "name": "rue_test_runner"
         },
         {
-          "crate": 75,
+          "crate": 76,
           "name": "libtest2_mimic"
         }
       ],
@@ -1154,43 +1198,47 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 20,
+          "crate": 19,
+          "name": "rue_perf_schema"
+        },
+        {
+          "crate": 21,
           "name": "rue_rir"
         },
         {
-          "crate": 26,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 71,
+          "crate": 72,
           "name": "libc"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde_json"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "sha2"
         },
         {
-          "crate": 117,
+          "crate": 118,
           "name": "tracing"
         },
         {
-          "crate": 121,
+          "crate": 122,
           "name": "tracing_subscriber"
         }
       ],
@@ -1214,43 +1262,47 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 9,
+          "crate": 10,
           "name": "rue_compiler"
         },
         {
-          "crate": 10,
+          "crate": 11,
           "name": "rue_error"
         },
         {
-          "crate": 20,
+          "crate": 19,
+          "name": "rue_perf_schema"
+        },
+        {
+          "crate": 21,
           "name": "rue_rir"
         },
         {
-          "crate": 26,
+          "crate": 27,
           "name": "rue_target"
         },
         {
-          "crate": 71,
+          "crate": 72,
           "name": "libc"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde_json"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "sha2"
         },
         {
-          "crate": 117,
+          "crate": 118,
           "name": "tracing"
         },
         {
-          "crate": 121,
+          "crate": 122,
           "name": "tracing_subscriber"
         }
       ],
@@ -1274,7 +1326,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 79,
+          "crate": 80,
           "name": "logos_codegen"
         }
       ],
@@ -1298,15 +1350,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 88,
+          "crate": 89,
           "name": "proc_macro2"
         },
         {
-          "crate": 91,
+          "crate": 92,
           "name": "quote"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "syn"
         }
       ],
@@ -1331,15 +1383,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 88,
+          "crate": 89,
           "name": "proc_macro2"
         },
         {
-          "crate": 91,
+          "crate": 92,
           "name": "quote"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "syn"
         }
       ],
@@ -1363,15 +1415,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 88,
+          "crate": 89,
           "name": "proc_macro2"
         },
         {
-          "crate": 91,
+          "crate": 92,
           "name": "quote"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "syn"
         }
       ],
@@ -1395,15 +1447,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 47,
+          "crate": 48,
           "name": "cfg_if"
         },
         {
-          "crate": 84,
+          "crate": 85,
           "name": "once_cell"
         },
         {
-          "crate": 128,
+          "crate": 129,
           "name": "zerocopy"
         }
       ],
@@ -1427,7 +1479,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 81,
+          "crate": 82,
           "name": "memchr"
         }
       ],
@@ -1473,11 +1525,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 40,
+          "crate": 41,
           "name": "anstyle"
         },
         {
-          "crate": 125,
+          "crate": 126,
           "name": "unicode_width"
         }
       ],
@@ -1586,7 +1638,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 44,
+          "crate": 45,
           "name": "bit_vec"
         }
       ],
@@ -1654,7 +1706,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 59,
+          "crate": 60,
           "name": "generic_array"
         }
       ],
@@ -1716,11 +1768,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 50,
+          "crate": 51,
           "name": "crossbeam_epoch"
         },
         {
-          "crate": 51,
+          "crate": 52,
           "name": "crossbeam_utils"
         }
       ],
@@ -1746,7 +1798,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 51,
+          "crate": 52,
           "name": "crossbeam_utils"
         }
       ],
@@ -1793,11 +1845,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 59,
+          "crate": 60,
           "name": "generic_array"
         },
         {
-          "crate": 122,
+          "crate": 123,
           "name": "typenum"
         }
       ],
@@ -1821,27 +1873,27 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 47,
+          "crate": 48,
           "name": "cfg_if"
         },
         {
-          "crate": 51,
+          "crate": 52,
           "name": "crossbeam_utils"
         },
         {
-          "crate": 61,
+          "crate": 62,
           "name": "hashbrown"
         },
         {
-          "crate": 76,
+          "crate": 77,
           "name": "lock_api"
         },
         {
-          "crate": 84,
+          "crate": 85,
           "name": "once_cell"
         },
         {
-          "crate": 85,
+          "crate": 86,
           "name": "parking_lot_core"
         }
       ],
@@ -1866,11 +1918,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 46,
+          "crate": 47,
           "name": "block_buffer"
         },
         {
-          "crate": 52,
+          "crate": 53,
           "name": "crypto_common"
         }
       ],
@@ -1977,7 +2029,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 122,
+          "crate": 123,
           "name": "typenum"
         }
       ],
@@ -2022,11 +2074,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 35,
+          "crate": 36,
           "name": "ahash"
         },
         {
-          "crate": 37,
+          "crate": 38,
           "name": "allocator_api2"
         }
       ],
@@ -2074,11 +2126,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 56,
+          "crate": 57,
           "name": "equivalent"
         },
         {
-          "crate": 62,
+          "crate": 63,
           "name": "hashbrown"
         }
       ],
@@ -2145,11 +2197,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 53,
+          "crate": 54,
           "name": "dashmap"
         },
         {
-          "crate": 61,
+          "crate": 62,
           "name": "hashbrown"
         }
       ],
@@ -2195,11 +2247,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 69,
+          "crate": 70,
           "name": "lexarg_error"
         },
         {
-          "crate": 70,
+          "crate": 71,
           "name": "lexarg_parser"
         }
       ],
@@ -2224,7 +2276,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 70,
+          "crate": 71,
           "name": "lexarg_parser"
         }
       ],
@@ -2290,7 +2342,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 65,
+          "crate": 66,
           "name": "json_write"
         }
       ],
@@ -2316,11 +2368,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lexarg"
         },
         {
-          "crate": 69,
+          "crate": 70,
           "name": "lexarg_error"
         }
       ],
@@ -2345,27 +2397,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 39,
+          "crate": 40,
           "name": "anstream"
         },
         {
-          "crate": 40,
+          "crate": 41,
           "name": "anstyle"
         },
         {
-          "crate": 69,
+          "crate": 70,
           "name": "lexarg_error"
         },
         {
-          "crate": 70,
+          "crate": 71,
           "name": "lexarg_parser"
         },
         {
-          "crate": 72,
+          "crate": 73,
           "name": "libtest_json"
         },
         {
-          "crate": 73,
+          "crate": 74,
           "name": "libtest_lexarg"
         }
       ],
@@ -2392,11 +2444,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 72,
+          "crate": 73,
           "name": "libtest_json"
         },
         {
-          "crate": 74,
+          "crate": 75,
           "name": "libtest2_harness"
         }
       ],
@@ -2423,7 +2475,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 101,
+          "crate": 102,
           "name": "scopeguard"
         }
       ],
@@ -2469,7 +2521,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 31,
+          "crate": 32,
           "name": "logos_derive"
         }
       ],
@@ -2497,31 +2549,31 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 42,
+          "crate": 43,
           "name": "beef"
         },
         {
-          "crate": 58,
+          "crate": 59,
           "name": "fnv"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lazy_static"
         },
         {
-          "crate": 88,
+          "crate": 89,
           "name": "proc_macro2"
         },
         {
-          "crate": 91,
+          "crate": 92,
           "name": "quote"
         },
         {
-          "crate": 99,
+          "crate": 100,
           "name": "regex_syntax"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "syn"
         }
       ],
@@ -2545,7 +2597,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 98,
+          "crate": 99,
           "name": "regex_automata"
         }
       ],
@@ -2692,7 +2744,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 128,
+          "crate": 129,
           "name": "zerocopy"
         }
       ],
@@ -2718,7 +2770,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 124,
+          "crate": 125,
           "name": "unicode_ident"
         }
       ],
@@ -2744,47 +2796,47 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 43,
+          "crate": 44,
           "name": "bit_set"
         },
         {
-          "crate": 44,
+          "crate": 45,
           "name": "bit_vec"
         },
         {
-          "crate": 45,
+          "crate": 46,
           "name": "bitflags"
         },
         {
-          "crate": 83,
+          "crate": 84,
           "name": "num_traits"
         },
         {
-          "crate": 92,
+          "crate": 93,
           "name": "rand"
         },
         {
-          "crate": 93,
+          "crate": 94,
           "name": "rand_chacha"
         },
         {
-          "crate": 95,
+          "crate": 96,
           "name": "rand_xorshift"
         },
         {
-          "crate": 99,
+          "crate": 100,
           "name": "regex_syntax"
         },
         {
-          "crate": 100,
+          "crate": 101,
           "name": "rusty_fork"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "tempfile"
         },
         {
-          "crate": 123,
+          "crate": 124,
           "name": "unarray"
         }
       ],
@@ -2835,7 +2887,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 88,
+          "crate": 89,
           "name": "proc_macro2"
         }
       ],
@@ -2861,7 +2913,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 94,
+          "crate": 95,
           "name": "rand_core"
         }
       ],
@@ -2888,11 +2940,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 87,
+          "crate": 88,
           "name": "ppv_lite86"
         },
         {
-          "crate": 94,
+          "crate": 95,
           "name": "rand_core"
         }
       ],
@@ -2917,7 +2969,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 60,
+          "crate": 61,
           "name": "getrandom"
         }
       ],
@@ -2943,7 +2995,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 94,
+          "crate": 95,
           "name": "rand_core"
         }
       ],
@@ -2967,11 +3019,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 55,
+          "crate": 56,
           "name": "either"
         },
         {
-          "crate": 97,
+          "crate": 98,
           "name": "rayon_core"
         }
       ],
@@ -2995,11 +3047,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 49,
+          "crate": 50,
           "name": "crossbeam_deque"
         },
         {
-          "crate": 51,
+          "crate": 52,
           "name": "crossbeam_utils"
         }
       ],
@@ -3023,15 +3075,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 36,
+          "crate": 37,
           "name": "aho_corasick"
         },
         {
-          "crate": 81,
+          "crate": 82,
           "name": "memchr"
         },
         {
-          "crate": 99,
+          "crate": 100,
           "name": "regex_syntax"
         }
       ],
@@ -3108,19 +3160,19 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 58,
+          "crate": 59,
           "name": "fnv"
         },
         {
-          "crate": 90,
+          "crate": 91,
           "name": "quick_error"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "tempfile"
         },
         {
-          "crate": 126,
+          "crate": 127,
           "name": "wait_timeout"
         }
       ],
@@ -3165,11 +3217,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 32,
+          "crate": 33,
           "name": "serde_derive"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde_core"
         }
       ],
@@ -3218,19 +3270,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 64,
+          "crate": 65,
           "name": "itoa"
         },
         {
-          "crate": 81,
+          "crate": 82,
           "name": "memchr"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "serde_core"
         },
         {
-          "crate": 129,
+          "crate": 130,
           "name": "zmij"
         }
       ],
@@ -3256,7 +3308,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 102,
+          "crate": 103,
           "name": "serde"
         }
       ],
@@ -3281,15 +3333,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 47,
+          "crate": 48,
           "name": "cfg_if"
         },
         {
-          "crate": 48,
+          "crate": 49,
           "name": "cpufeatures"
         },
         {
-          "crate": 54,
+          "crate": 55,
           "name": "digest"
         }
       ],
@@ -3313,7 +3365,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lazy_static"
         }
       ],
@@ -3356,15 +3408,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 88,
+          "crate": 89,
           "name": "proc_macro2"
         },
         {
-          "crate": 91,
+          "crate": 92,
           "name": "quote"
         },
         {
-          "crate": 124,
+          "crate": 125,
           "name": "unicode_ident"
         }
       ],
@@ -3418,7 +3470,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 33,
+          "crate": 34,
           "name": "thiserror_impl"
         }
       ],
@@ -3444,7 +3496,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 47,
+          "crate": 48,
           "name": "cfg_if"
         }
       ],
@@ -3468,19 +3520,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 102,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_spanned"
         },
         {
-          "crate": 114,
+          "crate": 115,
           "name": "toml_datetime"
         },
         {
-          "crate": 115,
+          "crate": 116,
           "name": "toml_edit"
         }
       ],
@@ -3507,7 +3559,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 102,
+          "crate": 103,
           "name": "serde"
         }
       ],
@@ -3532,27 +3584,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 63,
+          "crate": 64,
           "name": "indexmap"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "serde_spanned"
         },
         {
-          "crate": 114,
+          "crate": 115,
           "name": "toml_datetime"
         },
         {
-          "crate": 116,
+          "crate": 117,
           "name": "toml_write"
         },
         {
-          "crate": 127,
+          "crate": 128,
           "name": "winnow"
         }
       ],
@@ -3601,15 +3653,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 34,
+          "crate": 35,
           "name": "tracing_attributes"
         },
         {
-          "crate": 86,
+          "crate": 87,
           "name": "pin_project_lite"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing_core"
         }
       ],
@@ -3637,7 +3689,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 84,
+          "crate": 85,
           "name": "once_cell"
         }
       ],
@@ -3664,15 +3716,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 77,
+          "crate": 78,
           "name": "log"
         },
         {
-          "crate": 84,
+          "crate": 85,
           "name": "once_cell"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing_core"
         }
       ],
@@ -3698,11 +3750,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 102,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing_core"
         }
       ],
@@ -3726,55 +3778,55 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 80,
+          "crate": 81,
           "name": "matchers"
         },
         {
-          "crate": 82,
+          "crate": 83,
           "name": "nu_ansi_term"
         },
         {
-          "crate": 84,
+          "crate": 85,
           "name": "once_cell"
         },
         {
-          "crate": 98,
+          "crate": 99,
           "name": "regex_automata"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "serde"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "serde_json"
         },
         {
-          "crate": 107,
+          "crate": 108,
           "name": "sharded_slab"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "smallvec"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "thread_local"
         },
         {
-          "crate": 117,
+          "crate": 118,
           "name": "tracing"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "tracing_core"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "tracing_log"
         },
         {
-          "crate": 120,
+          "crate": 121,
           "name": "tracing_serde"
         }
       ],


### PR DESCRIPTION
Phase 3 of ADR-0067, on top of the Phase 1 schema (#2024) and Phase 2 accounting (#2026). One Rust binary replaces the removed shell runner and Python package: it reads the manifest, runs the corpus under the epoch's sampling policy, resolves what it actually measured, validates it, and emits one immutable run object.

## The runner does not judge

It records what happened — crashes, unresolvable pins, phase-sum violations — and hands the result to `validate_run`. Keeping judgement out of the producer is what makes the Phase 1 cross-check real: the runner writes its own `PhaseInvariant` record, and validation recomputes the invariant independently rather than trusting it. A runner that failed to notice its own bad sample is caught by `UnrecordedInvariantFailure`.

## Pins are resolved, never read back

`pins.rs` resolves from the tree in front of it and never consults the epoch, so validation compares two independently produced answers. A resolver that fell back to the declared value on error would defeat the check it exists to feed.

A workload's closure comes from the compiler's own `--emit deps` — the set it would actually read, not a guess at the import graph. Contents are then hashed with SHA-256 rather than trusting the report's own 64-bit fingerprints, which are sized for change detection inside one process rather than identity across machines. Files are keyed by module path, so two checkouts at different absolute paths agree.

Folding is length-framed and name-inclusive, so renaming a module or splitting one file into two changes the hash, and `("ab","c")` cannot collide with `("a","bc")`.

## Two bugs worth calling out, both caught before landing

**`toolchain_hash` must not be the compiler binary.** My first version hashed the compiler under measurement. The compiler revision is a *point within* a series, never part of its identity — so pinning its binary hash would make every commit fail its own epoch's pin check, and no series could ever contain two points. It now covers `rust-toolchain.toml`: the build environment, which changes rarely and deliberately, which is exactly the profile a pin wants.

**Peak memory must be per-child.** `getrusage(RUSAGE_CHILDREN)` reports a maximum across every child the process has ever reaped. Once the largest workload ran, every later workload would inherit its peak and the memory metric would be silently wrong for all but the biggest — a plausible-looking chart with wrong numbers. It now uses `wait4`. The end-to-end run below shows peak memory as 35.8 / 35.6 / **35.7** MB across samples; that non-monotonicity is the direct evidence the fix works, since `RUSAGE_CHILDREN` could only ever have been non-decreasing.

Also: both child pipes are drained on separate threads. Reading one to completion first deadlocks as soon as the other's buffer fills, and the benchmark JSON is large enough for that to be live.

## Batching

A batch of K compilations is summed and stored with its factor, leaving per-compile figures to be derived — storage keeps what was measured, not what a reader might want. Summing is sound because each addend partitions its own timeline exactly, so the sums partition the concatenation exactly; there's a test pinning that the invariant survives addition. Addition saturates, so a corrupt addend surfaces as an invariant violation rather than a panic that would destroy the evidence.

## Partial runs and exit codes

A run object is written whatever the verdict — evidence of broken collection is worth more than a missing file. A crashed workload stops that workload and lets the run continue, so every workload that completed validly still publishes. Exit codes separate "collection broke" (`2`) from "written but not appendable" (`3`), so a workflow can tell the difference.

## End-to-end evidence

```
rue-bench: wrote run.json (4175a840192a56d94f08c6ebdddf8d173d01d58b1da422a3c7c395d624e62d89)
rue-bench: complete run; a headline point may be published
EXIT=0
```

Verified on the emitted object: the file's own SHA-256 equals the content address the runner reports; three samples at batch size 5; the phase-sum invariant holds on every sample; driver overhead ~44 ms per batch of 5 sits outside the phase stack as intended.

Before the manifest carried resolved hashes, the same run correctly refused to append with three `PinMismatch` errors — the mechanism working, not a failure.

## Also added

`performance/manifest.toml` and the startup workload. The `local` epoch exists to exercise the runner during development; its sampling counts are placeholders and its environment policy admits only `local`, so a hosted runner cannot append to it. The published epochs — with counts, batching factors, and the flagging multiplier from Phase 4 — arrive with RUE-1188.

**One open question flagged in the manifest for RUE-1188:** the `local` epoch's `stdlib_hash` goes stale whenever the standard library changes, and a local run then reports a pin mismatch and exits 3. That is the mechanism working — an epoch pins what was measured — but it means std churn forces epoch churn. Whether a suite whose workloads never read `std` should pin `std` at all is worth settling before the real epochs are declared.

## Validation

- `//crates/rue-bench:rue-bench-test` — 22 tests: closure-hash folding (order independence, rename sensitivity, length framing, missing files erroring rather than defaulting), environment probes degrading to placeholders instead of failing, timestamp format agreement with the schema, and run assembly checked against validation for the appendable, unresolvable-pin, and crashed-workload cases.
- `scripts/rue quick` — 30 targets. `scripts/rue fmt`, `./gen-rust-project.sh`, `validate-rust-project.py` (132 crates, 33 first-party).

Refs RUE-1182, RUE-1186.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKydRZPZurnmNTMHxDqZK2)_