### PR TITLE
RUE-1187: add noise calibration for the performance suite

### DIFF
--- a/.github/workflows/performance-calibration.yml
+++ b/.github/workflows/performance-calibration.yml
@@ -1,0 +1,121 @@
+# Noise calibration for the compiler-performance suite (ADR-0067 Phase 4).
+#
+# Repeatedly measures ONE unchanged compiler revision on each hosted platform,
+# then reports what the hardware's noise implies for sampling counts, batching
+# factors, and the flagging rule.
+#
+# The method rests on measuring the same revision every time: nothing real is
+# changing, so any difference the flagging rule reports is a false positive by
+# construction, and `k` can be chosen as the smallest multiplier producing none.
+#
+# NOTHING THIS WORKFLOW PRODUCES MAY ENTER A SERIES. Output is uploaded as
+# workflow artifacts and never written to the data branch. This workflow holds
+# no write permission, so that is structural rather than a convention: there is
+# no path from a calibration artifact to published history.
+name: Performance calibration
+
+on:
+  workflow_dispatch:
+    inputs:
+      repetitions:
+        description: Calibration runs per platform
+        required: false
+        default: "12"
+
+# Read-only. Calibration must not be able to publish.
+permissions:
+  contents: read
+
+# Calibration measures noise, so two overlapping runs on one runner would
+# measure each other. Never cancel in progress: a partial calibration is not
+# usable, and restarting is cheaper than reasoning about a truncated sweep.
+concurrency:
+  group: performance-calibration
+  cancel-in-progress: false
+
+jobs:
+  calibrate:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            platform: x86_64-linux
+            image: ubuntu-24.04
+          - os: ubuntu-24.04-arm
+            platform: aarch64-linux
+            image: ubuntu-24.04
+          - os: macos-15
+            platform: aarch64-macos
+            image: macos-15
+    runs-on: ${{ matrix.os }}
+    name: calibrate (${{ matrix.platform }})
+    # Repeated measurement of a whole corpus is slow by design.
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Select Xcode 16.2
+        if: runner.os == 'macOS'
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+
+      - name: Install dotslash
+        uses: facebook/install-dotslash@v2
+
+      - name: Build the compiler and the runner
+        run: |
+          ./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench
+
+      - name: Run the calibration repetitions
+        env:
+          # The fingerprint records the environment policy this run satisfies.
+          # Set explicitly rather than detected, so a run can never quietly
+          # claim a runner class it is not.
+          RUE_BENCH_RUNNER_LABEL: github-hosted
+          RUE_BENCH_RUNNER_IMAGE: ${{ matrix.image }}
+        run: |
+          set -euo pipefail
+          mkdir -p calibration-runs
+          RUE="$(scripts/rue-bin)"
+          BENCH="$(./buck2 build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"
+          COMMIT="${{ github.sha }}"
+
+          for index in $(seq 1 "${{ inputs.repetitions }}"); do
+            echo "::group::calibration run $index"
+            # Exit 3 means "written but not appendable", which is expected here:
+            # the calibration epoch is not a collection target. Only a runner
+            # failure (2) should stop the sweep.
+            set +e
+            "$BENCH" \
+              --manifest performance/manifest.toml \
+              --platform "${{ matrix.platform }}" \
+              --epoch 1 \
+              --compiler "$RUE" \
+              --commit "$COMMIT" \
+              --repo-root . \
+              --out "calibration-runs/run-$(printf '%03d' "$index").json"
+            status=$?
+            set -e
+            if [ "$status" -eq 2 ]; then
+              echo "runner failed to produce a run object; stopping"
+              exit 1
+            fi
+            echo "::endgroup::"
+          done
+
+      - name: Analyse
+        run: |
+          BENCH="$(./buck2 build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"
+          "$BENCH" calibrate \
+            --runs calibration-runs \
+            --report "calibration-${{ matrix.platform }}.md"
+
+      - name: Upload calibration artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: calibration-${{ matrix.platform }}
+          path: |
+            calibration-runs/
+            calibration-${{ matrix.platform }}.md
+            calibration-${{ matrix.platform }}.json
+          retention-days: 30

--- a/crates/rue-bench/src/calibrate.rs
+++ b/crates/rue-bench/src/calibrate.rs
@@ -1,0 +1,648 @@
+//! Turning repeated runs into the constants an epoch pins.
+//!
+//! Calibration answers four questions the ADR deliberately leaves empty until
+//! there is evidence: how many samples a workload needs, how much a very short
+//! workload must batch, how large the flagging multiplier `k` must be, and how
+//! long the trailing window should be.
+//!
+//! The method rests on one property. Every calibration run measures the *same*
+//! compiler revision, so nothing real is changing. Any difference the flagging
+//! rule reports is therefore a false positive by construction, and `k` can be
+//! chosen as the smallest multiplier that produces none. That is a measurement
+//! of the hardware's noise rather than a guess dressed up as a threshold.
+//!
+//! Nothing produced here may enter a series. These are workflow artifacts; the
+//! collector never reads them.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use rue_perf_schema::{Metric, RunObject, Summary, flags_movement, sample_value};
+
+/// Candidate multipliers swept when choosing `k`.
+const K_CANDIDATES: &[f64] = &[1.0, 1.5, 2.0, 2.5, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0];
+
+/// Candidate trailing-window lengths swept alongside `k`.
+const WINDOW_CANDIDATES: &[usize] = &[3, 5, 10];
+
+/// Target relative uncertainty on a published median.
+///
+/// One percent: tight enough that a real regression of a few percent is
+/// visible, loose enough not to demand impractical sample counts on shared
+/// hardware.
+const TARGET_MEDIAN_UNCERTAINTY: f64 = 0.01;
+
+/// The shortest sample duration that does not fight the clock.
+///
+/// Below roughly this, per-process jitter and timer resolution dominate what is
+/// supposed to be a measurement of the compiler, which is what batching exists
+/// to fix.
+const MINIMUM_SAMPLE_NS: f64 = 50_000_000.0;
+
+/// Converting MAD to a standard-deviation-equivalent for a normal distribution.
+const MAD_TO_SIGMA: f64 = 1.4826;
+
+/// The median's standard error is this factor times the mean's, asymptotically.
+const MEDIAN_EFFICIENCY: f64 = 1.2533;
+
+/// What calibration recommends for one workload.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct WorkloadCalibration {
+    /// The workload calibrated.
+    pub workload: String,
+    /// Median per-compilation latency across every calibration run, in
+    /// nanoseconds.
+    pub median_latency_ns: u64,
+    /// Relative dispersion of latency, pooled across runs.
+    pub relative_mad: f64,
+    /// Samples needed for the median's relative uncertainty to reach the
+    /// target.
+    pub recommended_samples: u32,
+    /// Compilations per sample so that a sample is long enough to measure.
+    pub recommended_batch_size: u32,
+    /// The batch size the calibration runs actually used.
+    pub observed_batch_size: u32,
+}
+
+/// One point of the multiplier sweep.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SweepPoint {
+    /// The trailing-window length.
+    pub window: usize,
+    /// The multiplier.
+    pub k: f64,
+    /// How many comparisons this pairing flagged.
+    ///
+    /// Every one is false: nothing changed between calibration runs.
+    pub false_flags: usize,
+    /// How many comparisons were possible at this window length.
+    pub comparisons: usize,
+}
+
+/// What calibration recommends for the flagging rule.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct FlaggingRecommendation {
+    /// The smallest swept `(window, k)` producing no false flags.
+    ///
+    /// Absent when even the largest candidate still flags, which means the
+    /// hardware is too noisy for this corpus and the answer is more samples or
+    /// different hardware, not a larger multiplier.
+    pub recommended_window: Option<usize>,
+    /// The recommended multiplier.
+    pub recommended_k: Option<f64>,
+    /// The full sweep, so the choice is auditable rather than asserted.
+    pub sweep: Vec<SweepPoint>,
+}
+
+/// The calibration report.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct CalibrationReport {
+    /// The platform calibrated.
+    pub platform: String,
+    /// The epoch the calibration runs used.
+    pub epoch: u32,
+    /// How many runs were analysed.
+    pub runs: usize,
+    /// How many distinct environment fingerprints appeared across them.
+    ///
+    /// More than one means the hosted runner changed underneath the
+    /// calibration, which is itself a finding: it sets expectations for how
+    /// often environment annotations will appear in real collection.
+    pub distinct_environments: usize,
+    /// Per-workload recommendations.
+    pub workloads: Vec<WorkloadCalibration>,
+    /// The flagging-rule recommendation.
+    pub flagging: FlaggingRecommendation,
+}
+
+/// Why calibration could not run.
+#[derive(Debug)]
+pub struct CalibrationError(pub String);
+
+impl std::fmt::Display for CalibrationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Load every run object in a directory.
+pub fn load_runs(directory: &Path) -> Result<Vec<RunObject>, CalibrationError> {
+    let listing = std::fs::read_dir(directory).map_err(|error| {
+        CalibrationError(format!("could not read {}: {error}", directory.display()))
+    })?;
+    let mut runs = Vec::new();
+    for entry in listing {
+        let entry = entry.map_err(|error| CalibrationError(error.to_string()))?;
+        let path = entry.path();
+        if path.extension().is_none_or(|extension| extension != "json") {
+            continue;
+        }
+        let text = std::fs::read_to_string(&path).map_err(|error| {
+            CalibrationError(format!("could not read {}: {error}", path.display()))
+        })?;
+        let run: RunObject = serde_json::from_str(&text).map_err(|error| {
+            CalibrationError(format!("{} is not a run object: {error}", path.display()))
+        })?;
+        runs.push(run);
+    }
+    // Chronological order matters: the trailing window is a window in time.
+    runs.sort_by(|left, right| left.identity.started_at.cmp(&right.identity.started_at));
+    Ok(runs)
+}
+
+/// Analyse a set of calibration runs.
+pub fn calibrate(runs: &[RunObject]) -> Result<CalibrationReport, CalibrationError> {
+    let first = runs
+        .first()
+        .ok_or_else(|| CalibrationError("no calibration runs were supplied".to_string()))?;
+
+    // Comparing across epochs would measure the configuration difference rather
+    // than the hardware's noise, which is the one thing calibration must isolate.
+    if runs.iter().any(|run| {
+        run.identity.epoch != first.identity.epoch
+            || run.identity.platform != first.identity.platform
+    }) {
+        return Err(CalibrationError(
+            "calibration runs must all come from one platform and epoch".to_string(),
+        ));
+    }
+    // The whole method depends on nothing real changing between runs.
+    if runs
+        .iter()
+        .any(|run| run.identity.commit != first.identity.commit)
+    {
+        return Err(CalibrationError(
+            "calibration runs must all measure the same compiler revision, or a flagged \
+             difference would not be known to be false"
+                .to_string(),
+        ));
+    }
+
+    let mut fingerprints: Vec<String> = runs
+        .iter()
+        .filter_map(|run| run.identity.environment.fingerprint_id().ok())
+        .collect();
+    fingerprints.sort();
+    fingerprints.dedup();
+
+    let mut workload_ids: Vec<String> = runs
+        .iter()
+        .flat_map(|run| run.workloads.iter().map(|entry| entry.workload.clone()))
+        .collect();
+    workload_ids.sort();
+    workload_ids.dedup();
+
+    let mut workloads = Vec::new();
+    for workload in &workload_ids {
+        if let Some(calibration) = calibrate_workload(runs, workload) {
+            workloads.push(calibration);
+        }
+    }
+
+    let flagging = sweep_flagging(runs, &workload_ids);
+
+    Ok(CalibrationReport {
+        platform: first.identity.platform.clone(),
+        epoch: first.identity.epoch,
+        runs: runs.len(),
+        distinct_environments: fingerprints.len(),
+        workloads,
+        flagging,
+    })
+}
+
+/// Every latency observation for one workload, pooled across runs.
+fn pooled_latencies(runs: &[RunObject], workload: &str) -> Vec<u64> {
+    runs.iter()
+        .filter_map(|run| run.observation(workload))
+        .flat_map(|observation| observation.samples.iter())
+        .map(|sample| sample_value(sample, Metric::Latency))
+        .collect()
+}
+
+fn calibrate_workload(runs: &[RunObject], workload: &str) -> Option<WorkloadCalibration> {
+    let values = pooled_latencies(runs, workload);
+    let summary = Summary::of(&values)?;
+
+    let observed_batch_size = runs
+        .iter()
+        .filter_map(|run| run.observation(workload))
+        .flat_map(|observation| observation.samples.iter())
+        .map(|sample| sample.batch_size)
+        .next()
+        .unwrap_or(1);
+
+    Some(WorkloadCalibration {
+        workload: workload.to_string(),
+        median_latency_ns: summary.median,
+        relative_mad: summary.relative_mad(),
+        recommended_samples: recommended_samples(summary.relative_mad()),
+        recommended_batch_size: recommended_batch_size(summary.median),
+        observed_batch_size,
+    })
+}
+
+/// Samples needed for the median's relative uncertainty to reach the target.
+///
+/// From the asymptotic standard error of the median, `1.2533 * sigma / sqrt(n)`,
+/// with `sigma` estimated as `1.4826 * MAD`. Clamped to a sane range: at least
+/// three samples so a median means anything, and no more than 99 so one
+/// pathologically noisy workload cannot make collection unaffordable — a
+/// recommendation at the ceiling is itself the finding.
+fn recommended_samples(relative_mad: f64) -> u32 {
+    if relative_mad <= 0.0 {
+        return 3;
+    }
+    let relative_sigma = MAD_TO_SIGMA * relative_mad;
+    let needed = (MEDIAN_EFFICIENCY * relative_sigma / TARGET_MEDIAN_UNCERTAINTY).powi(2);
+    (needed.ceil() as u64).clamp(3, 99) as u32
+}
+
+/// Compilations per sample so a sample is long enough to measure.
+fn recommended_batch_size(median_latency_ns: u64) -> u32 {
+    if median_latency_ns == 0 {
+        return 1;
+    }
+    let needed = (MINIMUM_SAMPLE_NS / median_latency_ns as f64).ceil();
+    (needed.max(1.0) as u64).clamp(1, 1000) as u32
+}
+
+/// Sweep `(window, k)` and count false flags.
+///
+/// A comparison is made for every run with a full trailing window behind it.
+/// The window's summary is taken over the *medians* of its runs, matching §5:
+/// the pooled uncertainty combines the current run's dispersion with the
+/// dispersion of the trailing window's medians.
+fn sweep_flagging(runs: &[RunObject], workloads: &[String]) -> FlaggingRecommendation {
+    let mut per_workload_medians: BTreeMap<&str, Vec<Summary>> = BTreeMap::new();
+    for workload in workloads {
+        let summaries: Vec<Summary> = runs
+            .iter()
+            .filter_map(|run| run.observation(workload))
+            .filter_map(|observation| {
+                let values: Vec<u64> = observation
+                    .samples
+                    .iter()
+                    .map(|sample| sample_value(sample, Metric::Latency))
+                    .collect();
+                Summary::of(&values)
+            })
+            .collect();
+        per_workload_medians.insert(workload.as_str(), summaries);
+    }
+
+    let mut sweep = Vec::new();
+    for &window in WINDOW_CANDIDATES {
+        for &k in K_CANDIDATES {
+            let mut false_flags = 0;
+            let mut comparisons = 0;
+            for summaries in per_workload_medians.values() {
+                if summaries.len() <= window {
+                    continue;
+                }
+                for index in window..summaries.len() {
+                    let trailing: Vec<u64> = summaries[index - window..index]
+                        .iter()
+                        .map(|summary| summary.median)
+                        .collect();
+                    let Some(window_summary) = Summary::of(&trailing) else {
+                        continue;
+                    };
+                    comparisons += 1;
+                    if flags_movement(summaries[index], window_summary, k) {
+                        false_flags += 1;
+                    }
+                }
+            }
+            sweep.push(SweepPoint {
+                window,
+                k,
+                false_flags,
+                comparisons,
+            });
+        }
+    }
+
+    // Prefer the shortest window that works, then the smallest multiplier: a
+    // shorter window reacts sooner, and a smaller multiplier detects more.
+    let clean = sweep
+        .iter()
+        .filter(|point| point.comparisons > 0 && point.false_flags == 0)
+        .min_by(|left, right| {
+            left.window.cmp(&right.window).then(
+                left.k
+                    .partial_cmp(&right.k)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            )
+        });
+
+    FlaggingRecommendation {
+        recommended_window: clean.map(|point| point.window),
+        recommended_k: clean.map(|point| point.k),
+        sweep,
+    }
+}
+
+/// Render the report as reviewable prose.
+pub fn render(report: &CalibrationReport) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "# Calibration: {} epoch {}\n\n{} runs, {} distinct environment fingerprint(s).\n\n",
+        report.platform, report.epoch, report.runs, report.distinct_environments
+    ));
+    if report.distinct_environments > 1 {
+        out.push_str(
+            "The hosted runner changed underneath this calibration. That sets the expectation \
+             for how often environment annotations will appear in real collection.\n\n",
+        );
+    }
+
+    out.push_str("## Per-workload\n\n");
+    out.push_str("| workload | median | rel. MAD | samples | batch (observed) |\n");
+    out.push_str("| --- | ---: | ---: | ---: | ---: |\n");
+    for workload in &report.workloads {
+        out.push_str(&format!(
+            "| {} | {:.3} ms | {:.2}% | {} | {} ({}) |\n",
+            workload.workload,
+            workload.median_latency_ns as f64 / 1e6,
+            workload.relative_mad * 100.0,
+            workload.recommended_samples,
+            workload.recommended_batch_size,
+            workload.observed_batch_size,
+        ));
+    }
+
+    out.push_str("\n## Flagging rule\n\n");
+    match (
+        report.flagging.recommended_window,
+        report.flagging.recommended_k,
+    ) {
+        (Some(window), Some(k)) => out.push_str(&format!(
+            "Recommended: k = {k}, window = {window}. Smallest swept pairing with no false \
+             flags across runs of one unchanged revision.\n\n",
+        )),
+        _ => out.push_str(
+            "No swept pairing eliminated false flags. The hardware is noisier than this corpus \
+             can absorb; the answer is more samples or different hardware, not a larger \
+             multiplier.\n\n",
+        ),
+    }
+    out.push_str("| window | k | false flags | comparisons |\n| ---: | ---: | ---: | ---: |\n");
+    for point in &report.flagging.sweep {
+        if point.comparisons == 0 {
+            continue;
+        }
+        out.push_str(&format!(
+            "| {} | {} | {} | {} |\n",
+            point.window, point.k, point.false_flags, point.comparisons
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rue_perf_schema::{
+        EnvironmentFingerprint, Invocation, Phase, PhaseAccounting, RUN_SCHEMA_VERSION,
+        ResolvedPins, RunIdentity, Sample, WorkloadObservation,
+    };
+
+    fn sample(latency_ns: u64, batch: u32) -> Sample {
+        let phase_ns: BTreeMap<Phase, u64> =
+            Phase::ALL.into_iter().map(|phase| (phase, 0)).collect();
+        Sample {
+            batch_size: batch,
+            process_elapsed_ns: latency_ns * u64::from(batch) + 1,
+            peak_memory_bytes: 1024,
+            output_binary_bytes: 512,
+            phases: PhaseAccounting {
+                phase_ns,
+                mixed_parallel_ns: 0,
+                unattributed_ns: 0,
+                compiler_root_ns: latency_ns * u64::from(batch),
+            },
+        }
+    }
+
+    fn run(index: u32, latencies: &[u64], batch: u32) -> RunObject {
+        RunObject {
+            schema_version: RUN_SCHEMA_VERSION,
+            identity: RunIdentity {
+                suite_revision: 1,
+                epoch: 1,
+                platform: "aarch64-macos".to_string(),
+                commit: "a".repeat(40),
+                started_at: format!("2026-07-28T00:{index:02}:00Z"),
+                finished_at: format!("2026-07-28T00:{index:02}:30Z"),
+                pins: ResolvedPins {
+                    toolchain_hash: "t".to_string(),
+                    stdlib_hash: "s".to_string(),
+                    workload_source_hashes: BTreeMap::new(),
+                    invocation: Invocation {
+                        target: "aarch64-apple-darwin".to_string(),
+                        args: Vec::new(),
+                    },
+                },
+                environment: EnvironmentFingerprint {
+                    runner_label: "github-hosted".to_string(),
+                    runner_image: "macos-15".to_string(),
+                    runner_image_version: "macos15/1.0".to_string(),
+                    cpu_model: "Apple M2".to_string(),
+                    core_count: 4,
+                    memory_bytes: 1,
+                    kernel_version: "probe".to_string(),
+                    os_version: "probe".to_string(),
+                    architecture: "aarch64".to_string(),
+                },
+            },
+            workloads: vec![WorkloadObservation {
+                workload: "startup".to_string(),
+                samples: latencies.iter().map(|ns| sample(*ns, batch)).collect(),
+            }],
+            failures: Vec::new(),
+        }
+    }
+
+    fn quiet_runs(count: u32) -> Vec<RunObject> {
+        (0..count)
+            .map(|index| {
+                run(
+                    index,
+                    &[1_000_000, 1_001_000, 999_000, 1_000_500, 1_000_000],
+                    1,
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn calibration_refuses_runs_of_different_revisions() {
+        // The whole method rests on nothing real changing between runs.
+        let mut runs = quiet_runs(4);
+        runs[2].identity.commit = "b".repeat(40);
+        let error = calibrate(&runs).unwrap_err();
+        assert!(
+            error.to_string().contains("same compiler revision"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn calibration_refuses_runs_from_different_epochs() {
+        let mut runs = quiet_runs(4);
+        runs[1].identity.epoch = 2;
+        assert!(calibrate(&runs).is_err());
+    }
+
+    #[test]
+    fn calibration_needs_at_least_one_run() {
+        assert!(calibrate(&[]).is_err());
+    }
+
+    #[test]
+    fn quiet_hardware_yields_a_small_multiplier_and_few_samples() {
+        let report = calibrate(&quiet_runs(12)).unwrap();
+        assert_eq!(report.runs, 12);
+        assert_eq!(report.distinct_environments, 1);
+
+        let workload = &report.workloads[0];
+        assert!(workload.relative_mad < 0.01, "{}", workload.relative_mad);
+        assert!(
+            workload.recommended_samples <= 10,
+            "{}",
+            workload.recommended_samples
+        );
+
+        // Identical runs cannot produce a false flag at any multiplier, so the
+        // sweep settles on the shortest window and smallest k.
+        assert_eq!(report.flagging.recommended_window, Some(3));
+        assert_eq!(report.flagging.recommended_k, Some(1.0));
+    }
+
+    #[test]
+    fn noisy_hardware_demands_a_larger_multiplier() {
+        // Run-to-run medians swing widely, so small multipliers flag.
+        let latencies = [
+            vec![1_000_000, 1_010_000, 990_000],
+            vec![1_400_000, 1_390_000, 1_410_000],
+            vec![1_000_000, 1_005_000, 995_000],
+            vec![1_500_000, 1_490_000, 1_510_000],
+            vec![1_000_000, 1_002_000, 998_000],
+            vec![1_600_000, 1_590_000, 1_610_000],
+            vec![1_000_000, 1_004_000, 996_000],
+            vec![1_450_000, 1_440_000, 1_460_000],
+        ];
+        let runs: Vec<RunObject> = latencies
+            .iter()
+            .enumerate()
+            .map(|(index, values)| run(index as u32, values, 1))
+            .collect();
+        let report = calibrate(&runs).unwrap();
+
+        let smallest = report
+            .flagging
+            .sweep
+            .iter()
+            .find(|point| point.window == 3 && point.k == 1.0)
+            .unwrap();
+        assert!(smallest.false_flags > 0, "noisy data must flag at k = 1");
+
+        // Whatever it recommends must genuinely be clean at that pairing.
+        if let (Some(window), Some(k)) = (
+            report.flagging.recommended_window,
+            report.flagging.recommended_k,
+        ) {
+            let chosen = report
+                .flagging
+                .sweep
+                .iter()
+                .find(|point| point.window == window && point.k == k)
+                .unwrap();
+            assert_eq!(chosen.false_flags, 0);
+        }
+    }
+
+    #[test]
+    fn a_noisier_workload_is_recommended_more_samples() {
+        assert!(recommended_samples(0.05) > recommended_samples(0.005));
+    }
+
+    #[test]
+    fn sample_recommendations_stay_within_a_usable_range() {
+        // A floor so a median means something, a ceiling so one pathological
+        // workload cannot make collection unaffordable.
+        assert_eq!(recommended_samples(0.0), 3);
+        assert_eq!(recommended_samples(f64::MAX), 99);
+        assert!((3..=99).contains(&recommended_samples(0.02)));
+    }
+
+    #[test]
+    fn a_short_workload_is_recommended_batching_and_a_long_one_is_not() {
+        // 1 ms per compile needs batching to clear the measurement floor.
+        assert!(recommended_batch_size(1_000_000) > 1);
+        // 200 ms per compile is already well clear of it.
+        assert_eq!(recommended_batch_size(200_000_000), 1);
+    }
+
+    #[test]
+    fn batched_runs_report_per_compilation_latency() {
+        // Batching must not inflate the recommendation: a 1 ms compile measured
+        // in batches of 50 is still a 1 ms compile.
+        let runs: Vec<RunObject> = (0..4)
+            .map(|index| run(index, &[1_000_000, 1_000_000, 1_000_000], 50))
+            .collect();
+        let report = calibrate(&runs).unwrap();
+        assert_eq!(report.workloads[0].median_latency_ns, 1_000_000);
+        assert_eq!(report.workloads[0].observed_batch_size, 50);
+    }
+
+    #[test]
+    fn environment_drift_across_calibration_is_counted_and_surfaced() {
+        let mut runs = quiet_runs(6);
+        runs[3].identity.environment.runner_image_version = "macos15/2.0".to_string();
+        let report = calibrate(&runs).unwrap();
+        assert_eq!(report.distinct_environments, 2);
+        assert!(render(&report).contains("changed underneath"));
+    }
+
+    #[test]
+    fn the_report_renders_its_sweep_for_audit() {
+        let report = calibrate(&quiet_runs(8)).unwrap();
+        let rendered = render(&report);
+        assert!(rendered.contains("aarch64-macos"));
+        assert!(rendered.contains("Flagging rule"));
+        assert!(rendered.contains("startup"));
+        // The full sweep is shown, so a recommendation can be checked rather
+        // than taken on faith.
+        assert!(rendered.matches('|').count() > 20);
+    }
+
+    #[test]
+    fn runs_are_analysed_in_chronological_order() {
+        // The trailing window is a window in time; loading must not depend on
+        // filesystem ordering.
+        let directory = tempfile::tempdir().unwrap();
+        for index in [2u32, 0, 1] {
+            let run = run(index, &[1_000_000], 1);
+            std::fs::write(
+                directory.path().join(format!("{index}.json")),
+                serde_json::to_string(&run).unwrap(),
+            )
+            .unwrap();
+        }
+        let loaded = load_runs(directory.path()).unwrap();
+        let starts: Vec<&str> = loaded
+            .iter()
+            .map(|run| run.identity.started_at.as_str())
+            .collect();
+        assert_eq!(
+            starts,
+            vec![
+                "2026-07-28T00:00:00Z",
+                "2026-07-28T00:01:00Z",
+                "2026-07-28T00:02:00Z"
+            ]
+        );
+    }
+}

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -12,6 +12,7 @@
 //! out of the producer is what lets validation catch a producer that is itself
 //! wrong.
 
+mod calibrate;
 mod environment;
 mod measure;
 mod pins;
@@ -65,6 +66,12 @@ Required:
   --commit <sha>       40-character compiler revision being measured
   --out <path>         where to write the run object
 
+Subcommands:
+  calibrate --runs <dir> [--report <path>]
+                       analyse repeated runs and recommend sampling counts,
+                       batching factors, and the flagging rule. Produces
+                       artifacts only; nothing here enters a series.
+
 Optional:
   --repo-root <path>   root for resolving workload sources (default: .)
   --std-root <path>    standard-library root (default: <repo-root>/std)
@@ -72,6 +79,18 @@ Optional:
 ";
 
 fn main() -> ExitCode {
+    // `calibrate` reads runs that already exist; every other invocation
+    // produces one. Keeping them one binary means the calibration analysis and
+    // the collector can never disagree about what a run object means.
+    if std::env::args().nth(1).as_deref() == Some("calibrate") {
+        return match run_calibration() {
+            Ok(()) => ExitCode::from(exit::OK),
+            Err(message) => {
+                eprintln!("rue-bench: {message}");
+                ExitCode::from(exit::USAGE)
+            }
+        };
+    }
     let options = match parse_args() {
         Ok(options) => options,
         Err(message) => {
@@ -86,6 +105,45 @@ fn main() -> ExitCode {
             ExitCode::from(exit::USAGE)
         }
     }
+}
+
+/// Analyse a directory of calibration runs.
+///
+/// Nothing this produces may enter a series. The report is a workflow artifact
+/// and a recommendation for a maintainer, not a measurement.
+fn run_calibration() -> Result<(), String> {
+    let mut runs_dir = None;
+    let mut report_path = None;
+    let mut args = std::env::args().skip(2);
+    while let Some(flag) = args.next() {
+        let mut value = || {
+            args.next()
+                .ok_or_else(|| format!("{flag} requires a value"))
+        };
+        match flag.as_str() {
+            "--runs" => runs_dir = Some(PathBuf::from(value()?)),
+            "--report" => report_path = Some(PathBuf::from(value()?)),
+            other => return Err(format!("unrecognized argument {other:?}")),
+        }
+    }
+    let runs_dir = runs_dir.ok_or("calibrate requires --runs <directory>")?;
+
+    let runs = calibrate::load_runs(&runs_dir).map_err(|error| error.to_string())?;
+    let report = calibrate::calibrate(&runs).map_err(|error| error.to_string())?;
+    let rendered = calibrate::render(&report);
+
+    if let Some(path) = report_path {
+        std::fs::write(&path, &rendered)
+            .map_err(|error| format!("could not write {}: {error}", path.display()))?;
+        let json = path.with_extension("json");
+        let encoded = serde_json::to_string_pretty(&report)
+            .map_err(|error| format!("could not serialize the report: {error}"))?;
+        std::fs::write(&json, encoded)
+            .map_err(|error| format!("could not write {}: {error}", json.display()))?;
+        eprintln!("rue-bench: wrote {} and {}", path.display(), json.display());
+    }
+    println!("{rendered}");
+    Ok(())
 }
 
 fn parse_args() -> Result<Options, String> {

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -35,6 +35,7 @@ mod canonical;
 mod manifest;
 mod run;
 mod series;
+mod stats;
 mod validate;
 
 pub use canonical::{CanonicalError, canonical_json, content_address};
@@ -47,6 +48,10 @@ pub use run::{
     RunIdentity, RunObject, Sample, WorkloadObservation,
 };
 pub use series::{Metric, SeriesId};
+pub use stats::{
+    Summary, flags_movement, geometric_mean, median, median_absolute_deviation, pooled_uncertainty,
+    ratio, sample_value,
+};
 pub use validate::{
     Completeness, InvalidSample, InvalidSampleReason, ValidationError, ValidationOutcome,
     validate_run,

--- a/crates/rue-perf-schema/src/stats.rs
+++ b/crates/rue-perf-schema/src/stats.rs
@@ -1,0 +1,385 @@
+//! Robust statistics over raw samples.
+//!
+//! Everything here is derived, never stored. It lives with the schema rather
+//! than in one consumer because the calibrator and the dashboard must agree
+//! exactly on what "moved" means — two implementations of the flagging rule
+//! would drift, and the one that drifted would be the one declaring
+//! regressions.
+//!
+//! Medians and MAD rather than means and standard deviations: a single
+//! descheduled sample on a hosted runner is a large outlier, and the mean would
+//! carry it into the published figure.
+
+use crate::run::Sample;
+use crate::series::Metric;
+
+/// The value one sample contributes for a metric.
+///
+/// Batched samples report the batch's total, so latency is divided back down to
+/// a per-compilation figure. Memory and binary size are properties of a single
+/// compilation regardless of batching, so they are taken as-is.
+pub fn sample_value(sample: &Sample, metric: Metric) -> u64 {
+    match metric {
+        Metric::Latency => {
+            let batch = u64::from(sample.batch_size).max(1);
+            sample.phases.compiler_root_ns / batch
+        }
+        Metric::PeakMemory => sample.peak_memory_bytes,
+        Metric::BinarySize => sample.output_binary_bytes,
+    }
+}
+
+/// The median of a set of observations.
+///
+/// Even-sized sets average the two central values, rounding down. Returns
+/// `None` for an empty set: there is no median of nothing, and inventing zero
+/// would silently poison every comparison downstream.
+pub fn median(values: &[u64]) -> Option<u64> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+    let middle = sorted.len() / 2;
+    Some(if sorted.len() % 2 == 1 {
+        sorted[middle]
+    } else {
+        // Averaged as u128 so two large values cannot overflow on the way to a
+        // value that would have fit.
+        ((u128::from(sorted[middle - 1]) + u128::from(sorted[middle])) / 2) as u64
+    })
+}
+
+/// Median absolute deviation: the median of `|value - median|`.
+///
+/// This is the dispersion measure the system publishes. Unlike a standard
+/// deviation it does not move when one sample is wild, which on shared hosted
+/// hardware is the common case rather than the exception.
+pub fn median_absolute_deviation(values: &[u64]) -> Option<u64> {
+    let center = median(values)?;
+    let deviations: Vec<u64> = values.iter().map(|value| value.abs_diff(center)).collect();
+    median(&deviations)
+}
+
+/// Median and dispersion together, the pair every published figure carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Summary {
+    /// The median observation.
+    pub median: u64,
+    /// The median absolute deviation.
+    pub mad: u64,
+    /// How many observations went into it.
+    pub count: usize,
+}
+
+impl Summary {
+    /// Summarize a set of observations.
+    pub fn of(values: &[u64]) -> Option<Summary> {
+        Some(Summary {
+            median: median(values)?,
+            mad: median_absolute_deviation(values)?,
+            count: values.len(),
+        })
+    }
+
+    /// Dispersion as a fraction of the median.
+    ///
+    /// The comparable figure across workloads of wildly different absolute
+    /// cost, and the one calibration reads to choose sample counts.
+    pub fn relative_mad(&self) -> f64 {
+        if self.median == 0 {
+            return 0.0;
+        }
+        self.mad as f64 / self.median as f64
+    }
+}
+
+/// Whether a current observation counts as movement against a trailing window.
+///
+/// Implements ADR-0067 §5: flag only when the difference between the current
+/// median and the trailing-window median exceeds `k` times the pooled
+/// uncertainty of the two. Anything inside that bound is uncertain, not
+/// movement, and renders as such.
+///
+/// Pooling is in quadrature, treating the two dispersions as independent. That
+/// is an approximation — successive runs on one hosted runner are not fully
+/// independent — and it errs toward a *smaller* pooled figure than simple
+/// addition would give, so `k` is what absorbs the difference. Calibration
+/// chooses `k` against real data rather than deriving it, which is why the
+/// approximation is acceptable here.
+pub fn flags_movement(current: Summary, window: Summary, k: f64) -> bool {
+    let difference = current.median.abs_diff(window.median) as f64;
+    let pooled = pooled_uncertainty(current, window);
+    // A zero pooled uncertainty means both sets were perfectly consistent. Any
+    // real difference is then movement; an identical median is not.
+    if pooled == 0.0 {
+        return difference > 0.0;
+    }
+    difference > k * pooled
+}
+
+/// The pooled uncertainty of two summaries, combined in quadrature.
+pub fn pooled_uncertainty(current: Summary, window: Summary) -> f64 {
+    let a = current.mad as f64;
+    let b = window.mad as f64;
+    (a * a + b * b).sqrt()
+}
+
+/// The ratio of an observation to its baseline, as used by the headline index.
+///
+/// `None` when the baseline is zero, which is not a ratio and must not become
+/// one.
+pub fn ratio(observed: u64, baseline: u64) -> Option<f64> {
+    (baseline != 0).then(|| observed as f64 / baseline as f64)
+}
+
+/// The geometric mean of per-workload ratios: the headline index.
+///
+/// Equal weighting in log space, so corpus mass cannot weight the aggregate —
+/// which is the defect that made the previous system's headline move for
+/// reasons unrelated to the compiler. The cost is attenuation: a 10% regression
+/// in one of *n* workloads moves this by roughly 10%/*n*, which is why the index
+/// answers "is anything moving" and the per-workload views answer "how much".
+///
+/// `None` for an empty set or any non-positive ratio, since the logarithm of a
+/// non-positive number is not a number this can average.
+pub fn geometric_mean(ratios: &[f64]) -> Option<f64> {
+    if ratios.is_empty() || ratios.iter().any(|ratio| *ratio <= 0.0) {
+        return None;
+    }
+    let sum: f64 = ratios.iter().map(|ratio| ratio.ln()).sum();
+    Some((sum / ratios.len() as f64).exp())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn medians_handle_both_parities() {
+        assert_eq!(median(&[3, 1, 2]), Some(2));
+        assert_eq!(median(&[4, 1, 3, 2]), Some(2));
+        assert_eq!(median(&[7]), Some(7));
+    }
+
+    #[test]
+    fn there_is_no_median_of_nothing() {
+        // Returning zero would silently poison every ratio computed from it.
+        assert_eq!(median(&[]), None);
+        assert_eq!(median_absolute_deviation(&[]), None);
+        assert_eq!(Summary::of(&[]), None);
+    }
+
+    #[test]
+    fn averaging_two_large_medians_does_not_overflow() {
+        assert_eq!(median(&[u64::MAX, u64::MAX]), Some(u64::MAX));
+    }
+
+    #[test]
+    fn the_median_resists_a_single_wild_sample() {
+        // The case this whole choice exists for: one descheduled sample on a
+        // shared runner must not move the published figure.
+        let clean = [100, 101, 99, 100, 102];
+        let with_outlier = [100, 101, 99, 100, 100_000];
+        assert_eq!(median(&clean), Some(100));
+        assert_eq!(median(&with_outlier), Some(100));
+    }
+
+    #[test]
+    fn dispersion_measures_spread_not_magnitude() {
+        let tight = Summary::of(&[1000, 1001, 999, 1000]).unwrap();
+        let loose = Summary::of(&[1000, 1200, 800, 1000]).unwrap();
+        assert!(tight.mad < loose.mad);
+        assert!(tight.relative_mad() < loose.relative_mad());
+    }
+
+    #[test]
+    fn relative_dispersion_is_comparable_across_scales() {
+        // Two workloads a thousandfold apart in cost, equally noisy in
+        // proportion, must report the same relative figure.
+        let small = Summary::of(&[100, 110, 90, 100]).unwrap();
+        let large = Summary::of(&[100_000, 110_000, 90_000, 100_000]).unwrap();
+        assert!((small.relative_mad() - large.relative_mad()).abs() < 1e-12);
+    }
+
+    #[test]
+    fn a_zero_median_reports_no_relative_dispersion_rather_than_dividing() {
+        let zeroed = Summary::of(&[0, 0, 0]).unwrap();
+        assert_eq!(zeroed.relative_mad(), 0.0);
+    }
+
+    #[test]
+    fn movement_inside_the_uncertainty_bound_is_not_flagged() {
+        let current = Summary {
+            median: 1050,
+            mad: 40,
+            count: 9,
+        };
+        let window = Summary {
+            median: 1000,
+            mad: 40,
+            count: 9,
+        };
+        // Difference 50 against pooled ~56.6; at k=3 the bound is ~170.
+        assert!(!flags_movement(current, window, 3.0));
+    }
+
+    #[test]
+    fn movement_beyond_the_bound_is_flagged() {
+        let current = Summary {
+            median: 1400,
+            mad: 40,
+            count: 9,
+        };
+        let window = Summary {
+            median: 1000,
+            mad: 40,
+            count: 9,
+        };
+        assert!(flags_movement(current, window, 3.0));
+    }
+
+    #[test]
+    fn a_larger_multiplier_flags_strictly_less() {
+        let current = Summary {
+            median: 1200,
+            mad: 40,
+            count: 9,
+        };
+        let window = Summary {
+            median: 1000,
+            mad: 40,
+            count: 9,
+        };
+        assert!(flags_movement(current, window, 3.0));
+        assert!(!flags_movement(current, window, 10.0));
+    }
+
+    #[test]
+    fn noisier_data_raises_the_bar_for_the_same_difference() {
+        let window = Summary {
+            median: 1000,
+            mad: 40,
+            count: 9,
+        };
+        let noisy_window = Summary {
+            median: 1000,
+            mad: 400,
+            count: 9,
+        };
+        let current = Summary {
+            median: 1200,
+            mad: 40,
+            count: 9,
+        };
+        assert!(flags_movement(current, window, 3.0));
+        assert!(!flags_movement(current, noisy_window, 3.0));
+    }
+
+    #[test]
+    fn perfect_consistency_flags_any_real_difference_but_not_equality() {
+        let current = Summary {
+            median: 1001,
+            mad: 0,
+            count: 9,
+        };
+        let same = Summary {
+            median: 1000,
+            mad: 0,
+            count: 9,
+        };
+        assert!(flags_movement(current, same, 3.0));
+        assert!(!flags_movement(same, same, 3.0));
+    }
+
+    #[test]
+    fn flagging_is_symmetric_in_direction() {
+        // An improvement of the same size as a regression is equally movement;
+        // the rule detects change, and direction is presentation.
+        let window = Summary {
+            median: 1000,
+            mad: 40,
+            count: 9,
+        };
+        let faster = Summary {
+            median: 600,
+            mad: 40,
+            count: 9,
+        };
+        let slower = Summary {
+            median: 1400,
+            mad: 40,
+            count: 9,
+        };
+        assert!(flags_movement(faster, window, 3.0));
+        assert!(flags_movement(slower, window, 3.0));
+    }
+
+    #[test]
+    fn the_index_is_one_at_the_baseline() {
+        assert_eq!(geometric_mean(&[1.0, 1.0, 1.0]), Some(1.0));
+    }
+
+    #[test]
+    fn the_index_weights_workloads_equally_regardless_of_cost() {
+        // The defect that motivated the reset: a corpus reweighting must not
+        // move the headline. Two workloads, one a thousandfold more expensive,
+        // each regressed 10% — the index moves 10%, not somewhere between.
+        let index = geometric_mean(&[1.1, 1.1]).unwrap();
+        assert!((index - 1.1).abs() < 1e-12);
+    }
+
+    #[test]
+    fn the_index_attenuates_a_single_workload_regression() {
+        // Documents the acknowledged cost: a 10% regression in one of four
+        // workloads moves the index by roughly 10%/4.
+        let index = geometric_mean(&[1.1, 1.0, 1.0, 1.0]).unwrap();
+        assert!(index > 1.02 && index < 1.03, "{index}");
+    }
+
+    #[test]
+    fn the_index_is_symmetric_in_log_space() {
+        // A halving and a doubling cancel, which an arithmetic mean would not
+        // manage — it would report 1.25.
+        let index = geometric_mean(&[0.5, 2.0]).unwrap();
+        assert!((index - 1.0).abs() < 1e-12, "{index}");
+    }
+
+    #[test]
+    fn a_non_positive_ratio_has_no_index() {
+        assert_eq!(geometric_mean(&[1.0, 0.0]), None);
+        assert_eq!(geometric_mean(&[]), None);
+    }
+
+    #[test]
+    fn a_zero_baseline_yields_no_ratio() {
+        assert_eq!(ratio(100, 0), None);
+        assert_eq!(ratio(100, 50), Some(2.0));
+    }
+
+    #[test]
+    fn batched_latency_is_reported_per_compilation() {
+        use crate::run::{Phase, PhaseAccounting};
+        use std::collections::BTreeMap;
+
+        let phase_ns: BTreeMap<Phase, u64> =
+            Phase::ALL.into_iter().map(|phase| (phase, 0)).collect();
+        let sample = Sample {
+            batch_size: 40,
+            process_elapsed_ns: 1,
+            peak_memory_bytes: 4096,
+            output_binary_bytes: 512,
+            phases: PhaseAccounting {
+                phase_ns,
+                mixed_parallel_ns: 0,
+                unattributed_ns: 0,
+                compiler_root_ns: 40_000,
+            },
+        };
+        // Latency divides by the batch; the other metrics are per-compilation
+        // properties already and must not be.
+        assert_eq!(sample_value(&sample, Metric::Latency), 1_000);
+        assert_eq!(sample_value(&sample, Metric::PeakMemory), 4096);
+        assert_eq!(sample_value(&sample, Metric::BinarySize), 512);
+    }
+}

--- a/performance/manifest.toml
+++ b/performance/manifest.toml
@@ -58,3 +58,94 @@ batch_size = 5
 [epoch.flagging]
 k = 3.0
 window = 10
+
+# Calibration epochs (ADR-0067 Phase 4, RUE-1187).
+#
+# These exist so the calibration workflow has a sampling policy and an
+# environment policy to follow on each hosted platform. They are NOT collection
+# targets, and the content pins below are deliberate placeholders.
+#
+# That is sound because calibration does not compare across revisions: it
+# measures the dispersion of one unchanged revision, so comparability — which is
+# what the pins protect — is not in question. The runner reports a pin mismatch
+# and exits 3, and the workflow tolerates exactly that exit while still treating
+# a runner failure as fatal.
+#
+# The collection epochs, with pins that resolve and with the counts, batching
+# factors, and flagging multiplier this calibration produces, are declared in
+# RUE-1188. `aarch64-macos` is included from the start by maintainer decision,
+# which is also why its noise profile is the most interesting output here.
+
+[[epoch]]
+id = 1
+platform = "x86_64-linux"
+suite_revision = 1
+target = "x86_64-unknown-linux-gnu"
+args = []
+toolchain_hash = "calibration-epoch-pins-are-placeholders"
+stdlib_hash = "calibration-epoch-pins-are-placeholders"
+
+[epoch.workload_source_hashes]
+startup = "calibration-epoch-pins-are-placeholders"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+# Uncalibrated starting points. The whole purpose of the sweep is to replace
+# these with measured values, so treating them as meaningful would be circular.
+[epoch.sampling.startup]
+samples = 9
+batch_size = 5
+
+[epoch.flagging]
+k = 3.0
+window = 5
+
+[[epoch]]
+id = 1
+platform = "aarch64-linux"
+suite_revision = 1
+target = "aarch64-unknown-linux-gnu"
+args = []
+toolchain_hash = "calibration-epoch-pins-are-placeholders"
+stdlib_hash = "calibration-epoch-pins-are-placeholders"
+
+[epoch.workload_source_hashes]
+startup = "calibration-epoch-pins-are-placeholders"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+[epoch.sampling.startup]
+samples = 9
+batch_size = 5
+
+[epoch.flagging]
+k = 3.0
+window = 5
+
+[[epoch]]
+id = 1
+platform = "aarch64-macos"
+suite_revision = 1
+target = "aarch64-apple-darwin"
+args = []
+toolchain_hash = "calibration-epoch-pins-are-placeholders"
+stdlib_hash = "calibration-epoch-pins-are-placeholders"
+
+[epoch.workload_source_hashes]
+startup = "calibration-epoch-pins-are-placeholders"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "macos-15"
+
+[epoch.sampling.startup]
+samples = 9
+batch_size = 5
+
+[epoch.flagging]
+k = 3.0
+window = 5


### PR DESCRIPTION
Phase 4 of ADR-0067. Establishes the empirical constants the epochs pin — sample counts, batching factors, the flagging multiplier `k`, and the trailing-window length — none of which the ADR fixes, deliberately, until there is evidence.

`aarch64-macos` is in the matrix from the start per your call. That's also what makes it the most interesting output here: hosted macOS runners show the most environment churn, and the report counts distinct environment fingerprints so that churn gets quantified rather than assumed.

## The method

Every calibration run measures the **same compiler revision**, so nothing real is changing. Any difference the flagging rule reports is therefore a false positive *by construction*, and `k` can be chosen as the smallest multiplier producing none. That's a measurement of the hardware's noise rather than a guess dressed up as a threshold.

The analysis refuses runs of differing revisions, platforms, or epochs, since each breaks the assumption the method rests on:

```
calibration runs must all measure the same compiler revision, or a flagged
difference would not be known to be false
```

## Recommendations are derived, not asserted

- **Sample counts** from the asymptotic standard error of the median (`1.2533 · σ / √n`, σ estimated as `1.4826 · MAD`), solved for 1% relative uncertainty and clamped to 3–99. A recommendation sitting at the ceiling is itself the finding, not a number to use.
- **Batching factors** from the sample duration below which per-process jitter and timer resolution dominate.
- **`(window, k)`** by sweep, reported in full so a choice can be checked instead of taken on faith. Preference is the shortest window then the smallest multiplier — a shorter window reacts sooner, a smaller multiplier detects more.

A sweep that never reaches zero false flags says so plainly: *the hardware is noisier than this corpus can absorb; the answer is more samples or different hardware, not a larger multiplier.*

## Where the statistics live

In `rue-perf-schema`, not the runner. The calibrator and the Phase 6 dashboard must agree exactly on what "moved" means — two implementations of the flagging rule would drift, and the one that drifted would be the one declaring regressions. This also front-loads the index maths Phase 6 needs.

Medians and MAD throughout: one descheduled sample on a shared runner is a large outlier, and a mean would carry it into the published figure. There's a test pinning exactly that (`the_median_resists_a_single_wild_sample`), and one pinning the index's equal weighting against the corpus-mass defect that motivated the reset, plus one documenting its acknowledged 1/n attenuation.

## Structural guarantee

The workflow holds **no write permission**, so "nothing here enters a series" is structural rather than a convention — there is no path from a calibration artifact to published history. It also never cancels in progress: two overlapping runs on one runner would measure each other, and a truncated sweep is not usable.

## Local verification

Six runs through the analysis on this host:

```
| workload | median    | rel. MAD | samples | batch (observed) |
| startup  | 32.800 ms |    1.30% |       6 |            2 (5) |

Recommended: k = 1.5, window = 3.

| window | k   | false flags | comparisons |
|      3 | 1   |           1 |           3 |
|      3 | 1.5 |           0 |           3 |
```

It caught the false flag at `k = 1` and settled at 1.5. Six runs on a noisy shared container — the mechanism is what's demonstrated, not the numbers.

## Calibration epochs

Declared for the three hosted platforms with placeholder content pins. That's sound because calibration doesn't compare across revisions — comparability, which is what pins protect, isn't in question. The workflow tolerates the resulting exit 3 while still treating a runner failure (exit 2) as fatal.

## Validation

- `//crates/rue-bench:rue-bench-test` — 34 tests. `//crates/rue-perf-schema:rue-perf-schema-test` — 93 tests.
- `scripts/rue quick` — 30 targets. `scripts/rue fmt`.
- End-to-end: 6 real runs → analysis → rendered report, shown above.

## What happens after this merges

I'll trigger the workflow on all three platforms, read the artifacts, and bring you the numbers before Phase 5 declares anything. Constants are cheap to change now and expensive once epochs are declared and baselines are set.

Refs RUE-1182, RUE-1187.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKydRZPZurnmNTMHxDqZK2)_