### PR TITLE
RUE-1187: use upload-artifact v6 in the calibration workflow

### DIFF
--- a/.github/workflows/performance-calibration.yml
+++ b/.github/workflows/performance-calibration.yml
@@ -111,7 +111,7 @@ jobs:
             --report "calibration-${{ matrix.platform }}.md"
 
       - name: Upload calibration artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: calibration-${{ matrix.platform }}
           path: |


### PR DESCRIPTION
The calibration workflow pinned `actions/upload-artifact@v4`, which targets Node 20 and emits a deprecation warning on every run:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/upload-artifact@v4.
```

The rest of the repository is already on v6 (`ci.yml` ×2, `fuzz.yml`, `correctness-repetitions.yml`), so this was my outlier, introduced in #2028.

`.github/workflows/cache-probe.yml:77` still pins v4 and emits the same warning. That one predates this work, so I've left it alone rather than widening scope — happy to bump it too if you'd like it consistent.

Refs RUE-1182, RUE-1187.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKydRZPZurnmNTMHxDqZK2)_