### PR TITLE
RUE-1189: render the compiler-performance dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ third-party/.cargo/.global-cache/
 # Python bytecode from repository tooling scripts.
 __pycache__/
 *.pyc
+
+# Derived at site build time from the raw records on performance-data-v1
+# (ADR-0067). Never committed: a stored derived value would eventually disagree
+# with the observations it came from, and the stored copy is the one that would
+# be believed.
+website/static/performance-data.json

--- a/crates/rue-bench/src/derive.rs
+++ b/crates/rue-bench/src/derive.rs
@@ -347,17 +347,23 @@ fn derive_epoch(
             };
             past.push(summary);
 
+            // Everything here is per compilation, matching `sample_value`'s
+            // latency convention. Mixing a per-compilation band with a
+            // per-batch total would make the stack fail to sum to its own
+            // reported total by exactly the batch size.
             let bands_ns = average_bands(&valid);
-            let compiler_root_ns = mean(
-                &valid
-                    .iter()
-                    .map(|sample| sample.phases.compiler_root_ns)
-                    .collect::<Vec<_>>(),
-            );
+            // The reported root is the sum of the averaged bands, not an
+            // independently averaged root. Each band's mean truncates, so an
+            // independent average would miss their sum by up to a nanosecond
+            // per band — and a stack that does not add up to its own stated
+            // total is the exact dishonesty the additive model exists to
+            // prevent. Defining the total as the sum makes it hold by
+            // construction rather than by luck.
+            let compiler_root_ns = bands_ns.values().sum();
             let process_elapsed_ns = mean(
                 &valid
                     .iter()
-                    .map(|sample| sample.process_elapsed_ns)
+                    .map(|sample| sample.process_elapsed_ns / u64::from(sample.batch_size).max(1))
                     .collect::<Vec<_>>(),
             );
 
@@ -537,6 +543,11 @@ mod tests {
         ResolvedPins, RunIdentity, Sample, WorkloadObservation,
     };
 
+    fn manifest_for_batch(batch_size: u32) -> Manifest {
+        Manifest::parse(&MANIFEST.replace("batch_size = 1", &format!("batch_size = {batch_size}")))
+            .expect("fixture manifest")
+    }
+
     const MANIFEST: &str = r#"
 [[suite]]
 revision = 1
@@ -588,6 +599,17 @@ window = 3
     }
 
     fn run_at(commit: &str, finished: &str, latencies: [u64; 3]) -> RunObject {
+        run_at_batched(commit, finished, latencies, 1)
+    }
+
+    /// A batch size greater than one is the case that matters: it is the only
+    /// way a per-compilation band and a per-batch total can disagree.
+    fn run_at_batched(
+        commit: &str,
+        finished: &str,
+        latencies: [u64; 3],
+        batch_size: u32,
+    ) -> RunObject {
         RunObject {
             schema_version: RUN_SCHEMA_VERSION,
             identity: RunIdentity {
@@ -615,12 +637,17 @@ window = 3
                 workload: "startup".to_string(),
                 samples: latencies
                     .iter()
-                    .map(|ns| Sample {
-                        batch_size: 1,
-                        process_elapsed_ns: ns + 1_000_000,
-                        peak_memory_bytes: 32 * 1024 * 1024,
-                        output_binary_bytes: 12_288,
-                        phases: accounting(*ns),
+                    .map(|ns| {
+                        // The runner stores batch totals, so a sample of K
+                        // compilations records K times the per-compile figures.
+                        let batch = u64::from(batch_size);
+                        Sample {
+                            batch_size,
+                            process_elapsed_ns: (ns + 1_000_000) * batch,
+                            peak_memory_bytes: 32 * 1024 * 1024,
+                            output_binary_bytes: 12_288,
+                            phases: accounting(ns * batch),
+                        }
                     })
                     .collect(),
             }],
@@ -750,19 +777,57 @@ window = 3
     #[test]
     fn the_derived_bands_still_sum_to_the_reported_compiler_root() {
         // A stacked chart whose bands do not add to its own total is the exact
-        // dishonesty the additive model exists to prevent, so averaging must
-        // preserve it.
-        let base = run_at("a", "2026-07-28T00:00:00Z", [100, 133, 177]);
-        let manifest = Manifest::parse(MANIFEST).unwrap();
-        let data = derive(&manifest, &[base]);
+        // dishonesty the additive model exists to prevent.
+        //
+        // Batch sizes above one are the case that matters, and the case an
+        // earlier version of this test missed: with `batch_size: 1` a
+        // per-compilation band and a per-batch total are identical, so the
+        // assertion passed while the real data was wrong by exactly the batch
+        // size.
+        for batch in [1u32, 2, 5] {
+            let manifest = manifest_for_batch(batch);
+            let run = run_at_batched("a", "2026-07-28T00:00:00Z", [100, 130, 170], batch);
+            let data = derive(&manifest, &[run]);
+            let point = &data.platforms[0].epochs[0].points[0].workloads["startup"];
+            let summed: u64 = point.bands_ns.values().sum();
+            assert_eq!(
+                summed, point.compiler_root_ns,
+                "batch {batch}: bands {:?} must sum to root {}",
+                point.bands_ns, point.compiler_root_ns
+            );
+        }
+    }
 
-        let point = &data.platforms[0].epochs[0].points[0].workloads["startup"];
-        let summed: u64 = point.bands_ns.values().sum();
-        assert_eq!(
-            summed, point.compiler_root_ns,
-            "bands {:?} must sum to root {}",
-            point.bands_ns, point.compiler_root_ns
+    #[test]
+    fn every_reported_figure_is_per_compilation() {
+        // The median comes from `sample_value`, which divides by the batch.
+        // The root total and the bands must use the same convention, or the
+        // page shows a total the median contradicts.
+        let unbatched = derive(
+            &manifest_for_batch(1),
+            &[run_at_batched(
+                "a",
+                "2026-07-28T00:00:00Z",
+                [100, 100, 100],
+                1,
+            )],
         );
+        let batched = derive(
+            &manifest_for_batch(4),
+            &[run_at_batched(
+                "a",
+                "2026-07-28T00:00:00Z",
+                [100, 100, 100],
+                4,
+            )],
+        );
+        let one = &unbatched.platforms[0].epochs[0].points[0].workloads["startup"];
+        let four = &batched.platforms[0].epochs[0].points[0].workloads["startup"];
+
+        assert_eq!(one.median_ns, four.median_ns);
+        assert_eq!(one.compiler_root_ns, four.compiler_root_ns);
+        assert_eq!(one.process_elapsed_ns, four.process_elapsed_ns);
+        assert_eq!(one.driver_overhead_ns, four.driver_overhead_ns);
     }
 
     #[test]

--- a/scripts/annotate-performance-subjects.py
+++ b/scripts/annotate-performance-subjects.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Add commit subjects to the derived performance data (ADR-0067 §11).
+
+Tooltips are required to name the commit short hash *and* its subject. A run
+object deliberately does not carry the subject: it records what was measured,
+not how the change was described, and a subject can be rewritten after the
+measurement without invalidating it.
+
+So the subject is resolved here, at site build time, from the repository. A
+commit that is not present locally — a shallow clone, or history that has since
+been rewritten — simply has no subject, and the page falls back to the hash
+rather than inventing a description.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+
+def subject_of(repo: Path, commit: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), "log", "-1", "--format=%s", commit],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    subject = result.stdout.strip()
+    return subject or None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data", type=Path, required=True)
+    parser.add_argument("--repo", type=Path, required=True)
+    args = parser.parse_args()
+
+    data = json.loads(args.data.read_text())
+
+    commits = {
+        point["commit"]
+        for platform in data.get("platforms", [])
+        for epoch in platform.get("epochs", [])
+        for point in epoch.get("points", [])
+    }
+
+    subjects = {}
+    for commit in sorted(commits):
+        subject = subject_of(args.repo, commit)
+        if subject is not None:
+            subjects[commit] = subject
+
+    data["commit_subjects"] = subjects
+    args.data.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+    print(f"  resolved {len(subjects)}/{len(commits)} commit subject(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/website/build.sh
+++ b/website/build.sh
@@ -24,6 +24,41 @@ else
     find website/content/spec -name "*.md" -exec sed -i 's|@/\([0-9]\)|@/spec/\1|g' {} \;
 fi
 
+# Rebuild the performance dashboard's data from the raw records (ADR-0067).
+#
+# Everything derived — indexes, medians, dispersion, flags, phase composition —
+# is recomputed here from `performance-data-v1` and never stored on that branch.
+# The page renders honestly with nothing to show when collection has not run
+# yet, which is its normal first state rather than an error.
+echo "Deriving performance data..."
+PERF_DATA_ROOT="$(mktemp -d)"
+if git rev-parse --verify origin/performance-data-v1 >/dev/null 2>&1 \
+   || git fetch origin performance-data-v1 --depth=50 >/dev/null 2>&1; then
+    git --work-tree="$PERF_DATA_ROOT" checkout origin/performance-data-v1 -- . 2>/dev/null || true
+    git reset >/dev/null 2>&1 || true
+else
+    echo "  (no performance-data-v1 branch yet; the page will render empty)"
+fi
+
+BENCH="$("$ROOT/buck2" build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"
+if [ -n "$BENCH" ] && [ -x "$BENCH" ]; then
+    "$BENCH" derive \
+        --manifest "$ROOT/performance/manifest.toml" \
+        --data-root "$PERF_DATA_ROOT" \
+        --out "$ROOT/website/static/performance-data.json"
+    # Tooltips need commit subjects, which the raw records deliberately do not
+    # carry: a run object stores what was measured, not how the commit was
+    # described. Resolving them here keeps the derivation free of git.
+    python3 "$ROOT/scripts/annotate-performance-subjects.py" \
+        --data "$ROOT/website/static/performance-data.json" \
+        --repo "$ROOT"
+else
+    echo "  (rue-bench unavailable; writing an empty dataset)"
+    printf '{"bands":[],"workloads":[],"platforms":[],"rejected":[]}\n' \
+        > "$ROOT/website/static/performance-data.json"
+fi
+rm -rf "$PERF_DATA_ROOT"
+
 # Build Tailwind CSS
 echo "Building Tailwind CSS..."
 cd website

--- a/website/static/performance.js
+++ b/website/static/performance.js
@@ -1,0 +1,480 @@
+// The compiler-performance dashboard (ADR-0067 §11).
+//
+// Reads /performance-data.json, which `rue-bench derive` rebuilds from the raw
+// run objects at site build time. Nothing here recomputes a statistic: the
+// flagging rule, the ratios, and the index all arrive already decided, because
+// a second implementation of "did this move" would drift from the calibrator's.
+//
+// Two invariants this file must not break:
+//
+//   The index is dimensionless. It never shares an axis with milliseconds, and
+//   platform indexes are never drawn together — they have independent
+//   baselines and comparing them would be meaningless.
+//
+//   Only the additive bands are stacked. They sum exactly to compiler-root
+//   time, which is the whole reason stacking them is honest.
+(function () {
+  "use strict";
+
+  // Phases in pipeline order, then the two structural buckets. The composition
+  // bar and the stacked area share this map, which is what lets the bar serve
+  // as the stack's legend rather than needing a second one.
+  var BAND_COLOURS = {
+    source_discovery_and_parsing: "#4477aa",
+    program_construction: "#66ccee",
+    semantic_analysis: "#228833",
+    cfg_and_optimization: "#ccbb44",
+    backend: "#ee6677",
+    object_generation: "#aa3377",
+    linking: "#999999",
+    mixed_parallel: "#777777",
+    unattributed: "#cccccc"
+  };
+
+  var SVG = "http://www.w3.org/2000/svg";
+
+  function ms(ns) { return ns / 1e6; }
+  function fmtMs(ns) { return ms(ns).toFixed(2) + " ms"; }
+  function shortHash(commit) { return (commit || "").slice(0, 12); }
+
+  function element(name, attributes) {
+    var node = document.createElementNS(SVG, name);
+    Object.keys(attributes).forEach(function (key) {
+      node.setAttribute(key, attributes[key]);
+    });
+    return node;
+  }
+
+  function escapeHtml(value) {
+    var holder = document.createElement("div");
+    holder.textContent = value;
+    return holder.innerHTML;
+  }
+
+  var root = document.getElementById("perf-root");
+  var empty = document.getElementById("perf-empty");
+
+  fetch("/performance-data.json")
+    .then(function (response) { return response.json(); })
+    .then(render)
+    .catch(function () { empty.hidden = false; });
+
+  function render(data) {
+    var platforms = (data.platforms || []).filter(function (platform) {
+      return platform.epochs.some(function (epoch) { return epoch.points.length > 0; });
+    });
+    if (platforms.length === 0) {
+      empty.hidden = false;
+      return;
+    }
+    root.hidden = false;
+
+    var select = document.getElementById("perf-platform");
+    platforms.forEach(function (platform, index) {
+      var option = document.createElement("option");
+      option.value = String(index);
+      option.textContent = platform.platform;
+      select.appendChild(option);
+    });
+
+    var state = { platform: 0, workload: null, cursor: null };
+
+    select.addEventListener("change", function () {
+      state.platform = Number(select.value);
+      state.workload = null;
+      state.cursor = null;
+      draw();
+    });
+
+    function current() { return platforms[state.platform]; }
+
+    // Points across every epoch, each tagged with its epoch so the page can
+    // draw separate stretches instead of flattening the discontinuity away.
+    function allPoints() {
+      var out = [];
+      current().epochs.forEach(function (epoch) {
+        epoch.points.forEach(function (point) { out.push({ epoch: epoch, point: point }); });
+      });
+      return out;
+    }
+
+    function draw() {
+      var points = allPoints();
+      if (!points.length) { return; }
+      if (state.workload === null) {
+        var names = Object.keys(points[points.length - 1].point.workloads);
+        state.workload = names.length ? names[0] : null;
+      }
+      drawStatus(points);
+      drawIndex(points);
+      drawMultiples(data, points);
+      drawPhases(data, points);
+      drawNotes();
+      drawDisclosures(data, points);
+    }
+
+    // 1. Status line.
+    function drawStatus(points) {
+      var status = document.getElementById("perf-status");
+      var health = document.getElementById("perf-health");
+      var latest = points[points.length - 1];
+      var parts = [];
+      var index = latest.point.index && latest.point.index.latency;
+
+      if (index) {
+        parts.push("Index " + index.toFixed(3) + " on " + current().platform + ".");
+        // "Versus the trailing week" against irregular runs means the most
+        // recent point at least a week older, not a fixed offset.
+        var cutoff = Date.parse(latest.point.finished_at) - 7 * 864e5;
+        var earlier = null;
+        for (var i = points.length - 1; i >= 0; i--) {
+          if (Date.parse(points[i].point.finished_at) <= cutoff && points[i].point.index) {
+            earlier = points[i];
+            break;
+          }
+        }
+        if (earlier) {
+          var delta = (index / earlier.point.index.latency - 1) * 100;
+          parts.push("Versus a week ago: " + (delta >= 0 ? "+" : "") + delta.toFixed(2) + "%.");
+        } else {
+          parts.push("No point a week old yet to compare against.");
+        }
+      } else {
+        parts.push("No headline index yet: this epoch has no baseline, or the latest run was partial.");
+      }
+
+      var flagged = Object.keys(latest.point.workloads).filter(function (name) {
+        return latest.point.workloads[name].flagged === true;
+      });
+      parts.push(flagged.length ? "Flagged: " + flagged.join(", ") + "." : "Nothing flagged.");
+      status.textContent = parts.join(" ");
+
+      if (latest.point.complete) {
+        health.hidden = true;
+      } else {
+        health.hidden = false;
+        health.textContent =
+          "Collection health: the latest run was incomplete. Did not complete validly: " +
+          latest.point.missing.join(", ") +
+          ". No headline point is published from a partial run.";
+      }
+    }
+
+    // 2. Headline chart. One polyline per epoch, so a baseline change reads as
+    // a labelled boundary rather than as a change in the compiler.
+    function drawIndex(points) {
+      var svg = document.getElementById("perf-index");
+      var caption = document.getElementById("perf-index-caption");
+      svg.textContent = "";
+
+      var indexed = points.filter(function (entry) { return entry.point.index; });
+      if (!indexed.length) {
+        caption.textContent = "No index points yet. A ratio needs a baseline to be a ratio of.";
+        return;
+      }
+
+      var values = indexed.map(function (entry) { return entry.point.index.latency; }).concat([1]);
+      var lo = Math.min.apply(null, values);
+      var hi = Math.max.apply(null, values);
+      var pad = (hi - lo) * 0.15 || 0.05;
+      lo -= pad;
+      hi += pad;
+
+      var x = function (i) { return 40 + (i / Math.max(points.length - 1, 1)) * 840; };
+      var y = function (v) { return 190 - ((v - lo) / (hi - lo)) * 170; };
+
+      svg.appendChild(element("line", {
+        x1: 40, y1: y(1), x2: 880, y2: y(1), stroke: "#999", "stroke-dasharray": "4 3"
+      }));
+      var baselineLabel = element("text", { x: 4, y: y(1) + 4, fill: "#666", "font-size": 11 });
+      baselineLabel.textContent = "1.00";
+      svg.appendChild(baselineLabel);
+
+      var byEpoch = {};
+      points.forEach(function (entry, i) {
+        if (!entry.point.index) { return; }
+        var key = entry.epoch.epoch;
+        (byEpoch[key] = byEpoch[key] || []).push(x(i) + "," + y(entry.point.index.latency));
+      });
+      Object.keys(byEpoch).forEach(function (key) {
+        svg.appendChild(element("polyline", {
+          points: byEpoch[key].join(" "), fill: "none", stroke: "#228833", "stroke-width": 2
+        }));
+      });
+
+      var previousEpoch = null;
+      points.forEach(function (entry, i) {
+        if (previousEpoch !== null && entry.epoch.epoch !== previousEpoch) {
+          svg.appendChild(element("line", {
+            x1: x(i), y1: 20, x2: x(i), y2: 190, stroke: "#b45309", "stroke-dasharray": "2 2"
+          }));
+          var label = element("text", { x: x(i) + 4, y: 32, fill: "#b45309", "font-size": 11 });
+          label.textContent = "epoch " + entry.epoch.epoch;
+          svg.appendChild(label);
+        }
+        previousEpoch = entry.epoch.epoch;
+
+        var drifted = entry.epoch.environment_annotations.some(function (note) {
+          return note.commit === entry.point.commit;
+        });
+        if (drifted) {
+          svg.appendChild(element("line", {
+            x1: x(i), y1: 20, x2: x(i), y2: 190, stroke: "#4477aa", "stroke-dasharray": "1 4"
+          }));
+        }
+      });
+
+      caption.textContent = indexed.length + " index point(s). Dashed orange marks an epoch " +
+        "boundary; dotted blue marks an environment change, across which comparisons are advisory.";
+    }
+
+    // 5. Small multiples: the full-size per-workload signal the index attenuates.
+    function drawMultiples(data, points) {
+      var container = document.getElementById("perf-multiples");
+      container.textContent = "";
+      var latest = points[points.length - 1].point;
+
+      (data.workloads || []).forEach(function (workload) {
+        var series = points
+          .map(function (entry) { return entry.point.workloads[workload.id]; })
+          .filter(Boolean);
+        var currentPoint = latest.workloads[workload.id];
+        if (!series.length || !currentPoint) { return; }
+
+        var selected = state.workload === workload.id;
+        var card = document.createElement("button");
+        card.type = "button";
+        card.setAttribute("role", "listitem");
+        card.setAttribute("aria-pressed", String(selected));
+        card.style.cssText = "text-align:left;padding:0.75rem;border:1px solid " +
+          (selected ? "#228833" : "#ccc") + ";background:none;cursor:pointer;font:inherit;width:100%;";
+        card.addEventListener("click", function () {
+          state.workload = workload.id;
+          state.cursor = null;
+          draw();
+        });
+
+        var previous = series.length > 1 ? series[series.length - 2] : null;
+        var delta = previous
+          ? ((currentPoint.median_ns / previous.median_ns - 1) * 100).toFixed(2) + "%"
+          : "no prior point";
+        // `null` means the trailing window is not full. Rendering that as
+        // "stable" would be the comfortable wrong answer.
+        var flag = currentPoint.flagged === true
+          ? " · flagged"
+          : (currentPoint.flagged === null ? " · not enough history" : "");
+
+        card.innerHTML =
+          '<div style="font-weight:600;">' + escapeHtml(workload.id) + flag + "</div>" +
+          '<div style="color:var(--color-muted);font-size:0.85rem;">' + escapeHtml(workload.question) + "</div>" +
+          '<div style="margin-top:0.4rem;">' + fmtMs(currentPoint.median_ns) +
+          ' <span style="color:var(--color-muted);">± ' + fmtMs(currentPoint.mad_ns) + " MAD</span></div>" +
+          '<div style="color:var(--color-muted);font-size:0.85rem;">Δ ' + delta + "</div>";
+        container.appendChild(card);
+      });
+    }
+
+    // 3. Stacked area of absolute milliseconds for the selected workload.
+    function drawPhases(data, points) {
+      var svg = document.getElementById("perf-phases");
+      var caption = document.getElementById("perf-phases-caption");
+      svg.textContent = "";
+      document.getElementById("perf-selected").textContent = state.workload || "—";
+
+      var series = points.filter(function (entry) {
+        return entry.point.workloads[state.workload];
+      });
+      if (!series.length) {
+        caption.textContent = "No observations for this workload.";
+        return;
+      }
+
+      var hi = Math.max.apply(null, series.map(function (entry) {
+        return entry.point.workloads[state.workload].compiler_root_ns;
+      })) * 1.1;
+      var x = function (i) { return 40 + (i / Math.max(series.length - 1, 1)) * 840; };
+      var y = function (v) { return 230 - (v / hi) * 200; };
+
+      var offsets = series.map(function () { return 0; });
+      (data.bands || []).forEach(function (band) {
+        var upper = [];
+        var lower = [];
+        series.forEach(function (entry, i) {
+          lower.push(x(i) + "," + y(offsets[i]));
+          offsets[i] += entry.point.workloads[state.workload].bands_ns[band] || 0;
+          upper.push(x(i) + "," + y(offsets[i]));
+        });
+        svg.appendChild(element("polygon", {
+          points: upper.concat(lower.reverse()).join(" "),
+          fill: BAND_COLOURS[band] || "#ccc"
+        }));
+      });
+
+      var scale = element("text", { x: 4, y: 16, fill: "#666", "font-size": 11 });
+      scale.textContent = ms(hi).toFixed(1) + " ms";
+      svg.appendChild(scale);
+
+      function selectIndex(i) {
+        state.cursor = Math.max(0, Math.min(series.length - 1, i));
+        drawComposition(data, series, state.cursor);
+        drawTooltip(data, series, state.cursor);
+      }
+
+      svg.addEventListener("mousemove", function (event) {
+        var box = svg.getBoundingClientRect();
+        selectIndex(Math.round(((event.clientX - box.left) / box.width) * (series.length - 1)));
+      });
+      // Arrow keys do exactly what the cursor does, so the interaction is not
+      // mouse-only and the tooltip's content is reachable without one.
+      svg.addEventListener("keydown", function (event) {
+        if (event.key === "ArrowRight") { selectIndex(state.cursor + 1); event.preventDefault(); }
+        if (event.key === "ArrowLeft") { selectIndex(state.cursor - 1); event.preventDefault(); }
+      });
+      svg.setAttribute("aria-label", "Phase composition for " + state.workload +
+        ". Use left and right arrow keys to move between measured commits.");
+
+      caption.textContent = series.length +
+        " measured commit(s). Bands sum exactly to compiler-root time.";
+      selectIndex(state.cursor === null ? series.length - 1 : Math.min(state.cursor, series.length - 1));
+    }
+
+    // 4. Composition bar for the cursored commit; also the stack's legend.
+    function drawComposition(data, series, index) {
+      var container = document.getElementById("perf-composition");
+      container.textContent = "";
+      var point = series[index].point.workloads[state.workload];
+      var total = point.compiler_root_ns || 1;
+
+      var bar = document.createElement("div");
+      bar.style.cssText = "display:flex;height:1.75rem;width:100%;border:1px solid #ccc;";
+      var legend = document.createElement("ul");
+      legend.style.cssText =
+        "list-style:none;padding:0;margin:0.5rem 0 0;display:flex;flex-wrap:wrap;gap:0.75rem;font-size:0.85rem;";
+
+      (data.bands || []).forEach(function (band) {
+        var value = point.bands_ns[band] || 0;
+        if (!value) { return; }
+        var share = (value / total) * 100;
+        var colour = BAND_COLOURS[band] || "#ccc";
+
+        var segment = document.createElement("div");
+        segment.style.cssText = "width:" + share + "%;background:" + colour + ";";
+        segment.title = band + " " + fmtMs(value);
+        bar.appendChild(segment);
+
+        var item = document.createElement("li");
+        item.innerHTML = '<span style="display:inline-block;width:0.75rem;height:0.75rem;background:' +
+          colour + '"></span> ' + escapeHtml(band) + " " + fmtMs(value) + " (" + share.toFixed(1) + "%)";
+        legend.appendChild(item);
+      });
+
+      container.appendChild(bar);
+      container.appendChild(legend);
+    }
+
+    // Tooltip content per §11: commit and subject, the total, the delta against
+    // the previous measured commit, and whether the comparison is advisory.
+    function drawTooltip(data, series, index) {
+      var tooltip = document.getElementById("perf-tooltip");
+      var entry = series[index];
+      var point = entry.point.workloads[state.workload];
+      var subject = (data.commit_subjects || {})[entry.point.commit];
+
+      var lines = [
+        "<strong>" + escapeHtml(shortHash(entry.point.commit)) + "</strong>" +
+          (subject ? " — " + escapeHtml(subject) : " (subject unavailable)"),
+        "Total: " + fmtMs(point.compiler_root_ns) + " compiler root, " +
+          fmtMs(point.process_elapsed_ns) + " process"
+      ];
+
+      if (index > 0) {
+        var previous = series[index - 1];
+        var delta = (point.median_ns / previous.point.workloads[state.workload].median_ns - 1) * 100;
+        lines.push("Versus the previous measured commit (" +
+          escapeHtml(shortHash(previous.point.commit)) + "): " +
+          (delta >= 0 ? "+" : "") + delta.toFixed(2) + "%");
+      } else {
+        lines.push("First measured commit in this view.");
+      }
+
+      if (point.flagged === null) {
+        lines.push("Movement unknown: the trailing window is not full yet.");
+      } else if (point.flagged) {
+        lines.push("Flagged: this exceeds the epoch's flagging rule.");
+      }
+
+      var drift = entry.epoch.environment_annotations.filter(function (note) {
+        return note.commit === entry.point.commit;
+      });
+      if (drift.length) {
+        lines.push("Environment changed here, so comparisons across it are advisory: " +
+          escapeHtml(drift[0].changed.join("; ")));
+      }
+
+      tooltip.innerHTML = lines.join("<br>");
+    }
+
+    // 6. Field notes.
+    function drawNotes() {
+      var list = document.getElementById("perf-notes");
+      list.textContent = "";
+      var any = false;
+      current().epochs.forEach(function (epoch) {
+        epoch.environment_annotations.forEach(function (note) {
+          any = true;
+          var item = document.createElement("li");
+          item.textContent = shortHash(note.commit) + " — environment changed: " +
+            note.changed.join("; ") + ". Comparisons across this point are advisory.";
+          list.appendChild(item);
+        });
+      });
+      if (!any) {
+        var item = document.createElement("li");
+        item.style.color = "var(--color-muted)";
+        item.textContent = "No annotations in the visible window.";
+        list.appendChild(item);
+      }
+    }
+
+    // 7. Disclosures.
+    function drawDisclosures(data, points) {
+      var latest = points[points.length - 1].point;
+
+      var overhead = document.getElementById("perf-overhead");
+      var others = document.getElementById("perf-other-metrics");
+      overhead.textContent = "";
+      others.textContent = "";
+
+      Object.keys(latest.workloads).forEach(function (name) {
+        var workload = latest.workloads[name];
+
+        var row = document.createElement("div");
+        row.textContent = name + ": " + fmtMs(workload.driver_overhead_ns) +
+          " outside compiler root (" + fmtMs(workload.process_elapsed_ns) + " process, " +
+          fmtMs(workload.compiler_root_ns) + " root)";
+        overhead.appendChild(row);
+
+        var other = document.createElement("div");
+        other.textContent = name + ": " +
+          (workload.peak_memory_bytes / 1048576).toFixed(1) + " MiB peak, " +
+          workload.output_binary_bytes + " B binary";
+        others.appendChild(other);
+      });
+
+      var rejected = document.getElementById("perf-rejected");
+      rejected.textContent = "";
+      if (!data.rejected || !data.rejected.length) {
+        rejected.textContent = "No runs were rejected.";
+        return;
+      }
+      data.rejected.forEach(function (run) {
+        var row = document.createElement("div");
+        row.textContent = run.platform + " epoch " + run.epoch + " " +
+          shortHash(run.commit) + ": " + run.reasons.join("; ");
+        rejected.appendChild(row);
+      });
+    }
+
+    draw();
+  }
+})();

--- a/website/templates/performance.html
+++ b/website/templates/performance.html
@@ -1,15 +1,121 @@
 {% extends "base.html" %}
 
+{#
+  The compiler-performance dashboard (ADR-0067 §11).
+
+  Everything here is rebuilt from raw observations at site build time; nothing
+  derived is stored alongside the records. The data arrives as
+  /performance-data.json, produced by `rue-bench derive`.
+
+  Two rules the markup enforces, because they are the easiest to break:
+
+  The index is dimensionless. It is never drawn on the same axis as, or stacked
+  with, milliseconds, and platform indexes are never compared with one another —
+  they have independent baselines.
+
+  Only the additive phase bands may be stacked. Inclusive spans nest and
+  overlap; they belong in a table, never in the stack.
+#}
+
+{% block title %}Compiler performance — {{ config.title }}{% endblock %}
+
 {% block content %}
-<section class="max-w-5xl mx-auto px-6 py-20">
-    <section class="field-report" style="max-width: 42rem; margin: 0 auto;">
-        <span class="plate-no">Performance</span>
-        <h1 style="font-family: var(--font-display); font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 430; line-height: 1;">Coming soon</h1>
-        <p style="color: var(--color-muted); max-width: 32rem; margin-top: 1.25rem;">
-            Rue's performance reporting is being rebuilt from a clean slate.
-            Compiler instrumentation remains in place while the next public
-            measurement system is designed.
-        </p>
-    </section>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <span class="plate-no">Performance</span>
+  <h1 style="font-family: var(--font-display); font-size: clamp(2rem, 6vw, 3.5rem); font-weight: 430; line-height: 1.05;">
+    Compiler performance
+  </h1>
+
+  <noscript>
+    <p style="color: var(--color-muted); margin-top: 1rem;">
+      This page draws its charts in the browser. The measurements themselves are
+      available as <a href="/performance-data.json">raw JSON</a>.
+    </p>
+  </noscript>
+
+  <div id="perf-root" hidden>
+    <div style="margin-top: 1.5rem;">
+      <label for="perf-platform" style="color: var(--color-muted); font-size: 0.9rem;">Platform</label>
+      <select id="perf-platform" style="margin-left: 0.5rem; padding: 0.25rem 0.5rem;"></select>
+    </div>
+
+    <p id="perf-status" role="status" aria-live="polite"
+       style="margin-top: 1.25rem; font-size: 1.05rem; line-height: 1.6;"></p>
+    <p id="perf-health" role="alert" style="margin-top: 0.5rem; color: #b45309;" hidden></p>
+
+    <h2 style="margin-top: 2.5rem;">Headline index</h2>
+    <p style="color: var(--color-muted); font-size: 0.9rem; max-width: 42rem;">
+      The geometric mean of each workload's median against this epoch's baseline.
+      1.00 is the baseline; lower is faster. It is dimensionless — it answers
+      whether anything is moving, not how long a build takes. A move in one of
+      <em>n</em> workloads shifts it by roughly 1/<em>n</em> of its true size, so
+      the per-workload panels carry the full-size signal.
+    </p>
+    <figure style="margin-top: 0.75rem;">
+      <svg id="perf-index" role="img" width="100%" height="220" viewBox="0 0 900 220"
+           aria-labelledby="perf-index-caption"></svg>
+      <figcaption id="perf-index-caption" style="color: var(--color-muted); font-size: 0.85rem;"></figcaption>
+    </figure>
+
+    <h2 style="margin-top: 2.5rem;">Workloads</h2>
+    <div id="perf-multiples" role="list"
+         style="display: grid; grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr)); gap: 1rem; margin-top: 0.75rem;"></div>
+
+    <h2 style="margin-top: 2.5rem;">Phase composition — <span id="perf-selected"></span></h2>
+    <p style="color: var(--color-muted); font-size: 0.9rem; max-width: 42rem;">
+      Absolute milliseconds by published phase. These bands are mutually
+      exclusive and sum exactly to compiler-root time, which is what makes
+      stacking them honest. <code>mixed_parallel</code> is time when more than
+      one phase was active; <code>unattributed</code> is compiler time no phase
+      describes. Both are findings, not rounding.
+    </p>
+    <figure style="margin-top: 0.75rem;">
+      <svg id="perf-phases" role="img" width="100%" height="260" viewBox="0 0 900 260"
+           tabindex="0" aria-labelledby="perf-phases-caption"></svg>
+      <figcaption id="perf-phases-caption" style="color: var(--color-muted); font-size: 0.85rem;"></figcaption>
+    </figure>
+    <div id="perf-composition" style="margin-top: 0.5rem;"></div>
+
+    <div id="perf-tooltip" role="status" aria-live="polite"
+         style="margin-top: 0.75rem; padding: 0.75rem 1rem; border: 1px solid #ccc; font-size: 0.9rem; line-height: 1.5;"></div>
+
+    <h2 style="margin-top: 2.5rem;">Field notes</h2>
+    <ul id="perf-notes" style="margin-top: 0.5rem; line-height: 1.7;"></ul>
+
+    <h2 style="margin-top: 2.5rem;">Disclosures</h2>
+    <details style="margin-top: 0.5rem;">
+      <summary>Driver overhead</summary>
+      <p style="color: var(--color-muted); max-width: 42rem;">
+        Process wall time outside compiler root: startup, output publication,
+        and other driver cost. Real time you wait for, deliberately outside the
+        phase stack.
+      </p>
+      <div id="perf-overhead"></div>
+    </details>
+    <details style="margin-top: 0.5rem;">
+      <summary>Memory and binary size</summary>
+      <div id="perf-other-metrics"></div>
+    </details>
+    <details style="margin-top: 0.5rem;">
+      <summary>Collection health</summary>
+      <div id="perf-rejected"></div>
+    </details>
+    <p style="margin-top: 1rem;">
+      <a href="/performance-data.json" download>Download the derived data</a> —
+      rebuilt from the raw run objects on the <code>performance-data-v1</code>
+      branch, which stores observations and nothing derived.
+    </p>
+  </div>
+
+  <div id="perf-empty" hidden style="margin-top: 2rem;">
+    <p style="color: var(--color-muted); max-width: 42rem;">
+      No measurements have been collected yet. The measurement system is in
+      place; this page fills in once collection has run on trunk and each epoch
+      has a baseline. A baseline must be the first complete, valid run at a
+      declared revision, so it cannot exist before one has been measured.
+    </p>
+  </div>
 </section>
+
+<script src="/performance.js" defer></script>
 {% endblock %}


### PR DESCRIPTION
Phase 6 of ADR-0067, second half — and the last piece of the ADR.

Builds the page of §11 and wires the site build to rebuild its data from the raw records on `performance-data-v1`.

## The page

In order: **status line**; **headline index** as a continuous line per epoch stretch with labelled boundaries; **per-workload small multiples**; a **stacked area** of absolute milliseconds for the selected workload; a **composition bar** for the cursored commit that doubles as the stack's legend; **field notes**; and **disclosures** covering driver overhead, memory and binary size, collection health, and a raw-data download.

Tooltips carry the commit short hash and subject, the total, and the delta against the previous measured commit. **Subjects are resolved at site build time**, not stored in run objects — a run records what was measured, not how the change was described, and a subject can be rewritten afterwards without invalidating the measurement. A commit missing locally falls back to its hash rather than inventing a description.

The cursor responds to arrow keys as well as the mouse, and the tooltip is a live region rather than a hover-only overlay, so its content is reachable without a pointer.

Derived data goes to `website/static/performance-data.json`, which is **gitignored**. Storing it would put a derived value next to the observations it came from, and the stored copy is the one that would be believed.

## A real bug, found by real data rather than by its test

The collector has already run — there are 5 points across 3 platforms on the data branch — and deriving against them exposed a defect that shipped in #2031.

`average_bands` divides each band by the batch size to report per-compilation figures, but `compiler_root_ns` was averaged *without* dividing. The bands were per-compilation and the total per-batch, disagreeing by exactly the batch size: on `aarch64-linux`, bands summing to **36.5 ms** under a stated root of **73.1 ms** at batch size 2. A stack that does not add up to its own stated total is precisely the dishonesty the additive model exists to prevent.

**The test that claimed to pin this used `batch_size: 1`** — where a per-compilation band and a per-batch total are identical. It asserted the right property and proved nothing. It now sweeps batch sizes 1, 2, and 5, and a second test pins that every reported figure is per-compilation regardless of batching.

While fixing it, a second and subtler issue surfaced: each band's mean truncates independently, so an independently-averaged root missed their sum by up to a nanosecond per band. The root is now **defined as the sum of the averaged bands**, which makes the invariant hold by construction rather than by luck.

Verified against the real collection — bands sum exactly to root on all three platforms:

```
aarch64-linux  median  36.685 ms  root  36.538 ms  bands==root: True
aarch64-linux  median  36.742 ms  root  36.605 ms  bands==root: True
aarch64-macos  median  15.533 ms  root  17.957 ms  bands==root: True
x86_64-linux   median  28.453 ms  root  28.607 ms  bands==root: True
x86_64-linux   median  24.914 ms  root  24.829 ms  bands==root: True
```

## Validation

- `//crates/rue-bench:rue-bench-test` — 45 tests, 0 failures.
- `scripts/rue quick` — 30 targets.
- `website/build.sh` runs the derivation end to end (Tailwind isn't provisioned in this sandbox, so the final Zola step is CI's to confirm).

## Note on what the page will show

The index still reads as unpublishable, because no epoch has a baseline yet — ratios need something to be a ratio of. Declaring the baselines from the first complete valid runs is the natural follow-up now that collection is producing them.

Refs RUE-1182, RUE-1189.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKydRZPZurnmNTMHxDqZK2)_