### PR TITLE
Use upload-artifact v6 in the cache-probe workflow

### DIFF
--- a/.github/workflows/cache-probe.yml
+++ b/.github/workflows/cache-probe.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload probe logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cache-probe-logs
           path: |


### PR DESCRIPTION
The last remaining `actions/upload-artifact@v4` pin in the repository. It targets Node 20 and emits a deprecation warning on every run:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/upload-artifact@v4.
```

Everything else is already on v6. After this there are no v4 pins left.

Follow-up to #2029, which fixed the same issue in the calibration workflow. This one predated that work, so I flagged it rather than bundling it in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKydRZPZurnmNTMHxDqZK2)_