### PR TITLE
Declare epoch 2 baselines for all three platforms

### DIFF
--- a/performance/manifest.toml
+++ b/performance/manifest.toml
@@ -216,6 +216,13 @@ batch_size = 3
 k = 2.0
 window = 3
 
+# The first complete, valid run at a declared trunk revision, whose
+# per-workload medians define ratio 1.0 for this epoch. All three platforms
+# measured this same revision validly, so epoch 2 shares a baseline commit.
+[epoch.baseline]
+commit = "31ff07f6bac131723f60c2a18af5505a8b442320"
+run = "4ae3eb4cf1e47277c30ae6c3002b6c84c651e35634424e874e2cca8219b25973"
+
 [[epoch]]
 id = 2
 platform = "aarch64-linux"
@@ -239,6 +246,11 @@ batch_size = 2
 [epoch.flagging]
 k = 2.0
 window = 3
+
+# The first complete, valid run at this epoch's declared revision (see above).
+[epoch.baseline]
+commit = "31ff07f6bac131723f60c2a18af5505a8b442320"
+run = "b0bbb8dd1bbf4b617da6c9c642218ce8435e1f250fea060e5baf307555e8b9ad"
 
 [[epoch]]
 id = 2
@@ -266,3 +278,8 @@ batch_size = 4
 [epoch.flagging]
 k = 5.0
 window = 10
+
+# The first complete, valid run at this epoch's declared revision (see above).
+[epoch.baseline]
+commit = "31ff07f6bac131723f60c2a18af5505a8b442320"
+run = "ff0a3ab928b8e2e601604912404b9ed4b8140a27a2204300d5917143f533574b"


### PR DESCRIPTION
The dashboard's headline index is a ratio against a baseline, so an epoch with no baseline has nothing to normalize against and publishes no index. This names each collection epoch's baseline: the first complete, valid run that platform produced.

All three point at the same trunk revision (`31ff07f6bac1`) because that is the first commit at which every platform measured validly. Nothing requires epochs to agree on a commit, and a later epoch very likely will not.

Each baseline names a run by content address rather than by commit alone. A commit can be measured more than once — re-runs, retries — and the baseline has to be one specific observation, not whichever record happens to be found first.

## Verification

`rue-bench derive` against the live `performance-data-v1` branch:

```
rue-bench: derived 8 point(s) across 3 platform(s); 0 run(s) rejected

aarch64-linux  epoch 2  baseline=31ff07f6bac1
    31ff07f6bac1  ratio=1.0000  index=1.0000  complete=True
    cfd5d1e5ec7d  ratio=1.0015  index=1.0015  complete=True
    4d1df390423b  ratio=0.9670  index=0.9670  complete=True
aarch64-macos  epoch 2  baseline=31ff07f6bac1
    31ff07f6bac1  ratio=1.0000  index=1.0000  complete=True
    4d1df390423b  ratio=1.2965  index=1.2965  complete=True
x86_64-linux   epoch 2  baseline=31ff07f6bac1
    31ff07f6bac1  ratio=1.0000  index=1.0000  complete=True
    cfd5d1e5ec7d  ratio=0.8756  index=0.8756  complete=True
    4d1df390423b  ratio=1.0193  index=1.0193  complete=True
```

Baseline points read exactly 1.0, and no run is rejected. `//crates/rue-bench:rue-bench-test` and `//crates/rue-perf-schema:rue-perf-schema-test` pass.

Refs RUE-1188

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKydRZPZurnmNTMHxDqZK2)_