### PR TITLE
Rebuild the website when performance data changes

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,13 +1,18 @@
 name: Website
 
 on:
-  # Deploy post-merge on trunk only for website changes. Pull requests also
-  # build on specification changes because the spec is copied into the site.
+  # Deploy post-merge on trunk for changes to anything the site is built from.
+  # Pull requests also build on specification changes because the spec is
+  # copied into the site.
   push:
     branches: [trunk]
     paths:
       - 'website/**'
       - 'docs/spec/**'
+      # The performance dashboard derives from the manifest, so an epoch,
+      # sampling, or baseline declaration changes the published page even
+      # though no file under website/ moved.
+      - 'performance/**'
       - '.github/workflows/deploy-website.yml'
   # PRs still build (no deploy — that's trunk-only) on spec changes too, so a
   # spec edit that breaks the website build is caught before merge.
@@ -16,7 +21,17 @@ on:
     paths:
       - 'website/**'
       - 'docs/spec/**'
+      - 'performance/**'
       - '.github/workflows/deploy-website.yml'
+  # The dashboard's other input is the `performance-data-v1` branch, which is
+  # not part of this repository's source tree: no push to trunk can describe a
+  # new measurement, so no paths filter can notice one. Rebuilding when
+  # collection finishes is what keeps the published page current — without it
+  # the site only ever shows the data that existed the last time somebody
+  # happened to edit website/.
+  workflow_run:
+    workflows: ['Performance collection']
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -35,6 +50,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # Performance tooltips name each measured commit by subject, resolved
+          # from local history at build time. The default shallow checkout has
+          # none of the measured commits, so every tooltip degrades to a bare
+          # hash — the documented fallback, firing here for no better reason
+          # than clone depth.
+          fetch-depth: 0
 
       - name: Setup dotslash
         uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
@@ -42,6 +64,9 @@ jobs:
       - name: Build website
         run: website/build.sh
 
+      # A `workflow_run` event reports the default branch as `github.ref`
+      # regardless of what the triggering run measured, so these trunk-only
+      # gates admit a collection-triggered rebuild without restating them.
       - name: Add CNAME
         if: github.ref == 'refs/heads/trunk'
         run: echo "rue-lang.dev" > website/public/CNAME

--- a/website/build.sh
+++ b/website/build.sh
@@ -34,8 +34,17 @@ echo "Deriving performance data..."
 PERF_DATA_ROOT="$(mktemp -d)"
 if git rev-parse --verify origin/performance-data-v1 >/dev/null 2>&1 \
    || git fetch origin performance-data-v1 --depth=50 >/dev/null 2>&1; then
-    git --work-tree="$PERF_DATA_ROOT" checkout origin/performance-data-v1 -- . 2>/dev/null || true
+    # Loud on purpose. An empty page is honest only when there is genuinely
+    # nothing collected; once the branch exists, failing to read it and
+    # publishing an empty dashboard would overwrite real measurements with a
+    # claim that none were taken.
+    if ! git --work-tree="$PERF_DATA_ROOT" checkout origin/performance-data-v1 -- . 2>/dev/null; then
+        git reset >/dev/null 2>&1 || true
+        echo "  error: performance-data-v1 exists but could not be read" >&2
+        exit 1
+    fi
     git reset >/dev/null 2>&1 || true
+    echo "  read $(find "$PERF_DATA_ROOT/runs" -name '*.json' 2>/dev/null | wc -l | tr -d ' ') run object(s)"
 else
     echo "  (no performance-data-v1 branch yet; the page will render empty)"
 fi


### PR DESCRIPTION
The compiler-performance dashboard has been publishing an empty headline index since it shipped, despite collection running on every trunk commit and 20 valid run objects sitting on `performance-data-v1`.

Nothing is wrong with collection, derivation, or the page. The site simply never rebuilt.

## What was happening

The Website workflow deploys on pushes touching `website/**` or `docs/spec/**`. The dashboard's inputs are neither:

- its data is the `performance-data-v1` branch, which is not in this repository's source tree at all, so no push to trunk can describe a new measurement and no paths filter can notice one;
- its baselines are in `performance/manifest.toml`, which was not in the filter either.

So the published dataset stayed frozen at whatever the last website edit happened to capture. That edit — the dashboard's own commit — ran eighteen minutes before the epoch 2 baselines were declared, so it froze on the one state that renders nothing. A headline index is a ratio against a baseline, and there was no baseline to be a ratio of. The page dutifully reported "No index points yet."

Until recently a daily schedule refreshed the site regardless of what changed, which is what kept the previous benchmark charts current. It was removed with the legacy benchmark infrastructure two days before the new dashboard landed, so the new page inherited a workflow that no longer had any data-driven refresh.

## Changes

- Rebuild when the `Performance collection` workflow completes. This restores the refresh precisely rather than on a timer: the page is per-commit, so it should update when a commit is measured. Collection is deliberately not filtered on conclusion — the publish job stores valid runs from a partial sweep on purpose, and those deserve publishing too.
- Add `performance/**` to the paths filter for the manifest half (epochs, sampling, baselines).
- Restore `fetch-depth: 0`. Tooltips name each measured commit by subject, resolved from local history, and a shallow clone has none of the measured commits — so every tooltip fell back to a bare hash. The deep checkout was removed alongside the legacy annotation validation that also needed it.
- Stop reading the data branch best-effort. It was `|| true`, so a failed read published an empty dashboard over good measurements — a page asserting nothing was collected, which is the one thing the raw records prove false. An empty page is honest only before the branch exists.

## Verification

Derived from the live `performance-data-v1` branch and rendered the page in a browser against the result:

- 20 points across three platforms, 0 runs rejected;
- headline index 0.932 on aarch64-linux, up from no index at all;
- 7/7 commit subjects resolved, replacing "(subject unavailable)";
- the epoch's flagging rule firing on `startup`.

Before this change the same render produced "No headline index yet: this epoch has no baseline, or the latest run was partial."

`workflow_run` triggers only fire once the workflow file is on the default branch, so this PR's own CI will not exercise that path; the paths filter and checkout changes do build here.

Refs RUE-1189, RUE-1188.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MvH5VhawbsdVHSqzY6w8Mr)_