### PR TITLE
Stop discarding gate findings to EPIPE under pipefail

### DIFF
--- a/.claude/hooks/bookmark-guard.sh
+++ b/.claude/hooks/bookmark-guard.sh
@@ -30,7 +30,10 @@ esac
 [ -d "$repo_root/.jj" ] || exit 0
 
 bookmarks=$(cd "$repo_root" && jj log --no-graph -r @ -T 'bookmarks' 2>/dev/null) || exit 0
-if printf '%s' "$bookmarks" | grep -q 'push-'; then
+# Herestring, not a pipe: under `pipefail` a matching `grep -q` kills the
+# producer with EPIPE and the pipeline reports failure, so the guard would stop
+# blocking in exactly the case it exists to block (RUE-1155).
+if grep -q 'push-' <<<"$bookmarks"; then
   echo "BLOCKED by bookmark-guard: the working copy (@) is on pushed PR branch '$bookmarks'. Editing it would mutate a queued PR. Run jj new 'trunk()' (new work) or jj new <change> + jj squash (deliberate amend) first." >&2
   exit 2
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Check production debug assertions
         run: scripts/validate-debug-assert-policy.py
 
+      # The gates themselves must not fail open. `grep -q` behind a pipe under
+      # `pipefail` discards the very finding it just made (RUE-1011, RUE-1155).
+      - name: Check shell pipefail pipelines
+        run: scripts/validate-shell-pipefail-pipelines.py
+
       - name: Validate Buck test-tier ownership
         run: ./buck2 bxl //test_tiers.bxl:validate
 

--- a/BUCK
+++ b/BUCK
@@ -405,6 +405,15 @@ rue_sh_test(
 )
 
 rue_sh_test(
+    name = "shell-pipefail-pipeline-tool-tests",
+    test = "scripts/test-validate-shell-pipefail-pipelines.py",
+    resources = ["scripts/validate-shell-pipefail-pipelines.py"],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+    },
+)
+
+rue_sh_test(
     name = "release-configuration-tool-tests",
     test = "scripts/test-release-configuration.py",
     env = {

--- a/clippy.sh
+++ b/clippy.sh
@@ -77,7 +77,13 @@ while read -r TARGET ARTIFACT; do
     [ -s "$ARTIFACT" ] || continue
     # Strip ANSI colour codes so CI logs stay readable and grep is reliable.
     CLEANED="$(sed -E 's/\x1b\[[0-9;]*m//g' "$ARTIFACT")"
-    if printf '%s\n' "$CLEANED" | grep -qE '^error'; then
+    # Herestring, not a pipe: `grep -q` exits on its first match and closes the
+    # pipe, so a piped producer dies of EPIPE and `pipefail` reports *that*
+    # status for the whole pipeline. The `if` then reads false and the finding
+    # is discarded. The failure is inverted -- it only fires when grep DID match
+    # -- so a clean tree cannot distinguish this from a working gate (RUE-1155,
+    # the same construct RUE-1011 removed from scripts/test-wrapper-scripts.sh).
+    if grep -qE '^error' <<<"$CLEANED"; then
         FAILED=1
         echo "::group::clippy findings: $TARGET"
         printf '%s\n' "$CLEANED"

--- a/scripts/rue
+++ b/scripts/rue
@@ -145,7 +145,10 @@ case "$cmd" in
         # runs nothing, so this stays cheap.
         list_rc=0
         list_out="$(./buck2 run "$target" -- "$@" --list 2>/dev/null)" || list_rc=$?
-        if [[ $list_rc -eq 0 ]] && ! printf '%s' "$list_out" | grep -qE ': (test|benchmark)$'; then
+        # Herestring, not a pipe: under `pipefail` a matching `grep -q` kills the
+        # producer with EPIPE, and this test is negated -- so a filter that DID
+        # select cases would be rejected as matching nothing (RUE-1155).
+        if [[ $list_rc -eq 0 ]] && ! grep -qE ': (test|benchmark)$' <<<"$list_out"; then
             echo "scripts/rue unit: no tests matched the given filter in $target" >&2
             exit 1
         fi

--- a/scripts/test-cleanup-scripts.sh
+++ b/scripts/test-cleanup-scripts.sh
@@ -123,7 +123,9 @@ EOF
   chmod +x "$sb/fakebin/gh"
 
   run_script "$sb" jj-tidy
-  if calls "$sb" | grep -q 'git push .*--delete'; then
+  # Herestring, not a pipe: under `pipefail` a matching `grep -q` kills the
+  # producer with EPIPE and the assertion silently reads false (RUE-1155).
+  if grep -q 'git push .*--delete' <<<"$(calls "$sb")"; then
     check "jj-tidy: gh failure issues NO remote deletion" 1
   else
     check "jj-tidy: gh failure issues NO remote deletion" 0
@@ -158,13 +160,13 @@ EOF
   local del
   del="$(calls "$sb" | grep 'git push .*--delete' || true)"
   # push-aaa (ours, merged) must be deleted.
-  if printf '%s' "$del" | grep -q 'steveklabnik/push-aaa'; then
+  if grep -q 'steveklabnik/push-aaa' <<<"$del"; then
     check "jj-tidy: OUR merged branch is deleted" 0
   else
     check "jj-tidy: OUR merged branch is deleted" 1
   fi
   # push-bbb (other author, no merged/closed PR of ours) must NOT be deleted.
-  if printf '%s' "$del" | grep -q 'push-bbb'; then
+  if grep -q 'push-bbb' <<<"$del"; then
     check "jj-tidy: another author's branch is preserved" 1
   else
     check "jj-tidy: another author's branch is preserved" 0

--- a/scripts/test-validate-shell-pipefail-pipelines.py
+++ b/scripts/test-validate-shell-pipefail-pipelines.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Focused tests for the pipefail early-exit pipeline policy."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("validate-shell-pipefail-pipelines.py")
+SPEC = importlib.util.spec_from_file_location("pipefail_pipelines", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+policy = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(policy)
+
+
+class ScanTests(unittest.TestCase):
+    def scan(self, body: str, *, pipefail: bool = True) -> list[str]:
+        header = "#!/usr/bin/env bash\n"
+        if pipefail:
+            header += "set -euo pipefail\n"
+        source = header + textwrap.dedent(body)
+        return [finding.stage for finding in policy.scan(source, "probe.sh")]
+
+    def test_flags_grep_q_behind_a_pipe(self) -> None:
+        self.assertEqual(self.scan('printf "%s" "$x" | grep -q needle\n'), ["grep"])
+
+    def test_flags_every_short_circuiting_grep_flag(self) -> None:
+        for flags in ("-q", "-qE", "-Fxq", "-l", "-L", "-m 1"):
+            with self.subTest(flags=flags):
+                self.assertEqual(self.scan(f'cat f | grep {flags} needle\n'), ["grep"])
+
+    def test_flags_grep_variants_and_absolute_paths(self) -> None:
+        for tool in ("egrep", "fgrep", "zgrep", "rg", "/usr/bin/grep"):
+            with self.subTest(tool=tool):
+                self.assertEqual(
+                    self.scan(f'cat f | {tool} -q needle\n'), [tool]
+                )
+
+    def test_flags_head_behind_a_pipe(self) -> None:
+        self.assertEqual(self.scan('sed -n "s/a//p" f | head -n 1\n'), ["head"])
+
+    def test_ignores_scripts_without_pipefail(self) -> None:
+        # Without pipefail the pipeline reports grep's status, which is correct.
+        self.assertEqual(self.scan('cat f | grep -q x\n', pipefail=False), [])
+
+    def test_accepts_a_draining_grep(self) -> None:
+        # A plain grep reads its input to exhaustion, so no EPIPE is possible.
+        self.assertEqual(self.scan('cat f | grep needle\n'), [])
+
+    def test_accepts_the_herestring_fix(self) -> None:
+        self.assertEqual(self.scan('grep -q needle <<<"$text"\n'), [])
+        self.assertEqual(self.scan('grep -q needle <<<"$(cat f)"\n'), [])
+
+    def test_accepts_an_unpiped_early_exit_consumer(self) -> None:
+        self.assertEqual(self.scan('grep -q needle f\n'), [])
+        self.assertEqual(self.scan('head -n 1 f\n'), [])
+
+    def test_does_not_confuse_logical_or_with_a_pipe(self) -> None:
+        self.assertEqual(self.scan('grep -q needle f || head -n 1 f\n'), [])
+
+    def test_ignores_comments_and_quoted_pipes(self) -> None:
+        # This policy's own fix notes name the construct they ban.
+        self.assertEqual(self.scan('# replaced cat f | grep -q x with a herestring\n'), [])
+        self.assertEqual(self.scan("""grep -E 'a|head -n 1' f\n"""), [])
+
+    def test_honours_a_reviewed_allowance(self) -> None:
+        self.assertEqual(
+            self.scan('cat f | grep -q x  # pipefail-pipeline-ok: reviewed\n'), []
+        )
+
+    def test_flags_a_stage_inside_a_command_substitution(self) -> None:
+        self.assertEqual(self.scan('v="$(cat f | grep -q x && echo y)"\n'), ["grep"])
+
+
+class DiscoveryTests(unittest.TestCase):
+    def discover(self, files: dict[str, str]) -> tuple[list[str], list[str]]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for relative, contents in files.items():
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(contents)
+            scanned = [
+                p.relative_to(root).as_posix() for p in policy.shell_scripts(root)
+            ]
+            findings = [str(f) for f in policy.validate(root)]
+        return scanned, findings
+
+    BAD = "#!/usr/bin/env bash\nset -euo pipefail\ncat f | grep -q x\n"
+
+    def test_skips_build_output_and_vendored_trees(self) -> None:
+        # Scanning buck-out made the gate's runtime and result depend on
+        # whether a build had run.
+        scanned, findings = self.discover(
+            {f"{skipped}/nested/probe.sh": self.BAD for skipped in policy.SKIP_DIRECTORIES}
+        )
+        self.assertEqual(scanned, [])
+        self.assertEqual(findings, [])
+
+    def test_finds_extensionless_scripts_by_shebang(self) -> None:
+        scanned, findings = self.discover({"scripts/tool": self.BAD})
+        self.assertEqual(scanned, ["scripts/tool"])
+        self.assertEqual(len(findings), 1)
+
+    def test_ignores_non_shell_files(self) -> None:
+        scanned, _ = self.discover({"a.py": "# cat f | grep -q x\n", "b.rs": "fn f() {}\n"})
+        self.assertEqual(scanned, [])
+
+
+class RepositoryTests(unittest.TestCase):
+    def test_repository_is_clean(self) -> None:
+        # Under Buck this test runs from a sandbox holding only the validator,
+        # where a whole-tree scan would find nothing and pass vacuously -- the
+        # exact shape of fail-open this policy exists to prevent. Skip loudly
+        # instead; the authoritative scan is the `fmt` job's CI step.
+        root = SCRIPT.resolve().parent.parent
+        if not (root / "clippy.sh").exists():
+            self.skipTest("not a repository checkout; scan runs as a CI step")
+        findings = policy.validate(root)
+        self.assertEqual([str(finding) for finding in findings], [])
+
+
+class MechanismTests(unittest.TestCase):
+    """The bug this policy exists to prevent, demonstrated end to end."""
+
+    def run_bash(self, body: str) -> str:
+        with tempfile.TemporaryDirectory() as directory:
+            script = Path(directory) / "probe.sh"
+            script.write_text("#!/usr/bin/env bash\nset -euo pipefail\n" + textwrap.dedent(body))
+            return subprocess.run(
+                ["bash", str(script)], capture_output=True, text=True, check=False
+            ).stdout.strip()
+
+    # A payload large enough that the producer is still writing when `grep -q`
+    # matches on the first line and closes the pipe.
+    PAYLOAD = 'CLEANED="$(printf \'error: boom\\n\'; seq 1 200000)"\n'
+
+    def test_pipe_under_pipefail_discards_the_match(self) -> None:
+        self.assertEqual(
+            self.run_bash(
+                self.PAYLOAD
+                + 'if printf "%s\\n" "$CLEANED" | grep -qE "^error"; then\n'
+                '    echo DETECTED\nelse\n    echo MISSED\nfi\n'
+            ),
+            "MISSED",
+        )
+
+    def test_herestring_reports_the_match(self) -> None:
+        self.assertEqual(
+            self.run_bash(
+                self.PAYLOAD
+                + 'if grep -qE "^error" <<<"$CLEANED"; then\n'
+                '    echo DETECTED\nelse\n    echo MISSED\nfi\n'
+            ),
+            "DETECTED",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -189,7 +189,10 @@ test_rue_exec_resolves_from_caller_cwd() {
   ( cd "$sb/work" && FAKE_COMPILER="$sb/compiler" COMPILE_LOG="$sb/compile.log" \
       "$sb/scripts/rue" exec hello.rue ) >/dev/null 2>&1
   local cwd_line
-  cwd_line="$(grep '^cwd=' "$sb/compile.log" 2>/dev/null | head -1)"
+  # `grep -m1` reads the file directly. Piping into `head -1` would let head
+  # close the pipe and, under `pipefail`, grep's EPIPE becomes the pipeline's
+  # status -- the construct RUE-1011 already removed from this file (RUE-1155).
+  cwd_line="$(grep -m1 '^cwd=' "$sb/compile.log" 2>/dev/null)"
   check "scripts/rue exec: compiler runs in the caller's cwd" \
     "$([ "$cwd_line" = "cwd=$sb/work" ] && echo 0 || echo 1)"
   rm -rf "$sb"
@@ -202,7 +205,10 @@ test_rue_run_resolves_relative_output() {
   ( cd "$sb/work" && FAKE_COMPILER="$sb/compiler" COMPILE_LOG="$sb/compile.log" \
       "$sb/scripts/rue" run hello.rue -o out ) >/dev/null 2>&1
   local cwd_line
-  cwd_line="$(grep '^cwd=' "$sb/compile.log" 2>/dev/null | head -1)"
+  # `grep -m1` reads the file directly. Piping into `head -1` would let head
+  # close the pipe and, under `pipefail`, grep's EPIPE becomes the pipeline's
+  # status -- the construct RUE-1011 already removed from this file (RUE-1155).
+  cwd_line="$(grep -m1 '^cwd=' "$sb/compile.log" 2>/dev/null)"
   check "scripts/rue run: compiler runs in the caller's cwd" \
     "$([ "$cwd_line" = "cwd=$sb/work" ] && echo 0 || echo 1)"
   check "scripts/rue run: relative -o is written in the caller's cwd" \
@@ -275,7 +281,7 @@ EOF
     (cd "$sb/work" && TIER_LOG="$sb/tiers.log" "$sb/scripts/rue" "$tier") \
       >/dev/null 2>&1 || rc=$?
     check "scripts/rue $tier: delegates the named tier to test.sh" \
-      "$([ "$rc" -eq 0 ] && tail -1 "$sb/tiers.log" | grep -Fxq "$tier" && echo 0 || echo 1)"
+      "$([ "$rc" -eq 0 ] && grep -Fxq "$tier" <<<"$(tail -1 "$sb/tiers.log")" && echo 0 || echo 1)"
   done
 
   rc=0

--- a/scripts/validate-shell-pipefail-pipelines.py
+++ b/scripts/validate-shell-pipefail-pipelines.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Ban early-exit pipeline consumers in shell scripts that enable `pipefail`.
+
+`grep -q` (and `-l`, `-m N`, and `head -n`) stop reading as soon as they have
+their answer. That closes the pipe, the producer upstream dies of EPIPE, and
+under `set -o pipefail` the shell reports *the producer's* status for the whole
+pipeline. A test that matched therefore reports "no match", and a gate that
+found a violation reports a pass.
+
+The failure is inverted, which is what makes it durable: the broken pipe only
+happens when the consumer DID match, so a clean tree exercises the working path
+exclusively and cannot distinguish this construct from a correct one. It has
+reached trunk three times -- RUE-1011 (scripts/test-wrapper-scripts.sh),
+RUE-1155 (clippy.sh, the required lint gate, plus three more sites) -- so it is
+checked mechanically rather than by review.
+
+The fix is to remove the pipe: `grep -q PATTERN <<<"$text"`, a `case`, or
+`[[ ]]`. Where a pipeline is genuinely required, annotate the line with
+`# pipefail-pipeline-ok: <reason>` and the reason is reviewed here instead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Build outputs and vendored trees are not ours to police, and `buck-out` in
+# particular makes the scan's cost and result depend on whether a build has run.
+SKIP_DIRECTORIES = {
+    ".buckd",
+    ".git",
+    ".jj",
+    "buck-out",
+    "buck2-bin",
+    "node_modules",
+    "target",
+    "third-party",
+}
+
+SHEBANG = re.compile(r"^#!.*\b(?:ba|da|k|z)?sh\b")
+
+# `set -o pipefail`, `set -euo pipefail`, `set -uo pipefail`, ...
+PIPEFAIL = re.compile(r"^\s*set\s+(?:-[a-zA-Z]*o|-o)\s+pipefail\b", re.MULTILINE)
+
+# Consumers that stop reading before their input is exhausted. `grep` only
+# qualifies with a short-circuiting flag: a plain `grep` drains its input and is
+# safe. `-l`/`-L` stop at the first matching file, `-m N` after N matches.
+# The flag letter may sit anywhere in a short-option cluster (`-q`, `-qE`,
+# `-Fxq`), so match the cluster rather than requiring a word boundary after the
+# letter -- `-qE` is precisely what the clippy gate used.
+EARLY_EXIT = re.compile(
+    r"""^(?:
+          (?:\S*/)?(?:[ezf]?grep|rg) \b (?=[^\n]*\s-[a-zA-Z]*[qlLm])
+        | (?:\S*/)?head \b
+        )""",
+    re.VERBOSE,
+)
+
+ALLOW = re.compile(r"#\s*pipefail-pipeline-ok:\s*(?P<reason>\S.*?)\s*$")
+
+
+class Finding(NamedTuple):
+    path: str
+    line: int
+    stage: str
+
+    def __str__(self) -> str:
+        return (
+            f"{self.path}:{self.line}: early-exit consumer `{self.stage}` reads from a "
+            "pipe under `set -o pipefail`; a match kills the producer with EPIPE and the "
+            "pipeline reports failure. Use a herestring/case, or annotate with "
+            "`# pipefail-pipeline-ok: <reason>`"
+        )
+
+
+def strip_comment(line: str) -> str:
+    """Drop a trailing `#` comment, respecting quotes.
+
+    Comments matter here because this policy's own prose names the construct it
+    bans, as do the fix notes left at each repaired site.
+    """
+    quote = ""
+    for index, character in enumerate(line):
+        if quote:
+            if character == quote:
+                quote = ""
+            elif character == "\\" and quote == '"':
+                pass
+        elif character in "'\"":
+            quote = character
+        elif character == "#" and (index == 0 or line[index - 1].isspace()):
+            return line[:index]
+    return line
+
+
+def split_pipeline(line: str) -> list[str]:
+    """Split on `|`, keeping `||`, `|&`, and quoted pipes intact.
+
+    A `$(...)` body is its own quoting context, so `v="$(cat f | grep -q x)"`
+    contains a genuine pipeline even though the `|` sits inside double quotes.
+    """
+    stages: list[str] = []
+    current: list[str] = []
+    quote = ""
+    enclosing: list[str] = []
+    index = 0
+    while index < len(line):
+        character = line[index]
+        if quote == "'":
+            if character == "'":
+                quote = ""
+            current.append(character)
+        elif line[index : index + 2] == "$(":
+            enclosing.append(quote)
+            quote = ""
+            current.append(line[index : index + 2])
+            index += 2
+            continue
+        elif character == ")" and enclosing and not quote:
+            quote = enclosing.pop()
+            current.append(character)
+        elif quote:
+            if character == quote:
+                quote = ""
+            current.append(character)
+        elif character in "'\"":
+            quote = character
+            current.append(character)
+        elif character == "|":
+            if line[index : index + 2] in ("||", "|&"):
+                current.append(line[index : index + 2])
+                index += 2
+                continue
+            stages.append("".join(current))
+            current = []
+        else:
+            current.append(character)
+        index += 1
+    stages.append("".join(current))
+    return stages
+
+
+def shell_scripts(root: Path) -> list[Path]:
+    paths: list[Path] = []
+    # Prune while walking rather than filtering afterwards: `buck-out` alone
+    # holds enough build output to dominate the gate's runtime.
+    for directory, names, files in os.walk(root):
+        names[:] = sorted(name for name in names if name not in SKIP_DIRECTORIES)
+        for name in sorted(files):
+            path = Path(directory) / name
+            if path.is_symlink() or not path.is_file():
+                continue
+            if path.suffix and path.suffix != ".sh":
+                continue
+            try:
+                with path.open("r", encoding="utf-8", errors="strict") as handle:
+                    first = handle.readline()
+            except (OSError, UnicodeDecodeError):
+                continue
+            if path.suffix == ".sh" or SHEBANG.match(first):
+                paths.append(path)
+    return sorted(paths)
+
+
+def scan(source: str, path: str) -> list[Finding]:
+    if not PIPEFAIL.search(source):
+        return []
+
+    findings: list[Finding] = []
+    for number, raw in enumerate(source.splitlines(), start=1):
+        if ALLOW.search(raw):
+            continue
+        # A pipeline stage may begin after `(`, `$(`, `&&`, `;`, `then`, ... so
+        # compare against the stage's first word rather than the line's.
+        stages = split_pipeline(strip_comment(raw))
+        for stage in stages[1:]:
+            word = stage.strip().lstrip("(").strip()
+            if EARLY_EXIT.match(word):
+                findings.append(Finding(path, number, word.split()[0]))
+    return findings
+
+
+def validate(root: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in shell_scripts(root):
+        relative = path.relative_to(root).as_posix()
+        findings.extend(scan(path.read_text(encoding="utf-8"), relative))
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", type=Path, default=ROOT)
+    args = parser.parse_args()
+
+    findings = validate(args.root)
+    if findings:
+        for finding in findings:
+            print(f"error: {finding}", file=sys.stderr)
+        return 1
+
+    scanned = len(shell_scripts(args.root))
+    print(f"pipefail pipeline policy valid: {scanned} shell script(s) scanned")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/with-full-suite-lock
+++ b/scripts/with-full-suite-lock
@@ -20,7 +20,11 @@ owns_lock=0
 owner_value() {
     local key="$1"
     [[ -r "$lock_dir/owner" ]] || return 1
-    sed -n "s/^${key}=//p" "$lock_dir/owner" | head -n 1
+    # `sed ... | head -n 1` would let head close the pipe first, and under
+    # `pipefail` sed's EPIPE becomes the pipeline's status -- so a lock this
+    # process owns reads as unowned and never gets released (RUE-1155). sed
+    # stops at the first match itself, so no pipe is needed.
+    sed -n "s/^${key}=//{p;q;}" "$lock_dir/owner"
 }
 
 release_lock() {

--- a/scripts/with-full-suite-lock
+++ b/scripts/with-full-suite-lock
@@ -22,9 +22,11 @@ owner_value() {
     [[ -r "$lock_dir/owner" ]] || return 1
     # `sed ... | head -n 1` would let head close the pipe first, and under
     # `pipefail` sed's EPIPE becomes the pipeline's status -- so a lock this
-    # process owns reads as unowned and never gets released (RUE-1155). sed
-    # stops at the first match itself, so no pipe is needed.
-    sed -n "s/^${key}=//{p;q;}" "$lock_dir/owner"
+    # process owns reads as unowned and never gets released (RUE-1155). The
+    # address form stops at the first match itself, so no pipe is needed.
+    # (`s/^x=//{p;q;}` is NOT this: a block after `s` is not conditional on the
+    # substitution, and sed rejects it as an unknown `s` option.)
+    sed -n "/^${key}=/{s/^${key}=//;p;q;}" "$lock_dir/owner"
 }
 
 release_lock() {

--- a/scripts/worktree-gc
+++ b/scripts/worktree-gc
@@ -42,7 +42,11 @@ if [ -d .claude/worktrees ]; then
       [ -d "$d" ] || continue
       d="${d%/}"
       abs="$(cd "$d" 2>/dev/null && pwd)" || continue
-      if ! printf '%s\n' "$active" | grep -qxF "$abs"; then
+      # Herestring, not a pipe: under `pipefail` a matching `grep -q` kills the
+      # producer with EPIPE and the pipeline reports failure. This test is
+      # negated and guards an `rm -rf`, so that inversion would delete a live
+      # worktree precisely because it IS active (RUE-1155).
+      if ! grep -qxF "$abs" <<<"$active"; then
         rm -rf "${d:?}" && echo "  removed orphaned worktree ${d##*/}"
       fi
     done


### PR DESCRIPTION
Fixes RUE-1155. Refs RUE-1011, RUE-1152.

## The mechanism

`grep -q` stops reading at its first match and closes the pipe. The producer upstream then dies of EPIPE, and under `set -o pipefail` the shell reports *the producer's* status for the whole pipeline. The `if` reads false, and the finding is thrown away.

The failure is inverted, which is what makes it durable: the broken pipe only happens when the consumer **did** match. A clean tree exercises the working path exclusively and cannot distinguish this construct from a correct one — which is why RUE-1152's green run did not catch it.

Deterministic repro (also pinned as a test here):

```bash
set -euo pipefail
CLEANED="$(printf 'error: boom\n'; seq 1 200000)"
if printf '%s\n' "$CLEANED" | grep -qE '^error'; then echo DETECTED; else echo MISSED; fi
# -> MISSED
```

## Sites repaired

The issue reported `clippy.sh` and asked for an audit, on the theory that "a third is likely". There were eight, in five scripts beyond the two already known:

| Site | Consequence when it fires |
| --- | --- |
| `clippy.sh` | the required lint gate locates findings and reports `no lint violations` |
| `scripts/worktree-gc` | negated and guarding an `rm -rf` — deletes a worktree *because* it is active |
| `scripts/rue` | negated — a unit filter that did select cases is rejected as matching nothing |
| `scripts/with-full-suite-lock` | a lock the process owns reads as unowned and is never released |
| `.claude/hooks/bookmark-guard.sh` | the guard stops blocking in the one case it exists to block |
| `scripts/test-cleanup-scripts.sh`, `scripts/test-wrapper-scripts.sh` (×3) | assertions silently read false |

Each is fixed by removing the pipe — a herestring, `grep -m1` reading the file directly, or letting `sed` stop at the first match itself — rather than by working around the status.

Severity varies with payload size: `clippy.sh` handles output far larger than the pipe buffer and is the demonstrated case, while the small-payload sites are latent, firing only if their producer is still writing when the consumer exits. They are the same defect and equally cheap to remove, so they are all removed.

## Preventing the fourth instance

Review has now missed this three times, so it is checked mechanically. `scripts/validate-shell-pipefail-pipelines.py` rejects early-exit pipeline consumers (`grep -q/-l/-m`, `head`, and the `egrep`/`rg` variants) in any shell script that enables `pipefail`, with a reviewed `# pipefail-pipeline-ok: <reason>` escape hatch for genuine cases. It runs as a `fmt`-job CI step alongside the other whole-tree policies, matching the existing `validate-*.py` idiom; the tool tests are a premerge Buck target.

Two of the eight sites were found only because the validator's own tests caught a bug in its first regex (`-qE`, the exact flag the clippy gate used, slipped through a word-boundary assertion).

## Verification

- `clippy.sh` end to end: 63 targets, exit 0, no broken-pipe messages.
- `scripts/rue unit compiler durable_` passes; `scripts/rue unit compiler zzz_no_such_test_exists` still fails closed — both directions of the edited preflight.
- `scripts/test-cleanup-scripts.sh` (7 checks) and `scripts/test-wrapper-scripts.sh` (96 checks) pass.
- `scripts/rue quick`: 30 targets pass.
- `./buck2 bxl //test_tiers.bxl:validate` and `./buck2 test //:shell-pipefail-pipeline-tool-tests` (18 tests) pass.
- Repo scan is clean at 35 scripts, in 0.16s.

`scripts/rue premerge` has not been run locally; CI is the full-platform authority.

Note RUE-1153 would retire `clippy.sh` as the entry point, which does not overlap: the validator checks whatever shell scripts remain.

---
_Generated by [Claude Code](https://claude.ai/code/session_018LQuiFaSkCRSKGPQVnwdF1)_