### PR TITLE
Attribute declaration analysis and source loading to their phases

### DIFF
--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -969,7 +969,8 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
     // dependency edges runs before whole-program analysis opens `sema`. It is
     // real per-declaration work, so it gets its own leaf instead of widening
     // the pipeline's unattributed residual (RUE-786).
-    let declaration_reuse_span = info_span!("declaration_reuse").entered();
+    let declaration_reuse_span =
+        info_span!("declaration_reuse", phase = "semantic_analysis").entered();
     let input = CodegenInputDescriptor {
         semantic: SemanticInputDescriptor::new(
             merged.definitions().source_snapshot(),

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -6493,7 +6493,8 @@ impl CompilerSession {
             .revisioned
             .current_semantic_revision()
             .expect("semantic preparation observes a published source/import revision");
-        let declaration_shells_span = tracing::info_span!("declaration_shells").entered();
+        let declaration_shells_span =
+            tracing::info_span!("declaration_shells", phase = "semantic_analysis").entered();
         let query_shells = {
             let _span = tracing::info_span!("declaration_shell_projection").entered();
             self.queries.revisioned.projected_declaration_shells(
@@ -6519,7 +6520,11 @@ impl CompilerSession {
         };
         drop(declaration_shells_span);
         let declaration_semantics = {
-            let _span = tracing::info_span!("declaration_semantics_projection").entered();
+            let _span = tracing::info_span!(
+                "declaration_semantics_projection",
+                phase = "semantic_analysis"
+            )
+            .entered();
             self.queries.revisioned.projected_declaration_semantics(
                 runtime_revision,
                 merged.ast(),

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -500,7 +500,8 @@ pub(crate) fn load(
     // then the demand-driven import-discovery frontier. It was previously
     // timed only through the `parse_file` spans it happens to contain, which
     // left the rest of discovery in the root's unattributed residual (RUE-786).
-    let _span = tracing::info_span!("source_loading").entered();
+    let _span =
+        tracing::info_span!("source_loading", phase = "source_discovery_and_parsing").entered();
     let manifest = {
         let _span = tracing::info_span!("source_manifest").entered();
         let manifest = request


### PR DESCRIPTION
## What

Adds four `phase` span markers so ADR-0067's wall-clock phase accounting describes work it was previously charging to `unattributed`. No compiler logic changes — span field additions only, 9 insertions across three files.

## Why

The performance suite currently declares one workload, `startup`, which imports no `std`. Measuring any workload that does import `std` shows 84–95% of compiler-root time landing in `unattributed`:

| workload | lines | compile | unattributed (before) |
| --- | --- | --- | --- |
| dijkstra | 191 | 1.8s | 94.8% |
| ruelex | 2.2k | 4.1s | 85.8% |
| rill | 3.0k | 8.8s | 83.8% |
| mosaic | 6.1k | 11.3s | 88.1% |

Per ADR-0067 §2 that band means compiler time is moving somewhere the instrumentation does not describe, and it is invisible today only because the sole workload avoids the path. Any corpus expansion would produce a phase chart that is mostly one "we don't know" band.

Two gaps produced it.

**Declaration analysis ran outside `semantic_analysis`.** The marker sits on `sema`, which opens only after declaration analysis finishes. Since RUE-1092 cut body analysis over to registered queries, `sema` covers `compose_queried_bodies` — composition, not analysis — so declaration shell projection and the semantic nucleus batch, the dominant cost on any program with imports, ran under no marker.

**`source_loading` carried a marker only on its `import_read` leaf**, leaving discovery, planning, and staging unattributed.

## Changes

| span | file | phase |
| --- | --- | --- |
| `declaration_shells` | `crates/rue-compiler/src/session.rs` | `semantic_analysis` |
| `declaration_semantics_projection` | `crates/rue-compiler/src/session.rs` | `semantic_analysis` |
| `declaration_reuse` | `crates/rue-compiler/src/canonical_semantic.rs` | `semantic_analysis` |
| `source_loading` | `crates/rue/src/source_loader.rs` | `source_discovery_and_parsing` |

The inner `import_read` marker stays: the toolchain re-close path reaches it without `source_loading` active.

Following the rule in `crates/rue/src/timing.rs` — mark the work, not the orchestration — `toolchain_acquisition` stays unmarked. It drives semantic analysis rather than being a phase.

## Result

| workload | unattributed before | after |
| --- | --- | --- |
| dijkstra | 94.8% | 28.8% |
| ruelex | 85.8% | 49.7% |
| rill | 83.8% | 47.2% |

`mixed_parallel` stays at 0.0ms and `cfg_and_optimization` is unchanged, so none of the new markers nest inside another published phase — the hazard `timing.rs` warns about does not occur here.

## Deliberately not included

The remaining residual is the RUE-1027 reached-body frontier (`session.rs:6623`), which analyzes every reached body before `sema` opens. A marker there takes dijkstra to 5.3% and ruelex to 3.4% unattributed, verified locally, but RUE-1028 is actively replacing that coordinator with database-owned reachability. Instrumenting it belongs in that work, where the new scheduler gets a marker as it is written, rather than being added to a coordinator on its way out.

## Follow-up

This is a prerequisite for growing the workload corpus, not the corpus change itself. Expanding the suite is a new suite revision plus new epochs on all three platforms and a re-run of the RUE-1187 calibration sweep — the current sampling counts are calibrated against a 65ms probe alone. Measured candidate costs: `meridian` 109.7s and `caldera` 305.7s per compile, which do not fit a per-commit suite despite ADR-0067 §10 listing both.

---
_Generated by [Claude Code](https://claude.ai/code/session_0168xUoAsfYi42bJuRP9cJe7)_