### PR TITLE
Classify generated anonymous types by identity, not by name

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -376,6 +376,21 @@ struct TypeInternPoolInner {
     containment_dirty: bool,
     containment_metrics: TypeContainmentMetrics,
 
+    /// Structs and enums the compiler generated for anonymous types, recorded
+    /// at creation and layered like `types`.
+    ///
+    /// `__anon_struct_N` / `__anon_enum_N` are legal source declarations — only
+    /// `__rue_*` and `_start` are reserved — so "was this generated?" is
+    /// membership here, never a name prefix (RUE-1050). This is the authority
+    /// for consumers below semantic analysis, which cannot see the sema-side
+    /// registry: CFG destructor discovery and drop glue.
+    ///
+    /// Symbol spelling still tests the prefix. It cannot read this registry
+    /// until the provider boundary carries the same marks, because durable
+    /// export re-derives identities from the rendered symbol; see RUE-1193.
+    anonymous_structs: HashSet<StructId>,
+    anonymous_enums: HashSet<EnumId>,
+
     /// Nominal struct lookup: (defining file, source name) -> canonical `Type`.
     struct_by_file_name: HashMap<(FileId, Spur), Type>,
 
@@ -470,6 +485,8 @@ impl TypeInternPoolInner {
             containment_facts: Vec::new(),
             containment_dirty: false,
             containment_metrics: TypeContainmentMetrics::default(),
+            anonymous_structs: HashSet::new(),
+            anonymous_enums: HashSet::new(),
             struct_by_file_name: HashMap::new(),
             enum_by_file_name: HashMap::new(),
             symbol_paths: Arc::default(),
@@ -625,6 +642,10 @@ impl TypeInternPoolInner {
         flat.array_map.extend(self.array_map.iter());
         flat.ptr_const_map.extend(self.ptr_const_map.iter());
         flat.ptr_mut_map.extend(self.ptr_mut_map.iter());
+        flat.anonymous_structs
+            .extend(self.anonymous_structs.iter().copied());
+        flat.anonymous_enums
+            .extend(self.anonymous_enums.iter().copied());
         flat.struct_by_file_name
             .extend(self.struct_by_file_name.iter());
         flat.enum_by_file_name.extend(self.enum_by_file_name.iter());
@@ -665,6 +686,10 @@ impl TypeInternPoolInner {
             containment_facts: Vec::new(),
             containment_dirty,
             containment_metrics: TypeContainmentMetrics::default(),
+            // Empty locally; `is_anonymous_*` consults the base for entries
+            // below `base_len`, matching how `types` is layered.
+            anonymous_structs: HashSet::new(),
+            anonymous_enums: HashSet::new(),
             struct_by_file_name: HashMap::new(),
             enum_by_file_name: HashMap::new(),
             symbol_paths: Arc::clone(&self.symbol_paths),
@@ -672,6 +697,25 @@ impl TypeInternPoolInner {
             lang_item_structs: Arc::clone(&self.lang_item_structs),
             repr_c_structs: Arc::clone(&self.repr_c_structs),
         }
+    }
+
+    /// Whether this struct was generated for an anonymous type, consulting the
+    /// shared base for entries below `base_len`.
+    fn is_anonymous_struct(&self, id: StructId) -> bool {
+        self.anonymous_structs.contains(&id)
+            || self
+                .base
+                .as_ref()
+                .is_some_and(|base| base.is_anonymous_struct(id))
+    }
+
+    /// Enum counterpart of [`Self::is_anonymous_struct`].
+    fn is_anonymous_enum(&self, id: EnumId) -> bool {
+        self.anonymous_enums.contains(&id)
+            || self
+                .base
+                .as_ref()
+                .is_some_and(|base| base.is_anonymous_enum(id))
     }
 
     fn next_pool_index(&self) -> u32 {
@@ -2439,6 +2483,34 @@ impl TypeInternPool {
             .struct_metadata(struct_id)
     }
 
+    /// Record that this struct was generated for an anonymous type.
+    ///
+    /// Called by anonymous-type creation, which is the only authority on
+    /// generated-ness: the `__anon_struct_N` spelling is a legal source name
+    /// and must never be used to infer it (RUE-1050).
+    pub fn mark_anonymous_struct(&self, struct_id: StructId) {
+        let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        inner.anonymous_structs.insert(struct_id);
+    }
+
+    /// Enum counterpart of [`Self::mark_anonymous_struct`].
+    pub fn mark_anonymous_enum(&self, enum_id: EnumId) {
+        let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        inner.anonymous_enums.insert(enum_id);
+    }
+
+    /// Whether this struct was generated for an anonymous type.
+    pub fn is_anonymous_struct(&self, struct_id: StructId) -> bool {
+        let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+        inner.is_anonymous_struct(struct_id)
+    }
+
+    /// Whether this enum was generated for an anonymous type.
+    pub fn is_anonymous_enum(&self, enum_id: EnumId) -> bool {
+        let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+        inner.is_anonymous_enum(enum_id)
+    }
+
     /// Return the stable standard-library identity carried by a nominal type.
     pub fn struct_lang_item(&self, struct_id: StructId) -> Option<LangItem> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
@@ -3077,6 +3149,16 @@ impl FrozenTypeInternPool {
 
     pub fn struct_lang_item(&self, id: StructId) -> Option<LangItem> {
         self.inner.struct_lang_items.get(&id).copied()
+    }
+
+    /// Whether this struct was generated for an anonymous type (RUE-1050).
+    pub fn is_anonymous_struct(&self, id: StructId) -> bool {
+        self.inner.is_anonymous_struct(id)
+    }
+
+    /// Whether this enum was generated for an anonymous type (RUE-1050).
+    pub fn is_anonymous_enum(&self, id: EnumId) -> bool {
+        self.inner.is_anonymous_enum(id)
     }
 
     pub fn lang_item_type(&self, item: LangItem) -> Option<Type> {

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1053,8 +1053,8 @@ fn intern_named_callable_symbols(sema: &BodySema<'_>) {
         .methods
         .iter()
         .filter_map(|(&(struct_id, method), info)| {
-            let owner = sema.type_pool.struct_def(struct_id);
-            (!owner.name.starts_with("__anon_struct_")).then(|| {
+            // Membership, not the generated-name prefix (RUE-1050).
+            (!sema.anonymous_struct_ids.contains(&struct_id)).then(|| {
                 sema.method_symbol(struct_id, sema.interner.resolve(&method), info.has_self)
             })
         })
@@ -1496,7 +1496,10 @@ fn named_method_dependency_events(
     }
     for (callee_struct, callee_method) in referenced_methods {
         let owner_name = sema.type_pool.struct_def(*callee_struct).name.clone();
-        if owner_name.starts_with("__anon_struct_") {
+        // Membership, not the generated-name prefix: `__anon_struct_N` is a
+        // legal source declaration, and only `anonymous_struct_ids` knows which
+        // structs the compiler generated (RUE-1050).
+        if sema.anonymous_struct_ids.contains(callee_struct) {
             continue;
         }
         let info = sema
@@ -1574,7 +1577,10 @@ fn named_destructor_dependency_events(
     }
     for (callee_struct, callee_method) in referenced_methods {
         let owner_name = sema.type_pool.struct_def(*callee_struct).name.clone();
-        if owner_name.starts_with("__anon_struct_") {
+        // Membership, not the generated-name prefix: `__anon_struct_N` is a
+        // legal source declaration, and only `anonymous_struct_ids` knows which
+        // structs the compiler generated (RUE-1050).
+        if sema.anonymous_struct_ids.contains(callee_struct) {
             continue;
         }
         let info = sema
@@ -2226,8 +2232,10 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                 let type_name_str = struct_def.name.clone();
                 let method_name_str = sema.interner.resolve(&method_name).to_string();
 
-                // For anonymous structs, use the MethodInfo directly since there's no named StructDecl
-                if type_name_str.starts_with("__anon_struct_") {
+                // For anonymous structs, use the MethodInfo directly since there's no named StructDecl.
+                // Membership, not the generated-name prefix: a source struct may
+                // legally be called `__anon_struct_N` (RUE-1050).
+                if sema.anonymous_struct_ids.contains(&struct_id) {
                     sema.body_analysis_work.anonymous_method_record_lookups += 1;
                     let full_name =
                         sema.method_symbol(struct_id, &method_name_str, method_info.has_self);

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1052,11 +1052,10 @@ fn intern_named_callable_symbols(sema: &BodySema<'_>) {
     let mut symbols = sema
         .methods
         .iter()
-        .filter_map(|(&(struct_id, method), info)| {
-            // Membership, not the generated-name prefix (RUE-1050).
-            (!sema.anonymous_struct_ids.contains(&struct_id)).then(|| {
-                sema.method_symbol(struct_id, sema.interner.resolve(&method), info.has_self)
-            })
+        // Membership, not the generated-name prefix (RUE-1050).
+        .filter(|((struct_id, _), _)| !sema.anonymous_struct_ids.contains(struct_id))
+        .map(|(&(struct_id, method), info)| {
+            sema.method_symbol(struct_id, sema.interner.resolve(&method), info.has_self)
         })
         .collect::<Vec<_>>();
     symbols.sort();

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -476,10 +476,11 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
             .map(|(key, info)| (*key, *info))
             .collect::<Vec<_>>();
         for ((struct_id, method_name), info) in methods {
-            let owner = self.type_pool.struct_def(struct_id);
-            if owner.name.starts_with("__anon_struct_") {
+            // Membership, not the generated-name prefix (RUE-1050).
+            if self.anonymous_struct_ids.contains(&struct_id) {
                 continue;
             }
+            let owner = self.type_pool.struct_def(struct_id);
             let source_kind = if info.has_self {
                 Source::Method
             } else {
@@ -554,7 +555,8 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
                     .type_pool
                     .struct_metadata(id)
                     .expect("declaration dependency names a registered struct identity");
-                if def.is_builtin || def.name.starts_with("__anon_struct_") {
+                // Membership, not the generated-name prefix (RUE-1050).
+                if def.is_builtin || self.anonymous_struct_ids.contains(&id) {
                     return;
                 }
                 Some((

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -1013,6 +1013,10 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         }
         self.storage.generated_structs_mut().insert(name_spur, id);
         self.storage.anonymous_struct_ids_mut().insert(id);
+        // The pool is the authority for consumers below sema (symbol spelling,
+        // CFG destructor discovery, drop glue), which cannot see the sema-side
+        // registry (RUE-1050).
+        self.storage.body_type_pool().mark_anonymous_struct(id);
         let ty = Type::new_struct(id);
         self.storage
             .anonymous_struct_identities_mut()
@@ -1060,6 +1064,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         let (id, _) = self.storage.body_type_pool().register_enum(name_spur, def);
         self.storage.generated_enums_mut().insert(name_spur, id);
         self.storage.anonymous_enum_ids_mut().insert(id);
+        // See `find_or_create_anon_struct` (RUE-1050).
+        self.storage.body_type_pool().mark_anonymous_enum(id);
         let ty = Type::new_enum(id);
         self.storage
             .anonymous_enum_identities_mut()

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -655,7 +655,8 @@ impl<D: DeclarationPhase> Sema<'_, D> {
             .ok_or(F::UnmappedFunction)?;
         let method = self.interner.resolve(&method_name);
         let owner = self.type_pool.struct_def(struct_id);
-        if owner.name.starts_with("__anon_struct_") {
+        // Membership, not the generated-name prefix (RUE-1050).
+        if self.anonymous_struct_ids.contains(&struct_id) {
             return Err(F::AnonymousNominal);
         }
         self.stable_definition_token(
@@ -758,7 +759,10 @@ impl<D: DeclarationPhase> Sema<'_, D> {
             .type_pool
             .struct_metadata(id)
             .ok_or(F::UnsupportedType)?;
-        if def.name.starts_with("__anon_struct_") {
+        // Membership, not the generated-name prefix: `__anon_struct_N` is a
+        // legal source declaration and must still receive a named identity
+        // (RUE-1050).
+        if self.anonymous_struct_ids.contains(&id) {
             return Err(F::AnonymousNominal);
         }
         self.stable_definition_token(
@@ -771,7 +775,8 @@ impl<D: DeclarationPhase> Sema<'_, D> {
 
     pub(crate) fn enum_identity(&self, id: crate::EnumId) -> Result<SemanticDefinitionToken, F> {
         let def = self.type_pool.enum_metadata(id).ok_or(F::UnsupportedType)?;
-        if def.name.starts_with("__anon_enum_") {
+        // Membership, not the generated-name prefix (RUE-1050).
+        if self.anonymous_enum_ids.contains(&id) {
             return Err(F::AnonymousNominal);
         }
         self.stable_definition_token(

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -2028,7 +2028,8 @@ impl<'source, D: DeclarationPhase> TypeSyntaxHost for Sema<'source, D> {
                     .type_pool
                     .struct_metadata(id)
                     .expect("resolved declaration type names a registered struct identity");
-                (!def.is_builtin && !def.name.starts_with("__anon_struct_"))
+                // Membership, not the generated-name prefix (RUE-1050).
+                (!def.is_builtin && !self.anonymous_struct_ids.contains(&id))
                     .then_some((
                         def.file_id,
                         def.name,
@@ -2747,7 +2748,8 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
                     .type_pool
                     .struct_metadata(id)
                     .expect("resolved declaration type names a registered struct identity");
-                if !def.is_builtin && !def.name.starts_with("__anon_struct_") {
+                // Membership, not the generated-name prefix (RUE-1050).
+                if !def.is_builtin && !self.anonymous_struct_ids.contains(&id) {
                     self.record_resolved_declaration_type_target(
                         def.file_id,
                         def.name,

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -2382,7 +2382,10 @@ impl<'a> CfgBuilder<'a> {
                 TypeKind::Struct(struct_id) => {
                     let def = self.type_pool.struct_def(struct_id);
                     if def.destructor.is_some() && !def.is_builtin {
-                        if def.name.starts_with("__anon_struct_") {
+                        // Membership, not the generated-name prefix: a source
+                        // struct may legally be called `__anon_struct_N`, and
+                        // its destructor is an ordinary named one (RUE-1050).
+                        if self.type_pool.is_anonymous_struct(struct_id) {
                             self.anonymous_destructor_dependency_incomplete = true;
                         } else {
                             self.implicit_named_destructors.insert(struct_id);

--- a/crates/rue-cli-tests/cases/generated_name_lookalike_declarations.toml
+++ b/crates/rue-cli-tests/cases/generated_name_lookalike_declarations.toml
@@ -1,0 +1,101 @@
+# Source declarations that merely LOOK like the compiler's generated anonymous
+# types (RUE-1050). Only `__rue_*` and `_start` are reserved (RUE-125), so
+# `struct __anon_struct_5` is legal Rue and must be treated as the ordinary
+# named struct it is.
+#
+# Semantic analysis used to classify types by the generated-name PREFIX rather
+# than by identity, so a source declaration was mistaken for a generated
+# overlay. Method/destructor analysis then indexed the anonymous-type registry
+# with a named StructId and the canonical aggregate identity export refused to
+# issue a named identity, both surfacing as an E9000 ICE rather than a working
+# program.
+#
+# Generated names are `__anon_struct_{32 hex digits}`, so these short names
+# never collide with a real generated one by value -- classification is the
+# whole defect. Each case therefore declares the lookalike AND forces a genuine
+# generated anonymous type into the same program, so the two must be told apart
+# by identity rather than by spelling.
+
+[section]
+id = "cli.generated_name_lookalike_declarations"
+name = "Source declarations that look like generated anonymous types"
+description = "A legal __anon_struct_N/__anon_enum_N source declaration keeps named identity alongside real generated anonymous types (RUE-1050)."
+
+# Reproducer 1: method analysis. The lookalike's method and the generated
+# anonymous struct's method are both called, so both must resolve. 1 + 2 = 3.
+[[case]]
+name = "lookalike_struct_method_resolves_alongside_generated"
+description = "A source __anon_struct_N method is analyzed as a named method while a generated anonymous struct is live."
+files = [{ path = "main.rue", source = """
+struct __anon_struct_5 { x: i32, fn get(self) -> i32 { 1 } }
+fn A() -> type { struct { x: i32, fn get(self) -> i32 { 2 } } }
+fn main() -> i32 {
+    let n = __anon_struct_5 { x: 0 };
+    let T = A();
+    let a: T = T { x: 0 };
+    n.get() + a.get()
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 3
+
+# Reproducer 2: canonical aggregate identity. The lookalike is declared but not
+# used, so only the generated anonymous type is exercised -- the export must
+# still issue a named identity for the declaration rather than refusing it.
+[[case]]
+name = "lookalike_struct_declaration_does_not_block_aggregate_identity"
+description = "A declared-but-unused source __anon_struct_N does not break canonical aggregate identity export."
+files = [{ path = "main.rue", source = """
+struct __anon_struct_6 { x: i32, fn get(self) -> i32 { 1 } }
+fn A() -> type { struct { x: i32, fn get(self) -> i32 { 2 } } }
+fn main() -> i32 {
+    let T = A();
+    let a: T = T { x: 0 };
+    a.get()
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 2
+
+# The enum half of the same classifier. A source `__anon_enum_N` must keep its
+# named identity while a generated anonymous struct is live in the program.
+[[case]]
+name = "lookalike_enum_keeps_named_identity"
+description = "A source __anon_enum_N enum is classified by identity, not by its generated-looking name."
+files = [{ path = "main.rue", source = """
+enum __anon_enum_5 { A, B }
+fn S() -> type { struct { x: i32, fn get(self) -> i32 { 4 } } }
+fn main() -> i32 {
+    let e = __anon_enum_5.B;
+    let T = S();
+    let s: T = T { x: 0 };
+    match e {
+        __anon_enum_5.A => 0,
+        __anon_enum_5.B => s.get(),
+    }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 4
+
+# A destructor on the lookalike must be treated as a NAMED struct's destructor:
+# it participates in ordinary drop-source events and drop glue rather than being
+# routed down the generated-anonymous path.
+[[case]]
+name = "lookalike_struct_destructor_runs_as_named"
+description = "A drop fn on a source __anon_struct_N runs through the named-struct drop path."
+files = [{ path = "main.rue", source = """
+struct __anon_struct_7 { v: i32 }
+drop fn __anon_struct_7(self) { @dbg(self.v); }
+fn A() -> type { struct { x: i32, fn get(self) -> i32 { 2 } } }
+fn main() -> i32 {
+    let n = __anon_struct_7 { v: 9 };
+    let T = A();
+    let a: T = T { x: 0 };
+    @dbg(100);
+    a.get()
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+stdout = "100\n9\n"
+exit_code = 2

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -211,7 +211,8 @@ fn create_struct_drop_glue_function(
         callable_kind: rue_air::AnalyzedCallableKind::DropGlue,
         ordinary_owner: None,
         name: fn_name,
-        implicit_drop_source: if struct_def.name.starts_with("__anon_struct_") {
+        // Membership, not the generated-name prefix (RUE-1050).
+        implicit_drop_source: if type_pool.is_anonymous_struct(struct_id) {
             None
         } else {
             Some(rue_air::ImplicitDropDependencySourceEvent::NamedStruct {


### PR DESCRIPTION
Refs RUE-1050. Refs RUE-1193.

Deliberately a non-closing keyword: one acceptance criterion is not met, see "What is not fixed" below.

## The defect

`__anon_struct_N` / `__anon_enum_N` are legal source declarations — only `__rue_*` and `_start` are reserved (RUE-125) — but semantic analysis classified several types by the generated-name **prefix**. A source declaration was mistaken for a compiler-generated overlay, so method analysis indexed the anonymous-type registry with a named `StructId` and canonical aggregate identity refused to issue a named identity. Both surfaced as an E9000 ICE.

Generated names are `__anon_struct_{32 hex digits}`, so `__anon_struct_5` never collides with a real generated name *by value*. Classification was the whole defect.

## The fix

The authoritative registries already existed, and were already used correctly a few lines away from several of the broken sites: `anonymous_struct_ids` / `anonymous_enum_ids`, documented as "O(1) reverse membership for source anonymous nominal compatibility". Nine semantic sites now read membership instead of the prefix, spanning declaration dependency capture, method and destructor analysis, resolved declaration targets, and the stable-identity exports behind canonical aggregate identity.

Two consumers sit below semantic analysis and cannot reach that registry — CFG implicit-destructor discovery and drop-glue drop-source events. The type pool now records anonymity itself, marked at anonymous-type creation and layered like `types` so a derived epoch consults its shared base. No `StructDef`/`EnumDef` shape change was needed, so this is not a durable-format change.

## What is not fixed

Chasing the criterion "no generated-name prefix is treated as a language reservation" surfaced a **third, previously unreported bug**: symbol spelling also exempts anonymous types by prefix, so a source `__anon_struct_5` keeps a bare unqualified symbol and two of them in different files collide.

```rue
// helper.rue
pub struct __anon_struct_5 { x: i32, fn get(self) -> i32 { 7 } }
pub fn make() -> i32 { let h = __anon_struct_5 { x: 0 }; h.get() }

// main.rue — expects 8
const helper = @import("helper.rue");
struct __anon_struct_5 { x: i32, fn get(self) -> i32 { 1 } }
fn main() -> i32 { let n = __anon_struct_5 { x: 0 }; n.get() + helper.make() }
```

The pool registry in this PR was built to fix that site. Pointing `struct_symbol_name` at it fixes that program **and regresses both reproducers above** to `E1403 ... provider body export failed: MissingStableIdentity` — durable export re-derives identities from the rendered symbol, and the provider-side pool does not carry the epoch's marks. The bare spelling is load-bearing, which is exactly the reverse-rendering parity burden RUE-1128 exists to retire. That is a design decision rather than a mechanical conversion, so I stopped rather than guess and filed **RUE-1193** with the reproducer, the evidence, and three candidate resolutions.

Not a regression: trunk fails that program too, with a vaguer ICE.

## Tests

Four CLI cases in `generated_name_lookalike_declarations.toml`: both reported reproducers, the enum half, and a destructor on a lookalike declaration (which must take the named drop path). Each was verified to **fail on trunk** and pass here.

## Verification

- Both issue reproducers: E9000 on trunk → exit 3 and exit 2 (the expected values).
- New CLI cases: 4/4 fail on trunk, 4/4 pass here.
- `scripts/rue premerge`: **PASSED** (exit 0) on this tree.
- `scripts/rue quick` (30 targets), `//:spec-tests` (2178 passed), `//:ui-tests` (209 passed).
- `./clippy.sh`: clean across 63 targets.
- `scripts/rue fmt` clean.