### PR TITLE
RUE-1165: pin the remote worker image and separate CI cost signals

### DIFF
--- a/.github/workflows/cache-probe.yml
+++ b/.github/workflows/cache-probe.yml
@@ -5,7 +5,17 @@ name: Cache probe
 # (on a repo that has the BUILDBUDDY_API_KEY secret). It builds the same release
 # target graph as CI, clears the local buck-out, and rebuilds. The workflow fails
 # unless the second build converts locally executed cold actions into cache hits.
+#
+# RUE-1165: it also runs on a schedule, so cache health is a standing signal
+# rather than something a human has to think to ask for. A silently degraded
+# cache does not turn any lane red — it just makes every lane slower — so
+# without a recurring cold-to-warm probe the regression is invisible until
+# someone notices CI got expensive.
 on:
+  schedule:
+    # Mondays 05:00 UTC, ahead of the working week and clear of the 06:00
+    # release suite so the two do not contend for the same runner pool.
+    - cron: '0 5 * * 1'
   workflow_dispatch:
 
 permissions:
@@ -14,6 +24,10 @@ permissions:
 jobs:
   probe:
     runs-on: ubuntu-latest
+    # A cold build of the whole release graph plus a full rebuild is the point
+    # of the probe, not an anomaly; give it the same headroom as the scheduled
+    # release suite instead of the 6-hour default.
+    timeout-minutes: 120
     env:
       # A rerun gets a fresh namespace too, so its first build must be cold.
       CACHE_PROBE_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}

--- a/BUCK
+++ b/BUCK
@@ -384,7 +384,14 @@ rue_sh_test(
 rue_sh_test(
     name = "required-ci-container-pin-validation",
     test = "scripts/validate-required-ci-container-pins.py",
-    args = ["$(location :required-ci-workflows)/.github/workflows/ci.yml"],
+    args = [
+        "$(location :required-ci-workflows)/.github/workflows/ci.yml",
+        # The remote executor's worker image is required CI's other container
+        # (RUE-1165): the merge-group canary runs the compiler build on it. It
+        # must carry an immutable digest, not merely avoid a `latest` tag.
+        "--digest-pinned",
+        "$(location //platforms:remote-execution-platforms)/remote_cache.bzl",
+    ],
 )
 
 rue_sh_test(

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -95,7 +95,8 @@ they're recorded here so a future config change doesn't silently regress:
    relocatable, canonical fix — *not* an absolute-path `LD_LIBRARY_PATH` hack.
 5. **Container** (`platforms/remote_cache.bzl`): pinned to `rbe-ubuntu22-04`
    (Python 3.10 — the prelude's rustc wrapper needs ≥3.9; the default image ships
-   3.6).
+   3.6), by immutable digest rather than by its moving tag. See
+   "Updating the remote worker image" below.
 6. **Linker** (RUE-320): the remote worker needs **`cc`** instead of the absent
    `clang++`. A `remote-execution` constraint is inserted only into the explicit
    full-remote execution configuration. The cache-only configuration omits it
@@ -146,8 +147,13 @@ release build of `//crates/...` then a clean-and-rebuild, and reports buck2's
 `Commands: (cached / remote / local)` line. Each workflow attempt injects a
 unique, otherwise-unused Rust cfg so prior runs cannot satisfy the nominal cold
 phase. The probe fails unless that phase executes local actions and the warm
-phase increases cache hits while reducing local actions. Run it with
-`gh workflow run cache-probe.yml`.
+phase increases cache hits while reducing local actions. It runs weekly
+(Mondays 05:00 UTC) and on demand with `gh workflow run cache-probe.yml`.
+
+The schedule exists because cache degradation is silent by construction: the
+cache can only change speed, never correctness, so a dead or non-populating
+cache turns no lane red. Without a recurring genuinely-cold-then-warm probe, the
+regression surfaces only as CI gradually becoming expensive.
 
 Required CI also records per-step wall time and aggregate cached/remote/local
 command counts in each job summary via `scripts/ci-timed`. The probe answers
@@ -156,11 +162,68 @@ question of how expensive a real change's remaining local actions were. Both
 signals matter: a central Rust or ThinLTO change can have a high numerical hit
 rate while a few invalidated actions remain on the critical path.
 
+Each summary separates the four costs that a single wall-time number conflates:
+
+| Column | Question it answers |
+| --- | --- |
+| Cached | how many actions the remote cache served |
+| Remote | how many executed on the BuildBuddy worker |
+| Local | how many executed on the runner |
+| Test time | how long the test processes themselves ran |
+
+The first three are Buck's own accounting of how each action was *obtained*.
+The fourth is not: Rue's spec, UI, and CLI corpora are entire harnesses behind a
+single `sh_test` action, so their runtime is opaque to those counters. A corpus
+lane can report a 95 percent hit rate and still spend nearly all its wall time
+in one harness process — that is a corpus-sharding problem, not a cache problem,
+and the two are only distinguishable when the summary reports both.
+
 RUE-320 also adds a merge-group-only remote-execution canary. It disables action
 cache reads, selects the no-fallback `//platforms:remote_execution` executor, and
 requires Buck to report remotely executed actions. This is deliberately
 separate from the cache probe: one proves worker execution, the other proves
 unchanged-action reuse.
+
+## Updating the remote worker image
+
+The merge-group remote-execution canary claims "the compiler builds on the
+worker we reviewed". A moving tag would silently change what that proves, and
+would convert an upstream image republish into a merge-queue failure with no
+local reproduction. `//:required-ci-container-pin-validation` therefore rejects
+a `platforms/remote_cache.bzl` image reference without an `@sha256:` digest, and
+rejects a `latest` tag anywhere in required CI. BuildBuddy publishes no
+versioned tag for this image, so unlike the actionlint pin the digest stands
+alone rather than accompanying a reviewed release tag.
+
+1. Resolve the moving stream to its current immutable OCI index digest:
+
+   ```bash
+   docker buildx imagetools inspect gcr.io/flame-public/rbe-ubuntu22-04:latest
+   ```
+
+   The index digest covers every architecture, so the executor still selects the
+   linux/amd64 manifest from it.
+
+2. Update `container-image` in `platforms/remote_cache.bzl` to
+   `docker://gcr.io/flame-public/rbe-ubuntu22-04@sha256:<INDEX-DIGEST>` and
+   refresh the resolution date in the comment above it.
+
+3. Confirm the new image still satisfies the constraints recorded above —
+   Python ≥3.9 for the prelude's rustc wrapper, and a `cc` driver for the
+   RUE-320 linker select:
+
+   ```bash
+   docker run --rm gcr.io/flame-public/rbe-ubuntu22-04@sha256:<INDEX-DIGEST> \
+     bash -c 'python3 --version && cc --version'
+   ```
+
+4. Run the policy and its focused regression tests, then let the merge-group
+   `remote execution (linux-x64)` canary prove the worker end to end:
+
+   ```bash
+   ./buck2 test //:required-ci-container-pin-validation \
+     //:required-ci-container-pin-tool-tests
+   ```
 
 ## Toward a fully hermetic linker
 

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -291,10 +291,20 @@ shard summaries also show the number of measured cases next to wall time. Read
 wall time together with hit count: a small number of invalidated ThinLTO actions
 can dominate a release build even when its hit rate is above 90 percent.
 
+Each summary also reports the action-cache hit rate and the summed duration of
+the test processes themselves. That last figure is deliberately separate from
+the cached/remote/local counters, which describe only how Buck *obtained* each
+action: a corpus lane whose wall time is one harness process is a sharding
+problem, and a lane whose wall time is uncached actions is a cache problem.
+`docs/process/build-cache.md` explains the distinction.
+
 Containers executed by the workflow must use a reviewed, human-readable
 release tag and the immutable OCI index digest for that tag. The repository
 gate `//:required-ci-container-pin-validation` rejects a moving `latest` image
-reference, and the normal `./test.sh` run includes that gate.
+reference, and the normal `./test.sh` run includes that gate. The same gate
+covers the BuildBuddy worker image in `platforms/remote_cache.bzl`, which
+required CI's remote-execution canary executes: there it requires an immutable
+digest outright, since that image publishes no reviewable release tag.
 
 ## Updating actionlint
 

--- a/platforms/BUCK
+++ b/platforms/BUCK
@@ -1,5 +1,16 @@
 load(":remote_cache.bzl", "remote_cache_platform")
 
+# The execution-platform definition that names a BuildBuddy worker image.
+# Required CI's remote-execution canary runs the compiler build on that image,
+# so it is subject to the same reviewed-bytes rule as the workflow's own
+# containers; //:required-ci-container-pin-validation reads it from here and
+# fails the build if the digest is dropped (RUE-1165).
+filegroup(
+    name = "remote-execution-platforms",
+    srcs = ["remote_cache.bzl"],
+    visibility = ["PUBLIC"],
+)
+
 # Build-mode target platforms (RUE-277)
 #
 # These platforms put the //constraints:opt-level value into the *target

--- a/platforms/remote_cache.bzl
+++ b/platforms/remote_cache.bzl
@@ -29,7 +29,20 @@ def _remote_cache_platform_impl(ctx):
                 remote_execution_properties = {
                     "EstimatedMemory": "4GB",
                     "OSFamily": "Linux",
-                    "container-image": "docker://gcr.io/flame-public/rbe-ubuntu22-04:latest",
+                    # Pinned by immutable OCI index digest (RUE-1165). The
+                    # merge-group canary's claim is "this compiler builds on the
+                    # worker we reviewed"; a republished moving tag would silently
+                    # change what that proves, and would turn an upstream image
+                    # change into a merge-queue failure with no local repro.
+                    # BuildBuddy publishes no versioned tag for this image, only
+                    # a moving stream, so the digest stands alone rather than
+                    # accompanying a reviewed release tag as the actionlint pin
+                    # does. //:required-ci-container-pin-validation rejects a
+                    # reference without a digest; the resolution and update
+                    # procedure is in docs/process/build-cache.md.
+                    #
+                    # gcr.io/flame-public/rbe-ubuntu22-04, resolved 2026-07-28.
+                    "container-image": "docker://gcr.io/flame-public/rbe-ubuntu22-04@sha256:0d84a80bb0fc36ba5381942adcf6493249594dcc9044845c617b78c9b621cae3",
                 },
                 remote_execution_use_case = "buck2-default",
                 remote_output_paths = "output_paths",

--- a/scripts/ci-timed
+++ b/scripts/ci-timed
@@ -28,6 +28,8 @@ commands=0
 cached=0
 remote=0
 local_actions=0
+test_ms=0
+tests_seen=0
 cli_cases="—"
 while IFS= read -r line; do
     if [[ "$line" =~ Commands:[[:space:]]+([0-9]+)[[:space:]]+\(cached:[[:space:]]+([0-9]+),[[:space:]]+remote:[[:space:]]+([0-9]+),[[:space:]]+local:[[:space:]]+([0-9]+)\) ]]; then
@@ -37,10 +39,34 @@ while IFS= read -r line; do
         ((remote += BASH_REMATCH[3]))
         ((local_actions += BASH_REMATCH[4]))
     fi
+    # Buck's cached/remote/local counters describe how each action was *obtained*,
+    # not what a test spent once it started. Rue's corpora are whole harnesses
+    # behind a single sh_test action, so their runtime is opaque to those
+    # counters: a lane can show a 95% hit rate and still be dominated by one
+    # harness process. Buck reports each test's own duration on its result line
+    # ("Pass: root//:spec-tests (73.4s)"); summing those separates harness time
+    # from action-graph time (RUE-1165).
+    if [[ "$line" =~ (Pass|Fail|Timeout|Fatal|Omit):[[:space:]]+[^[:space:]]+[[:space:]]+\(([0-9]+m)?([0-9]+)(\.[0-9]+)?s\) ]]; then
+        ((tests_seen += 1))
+        minutes="${BASH_REMATCH[2]%m}"
+        fraction="${BASH_REMATCH[4]#.}000"
+        ((test_ms += ((10#${minutes:-0} * 60) + 10#${BASH_REMATCH[3]}) * 1000 + 10#${fraction:0:3}))
+    fi
     if [[ "$line" =~ cli-tests:[[:space:]]+measured[[:space:]]+([0-9]+)[[:space:]]+cases ]]; then
         cli_cases="${BASH_REMATCH[1]}"
     fi
 done <"$log"
+
+# Report only measured quantities: a step that built without running tests has
+# no opaque time, which is different from having measured zero.
+test_time="—"
+if [[ "$tests_seen" -gt 0 ]]; then
+    test_time="$((test_ms / 1000)).$(printf '%03d' "$((test_ms % 1000))")s"
+fi
+hit_rate="—"
+if [[ "$commands" -gt 0 ]]; then
+    hit_rate="$((cached * 100 / commands))%"
+fi
 
 if [[ "$status" -eq 0 && "${RUE_CI_REQUIRE_REMOTE_ACTIONS:-0}" == "1" && "$remote" -eq 0 ]]; then
     echo "::error::remote-execution canary completed without any remotely executed Buck actions" >&2
@@ -57,9 +83,14 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     {
         echo "### CI timing: $safe_label"
         echo
-        echo "| Result | Wall time | CLI cases | Buck invocations | Commands | Cached | Remote | Local |"
-        echo "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
-        echo "| $result | ${elapsed}s | $cli_cases | $invocations | $commands | $cached | $remote | $local_actions |"
+        echo "| Result | Wall time | Test time | Cache hits | CLI cases | Buck invocations | Commands | Cached | Remote | Local |"
+        echo "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+        echo "| $result | ${elapsed}s | $test_time | $hit_rate | $cli_cases | $invocations | $commands | $cached | $remote | $local_actions |"
+        echo
+        echo "<sup>Cached/Remote/Local count Buck actions by how each was obtained."
+        echo "Test time is the summed duration Buck reports for the test processes"
+        echo "themselves — opaque to those counters, and where a corpus lane's wall"
+        echo "time actually goes.</sup>"
         echo
     } >>"$GITHUB_STEP_SUMMARY"
 fi

--- a/scripts/test-required-ci-container-pins.py
+++ b/scripts/test-required-ci-container-pins.py
@@ -54,6 +54,47 @@ class RequiredCiContainerPinTests(unittest.TestCase):
             [],
         )
 
+    def digest_pins(self, source: str) -> list[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "remote_cache.bzl"
+            path.write_text(source)
+            return pins.validate_digest_pins(path)
+
+    def test_accepts_digest_pinned_executor_image(self) -> None:
+        self.assertEqual(
+            self.digest_pins(
+                '                    "container-image": "docker://gcr.io/x/y@sha256:'
+                + "0" * 64
+                + '",\n'
+            ),
+            [],
+        )
+
+    def test_rejects_executor_image_without_digest(self) -> None:
+        errors = self.digest_pins('"container-image": "docker://gcr.io/x/y:latest",\n')
+        self.assertEqual(len(errors), 1)
+        self.assertIn("is not pinned", errors[0])
+
+    def test_rejects_truncated_executor_digest(self) -> None:
+        errors = self.digest_pins(
+            '"container-image": "docker://gcr.io/x/y@sha256:' + "0" * 63 + '",\n'
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("is not pinned", errors[0])
+
+    def test_rejects_digest_pinned_file_with_no_image(self) -> None:
+        # A vacuous pass is the failure mode this gate exists to prevent.
+        errors = self.digest_pins('remote_execution_properties = {"OSFamily": "Linux"}\n')
+        self.assertEqual(len(errors), 1)
+        self.assertIn("no container-image property", errors[0])
+
+    def test_ignores_commented_executor_image(self) -> None:
+        errors = self.digest_pins(
+            '# "container-image": "docker://gcr.io/x/y:latest",\n'
+            '"container-image": "docker://gcr.io/x/y@sha256:' + "0" * 64 + '",\n'
+        )
+        self.assertEqual(errors, [])
+
     def test_ignores_latest_in_comments_and_quoted_hashes(self) -> None:
         self.assertEqual(
             self.validate(

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -692,6 +692,10 @@ test_ci_timed_preserves_status_and_summarizes_actions() {
 echo 'first line'
 echo 'Commands: 10 (cached: 7, remote: 1, local: 2)'
 echo 'Commands: 5 (cached: 3, remote: 1, local: 1)'
+echo '✓ Pass: root//:spec-tests (1m12.250s)'
+echo '✓ Pass: root//:ui-tests (7.5s)'
+echo '✗ Fail: root//:cli-tests (2s)'
+echo 'Skip: root//:stress-tests'
 echo 'cli-tests: measured 37 cases in /tmp/timings.jsonl'
 exit "${FAKE_EXIT:-0}"
 EOF
@@ -707,6 +711,12 @@ EOF
     "$(grep -Fq '| passed |' "$sb/summary" && grep -Fq '| 2 | 15 | 10 | 2 | 3 |' "$sb/summary" && echo 0 || echo 1)"
   check "ci-timed: CLI case count is included" \
     "$(grep -Fq '| 37 | 2 | 15 |' "$sb/summary" && echo 0 || echo 1)"
+  # 72.250 + 7.500 + 2.000, summed across minutes, fractional, and whole-second
+  # spellings; the duration-less Skip line contributes nothing.
+  check "ci-timed: opaque test-process time is separated from action counts" \
+    "$(grep -Fq '| 81.750s |' "$sb/summary" && echo 0 || echo 1)"
+  check "ci-timed: action-cache hit rate is reported" \
+    "$(grep -Fq '| 66% |' "$sb/summary" && echo 0 || echo 1)"
 
   rc=0
   RUE_CI_REQUIRE_REMOTE_ACTIONS=1 "$sb/ci-timed" "remote wrapper" -- "$sb/fake-command" >/dev/null 2>&1 || rc=$?

--- a/scripts/validate-required-ci-container-pins.py
+++ b/scripts/validate-required-ci-container-pins.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
-"""Reject moving container image tags in required CI workflows."""
+"""Reject unpinned container images in required CI workflows and executors.
+
+Two rules, both about the same property: required CI must execute exactly the
+bytes a human reviewed.
+
+* Every checked file rejects a moving `latest` tag.
+* Files named with `--digest-pinned` additionally require every executor
+  `container-image` property to carry an immutable `@sha256:` digest. These are
+  the remote-execution platform definitions, where a republished worker image
+  would silently change what a green canary proves.
+"""
 
 from __future__ import annotations
 
@@ -14,6 +24,13 @@ DEFAULT_WORKFLOWS = [ROOT / ".github" / "workflows" / "ci.yml"]
 LATEST_IMAGE = re.compile(
     r"(?P<image>[A-Za-z0-9][A-Za-z0-9._:/-]*:latest)(?=@|\s|[\"']|$)"
 )
+# The Buck `remote_execution_properties` entry naming the worker image, in
+# either Starlark (`"container-image": "docker://..."`) or YAML/RE-properties
+# (`container-image = docker://...`) spelling.
+CONTAINER_IMAGE = re.compile(
+    r"""["']?container-image["']?\s*[:=]\s*["'](?P<image>[^"']*)["']"""
+)
+IMMUTABLE_DIGEST = re.compile(r"@sha256:[0-9a-f]{64}\b")
 
 
 def uncommented(line: str) -> str:
@@ -50,19 +67,57 @@ def validate(path: Path) -> list[str]:
     return errors
 
 
+def validate_digest_pins(path: Path) -> list[str]:
+    """Require an immutable digest on every executor container image."""
+
+    errors: list[str] = []
+    found = 0
+    for line_number, line in enumerate(path.read_text().splitlines(), 1):
+        for match in CONTAINER_IMAGE.finditer(uncommented(line)):
+            found += 1
+            image = match.group("image")
+            if not IMMUTABLE_DIGEST.search(image):
+                errors.append(
+                    f"{path}:{line_number}: remote executor image {image!r} is not "
+                    "pinned; append the immutable @sha256:<digest> of the reviewed image"
+                )
+    if not found:
+        # A rename or refactor that drops the property would otherwise turn this
+        # gate into a vacuous pass, which is how RUE-1152 hid a dead formatting
+        # check.
+        errors.append(
+            f"{path}: no container-image property found; this file is declared "
+            "digest-pinned, so the gate would silently check nothing"
+        )
+    return errors
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("workflows", nargs="*", type=Path)
+    parser.add_argument(
+        "--digest-pinned",
+        action="append",
+        default=[],
+        type=Path,
+        metavar="FILE",
+        help="file whose container-image properties must carry an @sha256: digest",
+    )
     args = parser.parse_args()
 
     workflows = args.workflows or DEFAULT_WORKFLOWS
-    errors = [error for path in workflows for error in validate(path)]
+    checked = list(workflows) + list(args.digest_pinned)
+    errors = [error for path in checked for error in validate(path)]
+    errors += [error for path in args.digest_pinned for error in validate_digest_pins(path)]
     if errors:
         for error in errors:
             print(f"error: {error}", file=sys.stderr)
         return 1
 
-    print(f"required CI container pins valid: {len(workflows)} workflow(s)")
+    print(
+        f"required CI container pins valid: {len(workflows)} workflow(s), "
+        f"{len(args.digest_pinned)} digest-pinned executor file(s)"
+    )
     return 0
 
 


### PR DESCRIPTION
Closes RUE-1165.

Operate BuildBuddy as an observable accelerator that cannot quietly change what CI proves.

## Worker image pinned by digest

The merge-group remote-execution canary ran on `rbe-ubuntu22-04:latest` — a moving tag. Its whole claim is "this compiler builds on the worker we reviewed", and a republish silently changes what that means; it also converts an upstream image change into a merge-queue failure with no local reproduction.

`platforms/remote_cache.bzl` now pins the immutable OCI index digest (`sha256:0d84a80b…`, resolved 2026-07-28 — the index covers every architecture, so the executor still selects linux/amd64). BuildBuddy publishes no versioned tag for this image, so unlike the actionlint pin the digest stands alone rather than accompanying a reviewed release tag.

`//:required-ci-container-pin-validation` now covers that file too, with a stricter rule than the workflow one: a `container-image` property must carry an `@sha256:<digest>`, not merely avoid `latest`. It also fails if the property disappears entirely, so a rename or refactor cannot turn the gate into a vacuous pass (the RUE-1152 failure mode). Five focused cases added to the existing tool tests.

## Scheduled cache health

`cache-probe.yml` was `workflow_dispatch`-only. Cache degradation is silent by construction — the cache changes speed, never correctness, so a dead or non-populating cache turns no lane red and is noticed only as CI gradually becoming expensive. It now also runs weekly (Mondays 05:00 UTC, clear of the 06:00 release suite), with an explicit 120-minute timeout. The genuinely-cold-then-warm mechanism (per-attempt nonce, `scripts/check-cache-probe` counter assertions) is unchanged.

## Summaries separate the four costs

`scripts/ci-timed` reported wall time plus Buck's cached/remote/local counters. Those counters describe how each action was *obtained*; Rue's spec, UI, and CLI corpora are entire harnesses behind a single `sh_test` action, so their runtime is invisible to them. A corpus lane can report a 95% hit rate and still spend nearly all its wall time in one harness process — a sharding problem, not a cache problem, and previously indistinguishable.

Summaries now add an action-cache hit rate and the summed test-process duration (parsed from Buck's per-test result lines, handling `1m12.250s`, `7.5s`, and `2s` spellings; duration-less lines contribute nothing). A step that ran no tests reports `—` rather than a misleading zero.

## Acceptance criteria

| Criterion | Status |
| --- | --- |
| Remote worker image pinned by digest | this PR, plus a gate |
| Trusted PR / merge-group behavior documented; forks fall back without secrets | already satisfied — verified in `docs/process/build-cache.md` and every `Provision remote build cache` step, which treats an empty key as skip |
| Scheduled cache health: genuinely cold action then warm hit | this PR (schedule); cold-to-warm assertions pre-existing (RUE-1034) |
| RE canary diagnoses infrastructure without replacing correctness execution | already satisfied — merge-group-only, builds `//crates/rue:rue` alone; no correctness suite depends on it |
| Summaries separate cache hits, remote, local, opaque test time | this PR |
| Cache outage or missing credential makes CI slower, not wrong | already satisfied — `--prefer-local` means misses execute locally, and provisioning is gated on secret presence |
| `--prefer-remote` policy consistent with active platform constraints | already consistent — the `./buck2` wrapper forces `--prefer-local` unless an execution mode is explicit, and the sole `--prefer-remote` use is the canary paired with `//platforms:remote_execution`. Verified, not newly gated: a robust gate needs to associate a flag with its enclosing folded `run:` block, which is more workflow parsing than the invariant justifies today. |

## Verification

* `./buck2 test //:required-ci-container-pin-validation //:required-ci-container-pin-tool-tests //:wrapper-script-tests //:ci-gate-validation //:ci-gate-validator-tool-tests //:cli-shard-coverage-validation //:build-sharing-tests` — 7 pass
* `./buck2 test //... --exclude rue_heavy_suite --exclude rue_test_tier_slow --exclude rue_test_tier_stress` — 70 pass, 0 fail
* `scripts/rue quick` — pass
* End-to-end `scripts/ci-timed` over a real `buck2 test`: a 4s step reported `3.900s` test time, i.e. the wall time was harness process time, not action-graph time
* Digest independently re-resolved against `gcr.io` by digest (HTTP 200)

The worker image itself is proven end to end only by the merge-group `remote execution (linux-x64)` canary, which does not run on pull requests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5UUvPAbMuTyUhBoo1GFsF)_