### PR TITLE
Note that the cache counters cannot see test execution

### DIFF
--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -178,6 +178,17 @@ lane can report a 95 percent hit rate and still spend nearly all its wall time
 in one harness process — that is a corpus-sharding problem, not a cache problem,
 and the two are only distinguishable when the summary reports both.
 
+The separation is not a presentational choice: the first three counters *cannot*
+see test execution. A `buck2 test` run is handed to the test executor rather than
+evaluated as an action, so it never enters the `Commands:` accounting, and OSS
+buck2 ships no test-result cache to serve it from. In one `merge_group` run,
+`//:cli-tests-caldera` (which executed nothing) and `//:cli-tests-shard-1` (which
+ran for 11:18) both reported `Commands: 465 (cached: 465/464)`. A corpus job can
+therefore print a perfect hit rate while re-running an eleven-minute suite in
+full, and that reads as "everything was cached" to anyone who stops at the
+cache columns. Test time is the signal that separates those two runs. RUE-1118
+has the measurements.
+
 RUE-320 also adds a merge-group-only remote-execution canary. It disables action
 cache reads, selects the no-fallback `//platforms:remote_execution` executor, and
 requires Buck to report remotely executed actions. This is deliberately


### PR DESCRIPTION
One paragraph in `docs/process/build-cache.md`. Split out of RUE-1118 so it lands independently of the corpus-caching change in #2044 — it describes trunk as it is today, not that PR's machinery.

## The problem

The doc introduces `scripts/ci-timed`'s `Commands: N (cached: C, remote: R, local: L)` counters as the answer to "how expensive were a real change's remaining local actions." On a corpus lane that reading is wrong, and wrong in the direction that flatters the result.

A `buck2 test` run is handed to the test executor rather than evaluated as an action. It never enters the `Commands:` accounting, and OSS buck2 ships no test-result cache to serve it from. In one `merge_group` run:

- `//:cli-tests-caldera` — test ran `0.0s` → `Commands: 465 (cached: 465, remote: 0, local: 0)`
- `//:cli-tests-shard-1` — test ran `11:18.2` → `Commands: 465 (cached: 464, remote: 0, local: 1)`

Identical totals for a suite that executed nothing and one that ran for eleven minutes. So a corpus job can print a perfect hit rate while re-running its entire suite, and that reads as "everything was cached" to anyone who stops at the counters.

The RUE-1118 investigation nearly misread exactly this, which is the argument for recording it where the counters are introduced rather than leaving it to be rediscovered.

## What changed

One paragraph after the existing four-column summary table, stating that the cached/remote/local counters cover build actions only, giving the Caldera/shard-1 pair as the concrete case, and pointing at the table's **Test time** column as the signal that separates those two runs.

Docs only — no code, no targets, no CI behavior.

## Rebase note

Rebased onto current trunk. The original paragraph predates the four-column table and `ci-timed`'s `Test time` column, so it conflicted and had two stale edges, both fixed here:

- It asserted "on a corpus lane the job's wall time is the only honest signal." That was true when the summary reported no test time. `ci-timed` now measures and prints it, so the paragraph points at **Test time** instead.
- The table's prose already notes that corpora are opaque to the counters. The paragraph no longer restates that; it supplies the part the table does not — *why* they are opaque (a test execution is not an action at all, and there is no test-result cache), plus the measurement.

The commit's `Co-Authored-By`/session trailers were dropped to match the tool-neutral convention in AGENTS.md.