### PR TITLE
Run the heavy corpora as cacheable build actions

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -165,6 +165,13 @@ rue_sh_test(
     },
 )
 
+# RUE-1118: RUE_REAL_STD_PATH was missing here. Cases marked `real_std` compile
+# against the standard library, and rue-test-runner resolves it through that
+# variable with a cwd-relative fallback ("std", "../std", ...). Under the old
+# sh_test, which ran from the project root, the fallback silently found the real
+# std/ and the suite passed against an input Buck did not know about — the exact
+# false-hit hazard this file's header warns about. Declaring it makes std/ a
+# tracked input of the UI corpus.
 cached_corpus_suite(
     name = "ui-tests",
     labels = ["rue_heavy_suite"],
@@ -172,10 +179,12 @@ cached_corpus_suite(
     args = ["--quiet"],
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_REAL_STD_PATH": "$(location :std)/std",
         "RUE_UI_CASES": "$(location //crates/rue-ui-tests:cases)/cases",
     },
     absolutize = [
         "RUE_BINARY",
+        "RUE_REAL_STD_PATH",
         "RUE_UI_CASES",
     ],
 )

--- a/BUCK
+++ b/BUCK
@@ -1,8 +1,8 @@
 # Repo-root test-suite targets (RUE-144 / RUE-132).
 #
-# Each sh_test ties a test-harness binary to the rue compiler and the on-disk
-# inputs the suite actually reads (cases/, std/, docs/), so Buck owns the binary
-# handoff and caches each suite against its real inputs:
+# Each suite ties a test-harness binary to the rue compiler and the on-disk
+# inputs it actually reads (cases/, std/, docs/), so Buck owns the binary
+# handoff and keys each suite on its real inputs:
 #
 #   buck2 test //...        # runs unit tests + spec/UI/CLI suites + repo gates
 #
@@ -10,19 +10,42 @@
 # under std/ re-runs the CLI and spec suites (std/ MUST be a declared input here
 # or either suite could get false cache hits on standard-library changes).
 #
+# RUE-1118: the heavy corpora run through `cached_corpus_suite` rather than a
+# bare sh_test. buck2 re-executes every test invocation — test executions are
+# not actions and never reach the action cache — so a plain sh_test re-ran the
+# whole corpus on each merge even when the merge commit's tree was byte-identical
+# to the tree the PR run had just validated. The macro moves the harness into a
+# cacheable build action and leaves a thin sh_test asserting its stamp, so the
+# suite keeps its name, labels, and result line. See corpus.bzl for the input
+# contract this makes load-bearing.
+#
 # Mechanics: the harness binaries already locate everything via env vars
-# (rue-test-runner's find_rue_binary / find_dir), `$(exe_target ...)` /
-# `$(location ...)` expand to absolute paths, and sh_test runs from the
-# project root — so the harness binary itself can be the `test` command and
-# no wrapper script is needed. A filegroup's output directory is named after
-# the rule and contains its srcs at package-relative paths, hence the
-# `$(location ...)/cases` shape.
+# (rue-test-runner's find_rue_binary / find_dir), and a filegroup's output
+# directory is named after the rule and contains its srcs at package-relative
+# paths, hence the `$(location ...)/cases` shape. In an sh_test those macros
+# expand to absolute paths and the test runs from the project root; in a
+# genrule they are relative to the action's working directory, which is why
+# cached_corpus_suite routes them through scripts/corpus-action.
 #
 # These suites live at the repo root rather than in the harness crates' BUCK
 # files so that `buck2 test //crates/...` (quick-test.sh, test.sh's filtered
 # path) still means "unit tests only".
 
 load("//:test_defs.bzl", "rue_sh_test", "rue_test_suite")
+load(":corpus.bzl", "cached_corpus_suite")
+
+# The two halves of a cached corpus suite: the action wrapper that runs a
+# harness and writes its stamp, and the thin check that asserts the stamp.
+sh_binary(
+    name = "corpus-action",
+    main = "scripts/corpus-action",
+)
+
+sh_binary(
+    name = "corpus-stamp-check",
+    main = "scripts/corpus-stamp-check",
+    visibility = ["PUBLIC"],
+)
 
 # The formatting gate lives in fmt.sh, not here. A `fmt-check` sh_test used to
 # sit at this spot, taking its file list from `glob(["crates/**/*.rs"])`. A
@@ -115,16 +138,21 @@ filegroup(
     srcs = [".github/workflows/ci.yml"],
 )
 
-rue_sh_test(
+cached_corpus_suite(
     name = "spec-tests",
     labels = ["rue_heavy_suite"],
-    test = "//crates/rue-spec:rue-spec",
+    harness = "//crates/rue-spec:rue-spec",
     args = ["--quiet"],
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
         "RUE_REAL_STD_PATH": "$(location :std)/std",
         "RUE_SPEC_CASES": "$(location //crates/rue-spec:cases)/cases",
     },
+    absolutize = [
+        "RUE_BINARY",
+        "RUE_REAL_STD_PATH",
+        "RUE_SPEC_CASES",
+    ],
 )
 
 rue_sh_test(
@@ -137,15 +165,19 @@ rue_sh_test(
     },
 )
 
-rue_sh_test(
+cached_corpus_suite(
     name = "ui-tests",
     labels = ["rue_heavy_suite"],
-    test = "//crates/rue-ui-tests:rue-ui-tests",
+    harness = "//crates/rue-ui-tests:rue-ui-tests",
     args = ["--quiet"],
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
         "RUE_UI_CASES": "$(location //crates/rue-ui-tests:cases)/cases",
     },
+    absolutize = [
+        "RUE_BINARY",
+        "RUE_UI_CASES",
+    ],
 )
 
 # Shared verbatim by //:cli-tests and its shards so a slice runs exactly the
@@ -172,14 +204,38 @@ _CLI_TEST_ENV = dict(_CLI_TEST_BASE_ENV.items() + [
     ("RUE_CLI_CASE_TIER", "premerge"),
 ])
 
-# The bounded premerge CLI corpus. Explicit slow sections and automatic
-# examples are registered by //:cli-tests-slow instead.
-rue_sh_test(
+# Every _CLI_TEST_ENV entry is a path the harness hands to a compiler spawned
+# with a case's temp directory as cwd, so all of them must be absolute (see
+# corpus.bzl). The harness's find_dir fallbacks would otherwise resolve against
+# the action's working directory and silently miss the real corpus.
+_CLI_TEST_ABSOLUTIZE = [
+    "RUE_BINARY",
+    "RUE_CLI_CASES",
+    "RUE_EXAMPLES_DIR",
+    "RUE_REPO_DIR",
+    "RUE_STD_DIR",
+]
+
+# RUE-1083 recalibrated several per-case heavyweight compile budgets upward, so
+# the serialized aggregate can exceed a short outer bound. These replace the
+# test executor's timeout, which scripts/ci-heavy-suite used to pass and a build
+# action does not get; the per-case contracts in execution_contracts.toml remain
+# the honest gates. Re-tighten when the per-case budgets come back down.
+_CLI_TESTS_TIMEOUT_SECONDS = 1800
+_CLI_SHARD_TIMEOUT_SECONDS = 1200
+
+# The bounded premerge CLI corpus in one invocation: the canonical target that a
+# local `./test.sh` full run executes and that the RUE-924 corpus-omission audit
+# tracks (REQUIRED_CORPUS_HARNESSES in test.sh). Explicit slow sections and
+# automatic examples are registered by //:cli-tests-slow instead.
+cached_corpus_suite(
     name = "cli-tests",
     labels = ["rue_heavy_suite"],
-    test = "//crates/rue-cli-tests:rue-cli-tests",
+    harness = "//crates/rue-cli-tests:rue-cli-tests",
     args = _CLI_TEST_ARGS,
     env = _CLI_TEST_ENV,
+    absolutize = _CLI_TEST_ABSOLUTIZE,
+    timeout_seconds = _CLI_TESTS_TIMEOUT_SECONDS,
 )
 
 # Exhaustive behavior for declarative `tier = "slow"` CLI sections. This is a
@@ -201,11 +257,12 @@ rue_sh_test(
 # differential-opt corpus through that release-built compiler. The scheduled
 # full-release workflow owns exhaustive //... coverage off the PR critical
 # path (RUE-1129).
-rue_sh_test(
+cached_corpus_suite(
     name = "release-smoke",
-    test = "//crates/rue-cli-tests:rue-cli-tests",
+    harness = "//crates/rue-cli-tests:rue-cli-tests",
     args = ["--quiet", "differential_opt"],
     env = _CLI_TEST_ENV,
+    absolutize = _CLI_TEST_ABSOLUTIZE,
 )
 
 # RUE-1116: parallel CI shards of the CLI corpus. Same harness and declared
@@ -223,15 +280,17 @@ rue_sh_test(
 CLI_TEST_SHARD_COUNT = 4
 
 [
-    rue_sh_test(
+    cached_corpus_suite(
         name = "cli-tests-shard-{}".format(_shard),
         labels = ["rue_heavy_suite", "rue_cli_shard"],
-        test = "//crates/rue-cli-tests:rue-cli-tests",
+        harness = "//crates/rue-cli-tests:rue-cli-tests",
         args = _CLI_TEST_ARGS,
         env = dict(_CLI_TEST_ENV.items() + [
             ("RUE_CLI_TEST_SHARD", "{}/{}".format(_shard, CLI_TEST_SHARD_COUNT)),
             ("RUE_CLI_SHARD_WEIGHTS", "$(location //crates/rue-cli-tests:shard-weights)"),
         ]),
+        absolutize = _CLI_TEST_ABSOLUTIZE,
+        timeout_seconds = _CLI_SHARD_TIMEOUT_SECONDS,
     )
     for _shard in range(CLI_TEST_SHARD_COUNT)
 ]
@@ -298,6 +357,12 @@ CLI_TEST_SHARD_COUNT = 4
 # real maintained program (rill) for byte-stable output, not just the
 # purpose-built fixture. An edit under examples/ must therefore re-run it.
 rue_sh_test(
+    # RUE-1118: still a plain sh_test, so it re-runs on every invocation. Its
+    # harness is a shell script rather than a target, and unlike the corpus
+    # harnesses it reads repository paths directly rather than through declared
+    # env inputs — the input contract cached_corpus_suite depends on has to be
+    # established before caching this one would be sound rather than a false
+    # pass. It is also off the merge queue's critical path.
     name = "reproducible-programs",
     labels = ["rue_heavy_suite"],
     test = "scripts/test-reproducible-output.sh",
@@ -338,6 +403,8 @@ rue_sh_test(
 # reference oracle and native codegen. It lives at the root so full/no-argument
 # `test.sh` and CI include it while `quick-test.sh` remains unit-only.
 rue_sh_test(
+    # RUE-1118: still a plain sh_test, for the same reason as
+    # //:reproducible-programs above.
     name = "oracle-diff-generated-smoke",
     labels = ["rue_heavy_suite"],
     test = "scripts/oracle-diff-generated-smoke.sh",
@@ -753,6 +820,25 @@ rue_sh_test(
     test = "scripts/test-wrapper-scripts.sh",
     env = {
         "RUE_WRAPPER_ROOT": "$(location :wrapper-script-inputs)",
+    },
+)
+
+# RUE-1118: corpus-action decides whether a corpus suite's result is written to
+# the action cache, so its stamp-only-on-success and absolutization contracts
+# are pinned independently of any corpus actually running.
+filegroup(
+    name = "corpus-script-inputs",
+    srcs = [
+        "scripts/corpus-action",
+        "scripts/corpus-stamp-check",
+    ],
+)
+
+rue_sh_test(
+    name = "corpus-action-tests",
+    test = "scripts/test-corpus-action.sh",
+    env = {
+        "RUE_CORPUS_SCRIPTS_ROOT": "$(location :corpus-script-inputs)",
     },
 )
 

--- a/corpus.bzl
+++ b/corpus.bzl
@@ -62,25 +62,13 @@ def cached_corpus_suite(
         if key not in env:
             fail("cached_corpus_suite({}): absolutize names '{}', which is not in env".format(name, key))
 
-    action_env = dict(env.items())
-    action_env["RUE_CORPUS_ABSOLUTIZE"] = " ".join(absolutize)
-    if timeout_seconds != None:
-        action_env["RUE_CORPUS_TIMEOUT_SECONDS"] = str(timeout_seconds)
-
-    # A genrule cmd cannot use shell command substitution: `$(...)` is Buck's
-    # own macro syntax. Everything variable lives in `env` instead, and
-    # scripts/corpus-action does the resolving.
-    cmd = " ".join([
-        "$(exe_target //:corpus-action)",
-        "$OUT",
-        "$(exe_target {})".format(harness),
-    ] + ["'{}'".format(arg) for arg in args])
-
-    native.genrule(
+    _corpus_action(
         name = name + "-action",
-        out = "stamp.txt",
-        cmd = cmd,
-        env = action_env,
+        harness = harness,
+        harness_args = args,
+        corpus_env = env,
+        absolutize = absolutize,
+        timeout_seconds = timeout_seconds,
     )
 
     native.sh_test(
@@ -89,3 +77,56 @@ def cached_corpus_suite(
         test = "//:corpus-stamp-check",
         args = ["$(location :{}-action)".format(name)],
     )
+
+def _corpus_action_impl(ctx: AnalysisContext) -> list[Provider]:
+    stamp = ctx.actions.declare_output("stamp.txt")
+
+    action_env = dict(ctx.attrs.corpus_env.items())
+    action_env["RUE_CORPUS_ABSOLUTIZE"] = " ".join(ctx.attrs.absolutize)
+    if ctx.attrs.timeout_seconds != None:
+        action_env["RUE_CORPUS_TIMEOUT_SECONDS"] = str(ctx.attrs.timeout_seconds)
+
+    ctx.actions.run(
+        cmd_args(
+            ctx.attrs.wrapper[RunInfo],
+            stamp.as_output(),
+            ctx.attrs.harness[RunInfo],
+            ctx.attrs.harness_args,
+        ),
+        env = action_env,
+        category = "rue_corpus",
+        identifier = ctx.label.name,
+        # The corpus spawns the real compiler and links native binaries, so it
+        # belongs on the lane's own platform; this matches the repository's
+        # ordinary --prefer-local policy. It does not affect cache *reads* —
+        # lookup still happens before a miss executes.
+        local_only = True,
+        # THE POINT OF THIS RULE. `genrule` computes
+        #     cacheable = attrs.cacheable and (local_only or prefer_local)
+        # and passes it as allow_cache_upload, where local_only/prefer_local are
+        # driven purely by a Meta-internal label allowlist (uses_sudo, qt_moc,
+        # yarn_install, ...). A plain genrule therefore never uploads its result
+        # in this repository: the first merge_group run of RUE-1118 re-executed
+        # every corpus on a tree byte-identical to the one the PR run had just
+        # built, because nothing had ever been written to the cache. Stating the
+        # intent here is both honest and immune to a prelude bump reorganizing
+        # that label list.
+        allow_cache_upload = True,
+    )
+
+    return [DefaultInfo(default_output = stamp)]
+
+_corpus_action = rule(
+    impl = _corpus_action_impl,
+    attrs = {
+        # `attrs.arg` expands $(location ...) / $(exe_target ...) in the values
+        # and registers what they name as inputs of the action — which is what
+        # keys the cache entry, and what the input contract above is about.
+        "absolutize": attrs.list(attrs.string(), default = []),
+        "corpus_env": attrs.dict(attrs.string(), attrs.arg(), default = {}),
+        "harness": attrs.dep(providers = [RunInfo]),
+        "harness_args": attrs.list(attrs.string(), default = []),
+        "timeout_seconds": attrs.option(attrs.int(), default = None),
+        "wrapper": attrs.dep(providers = [RunInfo], default = "//:corpus-action"),
+    },
+)

--- a/corpus.bzl
+++ b/corpus.bzl
@@ -1,0 +1,91 @@
+"""Corpus suites that run as cacheable build actions (RUE-1118).
+
+buck2 re-executes every `buck2 test` invocation. Test executions are not
+actions: they are handed to the test executor, they never appear in buck2's
+`Commands: N (cached: ...)` accounting, and OSS buck2 ships no test-result
+cache. Measured on three CI runs of one byte-identical tree (two `pull_request`,
+one `merge_group`), build actions converged to 465/465 cache hits while the
+corpora re-ran in full every time, at 91-97% of the merge queue's critical path.
+
+`cached_corpus_suite` splits each corpus in two:
+
+  * a `genrule` that runs the harness and writes a stamp on success. This is an
+    ordinary action, keyed on its declared inputs, so a PR run uploads it and
+    the merge_group run reads it back.
+  * a thin `sh_test` that asserts the stamp exists. It keeps the target's name,
+    labels, and `Pass: root//:NAME (time)` result line, so `scripts/ci-heavy-suite`
+    and test.sh's RUE-924 corpus-omission audit keep working unchanged.
+
+THE INPUT CONTRACT IS NOW LOAD-BEARING. Under a plain `sh_test` an undeclared
+input was merely untracked — the suite re-ran regardless. Here an undeclared
+input is a false pass: change a file the action does not name, and the corpus
+reports success against the previous tree's result. Every path a harness reads
+at runtime MUST reach it through `env` (or `args`), and therefore through
+`$(location ...)`. When adding a corpus input, add it here, not just to the
+harness.
+"""
+
+load("//:test_defs.bzl", "rue_test_labels")
+
+def cached_corpus_suite(
+        name,
+        harness,
+        args = [],
+        env = {},
+        absolutize = [],
+        labels = [],
+        tier = "premerge",
+        timeout_seconds = None):
+    """Define a corpus suite whose expensive run is a cacheable build action.
+
+    Args:
+        name: the test target's name. The action becomes `NAME-action`.
+        harness: the corpus harness binary target.
+        args: arguments passed to the harness.
+        env: environment for the harness, as on the equivalent `sh_test`.
+        absolutize: the `env` keys holding paths. Buck expands `$(location ...)`
+            inside a genrule relative to the action's working directory, which is
+            not the project root, and the harnesses spawn the compiler with each
+            case's temp directory as cwd. `scripts/corpus-action` resolves these
+            to absolute paths immediately before the harness runs.
+        labels: labels for the test target. The action carries none: it is not a
+            test, and `rue_heavy_suite` drives test discovery.
+        tier: execution-tier ownership (RUE-1157), validated and applied by
+            `rue_test_labels`. It belongs on the test target rather than the
+            action for the same reason `labels` does: tier selection is how CI
+            and the local wrappers discover *tests*, and the action is not one.
+        timeout_seconds: outer bound replacing the test executor's timeout, which
+            a build action does not get. The per-case budgets in
+            execution_contracts.toml remain the honest gates.
+    """
+    for key in absolutize:
+        if key not in env:
+            fail("cached_corpus_suite({}): absolutize names '{}', which is not in env".format(name, key))
+
+    action_env = dict(env.items())
+    action_env["RUE_CORPUS_ABSOLUTIZE"] = " ".join(absolutize)
+    if timeout_seconds != None:
+        action_env["RUE_CORPUS_TIMEOUT_SECONDS"] = str(timeout_seconds)
+
+    # A genrule cmd cannot use shell command substitution: `$(...)` is Buck's
+    # own macro syntax. Everything variable lives in `env` instead, and
+    # scripts/corpus-action does the resolving.
+    cmd = " ".join([
+        "$(exe_target //:corpus-action)",
+        "$OUT",
+        "$(exe_target {})".format(harness),
+    ] + ["'{}'".format(arg) for arg in args])
+
+    native.genrule(
+        name = name + "-action",
+        out = "stamp.txt",
+        cmd = cmd,
+        env = action_env,
+    )
+
+    native.sh_test(
+        name = name,
+        labels = rue_test_labels(tier, labels),
+        test = "//:corpus-stamp-check",
+        args = ["$(location :{}-action)".format(name)],
+    )

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -221,14 +221,35 @@ Two consequences are worth knowing before changing a corpus target:
    a harness reads at runtime must reach it through `env`, and hence through
    `$(location ...)`.
 2. **Paths must be absolute.** `$(location ...)` expands to an absolute path in
-   an `sh_test`, which runs from the project root, but to a path relative to the
-   action's working directory in a genrule. The harnesses spawn the compiler with
-   each case's temp directory as cwd, and `find_dir` falls back to relative
-   defaults, so a relative value can resolve to a real but wrong directory and
-   quietly test nothing. `corpus-action` resolves everything named in the suite's
-   `absolutize` list immediately before the harness runs; it cannot be done in
-   BUCK because a genrule cmd has no shell command substitution — `$(...)` is
-   Buck's own macro syntax.
+   an `sh_test`, which runs from the project root, but to a project-relative path
+   in a build action. The harnesses spawn the compiler with each case's temp
+   directory as cwd, and `find_dir` falls back to relative defaults, so a
+   relative value can resolve to a real but wrong directory and quietly test
+   nothing. `corpus-action` resolves everything named in the suite's
+   `absolutize` list immediately before the harness runs.
+3. **The suite must be a rule that permits cache uploads.** `cached_corpus_suite`
+   defines its own rule rather than using `genrule` for one reason: the prelude
+   computes `cacheable = attrs.cacheable and (local_only or prefer_local)` and
+   passes that as `allow_cache_upload`, where those two flags come from a
+   Meta-internal label allowlist (`uses_sudo`, `qt_moc`, `yarn_install`, ...). A
+   plain genrule therefore never uploads here, and the first merge_group run of
+   RUE-1118 re-executed every corpus on a tree byte-identical to the one the PR
+   run had just built. The rule sets `allow_cache_upload = True` explicitly.
+
+### Reading whether a corpus was cache-served
+
+The thin `sh_test` reports `Pass: root//:NAME (0.0s)` whether the corpus ran for
+eleven minutes or was served from cache — it only checks the stamp. **Do not read
+that line as evidence of anything.** Two signals actually answer the question:
+
+- `Commands: N (cached: C, remote: R, local: L)` — the corpus is one action, so a
+  cache-served suite adds to `cached` and a re-executed one adds to `local`. The
+  pre-RUE-1118 baseline for a CLI shard was 465 commands; it is 466 now.
+- the job's wall time, which is unambiguous.
+
+This matters because the two failure modes look identical in the test output. A
+merge_group run that reports `Pass (0.0s)` on all eighteen corpus jobs while each
+one takes ten minutes is doing no caching at all.
 
 `//:reproducible-programs` and `//:oracle-diff-generated-smoke` remain plain
 `sh_test`s: their harnesses are shell scripts that read repository paths

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -178,11 +178,62 @@ lane can report a 95 percent hit rate and still spend nearly all its wall time
 in one harness process — that is a corpus-sharding problem, not a cache problem,
 and the two are only distinguishable when the summary reports both.
 
+The separation is not a presentational choice: the first three counters *cannot*
+see test execution. A `buck2 test` run is handed to the test executor rather than
+evaluated as an action, so it never enters the `Commands:` accounting, and OSS
+buck2 ships no test-result cache to serve it from. In one `merge_group` run,
+`//:cli-tests-caldera` (which executed nothing) and `//:cli-tests-shard-1` (which
+ran for 11:18) both reported `Commands: 465 (cached: 465/464)`. A corpus job can
+therefore print a perfect hit rate while re-running an eleven-minute suite in
+full, and that reads as "everything was cached" to anyone who stops at the
+cache columns. Test time is the signal that separates those two runs. RUE-1118
+has the measurements.
+
 RUE-320 also adds a merge-group-only remote-execution canary. It disables action
 cache reads, selects the no-fallback `//platforms:remote_execution` executor, and
 requires Buck to report remotely executed actions. This is deliberately
 separate from the cache probe: one proves worker execution, the other proves
 unchanged-action reuse.
+
+## Corpus suites are build actions (RUE-1118)
+
+Because test executions cannot be cached, a plain `sh_test` corpus re-ran on
+every merge even when the merge commit's tree was byte-identical to the tree the
+PR run had just validated. Three CI runs of one such tree — two `pull_request`,
+one `merge_group` — converged to 465/465 cached build actions while every corpus
+re-executed in full, at 91–97% of the merge queue's critical path.
+
+`cached_corpus_suite` (`corpus.bzl`) therefore splits each heavy corpus in two:
+
+- a **genrule** that runs the harness through `scripts/corpus-action` and writes
+  a stamp on success. This is an ordinary action, so the PR run uploads it and
+  the `merge_group` run reads it back like any compile;
+- a thin **`sh_test`** that asserts the stamp. It keeps the suite's name, labels,
+  and `Pass: root//:NAME (time)` result line, so `scripts/ci-heavy-suite` and
+  test.sh's RUE-924 corpus-omission audit keep working unchanged.
+
+Two consequences are worth knowing before changing a corpus target:
+
+1. **The declared input contract is now load-bearing.** Under a plain `sh_test`
+   an undeclared input was merely untracked — the suite re-ran regardless. Here
+   an undeclared input is a false pass: change a file the action does not name
+   and the corpus reports success against the previous tree's result. Every path
+   a harness reads at runtime must reach it through `env`, and hence through
+   `$(location ...)`.
+2. **Paths must be absolute.** `$(location ...)` expands to an absolute path in
+   an `sh_test`, which runs from the project root, but to a path relative to the
+   action's working directory in a genrule. The harnesses spawn the compiler with
+   each case's temp directory as cwd, and `find_dir` falls back to relative
+   defaults, so a relative value can resolve to a real but wrong directory and
+   quietly test nothing. `corpus-action` resolves everything named in the suite's
+   `absolutize` list immediately before the harness runs; it cannot be done in
+   BUCK because a genrule cmd has no shell command substitution — `$(...)` is
+   Buck's own macro syntax.
+
+`//:reproducible-programs` and `//:oracle-diff-generated-smoke` remain plain
+`sh_test`s: their harnesses are shell scripts that read repository paths
+directly rather than through declared env inputs, so establishing that contract
+has to come first. Both are off the merge queue's critical path.
 
 ## Updating the remote worker image
 

--- a/scripts/ci-heavy-suite
+++ b/scripts/ci-heavy-suite
@@ -28,13 +28,17 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# CLI correctness deadlines come from the same declarative authority as the
-# per-case hang profiles. They include generous headroom and are deliberately
-# not performance promises.
+# RUE-1118: the converted corpora run as cacheable build actions, and the test
+# executor only asserts the action's stamp — a sub-second check whatever the
+# corpus costs. An executor `--timeout` would therefore bound the wrong thing;
+# each suite's timeout_seconds in BUCK bounds the action that does the work.
+# //:cli-tests-slow is NOT converted, so it keeps the declarative policy from
+# RUE-1159. The per-case budgets in execution_contracts.toml remain the honest
+# gates for both.
 test_args=("$target")
 timings=""
 case "$target" in
-    //:cli-tests|//:cli-tests-slow)
+    //:cli-tests-slow)
         timeout_tool="${RUE_CLI_TIMEOUT_POLICY_TOOL:-scripts/cli-timeout-policy.py}"
         timeout="$("$timeout_tool" \
             --policy "${RUE_CLI_TIMEOUT_POLICY:-crates/rue-cli-tests/cases/execution_contracts.toml}" \
@@ -42,21 +46,15 @@ case "$target" in
             --target "$target")" || exit $?
         test_args+=(-- --timeout "$timeout")
         ;;
-    //:cli-tests-shard-*)
-        timeout_tool="${RUE_CLI_TIMEOUT_POLICY_TOOL:-scripts/cli-timeout-policy.py}"
-        timeout="$("$timeout_tool" \
-            --policy "${RUE_CLI_TIMEOUT_POLICY:-crates/rue-cli-tests/cases/execution_contracts.toml}" \
-            --weights "${RUE_CLI_SHARD_WEIGHTS:-crates/rue-cli-tests/shard-weights.json}" \
-            --target "$target")" || exit $?
-        if [[ -n "${RUNNER_TEMP:-}" ]]; then
-            timings="$RUNNER_TEMP/rue-cli-case-timings.jsonl"
-        else
-            timings="$(mktemp "${TMPDIR:-/tmp}/rue-cli-case-timings.XXXXXX")"
-        fi
-        test_args+=(-- --timeout "$timeout" --env "RUE_CLI_CASE_TIMINGS=$timings")
-        ;;
 esac
+
+# RUE-1159 repeats a shard to expose flakes, which only works if each repetition
+# actually executes. A cached corpus action would serve repetitions 2..N from the
+# first one's result and report a clean sweep having run the cases once, so a
+# repetition run is explicitly cache-free. This is a scheduled workflow, not the
+# merge-queue critical path, so the lost reuse costs nothing that matters.
 if [[ -n "${RUE_CORRECTNESS_REPETITION:-}" ]]; then
+    test_args+=(--no-remote-cache)
     test_args+=(--env "RUE_CORRECTNESS_REPETITION=$RUE_CORRECTNESS_REPETITION")
 fi
 

--- a/scripts/corpus-action
+++ b/scripts/corpus-action
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Run one corpus harness as a cacheable Buck build action (RUE-1118).
+#
+# buck2 re-executes every `buck2 test` invocation. Test executions are not
+# actions: they are handed to the test executor, they never appear in buck2's
+# `Commands: N (cached: ...)` accounting, and OSS buck2 has no test-result
+# cache. A corpus that runs as a *build* action instead is keyed on its declared
+# inputs like any other action, so the merge_group run reuses the result the PR
+# run uploaded rather than re-running the suite.
+#
+# usage: scripts/corpus-action STAMP HARNESS [ARG ...]
+#
+# Buck expands $(location) and $(exe_target) inside a genrule to paths relative
+# to the action's working directory, which is not the project root. The corpus
+# harnesses spawn the compiler with each case's temp directory as cwd, so every
+# path handed to them must be absolute. The environment variables named in
+# RUE_CORPUS_ABSOLUTIZE are resolved here, immediately before the harness runs,
+# rather than in BUCK: a genrule cmd cannot use shell command substitution
+# because `$(...)` is Buck's own macro syntax.
+set -uo pipefail
+
+if [[ $# -lt 2 ]]; then
+    echo "usage: scripts/corpus-action STAMP HARNESS [ARG ...]" >&2
+    exit 2
+fi
+
+stamp="$1"
+harness="$2"
+shift 2
+
+# Resolve a path without requiring GNU realpath (macOS runners ship BSD tools
+# and no coreutils). A directory resolves directly; anything else resolves
+# through its parent so that missing-but-declared outputs still absolutize.
+absolutize() {
+    local path="$1"
+    if [[ -d "$path" ]]; then
+        (cd "$path" && pwd)
+        return
+    fi
+    local dir base
+    dir="$(dirname "$path")"
+    base="$(basename "$path")"
+    if [[ ! -d "$dir" ]]; then
+        echo "error: cannot resolve '$path': no such directory '$dir'" >&2
+        return 1
+    fi
+    printf '%s/%s\n' "$(cd "$dir" && pwd)" "$base"
+}
+
+for name in ${RUE_CORPUS_ABSOLUTIZE:-}; do
+    value="${!name:-}"
+    if [[ -z "$value" ]]; then
+        echo "error: $name is listed in RUE_CORPUS_ABSOLUTIZE but is unset or empty" >&2
+        exit 2
+    fi
+    if ! resolved="$(absolutize "$value")"; then
+        echo "error: cannot absolutize $name='$value'" >&2
+        exit 2
+    fi
+    export "$name=$resolved"
+done
+# The harness must not observe this action's own plumbing.
+unset RUE_CORPUS_ABSOLUTIZE
+
+harness="$(absolutize "$harness")" || exit 2
+
+# The per-case budgets in execution_contracts.toml are the honest gates. This
+# outer bound only replaces the test executor's timeout, which a build action
+# does not get: without it a wedged harness runs until the GitHub job timeout
+# and reports nothing useful.
+timeout_seconds="${RUE_CORPUS_TIMEOUT_SECONDS:-}"
+unset RUE_CORPUS_TIMEOUT_SECONDS
+if [[ -n "$timeout_seconds" ]] && command -v timeout >/dev/null 2>&1; then
+    timeout "$timeout_seconds" "$harness" "$@"
+    status=$?
+    if [[ "$status" -eq 124 ]]; then
+        echo "error: corpus harness exceeded ${timeout_seconds}s: $harness $*" >&2
+    fi
+else
+    "$harness" "$@"
+    status=$?
+fi
+
+if [[ "$status" -ne 0 ]]; then
+    # Buck surfaces a failed action's stderr, and no stamp is written, so the
+    # failure cannot be cached and the next run re-executes the corpus.
+    echo "error: corpus harness failed (exit $status): $harness $*" >&2
+    exit "$status"
+fi
+
+# The stamp is the action's only output. Its content is deliberately not the
+# harness's stdout: an identical tree must produce an identical stamp, or the
+# artifact would differ between the PR run and the merge_group run for no
+# semantic reason.
+printf 'corpus harness passed\n' >"$stamp"

--- a/scripts/corpus-stamp-check
+++ b/scripts/corpus-stamp-check
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Assert that a corpus action produced its stamp (RUE-1118).
+#
+# The expensive corpus run is a cacheable build action; this is the thin test
+# that carries the suite's name, labels, and Pass/Fail result line. Buck builds
+# the action first, so reaching this script at all means the harness passed —
+# either in this run or in an earlier one whose result the action cache served.
+# A failing harness writes no stamp, so the suite fails as a build failure and
+# nothing is cached.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: scripts/corpus-stamp-check STAMP" >&2
+    exit 2
+fi
+
+stamp="$1"
+
+if [[ ! -f "$stamp" ]]; then
+    echo "error: corpus stamp does not exist: $stamp" >&2
+    exit 1
+fi
+
+if [[ ! -s "$stamp" ]]; then
+    echo "error: corpus stamp is empty: $stamp" >&2
+    exit 1
+fi

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -312,12 +312,18 @@ EOF
         "$(grep -Fxq 'test //... toolchains//... --exclude rue_heavy_suite --always-exclude --ignore-tests-attribute --exclude rue_test_tier_stress' "$sb/calls" && echo 0 || echo 1)"
     check "suite: heavy targets are discovered from the live graph" \
         "$(grep -Fxq 'uquery attrfilter(labels, rue_heavy_suite, //...)' "$sb/calls" && echo 0 || echo 1)"
-    check "suite: premerge CLI corpus receives the derived executor timeout" \
-        "$(grep -Fxq 'test //:cli-tests -- --timeout 3600' "$sb/calls" && echo 0 || echo 1)"
+    # RUE-1118: every converted corpus is now invoked bare. The corpus runs as a
+    # cacheable build action and the test executor only asserts its stamp, so an
+    # executor timeout here would bound a sub-second check while reading as if
+    # the corpus were still bounded; the real outer bound is each suite's
+    # timeout_seconds in BUCK. //:cli-tests-slow is not converted, so it keeps
+    # the RUE-1159 declarative timeout and is the only target that carries one.
     check "suite: slow CLI corpus receives the declarative executor timeout" \
         "$(grep -Fxq 'test //:cli-tests-slow -- --timeout 7200' "$sb/calls" && echo 0 || echo 1)"
-    check "suite: every other heavy target uses the default executor timeout" \
-        "$([ "$(grep -Ec '^test //:(spec-tests|ui-tests|oracle-diff-generated-smoke|reproducible-programs|frontend-diff-test)$' "$sb/calls")" -eq 5 ] && echo 0 || echo 1)"
+    check "suite: no converted corpus receives an executor timeout" \
+        "$([ "$(grep -Ec -- '^test //:(cli-tests|spec-tests|ui-tests|cli-tests-shard-[0-9]+) -- --timeout' "$sb/calls")" -eq 0 ] && echo 0 || echo 1)"
+    check "suite: every other heavy target is invoked bare, exactly once" \
+        "$([ "$(grep -Ec '^test //:(cli-tests|spec-tests|ui-tests|oracle-diff-generated-smoke|reproducible-programs|frontend-diff-test)$' "$sb/calls")" -eq 6 ] && echo 0 || echo 1)"
     # RUE-1117: the codegen differentials are heavy suites in their owning
     # crate package, so a local full run executes them one at a time too.
     check "suite: crate-package heavy suites are executed individually" \

--- a/scripts/test-corpus-action.sh
+++ b/scripts/test-corpus-action.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# test-corpus-action.sh — regression tests for scripts/corpus-action (RUE-1118).
+#
+# corpus-action is what makes a corpus suite's result cacheable, so its failure
+# modes are asymmetric: a spurious failure is loud and self-correcting, but
+# writing a stamp when the harness did not pass would cache a false green and
+# every later run of that tree would report success without executing anything.
+# These tests pin the stamp-only-on-success contract, and the absolutization
+# contract that keeps a harness from silently resolving a relative path against
+# the action's working directory instead of the real corpus.
+#
+# Each test runs the real script in a throwaway sandbox against a fake harness.
+set -uo pipefail
+
+if [ -n "${RUE_CORPUS_SCRIPTS_ROOT:-}" ]; then
+    SCRIPTS_DIR="$RUE_CORPUS_SCRIPTS_ROOT/scripts"
+else
+    SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
+CORPUS_ACTION="$SCRIPTS_DIR/corpus-action"
+
+failures=0
+tests=0
+
+check() {
+    local label="$1" expected="$2" actual="$3"
+    tests=$((tests + 1))
+    if [ "$expected" != "$actual" ]; then
+        echo "FAIL: $label: expected '$expected', got '$actual'" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+sandbox() {
+    mktemp -d "${TMPDIR:-/tmp}/rue-corpus-action-test.XXXXXX"
+}
+
+# A harness that passes writes a stamp.
+t_success() {
+    local dir stamp status
+    dir="$(sandbox)"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$dir/harness"
+    chmod +x "$dir/harness"
+    stamp="$dir/stamp.txt"
+    (cd "$dir" && "$CORPUS_ACTION" "$stamp" ./harness >/dev/null 2>&1)
+    status=$?
+    check "passing harness exits 0" "0" "$status"
+    check "passing harness writes a stamp" "yes" "$([ -s "$stamp" ] && echo yes || echo no)"
+    rm -rf "$dir"
+}
+
+# A harness that fails writes NO stamp: the action fails, nothing is cached,
+# and the next run re-executes the corpus.
+t_failure_writes_no_stamp() {
+    local dir stamp status
+    dir="$(sandbox)"
+    printf '#!/usr/bin/env bash\nexit 3\n' >"$dir/harness"
+    chmod +x "$dir/harness"
+    stamp="$dir/stamp.txt"
+    (cd "$dir" && "$CORPUS_ACTION" "$stamp" ./harness >/dev/null 2>&1)
+    status=$?
+    check "failing harness propagates its status" "3" "$status"
+    check "failing harness writes no stamp" "no" "$([ -e "$stamp" ] && echo yes || echo no)"
+    rm -rf "$dir"
+}
+
+# Declared path variables reach the harness as absolute paths. The corpus
+# harnesses spawn the compiler with a case temp dir as cwd, so a relative value
+# would resolve somewhere else entirely — or, worse, resolve to a real but wrong
+# directory and quietly test nothing.
+t_absolutize() {
+    local dir status observed
+    dir="$(sandbox)"
+    mkdir -p "$dir/cases"
+    printf '#!/usr/bin/env bash\nprintf "%%s" "$RUE_TEST_CASES" > "$OBSERVED"\nexit 0\n' >"$dir/harness"
+    chmod +x "$dir/harness"
+    (
+        cd "$dir" &&
+            OBSERVED="$dir/observed" \
+                RUE_TEST_CASES="cases" \
+                RUE_CORPUS_ABSOLUTIZE="RUE_TEST_CASES" \
+                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness >/dev/null 2>&1
+    )
+    status=$?
+    observed="$(cat "$dir/observed" 2>/dev/null)"
+    check "absolutized run succeeds" "0" "$status"
+    check "declared path reaches the harness absolute" "$(cd "$dir/cases" && pwd)" "$observed"
+    rm -rf "$dir"
+}
+
+# An unset variable named in RUE_CORPUS_ABSOLUTIZE is a BUCK wiring bug. Failing
+# closed matters more than usual here: continuing would let the harness fall back
+# to its own relative default and pass against the wrong corpus.
+t_missing_absolutize_target_fails() {
+    local dir status
+    dir="$(sandbox)"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$dir/harness"
+    chmod +x "$dir/harness"
+    (
+        cd "$dir" &&
+            RUE_CORPUS_ABSOLUTIZE="RUE_NOT_SET_ANYWHERE" \
+                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness >/dev/null 2>&1
+    )
+    status=$?
+    check "unset absolutize target fails" "2" "$status"
+    check "unset absolutize target writes no stamp" "no" "$([ -e "$dir/stamp.txt" ] && echo yes || echo no)"
+    rm -rf "$dir"
+}
+
+# The harness must not see this action's own plumbing variables.
+t_plumbing_is_hidden() {
+    local dir observed
+    dir="$(sandbox)"
+    printf '#!/usr/bin/env bash\nprintf "%%s|%%s" "${RUE_CORPUS_ABSOLUTIZE:-unset}" "${RUE_CORPUS_TIMEOUT_SECONDS:-unset}" > "$OBSERVED"\nexit 0\n' >"$dir/harness"
+    chmod +x "$dir/harness"
+    (
+        cd "$dir" &&
+            OBSERVED="$dir/observed" \
+                RUE_CORPUS_ABSOLUTIZE="" \
+                RUE_CORPUS_TIMEOUT_SECONDS="60" \
+                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness >/dev/null 2>&1
+    )
+    observed="$(cat "$dir/observed" 2>/dev/null)"
+    check "plumbing variables are unset for the harness" "unset|unset" "$observed"
+    rm -rf "$dir"
+}
+
+# A wedged harness is bounded, and a timeout is a failure, so no stamp is
+# written and the timed-out result is never cached.
+t_timeout() {
+    local dir status
+    dir="$(sandbox)"
+    if ! command -v timeout >/dev/null 2>&1; then
+        echo "skip: no timeout(1) on this host"
+        return
+    fi
+    printf '#!/usr/bin/env bash\nsleep 30\n' >"$dir/harness"
+    chmod +x "$dir/harness"
+    (
+        cd "$dir" &&
+            RUE_CORPUS_TIMEOUT_SECONDS=1 \
+                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness >/dev/null 2>&1
+    )
+    status=$?
+    check "timed-out harness fails" "124" "$status"
+    check "timed-out harness writes no stamp" "no" "$([ -e "$dir/stamp.txt" ] && echo yes || echo no)"
+    rm -rf "$dir"
+}
+
+t_usage() {
+    local status
+    "$CORPUS_ACTION" >/dev/null 2>&1
+    status=$?
+    check "no arguments is a usage error" "2" "$status"
+}
+
+t_success
+t_failure_writes_no_stamp
+t_absolutize
+t_missing_absolutize_target_fails
+t_plumbing_is_hidden
+t_timeout
+t_usage
+
+if [ "$failures" -ne 0 ]; then
+    echo "corpus-action: $failures/$tests checks failed" >&2
+    exit 1
+fi
+echo "corpus-action: $tests checks passed"

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -833,26 +833,32 @@ EOF
   check "ci-heavy-suite: labeled target with a result succeeds" \
     "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
 
-  : >"$sb/calls.log"
-  rc=0
-  (cd "$sb" && FAKE_CALL_LOG="$sb/calls.log" ./ci-heavy-suite //:cli-tests) >/dev/null 2>&1 || rc=$?
-  check "ci-heavy-suite: premerge CLI corpus receives the derived executor timeout" \
-    "$([ "$rc" -eq 0 ] && grep -Fxq 'test //:cli-tests -- --timeout 3600' "$sb/calls.log" && echo 0 || echo 1)"
-
+  # //:cli-tests-slow is the one CLI corpus RUE-1118 does not convert, so it is
+  # also the only one that still takes a declarative executor timeout.
   : >"$sb/calls.log"
   rc=0
   (cd "$sb" && FAKE_LABELED_TARGET=//:cli-tests-slow FAKE_CALL_LOG="$sb/calls.log" ./ci-heavy-suite //:cli-tests-slow) >/dev/null 2>&1 || rc=$?
   check "ci-heavy-suite: slow CLI corpus receives the declarative executor timeout" \
     "$([ "$rc" -eq 0 ] && grep -Fxq 'test //:cli-tests-slow -- --timeout 7200' "$sb/calls.log" && echo 0 || echo 1)"
 
+  # RUE-1159 flake detection only means anything if each repetition executes, so
+  # a repetition run must defeat the corpus action's cache.
   : >"$sb/calls.log"
   rc=0
-  (cd "$sb" && FAKE_LABELED_TARGET=//:cli-tests-shard-1 FAKE_CALL_LOG="$sb/calls.log" ./ci-heavy-suite //:cli-tests-shard-1) >/dev/null 2>&1 || rc=$?
-  check "ci-heavy-suite: CLI shard receives the cost-derived executor timeout" \
-    "$([ "$rc" -eq 0 ] && grep -Eq '^test //:cli-tests-shard-1 -- --timeout 1234 --env RUE_CLI_CASE_TIMINGS=' "$sb/calls.log" && echo 0 || echo 1)"
+  (cd "$sb" && RUE_CORRECTNESS_REPETITION=2 FAKE_CALL_LOG="$sb/calls.log" ./ci-heavy-suite //:cli-tests) >/dev/null 2>&1 || rc=$?
+  check "ci-heavy-suite: a correctness repetition runs cache-free" \
+    "$([ "$rc" -eq 0 ] && grep -Fq -- '--no-remote-cache' "$sb/calls.log" && grep -Fq 'RUE_CORRECTNESS_REPETITION=2' "$sb/calls.log" && echo 0 || echo 1)"
 
-  local other_target
-  for other_target in \
+  # RUE-1118: ci-heavy-suite no longer carries per-target executor timeouts for
+  # the converted corpora. Each runs as a cacheable build action and the test
+  # executor only asserts its stamp, so the outer bound belongs on the action —
+  # it is each suite's timeout_seconds in BUCK. A stray `--timeout` here would
+  # bound the wrong thing (a sub-second stamp check) and read as if the corpus
+  # were still bounded, so pin that every target is invoked identically and bare.
+  local heavy_target
+  for heavy_target in \
+    //:cli-tests \
+    //:cli-tests-shard-1 \
     //:spec-tests \
     //:ui-tests \
     //:oracle-diff-generated-smoke \
@@ -860,9 +866,9 @@ EOF
     //:tutorial-snippet-tests; do
     : >"$sb/calls.log"
     rc=0
-    (cd "$sb" && FAKE_LABELED_TARGET="$other_target" FAKE_CALL_LOG="$sb/calls.log" ./ci-heavy-suite "$other_target") >/dev/null 2>&1 || rc=$?
-    check "ci-heavy-suite: $other_target retains the default executor timeout" \
-      "$([ "$rc" -eq 0 ] && grep -Fxq "test $other_target" "$sb/calls.log" && echo 0 || echo 1)"
+    (cd "$sb" && FAKE_LABELED_TARGET="$heavy_target" FAKE_CALL_LOG="$sb/calls.log" ./ci-heavy-suite "$heavy_target") >/dev/null 2>&1 || rc=$?
+    check "ci-heavy-suite: $heavy_target is invoked without an executor timeout" \
+      "$([ "$rc" -eq 0 ] && grep -Fxq "test $heavy_target" "$sb/calls.log" && echo 0 || echo 1)"
   done
 
   # RUE-1117: heavy suites are no longer only root-package targets. The label,


### PR DESCRIPTION
Refs RUE-1118. **Supersedes #2000** — same branch, rebased onto current trunk. GitHub refuses to reopen a PR whose branch was force-pushed, so this is a new PR rather than a revival of that one; #2000's discussion is still the origin of this work.

## Why this is being reopened rather than re-decided

#2000 implemented this in full and was green on all 18 platform-corpus jobs across linux-x64, linux-arm64, and macOS. It stalled on one stated blocker: the clippy gate was fail-open and red on trunk, and fixing it meant either a red trunk or burying a corpus-caching change under 98 unrelated `needless_borrow` fixes.

That blocker is gone. RUE-1152 fixed the gate in #2001 (merged 07-27 06:21) and #2039 hardened it. #2000 was then closed at 07-27 17:29 — eleven hours after its blocker cleared — with no closing comment and a conflicted branch. Stale, not rejected.

## The problem (unchanged from #2000)

buck2 re-executes every `buck2 test` invocation. Test executions are not actions: they are handed to the test executor, never appear in buck2's `Commands:` accounting, and OSS buck2 ships no test-result cache. The merge queue therefore re-ran every corpus in full on each merge, even when the merge commit's tree was byte-identical to the tree the PR run had just validated.

Measured on three CI runs of one such tree: build actions converged to 465/465 cache hits while the corpora re-ran every time. The slowest `merge_group` job was 744s — 7s setup, 59s analysis and CAS materialization for a fully cached build, and **678s (91%) test execution**.

`cached_corpus_suite` splits each corpus into a cacheable action that runs the harness and writes a stamp, plus a thin `sh_test` asserting the stamp. The suite keeps its name, labels, and `Pass: root//:NAME (time)` line, so `scripts/ci-heavy-suite` and test.sh's RUE-924 omission audit work unchanged.

## What the rebase had to resolve

Trunk moved substantially in the days #2000 sat closed, so this was a re-integration rather than a replay. Six conflicts would each have broken the build:

- **Tier ownership (RUE-1157).** `cached_corpus_suite` called `native.sh_test` directly, which `//test_tiers.bxl:validate` now rejects. The macro takes a `tier` parameter (default `premerge`) routed through `rue_test_labels`. The tier goes on the test target rather than the action, for the same reason `labels` does — tier selection discovers *tests*, and the action is not one.
- **`//:cli-tests-caldera` no longer exists.** Trunk replaced the RUE-1083 success stub with the `large-example-{caldera,meridian}-{canary,slow,stress}` family. That conversion is dropped; those targets are not corpus harnesses and stay plain `rue_sh_test`.
- **Resurrected benchmark infrastructure.** The rebase reintroduced `benchmark-tool-inputs` and its ~20 `scripts/benchmark_*.py` sources, all deleted by the RUE-1183 benchmarking reset. Dropped.
- **Timeout ownership now splits.** `//:cli-tests-slow` is not converted, so it keeps RUE-1159's declarative executor timeout and is the only target that carries one. Every converted corpus is invoked bare, bounded by `timeout_seconds` on the action.
- **The `build-cache.md` counter note.** Trunk added a four-column summary table whose prose already says the corpora are opaque to the cache counters. This PR's paragraph was rewritten to supply only what the table does not — *why* they are opaque — and to point at the new `Test time` column rather than at wall time. Its new `## Corpus suites are build actions` section was moved below the RUE-320 canary paragraph, which the original placement orphaned mid-section. This paragraph is identical to the one in **#2043**, the docs-only split-out; whichever lands first, the other's hunk is a no-op.
- **The oracle-diff lanes (#2045, RUE-1117).** Landed on trunk between the first rebase pass and this one, and touches both `scripts/ci-heavy-suite` and `scripts/test-build-sharing.sh`. Its "crate-package heavy suites are executed individually" check and this PR's two executor-timeout checks are independent assertions and are now unioned rather than either replacing the other. The two new differentials are not converted — they stay plain heavy suites.

## Two decisions made during the rebase that want review

**1. A correctness repetition now runs cache-free.** RUE-1159's `correctness-repetitions.yml` re-runs a shard N times to expose flakes. A cached corpus action would serve repetitions 2..N from the first result and report a clean sweep having executed the cases exactly once — flake detection silently becoming a no-op. `ci-heavy-suite` now passes `--no-remote-cache` when `RUE_CORRECTNESS_REPETITION` is set, pinned by a new wrapper-script test. It is a scheduled workflow rather than the merge-queue critical path, so the lost reuse costs nothing that matters. This is a new decision, not one #2000 faced.

**2. CLI case timings now exist only on a cache miss.** `ci-heavy-suite` passed `--env RUE_CLI_CASE_TIMINGS=` so shards emit per-case measurements, uploaded as an artifact and feeding RUE-1158's `shard-weights.json`. Under this conversion the harness runs inside the action, so an executor `--env` no longer reaches it — and the path is a per-run `mktemp`/`RUNNER_TEMP` value, so threading it into the action env would change the digest on every run and defeat the entire PR. The consequence is that timings are produced only when the corpus actually executes. Arguably correct — a measurement of execution cannot exist when nothing executed — but shard weights would then refresh only on cache misses, and that deserves an explicit decision before this lands.

## The contract this makes load-bearing

Documented in `corpus.bzl` and `docs/process/build-cache.md`:

1. **Declared inputs now decide correctness.** Under a plain `sh_test` an undeclared input was merely untracked — the suite re-ran regardless. Here it is a false pass: change a file the action does not name and the corpus reports success against the previous tree's result. This is not theoretical; #2000's first CI run surfaced a UI-corpus input that had been passing against an undeclared `std/`, which is fixed here.
2. **Paths must be absolute.** `$(location ...)` expands absolute in an `sh_test` (which runs from the project root) but project-relative in a build action. The harnesses spawn the compiler with a case temp dir as cwd and `find_dir` falls back to relative defaults, so a relative value can resolve to a real but wrong directory and quietly test nothing. `corpus-action` resolves everything in a suite's `absolutize` list immediately before the harness runs.

## Verification on the rebased branch

Re-run after the rebase onto `c06ef00`:

- `//test_tiers.bxl:validate` — 83 premerge, 5 slow, 3 stress (83 = 81 + #2045's two oracle lanes).
- `scripts/test-wrapper-scripts.sh` — 102 checks.
- `scripts/test-build-sharing.sh` — 32 checks, including both the union'd RUE-1117 and RUE-1118 assertions.
- `//:corpus-action-tests` — 12 checks; `//:cli-shard-coverage-validation`, `//:ci-gate-validation` — pass.
- `scripts/ci-heavy-suite //:ui-tests` — the conversion executes end to end: the action builds, runs the harness, and fails closed on harness failure. It reports `208 passed; 1 failed`, and that one failure — `diagnostics.function_frame_too_large::cumulative_locals_exceed_frame_budget`, a 10s per-case timeout — **reproduces identically on unmodified trunk** (`./buck2 test //:ui-tests` at `c06ef00`: same 208/1, same case, same timeout, no genrule involved). It is host speed, not this change.

Not verifiable locally: actual cross-run reuse needs the shared cache, and OSS buck2 has no persistent local action cache, so a locally reverted edit re-runs rather than hitting the earlier result. Cross-run and cross-platform behavior is what CI on this PR will show. Worth confirming against the first `merge_group` run that the macOS and Linux lanes do not share entries — the per-platform digest separation rests on each action depending on the host-built `rue` and harness binaries.

Left as draft pending the two decisions above and a full CI run.