### PR TITLE
RUE-1117: give the codegen differential its own pre-merge CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,6 +430,25 @@ jobs:
             target: //:spec-tests
             name: spec
             check_name: linux-x64-spec
+          # RUE-1117: the RUE-205/RUE-204 codegen differential — every runnable
+          # CLI and spec case executed through the reference interpreter and
+          # compared against the compiler's own result. It is the check that
+          # catches codegen diverging from the language's semantics, so it
+          # belongs on the pre-merge critical path rather than in the nightly
+          # release sweep, where a divergence surfaces up to a day late,
+          # attributed to a schedule rather than to the PR that caused it, and
+          # only in release configuration. Both corpora are target-independent,
+          # so one linux-x64 lane each is the whole platform requirement.
+          - os: ubuntu-latest
+            cache_name: linux-x64
+            target: //crates/rue-oracle-diff:oracle-diff-test
+            name: oracle-diff
+            check_name: linux-x64-oracle-diff
+          - os: ubuntu-latest
+            cache_name: linux-x64
+            target: //crates/rue-oracle-diff:oracle-diff-spec-test
+            name: oracle-diff-spec
+            check_name: linux-x64-oracle-diff-spec
     runs-on: ${{ matrix.os }}
     name: test (${{ matrix.check_name }})
     steps:
@@ -632,6 +651,18 @@ jobs:
       - uses: actions/checkout@v6
       - name: Validate aggregate gate and platform responsibilities
         run: scripts/validate-ci-gate.py .github/workflows/ci.yml
+
+      # RUE-1117: `//:tier-ci-selector-validation` also runs this in the premerge
+      # Buck pass. Repeating it here needs no toolchain and keeps the structural
+      # answer to "does any job actually run this tier?" next to the rest of the
+      # CI contract, independent of whether the Buck lane got that far.
+      - name: Validate deliberate CI selection of every test tier
+        run: >-
+          scripts/validate-tier-ci-selectors.py
+          --test-defs test_defs.bzl
+          --test-tiers-bxl test_tiers.bxl
+          --workflow .github/workflows/ci.yml
+          --workflow .github/workflows/release.yml
 
   # The only stable branch-protection context. Matrix children may be reshaped
   # without changing this displayed name. The evaluator rejects missing,

--- a/BUCK
+++ b/BUCK
@@ -459,6 +459,49 @@ rue_sh_test(
     },
 )
 
+# RUE-1117: the declared inputs of the tier CI-selector gate. The tier
+# vocabulary and every workflow that is registered as deliberately selecting a
+# tier are inputs, so an edit to any of them re-runs the gate.
+filegroup(
+    name = "tier-ci-selector-inputs",
+    srcs = [
+        ".github/workflows/ci.yml",
+        ".github/workflows/release.yml",
+        "test_defs.bzl",
+        "test_tiers.bxl",
+    ],
+)
+
+# RUE-1117: `//test_tiers.bxl:validate` proves every test target owns exactly one
+# tier; it cannot prove any CI job runs that tier. This gate requires each tier
+# to be selected by a *named* job, so a target moved into a tier nothing selects
+# fails the build instead of quietly leaving required CI — the way the
+# RUE-205/RUE-204 codegen differential did.
+rue_sh_test(
+    name = "tier-ci-selector-validation",
+    test = "scripts/validate-tier-ci-selectors.py",
+    args = [
+        "--test-defs",
+        "$(location :tier-ci-selector-inputs)/test_defs.bzl",
+        "--test-tiers-bxl",
+        "$(location :tier-ci-selector-inputs)/test_tiers.bxl",
+        "--workflow",
+        "$(location :tier-ci-selector-inputs)/.github/workflows/ci.yml",
+        "--workflow",
+        "$(location :tier-ci-selector-inputs)/.github/workflows/release.yml",
+    ],
+)
+
+rue_sh_test(
+    name = "tier-ci-selector-tool-tests",
+    test = "scripts/test-validate-tier-ci-selectors.py",
+    resources = ["scripts/validate-tier-ci-selectors.py"],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "RUE_TIER_VALIDATION_ROOT": "$(location :tier-ci-selector-inputs)",
+    },
+)
+
 rue_sh_test(
     name = "ci-required-results-tool-tests",
     test = "scripts/test-ci-required-results.py",

--- a/crates/rue-oracle-diff/BUCK
+++ b/crates/rue-oracle-diff/BUCK
@@ -51,7 +51,11 @@ rue_binary(
 rue_sh_test(
     name = "oracle-diff-test",
     tier = "slow",
-    labels = ["rue_not_quick"],
+    # RUE-1117: `rue_heavy_suite` gives the differential the same execution
+    # contract as the other opaque corpus harnesses — its own CI lane through
+    # `scripts/ci-heavy-suite` (which fails closed if Buck reports no result for
+    # it), and exclusion from any broad pass that would otherwise absorb it.
+    labels = ["rue_not_quick", "rue_heavy_suite"],
     test = ":rue-oracle-diff",
     env = {
         "RUE_ORACLE_DIFF_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
@@ -68,7 +72,7 @@ rue_sh_test(
 rue_sh_test(
     name = "oracle-diff-spec-test",
     tier = "slow",
-    labels = ["rue_not_quick"],
+    labels = ["rue_not_quick", "rue_heavy_suite"],
     test = ":rue-oracle-diff",
     args = ["spec"],
     env = {

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -131,9 +131,29 @@ Required CI sets `RUE_TEST_TIER=premerge`; `scripts/rue all` exercises the
 complete union, while the scheduled release workflow gives the dedicated
 large-program targets their own compile-once jobs.
 
+A tier label says when a target runs, not that anything runs it. `validate`
+above cannot see CI, so a target moved into a tier no job selects keeps a valid
+label while its coverage leaves the merge queue — which is what happened to the
+codegen differential (RUE-1117). `scripts/validate-tier-ci-selectors.py`
+(`//:tier-ci-selector-validation`, and repeated in the toolchain-free
+`CI contract` job) closes that gap: every tier must be selected by a *named* CI
+job, registered in the script against the literal selection it relies on.
+
+An unfiltered `//...` run is deliberately not accepted as a selector. The
+nightly release sweep runs every tier by accident of not filtering, so it keeps
+reporting coverage through the very edit that strands a tier, and it names no
+owner. The gate is tier-granular; per-target coverage stays with each suite's
+own inventory gate (the RUE-924 audit in `test.sh`,
+`//:cli-shard-coverage-validation`).
+
 The exhaustive CLI- and specification-oracle differential harnesses are
-`slow`: premerge retains the fixed generated oracle smoke corpus as its bounded
-codegen canary. CLI corpus sections may likewise declare `tier = "slow"`.
+`slow`, and are the slow tier's pre-merge selector: `platform-corpus` runs
+`//crates/rue-oracle-diff:oracle-diff-test` and `:oracle-diff-spec-test` in two
+concurrent linux-x64 lanes (RUE-1117). Both corpora are target-independent, so
+one lane each is the whole platform requirement — the nightly release sweep is
+release-configuration coverage on top, not the primary signal. Premerge retains
+the fixed generated oracle smoke corpus as its bounded codegen canary.
+CLI corpus sections may likewise declare `tier = "slow"`.
 Automatic examples have the same declarative tier field.
 `//:cli-tests-slow` owns those real cases. Mosaic's shipped-program smoke and
 17 exhaustive behavior cases are slow, so the four required CLI shards do not

--- a/scripts/affected-targets
+++ b/scripts/affected-targets
@@ -72,6 +72,8 @@ SELECTABLE_CORPUS=(
     //:cli-tests-shard-2
     //:cli-tests-shard-3
     //:spec-tests
+    //crates/rue-oracle-diff:oracle-diff-test
+    //crates/rue-oracle-diff:oracle-diff-spec-test
 )
 
 # Out-of-graph (and belt-and-suspenders in-graph) paths that force a full run.

--- a/scripts/ci-heavy-suite
+++ b/scripts/ci-heavy-suite
@@ -2,8 +2,13 @@
 # Run one explicitly assigned CI heavy suite and fail if Buck omits its result.
 set -uo pipefail
 
-if [[ $# -ne 1 || "$1" != //:* ]]; then
-    echo "usage: scripts/ci-heavy-suite //:TARGET" >&2
+# Heavy suites live at the repository root (//:cli-tests) and, since RUE-1117,
+# in owning crate packages (//crates/rue-oracle-diff:oracle-diff-test). The
+# `rue_heavy_suite` label below — not the package path — is what decides whether
+# a target may run here, so this check only rejects a spelling Buck cannot
+# resolve to a single target in this cell.
+if [[ $# -ne 1 || "$1" != //*:* ]]; then
+    echo "usage: scripts/ci-heavy-suite //PACKAGE:TARGET" >&2
     exit 2
 fi
 target="$1"

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -274,6 +274,8 @@ if [[ "${1:-}" == "uquery" ]]; then
         printf '%s\n' \
             root//:cli-tests \
             root//:cli-tests-slow \
+            root//crates/rue-oracle-diff:oracle-diff-test \
+            root//crates/rue-oracle-diff:oracle-diff-spec-test \
             root//:frontend-diff-test \
             root//:oracle-diff-generated-smoke \
             root//:reproducible-programs \
@@ -289,7 +291,7 @@ elif [[ "${1:-}" == "test" ]]; then
         printf 'Pass: root//:tutorial-snippet-tests (0.0s)\n'
         printf 'Pass: root//:large-example-caldera-canary (0.0s)\n'
         printf 'Pass: root//:large-example-meridian-canary (0.0s)\n'
-    elif [[ "${2:-}" == //:* ]]; then
+    elif [[ "${2:-}" == //*:* ]]; then
         printf 'Pass: root%s (0.0s)\n' "${2:-}"
     else
         printf 'Pass: %s (0.0s)\n' "${2:-}"
@@ -316,6 +318,10 @@ EOF
         "$(grep -Fxq 'test //:cli-tests-slow -- --timeout 7200' "$sb/calls" && echo 0 || echo 1)"
     check "suite: every other heavy target uses the default executor timeout" \
         "$([ "$(grep -Ec '^test //:(spec-tests|ui-tests|oracle-diff-generated-smoke|reproducible-programs|frontend-diff-test)$' "$sb/calls")" -eq 5 ] && echo 0 || echo 1)"
+    # RUE-1117: the codegen differentials are heavy suites in their owning
+    # crate package, so a local full run executes them one at a time too.
+    check "suite: crate-package heavy suites are executed individually" \
+        "$([ "$(grep -Ec '^test //crates/rue-oracle-diff:oracle-diff(-spec)?-test$' "$sb/calls")" -eq 2 ] && echo 0 || echo 1)"
     check "suite: no concurrent heavy label sweep occurs" \
         "$(! grep -Fq -- '--include rue_heavy_suite' "$sb/calls" && echo 0 || echo 1)"
     check "suite: host lock is released" "$([[ ! -e "$sb/lock" ]] && echo 0 || echo 1)"

--- a/scripts/test-validate-tier-ci-selectors.py
+++ b/scripts/test-validate-tier-ci-selectors.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Focused tests for the tier CI-selector gate (RUE-1117)."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("validate-tier-ci-selectors.py")
+SPEC = importlib.util.spec_from_file_location("tier_ci_selectors", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+selectors = importlib.util.module_from_spec(SPEC)
+# `@dataclass` resolves annotations through `sys.modules[cls.__module__]`, so a
+# file loaded by spec alone must be registered before it executes.
+sys.modules[SPEC.name] = selectors
+SPEC.loader.exec_module(selectors)
+
+TIERS = ("premerge", "slow", "stress")
+
+CI_WORKFLOW = """name: CI
+on:
+  pull_request:
+jobs:
+  linux-premerge:
+    steps:
+      - name: Run complete target-independent premerge suite
+        env:
+          RUE_TEST_TIER: premerge
+        run: ./test.sh
+
+  platform-corpus:
+    strategy:
+      matrix:
+        include:
+          - target: //:spec-tests
+            check_name: linux-x64-spec
+          - target: //crates/rue-oracle-diff:oracle-diff-test
+            check_name: linux-x64-oracle-diff
+          - target: //crates/rue-oracle-diff:oracle-diff-spec-test
+            check_name: linux-x64-oracle-diff-spec
+"""
+
+RELEASE_WORKFLOW = """name: Release
+on:
+  schedule:
+    - cron: '0 6 * * *'
+jobs:
+  release-suite:
+    steps:
+      - name: Run full release suite
+        run: ./buck2 test //... toolchains//...
+
+  large-program:
+    steps:
+      - name: Run manual stress program
+        if: github.event_name == 'workflow_dispatch' && inputs.tier == 'stress'
+        run: ./buck2 test "//:large-example-${{ matrix.program }}-stress"
+"""
+
+
+def defs_source(tiers: tuple[str, ...]) -> str:
+    return "".join(
+        f'TEST_TIER_{tier.upper()} = "rue_test_tier_{tier}"\n' for tier in tiers
+    )
+
+
+def bxl_source(tiers: tuple[str, ...]) -> str:
+    body = "".join(f'    "rue_test_tier_{tier}",\n' for tier in tiers)
+    return f"_TEST_TIER_LABELS = [\n{body}]\n"
+
+
+class TierCiSelectorTests(unittest.TestCase):
+    def validate(
+        self,
+        *,
+        defs: str | None = None,
+        bxl: str | None = None,
+        ci: str | None = None,
+        release: str | None = None,
+        omit_release: bool = False,
+    ) -> list[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            defs_path = root / "test_defs.bzl"
+            bxl_path = root / "test_tiers.bxl"
+            ci_path = root / "ci.yml"
+            release_path = root / "release.yml"
+            defs_path.write_text(defs if defs is not None else defs_source(TIERS))
+            bxl_path.write_text(bxl if bxl is not None else bxl_source(TIERS))
+            ci_path.write_text(ci if ci is not None else CI_WORKFLOW)
+            release_path.write_text(
+                release if release is not None else RELEASE_WORKFLOW
+            )
+            workflows = {"ci.yml": ci_path}
+            if not omit_release:
+                workflows["release.yml"] = release_path
+            return selectors.validate(defs_path, bxl_path, workflows)
+
+    def test_registered_selectors_pass(self) -> None:
+        self.assertEqual(self.validate(), [])
+
+    def test_repository_state_is_valid(self) -> None:
+        # The gate must pass against the real files it ships to guard, not only
+        # against fixtures. Under Buck the declared input filegroup provides
+        # them at their repository-relative paths.
+        root = Path(
+            os.environ.get(
+                "RUE_TIER_VALIDATION_ROOT", Path(__file__).resolve().parent.parent
+            )
+        )
+        errors = selectors.validate(
+            root / "test_defs.bzl",
+            root / "test_tiers.bxl",
+            {
+                "ci.yml": root / ".github/workflows/ci.yml",
+                "release.yml": root / ".github/workflows/release.yml",
+            },
+        )
+        self.assertEqual(errors, [])
+
+    def test_deleted_oracle_lane_fails(self) -> None:
+        # The RUE-1117 regression itself: the differential leaves required CI
+        # while its `tier = "slow"` ownership stays perfectly valid.
+        stripped = "\n".join(
+            line
+            for line in CI_WORKFLOW.splitlines()
+            if "oracle-diff" not in line
+        ) + "\n"
+        errors = self.validate(ci=stripped)
+        self.assertEqual(len(errors), 2, errors)
+        for error in errors:
+            self.assertIn("rue_test_tier_slow", error)
+            self.assertIn("no longer selects it", error)
+
+    def test_renamed_job_fails(self) -> None:
+        errors = self.validate(ci=CI_WORKFLOW.replace("platform-corpus:", "corpus:"))
+        self.assertTrue(
+            any(
+                "no longer defines job 'platform-corpus'" in error
+                for error in errors
+            ),
+            errors,
+        )
+
+    def test_dropped_premerge_tier_filter_fails(self) -> None:
+        errors = self.validate(ci=CI_WORKFLOW.replace("RUE_TEST_TIER: premerge", ""))
+        self.assertTrue(
+            any("rue_test_tier_premerge" in error for error in errors), errors
+        )
+
+    def test_unfiltered_release_sweep_is_not_a_selector(self) -> None:
+        # release.yml runs `//...` with no tier filter, which executes every
+        # tier by accident. Removing every *named* stress selection must fail
+        # even though that sweep still runs the stress targets.
+        release = RELEASE_WORKFLOW.replace(
+            "      - name: Run manual stress program\n"
+            "        if: github.event_name == 'workflow_dispatch'"
+            " && inputs.tier == 'stress'\n"
+            '        run: ./buck2 test "//:large-example-${{ matrix.program }}-stress"\n',
+            "",
+        )
+        self.assertIn("//... toolchains//...", release)
+        errors = self.validate(release=release)
+        self.assertTrue(
+            any("rue_test_tier_stress" in error for error in errors), errors
+        )
+
+    def test_new_tier_without_a_selector_fails(self) -> None:
+        extended = TIERS + ("nightly",)
+        errors = self.validate(defs=defs_source(extended), bxl=bxl_source(extended))
+        self.assertTrue(
+            any(
+                "rue_test_tier_nightly has no declared CI selector" in error
+                for error in errors
+            ),
+            errors,
+        )
+
+    def test_removed_tier_leaves_a_stale_registration(self) -> None:
+        reduced = ("premerge", "slow")
+        errors = self.validate(defs=defs_source(reduced), bxl=bxl_source(reduced))
+        self.assertTrue(
+            any(
+                "rue_test_tier_stress is registered here but is no longer a "
+                "declared tier" in error
+                for error in errors
+            ),
+            errors,
+        )
+
+    def test_tier_vocabulary_drift_fails(self) -> None:
+        errors = self.validate(bxl=bxl_source(("premerge", "slow")))
+        self.assertEqual(len(errors), 1, errors)
+        self.assertIn("tier vocabulary drift", errors[0])
+
+    def test_missing_workflow_fails_closed(self) -> None:
+        errors = self.validate(omit_release=True)
+        self.assertTrue(
+            any("was not supplied to this validator" in error for error in errors),
+            errors,
+        )
+
+    def test_unparseable_workflow_fails_closed(self) -> None:
+        errors = self.validate(ci="name: CI\n")
+        self.assertTrue(
+            any("no top-level jobs mapping" in error for error in errors), errors
+        )
+
+    def test_unreadable_workflow_argument_is_reported(self) -> None:
+        workflows, errors = selectors.parse_workflow_args(["/nonexistent/ci.yml"])
+        self.assertEqual(workflows, {})
+        self.assertEqual(len(errors), 1)
+        self.assertIn("not a readable workflow file", errors[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -865,6 +865,22 @@ EOF
       "$([ "$rc" -eq 0 ] && grep -Fxq "test $other_target" "$sb/calls.log" && echo 0 || echo 1)"
   done
 
+  # RUE-1117: heavy suites are no longer only root-package targets. The label,
+  # not the package path, decides what may run here.
+  : >"$sb/calls.log"
+  rc=0
+  (cd "$sb" && FAKE_LABELED_TARGET=//crates/rue-oracle-diff:oracle-diff-test \
+    FAKE_CALL_LOG="$sb/calls.log" \
+    ./ci-heavy-suite //crates/rue-oracle-diff:oracle-diff-test) >/dev/null 2>&1 || rc=$?
+  check "ci-heavy-suite: a crate-package heavy suite is accepted" \
+    "$([ "$rc" -eq 0 ] && grep -Fxq 'test //crates/rue-oracle-diff:oracle-diff-test' "$sb/calls.log" && echo 0 || echo 1)"
+
+  rc=0
+  out="$(cd "$sb" && FAKE_LABELED_TARGET=//crates/rue-oracle-diff:oracle-diff-test \
+    ./ci-heavy-suite //crates/rue-oracle-diff/... 2>&1)" || rc=$?
+  check "ci-heavy-suite: a target pattern is still rejected as usage" \
+    "$([ "$rc" -eq 2 ] && grep -Fq 'usage: scripts/ci-heavy-suite' <<<"$out" && echo 0 || echo 1)"
+
   rc=0
   out="$(cd "$sb" && ./ci-heavy-suite //:spec-tests 2>&1)" || rc=$?
   check "ci-heavy-suite: unlabeled shard target fails closed" \
@@ -924,10 +940,15 @@ if [ "$1" = "uquery" ]; then
   case "$*" in
     *rue_cli_shard*) for t in ${FAKE_CLI_SHARDS:-}; do printf 'root%s\n' "$t"; done ;;
     *rue_dedicated_suite*) for t in ${FAKE_DEDICATED_SUITES:-}; do printf 'root%s\n' "$t"; done ;;
-    *rue_test_tier_slow*) printf 'root//:cli-tests-slow\n' ;;
+    *rue_test_tier_slow*)
+      for t in ${FAKE_SLOW_SUITES:-//:cli-tests-slow}; do printf 'root%s\n' "$t"; done
+      ;;
     *rue_test_tier_premerge*)
       for t in $FAKE_HEAVY_SUITES; do
-        [ "$t" = "//:cli-tests-slow" ] || printf 'root%s\n' "$t"
+        case " ${FAKE_SLOW_SUITES:-//:cli-tests-slow} " in
+          *" $t "*) ;;
+          *) printf 'root%s\n' "$t" ;;
+        esac
       done
       ;;
     *) for t in $FAKE_HEAVY_SUITES; do printf 'root%s\n' "$t"; done ;;
@@ -956,11 +977,14 @@ exit 90
 EOF
   chmod +x "$sb/buck2"
 
-  local all="//:cli-tests //:cli-tests-slow //:large-example-caldera-canary //:large-example-meridian-canary //:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests //:frontend-diff-test"
+  # RUE-1117: the oracle differentials are slow-tier heavy suites and required
+  # slow corpus, so the fixture must carry them alongside //:cli-tests-slow.
+  local slow="//:cli-tests-slow //crates/rue-oracle-diff:oracle-diff-test //crates/rue-oracle-diff:oracle-diff-spec-test"
+  local all="//:cli-tests $slow //:large-example-caldera-canary //:large-example-meridian-canary //:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests //:frontend-diff-test"
 
   # (1) Full corpus present + buck2 green -> test.sh reports success.
   local rc=0 out
-  out="$(cd "$sb" && RUE_CI_DEFER_HEAVY_SUITES= RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
+  out="$(cd "$sb" && RUE_CI_DEFER_HEAVY_SUITES= RUE_FULL_SUITE_LOCK_HELD=1 FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
   check "test.sh: unfiltered run with the full corpus reports success" \
     "$([ "$rc" -eq 0 ] && grep -Fxq '=== TEST SUITE: PASSED ===' <<< "$out" && echo 0 || echo 1)"
 
@@ -969,23 +993,32 @@ EOF
   # the premerge omission sentinels executed.
   : >"$sb/calls.log"; rc=0
   out="$(cd "$sb" && RUE_TEST_TIER=premerge RUE_CI_DEFER_HEAVY_SUITES= \
-      RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" \
+      RUE_FULL_SUITE_LOCK_HELD=1 FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" \
       FAKE_PASS_TARGETS="$all" FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
   check "test.sh: premerge selection uses the canonical Buck tier label" \
     "$([ "$rc" -eq 0 ] && grep -Fq -- '--include rue_test_tier_premerge' "$sb/calls.log" && echo 0 || echo 1)"
 
   : >"$sb/calls.log"; rc=0
   out="$(cd "$sb" && RUE_TEST_TIER=slow RUE_CI_DEFER_HEAVY_SUITES= \
-      RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" \
-      FAKE_PASS_TARGETS='//:cli-tests-slow' FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
+      RUE_FULL_SUITE_LOCK_HELD=1 FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" \
+      FAKE_PASS_TARGETS="$slow" FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
   check "test.sh: slow selection audits its real CLI corpus target" \
     "$([ "$rc" -eq 0 ] && grep -Fq -- '--include rue_test_tier_slow' "$sb/calls.log" && grep -Fq 'test //:cli-tests-slow -- --timeout 7200' "$sb/calls.log" && echo 0 || echo 1)"
+  # RUE-1117: a slow run that omits the codegen differential is the same
+  # false-green as an omitted CLI corpus, and must fail rather than tally.
+  rc=0
+  out="$(cd "$sb" && RUE_TEST_TIER=slow RUE_CI_DEFER_HEAVY_SUITES= \
+      RUE_FULL_SUITE_LOCK_HELD=1 FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" \
+      FAKE_PASS_TARGETS='//:cli-tests-slow' ./test.sh 2>&1)" || rc=$?
+  check "test.sh: an omitted oracle differential fails the slow run" \
+    "$([ "$rc" -ne 0 ] && grep -Fq 'CORPUS OMITTED' <<< "$out" \
+      && grep -Fq '//crates/rue-oracle-diff:oracle-diff-test' <<< "$out" && echo 0 || echo 1)"
 
   # (2) A corpus harness OMITTED while every buck2 invocation still exits 0 is
   #     the RUE-924 false-green: it must become a hard failure naming the suite.
-  local partial="//:cli-tests-slow //:large-example-caldera-canary //:large-example-meridian-canary //:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests //:frontend-diff-test"
+  local partial="$slow //:large-example-caldera-canary //:large-example-meridian-canary //:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests //:frontend-diff-test"
   rc=0
-  out="$(cd "$sb" && RUE_CI_DEFER_HEAVY_SUITES= RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$partial" ./test.sh 2>&1)" || rc=$?
+  out="$(cd "$sb" && RUE_CI_DEFER_HEAVY_SUITES= RUE_FULL_SUITE_LOCK_HELD=1 FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$partial" ./test.sh 2>&1)" || rc=$?
   check "test.sh: a silently omitted corpus harness fails the run" \
     "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
   check "test.sh: the omission message names the missing harness" \
@@ -996,7 +1029,7 @@ EOF
   # (3) A genuine buck2 failure with the full corpus present is still
   #     propagated verbatim (the audit must not mask real failures).
   rc=0
-  out="$(cd "$sb" && RUE_CI_DEFER_HEAVY_SUITES= RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" FAKE_BUCK_EXIT=17 ./test.sh 2>&1)" || rc=$?
+  out="$(cd "$sb" && RUE_CI_DEFER_HEAVY_SUITES= RUE_FULL_SUITE_LOCK_HELD=1 FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" FAKE_BUCK_EXIT=17 ./test.sh 2>&1)" || rc=$?
   check "test.sh: unfiltered buck2 failure exit code is propagated" \
     "$([ "$rc" -eq 17 ] && echo 0 || echo 1)"
 
@@ -1007,7 +1040,7 @@ EOF
   : >"$sb/calls.log"; rc=0
   out="$(cd "$sb" && CI=true RUE_TEST_TIER=premerge RUE_FULL_SUITE_LOCK_HELD=1 \
       RUE_CI_DEFER_HEAVY_SUITES='//:cli-tests //:spec-tests' \
-      FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$owned" \
+      FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$owned" \
       FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
   check "test.sh: required CI may defer live heavy suites" \
     "$([ "$rc" -eq 0 ] && grep -Fq 'Deferring heavy suite root//:cli-tests' <<<"$out" && echo 0 || echo 1)"
@@ -1021,7 +1054,7 @@ EOF
       RUE_CI_DEFER_HEAVY_SUITES= \
       RUE_CI_DEFER_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
       FAKE_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
-      FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" \
+      FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" \
       FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
   check "test.sh: required CI may defer the exact live dedicated-suite set" \
     "$([ "$rc" -eq 0 ] && grep -Fq -- '--exclude rue_dedicated_suite' "$sb/calls.log" && echo 0 || echo 1)"
@@ -1031,7 +1064,7 @@ EOF
       RUE_CI_DEFER_HEAVY_SUITES= \
       RUE_CI_DEFER_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
       FAKE_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test //:unowned-dedicated' \
-      FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
+      FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
   check "test.sh: a live dedicated target without a CI owner fails closed" \
     "$([ "$rc" -ne 0 ] && grep -Fq 'has no explicit CI owner' <<<"$out" && echo 0 || echo 1)"
 
@@ -1039,14 +1072,14 @@ EOF
   rc=0
   out="$(cd "$sb" && CI=true RUE_TEST_TIER=premerge RUE_FULL_SUITE_LOCK_HELD=1 \
       RUE_CI_DEFER_HEAVY_SUITES='//:missing-suite' \
-      FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
+      FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
   check "test.sh: unknown deferred CI suite fails closed" \
     "$([ "$rc" -ne 0 ] && grep -Fq 'not labeled rue_heavy_suite' <<<"$out" && echo 0 || echo 1)"
 
   rc=0
   out="$(cd "$sb" && CI= RUE_FULL_SUITE_LOCK_HELD=1 \
       RUE_CI_DEFER_HEAVY_SUITES='//:cli-tests' \
-      FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
+      FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
   check "test.sh: local callers cannot defer corpus coverage" \
     "$([ "$rc" -ne 0 ] && grep -Fq 'reserved for required CI' <<<"$out" && echo 0 || echo 1)"
 
@@ -1055,7 +1088,7 @@ EOF
       RUE_CI_DEFER_HEAVY_SUITES= \
       RUE_CI_DEFER_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
       FAKE_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
-      FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
+      FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
   check "test.sh: local callers cannot defer dedicated coverage" \
     "$([ "$rc" -ne 0 ] && grep -Fq 'reserved for required CI' <<<"$out" && echo 0 || echo 1)"
 

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -89,6 +89,8 @@ def validate(ci_path: Path, native_runner_path: Path = NATIVE_RUNNER_SCRIPT) -> 
         errors.append("ci-contract must not depend on another CI job")
     if "scripts/validate-ci-gate.py .github/workflows/ci.yml" not in contract:
         errors.append("ci-contract no longer runs the structural validator")
+    if "scripts/validate-tier-ci-selectors.py" not in contract:
+        errors.append("ci-contract no longer proves every test tier is CI-selected")
 
     remote = jobs.get("remote-execution", "")
     if "    if: github.event_name == 'merge_group'\n" not in remote:
@@ -145,6 +147,8 @@ def validate(ci_path: Path, native_runner_path: Path = NATIVE_RUNNER_SCRIPT) -> 
         "linux-x64-cli-shard-2",
         "linux-x64-cli-shard-3",
         "linux-x64-spec",
+        "linux-x64-oracle-diff",
+        "linux-x64-oracle-diff-spec",
     }
     if check_names != expected_checks:
         errors.append(

--- a/scripts/validate-tier-ci-selectors.py
+++ b/scripts/validate-tier-ci-selectors.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Require every Rue test tier to be selected by a *named* CI job (RUE-1117).
+
+`//test_tiers.bxl:validate` proves every first-party test target declares
+exactly one execution tier. It cannot prove anything ever runs that tier: a
+target moved into a tier no CI job selects keeps a valid ownership label while
+its coverage silently leaves the merge queue. That is how the RUE-205/RUE-204
+codegen differential left required CI — `tier = "slow"` was correct, and nothing
+selected the slow tier.
+
+Tier coverage was not absent even then, because `release.yml`'s nightly sweep
+runs `//...` with no tier filter and therefore happens to include every tier.
+That is exactly the property this gate refuses to accept as coverage: an
+unfiltered `//...` selects a tier by accident, so it keeps reporting "covered"
+through the very edit that strands a tier, and it says nothing about which job
+owns the tier or when it runs. Only a job that *names* the tier, or names
+targets belonging to it, counts here.
+
+What this proves:
+
+* the tier vocabulary in `test_defs.bzl` and `test_tiers.bxl` agrees;
+* every tier in that vocabulary has at least one declared CI selector, so a new
+  tier fails the build until a job is made responsible for it;
+* every declared selector still exists — its workflow, its job, and the literal
+  selection expression it was registered for. Deleting the oracle-diff lane, or
+  renaming its targets, fails here instead of going quiet.
+
+What it does not prove: that every *target* in a tier is selected. Coverage at
+that granularity belongs to each suite's own inventory gate (the RUE-924 audit
+in `test.sh`, `//:cli-shard-coverage-validation`). `//:cli-tests-slow` is
+deliberately nightly-only, and this gate is not the place to relitigate that.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+ACTION_ID = r"[A-Za-z_][A-Za-z0-9_-]*"
+JOB_RE = re.compile(rf"^  ({ACTION_ID}):\s*$", re.MULTILINE)
+BXL_TIER_RE = re.compile(r'^\s*"(rue_test_tier_[a-z]+)",\s*$', re.MULTILINE)
+DEFS_TIER_RE = re.compile(
+    r'^TEST_TIER_[A-Z]+ = "(rue_test_tier_[a-z]+)"$', re.MULTILINE
+)
+
+
+@dataclass(frozen=True)
+class Selector:
+    """One CI job deliberately responsible for executing a tier."""
+
+    workflow: str
+    job: str
+    # Literal text that must appear inside that job block. This is the
+    # registered *reason* the job selects the tier — a tier env filter, or the
+    # targets it names — so an edit that removes the selection fails here.
+    evidence: tuple[str, ...]
+    why: str
+
+
+TIER_SELECTORS: dict[str, tuple[Selector, ...]] = {
+    "rue_test_tier_premerge": (
+        Selector(
+            workflow="ci.yml",
+            job="linux-premerge",
+            evidence=("RUE_TEST_TIER: premerge", "./test.sh"),
+            why="the complete target-independent premerge suite on every PR",
+        ),
+    ),
+    "rue_test_tier_slow": (
+        Selector(
+            workflow="ci.yml",
+            job="platform-corpus",
+            evidence=(
+                "//crates/rue-oracle-diff:oracle-diff-test",
+                "//crates/rue-oracle-diff:oracle-diff-spec-test",
+            ),
+            why="the RUE-205/RUE-204 codegen differential, in its own pre-merge lane",
+        ),
+    ),
+    "rue_test_tier_stress": (
+        Selector(
+            workflow="release.yml",
+            job="large-program",
+            evidence=(
+                "inputs.tier == 'stress'",
+                '//:large-example-${{ matrix.program }}-stress',
+            ),
+            why="the manually dispatched 4x large-program stress matrix",
+        ),
+    ),
+}
+
+
+def job_blocks(workflow: str) -> dict[str, str]:
+    marker = workflow.find("\njobs:\n")
+    if marker < 0:
+        raise ValueError("workflow has no top-level jobs mapping")
+    body = workflow[marker + len("\njobs:\n") :]
+    matches = list(JOB_RE.finditer(body))
+    return {
+        match.group(1): body[match.start() : matches[index + 1].start()]
+        if index + 1 < len(matches)
+        else body[match.start() :]
+        for index, match in enumerate(matches)
+    }
+
+
+def declared_tiers(defs_path: Path, bxl_path: Path) -> tuple[set[str], list[str]]:
+    """Returns the agreed tier vocabulary and any disagreement between sources."""
+    defs_tiers = set(DEFS_TIER_RE.findall(defs_path.read_text()))
+    bxl_tiers = set(BXL_TIER_RE.findall(bxl_path.read_text()))
+    errors = []
+    if not defs_tiers:
+        errors.append(f"{defs_path}: no TEST_TIER_* constants found")
+    if not bxl_tiers:
+        errors.append(f"{bxl_path}: no tier labels found")
+    if defs_tiers and bxl_tiers and defs_tiers != bxl_tiers:
+        errors.append(
+            "tier vocabulary drift: "
+            f"{defs_path.name} declares {', '.join(sorted(defs_tiers))}; "
+            f"{bxl_path.name} selects {', '.join(sorted(bxl_tiers))}"
+        )
+    return defs_tiers | bxl_tiers, errors
+
+
+def validate(defs_path: Path, bxl_path: Path, workflows: dict[str, Path]) -> list[str]:
+    tiers, errors = declared_tiers(defs_path, bxl_path)
+    if errors:
+        return errors
+
+    registered = set(TIER_SELECTORS)
+    for tier in sorted(tiers - registered):
+        errors.append(
+            f"{tier} has no declared CI selector: give it a named job in a "
+            "workflow and register that job here. An unfiltered '//...' run is "
+            "not a selector."
+        )
+    for tier in sorted(registered - tiers):
+        errors.append(f"{tier} is registered here but is no longer a declared tier")
+
+    for tier in sorted(registered & tiers):
+        for selector in TIER_SELECTORS[tier]:
+            path = workflows.get(selector.workflow)
+            if path is None:
+                errors.append(
+                    f"{tier}: workflow {selector.workflow} was not supplied to "
+                    "this validator"
+                )
+                continue
+            try:
+                jobs = job_blocks(path.read_text())
+            except ValueError as error:
+                errors.append(f"{selector.workflow}: {error}")
+                continue
+            block = jobs.get(selector.job)
+            if block is None:
+                errors.append(
+                    f"{tier}: {selector.workflow} no longer defines job "
+                    f"'{selector.job}' ({selector.why})"
+                )
+                continue
+            for evidence in selector.evidence:
+                if evidence not in block:
+                    errors.append(
+                        f"{tier}: {selector.workflow} job '{selector.job}' no "
+                        f"longer selects it via {evidence!r} ({selector.why})"
+                    )
+    return errors
+
+
+def parse_workflow_args(values: list[str]) -> tuple[dict[str, Path], list[str]]:
+    workflows: dict[str, Path] = {}
+    errors: list[str] = []
+    for value in values:
+        path = Path(value)
+        if not path.is_file():
+            errors.append(f"{value}: not a readable workflow file")
+            continue
+        workflows[path.name] = path
+    return workflows, errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--test-defs", type=Path, required=True)
+    parser.add_argument("--test-tiers-bxl", type=Path, required=True)
+    parser.add_argument(
+        "--workflow",
+        action="append",
+        default=[],
+        help="path to a workflow file; registered by basename",
+    )
+    args = parser.parse_args()
+
+    workflows, errors = parse_workflow_args(args.workflow)
+    errors += validate(args.test_defs, args.test_tiers_bxl, workflows)
+    if errors:
+        for error in errors:
+            print(f"error: {error}")
+        return 1
+    print(
+        f"Rue tier CI selectors valid: {len(TIER_SELECTORS)} tiers, each "
+        "deliberately selected by a named CI job"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test.sh
+++ b/test.sh
@@ -116,6 +116,11 @@ REQUIRED_PREMERGE_CORPUS_HARNESSES=(
 
 REQUIRED_SLOW_CORPUS_HARNESSES=(
     //:cli-tests-slow
+    # The RUE-205/RUE-204 codegen differential. Both corpora run every runnable
+    # case through the reference interpreter, so a silent omission here hides
+    # exactly the miscompilation class the audit exists for (RUE-1117).
+    //crates/rue-oracle-diff:oracle-diff-test
+    //crates/rue-oracle-diff:oracle-diff-spec-test
 )
 
 if [[ $# -eq 0 ]]; then


### PR DESCRIPTION
## What

Two changes:

1. `//crates/rue-oracle-diff:oracle-diff-test` and `:oracle-diff-spec-test` each get their own linux-x64 `platform-corpus` lane.
2. A new gate requires every test tier to be selected by a *named* CI job.

## Why

The two differentials run every runnable CLI and spec case through the reference interpreter and compare the result against the compiler — the check that catches codegen diverging from the language's semantics (RUE-205/RUE-204). Both are `tier = "slow"`, and no required CI job selects the slow tier.

Coverage was not absent, as the re-scoped issue text suggested — `release.yml`'s nightly sweep runs `//...` with no tier filter, so it picks up both. But that is coverage by accident: up to a day after the offending merge, attributed to a schedule rather than to the PR that caused it, and only under `//platforms:release`, so a debug-only divergence is never exercised.

## How

**The lane.** Both corpora are target-independent, so one linux-x64 lane each is the whole platform requirement — no per-platform duplication to deduplicate later. They join the existing `platform-corpus` matrix, so they run concurrently with the CLI shards and spec corpus rather than extending the critical path, and they inherit that matrix's machinery for free: the RUE-1119 affected-targets determinator (both are added to `SELECTABLE_CORPUS`, so a PR that cannot affect them skips them and the merge queue still runs everything) and the `CI success` aggregate.

**Execution contract.** Labeling them `rue_heavy_suite` gives them the same contract as the other opaque corpus harnesses: `scripts/ci-heavy-suite` fails closed when Buck reports no result for the target, and the broad pass skips them. They are registered in `test.sh`'s `REQUIRED_SLOW_CORPUS_HARNESSES`, so a local slow/standard run that silently omits one fails the RUE-924 audit instead of tallying green. `ci-heavy-suite` previously accepted only `//:*`; it now accepts a heavy suite in its owning crate package, since the label — not the package path — is what decides membership.

**Tier coverage becomes checkable.** `//test_tiers.bxl:validate` proves every target owns exactly one tier; it cannot see CI, so a target moved into a tier nothing selects keeps a valid label while its coverage leaves the merge queue. That is precisely this bug. `scripts/validate-tier-ci-selectors.py` requires each tier to have a *named* selector, registered against the literal selection it depends on, so deleting the oracle lane or renaming its targets fails the build. An unfiltered `//...` run is deliberately **not** accepted as a selector: it runs every tier by accident, so it would have kept reporting "covered" through the exact edit that stranded the slow tier. The gate also pins that `test_defs.bzl` and `test_tiers.bxl` agree on the tier vocabulary, so a new tier fails until a job owns it. It runs as `//:tier-ci-selector-validation` and, toolchain-free, in the `CI contract` job.

Scope note: the gate is tier-granular, not target-granular. Per-target coverage stays with each suite's own inventory gate. `//:cli-tests-slow` remains deliberately nightly-only and this does not change that.

## Testing

Run locally on this branch:

- **Both differentials through the real CI entry point** — `scripts/ci-heavy-suite //crates/rue-oracle-diff:oracle-diff-test` and `:oracle-diff-spec-test`: `Pass 1` each, 0 harness/frontend/oracle failures, 0 disagreements.
- `./buck2 test //:tier-ci-selector-validation //:tier-ci-selector-tool-tests //:ci-gate-validation //:ci-gate-validator-tool-tests //:cli-shard-coverage-validation //:affected-targets-tool-tests` — `Pass 6`.
- `./buck2 bxl //test_tiers.bxl:validate` — 82 premerge, 5 slow, 3 stress; the premerge selection is unchanged at 81 targets and still contains only the bounded oracle smoke, so the premerge critical path does not grow.
- `scripts/test-wrapper-scripts.sh` (101 checks), `scripts/test-build-sharing.sh` (32 checks), `scripts/test-affected-targets.sh` (53 checks), `scripts/rue quick` (Pass 30) — all green.

New coverage: 12 tool-tests for the tier gate, including the RUE-1117 regression itself (deleting the oracle lane must fail) and the case that an unfiltered `//...` sweep does not count as a selector; plus wrapper-suite cases for a crate-package heavy suite, a rejected target pattern, and an omitted differential failing a slow run.

Full multi-platform validation runs on this PR's CI.

## Follow-up

None required for branch protection — `CI success` remains the only protected context, and it already aggregates `platform-corpus`.

Fixes RUE-1117

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdxgDPGNveZtaPg9vVS6VZ)_