### PR TITLE
RUE-1028: move body reachability onto structured query scheduling

### DIFF
--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -44,7 +44,6 @@ _DEPS = [
     "//third-party:annotate-snippets",
     "//third-party:lasso",
     "//third-party:libc",
-    "//third-party:rayon",
     "//third-party:sha2",
     "//third-party:serde",
     "//third-party:serde_json",

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1465,6 +1465,29 @@ fn removed_parallel_entry_points_cannot_return() {
 }
 
 #[test]
+fn compiler_parallelism_has_one_query_budget_and_no_peer_parallel_frontier() {
+    let root = include_str!("lib.rs");
+    let cfg = include_str!("queries.rs");
+    let backend = include_str!("backend.rs");
+    let database = include_str!("revisioned_query_database.rs");
+    assert!(
+        root.contains("QUERY_CONCURRENCY")
+            && root.contains("configure_thread_pool")
+            && database.contains("crate::query_concurrency()")
+            && database.contains("QueryRuntime::new(query_concurrency)"),
+        "compiler runtime configuration must feed the canonical query database budget"
+    );
+    for (module, source) in [("queries", cfg), ("backend", backend)] {
+        for forbidden in ["rayon", ".par_iter(", ".into_par_iter("] {
+            assert!(
+                !source.contains(forbidden),
+                "{module} reintroduced a process-global parallel frontier through {forbidden}"
+            );
+        }
+    }
+}
+
+#[test]
 fn orphaned_backend_inspection_exports_cannot_return() {
     let facade = include_str!("lib.rs");
     let backend = include_str!("backend.rs");

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -69,7 +69,7 @@ pub(crate) struct FunctionBackendProduct {
 /// Compile analyzed functions to a binary.
 ///
 /// This backend handles both architectures. It:
-/// 1. Generates machine code for each function in parallel
+/// 1. Generates machine code for each function
 /// 2. Creates object files with relocations
 /// 3. Links them into an executable
 ///
@@ -201,11 +201,8 @@ pub(crate) fn generate_backend_products(
     foreign_symbols: &[String],
     request: rue_codegen::BackendArtifactRequest,
 ) -> MultiErrorResult<Vec<FunctionBackendProduct>> {
-    // Rayon workers do not inherit the calling thread's current span, so the
-    // per-function subphase spans inside rue-codegen would otherwise be
-    // reported as extra timing roots. Hold the span by value and re-enter it
-    // inside the closure so every worker's subphases nest under this one
-    // `codegen` aggregate (RUE-786).
+    // Keep every per-function subphase nested under one `codegen` aggregate
+    // timing root (RUE-786).
     let codegen_span = info_span!("codegen", arch = ?options.target.arch(), phase = "backend");
     let _entered = codegen_span.clone().entered();
     let symbol_mappings = foreign_call_symbol_mappings(functions, foreign_symbols);
@@ -214,7 +211,7 @@ pub(crate) fn generate_backend_products(
         rue_codegen::MachineSymbolResolver::new_with_foreign(&symbol_mappings, &foreign_set);
 
     let results: Vec<CompileResult<FunctionBackendProduct>> = functions
-        .par_iter()
+        .iter()
         .map(|func| {
             let _worker = codegen_span.enter();
             let stable_atom_ids = func
@@ -282,8 +279,8 @@ fn project_backend_object(
     product: FunctionBackendProduct,
     target: Target,
 ) -> CompileResult<Vec<u8>> {
-    // Object serialization runs after the parallel codegen fan-out, so it is a
-    // sibling leaf of `codegen` rather than one of its subphases (RUE-786).
+    // Object serialization runs after code generation, so it is a sibling leaf
+    // of `codegen` rather than one of its subphases (RUE-786).
     let _span = info_span!("object_serialization", phase = "object_generation").entered();
     let mut obj_builder = ObjectBuilder::new(target, &product.machine_name)
         .code(product.machine_code.code)
@@ -418,7 +415,6 @@ fn validate_production_call_relocations(
 }
 
 // ============================================================================
-use rayon::prelude::*;
 use tracing::{info, info_span};
 
 use crate::linking::{link_internal_with_warnings, link_system_with_warnings};

--- a/crates/rue-compiler/src/body_query.rs
+++ b/crates/rue-compiler/src/body_query.rs
@@ -299,6 +299,22 @@ pub(crate) struct BodyClosurePublicationKey {
     pub(crate) epoch: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct BodyClosureMembershipKey {
+    pub(crate) closure: BodyClosureQueryKey,
+    pub(crate) instance: crate::FunctionInstanceKey,
+}
+
+impl rue_query::QueryKey for BodyClosureMembershipKey {
+    fn stable_identity(&self) -> String {
+        format!(
+            "{};member={:?}",
+            self.closure.stable_identity(),
+            self.instance
+        )
+    }
+}
+
 impl rue_query::QueryKey for BodyClosurePublicationKey {
     fn stable_identity(&self) -> String {
         format!("{};epoch={}", self.closure.stable_identity(), self.epoch)
@@ -309,6 +325,24 @@ impl rue_query::QueryKey for BodyClosurePublicationKey {
 pub(crate) struct BodyClosureBody {
     pub(crate) key: BodyQueryKey,
     pub(crate) bundle: Arc<rue_query::QueryTerminal<BodyAnalysisBundle>>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BodyReachabilityOutput {
+    pub(crate) reached: Arc<[crate::FunctionInstanceKey]>,
+    pub(crate) scheduling_errors: Arc<[(crate::FunctionInstanceKey, crate::CompileErrors)]>,
+    pub(crate) fatal: Option<BodyClosureFatal>,
+    pub(crate) parked_toolchain: Option<crate::ParkedToolchainModules>,
+}
+
+pub(crate) fn body_reachability_output_equal(
+    left: &BodyReachabilityOutput,
+    right: &BodyReachabilityOutput,
+) -> bool {
+    left.reached == right.reached
+        && left.scheduling_errors == right.scheduling_errors
+        && left.fatal == right.fatal
+        && left.parked_toolchain == right.parked_toolchain
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -338,6 +372,7 @@ pub(crate) enum BodyClosureFatal {
 
 #[derive(Debug, Clone)]
 pub(crate) struct BodyClosureOutput {
+    pub(crate) reached: Arc<[crate::FunctionInstanceKey]>,
     pub(crate) bodies: Arc<[BodyClosureBody]>,
     pub(crate) scheduling_errors: Arc<[(crate::FunctionInstanceKey, crate::CompileErrors)]>,
     pub(crate) fatal: Option<BodyClosureFatal>,
@@ -348,7 +383,8 @@ pub(crate) fn body_closure_output_equal(
     left: &BodyClosureOutput,
     right: &BodyClosureOutput,
 ) -> bool {
-    left.bodies.len() == right.bodies.len()
+    left.reached == right.reached
+        && left.bodies.len() == right.bodies.len()
         && left
             .bodies
             .iter()

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -266,11 +266,40 @@ pub(crate) use rue_linker::{
 };
 pub(crate) use rue_parser::Parser;
 
-/// Configure Rayon's global worker pool once, before issuing compiler queries.
+// Zero means no embedder/driver override has been installed yet. The first
+// session lazily snapshots host parallelism so constructing CompilerSession
+// directly retains the CLI's default behavior without a peer executor.
+static QUERY_CONCURRENCY: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Configure the compiler's shared structured-query concurrency budget.
+///
+/// Per-function CFG and backend work is deliberately serialized until it is
+/// represented as registered query batches, leaving one canonical concurrency
+/// authority for compiler work.
 pub fn configure_thread_pool(jobs: usize) {
-    if jobs > 0 {
-        let _ = rayon::ThreadPoolBuilder::new()
-            .num_threads(jobs)
-            .build_global();
+    let jobs = if jobs == 0 {
+        std::thread::available_parallelism()
+            .map(std::num::NonZeroUsize::get)
+            .unwrap_or(1)
+    } else {
+        jobs
+    };
+    QUERY_CONCURRENCY.store(jobs, std::sync::atomic::Ordering::Release);
+}
+
+pub(crate) fn query_concurrency() -> usize {
+    let configured = QUERY_CONCURRENCY.load(std::sync::atomic::Ordering::Acquire);
+    if configured != 0 {
+        return configured;
     }
+    let detected = std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(1);
+    let _ = QUERY_CONCURRENCY.compare_exchange(
+        0,
+        detected,
+        std::sync::atomic::Ordering::AcqRel,
+        std::sync::atomic::Ordering::Acquire,
+    );
+    QUERY_CONCURRENCY.load(std::sync::atomic::Ordering::Acquire)
 }

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -1,4 +1,3 @@
-use rayon::prelude::*;
 use tracing::{info, info_span};
 
 use crate::*;
@@ -336,17 +335,16 @@ pub(crate) fn build_functions_and_cfgs(
     // resolved through `legacy_to_machine` only at the codegen boundary; this
     // keeps presentation and durable CFG reuse independent of interner slots.
     let mut all_functions = projected;
-    // Function order controls indexed Rayon collection, object-file order,
-    // and final linker layout. Machine symbols are the stable semantic
+    // Function order controls CFG collection, object-file order, and final
+    // linker layout. Machine symbols are the stable semantic
     // identity shared by user, specialized, destructor, and glue functions.
     all_functions.sort_by(|left, right| left.4.cmp(&right.4));
 
-    // Entered once on the calling thread and held across the Rayon collect
-    // below, so the phase stays active for the whole parallel region.
+    // Entered once on the calling thread and held across the stable collection.
     let _span = info_span!("cfg_construction", phase = "cfg_and_optimization").entered();
 
     let results: Vec<_> = all_functions
-        .into_par_iter()
+        .into_iter()
         .map(
             |(func, semantic_identity, symbol, local_atoms, machine_name)| {
                 let legacy_name = func.name.clone();
@@ -866,12 +864,6 @@ fn compile_snapshot_impl(
     snapshot: &SourceSnapshot,
     options: &CompileOptions,
 ) -> MultiErrorResult<CompileOutput> {
-    // NOTE: the Rayon global thread pool is deliberately NOT configured here.
-    // `build_global()` panics if called twice, and the `--emit` driver path
-    // never reaches this function, so it was silently ignoring `-j`/`--jobs`
-    // (RUE-352). The jobs setting is now applied once in the driver's `main()`
-    // via `configure_thread_pool` before dispatching to any path.
-
     let mut session = CompilerSession::new();
     session.update_for_presentation(snapshot).into_result()?;
     compile_with_session(&mut session, snapshot, options)

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -12,34 +12,20 @@ use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
 #[cfg(test)]
-thread_local! {
-    static INJECT_BODY_TRANSACTION_FAILURE: std::cell::Cell<bool> =
-        const { std::cell::Cell::new(false) };
-}
-
-#[cfg(test)]
-pub(crate) fn with_test_body_transaction_failure<T>(run: impl FnOnce() -> T) -> T {
-    struct Reset;
-    impl Drop for Reset {
-        fn drop(&mut self) {
-            INJECT_BODY_TRANSACTION_FAILURE.with(|enabled| enabled.set(false));
-        }
-    }
-    INJECT_BODY_TRANSACTION_FAILURE.with(|enabled| {
-        assert!(
-            !enabled.replace(true),
-            "body transaction failure injection is not nestable"
-        );
-    });
-    let _reset = Reset;
-    run()
-}
-
-#[cfg(test)]
 #[derive(Debug, Default)]
 struct TestBodyClosureAnonymousDigestForcing {
     sealed: bool,
     digests: BTreeMap<crate::AnonymousNominalKey, u128>,
+}
+
+#[cfg(test)]
+pub(crate) struct TestBodyTransactionFailureGuard(Arc<std::sync::atomic::AtomicBool>);
+
+#[cfg(test)]
+impl Drop for TestBodyTransactionFailureGuard {
+    fn drop(&mut self) {
+        self.0.store(false, std::sync::atomic::Ordering::SeqCst);
+    }
 }
 
 use rue_query::{
@@ -73,16 +59,11 @@ use crate::typed_query_store::{TerminalKind, TypedQueryFamily};
 
 const IMPORT_INPUT_REVISION_RETENTION: usize = 64;
 const MODULE_QUERY_MEMO_RETENTION: usize = 4096;
-// Body-keyed families must retain the entire reached-body universe of one
-// cold compile. Terminal eviction below that size is not merely a cache miss:
-// the body-produced-anonymous projection resolves through the retained
-// BodyTransaction terminal, so evicting a still-reachable body's terminal
-// makes the projection fail (surfaced as a "did not publish a terminal"
-// internal diagnostic), and every coordinator restart recomputes each evicted
-// body from scratch. examples/caldera reaches more than 10,000 bodies and
-// exceeded the module-family cap (RUE-1083). RUE-1028's database-owned
-// reachability should replace this fixed cap with exact rooted membership.
-const BODY_QUERY_MEMO_RETENTION: usize = 65536;
+// The published body-closure lease owns the exact registered dependency cone
+// of the current reachability root. Body families therefore need only a small
+// unrooted history; a large reached program grows past this floor through its
+// exact pins and releases superseded/deleted members atomically.
+const BODY_QUERY_MEMO_RETENTION: usize = 8;
 const BODY_CLOSURE_MEMO_RETENTION: usize = 8;
 // Declaration-keyed families scale with the program's declaration universe
 // exactly as body-keyed families scale with reached bodies, and the
@@ -91,7 +72,7 @@ const BODY_CLOSURE_MEMO_RETENTION: usize = 8;
 // projection the body retention protects. Module-keyed families stay at the
 // module-scaled retention; real programs have orders of magnitude fewer
 // modules than declarations.
-const DECLARATION_QUERY_MEMO_RETENTION: usize = BODY_QUERY_MEMO_RETENTION;
+const DECLARATION_QUERY_MEMO_RETENTION: usize = 65536;
 // ResolveImport is keyed by parser occurrence plus demand mode, not by module.
 // Large programs can have thousands of sites per module universe (Caldera has
 // 4,093 occurrences), and rooted/speculative variants may both be retained.
@@ -542,9 +523,16 @@ pub(crate) struct RevisionedQueryDatabase {
     #[allow(dead_code)]
     body_analysis_bundles:
         QueryFamily<crate::body_query::BodyQueryKey, crate::body_query::BodyAnalysisBundle>,
+    #[cfg_attr(not(test), allow(dead_code))]
+    body_reachability: QueryFamily<
+        crate::body_query::BodyClosureQueryKey,
+        crate::body_query::BodyReachabilityOutput,
+    >,
     #[allow(dead_code)]
     body_closures:
         QueryFamily<crate::body_query::BodyClosureQueryKey, crate::body_query::BodyClosureOutput>,
+    #[cfg_attr(not(test), allow(dead_code))]
+    body_closure_memberships: QueryFamily<crate::body_query::BodyClosureMembershipKey, bool>,
     body_closure_publications: QueryFamily<
         crate::body_query::BodyClosurePublicationKey,
         Arc<rue_query::QueryTerminal<crate::body_query::BodyClosureOutput>>,
@@ -642,6 +630,15 @@ pub(crate) struct RevisionedQueryDatabase {
     /// lookup-pin set here. Behind a `Mutex` because promotion is a `&self`
     /// operation on the shared database.
     lookup_root_lease: Arc<Mutex<PublishedRootLookupLease>>,
+    #[allow(dead_code)]
+    body_closure_root: Arc<Mutex<PublishedBodyClosureRoot>>,
+    #[allow(dead_code)]
+    body_reachability_root: Arc<Mutex<PublishedBodyReachabilityRoot>>,
+    /// Session-scoped injection shared with structured body-query children.
+    /// Keeping it on the database avoids both thread-local scheduler escapes
+    /// and cross-test interference between independent compiler sessions.
+    #[cfg(test)]
+    inject_body_transaction_failure: Arc<std::sync::atomic::AtomicBool>,
     /// Test-only witness that the rooted-publication promotion hook took its
     /// non-empty branch — i.e. entered the promotion path at all (RUE-1091). The
     /// hook checks the observed set for emptiness FIRST, before formatting the
@@ -798,6 +795,7 @@ impl ObservedLookupRoot {
 #[derive(Debug)]
 struct RootLeaseEntry {
     observations: ObservedLookupRoot,
+    publication: u64,
 }
 
 #[derive(Debug, Default)]
@@ -807,6 +805,9 @@ struct PublishedRootLookupLease {
     /// predecessor, so the shared terminals of an edit/error/fix loop are never
     /// left unprotected across the swap.
     roots: BTreeMap<String, RootLeaseEntry>,
+    /// Monotonic identity for conditionally rolling back a publication without
+    /// overwriting a newer concurrent successor.
+    next_root_publication: u64,
     /// Last observed node incarnation per distinct logical lookup key, bounded
     /// FIFO, for rederivation-after-eviction detection.
     incarnations: BTreeMap<Arc<str>, (u64, u64)>,
@@ -879,10 +880,16 @@ fn replace_published_lookup_root(
         }
         lease.record_incarnation(identity, *incarnation);
     }
+    let publication = lease.next_root_publication;
+    lease.next_root_publication = lease
+        .next_root_publication
+        .checked_add(1)
+        .expect("lookup-root publication generation overflow");
     let prior = lease.roots.insert(
         root,
         RootLeaseEntry {
             observations: observed,
+            publication,
         },
     );
     let evictions_before = runtime.metrics().evictions;
@@ -896,19 +903,127 @@ struct PublishedLookupRootHandoff {
     runtime: QueryRuntime,
     root: String,
     observed: Option<ObservedLookupRoot>,
+    rollback: Option<PublishedLookupRootRollback>,
+}
+
+#[derive(Debug)]
+struct PublishedLookupRootRollback {
+    previous: Option<RootLeaseEntry>,
+    publication: u64,
+    previous_incarnations: BTreeMap<Arc<str>, (u64, u64)>,
+    previous_incarnation_order: BTreeSet<(u64, Arc<str>)>,
+    previous_next_incarnation_generation: u64,
+    previous_rederivations_after_eviction: u64,
+    previous_supersession_evictions: u64,
+    previous_next_root_publication: u64,
+    expected_next_root_publication: u64,
 }
 
 impl rue_query::QueryAttemptHandoff for PublishedLookupRootHandoff {
     fn commit(&mut self) {
+        assert!(
+            self.rollback.is_none(),
+            "lookup-root handoff commits from pending"
+        );
         let observed = self
             .observed
             .take()
             .expect("lookup-root handoff commits at most once");
-        replace_published_lookup_root(&self.lease, &self.runtime, self.root.clone(), observed);
+        let mut lease = self
+            .lease
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous_incarnations = lease.incarnations.clone();
+        let previous_incarnation_order = lease.incarnation_order.clone();
+        let previous_next_incarnation_generation = lease.next_incarnation_generation;
+        let previous_rederivations_after_eviction = lease.rederivations_after_eviction;
+        let previous_supersession_evictions = lease.supersession_evictions;
+        let previous_next_root_publication = lease.next_root_publication;
+        for (key, incarnation) in &observed.observed_keys {
+            let identity = key.display_identity();
+            if let Some(previous) = lease.seen_incarnation(&identity)
+                && previous != *incarnation
+            {
+                lease.rederivations_after_eviction += 1;
+            }
+            lease.record_incarnation(identity, *incarnation);
+        }
+        let publication = lease.next_root_publication;
+        lease.next_root_publication = lease
+            .next_root_publication
+            .checked_add(1)
+            .expect("lookup-root publication generation overflow");
+        let previous = lease.roots.insert(
+            self.root.clone(),
+            RootLeaseEntry {
+                observations: observed,
+                publication,
+            },
+        );
+        self.rollback = Some(PublishedLookupRootRollback {
+            previous,
+            publication,
+            previous_incarnations,
+            previous_incarnation_order,
+            previous_next_incarnation_generation,
+            previous_rederivations_after_eviction,
+            previous_supersession_evictions,
+            previous_next_root_publication,
+            expected_next_root_publication: lease.next_root_publication,
+        });
     }
 
     fn abort(&mut self) {
-        drop(self.observed.take());
+        let Some(rollback) = self.rollback.take() else {
+            drop(self.observed.take());
+            return;
+        };
+        let mut lease = self
+            .lease
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert_eq!(
+            lease.next_root_publication, rollback.expected_next_root_publication,
+            "a concurrently superseded lookup publication cannot be retried"
+        );
+        let current = lease
+            .roots
+            .get(&self.root)
+            .expect("an installed lookup root remains present until rollback");
+        assert_eq!(
+            current.publication, rollback.publication,
+            "lookup rollback cannot overwrite a newer root publication"
+        );
+        let installed = lease
+            .roots
+            .remove(&self.root)
+            .expect("the checked lookup publication remains installed");
+        if let Some(previous) = rollback.previous {
+            lease.roots.insert(self.root.clone(), previous);
+        }
+        lease.incarnations = rollback.previous_incarnations;
+        lease.incarnation_order = rollback.previous_incarnation_order;
+        lease.next_incarnation_generation = rollback.previous_next_incarnation_generation;
+        lease.rederivations_after_eviction = rollback.previous_rederivations_after_eviction;
+        lease.supersession_evictions = rollback.previous_supersession_evictions;
+        lease.next_root_publication = rollback.previous_next_root_publication;
+        self.observed = Some(installed.observations);
+    }
+}
+
+impl Drop for PublishedLookupRootHandoff {
+    fn drop(&mut self) {
+        let Some(rollback) = self.rollback.take() else {
+            return;
+        };
+        let evictions_before = self.runtime.metrics().evictions;
+        drop(rollback.previous);
+        let evictions = self.runtime.metrics().evictions - evictions_before;
+        let mut lease = self
+            .lease
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        lease.supersession_evictions = lease.supersession_evictions.saturating_add(evictions);
     }
 }
 
@@ -918,10 +1033,142 @@ struct PublishedBodyClosureLookupHandoff {
     runtime: QueryRuntime,
     observed: Option<BTreeMap<String, ObservedLookupRoot>>,
     retire_absent: bool,
+    rollback: Option<PublishedBodyClosureLookupRollback>,
+}
+
+#[derive(Debug)]
+struct PublishedBodyClosureLookupRollback {
+    previous_roots: BTreeMap<String, RootLeaseEntry>,
+    installed: BTreeMap<String, u64>,
+    previous_incarnations: BTreeMap<Arc<str>, (u64, u64)>,
+    previous_incarnation_order: BTreeSet<(u64, Arc<str>)>,
+    previous_next_incarnation_generation: u64,
+    previous_rederivations_after_eviction: u64,
+    previous_supersession_evictions: u64,
+    previous_next_root_publication: u64,
+    expected_next_root_publication: u64,
+}
+
+#[derive(Debug, Default)]
+struct PublishedBodyClosureRoot {
+    lease: rue_query::RetainedPinSet,
+    reached: BTreeSet<crate::FunctionInstanceKey>,
+    additions: u64,
+    deletions: u64,
+}
+
+#[derive(Debug, Default)]
+struct PublishedBodyReachabilityRoot {
+    lease: rue_query::RetainedPinSet,
+}
+
+#[derive(Debug)]
+struct PublishedBodyReachabilityTerminalHandoff {
+    root: Arc<Mutex<PublishedBodyReachabilityRoot>>,
+    pending: Option<rue_query::RetainedPinSet>,
+    previous: Option<PublishedBodyReachabilityRoot>,
+    installed: bool,
+}
+
+impl rue_query::QueryAttemptHandoff for PublishedBodyReachabilityTerminalHandoff {
+    fn commit(&mut self) {
+        let pending = self
+            .pending
+            .take()
+            .expect("body-reachability terminal handoff commits at most once");
+        let mut root = self
+            .root
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        self.previous = Some(std::mem::replace(
+            &mut *root,
+            PublishedBodyReachabilityRoot { lease: pending },
+        ));
+        self.installed = true;
+    }
+
+    fn abort(&mut self) {
+        if self.installed {
+            let previous = self
+                .previous
+                .take()
+                .expect("an installed reachability lease retains its predecessor");
+            let mut root = self
+                .root
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let installed = std::mem::replace(&mut *root, previous);
+            self.pending = Some(installed.lease);
+            self.installed = false;
+        } else {
+            drop(self.pending.take());
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PublishedBodyClosureTerminalHandoff {
+    root: Arc<Mutex<PublishedBodyClosureRoot>>,
+    pending: Option<rue_query::RetainedPinSet>,
+    pending_reached: Option<BTreeSet<crate::FunctionInstanceKey>>,
+    previous: Option<PublishedBodyClosureRoot>,
+    installed: bool,
+}
+
+impl rue_query::QueryAttemptHandoff for PublishedBodyClosureTerminalHandoff {
+    fn commit(&mut self) {
+        let pending = self
+            .pending
+            .take()
+            .expect("body-closure terminal handoff commits at most once");
+        let pending_reached = self
+            .pending_reached
+            .take()
+            .expect("body-closure terminal handoff retains exact membership");
+        let mut root = self
+            .root
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let additions = pending_reached.difference(&root.reached).count() as u64;
+        let deletions = root.reached.difference(&pending_reached).count() as u64;
+        let next = PublishedBodyClosureRoot {
+            lease: pending,
+            reached: pending_reached,
+            additions: root.additions.saturating_add(additions),
+            deletions: root.deletions.saturating_add(deletions),
+        };
+        let previous = std::mem::replace(&mut *root, next);
+        self.previous = Some(previous);
+        self.installed = true;
+    }
+
+    fn abort(&mut self) {
+        if self.installed {
+            let previous = self
+                .previous
+                .take()
+                .expect("an installed closure lease retains its predecessor");
+            let mut root = self
+                .root
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let installed = std::mem::replace(&mut *root, previous);
+            self.pending = Some(installed.lease);
+            self.pending_reached = Some(installed.reached);
+            self.installed = false;
+        } else {
+            drop(self.pending.take());
+            drop(self.pending_reached.take());
+        }
+    }
 }
 
 impl rue_query::QueryAttemptHandoff for PublishedBodyClosureLookupHandoff {
     fn commit(&mut self) {
+        assert!(
+            self.rollback.is_none(),
+            "body-closure lookup handoff commits from pending"
+        );
         let observed = self
             .observed
             .take()
@@ -931,7 +1178,17 @@ impl rue_query::QueryAttemptHandoff for PublishedBodyClosureLookupHandoff {
             .lease
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let evictions_before = self.runtime.metrics().evictions;
+        let mut rollback = PublishedBodyClosureLookupRollback {
+            previous_roots: BTreeMap::new(),
+            installed: BTreeMap::new(),
+            previous_incarnations: lease.incarnations.clone(),
+            previous_incarnation_order: lease.incarnation_order.clone(),
+            previous_next_incarnation_generation: lease.next_incarnation_generation,
+            previous_rederivations_after_eviction: lease.rederivations_after_eviction,
+            previous_supersession_evictions: lease.supersession_evictions,
+            previous_next_root_publication: lease.next_root_publication,
+            expected_next_root_publication: 0,
+        };
         for (root, observed) in observed {
             for (key, incarnation) in &observed.observed_keys {
                 let identity = key.display_identity();
@@ -942,23 +1199,99 @@ impl rue_query::QueryAttemptHandoff for PublishedBodyClosureLookupHandoff {
                 }
                 lease.record_incarnation(identity, *incarnation);
             }
-            lease.roots.insert(
-                root,
+            let publication = lease.next_root_publication;
+            lease.next_root_publication = lease
+                .next_root_publication
+                .checked_add(1)
+                .expect("lookup-root publication generation overflow");
+            let previous = lease.roots.insert(
+                root.clone(),
                 RootLeaseEntry {
                     observations: observed,
+                    publication,
                 },
             );
+            if let Some(previous) = previous {
+                rollback.previous_roots.insert(root.clone(), previous);
+            }
+            rollback.installed.insert(root, publication);
         }
         if self.retire_absent {
-            lease
+            let retired = lease
                 .roots
-                .retain(|root, _| !root.starts_with("body:") || reached.contains(root));
+                .keys()
+                .filter(|root| root.starts_with("body:") && !reached.contains(*root))
+                .cloned()
+                .collect::<Vec<_>>();
+            for root in retired {
+                let previous = lease
+                    .roots
+                    .remove(&root)
+                    .expect("a selected retired lookup root remains present");
+                rollback.previous_roots.insert(root, previous);
+            }
         }
-        lease.supersession_evictions += self.runtime.metrics().evictions - evictions_before;
+        rollback.expected_next_root_publication = lease.next_root_publication;
+        self.rollback = Some(rollback);
     }
 
     fn abort(&mut self) {
-        drop(self.observed.take());
+        let Some(rollback) = self.rollback.take() else {
+            drop(self.observed.take());
+            return;
+        };
+        let mut lease = self
+            .lease
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert_eq!(
+            lease.next_root_publication, rollback.expected_next_root_publication,
+            "a concurrently superseded lookup publication cannot be retried"
+        );
+        let mut observed = BTreeMap::new();
+        for (root, publication) in &rollback.installed {
+            let current = lease
+                .roots
+                .get(root)
+                .expect("an installed lookup root remains present until rollback");
+            assert_eq!(
+                current.publication, *publication,
+                "lookup rollback cannot overwrite a newer root publication"
+            );
+        }
+        for root in rollback.installed.keys() {
+            let installed = lease
+                .roots
+                .remove(root)
+                .expect("the checked lookup publication remains installed");
+            observed.insert(root.clone(), installed.observations);
+        }
+        for (root, previous) in rollback.previous_roots {
+            lease.roots.insert(root, previous);
+        }
+        lease.incarnations = rollback.previous_incarnations;
+        lease.incarnation_order = rollback.previous_incarnation_order;
+        lease.next_incarnation_generation = rollback.previous_next_incarnation_generation;
+        lease.rederivations_after_eviction = rollback.previous_rederivations_after_eviction;
+        lease.supersession_evictions = rollback.previous_supersession_evictions;
+        lease.next_root_publication = rollback.previous_next_root_publication;
+        self.observed = Some(observed);
+    }
+}
+
+impl Drop for PublishedBodyClosureLookupHandoff {
+    fn drop(&mut self) {
+        let Some(rollback) = self.rollback.take() else {
+            return;
+        };
+        let evictions_before = self.runtime.metrics().evictions;
+        drop(rollback.previous_roots);
+        let evictions = self.runtime.metrics().evictions - evictions_before;
+        let mut lease = self
+            .lease
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        lease.supersession_evictions = lease.supersession_evictions.saturating_add(evictions);
     }
 }
 
@@ -7642,7 +7975,10 @@ fn resolve_parsed_semantic_signature(
 
 impl Default for RevisionedQueryDatabase {
     fn default() -> Self {
-        Self::with_declaration_memo_retention(DECLARATION_QUERY_MEMO_RETENTION)
+        Self::with_declaration_memo_retention_and_concurrency(
+            DECLARATION_QUERY_MEMO_RETENTION,
+            crate::query_concurrency(),
+        )
     }
 }
 
@@ -7650,8 +7986,24 @@ impl RevisionedQueryDatabase {
     /// Construct the database with an explicit declaration-keyed memo
     /// retention. Production uses [`DECLARATION_QUERY_MEMO_RETENTION`];
     /// eviction-lifecycle tests pass a small cap so exceeding it stays cheap.
+    #[cfg(test)]
     pub(crate) fn with_declaration_memo_retention(declaration_memo_retention: usize) -> Self {
-        let runtime = QueryRuntime::new(1);
+        Self::with_declaration_memo_retention_and_concurrency(declaration_memo_retention, 1)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_query_concurrency(query_concurrency: usize) -> Self {
+        Self::with_declaration_memo_retention_and_concurrency(
+            DECLARATION_QUERY_MEMO_RETENTION,
+            query_concurrency,
+        )
+    }
+
+    fn with_declaration_memo_retention_and_concurrency(
+        declaration_memo_retention: usize,
+        query_concurrency: usize,
+    ) -> Self {
+        let runtime = QueryRuntime::new(query_concurrency);
         let module_store = Arc::new(Mutex::new(ModuleInputStore::default()));
         #[cfg(test)]
         let test_import_store = Arc::new(Mutex::new(TestImportInputStore {
@@ -10779,6 +11131,10 @@ impl RevisionedQueryDatabase {
             .expect("the DeclarationSemanticsProjection family has one canonical name");
         let provider_observation_meter = Arc::new(ProviderObservationCounters::default());
         let lookup_root_lease = Arc::new(Mutex::new(PublishedRootLookupLease::default()));
+        let body_closure_root = Arc::new(Mutex::new(PublishedBodyClosureRoot::default()));
+        let body_reachability_root = Arc::new(Mutex::new(PublishedBodyReachabilityRoot::default()));
+        #[cfg(test)]
+        let inject_body_transaction_failure = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let transactions_for_analysis_bundle = body_transactions.clone();
         let produced_for_analysis_bundle = body_produced_anonymous.clone();
         let canonical_for_analysis_bundle = canonical_bodies.clone();
@@ -10839,27 +11195,37 @@ impl RevisionedQueryDatabase {
                 },
             )
             .expect("the BodyAnalysisBundle family has one canonical name");
+        let transactions_for_body_references = body_transactions.clone();
+        let body_references = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.body-references",
+                BODY_QUERY_MEMO_RETENTION,
+                |left: &crate::body_query::BodyReferences,
+                 right: &crate::body_query::BodyReferences| left == right,
+                move |context, _, key: &crate::body_query::BodyQueryKey| {
+                    let transaction =
+                        context.query_registered(&transactions_for_body_references, key.clone())?;
+                    let rue_query::QueryOutcome::Success(transaction) = transaction.outcome()
+                    else {
+                        unreachable!("BodyTransaction publishes typed values")
+                    };
+                    Ok(QueryOutput::success(transaction.references().clone()))
+                },
+            )
+            .expect("the BodyReferences family has one canonical name");
         let toolchain_for_body_closure = body_toolchain_demands.clone();
-        let bundles_for_body_closure = body_analysis_bundles.clone();
+        let transactions_for_body_reachability = body_transactions.clone();
+        let references_for_body_closure = body_references.clone();
+        let produced_for_body_reachability = body_produced_anonymous.clone();
         let inputs_for_body_closure = body_inputs.clone();
         let declarations_for_body_closure = declaration_semantics_projection.clone();
-        #[cfg(test)]
-        let anonymous_digest_forcing_for_body_closure =
-            body_closure_anonymous_digest_forcing.clone();
-        let body_closures = runtime
+        let body_reachability = runtime
             .family_with_equality_and_evaluator(
-                "compiler.body-closure",
+                "compiler.body-reachability",
                 BODY_CLOSURE_MEMO_RETENTION,
-                crate::body_query::body_closure_output_equal,
+                crate::body_query::body_reachability_output_equal,
                 move |context, _, key: &crate::body_query::BodyClosureQueryKey| {
-                    #[cfg(test)]
-                    {
-                        anonymous_digest_forcing_for_body_closure
-                            .lock()
-                            .expect("body-closure forced-digest state is not poisoned")
-                            .sealed = true;
-                    }
-                    debug_assert!(
+                    assert!(
                         key.modules.windows(2).all(|pair| pair[0] < pair[1])
                             && key.roots.windows(2).all(|pair| pair[0] < pair[1])
                     );
@@ -10881,8 +11247,8 @@ impl RevisionedQueryDatabase {
                             failure,
                         } => {
                             return Ok(QueryOutput::success(
-                                crate::body_query::BodyClosureOutput {
-                                    bodies: Arc::from([]),
+                                crate::body_query::BodyReachabilityOutput {
+                                    reached: Arc::from([]),
                                     scheduling_errors: Arc::from([]),
                                     fatal: Some(
                                         crate::body_query::BodyClosureFatal::DeclarationFailed {
@@ -10919,51 +11285,116 @@ impl RevisionedQueryDatabase {
                         .cloned()
                         .map(|root| (root, 0usize))
                         .collect::<BTreeMap<_, _>>();
-                    let mut bodies = Vec::new();
+                    let mut reached_body_keys = Vec::new();
                     let mut scheduling_errors = BTreeMap::new();
                     let mut fatal = None;
                     let mut parked_toolchain = None;
                     let mut produced_anonymous = BTreeMap::new();
-                    // This request/revision-owned registry is the aggregation
-                    // authority for stable anonymous symbols. Per-body semantic
-                    // epochs and durable pools cannot see identities published
-                    // by another registered body transaction.
-                    let mut anonymous_digest_owners = BTreeMap::new();
-                    let mut anonymous_digest_collision = None;
-                    let body_closure_anonymous_digest =
-                        |identity: &crate::AnonymousNominalKey| {
-                            #[cfg(test)]
-                            {
-                                let canonical = identity.with_canonical_producer();
-                                if let Some(digest) = anonymous_digest_forcing_for_body_closure
-                                    .lock()
-                                    .expect("body-closure forced-digest state is not poisoned")
-                                    .digests
-                                    .get(canonical.as_ref())
-                                    .copied()
+                    let mut prefetched_transactions = BTreeMap::new();
+                    loop {
+                        // Only the ordinary stable frontier is batched. An
+                        // anonymous producer priority chain stays on the exact
+                        // serial path below, preserving producer-before-consumer
+                        // semantics while ordinary call SCCs remain graph edges
+                        // in BodyReferences rather than recursive queries.
+                        if priority_pending.is_empty() && prefetched_transactions.is_empty() {
+                            context.record_work(rue_query::WorkItem::new(
+                                "reachability.frontier.scans",
+                                1,
+                            ));
+                            context.record_work(rue_query::WorkItem::new(
+                                "reachability.frontier.scan-keys",
+                                pending.len() as u64,
+                            ));
+                            let frontier = pending
+                                .iter()
+                                .filter(|instance| {
+                                        !visited.contains(*instance)
+                                        && !prefetched_transactions.contains_key(*instance)
+                                        && collect_instance_anonymous_nominals(instance)
+                                            .into_iter()
+                                            .all(|identity| match identity.producer {
+                                                crate::StableProducerId::Function(producer) => {
+                                                    visited.contains(producer.as_ref())
+                                                }
+                                                crate::StableProducerId::Definition(_) => true,
+                                            })
+                                        && (!matches!(
+                                            instance,
+                                            crate::FunctionInstanceKey::Specialization { .. }
+                                        ) || instance_depth
+                                            .get(*instance)
+                                            .copied()
+                                            .unwrap_or(0)
+                                            <= rue_air::specialize::MAX_SPECIALIZATION_ROUNDS)
+                                })
+                                .cloned()
+                                .collect::<Vec<_>>();
+                            if !frontier.is_empty() {
+                                let frontier_keys = frontier
+                                    .iter()
+                                    .cloned()
+                                    .map(|instance| crate::body_query::BodyQueryKey {
+                                        instance,
+                                        configuration: key.configuration.clone(),
+                                    })
+                                    .collect::<Vec<_>>();
+                                let demands = context.query_registered_batch(
+                                    &toolchain_for_body_closure,
+                                    frontier_keys.clone(),
+                                )?;
+                                let mut batch_modules = BTreeSet::new();
+                                let mut batch_requesters = BTreeSet::new();
+                                for demand in demands {
+                                    let rue_query::QueryOutcome::Success(demand) =
+                                        demand.outcome()
+                                    else {
+                                        unreachable!(
+                                            "BodyToolchainDemands publishes typed values"
+                                        )
+                                    };
+                                    let mut any_absent = false;
+                                    for module in demand.modules() {
+                                        if !present_trusted_modules.contains(module.logical_path()) {
+                                            batch_modules.insert(module.clone());
+                                            any_absent = true;
+                                        }
+                                    }
+                                    if any_absent
+                                        && let Some(requester) = demand.requester()
+                                    {
+                                        batch_requesters.insert(requester.clone());
+                                    }
+                                }
+                                if !batch_modules.is_empty() {
+                                    parked_toolchain =
+                                        Some(crate::ParkedToolchainModules::new(
+                                            batch_modules,
+                                            batch_requesters,
+                                        ));
+                                    break;
+                                }
+                                let transactions = context.query_registered_batch(
+                                    &transactions_for_body_reachability,
+                                    frontier_keys,
+                                )?;
+                                context.record_work(rue_query::WorkItem::new(
+                                    "reachability.frontier.keys",
+                                    frontier.len() as u64,
+                                ));
+                                for (instance, transaction) in
+                                    frontier.into_iter().zip(transactions)
                                 {
-                                    return digest;
+                                    prefetched_transactions.insert(instance, transaction);
                                 }
                             }
-                            compiler_anonymous_identity_digest(identity)
-                        };
-                    // Declaration analysis can materialize anonymous nominals
-                    // without a reached body transaction. Seed those exact keys
-                    // into the same closure-wide authority before scheduling any
-                    // body, so declaration/declaration and declaration/body
-                    // collisions cannot bypass reconciliation.
-                    for nominal in projection.anonymous_nominals.iter() {
-                        register_body_closure_anonymous_digest(
-                            &mut anonymous_digest_owners,
-                            &mut anonymous_digest_collision,
-                            body_closure_anonymous_digest(&nominal.identity),
-                            &nominal.identity,
-                        );
-                    }
+                        }
 
-                    while let Some(instance) =
-                        priority_pending.pop().or_else(|| pending.pop_first())
-                    {
+                        let Some(instance) =
+                            priority_pending.pop().or_else(|| pending.pop_first())
+                        else {
+                            break;
+                        };
                         context.check_canceled()?;
                         let current_depth = instance_depth.get(&instance).copied().unwrap_or(0);
                         let deferred_producers = collect_instance_anonymous_nominals(&instance)
@@ -11100,17 +11531,30 @@ impl RevisionedQueryDatabase {
                             break;
                         }
 
-                        let bundle_terminal = context
-                            .query_registered(&bundles_for_body_closure, body_key.clone())?;
-                        let rue_query::QueryOutcome::Success(bundle) = bundle_terminal.outcome()
+                        // The ordinary frontier prefetches the expensive
+                        // BodyTransaction computations. Control outcomes must
+                        // remain transaction-only (they publish no
+                        // BodyReferences terminal), so interpret the exact
+                        // transaction before projecting schedulable references.
+                        let transaction_terminal =
+                            if let Some(transaction) = prefetched_transactions.remove(&instance) {
+                                transaction
+                            } else {
+                                context.query_registered(
+                                    &transactions_for_body_reachability,
+                                    body_key.clone(),
+                                )?
+                            };
+                        let rue_query::QueryOutcome::Success(transaction) =
+                            transaction_terminal.outcome()
                         else {
-                            unreachable!("BodyAnalysisBundle publishes typed values")
+                            unreachable!("BodyTransaction publishes typed values")
                         };
                         let deterministic_failure = matches!(
-                            bundle.transaction,
+                            transaction,
                             crate::body_query::BodyTransaction::DeterministicFailure { .. }
                         );
-                        match &bundle.transaction {
+                        match transaction {
                             crate::body_query::BodyTransaction::Control(
                                 crate::body_query::BodyTransactionControl::DeferredAnonymousProducers(
                                     producers,
@@ -11195,10 +11639,16 @@ impl RevisionedQueryDatabase {
                             | crate::body_query::BodyTransaction::DeterministicFailure { .. } => {}
                         }
 
-                        bodies.push(crate::body_query::BodyClosureBody {
-                            key: body_key,
-                            bundle: bundle_terminal.clone(),
-                        });
+                        let references_terminal = context.query_registered(
+                            &references_for_body_closure,
+                            body_key.clone(),
+                        )?;
+                        let rue_query::QueryOutcome::Success(references) =
+                            references_terminal.outcome()
+                        else {
+                            unreachable!("BodyReferences publishes typed values")
+                        };
+                        reached_body_keys.push(body_key.clone());
                         // A deterministic body diagnostic is terminal for this
                         // body's dependents. Keep scheduling references that
                         // were successfully discovered before the diagnostic so
@@ -11207,27 +11657,33 @@ impl RevisionedQueryDatabase {
                         if deterministic_failure {
                             failed_instances.insert(instance.clone());
                         }
-                        if let Some(crate::body_query::ProducedAnonymous::ProducerFailed(failure)) =
-                            bundle.produced_anonymous.as_ref()
-                        {
-                            fatal =
-                                Some(crate::body_query::BodyClosureFatal::ProducerFailed {
-                                    instance,
-                                    failure: failure.clone(),
-                                });
-                            break;
-                        }
-                        if let Some(crate::body_query::ProducedAnonymous::Produced(produced)) =
-                            bundle.produced_anonymous.as_ref()
-                        {
-                            for nominal in produced.0.iter() {
-                                register_body_closure_anonymous_digest(
-                                    &mut anonymous_digest_owners,
-                                    &mut anonymous_digest_collision,
-                                    body_closure_anonymous_digest(&nominal.identity),
-                                    &nominal.identity,
-                                );
-                            }
+                        if matches!(
+                            transaction,
+                            crate::body_query::BodyTransaction::Success { .. }
+                        ) {
+                            let produced_terminal = context.query_registered(
+                                &produced_for_body_reachability,
+                                body_key.clone(),
+                            )?;
+                            let rue_query::QueryOutcome::Success(produced) =
+                                produced_terminal.outcome()
+                            else {
+                                unreachable!("BodyProducedAnonymous publishes typed values")
+                            };
+                            let crate::body_query::ProducedAnonymous::Produced(produced) = produced
+                            else {
+                                let crate::body_query::ProducedAnonymous::ProducerFailed(failure) =
+                                    produced
+                                else {
+                                    unreachable!()
+                                };
+                                fatal =
+                                    Some(crate::body_query::BodyClosureFatal::ProducerFailed {
+                                        instance,
+                                        failure: failure.clone(),
+                                    });
+                                break;
+                            };
                             produced_anonymous.extend(
                                 produced
                                     .0
@@ -11260,7 +11716,7 @@ impl RevisionedQueryDatabase {
                                 }
                             }
                         }
-                        for reference in bundle.transaction.references().0.iter() {
+                        for reference in references.0.iter() {
                             match reference {
                                 crate::body_query::BodyReference::Callable(callable) => {
                                     match closure_callable_has_body(
@@ -11310,46 +11766,18 @@ impl RevisionedQueryDatabase {
                         }
                     }
 
-                    // Existing semantic/control failures, scheduling errors,
-                    // and toolchain parking have precedence over the collision
-                    // summary regardless of which fact was discovered first.
-                    // Promote a collision only for an otherwise complete
-                    // closure; this keeps the observable outcome traversal- and
-                    // scheduling-order independent.
-                    if fatal.is_none()
-                        && scheduling_errors.is_empty()
-                        && parked_toolchain.is_none()
-                        && let Some((digest, first, second)) = anonymous_digest_collision
-                    {
-                        fatal = Some(
-                            crate::body_query::BodyClosureFatal::AnonymousDigestCollision {
-                                digest,
-                                first,
-                                second,
-                            },
-                        );
-                    }
-                    bodies.sort_by(|left, right| left.key.instance.cmp(&right.key.instance));
+                    reached_body_keys
+                        .sort_by(|left, right| left.instance.cmp(&right.instance));
+                    let reached = reached_body_keys
+                        .iter()
+                        .map(|body| body.instance.clone())
+                        .collect::<Vec<_>>();
                     let scheduling_errors = scheduling_errors.into_iter().collect::<Vec<_>>();
                     let is_failure = !scheduling_errors.is_empty()
                         || fatal.is_some()
-                        || parked_toolchain.is_some()
-                        || bodies.iter().any(|body| {
-                            matches!(
-                                body.bundle.outcome(),
-                                rue_query::QueryOutcome::Success(
-                                    crate::body_query::BodyAnalysisBundle {
-                                        transaction:
-                                            crate::body_query::BodyTransaction::DeterministicFailure {
-                                                ..
-                                            },
-                                        ..
-                                    }
-                                )
-                            )
-                        });
-                    let output = crate::body_query::BodyClosureOutput {
-                        bodies: bodies.into(),
+                        || parked_toolchain.is_some();
+                    let output = crate::body_query::BodyReachabilityOutput {
+                        reached: reached.into(),
                         scheduling_errors: scheduling_errors.into(),
                         fatal,
                         parked_toolchain,
@@ -11361,11 +11789,203 @@ impl RevisionedQueryDatabase {
                     }))
                 },
             )
+            .expect("the BodyReachability family has one canonical name");
+        let reachability_for_membership = body_reachability.clone();
+        let body_closure_memberships = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.body-closure-membership",
+                BODY_QUERY_MEMO_RETENTION,
+                bool::eq,
+                move |context, _, key: &crate::body_query::BodyClosureMembershipKey| {
+                    let reachability = context
+                        .query_registered(&reachability_for_membership, key.closure.clone())?;
+                    let rue_query::QueryOutcome::Success(reachability) = reachability.outcome()
+                    else {
+                        unreachable!("BodyReachability publishes typed values")
+                    };
+                    Ok(QueryOutput::success(
+                        reachability.reached.binary_search(&key.instance).is_ok(),
+                    ))
+                },
+            )
+            .expect("the BodyClosureMembership family has one canonical name");
+        let reachability_for_closure = body_reachability.clone();
+        let memberships_for_closure = body_closure_memberships.clone();
+        let bundles_for_closure = body_analysis_bundles.clone();
+        let declarations_for_closure_aggregation = declaration_semantics_projection.clone();
+        #[cfg(test)]
+        let anonymous_digest_forcing_for_closure_aggregation =
+            body_closure_anonymous_digest_forcing.clone();
+        let body_closures = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.body-closure",
+                BODY_CLOSURE_MEMO_RETENTION,
+                crate::body_query::body_closure_output_equal,
+                move |context, _, key: &crate::body_query::BodyClosureQueryKey| {
+                    #[cfg(test)]
+                    {
+                        anonymous_digest_forcing_for_closure_aggregation
+                            .lock()
+                            .expect("body-closure forced-digest state is not poisoned")
+                            .sealed = true;
+                    }
+                    let reachability =
+                        context.query_registered(&reachability_for_closure, key.clone())?;
+                    let rue_query::QueryOutcome::Success(reachability) = reachability.outcome()
+                    else {
+                        unreachable!("BodyReachability publishes typed values")
+                    };
+                    let declarations = context.query_registered(
+                        &declarations_for_closure_aggregation,
+                        SemanticNucleusProjectionKey {
+                            modules: key.modules.clone(),
+                            configuration: key.configuration.clone(),
+                        },
+                    )?;
+                    let rue_query::QueryOutcome::Success(declarations) = declarations.outcome()
+                    else {
+                        unreachable!("DeclarationSemanticsProjection publishes typed values")
+                    };
+                    let mut anonymous_digest_owners = BTreeMap::new();
+                    let mut anonymous_digest_collision = None;
+                    let body_closure_anonymous_digest = |identity: &crate::AnonymousNominalKey| {
+                        #[cfg(test)]
+                        {
+                            let canonical = identity.with_canonical_producer();
+                            if let Some(digest) = anonymous_digest_forcing_for_closure_aggregation
+                                .lock()
+                                .expect("body-closure forced-digest state is not poisoned")
+                                .digests
+                                .get(canonical.as_ref())
+                                .copied()
+                            {
+                                return digest;
+                            }
+                        }
+                        compiler_anonymous_identity_digest(identity)
+                    };
+                    if let SemanticNucleusProjectionValue::Available(projection) = declarations {
+                        for nominal in projection.anonymous_nominals.iter() {
+                            register_body_closure_anonymous_digest(
+                                &mut anonymous_digest_owners,
+                                &mut anonymous_digest_collision,
+                                body_closure_anonymous_digest(&nominal.identity),
+                                &nominal.identity,
+                            );
+                        }
+                    }
+                    let membership_keys = reachability
+                        .reached
+                        .iter()
+                        .cloned()
+                        .map(|instance| crate::body_query::BodyClosureMembershipKey {
+                            closure: key.clone(),
+                            instance,
+                        })
+                        .collect::<Vec<_>>();
+                    for membership_key in membership_keys {
+                        let membership =
+                            context.query_registered(&memberships_for_closure, membership_key)?;
+                        debug_assert!(matches!(
+                            membership.outcome(),
+                            rue_query::QueryOutcome::Success(true)
+                        ));
+                    }
+                    let body_keys = reachability
+                        .reached
+                        .iter()
+                        .cloned()
+                        .map(|instance| crate::body_query::BodyQueryKey {
+                            instance,
+                            configuration: key.configuration.clone(),
+                        })
+                        .collect::<Vec<_>>();
+                    // Reachability has already produced these deep registered
+                    // cones through BodyReferences/BodyTransaction. Consume
+                    // the final bundles in this one endorsed task so validation
+                    // certificates are shared across bodies; a second batch
+                    // would isolate each proof and recursively revalidate the
+                    // same semantic cone N times.
+                    let mut bodies = Vec::with_capacity(body_keys.len());
+                    let mut has_deterministic_failure = false;
+                    let mut fatal = reachability.fatal.clone();
+                    for body_key in body_keys {
+                        let bundle =
+                            context.query_registered(&bundles_for_closure, body_key.clone())?;
+                        let rue_query::QueryOutcome::Success(bundle_value) = bundle.outcome()
+                        else {
+                            unreachable!("BodyAnalysisBundle publishes typed values")
+                        };
+                        has_deterministic_failure |= matches!(
+                            bundle_value.transaction,
+                            crate::body_query::BodyTransaction::DeterministicFailure { .. }
+                        );
+                        match bundle_value.produced_anonymous.as_ref() {
+                            Some(crate::body_query::ProducedAnonymous::ProducerFailed(failure)) => {
+                                fatal.get_or_insert_with(|| {
+                                    crate::body_query::BodyClosureFatal::ProducerFailed {
+                                        instance: body_key.instance.clone(),
+                                        failure: failure.clone(),
+                                    }
+                                });
+                            }
+                            Some(crate::body_query::ProducedAnonymous::Produced(produced)) => {
+                                for nominal in produced.0.iter() {
+                                    register_body_closure_anonymous_digest(
+                                        &mut anonymous_digest_owners,
+                                        &mut anonymous_digest_collision,
+                                        body_closure_anonymous_digest(&nominal.identity),
+                                        &nominal.identity,
+                                    );
+                                }
+                            }
+                            None => {}
+                        }
+                        bodies.push(crate::body_query::BodyClosureBody {
+                            key: body_key,
+                            bundle,
+                        });
+                    }
+                    if fatal.is_none()
+                        && reachability.scheduling_errors.is_empty()
+                        && reachability.parked_toolchain.is_none()
+                        && let Some((digest, first, second)) = anonymous_digest_collision
+                    {
+                        fatal = Some(
+                            crate::body_query::BodyClosureFatal::AnonymousDigestCollision {
+                                digest,
+                                first,
+                                second,
+                            },
+                        );
+                    }
+                    let output = crate::body_query::BodyClosureOutput {
+                        reached: reachability.reached.clone(),
+                        bodies: bodies.into(),
+                        scheduling_errors: reachability.scheduling_errors.clone(),
+                        fatal,
+                        parked_toolchain: reachability.parked_toolchain.clone(),
+                    };
+                    let terminal_kind = if output.scheduling_errors.is_empty()
+                        && output.fatal.is_none()
+                        && output.parked_toolchain.is_none()
+                        && !has_deterministic_failure
+                    {
+                        QueryTerminalKind::Success
+                    } else {
+                        QueryTerminalKind::Failure
+                    };
+                    Ok(QueryOutput::success(output).with_terminal_kind(terminal_kind))
+                },
+            )
             .expect("the BodyClosure family has one canonical name");
         let closures_for_publication = body_closures.clone();
+        let reachability_for_publication = body_reachability.clone();
         let names_for_closure_publication = lookup_names.clone();
         let imports_for_closure_publication = lookup_imports.clone();
         let lease_for_closure_publication = lookup_root_lease.clone();
+        let terminal_root_for_closure_publication = body_closure_root.clone();
+        let terminal_root_for_reachability_publication = body_reachability_root.clone();
         let runtime_for_closure_publication = runtime.clone();
         let body_closure_publications =
             runtime
@@ -11400,10 +12020,45 @@ impl RevisionedQueryDatabase {
                         let rue_query::QueryOutcome::Success(output) = closure.outcome() else {
                             unreachable!("BodyClosure publishes typed values")
                         };
-                        if output.fatal.is_none()
-                            && output.parked_toolchain.is_none()
+                        let well_formed_toolchain_park = output.parked_toolchain.is_some()
                             && output.scheduling_errors.is_empty()
-                        {
+                            && output.fatal.is_none()
+                            && output.bodies.iter().all(|body| {
+                                let rue_query::QueryOutcome::Success(bundle) =
+                                    body.bundle.outcome()
+                                else {
+                                    unreachable!("BodyAnalysisBundle publishes typed values")
+                                };
+                                !matches!(
+                                    &bundle.transaction,
+                                    crate::body_query::BodyTransaction::DeterministicFailure { .. }
+                                )
+                            });
+                        if closure.kind() == QueryTerminalKind::Success {
+                            context.register_attempt_handoff(PublishedBodyClosureTerminalHandoff {
+                                root: terminal_root_for_closure_publication.clone(),
+                                pending: Some(
+                                    context
+                                        .retain_observed_terminal_cone(&closure)
+                                        .expect(
+                                            "registered closure validation retains its exact dependency cone",
+                                        ),
+                                ),
+                                pending_reached: Some(output.reached.iter().cloned().collect()),
+                                previous: None,
+                                installed: false,
+                            });
+                            // Install the final exact closure cone before
+                            // releasing the acquisition-round reachability
+                            // root, so body protection transfers without a gap.
+                            context.register_attempt_handoff(
+                                PublishedBodyReachabilityTerminalHandoff {
+                                    root: terminal_root_for_reachability_publication.clone(),
+                                    pending: Some(rue_query::RetainedPinSet::new()),
+                                    previous: None,
+                                    installed: false,
+                                },
+                            );
                             let mut observed_lookup_roots = BTreeMap::new();
                             for body in output.bodies.iter() {
                                 let rue_query::QueryOutcome::Success(bundle) =
@@ -11450,7 +12105,38 @@ impl RevisionedQueryDatabase {
                                 runtime: runtime_for_closure_publication.clone(),
                                 observed: Some(observed_lookup_roots),
                                 retire_absent: true,
+                                rollback: None,
                             });
+                        } else if well_formed_toolchain_park {
+                            let reachability = context.query_registered(
+                                &reachability_for_publication,
+                                key.closure.clone(),
+                            )?;
+                            let rue_query::QueryOutcome::Success(reachability_output) =
+                                reachability.outcome()
+                            else {
+                                unreachable!("BodyReachability publishes typed values")
+                            };
+                            assert!(
+                                reachability_output.parked_toolchain.is_some()
+                                    && reachability_output.scheduling_errors.is_empty()
+                                    && reachability_output.fatal.is_none(),
+                                "a well-formed parked closure retains its exact reachability cone"
+                            );
+                            context.register_attempt_handoff(
+                                PublishedBodyReachabilityTerminalHandoff {
+                                    root: terminal_root_for_reachability_publication.clone(),
+                                    pending: Some(
+                                        context
+                                            .retain_observed_terminal_cone(&reachability)
+                                            .expect(
+                                                "registered reachability validation retains its exact dependency cone",
+                                            ),
+                                    ),
+                                    previous: None,
+                                    installed: false,
+                                },
+                            );
                         }
                         Ok(
                             QueryOutput::success(closure.clone())
@@ -11477,6 +12163,8 @@ impl RevisionedQueryDatabase {
                     provider_observation_meter: provider_observation_meter.clone(),
                     lookup_root_lease: lookup_root_lease.clone(),
                     runtime: runtime.clone(),
+                    #[cfg(test)]
+                    inject_body_transaction_failure: inject_body_transaction_failure.clone(),
                 })
                 .is_ok(),
             "BodyTransaction evaluator is installed once"
@@ -11507,16 +12195,11 @@ impl RevisionedQueryDatabase {
             body_transactions,
             canonical_bodies,
             body_analysis_bundles,
+            body_reachability,
             body_closures,
+            body_closure_memberships,
             body_closure_publications,
-            body_references: runtime
-                .family_with_equality(
-                    "compiler.body-references",
-                    BODY_QUERY_MEMO_RETENTION,
-                    |left: &crate::body_query::BodyReferences,
-                     right: &crate::body_query::BodyReferences| left == right,
-                )
-                .expect("the BodyReferences family has one canonical name"),
+            body_references,
             body_produced_anonymous,
             module_rirs,
             resolve_imports,
@@ -11548,6 +12231,10 @@ impl RevisionedQueryDatabase {
             lineage_additions: Vec::new(),
             provider_observation_meter,
             lookup_root_lease,
+            body_closure_root,
+            body_reachability_root,
+            #[cfg(test)]
+            inject_body_transaction_failure,
             #[cfg(test)]
             provider_probe: runtime
                 .family_with_equality(
@@ -11561,6 +12248,19 @@ impl RevisionedQueryDatabase {
 }
 
 impl RevisionedQueryDatabase {
+    #[cfg(test)]
+    pub(crate) fn inject_body_transaction_failure_for_test(
+        &self,
+    ) -> TestBodyTransactionFailureGuard {
+        use std::sync::atomic::Ordering::SeqCst;
+
+        assert!(
+            !self.inject_body_transaction_failure.swap(true, SeqCst),
+            "body transaction failure injection is not nestable"
+        );
+        TestBodyTransactionFailureGuard(self.inject_body_transaction_failure.clone())
+    }
+
     #[cfg(test)]
     fn force_body_closure_anonymous_digest_for_test(
         &self,
@@ -11947,6 +12647,8 @@ struct BodyTransactionEvaluator {
     provider_observation_meter: Arc<ProviderObservationCounters>,
     lookup_root_lease: Arc<Mutex<PublishedRootLookupLease>>,
     runtime: QueryRuntime,
+    #[cfg(test)]
+    inject_body_transaction_failure: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl BodyTransactionEvaluator {
@@ -12003,7 +12705,10 @@ impl BodyTransactionEvaluator {
         key: &crate::body_query::BodyQueryKey,
     ) -> Result<QueryOutput<crate::body_query::BodyTransaction>, QueryAbort> {
         #[cfg(test)]
-        if INJECT_BODY_TRANSACTION_FAILURE.with(std::cell::Cell::get) {
+        if self
+            .inject_body_transaction_failure
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
             return Ok(QueryOutput::success(
                 crate::body_query::BodyTransaction::DeterministicFailure {
                     diagnostic_basis: None,
@@ -13050,6 +13755,7 @@ impl BodyTransactionEvaluator {
                 runtime: self.runtime.clone(),
                 root: body_lookup_root_identity(key),
                 observed: Some(observed),
+                rollback: None,
             });
             let transaction = transaction.attach_provider_observations(
                 descriptors,
@@ -13286,6 +13992,42 @@ impl RevisionedQueryDatabase {
         })
     }
 
+    #[cfg(test)]
+    pub(crate) fn body_closure_membership_projection(
+        &self,
+        revision: Revision,
+        closure: crate::body_query::BodyClosureQueryKey,
+        instance: crate::FunctionInstanceKey,
+        cancellation: CancellationToken,
+    ) -> Result<Arc<rue_query::QueryTerminal<bool>>, QueryAbort> {
+        self.runtime
+            .request_registered(
+                &self.body_closure_memberships,
+                revision,
+                crate::body_query::BodyClosureMembershipKey { closure, instance },
+                cancellation,
+            )
+            .into_result()
+    }
+
+    #[cfg(test)]
+    fn body_closure_root_metrics(&self) -> (usize, u64, u64) {
+        let root = self
+            .body_closure_root
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        (root.lease.len(), root.additions, root.deletions)
+    }
+
+    #[cfg(test)]
+    fn body_reachability_root_len(&self) -> usize {
+        self.body_reachability_root
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .lease
+            .len()
+    }
+
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn canonical_body_projection(
         &self,
@@ -13305,20 +14047,9 @@ impl RevisionedQueryDatabase {
         key: crate::body_query::BodyQueryKey,
         cancellation: CancellationToken,
     ) -> Result<Arc<rue_query::QueryTerminal<crate::body_query::BodyReferences>>, QueryAbort> {
-        let transactions = self.body_transactions.clone();
-        self.runtime.query(
-            &self.body_references,
-            revision,
-            key.clone(),
-            cancellation,
-            move |context| {
-                let transaction = context.query_registered(&transactions, key)?;
-                let rue_query::QueryOutcome::Success(transaction) = transaction.outcome() else {
-                    unreachable!("BodyTransaction publishes typed values")
-                };
-                Ok(QueryOutput::success(transaction.references().clone()))
-            },
-        )
+        self.runtime
+            .request_registered(&self.body_references, revision, key, cancellation)
+            .into_result()
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
@@ -19169,6 +19900,92 @@ mod tests {
         assert_eq!(lease.seen_incarnation("key-0"), Some(10_000));
         assert_eq!(lease.seen_incarnation("key-1"), None);
         assert_eq!(lease.seen_incarnation("newest"), Some(20_000));
+    }
+
+    #[test]
+    fn body_publication_three_callback_transaction_rolls_back_and_retries() {
+        let closure_root = Arc::new(Mutex::new(PublishedBodyClosureRoot {
+            additions: 7,
+            deletions: 3,
+            ..PublishedBodyClosureRoot::default()
+        }));
+        let reachability_root = Arc::new(Mutex::new(PublishedBodyReachabilityRoot::default()));
+        let lookup_lease = Arc::new(Mutex::new(PublishedRootLookupLease {
+            roots: BTreeMap::from([(
+                "body:previous".to_owned(),
+                RootLeaseEntry {
+                    observations: ObservedLookupRoot::new(),
+                    publication: 0,
+                },
+            )]),
+            next_root_publication: 1,
+            rederivations_after_eviction: 5,
+            supersession_evictions: 2,
+            ..PublishedRootLookupLease::default()
+        }));
+        let mut closure_handoff = PublishedBodyClosureTerminalHandoff {
+            root: closure_root.clone(),
+            pending: Some(rue_query::RetainedPinSet::new()),
+            pending_reached: Some(BTreeSet::new()),
+            previous: None,
+            installed: false,
+        };
+        let mut reachability_handoff = PublishedBodyReachabilityTerminalHandoff {
+            root: reachability_root,
+            pending: Some(rue_query::RetainedPinSet::new()),
+            previous: None,
+            installed: false,
+        };
+        let mut lookup_handoff = PublishedBodyClosureLookupHandoff {
+            lease: lookup_lease.clone(),
+            runtime: QueryRuntime::new(1),
+            observed: Some(BTreeMap::from([(
+                "body:successor".to_owned(),
+                ObservedLookupRoot::new(),
+            )])),
+            retire_absent: true,
+            rollback: None,
+        };
+
+        rue_query::QueryAttemptHandoff::commit(&mut closure_handoff);
+        rue_query::QueryAttemptHandoff::commit(&mut reachability_handoff);
+        rue_query::QueryAttemptHandoff::commit(&mut lookup_handoff);
+        {
+            let lease = lookup_lease.lock().unwrap();
+            assert!(lease.roots.contains_key("body:successor"));
+            assert!(!lease.roots.contains_key("body:previous"));
+        }
+
+        // This is the callback order used when cancellation is observed after
+        // the final publication callback, and equally models the attempted
+        // prefix unwound after a later callback panic.
+        rue_query::QueryAttemptHandoff::abort(&mut lookup_handoff);
+        rue_query::QueryAttemptHandoff::abort(&mut reachability_handoff);
+        rue_query::QueryAttemptHandoff::abort(&mut closure_handoff);
+        {
+            let closure = closure_root.lock().unwrap();
+            assert_eq!(closure.additions, 7);
+            assert_eq!(closure.deletions, 3);
+            let lease = lookup_lease.lock().unwrap();
+            assert!(lease.roots.contains_key("body:previous"));
+            assert!(!lease.roots.contains_key("body:successor"));
+            assert_eq!(lease.rederivations_after_eviction, 5);
+            assert_eq!(lease.supersession_evictions, 2);
+            assert_eq!(lease.next_root_publication, 1);
+        }
+
+        rue_query::QueryAttemptHandoff::commit(&mut closure_handoff);
+        rue_query::QueryAttemptHandoff::commit(&mut reachability_handoff);
+        rue_query::QueryAttemptHandoff::commit(&mut lookup_handoff);
+        assert!(closure_handoff.installed);
+        assert!(reachability_handoff.installed);
+        assert!(
+            lookup_lease
+                .lock()
+                .unwrap()
+                .roots
+                .contains_key("body:successor")
+        );
     }
 
     #[test]
@@ -31126,6 +31943,528 @@ fn main() -> i32 {
         assert!(!database.body_inputs.contains_retained_key(&key));
     }
 
+    fn closure_membership(
+        database: &RevisionedQueryDatabase,
+        revision: Revision,
+        closure: &crate::body_query::BodyClosureQueryKey,
+        instance: &crate::FunctionInstanceKey,
+    ) -> Arc<rue_query::QueryTerminal<bool>> {
+        database
+            .body_closure_membership_projection(
+                revision,
+                closure.clone(),
+                instance.clone(),
+                CancellationToken::new(),
+            )
+            .expect("body-closure membership publishes a typed terminal")
+    }
+
+    #[test]
+    fn body_closure_edge_addition_and_deletion_stamp_memberships_independently() {
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let source = |main_body: &str| {
+            source_snapshot(
+                &[(
+                    1,
+                    "/main.rue",
+                    "main.rue",
+                    &format!(
+                        "fn leaf() -> i32 {{ 1 }}\n\
+                         fn stable() -> i32 {{ 2 }}\n\
+                         fn added() -> i32 {{ 3 }}\n\
+                         fn main() -> i32 {{ {main_body} }}\n"
+                    ),
+                )],
+                1,
+            )
+        };
+        let first_source = source("leaf() + stable()");
+        let added_source = source("leaf() + stable() + added()");
+        let deleted_source = source("stable() + added()");
+        let configuration = semantic_configuration();
+        let closure_key = crate::body_query::BodyClosureQueryKey {
+            modules: Arc::from([module.clone()]),
+            roots: Arc::from([free_function_instance(&module, "main")]),
+            configuration,
+        };
+        let leaf = free_function_instance(&module, "leaf");
+        let stable = free_function_instance(&module, "stable");
+        let added = free_function_instance(&module, "added");
+        let mut database = RevisionedQueryDatabase::default();
+
+        let first_revision = revision_for(&mut database, &first_source);
+        let first = database
+            .body_closure(
+                first_revision,
+                closure_key.clone(),
+                CancellationToken::new(),
+            )
+            .unwrap();
+        let first_root_metrics = database.body_closure_root_metrics();
+        let first_leaf = closure_membership(&database, first_revision, &closure_key, &leaf);
+        let first_stable = closure_membership(&database, first_revision, &closure_key, &stable);
+        let first_added = closure_membership(&database, first_revision, &closure_key, &added);
+        assert_eq!(
+            first_leaf.outcome(),
+            &rue_query::QueryOutcome::Success(true)
+        );
+        assert_eq!(
+            first_stable.outcome(),
+            &rue_query::QueryOutcome::Success(true)
+        );
+        assert_eq!(
+            first_added.outcome(),
+            &rue_query::QueryOutcome::Success(false)
+        );
+
+        let added_revision = revision_for(&mut database, &added_source);
+        let added_closure = database
+            .body_closure(
+                added_revision,
+                closure_key.clone(),
+                CancellationToken::new(),
+            )
+            .unwrap();
+        let added_root_metrics = database.body_closure_root_metrics();
+        let second_leaf = closure_membership(&database, added_revision, &closure_key, &leaf);
+        let second_stable = closure_membership(&database, added_revision, &closure_key, &stable);
+        let second_added = closure_membership(&database, added_revision, &closure_key, &added);
+        assert_eq!(second_leaf.stamp(), first_leaf.stamp());
+        assert_eq!(second_stable.stamp(), first_stable.stamp());
+        assert_ne!(second_added.stamp(), first_added.stamp());
+
+        let deleted_revision = revision_for(&mut database, &deleted_source);
+        let deleted_closure = database
+            .body_closure(
+                deleted_revision,
+                closure_key.clone(),
+                CancellationToken::new(),
+            )
+            .unwrap();
+        let deleted_root_metrics = database.body_closure_root_metrics();
+        let third_leaf = closure_membership(&database, deleted_revision, &closure_key, &leaf);
+        let third_stable = closure_membership(&database, deleted_revision, &closure_key, &stable);
+        let third_added = closure_membership(&database, deleted_revision, &closure_key, &added);
+        assert_ne!(third_leaf.stamp(), second_leaf.stamp());
+        assert_eq!(
+            third_leaf.outcome(),
+            &rue_query::QueryOutcome::Success(false)
+        );
+        assert_eq!(third_stable.stamp(), second_stable.stamp());
+        assert_eq!(third_added.stamp(), second_added.stamp());
+
+        let reached = |request: &BodyClosureRequest| {
+            let rue_query::QueryOutcome::Success(output) = request.terminal.outcome() else {
+                unreachable!("BodyClosure publishes typed values")
+            };
+            output.reached.to_vec()
+        };
+        assert_eq!(
+            reached(&first),
+            vec![
+                leaf.clone(),
+                free_function_instance(&module, "main"),
+                stable.clone(),
+            ]
+        );
+        assert_eq!(reached(&added_closure).len(), 4);
+        assert_eq!(
+            reached(&deleted_closure),
+            vec![
+                added.clone(),
+                free_function_instance(&module, "main"),
+                stable.clone(),
+            ]
+        );
+        assert_eq!(
+            (first_root_metrics.1, first_root_metrics.2),
+            (3, 0),
+            "the cold root accounts its exact reached membership as additions"
+        );
+        assert_eq!(
+            (added_root_metrics.1, added_root_metrics.2),
+            (4, 0),
+            "adding one call edge accounts one independent membership addition"
+        );
+        assert_eq!(
+            (deleted_root_metrics.1, deleted_root_metrics.2),
+            (4, 1),
+            "deleting one call edge accounts one independent membership deletion"
+        );
+    }
+
+    #[test]
+    fn body_closure_call_scc_is_a_finite_graph_not_a_query_cycle() {
+        let snapshot = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn a(value: i32) -> i32 { if value == 0 { 0 } else { b(value - 1) } }\n\
+                 fn b(value: i32) -> i32 { if value == 0 { 0 } else { a(value - 1) } }\n\
+                 fn main() -> i32 { a(2) }\n",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::with_query_concurrency(1);
+        let revision = revision_for(&mut database, &snapshot);
+        let closure = database
+            .body_closure(
+                revision,
+                crate::body_query::BodyClosureQueryKey {
+                    modules: Arc::from([module.clone()]),
+                    roots: Arc::from([free_function_instance(&module, "main")]),
+                    configuration: semantic_configuration(),
+                },
+                CancellationToken::new(),
+            )
+            .expect("ordinary call SCCs terminate through visited graph membership");
+        let rue_query::QueryOutcome::Success(output) = closure.terminal.outcome() else {
+            unreachable!("BodyClosure publishes typed values")
+        };
+        assert_eq!(output.reached.len(), 3);
+        assert!(output.fatal.is_none());
+        assert!(output.scheduling_errors.is_empty());
+    }
+
+    #[test]
+    fn body_closure_one_and_many_workers_publish_identical_reached_work_and_diagnostics() {
+        let snapshot = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn a() -> i32 { 1 }\n\
+                 fn b() -> i32 { 2 }\n\
+                 fn c() -> i32 { 3 }\n\
+                 fn d() -> i32 { 4 }\n\
+                 fn main() -> i32 { a() + b() + c() + d() }\n",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let key = crate::body_query::BodyClosureQueryKey {
+            modules: Arc::from([module.clone()]),
+            roots: Arc::from([free_function_instance(&module, "main")]),
+            configuration: semantic_configuration(),
+        };
+        let run = |workers| {
+            let mut database = RevisionedQueryDatabase::with_query_concurrency(workers);
+            let revision = revision_for(&mut database, &snapshot);
+            let request = database
+                .body_closure(revision, key.clone(), CancellationToken::new())
+                .unwrap();
+            let work = request
+                .body_executions
+                .values()
+                .filter(|execution| **execution == rue_query::RequestExecution::Computed)
+                .count();
+            let rue_query::QueryOutcome::Success(output) = request.terminal.outcome() else {
+                unreachable!("BodyClosure publishes typed values")
+            };
+            (
+                output.reached.to_vec(),
+                output.scheduling_errors.clone(),
+                output.fatal.clone(),
+                work,
+            )
+        };
+        assert_eq!(run(1), run(4));
+    }
+
+    #[test]
+    fn body_reachability_scans_each_prefetched_frontier_once() {
+        const CALLEES: usize = 16;
+        let mut text = (0..CALLEES)
+            .map(|index| format!("fn f{index}() -> i32 {{ {index} }}\n"))
+            .collect::<String>();
+        let expression = (0..CALLEES)
+            .map(|index| format!("f{index}()"))
+            .collect::<Vec<_>>()
+            .join(" + ");
+        text.push_str(&format!("fn main() -> i32 {{ {expression} }}\n"));
+        let snapshot = source_snapshot(&[(1, "/main.rue", "main.rue", &text)], 1);
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::with_query_concurrency(4);
+        let revision = revision_for(&mut database, &snapshot);
+        let attempt = database.runtime.request_registered(
+            &database.body_reachability,
+            revision,
+            crate::body_query::BodyClosureQueryKey {
+                modules: Arc::from([module.clone()]),
+                roots: Arc::from([free_function_instance(&module, "main")]),
+                configuration: semantic_configuration(),
+            },
+            CancellationToken::new(),
+        );
+        let terminal = attempt.terminal().expect("reachability publishes");
+        let rue_query::QueryOutcome::Success(output) = terminal.outcome() else {
+            unreachable!("BodyReachability publishes typed values")
+        };
+        assert_eq!(output.reached.len(), CALLEES + 1);
+        let work = |expected: &str| {
+            attempt
+                .work()
+                .iter()
+                .find_map(|(label, amount)| (label.as_ref() == expected).then_some(*amount))
+                .unwrap_or(0)
+        };
+        assert!(
+            work("reachability.frontier.scans") < output.reached.len() as u64
+                && work("reachability.frontier.scan-keys") <= output.reached.len() as u64 + 8,
+            "wide prefetched bodies must be consumed without a per-body pending-set rescan; \
+             got {} scans and {} scanned keys for {} reached bodies",
+            work("reachability.frontier.scans"),
+            work("reachability.frontier.scan-keys"),
+            output.reached.len(),
+        );
+    }
+
+    #[test]
+    fn injected_body_transaction_failure_runs_in_the_structured_frontier() {
+        let snapshot = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn first() -> i32 { 0 }\nfn second() -> i32 { 1 }\n",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let roots = [
+            free_function_instance(&module, "first"),
+            free_function_instance(&module, "second"),
+        ];
+        let mut database = RevisionedQueryDatabase::with_query_concurrency(4);
+        let revision = revision_for(&mut database, &snapshot);
+        let _injection = database.inject_body_transaction_failure_for_test();
+        let attempt = database.runtime.request_registered(
+            &database.body_reachability,
+            revision,
+            crate::body_query::BodyClosureQueryKey {
+                modules: Arc::from([module.clone()]),
+                roots: Arc::from(roots.clone()),
+                configuration: semantic_configuration(),
+            },
+            CancellationToken::new(),
+        );
+        let terminal = attempt
+            .terminal()
+            .expect("injected failure publishes reachability");
+        let rue_query::QueryOutcome::Success(output) = terminal.outcome() else {
+            unreachable!("BodyReachability publishes typed values")
+        };
+        assert_eq!(output.reached.len(), 2);
+        let work = |expected: &str| {
+            attempt
+                .work()
+                .iter()
+                .find_map(|(label, amount)| (label.as_ref() == expected).then_some(*amount))
+                .unwrap_or(0)
+        };
+        assert_eq!(
+            work("reachability.frontier.keys"),
+            2,
+            "failure injection remains visible in the production structured child"
+        );
+        assert!(
+            work("reachability.frontier.scans") >= 1,
+            "the injected attempt enters the ordinary frontier scanner"
+        );
+        for instance in roots {
+            let transaction = database.runtime.request_registered(
+                &database.body_transactions,
+                revision,
+                crate::body_query::BodyQueryKey {
+                    instance,
+                    configuration: semantic_configuration(),
+                },
+                CancellationToken::new(),
+            );
+            assert_eq!(
+                transaction.execution(),
+                rue_query::RequestExecution::Reused,
+                "each structured child publishes its injected transaction"
+            );
+            let terminal = transaction.terminal().expect("transaction publishes");
+            assert!(matches!(
+                terminal.outcome(),
+                rue_query::QueryOutcome::Success(
+                    crate::body_query::BodyTransaction::DeterministicFailure { .. }
+                )
+            ));
+        }
+    }
+
+    #[test]
+    fn body_closure_root_pins_reached_programs_past_the_history_floor_and_releases_deletions() {
+        const CALLEES: usize = 16;
+        let source = |reached_callees: usize| {
+            let mut text = (0..CALLEES)
+                .map(|index| format!("fn f{index}() -> i32 {{ {index} }}\n"))
+                .collect::<String>();
+            let expression = (0..reached_callees)
+                .map(|index| format!("f{index}()"))
+                .collect::<Vec<_>>()
+                .join(" + ");
+            text.push_str(&format!("fn main() -> i32 {{ {expression} }}\n"));
+            source_snapshot(&[(1, "/main.rue", "main.rue", &text)], 1)
+        };
+        let full = source(CALLEES);
+        let reduced = source(CALLEES / 2);
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let closure_key = crate::body_query::BodyClosureQueryKey {
+            modules: Arc::from([module.clone()]),
+            roots: Arc::from([free_function_instance(&module, "main")]),
+            configuration: semantic_configuration(),
+        };
+        let deleted_body_key = crate::body_query::BodyQueryKey {
+            instance: free_function_instance(&module, &format!("f{}", CALLEES - 1)),
+            configuration: semantic_configuration(),
+        };
+        let mut database = RevisionedQueryDatabase::with_query_concurrency(4);
+
+        let full_revision = revision_for(&mut database, &full);
+        let cold = database
+            .body_closure(full_revision, closure_key.clone(), CancellationToken::new())
+            .unwrap();
+        let rue_query::QueryOutcome::Success(cold_output) = cold.terminal.outcome() else {
+            unreachable!("BodyClosure publishes typed values")
+        };
+        assert_eq!(cold_output.reached.len(), CALLEES + 1);
+        assert!(
+            database.body_transactions.retention().terminals > CALLEES,
+            "the exact published root must grow body retention past its {}-terminal history floor",
+            BODY_QUERY_MEMO_RETENTION
+        );
+        assert!(
+            database
+                .body_transactions
+                .contains_retained_key(&deleted_body_key)
+        );
+        let cold_root = database.body_closure_root_metrics();
+        assert_eq!((cold_root.1, cold_root.2), ((CALLEES + 1) as u64, 0));
+
+        let warm = database
+            .body_closure(full_revision, closure_key.clone(), CancellationToken::new())
+            .unwrap();
+        assert_eq!(database.body_closure_root_metrics(), cold_root);
+        assert_eq!(warm.body_executions.len(), CALLEES + 1);
+        assert!(
+            warm.body_executions
+                .values()
+                .all(|execution| *execution == rue_query::RequestExecution::Reused),
+            "a warm rooted closure must validate and reuse every reached body"
+        );
+
+        let reduced_revision = revision_for(&mut database, &reduced);
+        let canceled = CancellationToken::new();
+        canceled.cancel();
+        assert!(matches!(
+            database.body_closure(reduced_revision, closure_key.clone(), canceled),
+            Err(QueryAbort::Canceled)
+        ));
+        assert_eq!(
+            database.body_closure_root_metrics(),
+            cold_root,
+            "an aborted successor must roll back without replacing the published root"
+        );
+        let reduced_request = database
+            .body_closure(reduced_revision, closure_key, CancellationToken::new())
+            .unwrap();
+        let rue_query::QueryOutcome::Success(reduced_output) = reduced_request.terminal.outcome()
+        else {
+            unreachable!("BodyClosure publishes typed values")
+        };
+        assert_eq!(reduced_output.reached.len(), CALLEES / 2 + 1);
+        let reduced_root = database.body_closure_root_metrics();
+        assert_eq!(
+            (reduced_root.1, reduced_root.2),
+            ((CALLEES + 1) as u64, (CALLEES / 2) as u64)
+        );
+        assert!(
+            reduced_root.0 < cold_root.0,
+            "replacing the root must release body-specific leases for deleted membership"
+        );
+        assert!(
+            !database
+                .body_transactions
+                .contains_retained_key(&deleted_body_key),
+            "the deleted predecessor body terminal must become unpinned and evict, \
+             proving validation observations outside the successor cone are not rooted"
+        );
+    }
+
+    /// Focused, opt-in latency witness for RUE-1028. This is deliberately not a
+    /// threshold test: it prints independently timed cold, warm-validation, and
+    /// edge-deletion closure requests so release engineering can compare the
+    /// same corpus across commits without mixing setup or source construction
+    /// into the measured interval.
+    #[test]
+    #[ignore]
+    fn body_closure_cold_warm_deletion_latency_benchmark() {
+        const CALLEES: usize = 128;
+        let source = |reached_callees: usize| {
+            let mut text = (0..CALLEES)
+                .map(|index| format!("fn f{index}() -> i32 {{ {index} }}\n"))
+                .collect::<String>();
+            let expression = (0..reached_callees)
+                .map(|index| format!("f{index}()"))
+                .collect::<Vec<_>>()
+                .join(" + ");
+            text.push_str(&format!("fn main() -> i32 {{ {expression} }}\n"));
+            source_snapshot(&[(1, "/main.rue", "main.rue", &text)], 1)
+        };
+        let full = source(CALLEES);
+        let reduced = source(CALLEES / 2);
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let closure_key = crate::body_query::BodyClosureQueryKey {
+            modules: Arc::from([module.clone()]),
+            roots: Arc::from([free_function_instance(&module, "main")]),
+            configuration: semantic_configuration(),
+        };
+        let mut database = RevisionedQueryDatabase::with_query_concurrency(4);
+        let full_revision = revision_for(&mut database, &full);
+
+        let cold_start = std::time::Instant::now();
+        let cold = database
+            .body_closure(full_revision, closure_key.clone(), CancellationToken::new())
+            .unwrap();
+        let cold_micros = cold_start.elapsed().as_micros();
+
+        let warm_start = std::time::Instant::now();
+        let warm = database
+            .body_closure(full_revision, closure_key.clone(), CancellationToken::new())
+            .unwrap();
+        let warm_micros = warm_start.elapsed().as_micros();
+
+        let reduced_revision = revision_for(&mut database, &reduced);
+        let deletion_start = std::time::Instant::now();
+        let deletion = database
+            .body_closure(reduced_revision, closure_key, CancellationToken::new())
+            .unwrap();
+        let deletion_micros = deletion_start.elapsed().as_micros();
+
+        let reached = |request: &BodyClosureRequest| {
+            let rue_query::QueryOutcome::Success(output) = request.terminal.outcome() else {
+                unreachable!("BodyClosure publishes typed values")
+            };
+            output.reached.len()
+        };
+        assert_eq!(reached(&cold), CALLEES + 1);
+        assert_eq!(reached(&warm), CALLEES + 1);
+        assert_eq!(reached(&deletion), CALLEES / 2 + 1);
+        eprintln!(
+            "RUE-1028 body-closure latency: bodies={} workers=4 cold_us={} warm_us={} deletion_us={}",
+            CALLEES + 1,
+            cold_micros,
+            warm_micros,
+            deletion_micros
+        );
+    }
+
     fn assert_forced_body_closure_digest_collision(first_body: &str, second_body: &str) {
         let source = format!(
             "fn First() -> type {{ {first_body} }}\n\
@@ -31457,6 +32796,98 @@ fn main() -> i32 {
             output.fatal.is_none(),
             "an already observed collision must not leak past the higher-precedence park"
         );
+    }
+
+    #[test]
+    fn parked_toolchain_rounds_retain_and_reuse_the_exact_reachability_cone() {
+        const CALLEES: usize = 16;
+        let source = |parked: bool| {
+            let mut text = (0..CALLEES)
+                .map(|index| {
+                    let next = if index + 1 == CALLEES {
+                        "parked()".to_owned()
+                    } else {
+                        format!("f{}()", index + 1)
+                    };
+                    format!("fn f{index}() -> i32 {{ {next} }}\n")
+                })
+                .collect::<String>();
+            if parked {
+                text.push_str("fn parked() -> i32 { let _value = @parse_u32(\"1\"); 0 }\n");
+            } else {
+                text.push_str("fn parked() -> i32 { 0 }\n");
+            }
+            text.push_str("fn root() -> i32 { f0() }\n");
+            source_snapshot(&[(1, "/main.rue", "main.rue", &text)], 1)
+        };
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let body_keys = (0..CALLEES)
+            .map(|index| free_function_instance(&module, &format!("f{index}")))
+            .collect::<Vec<_>>();
+        let mut reached_instances = body_keys.clone();
+        reached_instances.push(free_function_instance(&module, "root"));
+        let closure_key = crate::body_query::BodyClosureQueryKey {
+            modules: Arc::from([module.clone()]),
+            roots: Arc::from([free_function_instance(&module, "root")]),
+            configuration: semantic_configuration(),
+        };
+        let body_keys = reached_instances
+            .into_iter()
+            .map(|instance| crate::body_query::BodyQueryKey {
+                instance,
+                configuration: semantic_configuration(),
+            })
+            .collect::<Vec<_>>();
+        let mut database = RevisionedQueryDatabase::with_query_concurrency(4);
+        let parked_revision = revision_for(&mut database, &source(true));
+
+        let cold = database
+            .body_closure(
+                parked_revision,
+                closure_key.clone(),
+                CancellationToken::new(),
+            )
+            .expect("the first acquisition round publishes a typed park");
+        let rue_query::QueryOutcome::Success(cold_output) = cold.terminal.outcome() else {
+            unreachable!("BodyClosure publishes typed values")
+        };
+        assert!(cold_output.parked_toolchain.is_some());
+        assert_eq!(cold_output.bodies.len(), CALLEES + 1);
+        assert!(
+            database.body_reachability_root_len() > BODY_QUERY_MEMO_RETENTION,
+            "the parked exact cone must replace the bounded body history"
+        );
+
+        for round in 0..2 {
+            let warm = database
+                .body_closure(
+                    parked_revision,
+                    closure_key.clone(),
+                    CancellationToken::new(),
+                )
+                .expect("a later acquisition round reuses the parked cone");
+            for key in &body_keys {
+                assert_eq!(
+                    warm.execution_for(key),
+                    rue_query::RequestExecution::Reused,
+                    "parked acquisition round {round} must reuse {}",
+                    key.stable_identity()
+                );
+                assert!(warm.was_retained(key));
+            }
+        }
+
+        let success_revision = revision_for(&mut database, &source(false));
+        let success = database
+            .body_closure(success_revision, closure_key, CancellationToken::new())
+            .expect("the completed acquisition publishes the final closure");
+        assert_eq!(success.terminal.kind(), QueryTerminalKind::Success);
+        assert_eq!(
+            database.body_reachability_root_len(),
+            0,
+            "the final closure root takes over before the parked root releases"
+        );
+        assert!(database.body_closure_root_metrics().0 > 0);
     }
 
     fn anonymous_identity_for_digest_test(

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -13885,11 +13885,13 @@ mod tests {
         // A deterministic per-body stage failure must reach the caller as a real
         // compiler diagnostic rather than a disguised abort that panics the
         // uncanceled session.
-        let errors = crate::revisioned_query_database::with_test_body_transaction_failure(|| {
-            session
-                .canonical_semantic(&CompileOptions::default())
-                .unwrap_err()
-        });
+        let _injection = session
+            .queries
+            .revisioned
+            .inject_body_transaction_failure_for_test();
+        let errors = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap_err();
         let rendered = errors.to_string();
         assert!(
             rendered.contains("injected_body_transaction_failure"),

--- a/crates/rue-query/BUCK
+++ b/crates/rue-query/BUCK
@@ -2,4 +2,7 @@ load("//crates:defs.bzl", "rue_crate")
 
 rue_crate(
     name = "rue-query",
+    deps = [
+        "//third-party:tracing",
+    ],
 )

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -4,7 +4,7 @@
 //! their typed keys, results, equality, and algorithms outside the runtime.
 
 use std::cell::Cell;
-use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -14,6 +14,12 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, Weak};
 
 static NEXT_RUNTIME_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Registered evaluators historically ran on the requesting compiler thread,
+/// whose platform stack is materially larger than Rust's default spawned-thread
+/// stack. Keep structured batch children at that established floor so moving a
+/// valid deeply nested query onto a worker cannot create a stack overflow.
+const REGISTERED_BATCH_WORKER_STACK_BYTES: usize = 8 * 1024 * 1024;
 
 thread_local! {
     static HANDOFF_CALLBACK_PHASE: Cell<Option<HandoffCallbackPhase>> = const { Cell::new(None) };
@@ -38,6 +44,756 @@ impl HandoffCallbackGuard {
 
     fn active() -> bool {
         HANDOFF_CALLBACK_PHASE.with(|active| active.get().is_some())
+    }
+}
+
+#[cfg(test)]
+mod registered_batch_tests {
+    use std::sync::Barrier;
+    use std::thread;
+    use std::time::Duration;
+
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    struct Key(&'static str);
+
+    impl QueryKey for Key {
+        fn stable_identity(&self) -> String {
+            self.0.to_owned()
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    struct Slot(u64);
+
+    impl QueryKey for Slot {
+        fn stable_identity(&self) -> String {
+            self.0.to_string()
+        }
+    }
+
+    fn revision(id: u64) -> Revision {
+        Revision::new(id, id)
+    }
+
+    fn publish_empty(runtime: &QueryRuntime, revisions: impl IntoIterator<Item = Revision>) {
+        for revision in revisions {
+            runtime.publish_revision(revision, []).unwrap();
+        }
+    }
+
+    #[derive(Debug)]
+    struct CountingHandoff {
+        commits: Arc<AtomicUsize>,
+        aborts: Arc<AtomicUsize>,
+    }
+
+    impl QueryAttemptHandoff for CountingHandoff {
+        fn commit(&mut self) {
+            self.commits.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn abort(&mut self) {
+            self.aborts.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[derive(Debug)]
+    struct PinSetHandoff {
+        pins: Option<RetainedPinSet>,
+        committed: Arc<Mutex<Option<RetainedPinSet>>>,
+        events: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl QueryAttemptHandoff for PinSetHandoff {
+        fn commit(&mut self) {
+            *lock(&self.committed) = self.pins.take();
+            lock(&self.events).push("commit");
+        }
+
+        fn abort(&mut self) {
+            if self.pins.is_none() {
+                self.pins = lock(&self.committed).take();
+            }
+            lock(&self.events).push("abort");
+        }
+    }
+
+    fn run_registered_batch(worker_count: usize) -> QueryRequestAttempt<Arc<[u64]>> {
+        let runtime = QueryRuntime::new(worker_count);
+        publish_empty(&runtime, [revision(1)]);
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let rendezvous = (worker_count > 1).then(|| Arc::new(Barrier::new(worker_count.min(4))));
+        let active_for_child = active.clone();
+        let peak_for_child = peak.clone();
+        let rendezvous_for_child = rendezvous.clone();
+        let child = runtime
+            .family_with_evaluator::<Slot, u64, _>("registered-batch-child", 8, move |_, _, key| {
+                let now = active_for_child.fetch_add(1, Ordering::AcqRel) + 1;
+                peak_for_child.fetch_max(now, Ordering::AcqRel);
+                if let Some(rendezvous) = &rendezvous_for_child {
+                    rendezvous.wait();
+                    thread::sleep(Duration::from_millis((3 - key.0) * 2));
+                }
+                active_for_child.fetch_sub(1, Ordering::AcqRel);
+                Ok(QueryOutput::success(key.0)
+                    .with_diagnostics(vec![QueryDiagnostic::new(
+                        format!("diagnostic-{}", key.0),
+                        format!("payload-{}", key.0),
+                        None,
+                    )])
+                    .with_work(vec![WorkItem::new("batch-child", 1)]))
+            })
+            .unwrap();
+        let child_for_root = child.clone();
+        let root = runtime
+            .family_with_evaluator::<Key, Arc<[u64]>, _>(
+                "registered-batch-root",
+                8,
+                move |context, _, _| {
+                    let terminals =
+                        context.query_registered_batch(&child_for_root, (0..4).map(Slot))?;
+                    let mut values = Vec::new();
+                    let mut diagnostics = Vec::new();
+                    for terminal in terminals {
+                        let QueryOutcome::Success(value) = terminal.outcome() else {
+                            unreachable!()
+                        };
+                        values.push(*value);
+                        diagnostics.extend_from_slice(terminal.diagnostics());
+                    }
+                    Ok(QueryOutput::success(Arc::from(values)).with_diagnostics(diagnostics))
+                },
+            )
+            .unwrap();
+        let attempt =
+            runtime.request_registered(&root, revision(1), Key("root"), CancellationToken::new());
+        assert_eq!(
+            peak.load(Ordering::Acquire),
+            worker_count.min(4),
+            "the registered batch must use the runtime's shared permit budget"
+        );
+        attempt
+    }
+
+    #[test]
+    fn registered_batch_one_and_many_permits_reduce_adversarial_completion_stably() {
+        let one = run_registered_batch(1);
+        let many = run_registered_batch(4);
+        let one_terminal = one.terminal().unwrap();
+        let many_terminal = many.terminal().unwrap();
+        assert_eq!(one_terminal.outcome(), many_terminal.outcome());
+        assert_eq!(one_terminal.diagnostics(), many_terminal.diagnostics());
+        assert_eq!(one_terminal.work(), many_terminal.work());
+        assert_eq!(
+            one.dependencies()
+                .iter()
+                .map(|dependency| dependency.node.key())
+                .collect::<Vec<_>>(),
+            many.dependencies()
+                .iter()
+                .map(|dependency| dependency.node.key())
+                .collect::<Vec<_>>()
+        );
+        for attempt in [&one, &many] {
+            assert_eq!(
+                attempt
+                    .nested_attempts()
+                    .iter()
+                    .map(|nested| nested.node().key())
+                    .collect::<Vec<_>>(),
+                vec!["0", "1", "2", "3"]
+            );
+        }
+    }
+
+    #[test]
+    fn registered_batch_transfers_exact_leases_and_handoffs_before_child_teardown() {
+        let runtime = QueryRuntime::new(1);
+        publish_empty(&runtime, [revision(1)]);
+        let commits = Arc::new(AtomicUsize::new(0));
+        let aborts = Arc::new(AtomicUsize::new(0));
+        let child_commits = commits.clone();
+        let child_aborts = aborts.clone();
+        let child = runtime
+            .family_with_evaluator::<Slot, u64, _>(
+                "registered-batch-leased-child",
+                0,
+                move |context, _, key| {
+                    context.register_attempt_handoff(CountingHandoff {
+                        commits: child_commits.clone(),
+                        aborts: child_aborts.clone(),
+                    });
+                    Ok(QueryOutput::success(key.0))
+                },
+            )
+            .unwrap();
+        let committed = Arc::new(Mutex::new(None));
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let child_for_root = child.clone();
+        let committed_for_root = committed.clone();
+        let events_for_root = events.clone();
+        let root = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "registered-batch-leased-root",
+                1,
+                move |context, _, _| {
+                    context.query_registered_batch(&child_for_root, (0..3).map(Slot))?;
+                    context.register_attempt_handoff(PinSetHandoff {
+                        pins: Some(context.retain_observed_terminals()),
+                        committed: committed_for_root.clone(),
+                        events: events_for_root.clone(),
+                    });
+                    Ok(QueryOutput::success(3))
+                },
+            )
+            .unwrap();
+
+        let attempt =
+            runtime.request_registered(&root, revision(1), Key("root"), CancellationToken::new());
+        assert!(attempt.terminal().is_some());
+        assert_eq!(commits.load(Ordering::SeqCst), 3);
+        assert_eq!(aborts.load(Ordering::SeqCst), 0);
+        assert_eq!(lock(&committed).as_ref().map(RetainedPinSet::len), Some(3));
+        assert_eq!(child.retention().terminals, 3);
+        drop(lock(&committed).take());
+        assert_eq!(child.retention().terminals, 0);
+    }
+
+    #[test]
+    fn registered_batch_transfers_one_encapsulating_handoff_lifecycle_per_child() {
+        let runtime = QueryRuntime::new(2);
+        publish_empty(&runtime, [revision(1)]);
+        let commits = Arc::new(AtomicUsize::new(0));
+        let aborts = Arc::new(AtomicUsize::new(0));
+        let leaf_commits = commits.clone();
+        let leaf_aborts = aborts.clone();
+        let leaf = runtime
+            .family_with_evaluator::<Slot, u64, _>(
+                "registered-batch-handoff-leaf",
+                8,
+                move |context, _, key| {
+                    context.register_attempt_handoff(CountingHandoff {
+                        commits: leaf_commits.clone(),
+                        aborts: leaf_aborts.clone(),
+                    });
+                    Ok(QueryOutput::success(key.0))
+                },
+            )
+            .unwrap();
+        let leaf_for_child = leaf.clone();
+        let child = runtime
+            .family_with_evaluator::<Slot, u64, _>(
+                "registered-batch-handoff-child",
+                8,
+                move |context, _, key| {
+                    context.query_registered(&leaf_for_child, key.clone())?;
+                    Ok(QueryOutput::success(key.0))
+                },
+            )
+            .unwrap();
+        let child_for_root = child.clone();
+        let root = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "registered-batch-handoff-root",
+                8,
+                move |context, _, _| {
+                    context.query_registered_batch(&child_for_root, (0..3).map(Slot))?;
+                    let stack = lock(&context.task.stack);
+                    let observed = &stack
+                        .last()
+                        .expect("the root evaluator owns one frame")
+                        .observed_handoffs;
+                    assert_eq!(
+                        observed.len(),
+                        3,
+                        "each child transfers its root lifecycle, not its flattened history"
+                    );
+                    assert!(
+                        observed
+                            .iter()
+                            .all(|lifecycle| lifecycle.observed.len() == 1),
+                        "each transferred root still owns its leaf lifecycle"
+                    );
+                    Ok(QueryOutput::success(3))
+                },
+            )
+            .unwrap();
+
+        let attempt =
+            runtime.request_registered(&root, revision(1), Key("root"), CancellationToken::new());
+        assert!(attempt.terminal().is_some());
+        assert_eq!(commits.load(Ordering::SeqCst), 3);
+        assert_eq!(aborts.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn exact_terminal_cone_excludes_unrelated_observations_and_retains_every_dependency() {
+        let runtime = QueryRuntime::new(1);
+        publish_empty(&runtime, [revision(1)]);
+        let leaf = runtime
+            .family_with_evaluator::<Slot, u64, _>("exact-cone-leaf", 0, |_, _, key| {
+                Ok(QueryOutput::success(key.0))
+            })
+            .unwrap();
+        let leaf_for_middle = leaf.clone();
+        let middle = runtime
+            .family_with_evaluator::<Key, u64, _>("exact-cone-middle", 0, move |context, _, _| {
+                context.query_registered_batch(&leaf_for_middle, [Slot(0), Slot(2)])?;
+                Ok(QueryOutput::success(1))
+            })
+            .unwrap();
+        let committed = Arc::new(Mutex::new(None));
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let leaf_for_publication = leaf.clone();
+        let middle_for_publication = middle.clone();
+        let committed_for_publication = committed.clone();
+        let events_for_publication = events.clone();
+        let publication = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "exact-cone-publication",
+                0,
+                move |context, _, _| {
+                    let _proof = context.endorse_registered_validations();
+                    context.query_registered(&leaf_for_publication, Slot(1))?;
+                    let current =
+                        context.query_registered(&middle_for_publication, Key("current"))?;
+                    context.register_attempt_handoff(PinSetHandoff {
+                        pins: Some(
+                            context
+                                .retain_observed_terminal_cone(&current)
+                                .expect("the registered current cone is complete"),
+                        ),
+                        committed: committed_for_publication.clone(),
+                        events: events_for_publication.clone(),
+                    });
+                    Ok(QueryOutput::success(1))
+                },
+            )
+            .unwrap();
+
+        let attempt = runtime.request_registered(
+            &publication,
+            revision(1),
+            Key("publish"),
+            CancellationToken::new(),
+        );
+        assert!(attempt.terminal().is_some());
+        assert_eq!(
+            lock(&committed).as_ref().map(RetainedPinSet::len),
+            Some(3),
+            "the exact cone contains the current terminal and both batched leaves, \
+             not the unrelated leaf"
+        );
+        assert_eq!(leaf.retention().terminals, 2);
+        assert_eq!(middle.retention().terminals, 1);
+    }
+
+    #[test]
+    fn exact_terminal_cone_requires_proof_authority_and_an_observed_root() {
+        let runtime = QueryRuntime::new(1);
+        publish_empty(&runtime, [revision(1)]);
+        let leaf = runtime
+            .family_with_evaluator::<Key, u64, _>("exact-cone-rejection-leaf", 1, |_, _, _| {
+                Ok(QueryOutput::success(1))
+            })
+            .unwrap();
+        let unobserved = runtime
+            .request_registered(
+                &leaf,
+                revision(1),
+                Key("unobserved"),
+                CancellationToken::new(),
+            )
+            .into_result()
+            .unwrap();
+        let unobserved_for_check = unobserved.clone();
+        let leaf_for_check = leaf.clone();
+        let check = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "exact-cone-rejection-check",
+                1,
+                move |context, _, _| {
+                    let observed = context.query_registered(&leaf_for_check, Key("observed"))?;
+                    assert!(matches!(
+                        context.retain_observed_terminal_cone(&observed),
+                        Err(RetainTerminalConeError::NoRegisteredValidationScope)
+                    ));
+                    let _proof = context.endorse_registered_validations();
+                    assert!(matches!(
+                        context.retain_observed_terminal_cone(&unobserved_for_check),
+                        Err(RetainTerminalConeError::RootNotObserved)
+                    ));
+                    Ok(QueryOutput::success(1))
+                },
+            )
+            .unwrap();
+        assert!(
+            runtime
+                .request_registered(&check, revision(1), Key("check"), CancellationToken::new(),)
+                .terminal()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn exact_terminal_cone_rejects_an_incomplete_dependency_observation() {
+        let runtime = QueryRuntime::new(1);
+        publish_empty(&runtime, [revision(1)]);
+        let leaf = runtime
+            .family_with_evaluator::<Slot, u64, _>("exact-cone-incomplete-leaf", 1, |_, _, key| {
+                Ok(QueryOutput::success(key.0))
+            })
+            .unwrap();
+        let leaf_for_middle = leaf.clone();
+        let middle = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "exact-cone-incomplete-middle",
+                1,
+                move |context, _, _| {
+                    context.query_registered(&leaf_for_middle, Slot(0))?;
+                    Ok(QueryOutput::success(1))
+                },
+            )
+            .unwrap();
+        let middle_for_check = middle.clone();
+        let check = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "exact-cone-incomplete-check",
+                1,
+                move |context, _, _| {
+                    let _proof = context.endorse_registered_validations();
+                    let current = context.query_registered(&middle_for_check, Key("current"))?;
+                    let dependency = current.dependencies()[0].clone();
+                    let removed = {
+                        let mut leases = lock(&context.task.leases);
+                        let index = leases
+                            .held
+                            .iter()
+                            .position(|lease| {
+                                let identity = lease.identity();
+                                identity.0 == dependency.incarnation
+                                    && identity.1 == dependency.stamp
+                            })
+                            .expect("the child dependency starts observed");
+                        leases.held.remove(index)
+                    };
+                    drop(removed);
+                    assert!(matches!(
+                        context.retain_observed_terminal_cone(&current),
+                        Err(RetainTerminalConeError::DependencyNotObserved(observation))
+                            if observation == dependency
+                    ));
+                    Ok(QueryOutput::success(1))
+                },
+            )
+            .unwrap();
+        assert!(
+            runtime
+                .request_registered(&check, revision(1), Key("check"), CancellationToken::new(),)
+                .terminal()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn registered_batch_first_abort_has_the_stable_observation_and_work_prefix() {
+        let runtime = QueryRuntime::new(3);
+        publish_empty(&runtime, [revision(1)]);
+        let ran = Arc::new(Mutex::new(Vec::new()));
+        let ran_for_child = ran.clone();
+        let child = runtime
+            .family_with_evaluator::<Slot, u64, _>(
+                "registered-batch-failing-child",
+                8,
+                move |context, _, key| {
+                    lock(&ran_for_child).push(key.0);
+                    context.record_work(WorkItem::new(format!("child-{}", key.0), 1));
+                    if key.0 == 1 {
+                        Err(QueryAbort::MissingInput(InputIdentity::new(
+                            "batch", "missing",
+                        )))
+                    } else {
+                        Ok(QueryOutput::success(key.0))
+                    }
+                },
+            )
+            .unwrap();
+        let child_for_root = child.clone();
+        let root = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "registered-batch-failing-root",
+                8,
+                move |context, _, _| {
+                    context.query_registered_batch(&child_for_root, (0..3).map(Slot))?;
+                    Ok(QueryOutput::success(0))
+                },
+            )
+            .unwrap();
+
+        let attempt =
+            runtime.request_registered(&root, revision(1), Key("root"), CancellationToken::new());
+        assert_eq!(
+            attempt.abort(),
+            Some(&QueryAbort::MissingInput(InputIdentity::new(
+                "batch", "missing"
+            )))
+        );
+        let mut ran = lock(&ran).clone();
+        ran.sort_unstable();
+        assert_eq!(ran, vec![0, 1, 2]);
+        assert_eq!(
+            attempt
+                .nested_attempts()
+                .iter()
+                .map(|nested| nested.node().key())
+                .collect::<Vec<_>>(),
+            vec!["0", "1"]
+        );
+        assert_eq!(
+            attempt
+                .work()
+                .iter()
+                .map(|(identity, amount)| (identity.as_ref(), *amount))
+                .collect::<Vec<_>>(),
+            vec![("child-0", 1), ("child-1", 1)]
+        );
+    }
+
+    #[test]
+    fn registered_batch_cancellation_is_inherited_and_keeps_the_stable_prefix() {
+        let runtime = QueryRuntime::new(1);
+        publish_empty(&runtime, [revision(1)]);
+        let cancellation = CancellationToken::new();
+        let cancellation_for_child = cancellation.clone();
+        let child = runtime
+            .family_with_evaluator::<Slot, u64, _>(
+                "registered-batch-cancel-child",
+                8,
+                move |context, _, key| {
+                    context.record_work(WorkItem::new(format!("cancel-child-{}", key.0), 1));
+                    if key.0 == 1 {
+                        cancellation_for_child.cancel();
+                    }
+                    context.check_canceled()?;
+                    Ok(QueryOutput::success(key.0))
+                },
+            )
+            .unwrap();
+        let child_for_root = child.clone();
+        let root = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "registered-batch-cancel-root",
+                8,
+                move |context, _, _| {
+                    context.query_registered_batch(&child_for_root, (0..3).map(Slot))?;
+                    Ok(QueryOutput::success(0))
+                },
+            )
+            .unwrap();
+        let attempt = runtime.request_registered(&root, revision(1), Key("root"), cancellation);
+        assert_eq!(attempt.abort(), Some(&QueryAbort::Canceled));
+        assert_eq!(
+            attempt
+                .work()
+                .iter()
+                .map(|(identity, amount)| (identity.as_ref(), *amount))
+                .collect::<Vec<_>>(),
+            vec![("cancel-child-0", 1), ("cancel-child-1", 1)]
+        );
+    }
+
+    #[test]
+    fn registered_batch_preserves_typed_dependency_cycles() {
+        let runtime = QueryRuntime::new(2);
+        publish_empty(&runtime, [revision(1)]);
+        let family_slot = Arc::new(std::sync::OnceLock::new());
+        let family_slot_for_evaluator = family_slot.clone();
+        let cyclic = runtime
+            .family_with_evaluator::<Slot, u64, _>(
+                "registered-batch-cycle",
+                8,
+                move |context, _, key| {
+                    let family = family_slot_for_evaluator.get().unwrap();
+                    context.query_registered(family, key.clone())?;
+                    Ok(QueryOutput::success(key.0))
+                },
+            )
+            .unwrap();
+        family_slot.set(cyclic.clone()).unwrap();
+        let cyclic_for_root = cyclic.clone();
+        let root = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "registered-batch-cycle-root",
+                8,
+                move |context, _, _| {
+                    context.query_registered_batch(&cyclic_for_root, [Slot(0)])?;
+                    Ok(QueryOutput::success(0))
+                },
+            )
+            .unwrap();
+        let attempt =
+            runtime.request_registered(&root, revision(1), Key("root"), CancellationToken::new());
+        assert!(
+            matches!(attempt.abort(), Some(QueryAbort::Cycle(_))),
+            "exact recursive dependency must remain a typed cycle, got {:?}",
+            attempt.abort()
+        );
+    }
+
+    fn run_registered_batch_parent_cycle(worker_count: usize, through_external: bool) {
+        let runtime = QueryRuntime::new(worker_count);
+        publish_empty(&runtime, [revision(1)]);
+        let root_slot = Arc::new(std::sync::OnceLock::<QueryFamily<Key, u64>>::new());
+        let root_slot_for_external = root_slot.clone();
+        let external = runtime
+            .family_with_evaluator::<Slot, u64, _>(
+                "registered-batch-parent-cycle-external",
+                8,
+                move |context, _, key| {
+                    context.query_registered(root_slot_for_external.get().unwrap(), Key("root"))?;
+                    Ok(QueryOutput::success(key.0))
+                },
+            )
+            .unwrap();
+        let root_slot_for_child = root_slot.clone();
+        let external_for_child = external.clone();
+        let child = runtime
+            .family_with_evaluator::<Slot, u64, _>(
+                "registered-batch-parent-cycle-child",
+                8,
+                move |context, _, key| {
+                    if through_external {
+                        context.query_registered(&external_for_child, key.clone())?;
+                    } else {
+                        context
+                            .query_registered(root_slot_for_child.get().unwrap(), Key("root"))?;
+                    }
+                    Ok(QueryOutput::success(key.0))
+                },
+            )
+            .unwrap();
+        let child_for_root = child.clone();
+        let root = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "registered-batch-parent-cycle-root",
+                8,
+                move |context, _, _| {
+                    context.query_registered_batch(&child_for_root, [Slot(0)])?;
+                    Ok(QueryOutput::success(0))
+                },
+            )
+            .unwrap();
+        root_slot.set(root.clone()).unwrap();
+
+        let attempt =
+            runtime.request_registered(&root, revision(1), Key("root"), CancellationToken::new());
+        assert!(
+            matches!(attempt.abort(), Some(QueryAbort::Cycle(_))),
+            "a structured batch parent cycle must abort with {worker_count} permits \
+             (through_external={through_external}), got {:?}",
+            attempt.abort()
+        );
+    }
+
+    #[test]
+    fn registered_batch_parent_cycles_abort_with_one_and_many_permits() {
+        for worker_count in [1, 4] {
+            run_registered_batch_parent_cycle(worker_count, false);
+            run_registered_batch_parent_cycle(worker_count, true);
+        }
+    }
+
+    #[test]
+    fn registered_batch_child_taints_the_enclosing_registered_validation_proof() {
+        let runtime = QueryRuntime::new(2);
+        publish_empty(&runtime, [revision(1), revision(2)]);
+        let external = runtime
+            .family::<Slot, u64>("registered-batch-proof-external", 1)
+            .unwrap();
+        let external_for_child = external.clone();
+        let child = runtime
+            .family_with_evaluator::<Slot, u64, _>(
+                "registered-batch-proof-child",
+                1,
+                move |context, _, key| {
+                    context.query(&external_for_child, key.clone(), |_| {
+                        Ok(QueryOutput::success(key.0))
+                    })?;
+                    Ok(QueryOutput::success(key.0))
+                },
+            )
+            .unwrap();
+        runtime
+            .request_registered(&child, revision(1), Slot(0), CancellationToken::new())
+            .into_result()
+            .unwrap();
+        let child_for_root = child.clone();
+        let root = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "registered-batch-proof-root",
+                1,
+                move |context, _, _| {
+                    let proof = context.task.begin_validation();
+                    context.query_registered_batch(&child_for_root, [Slot(0)])?;
+                    assert!(
+                        !proof.registered_only(),
+                        "an unregistered evaluator in a batch child must taint the parent's proof"
+                    );
+                    Ok(QueryOutput::success(1))
+                },
+            )
+            .unwrap();
+        assert!(
+            runtime
+                .request_registered(&root, revision(2), Key("root"), CancellationToken::new(),)
+                .terminal()
+                .is_some()
+        );
+    }
+
+    #[test]
+    #[cfg(panic = "unwind")]
+    fn registered_batch_panic_restores_the_parent_permit() {
+        let runtime = QueryRuntime::new(1);
+        publish_empty(&runtime, [revision(1)]);
+        let root = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "registered-batch-panicking-root",
+                8,
+                |context, _, _| {
+                    let panicked = catch_unwind(AssertUnwindSafe(|| {
+                        let _donation = ParentPermitDonation::new(context.task.clone());
+                        panic!("batch coordinator panic");
+                    }));
+                    assert!(panicked.is_err());
+                    assert!(
+                        context.task.owns_permit.load(Ordering::Acquire),
+                        "unwinding the batch join interval must restore the parent permit"
+                    );
+                    Ok(QueryOutput::success(1))
+                },
+            )
+            .unwrap();
+        let attempt =
+            runtime.request_registered(&root, revision(1), Key("root"), CancellationToken::new());
+        assert!(attempt.terminal().is_some());
+
+        let recovery = runtime
+            .family::<Key, u64>("registered-batch-panic-recovery", 1)
+            .unwrap();
+        let recovered = runtime
+            .query(
+                &recovery,
+                revision(1),
+                Key("recovered"),
+                CancellationToken::new(),
+                |_| Ok(QueryOutput::success(1)),
+            )
+            .unwrap();
+        assert_eq!(recovered.outcome(), &QueryOutcome::Success(1));
     }
 }
 
@@ -314,11 +1070,11 @@ impl<V> QueryOutput<V> {
 /// Evaluators register a handoff through
 /// [`QueryContext::register_attempt_handoff`] while the attempt is active. The
 /// resulting terminal retains the handoff internally while it is pending. The
-/// runtime calls [`Self::commit`] exactly once only when the whole top-level
-/// rooted task that observed it completes successfully. Speculative validation
-/// does not commit; a later observed reuse can. A rooted abort leaves a published
-/// handoff pending for a later root, while terminal eviction calls
-/// [`Self::abort`].
+/// runtime calls [`Self::commit`] only when the whole top-level rooted task that
+/// observed it completes successfully. Speculative validation does not commit;
+/// a later observed reuse can. Cancellation or panic while committing rolls the
+/// attempted prefix back to pending for a later root, while terminal eviction
+/// calls [`Self::abort`] to release a still-pending resource.
 ///
 /// Handoffs are attempt-local control resources. They are never stored in
 /// [`QueryOutput`] or [`QueryTerminal`], do not participate in equality or
@@ -329,12 +1085,14 @@ impl<V> QueryOutput<V> {
 pub trait QueryAttemptHandoff: fmt::Debug + Send + 'static {
     /// Transfer the resource at successful rooted-task completion.
     ///
-    /// If this method unwinds, the runtime calls [`Self::abort`] on every
-    /// handoff in the rooted commit batch, including this one. Lifecycles whose
-    /// abort callbacks return are restored to pending before the original panic
-    /// resumes. If an abort callback also unwinds, that lifecycle is permanently
-    /// marked aborted; any terminal graph containing it becomes unavailable and
-    /// cannot be reused as a partial publication.
+    /// If this method unwinds, the runtime calls [`Self::abort`] in reverse order
+    /// on this callback and the earlier attempted prefix. Callbacks not yet
+    /// attempted remain untouched. Lifecycles whose attempted callbacks roll
+    /// back are restored to pending before the original panic resumes, so
+    /// `commit` may be called again on a later root. If an abort callback also
+    /// unwinds, that lifecycle is permanently marked aborted; any terminal graph
+    /// containing it becomes unavailable and cannot be reused as a partial
+    /// publication.
     fn commit(&mut self);
 
     /// Roll back a partial commit, or release a pending resource on eviction.
@@ -836,10 +1594,14 @@ pub struct QueryRuntime {
 struct RuntimeCore {
     identity: u64,
     permits: PermitBudget,
-    wait_graph: Mutex<BTreeMap<TaskId, WaitEdge>>,
+    wait_graph: Mutex<BTreeMap<TaskId, BTreeMap<TaskId, NodeIdentity>>>,
     family_names: Mutex<BTreeSet<Arc<str>>>,
     revisions: Mutex<RevisionStore>,
     nodes: Mutex<NodeRegistry>,
+    /// Spawned structured-batch workers currently alive across every root and
+    /// nesting depth. The caller always executes one child inline; this global
+    /// counter caps additional OS threads at `permits.maximum - 1`.
+    batch_workers: AtomicUsize,
     next_task: AtomicU64,
     next_family: AtomicU64,
     next_node: AtomicU64,
@@ -1087,6 +1849,7 @@ impl QueryRuntime {
                     retired_through: 0,
                 }),
                 nodes: Mutex::new(NodeRegistry::default()),
+                batch_workers: AtomicUsize::new(0),
                 next_task: AtomicU64::new(1),
                 next_family: AtomicU64::new(1),
                 next_node: AtomicU64::new(1),
@@ -1594,6 +2357,9 @@ impl QueryRuntime {
             validation_proofs: Mutex::new(Vec::new()),
             leases: Mutex::new(TaskLeases::default()),
             observed_handoffs: Mutex::new(Vec::new()),
+            checked_handoffs: Mutex::new(HashSet::new()),
+            #[cfg(test)]
+            handoff_validation_visits: AtomicUsize::new(0),
         });
         let result = match compute {
             Some(compute) => family.query_task(task.clone(), key, origin_request, compute),
@@ -2679,14 +3445,7 @@ where
                 ..
             } => assert_eq!(*actual_owner, owner),
         }
-        if let Err(cycle) = self.core.begin_wait(
-            task.id,
-            owner,
-            ExactNodeIdentity {
-                display: node.identity.clone(),
-                incarnation: node.incarnation,
-            },
-        ) {
+        if let Err(cycle) = self.core.begin_wait(task.id, owner, node.identity.clone()) {
             decrement_waiter(&mut state, attempt_id);
             self.core.metrics.cycles.fetch_add(1, Ordering::Relaxed);
             return Err(QueryAbort::Cycle(cycle));
@@ -2743,7 +3502,7 @@ where
             }
         };
         task.cancellation.unwatch(cancellation_watch);
-        self.core.end_wait(task.id);
+        self.core.end_wait(task.id, owner);
         if donated {
             task.acquire_permit(&self.core);
         }
@@ -3281,6 +4040,19 @@ pub enum PinError {
     ForeignFamily,
 }
 
+/// A final-terminal cone could not be proven complete from the current task's
+/// live registered-query observations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RetainTerminalConeError {
+    /// The caller did not establish a lexical registered-validation authority.
+    NoRegisteredValidationScope,
+    /// The proposed root was not observed by this task.
+    RootNotObserved,
+    /// One immutable edge in the proposed root's transitive cone had no
+    /// matching live task lease.
+    DependencyNotObserved(Observation),
+}
+
 /// Errors from minting or recording an exact-terminal adoption capability
 /// ([`QueryFamily::adoptable_terminal`] /
 /// [`QueryFamily::observe_adopted_terminal`]).
@@ -3329,8 +4101,14 @@ where
         if self.deferred.load(Ordering::Relaxed) {
             return;
         }
-        self.terminal.pins.fetch_sub(1, Ordering::AcqRel);
-        self.family.enforce_retention();
+        let previous = self.terminal.pins.fetch_sub(1, Ordering::AcqRel);
+        assert!(previous > 0, "a terminal pin releases exactly once");
+        if previous == 1 {
+            // Only the last pin can make this terminal newly evictable. A
+            // duplicate/root-overlap release cannot enable retention progress,
+            // so scanning the full family here would be pure quadratic work.
+            self.family.enforce_retention();
+        }
     }
 }
 
@@ -3409,6 +4187,36 @@ where
 pub struct QueryContext {
     task: Arc<Task>,
     not_send_or_sync: PhantomData<Rc<()>>,
+}
+
+type BatchCompletion<K, V> = (usize, u64, K, Arc<Task>, TaskQueryResult<V>);
+
+fn run_registered_batch_worker<K, V>(
+    queue: Arc<Mutex<VecDeque<(usize, u64, K)>>>,
+    family: QueryFamily<K, V>,
+    parent: Arc<Task>,
+    tracing_dispatch: tracing::Dispatch,
+    tracing_parent: tracing::Span,
+) -> std::thread::Result<Vec<BatchCompletion<K, V>>>
+where
+    K: QueryKey,
+    V: Clone + Send + Sync + 'static,
+{
+    tracing::dispatcher::with_default(&tracing_dispatch, || {
+        let _parent = tracing_parent.enter();
+        catch_unwind(AssertUnwindSafe(|| {
+            let mut completed = Vec::new();
+            loop {
+                let Some((index, request_id, key)) = lock(&queue).pop_front() else {
+                    break;
+                };
+                let child = parent.batch_child(request_id);
+                let result = family.query_task_registered(child.clone(), key.clone(), request_id);
+                completed.push((index, request_id, key, child, result));
+            }
+            completed
+        }))
+    })
 }
 
 impl QueryContext {
@@ -3509,6 +4317,12 @@ impl QueryContext {
         V: Clone + Send + Sync + 'static,
         F: FnOnce(&QueryContext) -> Result<QueryOutput<V>, QueryAbort>,
     {
+        // Caller-supplied evaluators have no family-owned re-demand authority.
+        // Crossing this boundary anywhere inside a registered-only validation
+        // walk must fail the certificate closed, including when a structured
+        // batch child computes the unregistered node rather than validating a
+        // retained one.
+        self.task.taint_validation_proofs();
         let request_id = self.task.next_nested_request();
         let result = if Arc::ptr_eq(&self.task_runtime(), &family.core) {
             family.query_task(self.task.clone(), key.clone(), request_id, compute)
@@ -3571,6 +4385,232 @@ impl QueryContext {
         result.into_result()
     }
 
+    /// Requests a stable-ordered batch of dependencies through one registered
+    /// family.
+    ///
+    /// Every item executes in a distinct child task, inheriting this task's
+    /// immutable revision and cancellation token while owning its own
+    /// wait-graph identity and execution permit. The parent donates its permit
+    /// for the complete join interval, which makes the same interface
+    /// progress-guaranteed when the runtime has one permit.
+    ///
+    /// Results are reduced in input order, independent of worker completion
+    /// order. Dependency observations, request leases, handoffs, work, and the
+    /// operational nested-attempt ledger are transferred into the parent before
+    /// a child task can release them. Callers must therefore supply keys in
+    /// their semantic stable order.
+    pub fn query_registered_batch<K, V>(
+        &self,
+        family: &QueryFamily<K, V>,
+        keys: impl IntoIterator<Item = K>,
+    ) -> Result<Vec<Arc<QueryTerminal<V>>>, QueryAbort>
+    where
+        K: QueryKey,
+        V: Clone + Send + Sync + 'static,
+    {
+        assert!(
+            family.inner.evaluator.is_some(),
+            "closure-free dependency requests require a registered evaluator"
+        );
+        if !Arc::ptr_eq(&self.task_runtime(), &family.core) {
+            return Err(QueryAbort::ForeignRuntime);
+        }
+        let items = keys
+            .into_iter()
+            .enumerate()
+            .map(|(index, key)| {
+                let request_id = self.task.next_nested_request();
+                (index, request_id, key)
+            })
+            .collect::<Vec<_>>();
+        if items.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let structured_waits = StructuredWaitGuard::new(
+            self.task.core.clone(),
+            self.task.id,
+            items.iter().map(|(_, request_id, key)| {
+                (
+                    TaskId(*request_id),
+                    NodeIdentity {
+                        family: family.inner.name.clone(),
+                        key: key.stable_identity().into(),
+                    },
+                )
+            }),
+        )
+        .map_err(QueryAbort::Cycle)?;
+        let worker_claim =
+            BatchWorkerClaim::new(self.task.core.clone(), items.len().saturating_sub(1));
+        let queue = Arc::new(Mutex::new(VecDeque::from(items)));
+        // `tracing` dispatch is thread-local. Carry the caller's subscriber into
+        // each child so scheduled evaluation keeps compiler timing/log events.
+        let tracing_dispatch = tracing::dispatcher::get_default(Clone::clone);
+        let tracing_parent = tracing::Span::current();
+        let donation = ParentPermitDonation::new(self.task.clone());
+        if donation.donated {
+            self.task
+                .core
+                .metrics
+                .donated_permits
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        let (mut completed, panic) = std::thread::scope(|scope| {
+            let mut workers = Vec::with_capacity(worker_claim.count);
+            for _ in 0..worker_claim.count {
+                let queue = queue.clone();
+                let family = family.clone();
+                let parent = self.task.clone();
+                let tracing_dispatch = tracing_dispatch.clone();
+                let tracing_parent = tracing_parent.clone();
+                workers.push(
+                    std::thread::Builder::new()
+                        .name("rue-query-batch".into())
+                        .stack_size(REGISTERED_BATCH_WORKER_STACK_BYTES)
+                        .spawn_scoped(scope, move || {
+                            run_registered_batch_worker(
+                                queue,
+                                family,
+                                parent,
+                                tracing_dispatch,
+                                tracing_parent,
+                            )
+                        })
+                        .expect("registered batch worker thread must spawn"),
+                );
+            }
+            let inline = run_registered_batch_worker(
+                queue.clone(),
+                family.clone(),
+                self.task.clone(),
+                tracing_dispatch.clone(),
+                tracing_parent.clone(),
+            );
+            let mut completed = Vec::new();
+            let mut panic = None;
+            match inline {
+                Ok(inline_completed) => completed.extend(inline_completed),
+                Err(payload) => panic = Some(payload),
+            }
+            for worker in workers {
+                match worker
+                    .join()
+                    .expect("registered batch workers catch their own unwinds")
+                {
+                    Ok(worker_completed) => completed.extend(worker_completed),
+                    Err(payload) if panic.is_none() => panic = Some(payload),
+                    Err(_) => {}
+                }
+            }
+            (completed, panic)
+        });
+        drop(structured_waits);
+        drop(donation);
+        if let Some(payload) = panic {
+            resume_unwind(payload);
+        }
+
+        completed.sort_unstable_by_key(|(index, ..)| *index);
+        let mut terminals = Vec::with_capacity(completed.len());
+        for (_, request_id, key, child, result) in completed {
+            self.task
+                .absorb_batch_child(&child, matches!(&result, TaskQueryResult::Terminal { .. }));
+            match &result {
+                TaskQueryResult::Terminal { terminal, work, .. } => {
+                    self.task.observe(terminal);
+                    self.task.observe_work(work);
+                }
+                TaskQueryResult::Aborted {
+                    dependencies,
+                    inputs,
+                    work,
+                    ..
+                } => self.task.observe_abort_prefix(dependencies, inputs, work),
+            }
+            self.task.record_nested(
+                request_id,
+                move || NodeIdentity {
+                    family: family.inner.name.clone(),
+                    key: key.stable_identity().into(),
+                },
+                &result,
+            );
+            terminals.push(result.into_result()?);
+        }
+        Ok(terminals)
+    }
+
+    /// Duplicates every terminal lease currently observed by this rooted task.
+    ///
+    /// The returned set is acquired while the task's original leases remain
+    /// live, so a publication handoff can promote the exact dependency cone
+    /// past request completion without an eviction window.
+    pub fn retain_observed_terminals(&self) -> RetainedPinSet {
+        let leases = lock(&self.task.leases);
+        let mut retained = RetainedPinSet::new();
+        for lease in &leases.held {
+            retained.lease_erased(lease.duplicate());
+        }
+        retained
+    }
+
+    /// Duplicates only the observed terminals reachable from one exact root.
+    ///
+    /// Validation can temporarily observe terminals from a superseded
+    /// predecessor before recomputing a successor. This graph walk follows the
+    /// immutable dependency observations of `root` through the task's live
+    /// request leases, excluding unrelated validation pins while preserving
+    /// continuous protection for the complete current cone.
+    pub fn retain_observed_terminal_cone<V>(
+        &self,
+        root: &Arc<QueryTerminal<V>>,
+    ) -> Result<RetainedPinSet, RetainTerminalConeError>
+    where
+        V: Clone + Send + Sync + 'static,
+    {
+        if lock(&self.task.validation_endorsements).is_empty() {
+            return Err(RetainTerminalConeError::NoRegisteredValidationScope);
+        }
+        let leases = lock(&self.task.leases);
+        let mut by_observation = BTreeMap::new();
+        let mut root_index = None;
+        for (index, lease) in leases.held.iter().enumerate() {
+            let identity = lease.identity();
+            by_observation
+                .entry((identity.0, identity.1))
+                .and_modify(|current: &mut usize| {
+                    if leases.held[*current].identity().2 < identity.2 {
+                        *current = index;
+                    }
+                })
+                .or_insert(index);
+            if identity == (root.node_incarnation, root.stamp, root.revision) {
+                root_index = Some(index);
+            }
+        }
+        let mut retained = RetainedPinSet::new();
+        let root_index = root_index.ok_or(RetainTerminalConeError::RootNotObserved)?;
+        let mut pending = vec![root_index];
+        let mut visited = BTreeSet::new();
+        while let Some(index) = pending.pop() {
+            let lease = &leases.held[index];
+            if !visited.insert(lease.identity()) {
+                continue;
+            }
+            for dependency in lease.dependencies() {
+                let index = by_observation
+                    .get(&(dependency.incarnation, dependency.stamp))
+                    .ok_or_else(|| {
+                        RetainTerminalConeError::DependencyNotObserved(dependency.clone())
+                    })?;
+                pending.push(*index);
+            }
+            retained.lease_erased(lease.duplicate());
+        }
+        Ok(retained)
+    }
+
     fn task_runtime(&self) -> Arc<RuntimeCore> {
         self.task.core.clone()
     }
@@ -3611,6 +4651,98 @@ struct Task {
     /// including nested queries. Only successful top-level completion claims
     /// and commits this aggregate; abort and unwind leave it `Pending`.
     observed_handoffs: Mutex<Vec<Arc<AttemptHandoffLifecycle>>>,
+    /// Lifecycle identities whose complete dependency DAG has already been
+    /// proven live by this rooted task. Every cached identity remains owned by
+    /// an observed root lifecycle for the task's lifetime.
+    checked_handoffs: Mutex<HashSet<usize>>,
+    #[cfg(test)]
+    handoff_validation_visits: AtomicUsize,
+}
+
+struct ParentPermitDonation {
+    task: Arc<Task>,
+    donated: bool,
+}
+
+impl ParentPermitDonation {
+    fn new(task: Arc<Task>) -> Self {
+        let donated = task.release_permit(&task.core);
+        Self { task, donated }
+    }
+}
+
+impl Drop for ParentPermitDonation {
+    fn drop(&mut self) {
+        if self.donated {
+            self.task.acquire_permit(&self.task.core);
+        }
+    }
+}
+
+struct BatchWorkerClaim {
+    core: Arc<RuntimeCore>,
+    count: usize,
+}
+
+impl BatchWorkerClaim {
+    fn new(core: Arc<RuntimeCore>, desired: usize) -> Self {
+        let limit = core.permits.maximum.saturating_sub(1);
+        let mut current = core.batch_workers.load(Ordering::Acquire);
+        let count = loop {
+            let count = desired.min(limit.saturating_sub(current));
+            match core.batch_workers.compare_exchange_weak(
+                current,
+                current + count,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => break count,
+                Err(actual) => current = actual,
+            }
+        };
+        Self { core, count }
+    }
+}
+
+impl Drop for BatchWorkerClaim {
+    fn drop(&mut self) {
+        self.core
+            .batch_workers
+            .fetch_sub(self.count, Ordering::AcqRel);
+    }
+}
+
+struct StructuredWaitGuard {
+    core: Arc<RuntimeCore>,
+    parent: TaskId,
+    children: Vec<TaskId>,
+}
+
+impl StructuredWaitGuard {
+    fn new(
+        core: Arc<RuntimeCore>,
+        parent: TaskId,
+        children: impl IntoIterator<Item = (TaskId, NodeIdentity)>,
+    ) -> Result<Self, Arc<[NodeIdentity]>> {
+        let mut guard = Self {
+            core,
+            parent,
+            children: Vec::new(),
+        };
+        for (child, node) in children {
+            guard.core.begin_wait(parent, child, node)?;
+            guard.children.push(child);
+        }
+        Ok(guard)
+    }
+}
+
+impl Drop for StructuredWaitGuard {
+    fn drop(&mut self) {
+        for child in self.children.drain(..) {
+            self.core.end_wait(self.parent, child);
+        }
+    }
 }
 
 /// Unwind-safe scope for operational nested-attempt ledger filtering.
@@ -3833,6 +4965,15 @@ impl RetainedPinSet {
             false
         }
     }
+
+    fn lease_erased(&mut self, lease: Box<dyn ObservedLease>) -> bool {
+        if self.observed.insert(lease.identity()) {
+            self.held.push(lease);
+            true
+        } else {
+            false
+        }
+    }
 }
 
 impl Drop for RetainedPinSet {
@@ -3846,6 +4987,12 @@ impl Drop for RetainedPinSet {
 /// type parameters lets one task hold observation leases across every family it
 /// touches without a second retention structure.
 trait ObservedLease: Send + Sync {
+    fn identity(&self) -> (u64, u64, Revision);
+
+    fn dependencies(&self) -> &[Observation];
+
+    fn duplicate(&self) -> Box<dyn ObservedLease>;
+
     /// Decrement-only release for batched teardown. Consumes the lease and
     /// decrements its terminal's pin count immediately, but defers the owning
     /// family's `enforce_retention` into the returned [`FamilyEnforcer`] rather
@@ -3860,6 +5007,26 @@ where
     K: QueryKey,
     V: Clone + Send + Sync + 'static,
 {
+    fn identity(&self) -> (u64, u64, Revision) {
+        (
+            self.terminal.node_incarnation,
+            self.terminal.stamp,
+            self.terminal.revision,
+        )
+    }
+
+    fn dependencies(&self) -> &[Observation] {
+        self.terminal.dependencies()
+    }
+
+    fn duplicate(&self) -> Box<dyn ObservedLease> {
+        Box::new(
+            self.family
+                .pin_terminal(&self.terminal)
+                .expect("a live terminal pin can be duplicated"),
+        )
+    }
+
     fn release_deferred(self: Box<Self>) -> FamilyEnforcer {
         // Narrow protection now: this pin no longer holds the terminal. This is
         // the same decrement `Drop` would perform, minus the enforcement pass.
@@ -4015,15 +5182,31 @@ type HandoffCommitBatch = (
 fn rollback_handoff_batches(
     owner: TaskId,
     mut batches: Vec<HandoffCommitBatch>,
-    abort_callbacks: bool,
+    attempted_callbacks: Vec<usize>,
 ) {
+    assert_eq!(
+        batches.len(),
+        attempted_callbacks.len(),
+        "root rollback records one attempted prefix per claimed lifecycle"
+    );
     let mut rollback_safe = vec![true; batches.len()];
-    if abort_callbacks {
-        for (index, (_, handoffs)) in batches.iter_mut().enumerate().rev() {
-            for handoff in handoffs.iter_mut().rev() {
-                if abort_handoff(&mut **handoff).is_err() {
-                    rollback_safe[index] = false;
-                }
+    for (index, (_, handoffs)) in batches.iter_mut().enumerate().rev() {
+        let attempted = attempted_callbacks[index];
+        assert!(
+            attempted <= handoffs.len(),
+            "an attempted callback prefix cannot exceed its lifecycle"
+        );
+        for handoff in handoffs[..attempted].iter_mut().rev() {
+            if abort_handoff(&mut **handoff).is_err() {
+                rollback_safe[index] = false;
+            }
+        }
+        if !rollback_safe[index] {
+            // This lifecycle can no longer be retried. Abort its untouched
+            // suffix as fail-closed cleanup, but preserve untouched callbacks
+            // in every lifecycle whose attempted prefix rolled back cleanly.
+            for handoff in handoffs[attempted..].iter_mut().rev() {
+                let _ = abort_handoff(&mut **handoff);
             }
         }
     }
@@ -4076,7 +5259,20 @@ impl AttemptHandoffLifecycle {
         matches!(*lock(&self.state), AttemptHandoffState::Committed)
     }
 
+    #[cfg(test)]
     fn collect_observed(lifecycle: &Arc<Self>, observed: &mut Vec<Arc<Self>>) -> bool {
+        let mut seen = observed
+            .iter()
+            .map(|lifecycle| Arc::as_ptr(lifecycle) as usize)
+            .collect::<HashSet<_>>();
+        Self::collect_observed_once(lifecycle, observed, &mut seen)
+    }
+
+    fn collect_observed_once(
+        lifecycle: &Arc<Self>,
+        observed: &mut Vec<Arc<Self>>,
+        seen: &mut HashSet<usize>,
+    ) -> bool {
         {
             let state = lock(&lifecycle.state);
             match &*state {
@@ -4085,17 +5281,16 @@ impl AttemptHandoffLifecycle {
                 AttemptHandoffState::Pending(_) | AttemptHandoffState::Committing { .. } => {}
             }
         }
+        let identity = Arc::as_ptr(lifecycle) as usize;
+        if !seen.insert(identity) {
+            return true;
+        }
         for dependency in lifecycle.observed.iter() {
-            if !Self::collect_observed(dependency, observed) {
+            if !Self::collect_observed_once(dependency, observed, seen) {
                 return false;
             }
         }
-        if !observed
-            .iter()
-            .any(|current| Arc::ptr_eq(current, lifecycle))
-        {
-            observed.push(lifecycle.clone());
-        }
+        observed.push(lifecycle.clone());
         true
     }
 
@@ -4214,6 +5409,80 @@ impl Drop for AttemptHandoffLifecycle {
 }
 
 impl Task {
+    fn batch_child(self: &Arc<Self>, id: u64) -> Arc<Self> {
+        let inherited_filter = lock(&self.nested_attempt_filters).last().cloned();
+        let inherits_registered_validation = !lock(&self.validation_endorsements).is_empty();
+        // These flags are intentionally shared: crossing an unregistered
+        // evaluator in any structured descendant taints every enclosing
+        // registered-only validation walk.
+        let inherited_validation_proofs = lock(&self.validation_proofs).clone();
+        Arc::new(Self {
+            id: TaskId(id),
+            core: self.core.clone(),
+            revision: self.revision,
+            cancellation: self.cancellation.clone(),
+            owns_permit: AtomicBool::new(false),
+            stack: Mutex::new(Vec::new()),
+            nested_attempts: Mutex::new(Vec::new()),
+            nested_attempt_filters: Mutex::new(inherited_filter.into_iter().collect()),
+            // A batch child is a structured descendant of the lexical proof
+            // scope, but starts with no endorsements: it must validate and pin
+            // its own complete cone before the parent can absorb either.
+            validation_endorsements: Mutex::new(
+                inherits_registered_validation
+                    .then(BTreeSet::new)
+                    .into_iter()
+                    .collect(),
+            ),
+            validation_proofs: Mutex::new(inherited_validation_proofs),
+            leases: Mutex::new(TaskLeases::default()),
+            observed_handoffs: Mutex::new(Vec::new()),
+            checked_handoffs: Mutex::new(HashSet::new()),
+            #[cfg(test)]
+            handoff_validation_visits: AtomicUsize::new(0),
+        })
+    }
+
+    fn absorb_batch_child(&self, child: &Arc<Self>, transfer_handoffs: bool) {
+        let mut child_leases = lock(&child.leases);
+        let mut parent_leases = lock(&self.leases);
+        for lease in child_leases.held.drain(..) {
+            let identity = lease.identity();
+            if parent_leases.observed.insert(identity) {
+                parent_leases.held.push(lease);
+            }
+        }
+        child_leases.observed.clear();
+        drop(parent_leases);
+        drop(child_leases);
+
+        let child_endorsements = std::mem::take(&mut *lock(&child.validation_endorsements));
+        if let Some(child_endorsements) = child_endorsements.last() {
+            for scope in lock(&self.validation_endorsements).iter_mut() {
+                scope.extend(child_endorsements.iter().copied());
+            }
+        }
+
+        let child_attempts = std::mem::take(&mut *lock(&child.nested_attempts));
+        lock(&self.nested_attempts).extend(child_attempts);
+
+        let child_handoffs = std::mem::take(&mut *lock(&child.observed_handoffs));
+        if !transfer_handoffs {
+            return;
+        }
+        lock(&self.checked_handoffs).extend(std::mem::take(&mut *lock(&child.checked_handoffs)));
+        assert!(
+            child_handoffs.len() <= 1,
+            "a structured child returns at most one encapsulating root lifecycle"
+        );
+        for handoff in child_handoffs {
+            assert!(
+                self.observe_handoff(handoff),
+                "a successful structured child returns a live handoff lifecycle"
+            );
+        }
+    }
+
     fn next_nested_request(&self) -> u64 {
         self.core.next_task.fetch_add(1, Ordering::Relaxed)
     }
@@ -4385,12 +5654,11 @@ impl Task {
         {
             return true;
         }
+        if !self.validate_handoff(&handoff) {
+            return false;
+        }
         let mut stack = lock(&self.stack);
         if let Some(frame) = stack.last_mut() {
-            let mut closure = Vec::new();
-            if !AttemptHandoffLifecycle::collect_observed(&handoff, &mut closure) {
-                return false;
-            }
             if !frame
                 .observed_handoffs
                 .iter()
@@ -4401,20 +5669,53 @@ impl Task {
             return true;
         }
         drop(stack);
-        let mut closure = Vec::new();
-        if !AttemptHandoffLifecycle::collect_observed(&handoff, &mut closure) {
-            return false;
-        }
         let mut observed = lock(&self.observed_handoffs);
-        for handoff in closure {
-            if !observed
-                .iter()
-                .any(|current| Arc::ptr_eq(current, &handoff))
-            {
-                observed.push(handoff);
-            }
+        if !observed
+            .iter()
+            .any(|current| Arc::ptr_eq(current, &handoff))
+        {
+            // Keep only the returned root. It owns its dependency lifecycle
+            // DAG, which the commit barrier expands once in dependency order.
+            observed.push(handoff);
         }
         true
+    }
+
+    fn validate_handoff(&self, handoff: &Arc<AttemptHandoffLifecycle>) -> bool {
+        let mut checked = lock(&self.checked_handoffs);
+        let mut newly_checked = HashSet::new();
+        if !self.validate_handoff_once(handoff, &checked, &mut newly_checked) {
+            return false;
+        }
+        checked.extend(newly_checked);
+        true
+    }
+
+    fn validate_handoff_once(
+        &self,
+        lifecycle: &Arc<AttemptHandoffLifecycle>,
+        checked: &HashSet<usize>,
+        newly_checked: &mut HashSet<usize>,
+    ) -> bool {
+        let identity = Arc::as_ptr(lifecycle) as usize;
+        if checked.contains(&identity) || !newly_checked.insert(identity) {
+            return true;
+        }
+        #[cfg(test)]
+        self.handoff_validation_visits
+            .fetch_add(1, Ordering::Relaxed);
+        {
+            let state = lock(&lifecycle.state);
+            match &*state {
+                AttemptHandoffState::Committed => return true,
+                AttemptHandoffState::Aborted => return false,
+                AttemptHandoffState::Pending(_) | AttemptHandoffState::Committing { .. } => {}
+            }
+        }
+        lifecycle
+            .observed
+            .iter()
+            .all(|dependency| self.validate_handoff_once(dependency, checked, newly_checked))
     }
 
     fn commit_handoffs(&self) -> Result<(), RootHandoffCommitFailure> {
@@ -4422,7 +5723,15 @@ impl Task {
             !self.owns_permit.load(Ordering::Acquire),
             "root handoffs commit only after releasing the execution permit"
         );
-        let observed = std::mem::take(&mut *lock(&self.observed_handoffs));
+        let roots = std::mem::take(&mut *lock(&self.observed_handoffs));
+        let mut observed = Vec::new();
+        let mut seen = HashSet::new();
+        for lifecycle in roots {
+            if !AttemptHandoffLifecycle::collect_observed_once(&lifecycle, &mut observed, &mut seen)
+            {
+                return Err(RootHandoffCommitFailure::Invalidated);
+            }
+        }
         let mut acquisition_order = observed.into_iter().enumerate().collect::<Vec<_>>();
         acquisition_order.sort_unstable_by_key(|(_, lifecycle)| Arc::as_ptr(lifecycle));
         let mut ordered_batches = Vec::with_capacity(acquisition_order.len());
@@ -4436,16 +5745,18 @@ impl Task {
                     let batches = ordered_batches
                         .into_iter()
                         .map(|(_, lifecycle, handoffs)| (lifecycle, handoffs))
-                        .collect();
-                    rollback_handoff_batches(self.id, batches, false);
+                        .collect::<Vec<_>>();
+                    let attempted_callbacks = vec![0; batches.len()];
+                    rollback_handoff_batches(self.id, batches, attempted_callbacks);
                     return Err(RootHandoffCommitFailure::Invalidated);
                 }
                 AttemptHandoffCommit::Canceled => {
                     let batches = ordered_batches
                         .into_iter()
                         .map(|(_, lifecycle, handoffs)| (lifecycle, handoffs))
-                        .collect();
-                    rollback_handoff_batches(self.id, batches, false);
+                        .collect::<Vec<_>>();
+                    let attempted_callbacks = vec![0; batches.len()];
+                    rollback_handoff_batches(self.id, batches, attempted_callbacks);
                     return Err(RootHandoffCommitFailure::Canceled);
                 }
             }
@@ -4457,14 +5768,16 @@ impl Task {
             .collect::<Vec<_>>();
 
         let mut failure = None;
-        let mut commit_started = false;
-        'commit: for (_, handoffs) in &mut batches {
+        let mut attempted_callbacks = vec![0; batches.len()];
+        'commit: for (batch_index, (_, handoffs)) in batches.iter_mut().enumerate() {
             for handoff in handoffs {
                 if self.cancellation.is_canceled() {
                     failure = Some(RootHandoffCommitFailure::Canceled);
                     break 'commit;
                 }
-                commit_started = true;
+                // Count the callback before entering user code: a panicking
+                // commit may already have installed state that abort must undo.
+                attempted_callbacks[batch_index] += 1;
                 if let Err(payload) = commit_handoff(&mut **handoff) {
                     failure = Some(RootHandoffCommitFailure::Panicked(payload));
                     break 'commit;
@@ -4476,9 +5789,10 @@ impl Task {
         }
         if let Some(failure) = failure {
             // Root publication is one transaction. Roll back every handoff,
-            // including earlier successful callbacks, before making any of the
-            // terminals claimable by another root.
-            rollback_handoff_batches(self.id, batches, commit_started);
+            // in the attempted prefix, including earlier successful callbacks,
+            // before making any of the terminals claimable by another root.
+            // Unattempted callbacks retain their pending state for retry.
+            rollback_handoff_batches(self.id, batches, attempted_callbacks);
             return Err(failure);
         }
 
@@ -4626,12 +5940,6 @@ impl Drop for Task {
     }
 }
 
-#[derive(Debug)]
-struct WaitEdge {
-    owner: TaskId,
-    node: ExactNodeIdentity,
-}
-
 impl RuntimeCore {
     fn revision_input(&self, revision: Revision, input: &InputIdentity) -> Option<u64> {
         let revisions = lock(&self.revisions);
@@ -4765,34 +6073,61 @@ impl RuntimeCore {
         &self,
         waiter: TaskId,
         owner: TaskId,
-        node: ExactNodeIdentity,
+        node: NodeIdentity,
     ) -> Result<(), Arc<[NodeIdentity]>> {
         let mut graph = lock(&self.wait_graph);
-        graph.insert(waiter, WaitEdge { owner, node });
-        let mut cursor = owner;
-        let mut nodes = Vec::new();
-        while let Some(edge) = graph.get(&cursor) {
-            nodes.push(edge.node.display.clone());
-            cursor = edge.owner;
-            if cursor == waiter {
-                nodes.push(
-                    graph
-                        .get(&waiter)
-                        .expect("new wait edge is present")
-                        .node
-                        .display
-                        .clone(),
-                );
+        let previous = graph.entry(waiter).or_default().insert(owner, node.clone());
+        assert!(
+            previous.is_none(),
+            "one task cannot register the same wait owner twice"
+        );
+        let mut path = Vec::new();
+        let mut visited = BTreeSet::new();
+        if wait_path(&graph, owner, waiter, &mut visited, &mut path) {
+            path.push(node);
+            let edges = graph.get_mut(&waiter).expect("new wait edge is present");
+            edges.remove(&owner);
+            if edges.is_empty() {
                 graph.remove(&waiter);
-                return Err(canonical_cycle(nodes));
             }
+            return Err(canonical_cycle(path));
         }
         Ok(())
     }
 
-    fn end_wait(&self, waiter: TaskId) {
-        lock(&self.wait_graph).remove(&waiter);
+    fn end_wait(&self, waiter: TaskId, owner: TaskId) {
+        let mut graph = lock(&self.wait_graph);
+        let Some(edges) = graph.get_mut(&waiter) else {
+            return;
+        };
+        edges.remove(&owner);
+        if edges.is_empty() {
+            graph.remove(&waiter);
+        }
     }
+}
+
+fn wait_path(
+    graph: &BTreeMap<TaskId, BTreeMap<TaskId, NodeIdentity>>,
+    current: TaskId,
+    target: TaskId,
+    visited: &mut BTreeSet<TaskId>,
+    path: &mut Vec<NodeIdentity>,
+) -> bool {
+    if !visited.insert(current) {
+        return false;
+    }
+    let Some(edges) = graph.get(&current) else {
+        return false;
+    };
+    for (owner, node) in edges {
+        path.push(node.clone());
+        if *owner == target || wait_path(graph, *owner, target, visited, path) {
+            return true;
+        }
+        path.pop();
+    }
+    false
 }
 
 #[derive(Debug)]
@@ -5072,6 +6407,30 @@ mod tests {
         }
 
         fn abort(&mut self) {
+            lock(&self.events).push("abort");
+        }
+    }
+
+    #[derive(Debug)]
+    struct RetryStateHandoff {
+        name: &'static str,
+        pending: bool,
+        events: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl QueryAttemptHandoff for RetryStateHandoff {
+        fn commit(&mut self) {
+            assert!(self.pending, "a retryable handoff commits from pending");
+            self.pending = false;
+            lock(&self.events).push(self.name);
+        }
+
+        fn abort(&mut self) {
+            assert!(
+                !self.pending,
+                "an unattempted handoff must not be aborted during rollback"
+            );
+            self.pending = true;
             lock(&self.events).push("abort");
         }
     }
@@ -6419,6 +7778,11 @@ mod tests {
                         commits: evaluator_commits.clone(),
                         aborts: evaluator_aborts.clone(),
                     });
+                    context.register_attempt_handoff(RetryStateHandoff {
+                        name: "suffix-commit",
+                        pending: true,
+                        events: Arc::new(Mutex::new(Vec::new())),
+                    });
                     Ok(QueryOutput::success(1))
                 },
             )
@@ -6452,6 +7816,77 @@ mod tests {
         assert_eq!(retry.execution(), RequestExecution::Reused);
         assert_eq!(commits.load(Ordering::SeqCst), 2);
         assert_eq!(aborts.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn cancellation_preserves_unattempted_lifecycles_for_retry() {
+        let runtime = QueryRuntime::new(1);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let first = Arc::new(AttemptHandoffLifecycle::new(
+            vec![Box::new(RetryStateHandoff {
+                name: "first",
+                pending: true,
+                events: events.clone(),
+            })],
+            Vec::new(),
+        ));
+        let second = Arc::new(AttemptHandoffLifecycle::new(
+            vec![
+                Box::new(RetryStateHandoff {
+                    name: "second",
+                    pending: true,
+                    events: events.clone(),
+                }),
+                Box::new(RetryStateHandoff {
+                    name: "third",
+                    pending: true,
+                    events: events.clone(),
+                }),
+            ],
+            Vec::new(),
+        ));
+        let owner = TaskId(1);
+        let cancellation = CancellationToken::new();
+        let AttemptHandoffCommit::Claimed(mut first_handoffs) =
+            first.begin_commit(owner, &cancellation, &runtime.core)
+        else {
+            panic!("fresh lifecycle is claimable")
+        };
+        let AttemptHandoffCommit::Claimed(second_handoffs) =
+            second.begin_commit(owner, &cancellation, &runtime.core)
+        else {
+            panic!("the untouched lifecycle is claimable")
+        };
+        first_handoffs[0].commit();
+        rollback_handoff_batches(
+            owner,
+            vec![
+                (first.clone(), first_handoffs),
+                (second.clone(), second_handoffs),
+            ],
+            vec![1, 0],
+        );
+
+        let retry = TaskId(2);
+        let AttemptHandoffCommit::Claimed(mut first_handoffs) =
+            first.begin_commit(retry, &cancellation, &runtime.core)
+        else {
+            panic!("the attempted lifecycle returns to pending")
+        };
+        let AttemptHandoffCommit::Claimed(mut second_handoffs) =
+            second.begin_commit(retry, &cancellation, &runtime.core)
+        else {
+            panic!("the unattempted lifecycle remains pending")
+        };
+        for handoff in first_handoffs.iter_mut().chain(second_handoffs.iter_mut()) {
+            handoff.commit();
+        }
+        first.finish_commit(retry);
+        second.finish_commit(retry);
+        assert_eq!(
+            *lock(&events),
+            ["first", "abort", "first", "second", "third"]
+        );
     }
 
     #[test]
@@ -6571,6 +8006,8 @@ mod tests {
             validation_proofs: Mutex::new(Vec::new()),
             leases: Mutex::new(TaskLeases::default()),
             observed_handoffs: Mutex::new(Vec::new()),
+            checked_handoffs: Mutex::new(HashSet::new()),
+            handoff_validation_visits: AtomicUsize::new(0),
         };
         task.push(ExactNodeIdentity {
             display: NodeIdentity {
@@ -6590,6 +8027,58 @@ mod tests {
         assert!(
             lock(&task.observed_handoffs).is_empty(),
             "a root must not retain the shared committed lifecycle"
+        );
+    }
+
+    #[test]
+    fn rooted_task_validates_each_shared_handoff_lifecycle_once() {
+        let runtime = QueryRuntime::new(1);
+        let mut chain = vec![Arc::new(AttemptHandoffLifecycle::new(
+            Vec::new(),
+            Vec::new(),
+        ))];
+        for _ in 0..1_024 {
+            chain.push(Arc::new(AttemptHandoffLifecycle::new(
+                Vec::new(),
+                vec![chain.last().unwrap().clone()],
+            )));
+        }
+        let task = Task {
+            id: TaskId(44),
+            core: runtime.core.clone(),
+            revision: revision(1),
+            cancellation: CancellationToken::new(),
+            owns_permit: AtomicBool::new(false),
+            stack: Mutex::new(Vec::new()),
+            nested_attempts: Mutex::new(Vec::new()),
+            nested_attempt_filters: Mutex::new(Vec::new()),
+            validation_endorsements: Mutex::new(Vec::new()),
+            validation_proofs: Mutex::new(Vec::new()),
+            leases: Mutex::new(TaskLeases::default()),
+            observed_handoffs: Mutex::new(Vec::new()),
+            checked_handoffs: Mutex::new(HashSet::new()),
+            handoff_validation_visits: AtomicUsize::new(0),
+        };
+        task.push(ExactNodeIdentity {
+            display: NodeIdentity {
+                family: Arc::from("handoff-cache-test"),
+                key: Arc::from("root"),
+            },
+            incarnation: 1,
+        });
+
+        assert!(task.observe_handoff(chain.last().unwrap().clone()));
+        assert_eq!(
+            task.handoff_validation_visits.load(Ordering::Relaxed),
+            chain.len()
+        );
+        for lifecycle in chain.iter().rev() {
+            assert!(task.observe_handoff(lifecycle.clone()));
+        }
+        assert_eq!(
+            task.handoff_validation_visits.load(Ordering::Relaxed),
+            chain.len(),
+            "repeated observations of a shared deep DAG are constant-time cache hits"
         );
     }
 
@@ -6735,7 +8224,7 @@ mod tests {
                 (first.clone(), first_handoffs),
                 (second.clone(), second_handoffs),
             ],
-            true,
+            vec![1, 1],
         );
 
         let retry_owner = TaskId(2);
@@ -6767,7 +8256,9 @@ mod tests {
             .next()
             .expect("commit barrier ends before root-abort cleanup");
         assert!(commit_body.contains("commit_handoff(&mut **handoff)"));
-        assert!(commit_body.contains("rollback_handoff_batches(self.id, batches, commit_started)"));
+        assert!(
+            commit_body.contains("rollback_handoff_batches(self.id, batches, attempted_callbacks)")
+        );
     }
 
     #[test]
@@ -6837,6 +8328,8 @@ mod tests {
             validation_proofs: Mutex::new(Vec::new()),
             leases: Mutex::new(TaskLeases::default()),
             observed_handoffs: Mutex::new(Vec::new()),
+            checked_handoffs: Mutex::new(HashSet::new()),
+            handoff_validation_visits: AtomicUsize::new(0),
         });
         assert!(task.observe_handoff(parent.clone()));
         child.abort();
@@ -10398,6 +11891,43 @@ mod tests {
     // body leases many terminals in one family runs exactly one retention
     // enforcement pass at completion — not one per released pin — while still
     // converging to the same final retained state as the per-pin path.
+    #[test]
+    fn duplicate_pin_drop_defers_retention_until_the_last_pin_releases() {
+        let runtime = QueryRuntime::new(1);
+        publish_empty(&runtime, [revision(1)]);
+        let family = runtime
+            .family::<Slot, u64>("last-pin-enforcement", 0)
+            .unwrap();
+        let attempt = runtime.request(
+            &family,
+            revision(1),
+            Slot(0),
+            CancellationToken::new(),
+            |_| Ok(QueryOutput::success(0)),
+        );
+        let terminal = attempt.terminal().unwrap().clone();
+        let first = family.pin_terminal(&terminal).unwrap();
+        let last = family.pin_terminal(&terminal).unwrap();
+        drop(attempt);
+        let before = runtime.metrics().retention_enforcements;
+
+        drop(first);
+        assert_eq!(
+            runtime.metrics().retention_enforcements,
+            before,
+            "a non-last pin release cannot make retention progress"
+        );
+        assert_eq!(family.retention().terminals, 1);
+
+        drop(last);
+        assert_eq!(
+            runtime.metrics().retention_enforcements,
+            before + 1,
+            "the last pin release runs the deferred retention pass"
+        );
+        assert_eq!(family.retention().terminals, 0);
+    }
+
     #[test]
     fn batched_task_lease_release_enforces_once_per_family_and_converges() {
         let runtime = QueryRuntime::new(8);

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -215,8 +215,8 @@ const VERSION: &str = rue_compiler::VERSION;
 /// Highest explicit `-j`/`--jobs` value accepted by the CLI.
 ///
 /// `0` still means auto-detect. A fixed generous ceiling catches accidental
-/// values like `-j 100000` before Rayon tries to spawn an impractical number
-/// of worker threads, while still leaving ample room above current CI and
+/// values like `-j 100000` before the compiler schedules an impractical number
+/// of workers, while still leaving ample room above current CI and
 /// workstation core counts.
 const MAX_EXPLICIT_JOBS: usize = 256;
 
@@ -1025,11 +1025,9 @@ fn main() {
         options.benchmark_json,
     );
 
-    // Configure Rayon's global thread pool ONCE, before dispatching to either
-    // the `--emit` path or the normal compile path. `build_global()` panics if
-    // called twice, so it lives here rather than inside a per-compilation entry
-    // point — the previous placement meant `--emit` ignored `-j`/`--jobs`
-    // entirely (RUE-352).
+    // Configure the compiler's shared structured-query budget before
+    // dispatching to either the `--emit` path or the normal compile path, so
+    // every driver path honors `-j`/`--jobs` (RUE-352).
     configure_thread_pool(options.jobs);
 
     // Discover and load @import-ed modules from disk, transitively. Sema


### PR DESCRIPTION
## Summary

- add bounded structured batch queries with typed cycle detection, cancellation, stable reduction, exact dependency-cone retention, and transactional resource handoff
- make body reachability a distinct production query authority and schedule ordinary body frontiers through it
- retain exact parked and final body cones with rollback-safe publication ordering
- remove the parallel peer paths from CFG and backend orchestration so query scheduling is the sole concurrency authority

## Correctness

Publication handoffs now roll back only attempted callback prefixes and preserve untouched work for retry. Compiler root publications retain and restore predecessor roots plus lookup metadata. Regression coverage exercises cancellation across closure installation, parked-root clearing, and lookup publication, then verifies a successful retry.

## Performance

Local large-example measurements on the same macOS host:

| Workload | This branch | Upstream baseline |
| --- | ---: | ---: |
| Meridian, default jobs | 35.47s | 23.74s |
| Meridian, one job | 31.87s | 123.24s |
| Caldera, default jobs | 119.71s | did not finish in 396.95s |

This removes the pathological single-worker and Caldera behavior. The default Meridian cost is the intentional temporary serialization of CFG and codegen; follow-up query fan-out is tracked separately.

skip RUE-1030. skip RUE-1031.

## Validation

- full serialized test suite
- 103 rue-query unit tests
- 847 compiler unit tests (1 benchmark ignored)
- 2,175 specification cases (18 ignored)
- 1,691 CLI cases (11 ignored) plus 18 slow CLI cases
- 209 UI cases
- Meridian and Caldera slow example suites
- frontend/oracle differential and reproducibility suites
- adversarial architecture and cancellation review

Fixes RUE-1028.