### PR TITLE
RUE-1158: make CLI case timings an output of the corpus action

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -300,6 +300,12 @@ CLI_TEST_SHARD_COUNT = 4
         ]),
         absolutize = _CLI_TEST_ABSOLUTIZE,
         timeout_seconds = _CLI_SHARD_TIMEOUT_SECONDS,
+        # RUE-1158 rebalances the shards from measured per-case cost. The
+        # measurements are a declared output of the action rather than an
+        # executor --env path, so a cache hit replays the timings that produced
+        # the tree instead of leaving shard-weights.json to refresh only when a
+        # shard actually executes. See cached_corpus_suite's case_timings doc.
+        case_timings = True,
     )
     for _shard in range(CLI_TEST_SHARD_COUNT)
 ]

--- a/corpus.bzl
+++ b/corpus.bzl
@@ -35,7 +35,8 @@ def cached_corpus_suite(
         absolutize = [],
         labels = [],
         tier = "premerge",
-        timeout_seconds = None):
+        timeout_seconds = None,
+        case_timings = False):
     """Define a corpus suite whose expensive run is a cacheable build action.
 
     Args:
@@ -57,6 +58,15 @@ def cached_corpus_suite(
         timeout_seconds: outer bound replacing the test executor's timeout, which
             a build action does not get. The per-case budgets in
             execution_contracts.toml remain the honest gates.
+        case_timings: emit RUE-1158's per-case measurements as a declared
+            *output* of the action, exposed as the `[timings]` sub-target. It
+            must be an output rather than an `--env` path: the harness now runs
+            inside the action, where a test-executor `--env` never reaches it,
+            and a per-run mktemp path would change the action's digest on every
+            run and defeat the caching this rule exists for. As an output it is
+            stored with the stamp and materialized on a cache hit, so
+            shard-weights.json keeps refreshing on replayed runs rather than
+            only when a corpus actually executes.
     """
     for key in absolutize:
         if key not in env:
@@ -69,6 +79,7 @@ def cached_corpus_suite(
         corpus_env = env,
         absolutize = absolutize,
         timeout_seconds = timeout_seconds,
+        case_timings = case_timings,
     )
 
     native.sh_test(
@@ -82,7 +93,29 @@ def _corpus_action_impl(ctx: AnalysisContext) -> list[Provider]:
     stamp = ctx.actions.declare_output("stamp.txt")
 
     action_env = dict(ctx.attrs.corpus_env.items())
-    action_env["RUE_CORPUS_ABSOLUTIZE"] = " ".join(ctx.attrs.absolutize)
+    absolutize = list(ctx.attrs.absolutize)
+
+    # RUE-1158's per-case measurements. This is an action *output*, not an
+    # `--env` path: the harness runs inside the action now, so a test-executor
+    # --env never reaches it, and the old per-run mktemp/RUNNER_TEMP path would
+    # change the action's digest on every run and defeat the caching entirely.
+    # Declared as an output it travels with the stamp in the cache entry, so a
+    # replayed merge_group run materializes the timings the PR run measured and
+    # shard-weights.json keeps refreshing on cached runs.
+    #
+    # The path is derived from the target name, so it is stable across runs and
+    # digest-neutral. It is absolutized for the same reason every other corpus
+    # path is: the harness File::create()s it after the compiler has already
+    # moved cwd into a case temp directory.
+    timings = None
+    extra_outputs = []
+    if ctx.attrs.case_timings:
+        timings = ctx.actions.declare_output("case-timings.jsonl")
+        action_env["RUE_CLI_CASE_TIMINGS"] = cmd_args(timings.as_output())
+        absolutize.append("RUE_CLI_CASE_TIMINGS")
+        extra_outputs.append(timings)
+
+    action_env["RUE_CORPUS_ABSOLUTIZE"] = " ".join(absolutize)
     if ctx.attrs.timeout_seconds != None:
         action_env["RUE_CORPUS_TIMEOUT_SECONDS"] = str(ctx.attrs.timeout_seconds)
 
@@ -114,7 +147,17 @@ def _corpus_action_impl(ctx: AnalysisContext) -> list[Provider]:
         allow_cache_upload = True,
     )
 
-    return [DefaultInfo(default_output = stamp)]
+    sub_targets = {}
+    if timings != None:
+        sub_targets["timings"] = [DefaultInfo(default_output = timings)]
+
+    # The stamp stays the default output: `//:NAME`'s sh_test asserts it, and a
+    # corpus's result is the pass, not the measurement.
+    return [DefaultInfo(
+        default_output = stamp,
+        other_outputs = extra_outputs,
+        sub_targets = sub_targets,
+    )]
 
 _corpus_action = rule(
     impl = _corpus_action_impl,
@@ -123,6 +166,7 @@ _corpus_action = rule(
         # and registers what they name as inputs of the action — which is what
         # keys the cache entry, and what the input contract above is about.
         "absolutize": attrs.list(attrs.string(), default = []),
+        "case_timings": attrs.bool(default = False),
         "corpus_env": attrs.dict(attrs.string(), attrs.arg(), default = {}),
         "harness": attrs.dep(providers = [RunInfo]),
         "harness_args": attrs.list(attrs.string(), default = []),

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -235,6 +235,19 @@ Two consequences are worth knowing before changing a corpus target:
    plain genrule therefore never uploads here, and the first merge_group run of
    RUE-1118 re-executed every corpus on a tree byte-identical to the one the PR
    run had just built. The rule sets `allow_cache_upload = True` explicitly.
+4. **A measurement the corpus produces must be a declared output, not a path
+   handed in.** RUE-1158 rebalances the CLI shards from per-case timings, which
+   `ci-heavy-suite` used to collect by passing `--env RUE_CLI_CASE_TIMINGS=` to
+   the test executor. Neither half of that survives the conversion: the harness
+   now runs inside the action, where an executor `--env` never reaches it, and
+   the path was a per-run `mktemp`/`RUNNER_TEMP` value, which would change the
+   action's digest on every run and defeat the caching entirely. The timings are
+   a second declared output (`cached_corpus_suite(case_timings = True)`, exposed
+   as `:NAME-action[timings]`), so they are stored with the stamp and
+   materialize on a cache hit. `ci-heavy-suite` fetches that sub-target after the
+   run and copies it to the path `ci.yml` uploads. The general rule: anything a
+   corpus *produces* that outlives the run belongs in the action's outputs, or it
+   silently stops existing the moment the suite starts being cache-served.
 
 ### Reading whether a corpus was cache-served
 
@@ -244,7 +257,10 @@ that line as evidence of anything.** Two signals actually answer the question:
 
 - `Commands: N (cached: C, remote: R, local: L)` — the corpus is one action, so a
   cache-served suite adds to `cached` and a re-executed one adds to `local`. The
-  pre-RUE-1118 baseline for a CLI shard was 465 commands; it is 466 now.
+  pre-RUE-1118 baseline for a CLI shard was 465 commands; it is 466 now. A
+  shard's `cli-tests: measured N cases` line answers it too: the timings are an
+  output of that same action, so `N` is the case count of whichever run produced
+  the cache entry, not proof that this run executed anything.
 - the job's wall time, which is unambiguous.
 
 This matters because the two failure modes look identical in the test output. A

--- a/scripts/ci-heavy-suite
+++ b/scripts/ci-heavy-suite
@@ -36,7 +36,16 @@ trap cleanup EXIT
 # RUE-1159. The per-case budgets in execution_contracts.toml remain the honest
 # gates for both.
 test_args=("$target")
+
+# RUE-1158 shard weights. The measurements are a declared output of the corpus
+# action (`:NAME-action[timings]`), not an executor `--env` path, so they are
+# stored in the cache entry alongside the stamp and materialize on a hit too.
+# Copy them to the stable path ci.yml's upload step expects, after the run.
 timings=""
+if [[ "$target" == //:cli-tests-shard-* ]]; then
+    timings="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/rue-cli-case-timings.jsonl"
+fi
+
 case "$target" in
     //:cli-tests-slow)
         timeout_tool="${RUE_CLI_TIMEOUT_POLICY_TOOL:-scripts/cli-timeout-policy.py}"
@@ -60,22 +69,27 @@ fi
 
 ./buck2 test "${test_args[@]}" 2>&1 | tee "$log"
 status=${PIPESTATUS[0]}
-if [[ -n "$timings" && -s "$timings" ]]; then
-    timing_cases="$(grep -c '"event":"rue_cli_case_timing"' "$timings")"
-    echo "cli-tests: measured $timing_cases cases in $timings"
-fi
 if [[ "$status" -ne 0 ]]; then
     exit "$status"
+fi
+
+if [[ -n "$timings" ]]; then
+    # The sh_test only asserts the stamp, so the timings output is not
+    # materialized by the test run. Ask for it explicitly; this is a cache
+    # lookup on the action that just ran, never a re-execution of the corpus.
+    if produced="$(./buck2 build --show-simple-output "${target}-action[timings]" 2>/dev/null)" \
+        && [[ -n "$produced" && -f "$produced" ]]; then
+        cp "$produced" "$timings"
+        timing_cases="$(grep -c '"event":"rue_cli_case_timing"' "$timings" || true)"
+        echo "cli-tests: measured $timing_cases cases in $timings"
+    else
+        # Not fatal: the artifact upload is `if-no-files-found: ignore`, and the
+        # suite's own Buck result below remains the required signal.
+        echo "cli-tests: no case timings produced for $target" >&2
+    fi
 fi
 
 if ! grep -qE "(Pass|Fail|Skip|Timeout|Fatal|Omit|Flaky): root${target} " "$log"; then
     echo "error: explicit CI shard produced no result for $target" >&2
     exit 1
-fi
-
-if [[ -n "$timings" && ! -s "$timings" ]]; then
-    # A remotely cached Buck test result does not replay the test process's
-    # out-of-sandbox metrics file. That is a legitimate zero-execution run,
-    # not a corpus omission; the explicit Buck result above remains required.
-    echo "cli-tests: measured 0 cases (cached result or unavailable timings)"
 fi

--- a/scripts/test-corpus-action.sh
+++ b/scripts/test-corpus-action.sh
@@ -88,6 +88,34 @@ t_absolutize() {
     rm -rf "$dir"
 }
 
+# RUE-1158's case-timings variable names a declared *output*, so the file does
+# not exist when the harness starts. It must still absolutize — the harness
+# creates it after the compiler has moved cwd into a case temp directory, so a
+# relative value would write the measurements somewhere else and the action
+# would fail its declared output.
+t_absolutize_declared_output() {
+    local dir status observed
+    dir="$(sandbox)"
+    mkdir -p "$dir/out"
+    printf '#!/usr/bin/env bash\nprintf "%%s" "$RUE_CLI_CASE_TIMINGS" > "$OBSERVED"\n: > "$RUE_CLI_CASE_TIMINGS"\nexit 0\n' >"$dir/harness"
+    chmod +x "$dir/harness"
+    (
+        cd "$dir" &&
+            OBSERVED="$dir/observed" \
+                RUE_CLI_CASE_TIMINGS="out/case-timings.jsonl" \
+                RUE_CORPUS_ABSOLUTIZE="RUE_CLI_CASE_TIMINGS" \
+                "$CORPUS_ACTION" "$dir/stamp.txt" ./harness >/dev/null 2>&1
+    )
+    status=$?
+    observed="$(cat "$dir/observed" 2>/dev/null)"
+    check "not-yet-created output absolutizes" "0" "$status"
+    check "declared output path reaches the harness absolute" \
+        "$(cd "$dir/out" && pwd)/case-timings.jsonl" "$observed"
+    check "harness wrote through the absolutized output path" \
+        "yes" "$([ -e "$dir/out/case-timings.jsonl" ] && echo yes || echo no)"
+    rm -rf "$dir"
+}
+
 # An unset variable named in RUE_CORPUS_ABSOLUTIZE is a BUCK wiring bug. Failing
 # closed matters more than usual here: continuing would let the harness fall back
 # to its own relative default and pass against the wrong corpus.
@@ -157,6 +185,7 @@ t_usage() {
 t_success
 t_failure_writes_no_stamp
 t_absolutize
+t_absolutize_declared_output
 t_missing_absolutize_target_fails
 t_plumbing_is_hidden
 t_timeout

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -813,16 +813,18 @@ if [ "$1" = "bxl" ]; then
 fi
 if [ "$1" = "test" ]; then
   if [ -n "${FAKE_CALL_LOG:-}" ]; then printf '%s\n' "$*" >>"$FAKE_CALL_LOG"; fi
-  for arg in "$@"; do
-    case "$arg" in
-      RUE_CLI_CASE_TIMINGS=*)
-        timing_path="${arg#RUE_CLI_CASE_TIMINGS=}"
-        printf '%s\n' '{"event":"rue_cli_case_timing","name":"fake","elapsed_s":0.1}' >"$timing_path"
-        ;;
-    esac
-  done
   if [ "${FAKE_OMIT:-0}" != 1 ]; then printf 'Pass: root%s (0.1s)\n' "$2"; fi
   exit "${FAKE_EXIT:-0}"
+fi
+# RUE-1118: case timings are a declared output of the corpus action, fetched
+# after the run rather than handed in as an executor --env path.
+if [ "$1" = "build" ]; then
+  if [ -n "${FAKE_CALL_LOG:-}" ]; then printf '%s\n' "$*" >>"$FAKE_CALL_LOG"; fi
+  if [ "${FAKE_NO_TIMINGS:-0}" = 1 ]; then exit 1; fi
+  out="$PWD/fake-case-timings.jsonl"
+  printf '%s\n' '{"event":"rue_cli_case_timing","name":"fake","elapsed_s":0.1}' >"$out"
+  printf '%s\n' "$out"
+  exit 0
 fi
 exit 90
 EOF
@@ -870,6 +872,41 @@ EOF
     check "ci-heavy-suite: $heavy_target is invoked without an executor timeout" \
       "$([ "$rc" -eq 0 ] && grep -Fxq "test $heavy_target" "$sb/calls.log" && echo 0 || echo 1)"
   done
+
+  # RUE-1158 under RUE-1118: per-case timings are a declared output of the
+  # corpus action, so they are stored in the cache entry and materialize on a
+  # hit too. ci-heavy-suite fetches the [timings] sub-target after the run and
+  # copies it to the stable path ci.yml's upload step reads, rather than handing
+  # the harness a per-run mktemp path that would change the digest every run.
+  : >"$sb/calls.log"
+  rc=0
+  local timings_dir="$sb/runner-temp"
+  mkdir -p "$timings_dir"
+  (cd "$sb" && FAKE_LABELED_TARGET=//:cli-tests-shard-1 FAKE_CALL_LOG="$sb/calls.log" \
+    RUNNER_TEMP="$timings_dir" ./ci-heavy-suite //:cli-tests-shard-1) >/dev/null 2>&1 || rc=$?
+  check "ci-heavy-suite: a shard fetches timings from the action output" \
+    "$([ "$rc" -eq 0 ] && grep -Fq -- '--show-simple-output //:cli-tests-shard-1-action[timings]' "$sb/calls.log" && echo 0 || echo 1)"
+  check "ci-heavy-suite: shard timings reach the upload path" \
+    "$(grep -Fq '"event":"rue_cli_case_timing"' "$timings_dir/rue-cli-case-timings.jsonl" 2>/dev/null && echo 0 || echo 1)"
+  check "ci-heavy-suite: no per-run timings path is handed to the executor" \
+    "$(! grep -Fq 'RUE_CLI_CASE_TIMINGS=' "$sb/calls.log" && echo 0 || echo 1)"
+
+  # An unsharded corpus emits no case timings, so it must not ask for them.
+  : >"$sb/calls.log"
+  rc=0
+  (cd "$sb" && FAKE_LABELED_TARGET=//:spec-tests FAKE_CALL_LOG="$sb/calls.log" \
+    RUNNER_TEMP="$timings_dir" ./ci-heavy-suite //:spec-tests) >/dev/null 2>&1 || rc=$?
+  check "ci-heavy-suite: a non-shard corpus requests no timings" \
+    "$([ "$rc" -eq 0 ] && ! grep -Fq 'timings' "$sb/calls.log" && echo 0 || echo 1)"
+
+  # The artifact upload is if-no-files-found:ignore and the suite's own Buck
+  # result is the required signal, so an absent timings output must not fail the
+  # lane — it must only say so.
+  rc=0
+  out="$(cd "$sb" && FAKE_LABELED_TARGET=//:cli-tests-shard-1 FAKE_NO_TIMINGS=1 \
+    RUNNER_TEMP="$timings_dir" ./ci-heavy-suite //:cli-tests-shard-1 2>&1)" || rc=$?
+  check "ci-heavy-suite: a missing timings output is reported, not fatal" \
+    "$([ "$rc" -eq 0 ] && grep -Fq 'no case timings produced' <<<"$out" && echo 0 || echo 1)"
 
   # RUE-1117: heavy suites are no longer only root-package targets. The label,
   # not the package path, decides what may run here.


### PR DESCRIPTION
Follow-up to #2044, which merged with this left open as decision 2 in its description.

## The problem #2044 introduced

RUE-1118 moved each heavy corpus into a cacheable build action. That broke how RUE-1158's shard weights are measured, in a way that fails quiet rather than loud.

`ci-heavy-suite` collected per-case timings by passing `--env RUE_CLI_CASE_TIMINGS=<mktemp path>` to the test executor. Neither half of that survives the conversion:

- the harness now runs **inside the action**, where an executor `--env` never reaches it;
- the path was a per-run `RUNNER_TEMP`/`mktemp` value, so threading it into the action's environment would change the digest on **every** run and defeat the caching outright.

So the measurements existed only when a corpus actually executed. `shard-weights.json` would refresh on cache misses alone — and the whole point of #2044 is to make cache hits the common case. The old code already anticipated this and printed `measured 0 cases (cached result or unavailable timings)`, which is an honest report of a capability that had quietly stopped working.

## The fix

Declare the timings as a **second output of the action**, opted into by `cached_corpus_suite(case_timings = True)` and exposed as `:NAME-action[timings]`.

The path is derived from the target name, so it is stable across runs and digest-neutral — it does not reintroduce the per-run-value problem. Being an output, it is stored in the cache entry alongside the stamp and materializes on a hit like any other artifact. `ci-heavy-suite` fetches that sub-target after the run and copies it to the path `ci.yml` already uploads, so **the workflow is unchanged** — no edit to `ci.yml`, and the upload step's `if-no-files-found: ignore` still covers the absent case.

`RUE_CLI_CASE_TIMINGS` joins the suite's `absolutize` list for the same reason every other corpus path is on it: the harness `File::create()`s it after the compiler has already moved cwd into a case temp directory.

## The contract this generalizes

Recorded in `corpus.bzl` and as point 4 in `build-cache.md`'s corpus section, next to the existing declared-inputs and absolute-paths rules:

> Anything a corpus *produces* that outlives the run belongs in the action's declared outputs, or it silently stops existing the moment the suite starts being cache-served.

The inputs contract from #2044 says an undeclared input becomes a false pass. This is its mirror on the output side, and it is the less obvious of the two — nothing turns red, a downstream artifact just stops being refreshed.

## Verification

Run locally on this branch, on top of trunk at `10e4b42`:

- **The property this exists for.** A cold `scripts/ci-heavy-suite //:cli-tests-shard-0` reports `cli-tests: measured 427 cases`. An immediate re-run reports the **same 427 in 0.6s total**, without re-executing the corpus — precisely the run the old wiring reported as `measured 0 cases`.
- `./buck2 build --show-simple-output '//:cli-tests-shard-0-action[timings]'` — 427 well-formed `rue_cli_case_timing` records.
- `scripts/test-wrapper-scripts.sh` — 107 checks (102 + 5 new).
- `scripts/test-corpus-action.sh` — 15 checks (12 + 3 new).
- `scripts/test-build-sharing.sh` — 32 checks.
- `//test_tiers.bxl:validate` — 83 premerge, 5 slow, 3 stress, unchanged.
- `//:corpus-action-tests //:cli-shard-coverage-validation //:ci-gate-validation //:tier-ci-selector-validation` — Pass 4.
- `./buck2 starlark lint corpus.bzl` — clean. The 8 `BUCK` lints are pre-existing and identical in count on trunk.

New coverage:

- ci-heavy-suite requests `[timings]` for a shard, lands it at the upload path, hands **no** `RUE_CLI_CASE_TIMINGS=` to the executor, requests nothing for an unsharded corpus, and treats an absent timings output as reported-not-fatal.
- corpus-action absolutizes a declared *output* — a path that does not exist yet — and the harness writes through it.

## Note on how this got here

#2044 reached the front of the merge queue while this change was being written, so it landed without it. Nothing is lost: this is additive and the interim behavior is the documented, if degraded, `measured 0 cases`.

Draft pending CI, which is where the cross-run and cross-platform cache behavior actually shows. The specific thing to confirm on the first `merge_group` run is that a cache-served shard prints a nonzero `measured N cases` — that is the whole claim, and it cannot be proven locally, since OSS buck2 has no persistent action cache across daemon restarts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXADK2DMmYkhLEFWtXyBoP)_