### PR TITLE
Give spec cases an explicit platform responsibility

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -514,7 +514,15 @@ rue_sh_test(
 rue_sh_test(
     name = "ci-gate-validation",
     test = "scripts/validate-ci-gate.py",
-    args = ["$(location :required-ci-workflows)/.github/workflows/ci.yml"],
+    args = [
+        "$(location :required-ci-workflows)/.github/workflows/ci.yml",
+        # RUE-1161: the harness's declared platform responsibility matrix is a
+        # real input, so a lane added to (or removed from) either side without
+        # the other fails here instead of silently crediting specification
+        # coverage to cases no lane executes.
+        "--test-runner-source",
+        "$(location //crates/rue-test-runner:platform-responsibility-source)/src/lib.rs",
+    ],
     resources = [
         "scripts/ci-required-results.py",
         "scripts/run-native-platform-corpus.sh",
@@ -532,6 +540,7 @@ rue_sh_test(
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
         "RUE_CI_WORKFLOW": "$(location :required-ci-workflows)/.github/workflows/ci.yml",
+        "RUE_TEST_RUNNER_SOURCE": "$(location //crates/rue-test-runner:platform-responsibility-source)/src/lib.rs",
     },
 )
 

--- a/crates/rue-spec/README.md
+++ b/crates/rue-spec/README.md
@@ -102,6 +102,70 @@ The `spec` field links tests to specification paragraphs using the format `{chap
 - `3.1:1` - Chapter 3, Section 1, Paragraph 1
 - `4.2:5` - Chapter 4, Section 2, Paragraph 5
 
+#### Filtering by Specification Paragraph
+
+An argument shaped like a specification ID selects the cases citing it, instead
+of being matched against test names (`section.id::case_name`):
+
+```bash
+scripts/rue spec 4.2       # every case citing a paragraph in section 4.2
+scripts/rue spec 4.2:5     # only the cases citing paragraph 4.2:5
+scripts/rue spec --spec 4.2:5   # explicit form
+scripts/rue spec arithmetic     # ordinary libtest name filter, unchanged
+```
+
+A selector that matches no case exits non-zero. A filter that silently selects
+nothing is how a mistyped paragraph ID becomes false evidence that a rule is
+exercised.
+
+### Platform Responsibility
+
+Each case declares, structurally, which lane is responsible for executing it:
+
+| Responsibility | What the case asserts | Who runs it |
+| --- | --- | --- |
+| Semantic | diagnostics, semantics, and target-independent golden IR (tokens/AST/RIR/AIR/CFG) | the Linux-complete lane |
+| Native | compiles and runs a real program for the host's target | the Linux-complete lane, plus the native lane of every `only_on` host |
+| Backend | architecture-specific golden output for a declared `target` | the Linux-complete lane when it only emits; the matching native lane when it also executes |
+
+The classification is derived from the assertions a case makes, so it cannot
+drift from what the case does. Loading the corpus **rejects** a case whose
+platform responsibility is ambiguous:
+
+- backend-specific golden output (`expected_mir`, `expected_lowering`,
+  `expected_liveness`, `expected_regalloc`, `expected_asm`,
+  `expected_stackframe`) with no declared `target` — the expectation belongs to
+  one architecture, but nothing says which;
+- a `target` whose architecture differs from an `only_on` host;
+- a `target` combined with execution assertions and no `only_on` scope, which
+  would ask whichever host runs the suite to execute a foreign-architecture
+  program.
+
+Because `//:spec-traceability` loads the whole corpus, that gate is where an
+ambiguous case surfaces first — a cheap, standalone required check.
+
+#### `only_on` and CI reachability
+
+`only_on` scopes a case to specific hosts. Required CI executes
+`x86-64-linux` (complete lane), `aarch64-linux`, and `aarch64-macos`
+(native lanes) — the list in `rue_test_runner::CI_EXECUTED_TARGETS`, which
+`scripts/validate-ci-gate.py` keeps in lockstep with `.github/workflows/ci.yml`.
+
+`x86-64-macos` is a legal host name so the suite runs on an Intel Mac, but no
+required lane is one. A case scoped only to platforms outside the matrix
+therefore **does not count as specification coverage**: it still runs for a
+developer on that host, but nothing in CI executes it, so it cannot stand as
+evidence that a rule holds. The traceability report lists every such case.
+
+#### Focused coverage
+
+A normative rule's coverage must include at least one *focused* case — at most
+`FOCUSED_CASE_MAX_SOURCE_LINES` (40) lines of source. A rule whose only evidence
+is a large multi-feature program is covered on paper only: when it regresses,
+the failure names the program rather than the rule. Large programs remain
+valuable as integration and slow-tier coverage; they just cannot be a rule's
+sole evidence.
+
 
 ### Language Specification
 
@@ -181,6 +245,14 @@ The traceability check is run as the `//:spec-traceability` Buck target and is
 included in `./test.sh` and `./buck2 test //...`. It fails if:
 - Any spec paragraph has no covering test (coverage < 100%)
 - Any test references a non-existent spec paragraph ID
+- Any normative rule is covered only through a large program (see
+  "Focused coverage" above)
+- Any case declares an ambiguous platform responsibility (see
+  "Platform Responsibility" above)
+
+A case only contributes coverage when it actually runs: skipped cases,
+preview cases allowed to fail, and cases scoped to platforms no required CI lane
+executes are all reported but not credited.
 
 
 ## Fuzz testing

--- a/crates/rue-spec/src/main.rs
+++ b/crates/rue-spec/src/main.rs
@@ -14,9 +14,18 @@
 //! # Run all specification tests
 //! ./buck2 run //crates/rue-spec:rue-spec
 //!
-//! # Filter tests by pattern
+//! # Filter tests by pattern (matches `section::case` test names)
 //! ./buck2 run //crates/rue-spec:rue-spec -- "arithmetic"
+//!
+//! # Filter by specification section or paragraph
+//! ./buck2 run //crates/rue-spec:rue-spec -- 4.2
+//! ./buck2 run //crates/rue-spec:rue-spec -- --spec 4.2:5
 //! ```
+//!
+//! An argument shaped like a specification ID (`4.2`, `4.3a`, `4.2:5`), or one
+//! passed with `--spec`, selects the cases citing it rather than being matched
+//! against test names. A selector that matches no case is an error, not an
+//! empty pass.
 //!
 //! ## Traceability Reports
 //!
@@ -110,6 +119,98 @@ fn run_case_wrapper(
     run_test_case(case, rue_binary).map_err(|e| RunError::fail(e.to_string()))
 }
 
+/// libtest flags that consume the argument after them. A paragraph-shaped
+/// value belonging to one of these is that flag's value, not a selector.
+const VALUE_TAKING_FLAGS: &[&str] = &[
+    "--skip",
+    "--format",
+    "--test-threads",
+    "--logfile",
+    "--color",
+    "-Z",
+];
+
+/// Whether `argument` has the shape of a specification selector: a section
+/// (`4.2`, `4.3a`) or a single paragraph (`4.2:5`).
+///
+/// libtest filters match *test names* (`section.id::case_name`), which never
+/// contain paragraph IDs — so before RUE-1161 the documented
+/// `scripts/rue spec 4.2` silently selected zero cases and reported a pass.
+fn is_spec_selector(argument: &str) -> bool {
+    let (section, paragraph) = match argument.split_once(':') {
+        Some((section, paragraph)) => (section, Some(paragraph)),
+        None => (argument, None),
+    };
+    let Some((chapter, subsection)) = section.split_once('.') else {
+        return false;
+    };
+    let chapter_ok = !chapter.is_empty() && chapter.bytes().all(|b| b.is_ascii_digit());
+    let subsection_ok = !subsection.is_empty()
+        && subsection
+            .bytes()
+            .all(|b| b.is_ascii_digit() || b.is_ascii_lowercase())
+        && subsection.starts_with(|c: char| c.is_ascii_digit());
+    let paragraph_ok =
+        paragraph.is_none_or(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()));
+    chapter_ok && subsection_ok && paragraph_ok
+}
+
+/// Whether a case citing `spec_ids` is selected by `selector`.
+///
+/// A bare section selector (`4.2`) matches every paragraph in that section; a
+/// full paragraph selector (`4.2:5`) matches only that paragraph.
+fn selector_matches(selector: &str, spec_ids: &[String]) -> bool {
+    if selector.contains(':') {
+        return spec_ids.iter().any(|id| id == selector);
+    }
+    spec_ids.iter().any(|id| {
+        id.split_once(':')
+            .is_some_and(|(section, _)| section == selector)
+    })
+}
+
+/// Split raw argv into specification selectors and the arguments the libtest
+/// harness should still parse.
+fn partition_spec_selectors(raw_args: &[String]) -> (Vec<String>, Vec<String>) {
+    let mut selectors = Vec::new();
+    let mut harness_args = Vec::new();
+    let mut arguments = raw_args.iter();
+
+    if let Some(program) = arguments.next() {
+        harness_args.push(program.clone());
+    }
+
+    let mut previous: Option<&str> = None;
+    let mut expecting_selector = false;
+    for argument in arguments {
+        if expecting_selector {
+            selectors.push(argument.clone());
+            expecting_selector = false;
+            previous = None;
+            continue;
+        }
+        if argument == "--spec" {
+            expecting_selector = true;
+            continue;
+        }
+        if let Some(value) = argument.strip_prefix("--spec=") {
+            selectors.push(value.to_string());
+            previous = None;
+            continue;
+        }
+        let is_flag_value = previous.is_some_and(|flag| VALUE_TAKING_FLAGS.contains(&flag));
+        if !is_flag_value && is_spec_selector(argument) {
+            selectors.push(argument.clone());
+            previous = None;
+            continue;
+        }
+        previous = Some(argument.as_str());
+        harness_args.push(argument.clone());
+    }
+
+    (selectors, harness_args)
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum PreviewDisposition {
     Ignore(String),
@@ -171,6 +272,8 @@ fn main() {
         return;
     }
 
+    let (spec_selectors, harness_args) = partition_spec_selectors(&raw_args);
+
     let platform_selection = PlatformCaseSelection::from_env().unwrap_or_else(|error| {
         eprintln!("error: {error}");
         std::process::exit(2);
@@ -204,6 +307,13 @@ fn main() {
             if !platform_selection.includes(&case.only_on) {
                 continue;
             }
+            if !spec_selectors.is_empty()
+                && !spec_selectors
+                    .iter()
+                    .any(|selector| selector_matches(selector, &case.spec))
+            {
+                continue;
+            }
             let test_name = format!("{}::{}", section_id, case.name);
             let skip = case.skip;
             let is_preview = case.preview.is_some();
@@ -231,10 +341,21 @@ fn main() {
     }
 
     if tests.is_empty() {
-        eprintln!(
-            "error: platform case selection {platform_selection:?} selected no spec cases on {}",
-            rue_test_runner::get_host_target()
-        );
+        if spec_selectors.is_empty() {
+            eprintln!(
+                "error: platform case selection {platform_selection:?} selected no spec cases on {}",
+                rue_test_runner::get_host_target()
+            );
+        } else {
+            // A filter that matches nothing must not report a pass: that is how
+            // a mistyped paragraph ID turns into false evidence that a rule is
+            // exercised (RUE-1161).
+            eprintln!(
+                "error: no spec case cites {} (selection {platform_selection:?} on {})",
+                spec_selectors.join(", "),
+                rue_test_runner::get_host_target()
+            );
+        }
         std::process::exit(1);
     }
 
@@ -245,13 +366,88 @@ fn main() {
     //
     // Preview tests with `preview_should_pass = true` fail normally,
     // providing real test output for implemented portions of preview features.
-    Harness::with_env().discover(tests).main();
+    Harness::with_args(harness_args).discover(tests).main();
 }
 
 #[cfg(test)]
 mod runner_tests {
     use super::*;
     use rue_test_runner::TestFailure;
+
+    fn selectors(args: &[&str]) -> Vec<String> {
+        let raw: Vec<String> = std::iter::once("rue-spec")
+            .chain(args.iter().copied())
+            .map(str::to_string)
+            .collect();
+        partition_spec_selectors(&raw).0
+    }
+
+    fn harness_args(args: &[&str]) -> Vec<String> {
+        let raw: Vec<String> = std::iter::once("rue-spec")
+            .chain(args.iter().copied())
+            .map(str::to_string)
+            .collect();
+        partition_spec_selectors(&raw).1
+    }
+
+    #[test]
+    fn spec_selector_shape_matches_section_and_paragraph_ids() {
+        assert!(is_spec_selector("4.2"));
+        assert!(is_spec_selector("4.3a"));
+        assert!(is_spec_selector("4.2:5"));
+        assert!(is_spec_selector("11.10:123"));
+
+        assert!(!is_spec_selector("arithmetic"));
+        assert!(!is_spec_selector("expressions.arithmetic"));
+        assert!(!is_spec_selector("--quiet"));
+        assert!(!is_spec_selector("4."));
+        assert!(!is_spec_selector("4.2:"));
+        assert!(!is_spec_selector("4.2:x"));
+    }
+
+    #[test]
+    fn paragraph_selectors_are_split_out_of_the_harness_arguments() {
+        assert_eq!(selectors(&["--quiet", "4.2"]), vec!["4.2".to_string()]);
+        assert_eq!(
+            harness_args(&["--quiet", "4.2"]),
+            vec!["rue-spec".to_string(), "--quiet".to_string()]
+        );
+
+        assert_eq!(selectors(&["--spec", "4.2:5"]), vec!["4.2:5".to_string()]);
+        assert_eq!(selectors(&["--spec=4.2:5"]), vec!["4.2:5".to_string()]);
+
+        // A name filter still reaches libtest untouched.
+        assert!(selectors(&["arithmetic"]).is_empty());
+        assert_eq!(
+            harness_args(&["arithmetic"]),
+            vec!["rue-spec".to_string(), "arithmetic".to_string()]
+        );
+
+        // A paragraph-shaped value belonging to a flag stays that flag's value.
+        assert!(selectors(&["--skip", "4.2"]).is_empty());
+        assert_eq!(
+            harness_args(&["--skip", "4.2"]),
+            vec![
+                "rue-spec".to_string(),
+                "--skip".to_string(),
+                "4.2".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn section_selectors_match_every_paragraph_in_the_section() {
+        let cited = vec!["4.2:5".to_string(), "9.1:2".to_string()];
+
+        assert!(selector_matches("4.2", &cited));
+        assert!(selector_matches("9.1", &cited));
+        assert!(selector_matches("4.2:5", &cited));
+
+        assert!(!selector_matches("4.2:6", &cited));
+        assert!(!selector_matches("4.20", &cited));
+        assert!(!selector_matches("4.1", &cited));
+        assert!(!selector_matches("4.2", &[]));
+    }
 
     #[test]
     fn preview_disposition_rejects_xpass_and_fatal_failure() {

--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -54,7 +54,10 @@
 //! }
 //! ```
 
-use rue_test_runner::{discover_files, load_test_files};
+use rue_test_runner::{
+    CI_EXECUTED_TARGETS, PlatformResponsibility, classify_platform_responsibility, discover_files,
+    load_test_files, runs_on_required_ci,
+};
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
@@ -108,6 +111,10 @@ pub struct TestReference {
     /// Full test name in the format `section::case_name`
     /// (e.g., "lexical.comments::line_comment_after_code").
     pub test_name: String,
+    /// Lines of Rue source the case compiles. Used by the focused-case gate:
+    /// a normative rule whose only evidence is a large program is coverage on
+    /// paper, but nothing in the failure output points at the rule.
+    pub source_lines: usize,
 }
 
 /// A complete traceability report linking specification paragraphs to tests.
@@ -143,7 +150,49 @@ pub struct TraceabilityReport {
     /// normative rule (erasing its coverage requirement) — as nearly happened
     /// with 3.7:49 on 2026-07-04.
     pub duplicate_rule_ids: Vec<String>,
+    /// How many cases each lane is responsible for executing.
+    pub responsibility_census: ResponsibilityCensus,
+    /// Cases excluded from coverage because their `only_on` scope names no
+    /// platform any required CI lane executes. Each entry is
+    /// `(test_name, only_on)`. Reported so the exclusion is visible rather than
+    /// silent; a rule left uncovered by it fails the gate the ordinary way.
+    pub platform_unreachable_cases: Vec<(String, Vec<String>)>,
 }
+
+/// How the corpus divides across the lanes that execute it.
+///
+/// Reported so the platform split is a visible fact of every traceability run
+/// rather than an implicit property of the workflow file.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ResponsibilityCensus {
+    /// Target-independent cases, owned by the Linux-complete lane.
+    pub semantic: usize,
+    /// Cases that build and run a program for the executing host's target.
+    pub native: usize,
+    /// Cases pinning architecture-specific output for a declared `target`.
+    pub backend: usize,
+}
+
+impl ResponsibilityCensus {
+    fn record(&mut self, responsibility: PlatformResponsibility) {
+        match responsibility {
+            PlatformResponsibility::Semantic => self.semantic += 1,
+            PlatformResponsibility::Native => self.native += 1,
+            PlatformResponsibility::Backend => self.backend += 1,
+        }
+    }
+}
+
+/// The largest program a spec case may use and still count as *focused*
+/// evidence for a normative rule.
+///
+/// A rule whose only coverage is a large multi-feature program is covered on
+/// paper only: when it regresses, the failure names the program rather than the
+/// rule, and the case usually fails for one of the dozen other rules it also
+/// touches first. Large programs remain valuable as integration and slow-tier
+/// coverage — they just cannot be a normative rule's sole evidence (RUE-1161).
+/// The largest case in the corpus today is 28 lines.
+pub const FOCUSED_CASE_MAX_SOURCE_LINES: usize = 40;
 
 /// Normative paragraphs that currently have no *running* test, tracked as known
 /// gaps pending compiler-feature implementation.
@@ -294,14 +343,37 @@ impl TraceabilityReport {
             .collect()
     }
 
+    /// Normative paragraphs whose every covering case exceeds
+    /// [`FOCUSED_CASE_MAX_SOURCE_LINES`].
+    ///
+    /// Such a rule has coverage only through a large program. Each entry is
+    /// `(paragraph_id, smallest_covering_case, its_source_lines)`.
+    pub fn unfocused_normative_coverage(&self) -> Vec<(&String, &str, usize)> {
+        self.paragraphs
+            .values()
+            .filter(|para| Self::is_normative(para))
+            .filter_map(|para| {
+                let tests = self.coverage.get(&para.id)?;
+                let smallest = tests.iter().min_by_key(|test| test.source_lines)?;
+                (smallest.source_lines > FOCUSED_CASE_MAX_SOURCE_LINES).then_some((
+                    &para.id,
+                    smallest.test_name.as_str(),
+                    smallest.source_lines,
+                ))
+            })
+            .collect()
+    }
+
     /// Whether the traceability gate should fail: any *unexpected* uncovered
-    /// normative rule, any stale allowlist entry, any orphan reference, or any
-    /// duplicate rule id.
+    /// normative rule, any stale allowlist entry, any orphan reference, any
+    /// duplicate rule id, or any normative rule covered only through a large
+    /// program.
     pub fn gate_failing(&self) -> bool {
         !self.unexpected_uncovered_normative_paragraphs().is_empty()
             || !self.stale_known_uncovered().is_empty()
             || !self.orphan_references.is_empty()
             || !self.duplicate_rule_ids.is_empty()
+            || !self.unfocused_normative_coverage().is_empty()
     }
 
     /// Returns the coverage percentage for normative paragraphs (0.0 to 100.0).
@@ -475,6 +547,49 @@ impl TraceabilityReport {
             );
             for (test_name, ref_id) in &self.orphan_references {
                 println!("  {} references non-existent '{}'", test_name, ref_id);
+            }
+            println!();
+        }
+
+        // Which lane owns executing each part of the corpus.
+        let census = self.responsibility_census;
+        println!(
+            "Platform responsibility: {} semantic (Linux-complete lane), {} native \
+             (host execution), {} backend (declared target)",
+            census.semantic, census.native, census.backend
+        );
+        println!();
+
+        // Cases whose platform scope names no required CI lane. They still run
+        // for a developer on that host, but nothing in CI executes them, so
+        // they cannot stand as evidence that a rule holds.
+        if !self.platform_unreachable_cases.is_empty() {
+            println!(
+                "Cases not executed by any required CI lane ({}, not counted as coverage):",
+                self.platform_unreachable_cases.len()
+            );
+            for (test_name, only_on) in &self.platform_unreachable_cases {
+                println!(
+                    "  {} is only_on {:?}; required lanes run {:?}",
+                    test_name, only_on, CI_EXECUTED_TARGETS
+                );
+            }
+            println!();
+        }
+
+        // Normative rules whose only evidence is a large program.
+        let unfocused = self.unfocused_normative_coverage();
+        if !unfocused.is_empty() {
+            println!(
+                "Normative paragraphs covered only through large programs ({}):",
+                unfocused.len()
+            );
+            for (id, test_name, lines) in unfocused {
+                println!(
+                    "  {} smallest covering case '{}' is {} lines (budget {}) — add a \
+                     focused case; the large program stays as integration coverage",
+                    id, test_name, lines, FOCUSED_CASE_MAX_SOURCE_LINES
+                );
             }
             println!();
         }
@@ -760,21 +875,35 @@ pub fn generate_report(spec_dir: &Path, cases_dir: &Path) -> Result<Traceability
     }
 
     // Process test files
+    let mut platform_unreachable_cases = Vec::new();
+    let mut responsibility_census = ResponsibilityCensus::default();
     for (_, test_file) in &test_files {
         for case in &test_file.case {
             let test_name = format!("{}::{}", test_file.section.id, case.name);
+            // `load_test_files` has already rejected ambiguous cases, so every
+            // case here classifies.
+            if let Ok(responsibility) = classify_platform_responsibility(case) {
+                responsibility_census.record(responsibility);
+            }
+            let reachable = runs_on_required_ci(&case.only_on);
+            if !reachable && !case.spec.is_empty() {
+                platform_unreachable_cases.push((test_name.clone(), case.only_on.clone()));
+            }
             let counts_as_coverage =
-                !case.skip && (case.preview.is_none() || case.preview_should_pass);
+                !case.skip && (case.preview.is_none() || case.preview_should_pass) && reachable;
 
             for spec_ref in &case.spec {
                 if let Some(tests) = coverage.get_mut(spec_ref) {
                     // A skipped or preview-allowed-to-fail case never exercises
                     // the rule, so it must not mark the paragraph as covered
-                    // (RUE-132). Its reference is still valid, so it is not an
-                    // orphan — it simply doesn't contribute coverage.
+                    // (RUE-132). The same holds along the platform axis: a case
+                    // scoped to a host no required lane runs never executes in
+                    // CI (RUE-1161). Their references are still valid, so they
+                    // are not orphans — they simply contribute no coverage.
                     if counts_as_coverage {
                         tests.push(TestReference {
                             test_name: test_name.clone(),
+                            source_lines: case.source.lines().count(),
                         });
                     }
                 } else {
@@ -789,6 +918,8 @@ pub fn generate_report(spec_dir: &Path, cases_dir: &Path) -> Result<Traceability
         coverage,
         orphan_references,
         duplicate_rule_ids,
+        responsibility_census,
+        platform_unreachable_cases,
     })
 }
 
@@ -1024,6 +1155,7 @@ fn main() { }
             "1.1:1".to_string(),
             vec![TestReference {
                 test_name: "test::case1".to_string(),
+                source_lines: 1,
             }],
         );
         coverage.insert("1.1:2".to_string(), vec![]);
@@ -1033,6 +1165,8 @@ fn main() { }
             coverage,
             orphan_references: vec![],
             duplicate_rule_ids: vec![],
+            responsibility_census: ResponsibilityCensus::default(),
+            platform_unreachable_cases: vec![],
         };
 
         assert_eq!(report.covered_count(), 1);
@@ -1121,6 +1255,107 @@ exit_code = 0
     }
 
     #[test]
+    fn platform_unreachable_cases_do_not_count_as_coverage() {
+        // Two rules, each covered by exactly one platform-scoped case: one
+        // scoped to a host a required lane runs, one scoped only to Intel
+        // macOS, which nothing in required CI executes (RUE-1161).
+        let spec = r#"
+{{ rule(id="1.1:1", cat="normative") }}
+Covered by a case a required lane runs.
+
+{{ rule(id="1.1:2", cat="normative") }}
+Referenced only by a case no required lane runs.
+"#;
+        let cases = r#"
+[section]
+id = "t.section"
+name = "T"
+
+[[case]]
+name = "on_a_required_lane"
+spec = ["1.1:1"]
+only_on = ["aarch64-macos"]
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+
+[[case]]
+name = "on_no_lane"
+spec = ["1.1:2"]
+only_on = ["x86-64-macos"]
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+"#;
+        let spec_dir = tempfile::tempdir().unwrap();
+        fs::write(spec_dir.path().join("s.md"), spec).unwrap();
+        let cases_dir = tempfile::tempdir().unwrap();
+        fs::write(cases_dir.path().join("c.toml"), cases).unwrap();
+
+        let report = generate_report(spec_dir.path(), cases_dir.path()).unwrap();
+
+        assert!(!report.coverage["1.1:1"].is_empty(), "native lane covers");
+        assert!(
+            report.coverage["1.1:2"].is_empty(),
+            "a case no required lane executes must not count as coverage"
+        );
+        assert_eq!(
+            report.platform_unreachable_cases,
+            vec![(
+                "t.section::on_no_lane".to_string(),
+                vec!["x86-64-macos".to_string()]
+            )]
+        );
+        // The reference is valid, so it is reported as unreachable, not orphaned.
+        assert!(report.orphan_references.is_empty());
+    }
+
+    #[test]
+    fn large_programs_cannot_be_a_normative_rules_only_coverage() {
+        let spec = r#"
+{{ rule(id="1.1:1", cat="normative") }}
+Covered only by a large program.
+
+{{ rule(id="1.1:2", cat="normative") }}
+Covered by the same large program and a focused case.
+"#;
+        let body = "    let _x: i32 = 0;\n".repeat(FOCUSED_CASE_MAX_SOURCE_LINES + 1);
+        let cases = format!(
+            r#"
+[section]
+id = "t.section"
+name = "T"
+
+[[case]]
+name = "large_program"
+spec = ["1.1:1", "1.1:2"]
+source = """
+fn main() -> i32 {{
+{body}    0
+}}
+"""
+exit_code = 0
+
+[[case]]
+name = "focused"
+spec = ["1.1:2"]
+source = "fn main() -> i32 {{ 0 }}"
+exit_code = 0
+"#
+        );
+        let spec_dir = tempfile::tempdir().unwrap();
+        fs::write(spec_dir.path().join("s.md"), spec).unwrap();
+        let cases_dir = tempfile::tempdir().unwrap();
+        fs::write(cases_dir.path().join("c.toml"), cases).unwrap();
+
+        let report = generate_report(spec_dir.path(), cases_dir.path()).unwrap();
+
+        let unfocused = report.unfocused_normative_coverage();
+        assert_eq!(unfocused.len(), 1, "got {unfocused:?}");
+        assert_eq!(unfocused[0].0, "1.1:1");
+        assert_eq!(unfocused[0].1, "t.section::large_program");
+        assert!(report.gate_failing());
+    }
+
+    #[test]
     fn test_known_uncovered_allowlist_gates_correctly() {
         // Build a report seeding EVERY allowlisted rule as an uncovered
         // normative paragraph (mirroring production, where they all exist), plus
@@ -1140,6 +1375,7 @@ exit_code = 0
                 let tests = if covered {
                     vec![TestReference {
                         test_name: "t::c".to_string(),
+                        source_lines: 1,
                     }]
                 } else {
                     vec![]
@@ -1157,6 +1393,8 @@ exit_code = 0
                 coverage,
                 orphan_references: vec![],
                 duplicate_rule_ids: vec![],
+                responsibility_census: ResponsibilityCensus::default(),
+                platform_unreachable_cases: vec![],
             }
         }
 

--- a/crates/rue-test-runner/BUCK
+++ b/crates/rue-test-runner/BUCK
@@ -1,5 +1,14 @@
 load("//crates:defs.bzl", "rue_crate")
 
+# The declared platform responsibility matrix (CI_EXECUTED_TARGETS) lives here,
+# so the CI-gate validator reads this source as an input and fails when the
+# matrix and the workflow's lanes drift apart (RUE-1161).
+filegroup(
+    name = "platform-responsibility-source",
+    srcs = ["src/lib.rs"],
+    visibility = ["PUBLIC"],
+)
+
 rue_crate(
     name = "rue-test-runner",
     deps = [

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -429,6 +429,40 @@ impl Case {
             || self.expected_stackframe.is_some()
     }
 
+    /// Whether verifying this case requires *running* the produced binary, as
+    /// opposed to only building it.
+    ///
+    /// `compile_only` stops at the executable, and the warning assertions are
+    /// compile-time. Only these assertions need a host that can execute the
+    /// case's target, which is what makes cross-compilation to a foreign
+    /// architecture legal for some cases and impossible for others.
+    pub fn requires_program_execution(&self) -> bool {
+        !self.compile_only
+            && (self.exit_code.is_some()
+                || self.expected_stdout.is_some()
+                || self.runtime_error.is_some()
+                || self.runtime_exit_code.is_some()
+                || self.stdin.is_some()
+                || self.stderr_contains.is_some())
+    }
+
+    /// The names of the backend-specific golden assertions this case sets, in
+    /// declaration order. Used to name the offending fields when a case pins
+    /// architecture-specific output without declaring its `target`.
+    pub fn target_specific_golden_ir_fields(&self) -> Vec<&'static str> {
+        [
+            ("expected_mir", self.expected_mir.is_some()),
+            ("expected_lowering", self.expected_lowering.is_some()),
+            ("expected_liveness", self.expected_liveness.is_some()),
+            ("expected_regalloc", self.expected_regalloc.is_some()),
+            ("expected_asm", self.expected_asm.is_some()),
+            ("expected_stackframe", self.expected_stackframe.is_some()),
+        ]
+        .into_iter()
+        .filter_map(|(field, present)| present.then_some(field))
+        .collect()
+    }
+
     /// Whether this case carries assertions that require actually compiling
     /// the program to a binary (and, unless `compile_only`, running it).
     ///
@@ -613,6 +647,190 @@ impl PlatformCaseSelection {
             Self::Native => !only_on.is_empty() && should_skip_for_platform(only_on).is_none(),
         }
     }
+}
+
+/// The platforms a required CI lane actually executes cases on.
+///
+/// This is the executable half of the platform responsibility matrix
+/// (RUE-1160/RUE-1161): `x86-64-linux` runs the complete target-independent
+/// corpus, and the two native lanes run every `only_on`-scoped case for their
+/// host. `x86-64-macos` is in [`KNOWN_TARGETS`] because a developer can run the
+/// suite on an Intel Mac, but no required lane does — a case scoped only to it
+/// executes nowhere in CI, so it must not be credited as specification coverage.
+///
+/// `scripts/validate-ci-gate.py` keeps this list and `.github/workflows/ci.yml`
+/// in lockstep, so adding a lane (or dropping one) cannot silently diverge from
+/// what the harness believes CI covers.
+pub const CI_EXECUTED_TARGETS: &[&str] = &["x86-64-linux", "aarch64-linux", "aarch64-macos"];
+
+/// The architecture component of a platform name in [`KNOWN_TARGETS`], i.e.
+/// everything before the trailing `-<os>` (`x86-64-linux` -> `x86-64`).
+///
+/// Returns `None` for a name that is not a known platform; callers reach this
+/// only after [`validate_only_on_targets`] has accepted the name.
+pub fn target_architecture(target: &str) -> Option<&str> {
+    if !KNOWN_TARGETS.contains(&target) {
+        return None;
+    }
+    target.rsplit_once('-').map(|(arch, _os)| arch)
+}
+
+/// Whether a case scoped by `only_on` executes on at least one platform that
+/// required CI runs.
+///
+/// An empty `only_on` means the case is target-independent and runs everywhere,
+/// including the Linux-complete lane.
+pub fn runs_on_required_ci(only_on: &[String]) -> bool {
+    only_on.is_empty()
+        || only_on
+            .iter()
+            .any(|platform| CI_EXECUTED_TARGETS.contains(&platform.as_str()))
+}
+
+/// Which lane is responsible for executing a case (RUE-1161).
+///
+/// The classification is structural — derived from the assertions a case
+/// actually makes — so it cannot drift from what the case does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlatformResponsibility {
+    /// Target-independent: diagnostics, semantic assertions, and golden IR up
+    /// to AIR/CFG. The Linux-complete lane owns these; running them again on
+    /// every native host would be three copies of one result.
+    Semantic,
+    /// Compiles and runs a real program for the host's native target. The
+    /// Linux-complete lane owns the unscoped ones; an `only_on` list hands the
+    /// case to the matching native lane as well.
+    Native,
+    /// Pins architecture-specific output for an explicitly declared `target`.
+    /// Cross-compiled emission is host-independent and stays on the
+    /// Linux-complete lane; a backend case that also *executes* belongs to the
+    /// native lane for its architecture.
+    Backend,
+}
+
+/// A case whose platform responsibility cannot be determined from its metadata.
+///
+/// Each variant describes a declaration that leaves it genuinely undecidable
+/// which architecture a case is about, or that asks a host to execute a program
+/// built for a different one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlatformResponsibilityAmbiguity {
+    /// Backend-specific golden output with no declared `target`: the expected
+    /// text is one architecture's, but nothing says which, so the case silently
+    /// pins whatever the compiler's default target happens to be.
+    UndeclaredArchitecture { fields: String },
+    /// A `target` whose architecture differs from a host in `only_on`. The case
+    /// claims two architectures at once.
+    ScopeArchitectureMismatch { target: String, platform: String },
+    /// A `target` combined with assertions that run the program, and no
+    /// `only_on` scope: the case builds for one architecture and then asks
+    /// whichever host is running the suite to execute the result.
+    UnscopedForeignExecution { target: String },
+}
+
+/// A [`PlatformResponsibilityAmbiguity`] located in a specific case.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlatformResponsibilityError {
+    /// The name of the offending test case.
+    pub test_name: String,
+    /// The section ID the test belongs to.
+    pub section_id: String,
+    /// What makes the case's platform responsibility undecidable.
+    pub ambiguity: PlatformResponsibilityAmbiguity,
+}
+
+impl std::fmt::Display for PlatformResponsibilityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "test '{}::{}' ", self.section_id, self.test_name)?;
+        match &self.ambiguity {
+            PlatformResponsibilityAmbiguity::UndeclaredArchitecture { fields } => write!(
+                f,
+                "asserts backend-specific golden output ({fields}) without declaring \
+                 `target`. That output belongs to one architecture; add \
+                 `target = \"<arch>-<os>\"` so the case declares which."
+            ),
+            PlatformResponsibilityAmbiguity::ScopeArchitectureMismatch { target, platform } => {
+                write!(
+                    f,
+                    "declares `target = \"{target}\"` but is scoped to `only_on` platform \
+                     '{platform}' of a different architecture. Scope the case to hosts of \
+                     its own architecture, or drop the mismatched entry."
+                )
+            }
+            PlatformResponsibilityAmbiguity::UnscopedForeignExecution { target } => write!(
+                f,
+                "declares `target = \"{target}\"` and asserts runtime behavior, but no \
+                 `only_on` scope. Whichever host runs the suite would be asked to execute a \
+                 program built for {target}. Add `only_on` listing the hosts of that \
+                 architecture, or use `compile_only` and keep it a cross-compilation case."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PlatformResponsibilityError {}
+
+/// Classify which lane owns executing `case`, or explain why its platform
+/// responsibility is ambiguous.
+pub fn classify_platform_responsibility(
+    case: &Case,
+) -> Result<PlatformResponsibility, PlatformResponsibilityAmbiguity> {
+    let executes = case.has_execution_assertions();
+
+    if case.has_target_specific_golden_ir_assertions() && case.target.is_none() {
+        return Err(PlatformResponsibilityAmbiguity::UndeclaredArchitecture {
+            fields: case.target_specific_golden_ir_fields().join(", "),
+        });
+    }
+
+    let Some(target) = case.target.as_deref() else {
+        return Ok(if executes {
+            PlatformResponsibility::Native
+        } else {
+            PlatformResponsibility::Semantic
+        });
+    };
+
+    // An unknown `target` is the compiler driver's error to report, not a
+    // responsibility ambiguity; classification stays silent about it.
+    if let Some(target_arch) = target_architecture(target) {
+        for platform in &case.only_on {
+            if target_architecture(platform).is_some_and(|arch| arch != target_arch) {
+                return Err(PlatformResponsibilityAmbiguity::ScopeArchitectureMismatch {
+                    target: target.to_string(),
+                    platform: platform.clone(),
+                });
+            }
+        }
+    }
+
+    // Cross-compiling and stopping at the executable is host-independent; only
+    // running the result needs a host of the declared architecture.
+    if case.requires_program_execution() && case.only_on.is_empty() {
+        return Err(PlatformResponsibilityAmbiguity::UnscopedForeignExecution {
+            target: target.to_string(),
+        });
+    }
+
+    Ok(PlatformResponsibility::Backend)
+}
+
+/// Validate that every case in a file declares an unambiguous platform
+/// responsibility. Returns one error per offending case.
+pub fn validate_platform_responsibility(test_file: &TestFile) -> Vec<PlatformResponsibilityError> {
+    test_file
+        .case
+        .iter()
+        .filter_map(|case| {
+            classify_platform_responsibility(case)
+                .err()
+                .map(|ambiguity| PlatformResponsibilityError {
+                    test_name: case.name.clone(),
+                    section_id: test_file.section.id.clone(),
+                    ambiguity,
+                })
+        })
+        .collect()
 }
 
 /// Check if a test should be skipped based on `only_on` restrictions.
@@ -1635,6 +1853,7 @@ pub fn load_test_files(cases_dir: &Path) -> Result<Vec<(String, TestFile)>, Stri
     let mut stray_error_assertions: Vec<StrayErrorAssertionError> = Vec::new();
     let mut bare_compile_fail: Vec<BareCompileFailError> = Vec::new();
     let mut compile_fail_exit_codes: Vec<CompileFailExitCodeError> = Vec::new();
+    let mut platform_responsibility: Vec<PlatformResponsibilityError> = Vec::new();
 
     let toml_files = discover_files(cases_dir, "toml").map_err(|error| {
         format!(
@@ -1674,6 +1893,11 @@ pub fn load_test_files(cases_dir: &Path) -> Result<Vec<(String, TestFile)>, Stri
                 // Reject runtime exit-code assertions on cases that never
                 // produce or execute a program.
                 compile_fail_exit_codes.extend(validate_compile_fail_exit_codes(&spec));
+
+                // Reject cases whose platform responsibility is ambiguous: an
+                // architecture-specific expectation with no declared target, or
+                // a declared target a scoped host cannot execute (RUE-1161).
+                platform_responsibility.extend(validate_platform_responsibility(&spec));
 
                 // Build a relative path from cases_dir to create the identifier
                 // e.g., "expressions/match" for "cases/expressions/match.toml"
@@ -1747,6 +1971,19 @@ pub fn load_test_files(cases_dir: &Path) -> Result<Vec<(String, TestFile)>, Stri
             "{} `compile_fail` case(s) have no error assertion:\n  - {}",
             bare_compile_fail.len(),
             bare_compile_fail
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n  - ")
+        ));
+    }
+
+    // Report cases with an undecidable platform responsibility.
+    if !platform_responsibility.is_empty() {
+        return Err(format!(
+            "{} case(s) have an ambiguous platform responsibility:\n  - {}",
+            platform_responsibility.len(),
+            platform_responsibility
                 .iter()
                 .map(ToString::to_string)
                 .collect::<Vec<_>>()
@@ -4236,6 +4473,192 @@ exit_code = 42
                 "test harness target whitelist is missing compiler target {target}"
             );
         }
+    }
+
+    #[test]
+    fn ci_executed_targets_are_known_platforms() {
+        for target in CI_EXECUTED_TARGETS {
+            assert!(
+                KNOWN_TARGETS.contains(target),
+                "CI-executed platform {target} is not a known target name"
+            );
+        }
+        // Every compiler target must be executed somewhere in required CI, or a
+        // backend's runtime behavior would only ever be cross-compiled.
+        for target in Target::all() {
+            assert!(
+                CI_EXECUTED_TARGETS.contains(&target.name()),
+                "compiler target {target} has no required CI lane executing its cases"
+            );
+        }
+    }
+
+    #[test]
+    fn required_ci_reachability_follows_the_platform_matrix() {
+        assert!(runs_on_required_ci(&[]), "unscoped cases run everywhere");
+        assert!(runs_on_required_ci(&["aarch64-macos".to_string()]));
+        assert!(runs_on_required_ci(&[
+            "x86-64-macos".to_string(),
+            "x86-64-linux".to_string(),
+        ]));
+        // Intel macOS is a legal host for a developer, but no required lane
+        // runs it, so a case scoped only to it executes nowhere in CI.
+        assert!(!runs_on_required_ci(&["x86-64-macos".to_string()]));
+    }
+
+    #[test]
+    fn target_architecture_splits_known_platform_names() {
+        assert_eq!(target_architecture("x86-64-linux"), Some("x86-64"));
+        assert_eq!(target_architecture("x86-64-macos"), Some("x86-64"));
+        assert_eq!(target_architecture("aarch64-macos"), Some("aarch64"));
+        assert_eq!(target_architecture("riscv64-linux"), None);
+    }
+
+    fn case_with(mutate: impl FnOnce(&mut Case)) -> Case {
+        let mut case = Case {
+            name: "case".to_string(),
+            source: "fn main() -> i32 { 0 }".to_string(),
+            ..Default::default()
+        };
+        mutate(&mut case);
+        case
+    }
+
+    #[test]
+    fn responsibility_classifies_target_independent_cases_as_semantic() {
+        let diagnostic = case_with(|case| {
+            case.compile_fail = true;
+            case.error_contains = ErrorContains(vec!["type mismatch".to_string()]);
+        });
+        assert_eq!(
+            classify_platform_responsibility(&diagnostic),
+            Ok(PlatformResponsibility::Semantic)
+        );
+
+        let golden_air = case_with(|case| case.expected_air = Some("air {}".to_string()));
+        assert_eq!(
+            classify_platform_responsibility(&golden_air),
+            Ok(PlatformResponsibility::Semantic)
+        );
+    }
+
+    #[test]
+    fn responsibility_classifies_executing_cases_as_native() {
+        let unscoped = case_with(|case| case.exit_code = Some(0));
+        assert_eq!(
+            classify_platform_responsibility(&unscoped),
+            Ok(PlatformResponsibility::Native)
+        );
+
+        let scoped = case_with(|case| {
+            case.exit_code = Some(0);
+            case.only_on = vec!["aarch64-macos".to_string()];
+        });
+        assert_eq!(
+            classify_platform_responsibility(&scoped),
+            Ok(PlatformResponsibility::Native)
+        );
+    }
+
+    #[test]
+    fn responsibility_classifies_declared_cross_compilation_as_backend() {
+        let emit_only = case_with(|case| {
+            case.target = Some("aarch64-linux".to_string());
+            case.expected_asm = Some("ret".to_string());
+        });
+        assert_eq!(
+            classify_platform_responsibility(&emit_only),
+            Ok(PlatformResponsibility::Backend)
+        );
+
+        // Cross-compiling without running the result is host-independent, so
+        // it needs no `only_on` scope.
+        let cross_compile_only = case_with(|case| {
+            case.target = Some("aarch64-linux".to_string());
+            case.compile_only = true;
+        });
+        assert_eq!(
+            classify_platform_responsibility(&cross_compile_only),
+            Ok(PlatformResponsibility::Backend)
+        );
+
+        let executed_on_its_own_arch = case_with(|case| {
+            case.target = Some("aarch64-linux".to_string());
+            case.exit_code = Some(0);
+            case.only_on = vec!["aarch64-linux".to_string(), "aarch64-macos".to_string()];
+        });
+        assert_eq!(
+            classify_platform_responsibility(&executed_on_its_own_arch),
+            Ok(PlatformResponsibility::Backend)
+        );
+    }
+
+    #[test]
+    fn responsibility_rejects_backend_golden_output_without_a_target() {
+        let ambiguous = case_with(|case| {
+            case.expected_asm = Some("ret".to_string());
+            case.expected_regalloc = Some("v0 -> x0".to_string());
+        });
+        assert_eq!(
+            classify_platform_responsibility(&ambiguous),
+            Err(PlatformResponsibilityAmbiguity::UndeclaredArchitecture {
+                fields: "expected_regalloc, expected_asm".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn responsibility_rejects_foreign_architecture_execution() {
+        let unscoped = case_with(|case| {
+            case.target = Some("aarch64-linux".to_string());
+            case.exit_code = Some(0);
+        });
+        assert_eq!(
+            classify_platform_responsibility(&unscoped),
+            Err(PlatformResponsibilityAmbiguity::UnscopedForeignExecution {
+                target: "aarch64-linux".to_string(),
+            })
+        );
+
+        let mismatched = case_with(|case| {
+            case.target = Some("aarch64-linux".to_string());
+            case.exit_code = Some(0);
+            case.only_on = vec!["x86-64-linux".to_string()];
+        });
+        assert_eq!(
+            classify_platform_responsibility(&mismatched),
+            Err(PlatformResponsibilityAmbiguity::ScopeArchitectureMismatch {
+                target: "aarch64-linux".to_string(),
+                platform: "x86-64-linux".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn load_rejects_ambiguous_platform_responsibility() {
+        let directory = tempfile::tempdir().expect("temporary cases directory");
+        std::fs::write(
+            directory.path().join("cases.toml"),
+            r#"
+[section]
+id = "test.section"
+name = "Test"
+
+[[case]]
+name = "undeclared_arch"
+source = "fn main() -> i32 { 0 }"
+expected_asm = "ret"
+"#,
+        )
+        .expect("write case file");
+
+        let error = load_test_files(directory.path()).expect_err("ambiguous case must not load");
+        assert!(
+            error.contains("ambiguous platform responsibility")
+                && error.contains("undeclared_arch")
+                && error.contains("expected_asm"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/scripts/test-validate-ci-gate.py
+++ b/scripts/test-validate-ci-gate.py
@@ -10,10 +10,15 @@ SPEC = importlib.util.spec_from_file_location("validate_ci_gate", SCRIPT)
 MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 SOURCE = Path(os.environ["RUE_CI_WORKFLOW"])
+# Under Buck the crate source is a declared input; a direct run falls back to
+# the checkout path the validator resolves on its own.
+TEST_RUNNER_SOURCE = Path(
+    os.environ.get("RUE_TEST_RUNNER_SOURCE", MODULE.TEST_RUNNER_SOURCE)
+)
 
 
 class GateValidatorTests(unittest.TestCase):
-    def validate_text(self, text, native_runner=None):
+    def validate_text(self, text, native_runner=None, test_runner=None):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "ci.yml"
             path.write_text(text)
@@ -23,10 +28,18 @@ class GateValidatorTests(unittest.TestCase):
                 if native_runner is not None
                 else MODULE.NATIVE_RUNNER_SCRIPT.read_text()
             )
-            return MODULE.validate(path, runner_path)
+            test_runner_path = Path(directory) / "lib.rs"
+            test_runner_path.write_text(
+                test_runner
+                if test_runner is not None
+                else TEST_RUNNER_SOURCE.read_text()
+            )
+            return MODULE.validate(path, runner_path, test_runner_path)
 
     def test_current_workflow_is_valid(self):
-        self.assertEqual(MODULE.validate(SOURCE), [])
+        self.assertEqual(
+            MODULE.validate(SOURCE, MODULE.NATIVE_RUNNER_SCRIPT, TEST_RUNNER_SOURCE), []
+        )
 
     def test_removing_or_renaming_job_fails_inventory(self):
         source = SOURCE.read_text()
@@ -69,6 +82,34 @@ class GateValidatorTests(unittest.TestCase):
         self.assertIn("platform-corpus responsibility drift", "\n".join(
             self.validate_text(changed)
         ))
+
+    def test_declared_platform_matrix_matches_the_harness(self):
+        self.assertEqual(
+            sorted(MODULE.ci_executed_targets(TEST_RUNNER_SOURCE.read_text())),
+            sorted(MODULE.PLATFORM_LANES),
+        )
+
+    def test_platform_declared_ci_executed_without_a_lane_fails(self):
+        runner = TEST_RUNNER_SOURCE.read_text().replace(
+            '"aarch64-macos"]', '"aarch64-macos", "riscv64-linux"]', 1
+        )
+        errors = "\n".join(self.validate_text(SOURCE.read_text(), test_runner=runner))
+        self.assertIn("CI_EXECUTED_TARGETS drift", errors)
+        self.assertIn("riscv64-linux", errors)
+
+    def test_dropping_a_native_lane_fails_the_platform_matrix(self):
+        changed = SOURCE.read_text().replace("os: macos-15", "os: macos-14", 1)
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("aarch64-macos is declared CI-executed", errors)
+
+    def test_unreadable_platform_matrix_is_reported(self):
+        with tempfile.TemporaryDirectory() as directory:
+            missing = Path(directory) / "absent.rs"
+            errors = MODULE.validate(SOURCE, MODULE.NATIVE_RUNNER_SCRIPT, missing)
+        self.assertTrue(
+            any("platform responsibility matrix unreadable" in error for error in errors),
+            errors,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -10,6 +10,32 @@ from pathlib import Path
 
 RESULTS_SCRIPT = Path(__file__).with_name("ci-required-results.py")
 NATIVE_RUNNER_SCRIPT = Path(__file__).with_name("run-native-platform-corpus.sh")
+TEST_RUNNER_SOURCE = (
+    Path(__file__).resolve().parents[1] / "crates/rue-test-runner/src/lib.rs"
+)
+
+# RUE-1161: the platform each entry of the harness's CI_EXECUTED_TARGETS claims
+# a required lane for, and the workflow text that proves that lane exists. The
+# harness refuses to credit specification coverage to a case scoped to a
+# platform outside this list, so a lane removed from ci.yml without updating the
+# constant would silently keep crediting cases nothing runs.
+PLATFORM_LANES = {
+    "x86-64-linux": ("linux-premerge", "runs-on: ubuntu-latest"),
+    "aarch64-linux": ("native-platforms", "os: ubuntu-24.04-arm"),
+    "aarch64-macos": ("native-platforms", "os: macos-15"),
+}
+
+CI_EXECUTED_TARGETS_RE = re.compile(
+    r"pub const CI_EXECUTED_TARGETS: &\[&str\] = &\[(?P<body>.*?)\];", re.DOTALL
+)
+
+
+def ci_executed_targets(runner_source: str) -> list[str]:
+    """The platform names the shared test harness believes required CI runs."""
+    match = CI_EXECUTED_TARGETS_RE.search(runner_source)
+    if not match:
+        raise ValueError("CI_EXECUTED_TARGETS not found in the test-runner source")
+    return re.findall(r'"([^"]+)"', match.group("body"))
 SPEC = importlib.util.spec_from_file_location("ci_required_results", RESULTS_SCRIPT)
 RESULTS = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
@@ -42,7 +68,11 @@ def list_needs(block: str) -> set[str]:
     return set(re.findall(rf"^      - ({ACTION_ID})$", match.group(1), re.MULTILINE))
 
 
-def validate(ci_path: Path, native_runner_path: Path = NATIVE_RUNNER_SCRIPT) -> list[str]:
+def validate(
+    ci_path: Path,
+    native_runner_path: Path = NATIVE_RUNNER_SCRIPT,
+    test_runner_path: Path = TEST_RUNNER_SOURCE,
+) -> list[str]:
     workflow = ci_path.read_text()
     native_runner = native_runner_path.read_text()
     errors: list[str] = []
@@ -158,6 +188,31 @@ def validate(ci_path: Path, native_runner_path: Path = NATIVE_RUNNER_SCRIPT) -> 
             + ", ".join(sorted(check_names))
         )
 
+    # RUE-1161: the harness's platform responsibility matrix must name exactly
+    # the platforms required CI executes cases on.
+    try:
+        declared = ci_executed_targets(test_runner_path.read_text())
+    except (OSError, ValueError) as error:
+        errors.append(f"platform responsibility matrix unreadable: {error}")
+    else:
+        if set(declared) != set(PLATFORM_LANES):
+            errors.append(
+                "CI_EXECUTED_TARGETS drift: harness declares "
+                + ", ".join(sorted(declared))
+                + "; workflow lanes cover "
+                + ", ".join(sorted(PLATFORM_LANES))
+            )
+        for platform in declared:
+            lane = PLATFORM_LANES.get(platform)
+            if lane is None:
+                continue
+            job, marker = lane
+            if marker not in jobs.get(job, ""):
+                errors.append(
+                    f"platform {platform} is declared CI-executed but job {job} "
+                    f"no longer contains {marker!r}"
+                )
+
     for sanitizer in ("valgrind", "asan"):
         block = jobs.get(sanitizer, "")
         if "runs-on: ubuntu-latest" not in block:
@@ -173,8 +228,14 @@ def validate(ci_path: Path, native_runner_path: Path = NATIVE_RUNNER_SCRIPT) -> 
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("workflow", type=Path)
+    parser.add_argument(
+        "--test-runner-source",
+        type=Path,
+        default=TEST_RUNNER_SOURCE,
+        help="rue-test-runner source declaring the platform responsibility matrix",
+    )
     args = parser.parse_args()
-    errors = validate(args.workflow)
+    errors = validate(args.workflow, NATIVE_RUNNER_SCRIPT, args.test_runner_source)
     if errors:
         for error in errors:
             print(f"error: {error}")


### PR DESCRIPTION
Fixes RUE-1161.

Specification cases already carried platform metadata (`only_on`, `target`), but nothing modeled what it meant. Two honesty holes were reachable through it, and one documented workflow silently did not work.

## Platform responsibility

Every case is classified structurally, from the assertions it actually makes:

| Responsibility | Asserts | Executed by |
| --- | --- | --- |
| Semantic | diagnostics, semantics, target-independent golden IR (tokens/AST/RIR/AIR/CFG) | the Linux-complete lane |
| Native | builds and runs a program for the executing host's target | the Linux-complete lane, plus the native lane of every `only_on` host |
| Backend | architecture-specific output for a declared `target` | the Linux-complete lane when it only emits; the matching native lane when it also runs the result |

Loading any corpus now **rejects** a case whose responsibility is undecidable:

- backend golden output (`expected_mir`, `expected_asm`, …) with no declared `target` — the expectation belongs to one architecture, but nothing says which;
- a `target` whose architecture differs from an `only_on` host;
- a `target` with assertions that *run* the program and no `only_on` scope, which would ask whichever host runs the suite to execute a foreign-architecture binary. Cross-compiling and stopping at the executable (`compile_only`) stays legal, since it is host-independent.

`//:spec-traceability` loads the whole corpus, so the standalone required check is where an ambiguous case surfaces first — no new target needed. The current spec, UI, and CLI corpora are all clean under these rules.

## Coverage now requires CI reachability

`x86-64-macos` is a legal host name so the suite runs on an Intel Mac, but no required lane is one. `expressions.intrinsics::target_combined_detection_x86_64_macos` was therefore counted as full specification coverage while executing nowhere in CI — the RUE-132 "a test that never runs cannot fail" class, reached along the platform axis.

Coverage now requires the case to be executable on at least one platform in the declared matrix. Normative coverage is unchanged at 99.6% (776/779): no paragraph depended on that case, and the traceability summary lists every excluded case rather than dropping it silently.

`rue_test_runner::CI_EXECUTED_TARGETS` is a declared Buck input of `scripts/validate-ci-gate.py`, which fails if it and `ci.yml`'s lanes drift in either direction — a platform declared CI-executed with no lane, or a lane removed while the constant still credits it.

## Paragraph filtering was broken

`scripts/rue spec 4.2` is documented in AGENTS.md and named in the acceptance criteria, but libtest filters match test names (`section.id::case_name`), which never contain paragraph IDs. It selected **zero** cases and reported a pass.

An argument shaped like a specification ID, or one passed with `--spec`, now selects the cases citing it; ordinary name filters are untouched, and a paragraph-shaped value belonging to a flag (`--skip 4.2`) stays that flag's value.

```
scripts/rue spec 4.2      # 98 cases citing section 4.2
scripts/rue spec 4.2:5    # 13 cases citing paragraph 4.2:5
scripts/rue spec 4.999:1  # error: no spec case cites 4.999:1
```

A selector matching nothing exits non-zero — an empty filter reporting a pass is how a mistyped ID becomes false evidence that a rule is exercised.

## Focused coverage

Audited for normative rules covered only through a large program: **none exist** — the largest sole-coverage case is 21 lines, the largest case in the corpus is 28. The deliverable is that audit plus a gate at a 40-line focused-case budget so it stays true. Large programs remain integration and slow-tier coverage; they just cannot be a rule's sole evidence. This threshold is the one judgment call here and is easy to raise if it ever bites.

## Unchanged

Preview and known-bug expected-result semantics, including XPASS handling, are untouched; `//:spec-traceability` remains a standalone required check; `RUE_PLATFORM_CASE_SELECTION=native` still registers exactly the `only_on` cases for the host (13 on x86-64-linux).

## Testing

Green: `rue-test-runner` and `rue-spec` unit tests (new cases for each classification, each ambiguity, CI reachability, and selector parsing), `//:spec-tests`, `//:spec-traceability`, `//:ci-gate-validation`, `//:ci-gate-validator-tool-tests`, `//:wrapper-script-tests`, `//:tier-ci-selector-validation`, `./fmt.sh`, `./clippy.sh`. The full premerge tier was still finishing when this PR was opened; CI is the authority.

One pre-existing failure on this host: `diagnostics.function_frame_too_large::cumulative_locals_exceed_frame_budget` times out in `//:ui-tests`. Verified by stashing that it fails identically on unmodified trunk — unrelated to this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cv3HLfUuxX2wTww3BJz5Qi)_