### PR TITLE
RUE-1177/1178/1179: reconcile three spec self-contradictions

### DIFF
--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -108,7 +108,12 @@ pub struct ConstDecl {
     pub visibility: Visibility,
     /// Constant name
     pub name: Ident,
-    /// Optional type annotation (usually inferred)
+    /// Type annotation. Syntactically optional so the parser can accept both
+    /// forms, but a *value* constant must carry one: an unannotated value
+    /// constant is rejected as E0475 (spec 6.5:4). It is legitimately absent
+    /// only for the constants that name no value type — module bindings,
+    /// their aliases and re-exports (chapter 10), and callable function
+    /// aliases (6.5:15).
     pub ty: Option<TypeExpr>,
     /// Initializer expression
     pub init: Box<Expr>,

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -191,11 +191,55 @@ error_contains = "cannot be known at compile time"
 
 [[case]]
 name = "comptime_cannot_call_function"
-spec = ["4.14:4"]
+spec = ["4.14:4", "4.14:28"]
+description = "A call to a function with runtime parameters is not comptime-evaluable inside a comptime block"
 source = """
 fn add(a: i32, b: i32) -> i32 { a + b }
 fn main() -> i32 {
     comptime { add(1, 2) }
+}
+"""
+compile_fail = true
+error_contains = "cannot be known at compile time"
+
+# A fully-comptime call (4.14:28) is comptime-evaluable inside a comptime block
+# too, not only in a comptime-argument position. These three cases pin the
+# agreement between the general restriction (4.14:4) and the call rule (4.14:28).
+
+[[case]]
+name = "comptime_block_calls_fully_comptime_fn"
+spec = ["4.14:4", "4.14:28"]
+description = "A fully-comptime call is permitted inside a comptime block"
+source = """
+fn inc(comptime n: i32) -> i32 { n + 1 }
+fn main() -> i32 {
+    comptime { inc(4) }
+}
+"""
+exit_code = 5
+
+[[case]]
+name = "comptime_block_calls_nested_fully_comptime"
+spec = ["4.14:4", "4.14:28"]
+description = "Fully-comptime calls nest inside a comptime block: the inner call is a comptime-evaluable argument"
+source = """
+fn inc(comptime n: i32) -> i32 { n + 1 }
+fn dbl(comptime n: i32) -> i32 { n * 2 }
+fn main() -> i32 {
+    comptime { dbl(inc(4)) }
+}
+"""
+exit_code = 10
+
+[[case]]
+name = "comptime_block_call_rejects_runtime_argument"
+spec = ["4.14:4", "4.14:28"]
+description = "An all-comptime function called with a runtime argument is still not comptime-evaluable"
+source = """
+fn inc(comptime n: i32) -> i32 { n + 1 }
+fn main() -> i32 {
+    let x = 10;
+    comptime { inc(x) }
 }
 """
 compile_fail = true

--- a/crates/rue-spec/cases/modules/bindings.toml
+++ b/crates/rue-spec/cases/modules/bindings.toml
@@ -111,6 +111,73 @@ aux_files = { "math.rue" = "pub fn add(a: i32, b: i32) -> i32 { a + b }" }
 compile_fail = true
 error_contains = "type mismatch"
 
+# A module is not the unit value either: where `()` is the expected type, a
+# module expression is a type mismatch like any other (10.4:6).
+
+[[case]]
+name = "module_as_unit_tail_expression_error"
+spec = ["10.4:6"]
+description = "A module as the tail expression of a unit-typed block is E0206, not the unit value"
+source = """
+fn sink() {
+    let math = @import("math");
+    math
+}
+fn main() -> i32 { sink(); 0 }
+"""
+aux_files = { "math.rue" = "pub fn add(a: i32, b: i32) -> i32 { a + b }" }
+compile_fail = true
+error_contains = ["E0206", "expected ()", "found <module>"]
+
+[[case]]
+name = "module_as_unit_argument_error"
+spec = ["10.4:6"]
+description = "Passing a module where a `()` parameter is expected is E0206"
+source = """
+fn sink(x: ()) -> i32 { 0 }
+fn main() -> i32 {
+    let math = @import("math");
+    sink(math)
+}
+"""
+aux_files = { "math.rue" = "pub fn add(a: i32, b: i32) -> i32 { a + b }" }
+compile_fail = true
+error_contains = ["E0206", "expected ()", "found <module>"]
+
+# =============================================================================
+# Module expressions in statement position (10.4:7)
+# =============================================================================
+# No type is expected in statement position, so the module is discarded without
+# being materialized. This is not a module *value* — see 10.4:6.
+
+[[case]]
+name = "module_expression_statement_discarded"
+spec = ["10.4:7"]
+description = "A bare module expression statement is accepted and discarded"
+source = """
+fn main() -> i32 {
+    let math = @import("math");
+    math;
+    math.add(1, 2)
+}
+"""
+aux_files = { "math.rue" = "pub fn add(a: i32, b: i32) -> i32 { a + b }" }
+exit_code = 3
+
+[[case]]
+name = "module_block_statement_discarded"
+spec = ["10.4:7"]
+description = "A block statement whose tail is a module expression is accepted and discarded"
+source = """
+fn main() -> i32 {
+    let math = @import("math");
+    { math };
+    math.add(2, 3)
+}
+"""
+aux_files = { "math.rue" = "pub fn add(a: i32, b: i32) -> i32 { a + b }" }
+exit_code = 5
+
 # =============================================================================
 # Per-file scoping of module bindings (10.4:8) — RUE-113
 # =============================================================================

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -31,6 +31,8 @@ operations are supported within comptime blocks:
 - Bitwise operators (`&`, `|`, `^`, `<<`, `>>`, `~`)
 - `let` bindings of comptime values
 - References to file-level constants and to `comptime` parameters in scope
+- Fully-comptime calls (4.14:28): a call to a function whose parameters are all
+  declared `comptime`, applied to comptime-evaluable arguments
 
 Evaluation follows runtime semantics exactly: arithmetic is checked at the operands' type (Chapter 8.1), the full value range of every integer type is supported (including negative results and `u64` values above `i64::MAX`), shift amounts are masked modulo the bit width and shift results truncate to the operand width (4.3a:10), and `&&`/`||` short-circuit.
 
@@ -52,7 +54,10 @@ fn main() -> i32 {
 It is a compile-time error if an expression inside a comptime block cannot be evaluated at compile time. This includes:
 
 - References to runtime variables
-- Function calls (except to comptime-evaluable functions in future versions)
+- Calls that are not fully-comptime calls (4.14:28): a call to a function with
+  any non-`comptime` parameter is never comptime-evaluable, because that
+  function's body runs at runtime, and a call to an all-`comptime` function is
+  comptime-evaluable only when every argument is itself comptime-evaluable
 - Operations that would panic at runtime: integer overflow at the operands' type (including in intermediate results), division by zero, and remainder by zero
 
 ```rue
@@ -61,6 +66,21 @@ fn main() -> i32 {
     comptime { x + 1 }  // ERROR: x cannot be known at compile time
 }
 ```
+
+A fully-comptime call is permitted, because every parameter is bound to a
+compile-time value:
+
+```rue
+fn inc(comptime n: i32) -> i32 { n + 1 }
+
+fn main() -> i32 {
+    comptime { inc(4) }  // 5: fully-comptime call (4.14:28)
+}
+```
+
+A call to `fn add(a: i32, b: i32)` would be rejected in the same position
+because `add` has runtime parameters, and `inc(x)` would be rejected for a
+runtime `x` because the argument is not comptime-evaluable.
 
 ## Comptime Parameters
 

--- a/docs/spec/src/10-modules/04-module-bindings.md
+++ b/docs/spec/src/10-modules/04-module-bindings.md
@@ -113,9 +113,10 @@ fn main() -> i32 {
 {{ rule(id="10.4:12", cat="normative") }}
 
 A value constant declared at the top level of a module's file is a member of
-that module. Accessing it through the module yields the constant's value,
-with the constant's declared (or inferred, 6.5:4) type. The access is itself
-compile-time evaluable, so it may appear in another constant's initializer.
+that module. Accessing it through the module yields the constant's value, with
+the constant's declared type — a value constant always carries an explicit type
+annotation (6.5:4). The access is itself compile-time evaluable, so it may
+appear in another constant's initializer.
 
 {{ rule(id="10.4:13", cat="normative") }}
 
@@ -228,12 +229,15 @@ fn main() -> i32 {
 {{ rule(id="10.4:6", cat="legality-rule") }}
 
 A module is not a runtime value. It is a compile-time error to use a module
-binding as a function argument, as a struct field value, or as an operand of
-an operator such as `==`.
+binding where a value of some type is expected — as a function argument, as a
+struct field value, as an operand of an operator such as `==`, or as an
+expression whose type must match an expected type. This includes the expected
+type `()`: a module expression is never treated as the unit value. The
+diagnostic is a type mismatch (`E0206`) reporting `<module>` as the found type.
 
-{{ rule(id="10.4:7") }}
+{{ rule(id="10.4:7", cat="legality-rule") }}
 
-In a few value positions (for example, the tail expression of a block whose
-type is `()`) a module expression is currently accepted and treated as the
-unit value. Programs must not rely on this; it is an artifact of the current
-implementation, not a guarantee.
+A module expression in statement position — a bare expression statement such as
+`m;`, or a block statement whose tail is a module expression — is accepted. No
+type is expected there, so the module is discarded without being materialized as
+a value. This is not an exception to 10.4:6: no module value is produced.


### PR DESCRIPTION
Three rules surfaced by the 2026-07-28 audit disagreed either with the shipped compiler or with a second live rule. Each is corrected against verified current behavior. No language behavior changes.

## Fixes RUE-1177 — comptime call rules

Rule 4.14:4 listed "Function calls (except to comptime-evaluable functions in future versions)" as never comptime-evaluable, while 4.14:28 normatively defines fully-comptime calls. The compiler implements 4.14:28:

- `comptime { inc(4) }` for `fn inc(comptime n: i32)` — compiles, evaluates to 5
- `comptime { add(1, 2) }` for `fn add(a: i32, b: i32)` — `E1200`
- `comptime { inc(x) }` for a runtime `x` — `E1200`

4.14:4 now states the call policy by reference to 4.14:28 rather than contradicting it, and 4.14:2's supported-operations list admits the same class. Both negative classes stay explicit.

## Fixes RUE-1178 — module-value unit artifact

Rule 10.4:7 described a module expression in unit-typed value position as "accepted and treated as the unit value", contradicting 10.4:6. **That artifact no longer exists** — the compiler rejects it in tail position and in a `()` parameter alike, with `error: [E0206]: type mismatch: expected (), found `<code>&lt;module&gt;</code>.

So it is removed rather than softened. 10.4:6 absorbs the `()` case explicitly and names the diagnostic. 10.4:7 is rewritten to state the behavior that does remain — a module expression in statement position (`m;`, `{ m };`) is discarded without being materialized, which produces no module value and so is not an exception to 10.4:6.

## Fixes RUE-1179 — module-constant typing

The module chapter cited a constant's "declared (or inferred, 6.5:4)" type, but 6.5:4 requires an annotation on every value constant (E0475) and no inference exists. `crates/rue-parser/src/ast.rs` carried the same stale "usually inferred" description on `ConstDecl::ty`. Both now match the explicit-annotation policy and name the cases that legitimately carry no annotation: module bindings, their aliases and re-exports, and callable function aliases. 6.5:4 already identified the alias exception and is unchanged.

## Traceability

Seven cases added. Fully-comptime calls *inside a comptime block* were untested — 4.14:28 was covered only in comptime-argument position, which is not the position 4.14:4 governs, which is how the two rules drifted apart unnoticed. 10.4:7 was uncategorized and therefore informative (no coverage required); it is now a `legality-rule` with coverage.

## Verification

- `scripts/rue spec` — 2185 passed, 0 failed, 15 ignored (baseline before the change: 2178 passed, 0 failed)
- `scripts/rue quick` — 844 passed, 0 failed
- Traceability — normative coverage 99.6%, `legality-rule` 142/142; the 3 uncovered normatives are the pre-existing FFI allowlist entries
- Each finding was confirmed against a compiled program on trunk before editing, per the evidence rule in AGENTS.md
