### PR TITLE
Correct the documented merge command for the merge queue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,11 +259,18 @@ jj new 'trunk()'
 jj describe -m 'RUE-NNN: concise summary'
 jj git push --remote upstream -c @
 gh pr create --repo rue-language/rue --base trunk --head <bookmark>
-gh pr merge <number> --repo rue-language/rue --auto --squash
+gh pr merge <number> --repo rue-language/rue --auto
 # wait for the authoritative MERGED state
 jj git fetch
 jj new 'trunk()'
 ```
+
+`trunk` is behind a merge queue, so `--auto` enqueues the PR and the queue
+performs the merge once it reaches the front and merge-group CI passes. Do not
+pass a merge-method flag: squash is disabled on the repository (`--squash`
+fails with a 405), and the queue owns the method regardless. A direct
+`gh pr merge` without `--auto` is refused by branch protection with
+"Changes must be made through the merge queue".
 
 For a fork-based contribution, push with `--remote origin` and pass
 `--head <user>:<bookmark>` when creating the PR.


### PR DESCRIPTION
The maintainer flow in AGENTS.md documented:

```bash
gh pr merge <number> --repo rue-language/rue --auto --squash
```

Both halves of that fail in practice. Hit while landing #2050:

- `--squash` → `405 Squash merges are not allowed on this repository`
- a direct merge without `--auto` → `405 Repository rule violations found: Changes must be made through the merge queue`

`docs/process/fork-workflow.md` already documents the correct queue-based form (`gh pr merge <n> --repo rue-language/rue --auto   # queue it immediately`), so AGENTS.md was the lone outlier. This drops the method flag and states what the queue owns, so the next reader doesn't re-derive it from a pair of 405s.

## Verified vs. inferred

Verified empirically on #2050: squash is rejected; direct merge is blocked by the queue rule; auto-merge enqueues and the queue merges (producing linear history).

Not verified: whether merge-commit is also enabled alongside rebase — this session cannot read the repository's `allow_*_merge` settings. It doesn't change the guidance, since the queue performs the merge and owns the method, but if `gh` ever asks for an explicit method on this repo, that's the reason and the flag belongs in this doc.

No code or test changes; documentation only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cv3HLfUuxX2wTww3BJz5Qi)_