### PR TITLE
Elide empty frames and unnecessary leaf prologues

### DIFF
--- a/crates/rue-cli-tests/cases/frameless_leaf.toml
+++ b/crates/rue-cli-tests/cases/frameless_leaf.toml
@@ -1,0 +1,89 @@
+# Frameless leaf execution (RUE-1171).
+#
+# A leaf function with no locals, spills, homed parameters, sret pointer,
+# calls, or stack arguments gets no frame pointer and no frame allocation: its
+# prologue is at most the callee-saved pushes the register allocator needed.
+# These cases run the real binary so the elided prologue is validated against
+# the platform ABI on both backends, not just inspected as assembly.
+
+[section]
+id = "cli.frameless-leaf"
+name = "Frameless leaf prologues"
+description = "Leaf functions that need no frame still return correctly, and framed leaves still work alongside them."
+
+[[case]]
+name = "frameless_leaf_returns_and_restores_callee_saved"
+files = [{ path = "main.rue", source = """
+fn frameless() -> i32 {
+    7
+}
+
+fn framed(n: i32) -> i32 {
+    n + 1
+}
+
+fn main() -> i32 {
+    // `keep` is live across the frameless call, so a callee-saved register
+    // holds it: if the frameless prologue failed to save and restore what it
+    // clobbers, this value would come back wrong.
+    let keep = 100;
+    let a = frameless();
+    let b = framed(4);
+    @dbg(keep);
+    @dbg(a);
+    @dbg(b);
+    0
+}
+""" }]
+stdout = "100\n7\n5\n"
+
+[[case]]
+name = "frameless_leaves_nest_under_a_framed_caller"
+files = [{ path = "main.rue", source = """
+fn zero() -> i32 {
+    0
+}
+
+fn one() -> i32 {
+    1
+}
+
+fn two() -> i32 {
+    2
+}
+
+// A caller is never a leaf, so it keeps its frame and its return address
+// across every frameless callee.
+fn sum() -> i32 {
+    zero() + one() + two()
+}
+
+fn main() -> i32 {
+    @dbg(sum());
+    @dbg(sum() + zero());
+    0
+}
+""" }]
+stdout = "3\n3\n"
+
+[[case]]
+name = "frameless_leaf_in_a_loop_keeps_the_stack_balanced"
+files = [{ path = "main.rue", source = """
+fn step() -> i32 {
+    3
+}
+
+fn main() -> i32 {
+    let mut total = 0;
+    let mut i = 0;
+    // Calling a frameless leaf many times would drift the stack pointer if its
+    // pushes and pops were not balanced.
+    while i < 1000 {
+        total = total + step();
+        i = i + 1;
+    }
+    @dbg(total);
+    0
+}
+""" }]
+stdout = "3000\n"

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -56,6 +56,27 @@
 //!
 //! For values that cannot be encoded as logical immediates, we materialize the constant
 //! in a scratch register (X9) using MOVZ/MOVK and then use the register-register form.
+//!
+//! # Frameless Leaves
+//!
+//! The usual prologue saves the FP/LR pair, sets X29 to the new frame pointer,
+//! pushes the callee-saved registers in pairs, and reserves the slot region. A
+//! leaf function with no frame slots at all — no locals, no register-allocator
+//! spills, no homed parameters, no sret pointer cell — and no calls needs none
+//! of that, so frame planning omits its frame pointer (RUE-1171) and its
+//! prologue shrinks to the callee-saved pushes:
+//!
+//! ```asm
+//! str x19, [sp, #-16]!     ; Save callee-saved registers (if any were used)
+//! ...                      ; body: no FP-relative operand can exist
+//! ldr x19, [sp], #16
+//! ret
+//! ```
+//!
+//! The FP/LR save can be dropped only because the function makes no call: X30
+//! still holds this function's return address when `ret` executes. The decision
+//! is made once, by `codegen_pipeline::plan_frame_pointer`, and reaches this
+//! module as the frame layout's [`crate::frame_layout::FramePointer`].
 
 use rue_error::{CompileError, CompileResult, ErrorKind, ice_error};
 
@@ -369,8 +390,20 @@ pub struct Emitter<'a> {
     has_sret: bool,
     /// Callee-saved registers that need to be preserved.
     callee_saved: Vec<Reg>,
-    /// Whether a stack frame was emitted (prologue was executed).
+    /// Whether a prologue was emitted, and so an epilogue must be too.
     has_frame: bool,
+    /// Whether the prologue established X29 as a frame pointer (and saved the
+    /// FP/LR pair). False for an eligible frameless leaf, whose prologue is at
+    /// most the callee-saved pushes (RUE-1171).
+    has_frame_pointer: bool,
+    /// Whether frame planning classified this function as a frameless leaf.
+    /// Distinct from `has_frame_pointer`, which is also false for a synthetic
+    /// emitter built with no frame facts at all.
+    frameless: bool,
+    /// An FP-relative operand reached a function planned as frameless. That is
+    /// an internal inconsistency, reported after emission rather than silently
+    /// encoded against a frame pointer that was never established.
+    frameless_frame_reference: bool,
     /// Canonical checked layout supplied by the production pipeline.
     frame_layout: Option<crate::frame_layout::FrameLayout>,
     /// String constants (for StringConstPtr/StringConstLen)
@@ -418,6 +451,9 @@ impl<'a> Emitter<'a> {
             has_sret: false,
             callee_saved: callee_saved.to_vec(),
             has_frame: false,
+            has_frame_pointer: false,
+            frameless: false,
+            frameless_frame_reference: false,
             frame_layout: None,
             strings,
             inst_start: 0,
@@ -510,12 +546,36 @@ impl<'a> Emitter<'a> {
     /// adjusts negative FP-relative offsets to skip past the callee-saved area.
     ///
     /// Positive offsets (stack arguments) are left unchanged.
-    fn adjust_fp_offset(&self, base: Reg, offset: i32) -> i32 {
-        if base == Reg::Fp && offset < 0 {
+    ///
+    /// This is the single funnel every FP-based operand passes through, so it
+    /// is also where a frameless function is checked against actually naming a
+    /// frame location (RUE-1171).
+    fn adjust_fp_offset(&mut self, base: Reg, offset: i32) -> i32 {
+        if base != Reg::Fp {
+            return offset;
+        }
+        if self.frameless {
+            self.frameless_frame_reference = true;
+        }
+        if offset < 0 {
             offset - self.callee_saved_stack_size()
         } else {
             offset
         }
+    }
+
+    /// The canonical frame layout for this function, falling back to a framed
+    /// layout derived from the slot counts when no pipeline layout was supplied
+    /// (a directly constructed emitter in a synthetic test).
+    fn frame(&self) -> crate::frame_layout::FrameLayout {
+        self.frame_layout.unwrap_or_else(|| {
+            crate::frame_layout::FrameLayout::try_new(
+                crate::frame_layout::SavedRegScheme::Aarch64,
+                self.callee_saved.len(),
+                self.num_locals + self.num_params + self.has_sret as u32,
+            )
+            .expect("emitter frame must fit the checked function-frame budget")
+        })
     }
 
     // ==================== Main emit entry point ====================
@@ -566,17 +626,30 @@ impl<'a> Emitter<'a> {
             }
         }
 
-        if self.num_locals > 0
-            || self.num_params > 0
-            || self.has_sret
-            || !self.callee_saved.is_empty()
-        {
-            self.has_frame = true;
+        // A frame pointer exists to address frame slots; an eligible frameless
+        // leaf has none, so its prologue is at most the callee-saved pushes and
+        // it neither establishes X29 nor saves the FP/LR pair (RUE-1171).
+        self.frameless = self.frame().frame_pointer() == crate::frame_layout::FramePointer::Omitted;
+        self.has_frame_pointer = !self.frameless
+            && (self.num_locals > 0
+                || self.num_params > 0
+                || self.has_sret
+                || !self.callee_saved.is_empty());
+        self.has_frame = self.has_frame_pointer || !self.callee_saved.is_empty();
+        if self.has_frame {
             self.emit_prologue();
         }
 
         for inst in self.mir.iter() {
             self.emit_inst(inst);
+        }
+
+        if self.frameless_frame_reference {
+            return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+                "frame planning omitted the frame pointer but an FP-relative \
+                 operand was emitted"
+                    .to_string(),
+            )));
         }
 
         self.apply_fixups()
@@ -586,15 +659,17 @@ impl<'a> Emitter<'a> {
     fn emit_prologue(&mut self) {
         self.record_comment("prologue");
 
-        // stp x29, x30, [sp, #-16]!   ; Save FP and LR
-        self.begin_inst();
-        self.emit_stp_pre(Reg::Fp, Reg::Lr, -16);
-        end_inst!(self, "stp x29, x30, [sp, #-16]!");
+        if self.has_frame_pointer {
+            // stp x29, x30, [sp, #-16]!   ; Save FP and LR
+            self.begin_inst();
+            self.emit_stp_pre(Reg::Fp, Reg::Lr, -16);
+            end_inst!(self, "stp x29, x30, [sp, #-16]!");
 
-        // mov x29, sp                 ; Set up frame pointer
-        self.begin_inst();
-        self.emit_mov_rr(Reg::Fp, Reg::Sp);
-        end_inst!(self, "mov x29, sp");
+            // mov x29, sp                 ; Set up frame pointer
+            self.begin_inst();
+            self.emit_mov_rr(Reg::Fp, Reg::Sp);
+            end_inst!(self, "mov x29, sp");
+        }
 
         // Save callee-saved registers in pairs.
         // Each STP/STR pre-index instruction decrements SP by 16 bytes.
@@ -624,16 +699,11 @@ impl<'a> Emitter<'a> {
         // (stack-passed args are copied into the frame param area below so
         // the body can address every param slot uniformly), and the incoming
         // sret pointer slot, if any.
+        //
+        // A frameless leaf has no slots at all, so nothing is reserved here.
         let total_slots = self.num_locals + self.num_params + self.has_sret as u32;
         if total_slots > 0 {
-            let frame = self.frame_layout.unwrap_or_else(|| {
-                crate::frame_layout::FrameLayout::try_new(
-                    crate::frame_layout::SavedRegScheme::Aarch64,
-                    self.callee_saved.len(),
-                    total_slots,
-                )
-                .expect("emitter frame must fit the checked function-frame budget")
-            });
+            let frame = self.frame();
             let stack_size = frame.frame_size() as i32 - frame.saved_area_bytes();
             if stack_size > 0 {
                 self.begin_inst();
@@ -1456,15 +1526,7 @@ impl<'a> Emitter<'a> {
         if self.num_locals > 0 || self.num_params > 0 || self.has_sret {
             // Must mirror the prologue's allocation exactly: locals + ALL
             // params + the sret pointer slot.
-            let total_slots = self.num_locals + self.num_params + self.has_sret as u32;
-            let frame = self.frame_layout.unwrap_or_else(|| {
-                crate::frame_layout::FrameLayout::try_new(
-                    crate::frame_layout::SavedRegScheme::Aarch64,
-                    self.callee_saved.len(),
-                    total_slots,
-                )
-                .expect("emitter frame must fit the checked function-frame budget")
-            });
+            let frame = self.frame();
             let stack_size = frame.frame_size() as i32 - frame.saved_area_bytes();
             if stack_size > 0 {
                 self.begin_inst();
@@ -1500,9 +1562,14 @@ impl<'a> Emitter<'a> {
         }
 
         // ldp x29, x30, [sp], #16     ; Restore FP and LR
-        self.begin_inst();
-        self.emit_ldp_post(Reg::Fp, Reg::Lr, 16);
-        end_inst!(self, "ldp x29, x30, [sp], #16");
+        //
+        // A frameless leaf never saved them: it makes no call, so LR still
+        // holds this function's return address.
+        if self.has_frame_pointer {
+            self.begin_inst();
+            self.emit_ldp_post(Reg::Fp, Reg::Lr, 16);
+            end_inst!(self, "ldp x29, x30, [sp], #16");
+        }
     }
 
     /// Apply pending fixups for forward branches.

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -1315,6 +1315,18 @@ impl Aarch64Mir {
         self.instructions.iter()
     }
 
+    /// Whether this function calls nothing — the eligibility precondition for
+    /// a frameless prologue (RUE-1171).
+    ///
+    /// `svc` does not count: a supervisor call returns through ELR, so it
+    /// leaves the link register the FP/LR save would have preserved intact.
+    pub fn is_leaf(&self) -> bool {
+        !self
+            .instructions
+            .iter()
+            .any(|inst| matches!(inst, Aarch64Inst::Bl { .. }))
+    }
+
     /// Consume the MIR and return its instructions.
     pub fn into_instructions(self) -> Vec<Aarch64Inst> {
         self.instructions

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -108,6 +108,7 @@ fn prepare_backend_with_artifacts(
         },
         schedule::schedule,
         verify::verify_stack_alignment,
+        Aarch64Mir::is_leaf,
     )
 }
 

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -10,7 +10,7 @@ use rue_cfg::{Cfg, CfgArgMode, CfgInstData, CfgValue};
 use rue_error::{CompileError, CompileResult, ErrorKind};
 use tracing::info_span;
 
-use crate::frame_layout::{FrameLayout, SavedRegScheme};
+use crate::frame_layout::{FrameLayout, FramePointer, SavedRegScheme};
 
 /// How the callee prologue homes one source parameter's incoming argument
 /// registers into its frame parameter slots (ADR-0052 phase 5.8, RUE-1005).
@@ -52,6 +52,30 @@ pub(crate) fn param_homing_plan(cfg: &Cfg) -> Vec<ParamHoming> {
             reg_count: param.crossing_regs,
         })
         .collect()
+}
+
+/// Decide whether the final frame needs a frame pointer and a slot region, or
+/// whether the function is an eligible frameless leaf (RUE-1171).
+///
+/// Two facts make a frame unavoidable:
+///
+/// - **Any frame slot.** A local, a register-allocator spill, a homed
+///   parameter, or the incoming sret pointer cell is addressed FP-relative, so
+///   the frame pointer and the slot region both have to exist. Conversely
+///   `total_slots == 0` means nothing in the body can name a frame location:
+///   every FP-based address this backend emits — lowering's local, parameter,
+///   and sret addressing and allocation's spill reloads — is derived from a
+///   slot index. The emitters assert this rather than assume it, and raise an
+///   internal error if an FP-relative operand reaches a frameless function.
+/// - **Any call.** A call needs the call-boundary stack alignment the slot
+///   region's rounding establishes, and on AArch64 it clobbers the link
+///   register that the FP/LR save preserves. Only leaves are eligible.
+pub(crate) fn plan_frame_pointer(total_slots: u32, is_leaf: bool) -> FramePointer {
+    if total_slots == 0 && is_leaf {
+        FramePointer::Omitted
+    } else {
+        FramePointer::Established
+    }
 }
 
 /// A target's MIR after allocation, peephole optimization, scheduling, and
@@ -157,7 +181,17 @@ pub(crate) fn validate_pre_lowering_budget(
 /// Run the canonical backend pipeline while carrying optional diagnostic
 /// observations alongside the same lowering and allocation execution.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn prepare_mir_with_artifacts<M, R, D, Lower, Allocate, Peephole, Schedule, Verify>(
+pub(crate) fn prepare_mir_with_artifacts<
+    M,
+    R,
+    D,
+    Lower,
+    Allocate,
+    Peephole,
+    Schedule,
+    Verify,
+    IsLeaf,
+>(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,
     arg_reg_count: u32,
@@ -168,6 +202,7 @@ pub(crate) fn prepare_mir_with_artifacts<M, R, D, Lower, Allocate, Peephole, Sch
     peephole: Peephole,
     schedule: Schedule,
     verify: Verify,
+    is_leaf: IsLeaf,
 ) -> CompileResult<(PreparedMir<M, R>, D)>
 where
     Lower: FnOnce() -> CompileResult<(M, D)>,
@@ -175,6 +210,7 @@ where
     Peephole: FnOnce(&mut M),
     Schedule: FnOnce(&mut M),
     Verify: FnOnce(&M) -> CompileResult<()>,
+    IsLeaf: FnOnce(&M) -> bool,
 {
     let num_locals_original = cfg.num_locals();
     let num_params = cfg.num_params();
@@ -211,8 +247,16 @@ where
         .ok_or_else(|| frame_budget_error(cfg, None))?;
     let total_slots = checked_slot_sum([total_locals, num_params, u32::from(has_sret)])
         .ok_or_else(|| frame_budget_error(cfg, None))?;
-    let frame_layout = FrameLayout::try_new(scheme, used_callee_saved.len(), total_slots)
-        .map_err(|_| frame_budget_error(cfg, None))?;
+    // Frame planning is the last thing the pipeline decides: the eligible-leaf
+    // question can only be answered once allocation, peephole, and scheduling
+    // have settled the final instruction stream and the final spill count.
+    let frame_layout = match plan_frame_pointer(total_slots, is_leaf(&mir)) {
+        FramePointer::Omitted => FrameLayout::frameless(scheme, used_callee_saved.len()),
+        FramePointer::Established => {
+            FrameLayout::try_new(scheme, used_callee_saved.len(), total_slots)
+                .map_err(|_| frame_budget_error(cfg, None))?
+        }
+    };
 
     Ok((
         PreparedMir {
@@ -238,7 +282,22 @@ mod tests {
     use rue_cfg::{Cfg, CfgArgMode, CfgCallArg, CfgInst, CfgInstData};
     use rue_span::Span;
 
-    use super::{SavedRegScheme, prepare_mir_with_artifacts, validate_pre_lowering_budget};
+    use super::{
+        FramePointer, SavedRegScheme, plan_frame_pointer, prepare_mir_with_artifacts,
+        validate_pre_lowering_budget,
+    };
+
+    #[test]
+    fn only_a_slotless_leaf_omits_the_frame_pointer() {
+        assert_eq!(plan_frame_pointer(0, true), FramePointer::Omitted);
+        // One real frame consumer — a local, a spill, a homed parameter, or the
+        // sret pointer cell — restores the frame.
+        assert_eq!(plan_frame_pointer(1, true), FramePointer::Established);
+        // A call needs the call-boundary alignment and, on AArch64, the FP/LR
+        // save, even with nothing to store in the frame.
+        assert_eq!(plan_frame_pointer(0, false), FramePointer::Established);
+        assert_eq!(plan_frame_pointer(3, false), FramePointer::Established);
+    }
 
     #[test]
     fn pass_order_and_frame_slot_formulas_are_single_source() {
@@ -285,12 +344,19 @@ mod tests {
                 assert_eq!(*mir, 16);
                 Ok(())
             },
+            |mir| {
+                events.borrow_mut().push("is_leaf");
+                assert_eq!(*mir, 16, "frame planning sees the final instruction stream");
+                true
+            },
         )
         .expect("synthetic pipeline should succeed");
 
         assert_eq!(
             events.into_inner(),
-            ["lower", "allocate", "peephole", "schedule", "verify"]
+            [
+                "lower", "allocate", "peephole", "schedule", "verify", "is_leaf"
+            ]
         );
         assert_eq!(prepared.mir, 16);
         assert_eq!(prepared.total_locals, 7);

--- a/crates/rue-codegen/src/frame_layout.rs
+++ b/crates/rue-codegen/src/frame_layout.rs
@@ -125,6 +125,28 @@ pub fn align_frame_size(bytes: i32) -> i32 {
     .expect("validated frame size fits i32")
 }
 
+/// Whether a function establishes a frame pointer at all (RUE-1171).
+///
+/// A frame pointer exists to address frame slots. A function with no frame
+/// storage whatsoever — no locals, no spills, no homed parameters, no sret
+/// pointer cell — and no calls has nothing to address and nothing to keep
+/// aligned, so its prologue can skip the frame-pointer setup and the slot
+/// region entirely. Calls are excluded because a call both consumes the
+/// call-boundary alignment the slot region establishes and, on AArch64,
+/// clobbers the link register the FP/LR save preserves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FramePointer {
+    /// The prologue establishes a frame pointer and allocates the slot region;
+    /// every frame slot is addressed FP-relative.
+    Established,
+    /// No frame pointer and no slot region. Callee-saved registers, if the
+    /// allocator used any, are still saved and restored — they are addressed by
+    /// the push/pop (pre/post-indexed) instructions themselves, not the frame
+    /// pointer — and their offsets below the entry stack pointer are the same
+    /// numbers [`FrameLayout::slot_offset`]'s saved-area helpers report.
+    Omitted,
+}
+
 /// How a target saves the registers that sit between the frame pointer and the
 /// slot region. Their total byte span shifts every frame-slot offset down.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -146,14 +168,26 @@ pub fn aarch64_callee_saved_pairs_bytes(num_callee_saved: usize) -> u64 {
 }
 
 impl SavedRegScheme {
+    /// Bytes the prologue's callee-saved pushes occupy, excluding any
+    /// frame-pointer save. This is the whole saved area of a frameless function
+    /// ([`FramePointer::Omitted`]).
+    pub fn callee_saved_bytes(self, num_callee_saved: usize) -> u64 {
+        match self {
+            SavedRegScheme::X86_64 => num_callee_saved as u64 * frame_cell_bytes(),
+            SavedRegScheme::Aarch64 => aarch64_callee_saved_pairs_bytes(num_callee_saved),
+        }
+    }
+
     /// Bytes reserved for saved registers between the frame pointer and the
     /// slot region, given `num_callee_saved` saved general-purpose registers.
     pub fn saved_area_bytes(self, num_callee_saved: usize) -> u64 {
         match self {
-            SavedRegScheme::X86_64 => num_callee_saved as u64 * frame_cell_bytes(),
+            // The saved RBP sits *above* the frame pointer, so it is not part
+            // of this area.
+            SavedRegScheme::X86_64 => self.callee_saved_bytes(num_callee_saved),
             // FP/LR pair plus the paired callee-saved registers.
             SavedRegScheme::Aarch64 => {
-                STACK_FRAME_ALIGNMENT + aarch64_callee_saved_pairs_bytes(num_callee_saved)
+                STACK_FRAME_ALIGNMENT + self.callee_saved_bytes(num_callee_saved)
             }
         }
     }
@@ -168,11 +202,29 @@ impl SavedRegScheme {
 #[derive(Debug, Clone, Copy)]
 pub struct FrameLayout {
     scheme: SavedRegScheme,
+    frame_pointer: FramePointer,
     saved_area_bytes: u64,
     num_slots: u32,
 }
 
 impl FrameLayout {
+    /// Build the layout of a function that establishes no frame pointer and
+    /// allocates no slot region: only the callee-saved registers the allocator
+    /// actually used are pushed (RUE-1171).
+    ///
+    /// Callers must have established that the function has zero frame slots and
+    /// makes no calls; see [`FramePointer::Omitted`]. No budget check is needed
+    /// because the saved area is bounded by the target's allocatable
+    /// callee-saved register count.
+    pub fn frameless(scheme: SavedRegScheme, num_callee_saved: usize) -> Self {
+        Self {
+            scheme,
+            frame_pointer: FramePointer::Omitted,
+            saved_area_bytes: scheme.callee_saved_bytes(num_callee_saved),
+            num_slots: 0,
+        }
+    }
+
     /// Build a frame layout for `num_slots` slot cells sitting below the saved
     /// registers described by `scheme`.
     pub fn try_new(
@@ -200,13 +252,21 @@ impl FrameLayout {
         }
         Ok(Self {
             scheme,
+            frame_pointer: FramePointer::Established,
             saved_area_bytes,
             num_slots,
         })
     }
 
+    /// Whether this function establishes a frame pointer and a slot region.
+    #[inline]
+    pub fn frame_pointer(&self) -> FramePointer {
+        self.frame_pointer
+    }
+
     /// Bytes reserved for saved registers between the frame pointer and the
-    /// slot region.
+    /// slot region. With the frame pointer omitted this is the whole frame:
+    /// the callee-saved pushes and nothing else.
     #[inline]
     pub fn saved_area_bytes(&self) -> i32 {
         self.saved_area_bytes as i32
@@ -219,6 +279,19 @@ impl FrameLayout {
         -self.saved_area_bytes() + slot_offset_pre_saved(slot)
     }
 
+    /// Byte granularity this frame maintains.
+    ///
+    /// A framed function keeps the call-boundary [`STACK_FRAME_ALIGNMENT`]. A
+    /// frameless leaf makes no calls, so it only has to keep the stack pointer
+    /// on the granularity its saved-register pushes move it by: one cell per
+    /// push on x86-64, a 16-byte pair on AArch64.
+    pub fn alignment(&self) -> u64 {
+        match (self.frame_pointer, self.scheme) {
+            (FramePointer::Omitted, SavedRegScheme::X86_64) => frame_cell_bytes(),
+            _ => STACK_FRAME_ALIGNMENT,
+        }
+    }
+
     /// Byte size of frame slot `slot`. Uniform [`frame_cell_bytes`] today.
     #[inline]
     pub fn slot_size(&self, _slot: u32) -> u64 {
@@ -228,6 +301,11 @@ impl FrameLayout {
     /// Total frame size in bytes, including the saved-register area and the
     /// 16-byte-aligned slot region.
     pub fn frame_size(&self) -> u64 {
+        if self.frame_pointer == FramePointer::Omitted {
+            // No slot region to round up and no frame pointer to align against:
+            // the callee-saved pushes are the entire frame.
+            return self.saved_area_bytes;
+        }
         let slots = slot_region_bytes(self.num_slots);
         match self.scheme {
             // The saved GPR pushes are not 16-aligned on x86-64, so the whole
@@ -320,6 +398,46 @@ mod tests {
         // saved = 16 + 16 = 32, slots = 24 -> round16(24) = 32; total = 64.
         assert_eq!(layout.frame_size(), 64);
         assert_eq!(layout.slot_offset(0), -32 - 8);
+    }
+
+    #[test]
+    fn frameless_layouts_are_only_the_callee_saved_pushes() {
+        // x86-64: one 8-byte push per saved register, no `push rbp` and no
+        // 16-byte rounding — a frameless leaf has no call boundary to align.
+        let x86 = FrameLayout::frameless(SavedRegScheme::X86_64, 1);
+        assert_eq!(x86.frame_pointer(), FramePointer::Omitted);
+        assert_eq!(x86.frame_size(), 8);
+        assert_eq!(x86.saved_area_bytes(), 8);
+        assert_eq!(
+            FrameLayout::frameless(SavedRegScheme::X86_64, 0).frame_size(),
+            0
+        );
+
+        // AArch64: 16-byte pairs, and the FP/LR pair is no longer saved.
+        let arm = FrameLayout::frameless(SavedRegScheme::Aarch64, 1);
+        assert_eq!(arm.frame_size(), 16);
+        assert_eq!(arm.saved_area_bytes(), 16);
+        assert_eq!(
+            FrameLayout::frameless(SavedRegScheme::Aarch64, 3).frame_size(),
+            32
+        );
+        assert_eq!(
+            FrameLayout::frameless(SavedRegScheme::Aarch64, 0).frame_size(),
+            0
+        );
+    }
+
+    #[test]
+    fn a_frame_slot_restores_the_full_framed_layout() {
+        // Adding one real frame consumer to the frameless x86-64 case above
+        // brings back the frame pointer, the slot cell, and 16-byte rounding.
+        let framed = FrameLayout::try_new(SavedRegScheme::X86_64, 1, 1).unwrap();
+        assert_eq!(framed.frame_pointer(), FramePointer::Established);
+        assert_eq!(framed.frame_size(), 16);
+        // And on AArch64 the FP/LR pair is saved again.
+        let framed = FrameLayout::try_new(SavedRegScheme::Aarch64, 1, 1).unwrap();
+        assert_eq!(framed.saved_area_bytes(), 32);
+        assert_eq!(framed.frame_size(), 48);
     }
 
     #[test]

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -114,6 +114,10 @@ pub struct StackFrameInfo {
     pub frame_size: usize,
     /// Required alignment in bytes.
     pub alignment: usize,
+    /// Whether the function establishes a frame pointer. A frameless leaf
+    /// (RUE-1171) has none, so its saved-register offsets are reported relative
+    /// to the stack pointer on entry rather than to a frame pointer.
+    pub uses_frame_pointer: bool,
     /// All stack slots (locals, spills, callee-saved, params).
     pub slots: Vec<StackSlot>,
     /// Argument passing locations.
@@ -126,15 +130,25 @@ pub struct StackFrameInfo {
 
 impl std::fmt::Display for StackFrameInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let fp_name = match self.target.arch() {
-            Arch::X86_64 => "rbp",
-            Arch::Aarch64 => "fp",
+        // A frameless leaf has no frame pointer to report against; its saved
+        // registers sit directly below the stack pointer as it was on entry,
+        // at the same offsets the framed layout would have used (RUE-1171).
+        let fp_name = if !self.uses_frame_pointer {
+            "sp"
+        } else {
+            match self.target.arch() {
+                Arch::X86_64 => "rbp",
+                Arch::Aarch64 => "fp",
+            }
         };
 
         writeln!(f, "=== Stack Frame ({}) ===", self.function_name)?;
         writeln!(f)?;
         writeln!(f, "Frame size: {} bytes", self.frame_size)?;
         writeln!(f, "Alignment: {} bytes", self.alignment)?;
+        if !self.uses_frame_pointer {
+            writeln!(f, "Frame pointer: none (frameless leaf)")?;
+        }
         writeln!(f)?;
 
         // Group slots by kind
@@ -297,6 +311,10 @@ fn generate_x86_64_stack_frame(
     use crate::frame_layout::frame_cell_bytes;
     let frame = prepared.frame_layout;
     let stack_size = frame.frame_size() as i32;
+    // An eligible frameless leaf establishes no RBP; its saved registers sit
+    // below the entry stack pointer at the offsets computed below (RUE-1171).
+    let uses_frame_pointer =
+        frame.frame_pointer() == crate::frame_layout::FramePointer::Established;
 
     let mut slots = Vec::new();
 
@@ -399,7 +417,8 @@ fn generate_x86_64_stack_frame(
     Ok(StackFrameInfo {
         function_name: function_name.to_string(),
         frame_size: stack_size as usize,
-        alignment: 16,
+        alignment: frame.alignment() as usize,
+        uses_frame_pointer,
         slots,
         arguments,
         return_location,
@@ -437,6 +456,10 @@ fn generate_aarch64_stack_frame(
     // (the prologue copies stack-passed args into the frame param area).
     let frame = prepared.frame_layout;
     let frame_size = frame.frame_size() as usize;
+    // An eligible frameless leaf establishes no FP and saves no FP/LR pair; its
+    // callee-saved pairs sit below the entry stack pointer (RUE-1171).
+    let uses_frame_pointer =
+        frame.frame_pointer() == crate::frame_layout::FramePointer::Established;
 
     // Every FP-relative location below is derived from the same frame-layout
     // authority the emitter uses (RUE-774), so the reported slots match the
@@ -568,7 +591,8 @@ fn generate_aarch64_stack_frame(
     Ok(StackFrameInfo {
         function_name: function_name.to_string(),
         frame_size,
-        alignment: 16,
+        alignment: frame.alignment() as usize,
+        uses_frame_pointer,
         slots,
         arguments,
         return_location,
@@ -617,8 +641,22 @@ mod tests {
         let info = generate_stack_frame_info(&cfg, "test", &type_pool, &interner, target).unwrap();
 
         assert_eq!(info.function_name, "test");
-        assert_eq!(info.alignment, 16);
         assert!(!info.return_location.registers.is_empty());
+        // `return 42` is a leaf with no locals, parameters, spills, or sret
+        // pointer, so it gets no frame pointer and no slot region: the frame is
+        // just the callee-saved push the allocator needed (RUE-1171).
+        assert!(!info.uses_frame_pointer);
+        assert_eq!(info.alignment, 8);
+        assert!(
+            info.slots
+                .iter()
+                .all(|slot| slot.kind == StackSlotKind::CalleeSaved),
+            "a frameless leaf reports no slot-region cells: {:?}",
+            info.slots
+        );
+        let output = info.to_string();
+        assert!(output.contains("Frame pointer: none (frameless leaf)"));
+        assert!(output.contains("Layout (sp-relative):"));
     }
 
     #[test]
@@ -627,6 +665,7 @@ mod tests {
             function_name: "main".to_string(),
             frame_size: 32,
             alignment: 16,
+            uses_frame_pointer: true,
             slots: vec![
                 StackSlot {
                     name: Some("saved rbx".to_string()),
@@ -662,6 +701,127 @@ mod tests {
         assert!(output.contains("saved rbx"));
         assert!(output.contains("rdi"));
         assert!(output.contains("rax"));
+    }
+
+    /// Assembly and reported layout for `name` on `target`, from the same
+    /// production backend the compiler runs.
+    fn frame_projection(source: &str, name: &str, target: Target) -> (String, StackFrameInfo) {
+        let (cfg, type_pool, interner) = compile_named_fn(source, name);
+        let request = crate::BackendArtifactRequest {
+            asm: true,
+            ..Default::default()
+        };
+        let product = match target.arch() {
+            Arch::X86_64 => crate::x86_64::generate_product_with_symbols_and_atoms(
+                &cfg,
+                &type_pool,
+                &[],
+                &interner,
+                crate::MachineSymbolResolver::default(),
+                &[],
+                request,
+            ),
+            Arch::Aarch64 => crate::aarch64::generate_product_with_symbols_and_atoms(
+                &cfg,
+                &type_pool,
+                &[],
+                &interner,
+                target,
+                crate::MachineSymbolResolver::default(),
+                &[],
+                request,
+            ),
+        }
+        .expect("backend generation should succeed");
+        let info = generate_stack_frame_info(&cfg, name, &type_pool, &interner, target)
+            .expect("stack frame projection should succeed");
+        (product.artifacts.asm.expect("assembly projection"), info)
+    }
+
+    /// RUE-1171: a leaf function with no locals, spills, homed parameters, sret
+    /// pointer, calls, or stack arguments emits no frame allocation and no
+    /// frame-pointer setup on either backend. Adding one real frame consumer —
+    /// here a homed parameter — restores the full prologue and epilogue. The
+    /// reported stack frame agrees with the emitted code in both cases.
+    #[test]
+    fn frameless_leaves_elide_the_frame_and_one_consumer_restores_it() {
+        let source = "\
+fn frameless() -> i32 {
+    7
+}
+
+fn framed(n: i32) -> i32 {
+    n
+}
+
+fn main() -> i32 {
+    frameless() + framed(1)
+}
+";
+
+        // Frame-pointer setup and slot allocation, per backend. These are the
+        // exact mnemonics the prologue/epilogue emit.
+        let frame_markers = |target: Target| -> &'static [&'static str] {
+            match target.arch() {
+                Arch::X86_64 => &["push rbp", "mov rbp, rsp", "pop rbp", "lea rsp, [rbp"],
+                Arch::Aarch64 => &["stp x29, x30", "mov x29, sp", "ldp x29, x30"],
+            }
+        };
+
+        for target in [Target::X86_64Linux, Target::Aarch64Linux] {
+            let (asm, info) = frame_projection(source, "frameless", target);
+            for marker in frame_markers(target) {
+                assert!(
+                    !asm.contains(marker),
+                    "frameless leaf still emits `{marker}` on {target:?}:\n{asm}"
+                );
+            }
+            assert!(
+                !asm.contains("sub rsp") && !asm.contains("sub sp, sp"),
+                "frameless leaf still allocates a frame on {target:?}:\n{asm}"
+            );
+            // Only the callee-saved registers the allocator actually used are
+            // saved, and the reported frame is exactly those pushes.
+            assert!(!info.uses_frame_pointer);
+            assert!(
+                info.slots
+                    .iter()
+                    .all(|slot| slot.kind == StackSlotKind::CalleeSaved),
+                "frameless leaf reports slot-region cells on {target:?}: {:?}",
+                info.slots
+            );
+            let scheme = match target.arch() {
+                Arch::X86_64 => crate::frame_layout::SavedRegScheme::X86_64,
+                Arch::Aarch64 => crate::frame_layout::SavedRegScheme::Aarch64,
+            };
+            let saved_bytes = scheme.callee_saved_bytes(saved_register_count(&info));
+            assert_eq!(
+                info.frame_size, saved_bytes as usize,
+                "reported frame on {target:?} must be exactly the callee-saved pushes"
+            );
+
+            let (asm, info) = frame_projection(source, "framed", target);
+            for marker in frame_markers(target) {
+                assert!(
+                    asm.contains(marker),
+                    "one homed parameter must restore `{marker}` on {target:?}:\n{asm}"
+                );
+            }
+            assert!(info.uses_frame_pointer);
+            assert!(
+                info.slots
+                    .iter()
+                    .any(|slot| slot.kind == StackSlotKind::Parameter),
+                "the restored frame must report its parameter slot on {target:?}"
+            );
+        }
+    }
+
+    fn saved_register_count(info: &StackFrameInfo) -> usize {
+        info.slots
+            .iter()
+            .filter(|slot| slot.kind == StackSlotKind::CalleeSaved)
+            .count()
     }
 
     /// Compile a Rue function to a validated CFG for the codegen tests.

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -73,6 +73,26 @@
 //! ret                                  ; Return to caller
 //! ```
 //!
+//! ## Frameless Leaves
+//!
+//! The frame above exists to hold frame slots. A leaf function with none — no
+//! locals, no register-allocator spills, no homed parameters, no sret pointer
+//! cell — and no calls has nothing to store and no call boundary to align, so
+//! frame planning omits its frame pointer entirely (RUE-1171). Its prologue and
+//! epilogue are at most the callee-saved pushes and their matching pops:
+//!
+//! ```asm
+//! push r12                 ; Save callee-saved registers (if any were used)
+//! ...                      ; body: no RBP-relative operand can exist
+//! pop r12
+//! ret
+//! ```
+//!
+//! Calls are excluded because `call` requires 16-byte-aligned RSP, which the
+//! slot region's rounding is what establishes. The decision is made once, by
+//! `codegen_pipeline::plan_frame_pointer`, and reaches this module as the
+//! frame layout's [`crate::frame_layout::FramePointer`].
+//!
 //! ## Key Invariants
 //!
 //! 1. **RBP-relative stack arguments**: Stack arguments (7th ABI slot and beyond)
@@ -88,6 +108,8 @@
 //!
 //! 3. **16-byte stack alignment**: RSP is aligned to 16 bytes after the prologue.
 //!    The alignment calculation accounts for the number of callee-saved pushes.
+//!    A frameless leaf is the one exception, and it makes no calls, so there is
+//!    no call boundary that could observe the difference.
 //!
 //! 4. **Callee-saved registers**: R12-R15 and RBX are callee-saved per System V AMD64 ABI.
 //!    Register allocation determines which are actually used and need saving.
@@ -238,8 +260,20 @@ pub struct Emitter<'a> {
     callee_saved: Vec<Reg>,
     /// String table (indexed by string_id in StringConstPtr/StringConstLen).
     strings: &'a [String],
-    /// Whether a stack frame was emitted (prologue was executed).
+    /// Whether a prologue was emitted, and so an epilogue must be too.
     has_frame: bool,
+    /// Whether the prologue established RBP as a frame pointer. False for an
+    /// eligible frameless leaf, whose prologue is at most the callee-saved
+    /// pushes (RUE-1171).
+    has_frame_pointer: bool,
+    /// Whether frame planning classified this function as a frameless leaf.
+    /// Distinct from `has_frame_pointer`, which is also false for a synthetic
+    /// emitter built with no frame facts at all.
+    frameless: bool,
+    /// An RBP-relative operand reached a function planned as frameless. That is
+    /// an internal inconsistency, reported after emission rather than silently
+    /// encoded against a frame pointer that was never established.
+    frameless_frame_reference: bool,
     /// Canonical checked layout supplied by the production pipeline.
     frame_layout: Option<crate::frame_layout::FrameLayout>,
     /// Byte offset where the current instruction started (for recording).
@@ -291,6 +325,9 @@ impl<'a> Emitter<'a> {
             callee_saved: callee_saved.to_vec(),
             strings,
             has_frame: false,
+            has_frame_pointer: false,
+            frameless: false,
+            frameless_frame_reference: false,
             frame_layout: None,
             inst_start: 0,
             emit_asm: false,
@@ -367,12 +404,36 @@ impl<'a> Emitter<'a> {
     ///
     /// Positive offsets (stack arguments) are left unchanged since they're above
     /// the saved RBP and return address.
-    fn adjust_fp_offset(&self, base: Reg, offset: i32) -> i32 {
-        if base == Reg::Rbp && offset < 0 {
+    ///
+    /// This is the single funnel every RBP-based operand passes through, so it
+    /// is also where a frameless function is checked against actually naming a
+    /// frame location (RUE-1171).
+    fn adjust_fp_offset(&mut self, base: Reg, offset: i32) -> i32 {
+        if base != Reg::Rbp {
+            return offset;
+        }
+        if self.frameless {
+            self.frameless_frame_reference = true;
+        }
+        if offset < 0 {
             offset - self.callee_saved_size()
         } else {
             offset
         }
+    }
+
+    /// The canonical frame layout for this function, falling back to a framed
+    /// layout derived from the slot counts when no pipeline layout was supplied
+    /// (a directly constructed emitter in a synthetic test).
+    fn frame(&self) -> crate::frame_layout::FrameLayout {
+        self.frame_layout.unwrap_or_else(|| {
+            crate::frame_layout::FrameLayout::try_new(
+                crate::frame_layout::SavedRegScheme::X86_64,
+                self.callee_saved.len(),
+                self.num_locals + self.num_params + self.has_sret as u32,
+            )
+            .expect("emitter frame must fit the checked function-frame budget")
+        })
     }
 
     // ==================== Main emit entry point ====================
@@ -424,19 +485,32 @@ impl<'a> Emitter<'a> {
             }
         }
 
-        // Emit function prologue if we have local variables, parameters,
-        // an sret pointer to save, or callee-saved regs
-        if self.num_locals > 0
-            || self.num_params > 0
-            || self.has_sret
-            || !self.callee_saved.is_empty()
-        {
-            self.has_frame = true;
+        // A frame pointer exists to address frame slots; an eligible frameless
+        // leaf has none, so its prologue is at most the callee-saved pushes and
+        // it never establishes RBP (RUE-1171).
+        self.frameless = self.frame().frame_pointer() == crate::frame_layout::FramePointer::Omitted;
+        self.has_frame_pointer = !self.frameless
+            && (self.num_locals > 0
+                || self.num_params > 0
+                || self.has_sret
+                || !self.callee_saved.is_empty());
+        self.has_frame = self.has_frame_pointer || !self.callee_saved.is_empty();
+        if self.has_frame {
             self.emit_prologue();
         }
 
         for inst in self.mir.iter() {
             self.emit_inst(inst);
+        }
+        if self.frameless_frame_reference {
+            return Err(ice_error!(
+                "frameless function references the frame pointer",
+                phase: "codegen/emit",
+                details: {
+                    "reason" => "frame planning omitted the frame pointer but an \
+                                 RBP-relative operand was emitted"
+                }
+            ));
         }
         self.apply_fixups()
     }
@@ -489,17 +563,19 @@ impl<'a> Emitter<'a> {
     fn emit_prologue(&mut self) {
         self.record_comment("prologue");
 
-        // push rbp: 55
-        self.begin_inst();
-        self.code.push(0x55);
-        end_inst!(self, "push rbp");
+        if self.has_frame_pointer {
+            // push rbp: 55
+            self.begin_inst();
+            self.code.push(0x55);
+            end_inst!(self, "push rbp");
 
-        // mov rbp, rsp: 48 89 E5
-        self.begin_inst();
-        self.code.push(0x48);
-        self.code.push(0x89);
-        self.code.push(0xE5);
-        end_inst!(self, "mov rbp, rsp");
+            // mov rbp, rsp: 48 89 E5
+            self.begin_inst();
+            self.code.push(0x48);
+            self.code.push(0x89);
+            self.code.push(0xE5);
+            end_inst!(self, "mov rbp, rsp");
+        }
 
         // Save callee-saved registers AFTER rbp setup
         // This ensures stack args are at fixed offsets from rbp
@@ -518,15 +594,10 @@ impl<'a> Emitter<'a> {
         // - one slot for the incoming sret pointer, if any
         // Each slot is one frame cell; the total (including callee-saved
         // pushes) is 16-byte aligned by the frame-layout authority.
-        let total_slots = self.num_locals + self.num_params + self.has_sret as u32;
-        let frame = self.frame_layout.unwrap_or_else(|| {
-            crate::frame_layout::FrameLayout::try_new(
-                crate::frame_layout::SavedRegScheme::X86_64,
-                self.callee_saved.len(),
-                total_slots,
-            )
-            .expect("emitter frame must fit the checked function-frame budget")
-        });
+        //
+        // A frameless leaf has no slots at all, so this is zero and no `sub
+        // rsp` is emitted: there is no call boundary left to align for.
+        let frame = self.frame();
         let stack_size = frame.frame_size() as i32 - frame.saved_area_bytes();
 
         if stack_size > 0 {
@@ -620,13 +691,11 @@ impl<'a> Emitter<'a> {
     fn emit_epilogue(&mut self) {
         self.record_comment("epilogue");
 
-        // Point RSP at the callee-saved area (skip locals and alignment padding)
+        // Point RSP at the callee-saved area (skip locals and alignment
+        // padding). A frameless leaf allocated neither, and has no RBP to
+        // recompute RSP from: the pops below already sit at RSP.
         let size = self.callee_saved_size();
-        if !self.callee_saved.is_empty()
-            || self.num_locals > 0
-            || self.num_params > 0
-            || self.has_sret
-        {
+        if self.has_frame_pointer {
             self.begin_inst();
             self.emit_lea_rsp_rbp_offset(-size);
             end_inst!(self, "lea rsp, [rbp{}]", format_offset(-size));
@@ -641,9 +710,11 @@ impl<'a> Emitter<'a> {
         }
 
         // Pop rbp to restore caller's frame pointer
-        self.begin_inst();
-        self.emit_pop(Reg::Rbp);
-        end_inst!(self, "pop rbp");
+        if self.has_frame_pointer {
+            self.begin_inst();
+            self.emit_pop(Reg::Rbp);
+            end_inst!(self, "pop rbp");
+        }
     }
 
     /// Apply all fixups for forward jumps.

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -1004,6 +1004,19 @@ impl X86Mir {
         self.instructions.iter()
     }
 
+    /// Whether this function calls nothing — the eligibility precondition for
+    /// a frameless prologue (RUE-1171).
+    ///
+    /// `syscall` does not count: it neither pushes a return address (so it
+    /// imposes no call-boundary alignment) nor clobbers a register the
+    /// prologue would otherwise preserve.
+    pub fn is_leaf(&self) -> bool {
+        !self
+            .instructions
+            .iter()
+            .any(|inst| matches!(inst, X86Inst::CallRel { .. }))
+    }
+
     /// Consume the MIR and return its instructions.
     pub fn into_instructions(self) -> Vec<X86Inst> {
         self.instructions

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -101,6 +101,7 @@ fn prepare_backend_with_artifacts(
         },
         schedule::schedule,
         verify::verify_stack_alignment,
+        X86Mir::is_leaf,
     )
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,11 @@ The `stackframe` view reports each frame's byte-based layout — per-slot offset
 and sizes, callee-saved registers, and the 16-byte-aligned total — from the
 single frame-layout authority (`rue-codegen`'s `frame_layout`, RUE-975), the
 same byte product both backends' prologue/epilogue and spill allocators consume,
-rather than re-deriving `slot * 8` arithmetic per backend. Physical stack layout
+rather than re-deriving `slot * 8` arithmetic per backend. That authority also
+records whether the function establishes a frame pointer at all: a leaf with no
+frame slots and no calls needs neither a frame pointer nor a slot region, so its
+prologue is at most the callee-saved pushes and the view reports its saved
+registers relative to the entry stack pointer (RUE-1171). Physical stack layout
 is one representation produced by the ADR-0052 canonical layout authority; the
 internal value decomposition stays slot-shaped, so under the default layout the
 reported offsets are unchanged.


### PR DESCRIPTION
A frame pointer exists to address frame slots. Both emitters established one whenever anything at all needed saving, so a leaf function with no locals, spills, homed parameters, or sret pointer cell still paid for a frame pointer, an aligned slot region, and — on AArch64 — an FP/LR save it had no use for.

Fixes RUE-1171. Refs RUE-1146.

## What changed

Frame planning becomes an explicit decision the pipeline takes once, after allocation and scheduling have settled the final instruction stream and the final spill count.

- **`frame_layout.rs`** — `FrameLayout` now records a `FramePointer` (`Established` / `Omitted`), with `FrameLayout::frameless()`, `alignment()`, and `SavedRegScheme::callee_saved_bytes()` (the saved area minus any frame-pointer save).
- **`codegen_pipeline.rs`** — `plan_frame_pointer(total_slots, is_leaf)` is the single authority. It omits the frame pointer only when the function has zero frame slots **and** makes no call. A call is disqualifying for two reasons: it needs the call-boundary stack alignment that the slot region's rounding is what establishes, and on AArch64 it clobbers the link register that the FP/LR save preserves.
- **Both emitters** gate the frame-pointer setup and teardown on that plan. A frameless leaf's prologue and epilogue are at most the callee-saved pushes and their matching pops.
- **`stack_frame.rs`** — `--emit stackframe` reports `uses_frame_pointer`, labels a frameless leaf's saved registers `sp`-relative (the offsets are numerically the same), and reports its real frame size and alignment.

## Soundness

`adjust_fp_offset` is the single funnel every FP-based operand passes through in either emitter, so it is also where the plan is checked: an FP-relative operand reaching a function planned frameless raises an internal error rather than encoding against a frame pointer that was never established. That backstop caught a real bug in the first draft of this change, where the check was keyed off prologue emission instead of the plan.

Alignment is unaffected: the only functions that drop the 16-byte call-boundary alignment are ones with no call to observe it. On AArch64, dropping the FP/LR save is safe only because the function makes no call, so X30 still holds its own return address at `ret`.

## Effect

| | before | after |
|---|---|---|
| `fn konst() -> i32 { 7 }`, x86-64 | 10 instructions / 29 bytes | 5 / 14 |
| same, AArch64 | 8 instructions / 32 bytes | 5 / 20 |

Callers keep their frames, and adding one parameter to a leaf restores the full prologue and epilogue.

The win is currently narrow — 11 of 131 functions in `examples/jsonfmt`, 2 of 57 in `examples/dijkstra`. Almost every function with parameters homes them to frame slots unconditionally, which is a real frame consumer, so it stays framed. That is the argument-homing cost RUE-1146 tracks; those functions become eligible here without further changes once it lands.

## Tests

- Frame-layout unit tests for the frameless and framed layouts on both schemes.
- A `plan_frame_pointer` truth table covering slots, calls, and both.
- A cross-backend test asserting the emitted assembly and the reported stack frame agree, for a frameless leaf and for the same leaf with one homed parameter.
- Three CLI execution cases (`cases/frameless_leaf.toml`): callee-saved restore across a frameless call, frameless leaves nested under a framed caller, and 1000 iterations checking the stack stays balanced.

`scripts/rue quick`, the codegen unit suite, and `scripts/rue premerge` pass. AArch64 encodings were checked by disassembling the emitted binary; native AArch64 execution is CI's to confirm.

---
_Generated by [Claude Code](https://claude.ai/code/session_019gkDo9bBaWYgaVDFnwUBRB)_