### PR TITLE
RUE-1181: define bounds checks by observable trap behavior

### DIFF
--- a/crates/rue-spec/cases/runtime/bounds.toml
+++ b/crates/rue-spec/cases/runtime/bounds.toml
@@ -183,3 +183,60 @@ fn main() -> i32 {
 }
 """
 runtime_error = "index out of bounds"
+
+# =============================================================================
+# Bounds checks are an observable-behavior obligation (8.2:9)
+# =============================================================================
+# 8.2:5 requires an out-of-range access to trap *as if* tested at the point of
+# navigation; it does not require a distinct test instruction per access. 8.2:9
+# bounds what a check-eliding transformation may do. These cases pin the
+# clauses that are observable from source: a trap must not appear on a path the
+# program does not take, and must not disappear from one it does. The
+# no-reorder-across-an-observable-effect clause is enforced by the
+# differential-opt harness (RUE-236) rather than here, since the spec corpus
+# does not assert on interleaved output.
+
+[[case]]
+name = "no_trap_on_untaken_branch"
+spec = ["8.2:9", "7.1:10"]
+description = "An out-of-range access on a branch that is not taken must not trap: a check may not be speculated onto an unexecuted path"
+source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 20, 30];
+    let i: u64 = 5;
+    if i < 3 { arr[i] } else { 7 }
+}
+"""
+exit_code = 7
+
+[[case]]
+name = "no_trap_on_zero_trip_loop"
+spec = ["8.2:9"]
+description = "An out-of-range access in a loop body that never executes must not trap: a hoisted check may not fire for a zero-trip loop"
+source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 20, 30];
+    let n: u64 = 0;
+    let mut i: u64 = 0;
+    let mut acc: i32 = 9;
+    while i < n {
+        acc = arr[i + 5];
+        i = i + 1;
+    }
+    acc
+}
+"""
+exit_code = 9
+
+[[case]]
+name = "trap_preserved_on_taken_branch"
+spec = ["8.2:9", "8.2:1"]
+description = "An out-of-range access on a branch that is taken must still trap: a transformation may not remove a trap the program would take"
+source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 20, 30];
+    let i: u64 = 5;
+    if i > 3 { arr[i] } else { 7 }
+}
+"""
+runtime_error = "index out of bounds"

--- a/docs/designs/0044-optimization-levels.md
+++ b/docs/designs/0044-optimization-levels.md
@@ -180,6 +180,17 @@ Two clarifications that keep the invariant honest:
    level may optimize them away or let a fold silently wrap. `constfold` already
    guards these; any future pass inherits the obligation. This is precisely the
    class RUE-348 lived in.
+3. **Bounds *traps* are observable; bounds *checks* are not.** Spec 8.2:5 states
+   the obligation as observable behavior — an out-of-range access traps as if
+   tested at the point of navigation — rather than as a mandated instruction, so
+   a pass may elide, combine, or hoist the dynamic test for an access it proves
+   in range. Spec 8.2:9 fixes the limits: a transformation may not introduce a
+   trap on an execution that would not have trapped (including speculating a
+   check onto an untaken path, or letting a hoisted check fire for a zero-trip
+   loop), may not remove a trap the program would take, may not reorder a trap
+   across an observable effect, and must preserve which access traps first. Any
+   range-analysis or bounds-check-elimination pass cites 8.2:9 and ships with
+   differential coverage for these cases.
 
 The invariant is not merely aspirational: it is **mechanically enforced** by the
 RUE-236 differential-opt harness. Every pass we add at `-O2`/`-O3` must keep the
@@ -242,6 +253,11 @@ coverage. Placement follows the cost/risk triage above:
   **`-O3`**.
 - **Loop optimizations** (invariant hoisting / LICM, unrolling): compile-time and
   size cost, speculative payoff → **`-O3`**.
+- **Range analysis / bounds-check elimination**: removes the dynamic test for
+  accesses proven in range, under the trap-preservation limits of spec 8.2:9
+  (see clarification 3 above) → **`-O2`** for the locally provable cases, with
+  loop-carried range facts arriving alongside the loop passes at **`-O3`**.
+
 - **Vectorization / SIMD**: far future, most speculative, per-backend → **`-O3`**.
 
 ### Where the level knob lives

--- a/docs/spec/src/07-arrays/01-fixed-arrays.md
+++ b/docs/spec/src/07-arrays/01-fixed-arrays.md
@@ -116,10 +116,12 @@ also 8.2:3).
 
 {{ rule(id="7.1:10", cat="dynamic-semantics") }}
 
-For variable indices, bounds **MUST** be checked at runtime, before the element
-is read, at the moment the index navigates into the array (core calculus
-`docs/formal/01-core-calculus.md` §6.5: the check precedes the projection that
-reads the element; see also 8.2:5).
+For variable indices, an out-of-range access **MUST** trap as if the bound were
+tested at the moment the index navigates into the array, before the element is
+read (core calculus `docs/formal/01-core-calculus.md` §6.5: the check precedes
+the projection that reads the element; see also 8.2:5). This constrains
+observable behavior, not emitted code: an implementation may omit or move the
+dynamic test where it proves the trap behavior unchanged, subject to 8.2:9.
 
 {{ rule(id="7.1:11", cat="dynamic-semantics") }}
 

--- a/docs/spec/src/08-runtime-behavior/02-bounds-checking.md
+++ b/docs/spec/src/08-runtime-behavior/02-bounds-checking.md
@@ -8,11 +8,11 @@ template = "spec/page.html"
 
 {{ rule(id="8.2:1", cat="dynamic-semantics") }}
 
-Array access with an out-of-range index **MUST** cause a runtime panic. The bound
-is checked at the moment the index is used to navigate into the array; an index
-`i` is out of range for an `[T; n]` when `i` is negative or `i ≥ n`, and either
-case traps (core calculus `docs/formal/01-core-calculus.md` §6.5, and the `bounds`
-trap category of §6.12).
+Array access with an out-of-range index **MUST** cause a runtime panic, taking
+effect as of the moment the index is used to navigate into the array (8.2:5); an
+index `i` is out of range for an `[T; n]` when `i` is negative or `i ≥ n`, and
+either case traps (core calculus `docs/formal/01-core-calculus.md` §6.5, and the
+`bounds` trap category of §6.12).
 
 {{ rule(id="8.2:2", cat="dynamic-semantics") }}
 
@@ -33,10 +33,41 @@ A constant index is an expression that can be fully evaluated at compile time. T
 
 {{ rule(id="8.2:5", cat="dynamic-semantics") }}
 
-For variable indices, bounds checking **MUST** be performed at runtime, before the
-element is read, at the point where the index navigates into the array (core
-calculus `docs/formal/01-core-calculus.md` §6.5: the check precedes the projection
-that reads the element).
+For variable indices, an out-of-range access **MUST** trap as if the bound were
+tested at the point where the index navigates into the array, before the element
+is read (core calculus `docs/formal/01-core-calculus.md` §6.5: the check precedes
+the projection that reads the element).
+
+This is an obligation on observable behavior, not on emitted code. The core
+calculus rules `(D-Index)` and `(D-Index-Trap)` say what reading an index
+*means*; they do not require that a conforming implementation execute a distinct
+test instruction at each access. An implementation **MAY** eliminate, combine,
+hoist, or otherwise transform the dynamic test — including omitting it entirely
+for an access it proves in range — subject to 8.2:9.
+
+{{ rule(id="8.2:9", cat="normative") }}
+
+A transformation of bounds checks **MUST** preserve the trap behavior of the
+untransformed program, which is observable (8.0:1). Specifically, such a
+transformation:
+
+- **MUST NOT** introduce a trap on an execution that would not have trapped.
+  In particular a check **MUST NOT** be speculated onto a path the original
+  program does not take, and a check hoisted out of a loop **MUST NOT** trap
+  when the loop body never executes.
+- **MUST NOT** remove a trap the untransformed program would take.
+- **MUST NOT** reorder a trap across an observable effect: every observable
+  effect the original program performs before trapping **MUST** still be
+  performed before the trap, and an effect the original program reaches only
+  after the trap point **MUST NOT** be performed at all.
+- **MUST** take the trap the untransformed program would have taken first,
+  where more than one access is out of range on the same execution.
+
+An access proven in range on every execution that reaches it therefore needs no
+dynamic test: omitting it satisfies each clause above vacuously. Which accesses
+an implementation proves is implementation-defined and **MUST NOT** be relied
+on — a program cannot observe whether a check was elided, only whether the trap
+required by 8.2:1 and 8.2:2 occurs.
 
 {{ rule(id="8.2:6") }}
 


### PR DESCRIPTION
Rules 7.1:10 and 8.2:5 both said bounds "**MUST** be checked at runtime ... at the point where the index navigates into the array". Read literally that mandates a dynamic test instruction at every access, even one range analysis proves in bounds — which would forbid redundant-check elimination, hoisting, and vectorization before those passes exist.

Per the ruling on the issue ("we certainly want to allow bounds to be elided if they can be proven to not be needed"), both rules now state the obligation as **observable behavior**: an out-of-range access traps *as if* the bound were tested at the point of navigation. The mechanism is left to the implementation, which may elide, combine, or hoist the test for an access it proves in range. 8.2:1 is reworded to match.

## The formal core needed no change

Worth noting since prose/formal-core correspondence is the usual risk in a change like this: `(D-Index)` and `(D-Index-Trap)` in `docs/formal/01-core-calculus.md` §6.5 already define what *reading* an index means rather than mandating an emitted check. The new prose is closer to the formal core than the old prose was.

## New rule 8.2:9

Relaxing 8.2:5 without bounding it would license real miscompiles, so the freedom comes with limits. A check-eliding transformation:

- **MUST NOT** introduce a trap on an execution that would not have trapped — no speculating a check onto an untaken path, no hoisted check firing for a zero-trip loop;
- **MUST NOT** remove a trap the program would take;
- **MUST NOT** reorder a trap across an observable effect;
- **MUST** preserve which access traps first when several are out of range.

## Traceability

Three cases cover the clauses observable from source, each verified at `-O0` through `-O3` before being written:

| Case | Behavior |
| --- | --- |
| `no_trap_on_untaken_branch` | out-of-range index on a not-taken branch → exit 7, no trap |
| `no_trap_on_zero_trip_loop` | out-of-range index in a zero-trip loop body → exit 9, no trap |
| `trap_preserved_on_taken_branch` | out-of-range index on a taken branch → still traps |

The no-reorder-across-an-observable-effect clause is **not** covered here: the spec corpus has no stdout assertion, so interleaving is not observable to it. That clause's enforcement point is the RUE-236 differential-opt harness. The case block says so explicitly rather than leaving the gap to look like coverage.

## ADR-0044

Gains the matching invariant clarification — bounds *traps* are observable, bounds *checks* are not — alongside the existing checked-arithmetic clarification, and lists range analysis / bounds-check elimination among plausible future passes citing 8.2:9, so whichever pass lands it inherits the limits.

## Verification

- `scripts/rue spec` — 2188 passed, 0 failed, 15 ignored
- `scripts/rue premerge` — passed
- Traceability — normative coverage 99.6%, `legality-rule` 142/142; 8.2:9 covered; the 3 uncovered normatives are the pre-existing FFI allowlist entries
- Existing bounds-check tests unchanged and still passing, per the issue's acceptance criteria
